### PR TITLE
Fixed link to release notes

### DIFF
--- a/release-notes/1.0/README.md
+++ b/release-notes/1.0/README.md
@@ -4,4 +4,4 @@ The following Microsoft.Data.SqlClient 1.0 releases have been shipped.
 
 | Release Date | Description | |
 | :-- | :-- | :--: |
-| 2019/05/06 | 1.0.0 Preview 1 | [release notes](1.0.0/1.0.0.md) |
+| 2019/05/06 | 1.0.0 Preview 1 | [release notes](1.0.0.md) |


### PR DESCRIPTION
Release notes current url goes to `1.0.0` folder which doesn't exist as the release notes are in the root folder of the readme.