### PR TITLE
perf: rework TdsParserStateObject and SqlDataReader snapshots

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -803,7 +803,7 @@ namespace Microsoft.Data.SqlClient
             }
 
 #if DEBUG
-            if (_stateObj._pendingData)
+            if (_stateObj.HasPendingData)
             {
                 byte token;
                 if (!_stateObj.TryPeekByte(out token))
@@ -936,7 +936,7 @@ namespace Microsoft.Data.SqlClient
 
             try
             {
-                if ((!_isClosed) && (parser != null) && (stateObj != null) && (stateObj._pendingData))
+                if ((!_isClosed) && (parser != null) && (stateObj != null) && (stateObj.HasPendingData))
                 {
                     // It is possible for this to be called during connection close on a
                     // broken connection, so check state first.
@@ -1118,7 +1118,7 @@ namespace Microsoft.Data.SqlClient
         {
             // warning:  Don't check the MetaData property within this function
             // warning:  as it will be a reentrant call
-            while (_parser != null && _stateObj != null && _stateObj._pendingData && !_metaDataConsumed)
+            while (_parser != null && _stateObj != null && _stateObj.HasPendingData && !_metaDataConsumed)
             {
                 if (_parser.State == TdsParserState.Broken || _parser.State == TdsParserState.Closed)
                 {
@@ -3053,7 +3053,7 @@ namespace Microsoft.Data.SqlClient
 
                 Debug.Assert(null != _command, "unexpected null command from the data reader!");
 
-                while (_stateObj._pendingData)
+                while (_stateObj.HasPendingData)
                 {
                     byte token;
                     if (!_stateObj.TryPeekByte(out token))
@@ -3137,7 +3137,7 @@ namespace Microsoft.Data.SqlClient
                         moreRows = false;
                         return true;
                 }
-                if (_stateObj._pendingData)
+                if (_stateObj.HasPendingData)
                 {
                     // Consume error's, info's, done's on HasMoreRows, so user obtains error on Read.
                     byte b;
@@ -3178,7 +3178,7 @@ namespace Microsoft.Data.SqlClient
                             moreRows = false;
                             return false;
                         }
-                        if (_stateObj._pendingData)
+                        if (_stateObj.HasPendingData)
                         {
                             if (!_stateObj.TryPeekByte(out b))
                             {
@@ -3451,7 +3451,7 @@ namespace Microsoft.Data.SqlClient
                         if (moreRows)
                         {
                             // read the row from the backend (unless it's an altrow were the marker is already inside the altrow ...)
-                            while (_stateObj._pendingData)
+                            while (_stateObj.HasPendingData)
                             {
                                 if (_altRowStatus != ALTROWSTATUS.AltRow)
                                 {
@@ -3483,7 +3483,7 @@ namespace Microsoft.Data.SqlClient
                             }
                         }
 
-                        if (!_stateObj._pendingData)
+                        if (!_stateObj.HasPendingData)
                         {
                             if (!TryCloseInternal(false /*closeReader*/))
                             {
@@ -3507,7 +3507,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             // if we are in SingleRow mode, and we've read the first row,
                             // read the rest of the rows, if any
-                            while (_stateObj._pendingData && !_sharedState._dataReady)
+                            while (_stateObj.HasPendingData && !_sharedState._dataReady)
                             {
                                 if (!_parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady))
                                 {
@@ -3548,7 +3548,7 @@ namespace Microsoft.Data.SqlClient
                 more = false;
 
 #if DEBUG
-                if ((!_sharedState._dataReady) && (_stateObj._pendingData))
+                if ((!_sharedState._dataReady) && (_stateObj.HasPendingData))
                 {
                     byte token;
                     if (!_stateObj.TryPeekByte(out token))

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Data.SqlClient
 
         private Task _currentTask;
         private Snapshot _snapshot;
+        private Snapshot _cachedSnapshot;
         private CancellationTokenSource _cancelAsyncOnCloseTokenSource;
         private CancellationToken _cancelAsyncOnCloseToken;
 
@@ -3770,6 +3771,10 @@ namespace Microsoft.Data.SqlClient
                 {
                     // reset snapshot to save memory use.  We can safely do that here because all SqlDataReader values are stable.
                     // The retry logic can use the current values to get back to the right state.
+                    if (_cachedSnapshot is null)
+                    {
+                        _cachedSnapshot = _snapshot;
+                    }
                     _snapshot = null;
                     PrepareAsyncInvocation(useSnapshot: true);
                 }
@@ -4659,6 +4664,10 @@ namespace Microsoft.Data.SqlClient
                         if (!rowTokenRead)
                         {
                             rowTokenRead = true;
+                            if (_cachedSnapshot is null)
+                            {
+                                _cachedSnapshot = _snapshot;
+                            }
                             _snapshot = null;
                             PrepareAsyncInvocation(useSnapshot: true);
                         }
@@ -5112,28 +5121,27 @@ namespace Microsoft.Data.SqlClient
 
                 if (_snapshot == null)
                 {
-                    _snapshot = new Snapshot
-                    {
-                        _dataReady = _sharedState._dataReady,
-                        _haltRead = _haltRead,
-                        _metaDataConsumed = _metaDataConsumed,
-                        _browseModeInfoConsumed = _browseModeInfoConsumed,
-                        _hasRows = _hasRows,
-                        _altRowStatus = _altRowStatus,
-                        _nextColumnDataToRead = _sharedState._nextColumnDataToRead,
-                        _nextColumnHeaderToRead = _sharedState._nextColumnHeaderToRead,
-                        _columnDataBytesRead = _columnDataBytesRead,
-                        _columnDataBytesRemaining = _sharedState._columnDataBytesRemaining,
+                    _snapshot = Interlocked.Exchange(ref _cachedSnapshot, null) ?? new Snapshot();
 
-                        // _metadata and _altaMetaDataSetCollection must be Cloned
-                        // before they are updated
-                        _metadata = _metaData,
-                        _altMetaDataSetCollection = _altMetaDataSetCollection,
-                        _tableNames = _tableNames,
+                    _snapshot._dataReady = _sharedState._dataReady;
+                    _snapshot._haltRead = _haltRead;
+                    _snapshot._metaDataConsumed = _metaDataConsumed;
+                    _snapshot._browseModeInfoConsumed = _browseModeInfoConsumed;
+                    _snapshot._hasRows = _hasRows;
+                    _snapshot._altRowStatus = _altRowStatus;
+                    _snapshot._nextColumnDataToRead = _sharedState._nextColumnDataToRead;
+                    _snapshot._nextColumnHeaderToRead = _sharedState._nextColumnHeaderToRead;
+                    _snapshot._columnDataBytesRead = _columnDataBytesRead;
+                    _snapshot._columnDataBytesRemaining = _sharedState._columnDataBytesRemaining;
 
-                        _currentStream = _currentStream,
-                        _currentTextReader = _currentTextReader,
-                    };
+                    // _metadata and _altaMetaDataSetCollection must be Cloned
+                    // before they are updated
+                    _snapshot._metadata = _metaData;
+                    _snapshot._altMetaDataSetCollection = _altMetaDataSetCollection;
+                    _snapshot._tableNames = _tableNames;
+
+                    _snapshot._currentStream = _currentStream;
+                    _snapshot._currentTextReader = _currentTextReader;
 
                     _stateObj.SetSnapshot();
                 }
@@ -5186,6 +5194,10 @@ namespace Microsoft.Data.SqlClient
             stateObj._permitReplayStackTraceToDiffer = false;
 #endif
 
+            if (_cachedSnapshot is null)
+            {
+                _cachedSnapshot = _snapshot;
+            }
             // We are setting this to null inside the if-statement because stateObj==null means that the reader hasn't been initialized or has been closed (either way _snapshot should already be null)
             _snapshot = null;
         }
@@ -5224,6 +5236,10 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(_snapshot != null, "Should currently have a snapshot");
             Debug.Assert(_stateObj != null && !_stateObj._asyncReadWithoutSnapshot, "Already in async without snapshot");
 
+            if (_cachedSnapshot is null)
+            {
+                _cachedSnapshot = _snapshot;
+            }
             _snapshot = null;
             _stateObj.ResetSnapshot();
             _stateObj._asyncReadWithoutSnapshot = true;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -697,11 +697,11 @@ namespace Microsoft.Data.SqlClient
                     // or if MARS is off, then a datareader exists
                     throw ADP.OpenReaderExists(parser.MARSOn);
                 }
-                else if (!parser.MARSOn && parser._physicalStateObj._pendingData)
+                else if (!parser.MARSOn && parser._physicalStateObj.HasPendingData)
                 {
                     parser.DrainData(parser._physicalStateObj);
                 }
-                Debug.Assert(!parser._physicalStateObj._pendingData, "Should not have a busy physicalStateObject at this point!");
+                Debug.Assert(!parser._physicalStateObj.HasPendingData, "Should not have a busy physicalStateObject at this point!");
 
                 parser.RollbackOrphanedAPITransactions();
             }
@@ -840,7 +840,7 @@ namespace Microsoft.Data.SqlClient
             // obtains a clone.
 
             Debug.Assert(!HasLocalTransactionFromAPI, "Upon ResetConnection SqlInternalConnectionTds has a currently ongoing local transaction.");
-            Debug.Assert(!_parser._physicalStateObj._pendingData, "Upon ResetConnection SqlInternalConnectionTds has pending data.");
+            Debug.Assert(!_parser._physicalStateObj.HasPendingData, "Upon ResetConnection SqlInternalConnectionTds has pending data.");
 
             if (_fResetConnection)
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2799,7 +2799,7 @@ namespace Microsoft.Data.SqlClient
                     }
                 }
                 // Skip the bogus DONE counts sent by the server
-                if (stateObj._receivedColMetaData || (curCmd != TdsEnums.SELECT))
+                if (stateObj.HasReceivedColumnMetadata || (curCmd != TdsEnums.SELECT))
                 {
                     cmd.OnStatementCompleted(count);
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -502,7 +502,7 @@ namespace Microsoft.Data.SqlClient
             {
                 session = _sessionPool.GetSession(owner);
 
-                Debug.Assert(!session._pendingData, "pending data on a pooled MARS session");
+                Debug.Assert(!session.HasPendingData, "pending data on a pooled MARS session");
             }
             else
             {
@@ -943,7 +943,7 @@ namespace Microsoft.Data.SqlClient
 
             if (!connectionIsDoomed && null != _physicalStateObj)
             {
-                if (_physicalStateObj._pendingData)
+                if (_physicalStateObj.HasPendingData)
                 {
                     DrainData(_physicalStateObj);
                 }
@@ -1800,7 +1800,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             if (token == TdsEnums.SQLERROR)
                             {
-                                stateObj._errorTokenReceived = true; // Keep track of the fact error token was received - for Done processing.
+                                stateObj.HasReceivedError = true; // Keep track of the fact error token was received - for Done processing.
                             }
 
                             SqlError error;
@@ -2320,18 +2320,18 @@ namespace Microsoft.Data.SqlClient
                         break;
                 }
 
-                Debug.Assert(stateObj._pendingData || !dataReady, "dataReady is set, but there is no pending data");
+                Debug.Assert(stateObj.HasPendingData || !dataReady, "dataReady is set, but there is no pending data");
             }
 
             // Loop while data pending & runbehavior not return immediately, OR
             // if in attention case, loop while no more pending data & attention has not yet been
             // received.
-            while ((stateObj._pendingData &&
+            while ((stateObj.HasPendingData &&
                     (RunBehavior.ReturnImmediately != (RunBehavior.ReturnImmediately & runBehavior))) ||
-                (!stateObj._pendingData && stateObj._attentionSent && !stateObj._attentionReceived));
+                (!stateObj.HasPendingData && stateObj._attentionSent && !stateObj.HasReceivedAttention));
 
 #if DEBUG
-            if ((stateObj._pendingData) && (!dataReady))
+            if ((stateObj.HasPendingData) && (!dataReady))
             {
                 byte token;
                 if (!stateObj.TryPeekByte(out token))
@@ -2342,7 +2342,7 @@ namespace Microsoft.Data.SqlClient
             }
 #endif
 
-            if (!stateObj._pendingData)
+            if (!stateObj.HasPendingData)
             {
                 if (null != CurrentTransaction)
                 {
@@ -2352,7 +2352,7 @@ namespace Microsoft.Data.SqlClient
 
             // if we received an attention (but this thread didn't send it) then
             // we throw an Operation Cancelled error
-            if (stateObj._attentionReceived)
+            if (stateObj.HasReceivedAttention)
             {
                 // Dev11 #344723: SqlClient stress hang System_Data!Tcp::ReadSync via a call to SqlDataReader::Close
                 // Spin until SendAttention has cleared _attentionSending, this prevents a race condition between receiving the attention ACK and setting _attentionSent
@@ -2363,7 +2363,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // Reset attention state.
                     stateObj._attentionSent = false;
-                    stateObj._attentionReceived = false;
+                    stateObj.HasReceivedAttention = false;
 
                     if (RunBehavior.Clean != (RunBehavior.Clean & runBehavior) && !stateObj._internalTimeout)
                     {
@@ -2781,7 +2781,7 @@ namespace Microsoft.Data.SqlClient
             {
                 Debug.Assert(TdsEnums.DONE_MORE != (status & TdsEnums.DONE_MORE), "Not expecting DONE_MORE when receiving DONE_ATTN");
                 Debug.Assert(stateObj._attentionSent, "Received attention done without sending one!");
-                stateObj._attentionReceived = true;
+                stateObj.HasReceivedAttention = true;
                 Debug.Assert(stateObj._inBytesUsed == stateObj._inBytesRead && stateObj._inBytesPacket == 0, "DONE_ATTN received with more data left on wire");
             }
             if ((null != cmd) && (TdsEnums.DONE_COUNT == (status & TdsEnums.DONE_COUNT)))
@@ -2805,7 +2805,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            stateObj._receivedColMetaData = false;
+            stateObj.HasReceivedColumnMetadata = false;
 
             // Surface exception for DONE_ERROR in the case we did not receive an error token
             // in the stream, but an error occurred.  In these cases, we throw a general server error.  The
@@ -2814,7 +2814,7 @@ namespace Microsoft.Data.SqlClient
             // the server has reached its max connection limit.  Bottom line, we need to throw general
             // error in the cases where we did not receive an error token along with the DONE_ERROR.
             if ((TdsEnums.DONE_ERROR == (TdsEnums.DONE_ERROR & status)) && stateObj.ErrorCount == 0 &&
-                  stateObj._errorTokenReceived == false && (RunBehavior.Clean != (RunBehavior.Clean & run)))
+                  stateObj.HasReceivedError == false && (RunBehavior.Clean != (RunBehavior.Clean & run)))
             {
                 stateObj.AddError(new SqlError(0, 0, TdsEnums.MIN_ERROR_CLASS, _server, SQLMessage.SevereError(), "", 0));
 
@@ -2848,17 +2848,17 @@ namespace Microsoft.Data.SqlClient
             // stop if the DONE_MORE bit isn't set (see above for attention handling)
             if (TdsEnums.DONE_MORE != (status & TdsEnums.DONE_MORE))
             {
-                stateObj._errorTokenReceived = false;
+                stateObj.HasReceivedError = false;
                 if (stateObj._inBytesUsed >= stateObj._inBytesRead)
                 {
-                    stateObj._pendingData = false;
+                    stateObj.HasPendingData = false;
                 }
             }
 
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //
-            if (!stateObj._pendingData && stateObj._hasOpenResult)
+            if (!stateObj.HasPendingData && stateObj.HasOpenResult)
             {
                 /*
                                 Debug.Assert(!((sqlTransaction != null               && _distributedTransaction != null) ||
@@ -4202,7 +4202,7 @@ namespace Microsoft.Data.SqlClient
             {
                 DrainData(stateObj);
 
-                stateObj._pendingData = false;
+                stateObj.HasPendingData = false;
             }
 
             ThrowExceptionAndWarning(stateObj);
@@ -4714,7 +4714,7 @@ namespace Microsoft.Data.SqlClient
 
             // We get too many DONE COUNTs from the server, causing too many StatementCompleted event firings.
             // We only need to fire this event when we actually have a meta data stream with 0 or more rows.
-            stateObj._receivedColMetaData = true;
+            stateObj.HasReceivedColumnMetadata = true;
             return true;
         }
 
@@ -8072,7 +8072,7 @@ namespace Microsoft.Data.SqlClient
 
             _physicalStateObj.WritePacket(TdsEnums.HARDFLUSH);
             _physicalStateObj.ResetSecurePasswordsInformation();
-            _physicalStateObj._pendingData = true;
+            _physicalStateObj.HasPendingData = true;
             _physicalStateObj._messageStatus = 0;
         }// tdsLogin
 
@@ -8100,7 +8100,7 @@ namespace Microsoft.Data.SqlClient
             _physicalStateObj.WriteByteArray(accessToken, accessToken.Length, 0);
 
             _physicalStateObj.WritePacket(TdsEnums.HARDFLUSH);
-            _physicalStateObj._pendingData = true;
+            _physicalStateObj.HasPendingData = true;
             _physicalStateObj._messageStatus = 0;
 
             _connHandler._federatedAuthenticationRequested = true;
@@ -8397,7 +8397,7 @@ namespace Microsoft.Data.SqlClient
 
                 Task writeTask = stateObj.WritePacket(TdsEnums.HARDFLUSH);
                 Debug.Assert(writeTask == null, "Writes should not pend when writing sync");
-                stateObj._pendingData = true;
+                stateObj.HasPendingData = true;
                 stateObj._messageStatus = 0;
 
                 SqlDataReader dtcReader = null;
@@ -9828,7 +9828,7 @@ namespace Microsoft.Data.SqlClient
             WriteShort(0, stateObj);
             WriteInt(0, stateObj);
 
-            stateObj._pendingData = true;
+            stateObj.HasPendingData = true;
             stateObj._messageStatus = 0;
             return stateObj.WritePacket(TdsEnums.HARDFLUSH);
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Data.SqlClient
                 else if ((okToReuse) && (_freeStateObjectCount < MaxInactiveCount))
                 {
                     // Session is good to re-use and our cache has space
-                    Debug.Assert(!session._pendingData, "pending data on a pooled session?");
+                    Debug.Assert(!session.HasPendingData, "pending data on a pooled session?");
 
                     _freeStateObjects[_freeStateObjectCount] = session;
                     _freeStateObjectCount++;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -22,6 +22,17 @@ namespace Microsoft.Data.SqlClient
 
     internal abstract class TdsParserStateObject
     {
+        [Flags]
+        internal enum SnapshottedStateFlags : byte
+        {
+            None = 0,
+            PendingData = 1 << 1,
+            OpenResult = 1 << 2,
+            ErrorTokenReceived = 1 << 3,  // Keep track of whether an error was received for the result. This is reset upon each done token
+            ColMetaDataReceived = 1 << 4, // Used to keep track of when to fire StatementCompleted event.
+            AttentionReceived = 1 << 5    // NOTE: Received is not volatile as it is only ever accessed\modified by TryRun its callees (i.e. single threaded access)
+        }
+
         private const int AttentionTimeoutSeconds = 5;
 
         // Ticks to consider a connection "good" after a successful I/O (10,000 ticks = 1 ms)
@@ -54,41 +65,50 @@ namespace Microsoft.Data.SqlClient
         internal int _outBytesUsed = TdsEnums.HEADER_LEN; // number of bytes used in internal write buffer -
                                                           // - initialize past header
                                                           // In buffer variables
-        protected byte[] _inBuff;                         // internal read buffer - initialize on login
-        internal int _inBytesUsed = 0;                   // number of bytes used in internal read buffer
-        internal int _inBytesRead = 0;                   // number of bytes read into internal read buffer
 
-        internal int _inBytesPacket = 0;                   // number of bytes left in packet
+        /// <summary>
+        /// internal read buffer - initialize on login
+        /// </summary>
+        protected byte[] _inBuff;
+        /// <summary>
+        /// number of bytes used in internal read buffer
+        /// </summary>
+        internal int _inBytesUsed;
+        /// <summary>
+        /// number of bytes read into internal read buffer
+        /// </summary>
+        internal int _inBytesRead;
+
+        /// <summary>
+        /// number of bytes left in packet
+        /// </summary>
+        internal int _inBytesPacket;
 
         // Packet state variables
-        internal byte _outputMessageType = 0;                   // tds header type
-        internal byte _messageStatus;                               // tds header status
-        internal byte _outputPacketNumber = 1;                   // number of packets sent to server in message - start at 1 per ramas
+        internal byte _outputMessageType;                   // tds header type
+        internal byte _messageStatus;                       // tds header status
+        internal byte _outputPacketNumber = 1;              // number of packets sent to server in message - start at 1 per ramas
         internal uint _outputPacketCount;
-        internal bool _pendingData = false;
-        internal volatile bool _fResetEventOwned = false;               // ResetEvent serializing call to sp_reset_connection
-        internal volatile bool _fResetConnectionSent = false;               // For multiple packet execute
+        internal volatile bool _fResetEventOwned;           // ResetEvent serializing call to sp_reset_connection
+        internal volatile bool _fResetConnectionSent;       // For multiple packet execute
+        internal bool _bulkCopyOpperationInProgress;        // Set to true during bulk copy and used to turn toggle write timeouts.
+        internal bool _bulkCopyWriteTimeout;                // Set to trun when _bulkCopyOpeperationInProgress is trun and write timeout happens
 
-        internal bool _errorTokenReceived = false;               // Keep track of whether an error was received for the result.
-                                                                 // This is reset upon each done token - there can be
-
-        internal bool _bulkCopyOpperationInProgress = false;        // Set to true during bulk copy and used to turn toggle write timeouts.
-        internal bool _bulkCopyWriteTimeout = false;                // Set to trun when _bulkCopyOpeperationInProgress is trun and write timeout happens
-
-        // SNI variables                                                     // multiple resultsets in one batch.
-
-        protected readonly object _writePacketLockObject = new object();        // Used to synchronize access to _writePacketCache and _pendingWritePackets
+        // SNI variables
+        /// <summary>
+        /// Used to synchronize access to _writePacketCache and _pendingWritePackets
+        /// </summary>
+        protected readonly object _writePacketLockObject = new object();
 
         // Async variables
-        private int _pendingCallbacks;                            // we increment this before each async read/write call and decrement it in the callback.  We use this to determine when to release the GcHandle...
+        private int _pendingCallbacks;                      // we increment this before each async read/write call and decrement it in the callback.  We use this to determine when to release the GcHandle...
 
         // Timeout variables
         private long _timeoutMilliseconds;
-        private long _timeoutTime;                                 // variable used for timeout computations, holds the value of the hi-res performance counter at which this request should expire
-        internal volatile bool _attentionSent = false;               // true if we sent an Attention to the server
-        internal bool _attentionReceived = false;               // NOTE: Received is not volatile as it is only ever accessed\modified by TryRun its callees (i.e. single threaded access)
-        internal volatile bool _attentionSending = false;
-        internal bool _internalTimeout = false;               // an internal timeout occurred
+        private long _timeoutTime;                          // variable used for timeout computations, holds the value of the hi-res performance counter at which this request should expire
+        internal volatile bool _attentionSent;              // true if we sent an Attention to the server
+        internal volatile bool _attentionSending;
+        internal bool _internalTimeout;                     // an internal timeout occurred
 
         private readonly LastIOTimer _lastSuccessfulIOTimer;
 
@@ -113,37 +133,33 @@ namespace Microsoft.Data.SqlClient
         private const int _waitForCancellationLockPollTimeout = 100;
         private WeakReference _cancellationOwner = new WeakReference(null);
 
-        internal bool _hasOpenResult = false;
         // Cache the transaction for which this command was executed so upon completion we can
         // decrement the appropriate result count.
-        internal SqlInternalTransaction _executedUnderTransaction = null;
+        internal SqlInternalTransaction _executedUnderTransaction;
 
         // TDS stream processing variables
         internal ulong _longlen;                                     // plp data length indicator
         internal ulong _longlenleft;                                 // Length of data left to read (64 bit lengths)
-        internal int[] _decimalBits = null;                // scratch buffer for decimal/numeric data
+        internal int[] _decimalBits;                // scratch buffer for decimal/numeric data
         internal byte[] _bTmp = new byte[TdsEnums.YUKON_HEADER_LEN];  // Scratch buffer for misc use
-        internal int _bTmpRead = 0;                   // Counter for number of temporary bytes read
-        internal Decoder _plpdecoder = null;             // Decoder object to process plp character data
-        internal bool _accumulateInfoEvents = false;               // TRUE - accumulate info messages during TdsParser.Run, FALSE - fire them
-        internal List<SqlError> _pendingInfoEvents = null;
-        internal byte[] _bLongBytes = null;                 // scratch buffer to serialize Long values (8 bytes).
-        internal byte[] _bIntBytes = null;                 // scratch buffer to serialize Int values (4 bytes).
-        internal byte[] _bShortBytes = null;                 // scratch buffer to serialize Short values (2 bytes).
-        internal byte[] _bDecimalBytes = null;                 // scratch buffer to serialize decimal values (17 bytes).
+        internal int _bTmpRead;                   // Counter for number of temporary bytes read
+        internal Decoder _plpdecoder;             // Decoder object to process plp character data
+        internal bool _accumulateInfoEvents;               // TRUE - accumulate info messages during TdsParser.Run, FALSE - fire them
+        internal List<SqlError> _pendingInfoEvents;
+        internal byte[] _bLongBytes;                 // scratch buffer to serialize Long values (8 bytes).
+        internal byte[] _bIntBytes;                 // scratch buffer to serialize Int values (4 bytes).
+        internal byte[] _bShortBytes;                 // scratch buffer to serialize Short values (2 bytes).
+        internal byte[] _bDecimalBytes;                 // scratch buffer to serialize decimal values (17 bytes).
 
 
         //
         // DO NOT USE THIS BUFFER FOR OTHER THINGS.
         // ProcessHeader can be called ANYTIME while doing network reads.
         private byte[] _partialHeaderBuffer = new byte[TdsEnums.HEADER_LEN];   // Scratch buffer for ProcessHeader
-        internal int _partialHeaderBytesRead = 0;
+        internal int _partialHeaderBytesRead;
 
-        internal _SqlMetaDataSet _cleanupMetaData = null;
-        internal _SqlMetaDataSetCollection _cleanupAltMetaDataSetArray = null;
-
-
-        internal bool _receivedColMetaData;      // Used to keep track of when to fire StatementCompleted  event.
+        internal _SqlMetaDataSet _cleanupMetaData;
+        internal _SqlMetaDataSetCollection _cleanupAltMetaDataSetArray;
 
         private SniContext _sniContext = SniContext.Undefined;
 #if DEBUG
@@ -159,33 +175,35 @@ namespace Microsoft.Data.SqlClient
         internal TaskCompletionSource<object> _networkPacketTaskSource;
         private Timer _networkPacketTimeout;
         internal bool _syncOverAsync = true;
-        private bool _snapshotReplay = false;
+        private bool _snapshotReplay;
         private StateSnapshot _snapshot;
+        private StateSnapshot _cachedSnapshot;
+        private SnapshottedStateFlags _snapshottedState;
         internal ExecutionContext _executionContext;
-        internal bool _asyncReadWithoutSnapshot = false;
+        internal bool _asyncReadWithoutSnapshot;
 #if DEBUG
         // Used to override the assert than ensures that the stacktraces on subsequent replays are the same
         // This is useful is you are purposefully running the replay from a different thread (e.g. during SqlDataReader.Close)
-        internal bool _permitReplayStackTraceToDiffer = false;
+        internal bool _permitReplayStackTraceToDiffer;
 
         // Used to indicate that the higher level object believes that this stateObj has enough data to complete an operation
         // If this stateObj has to read, then it will raise an assert
-        internal bool _shouldHaveEnoughData = false;
+        internal bool _shouldHaveEnoughData;
 #endif
 
         // local exceptions to cache warnings and errors
         internal SqlErrorCollection _errors;
         internal SqlErrorCollection _warnings;
         internal object _errorAndWarningsLock = new object();
-        private bool _hasErrorOrWarning = false;
+        private bool _hasErrorOrWarning;
 
         // local exceptions to cache warnings and errors that occurred prior to sending attention
         internal SqlErrorCollection _preAttentionErrors;
         internal SqlErrorCollection _preAttentionWarnings;
 
-        private volatile TaskCompletionSource<object> _writeCompletionSource = null;
-        protected volatile int _asyncWriteCount = 0;
-        private volatile Exception _delayedWriteAsyncCallbackException = null; // set by write async callback if completion source is not yet created
+        private volatile TaskCompletionSource<object> _writeCompletionSource;
+        protected volatile int _asyncWriteCount;
+        private volatile Exception _delayedWriteAsyncCallbackException; // set by write async callback if completion source is not yet created
 
         // _readingcount is incremented when we are about to read.
         // We check the parser state afterwards.
@@ -224,13 +242,13 @@ namespace Microsoft.Data.SqlClient
 
         // Prevents any pending read from completing until the user signals it using
         // CompletePendingReadWithSuccess() or CompletePendingReadWithFailure(int errorCode) in SqlCommand\SqlDataReader
-        internal static bool _forcePendingReadsToWaitForUser;
-        internal TaskCompletionSource<object> _realNetworkPacketTaskSource = null;
+        internal static bool _forcePendingReadsToWaitForUser = false;
+        internal TaskCompletionSource<object> _realNetworkPacketTaskSource;
 
         // Field is never assigned to, and will always have its default value
 #pragma warning disable 0649
         // Set to true to enable checking the call stacks match when packet retry occurs.
-        internal static bool _checkNetworkPacketRetryStacks;
+        internal static bool _checkNetworkPacketRetryStacks = false;
 #pragma warning restore 0649
 #endif
 
@@ -311,17 +329,7 @@ namespace Microsoft.Data.SqlClient
                 return _debugOnlyCopyOfSniContext;
             }
         }
-#endif
 
-        internal bool HasOpenResult
-        {
-            get
-            {
-                return _hasOpenResult;
-            }
-        }
-
-#if DEBUG
         internal void InvalidateDebugOnlyCopyOfSniContext()
         {
             _debugOnlyCopyOfSniContext = SniContext.Undefined;
@@ -608,7 +616,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             _cancelled = true;
 
-                            if (_pendingData && !_attentionSent)
+                            if (HasPendingData && !_attentionSent)
                             {
                                 bool hasParserLock = false;
                                 // Keep looping until we have the parser lock (and so are allowed to write), or the connection closes\breaks
@@ -799,7 +807,7 @@ namespace Microsoft.Data.SqlClient
                 TdsParserState state = Parser.State;
                 if (state != TdsParserState.Broken && state != TdsParserState.Closed)
                 {
-                    if (_pendingData)
+                    if (HasPendingData)
                     {
                         Parser.DrainData(this); // This may throw - taking us to catch block.c
                     }
@@ -849,7 +857,7 @@ namespace Microsoft.Data.SqlClient
                 _executedUnderTransaction.DecrementAndObtainOpenResultCount();
                 _executedUnderTransaction = null;
             }
-            _hasOpenResult = false;
+            HasOpenResult = false;
         }
 
         internal int DecrementPendingCallbacks(bool release)
@@ -889,7 +897,7 @@ namespace Microsoft.Data.SqlClient
 
         internal int IncrementAndObtainOpenResultCount(SqlInternalTransaction transaction)
         {
-            _hasOpenResult = true;
+            HasOpenResult = true;
 
             if (transaction == null)
             {
@@ -962,13 +970,13 @@ namespace Microsoft.Data.SqlClient
                     Task writePacketTask = WritePacket(TdsEnums.HARDFLUSH);
                     if (writePacketTask == null)
                     {
-                        _pendingData = true;
+                        HasPendingData = true;
                         _messageStatus = 0;
                         return null;
                     }
                     else
                     {
-                        return AsyncHelper.CreateContinuationTask(writePacketTask, () => { _pendingData = true; _messageStatus = 0; });
+                        return AsyncHelper.CreateContinuationTask(writePacketTask, () => { HasPendingData = true; _messageStatus = 0; });
                     }
                 }
             }
@@ -1127,6 +1135,49 @@ namespace Microsoft.Data.SqlClient
             _outputPacketNumber = 1;
             _outputPacketCount = 0;
         }
+
+        private void SetSnapshottedState(SnapshottedStateFlags flag, bool value)
+        {
+            if (value)
+            {
+                _snapshottedState |= flag;
+            }
+            else
+            {
+                _snapshottedState &= ~flag;
+            }
+        }
+
+        internal bool HasOpenResult
+        {
+            get => _snapshottedState.HasFlag(SnapshottedStateFlags.OpenResult);
+            set => SetSnapshottedState(SnapshottedStateFlags.OpenResult, value);
+        }
+
+        internal bool HasPendingData
+        {
+            get => _snapshottedState.HasFlag(SnapshottedStateFlags.PendingData);
+            set => SetSnapshottedState(SnapshottedStateFlags.PendingData, value);
+        }
+
+        internal bool HasReceivedError
+        {
+            get => _snapshottedState.HasFlag(SnapshottedStateFlags.ErrorTokenReceived);
+            set => SetSnapshottedState(SnapshottedStateFlags.ErrorTokenReceived, value);
+        }
+
+        internal bool HasReceivedAttention
+        {
+            get => _snapshottedState.HasFlag(SnapshottedStateFlags.AttentionReceived);
+            set => SetSnapshottedState(SnapshottedStateFlags.AttentionReceived, value);
+        }
+
+        internal bool HasReceivedColumnMetadata
+        {
+            get => _snapshottedState.HasFlag(SnapshottedStateFlags.ColMetaDataReceived);
+            set => SetSnapshottedState(SnapshottedStateFlags.ColMetaDataReceived, value);
+        }
+
 
         internal bool SetPacketSize(int size)
         {
@@ -1991,14 +2042,29 @@ namespace Microsoft.Data.SqlClient
 
         internal void SetSnapshot()
         {
-            _snapshot = new StateSnapshot(this);
-            _snapshot.Snap();
+            StateSnapshot snapshot = _snapshot;
+            if (snapshot is null)
+            {
+                snapshot = Interlocked.Exchange(ref _cachedSnapshot, null) ?? new StateSnapshot();
+            }
+            else
+            {
+                snapshot.Clear();
+            }
+            _snapshot = snapshot;
+            _snapshot.Snap(this);
             _snapshotReplay = false;
         }
 
         internal void ResetSnapshot()
         {
-            _snapshot = null;
+            if (_snapshot != null)
+            {
+                StateSnapshot snapshot = _snapshot;
+                _snapshot = null;
+                snapshot.Clear();
+                Interlocked.CompareExchange(ref _cachedSnapshot, snapshot, null);
+            }
             _snapshotReplay = false;
         }
 
@@ -3735,7 +3801,7 @@ namespace Microsoft.Data.SqlClient
                 Debug.Assert(_asyncWriteCount == 0, "StateObj still has outstanding async writes");
                 Debug.Assert(_delayedWriteAsyncCallbackException == null, "StateObj has an unobserved exceptions from an async write");
                 // Attention\Cancellation\Timeouts
-                Debug.Assert(!_attentionReceived && !_attentionSent && !_attentionSending, $"StateObj is still dealing with attention: Sent: {_attentionSent}, Received: {_attentionReceived}, Sending: {_attentionSending}");
+                Debug.Assert(!HasReceivedAttention && !_attentionSent && !_attentionSending, $"StateObj is still dealing with attention: Sent: {_attentionSent}, Received: {HasReceivedAttention}, Sending: {_attentionSending}");
                 Debug.Assert(!_cancelled, "StateObj still has cancellation set");
                 Debug.Assert(!_internalTimeout, "StateObj still has internal timeout set");
                 // Errors and Warnings
@@ -3821,46 +3887,71 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private class PacketData
+        private sealed class StateSnapshot
         {
-            public byte[] Buffer;
-            public int Read;
-#if DEBUG
-            public string Stack;
-#endif
-        }
-
-        private class StateSnapshot
-        {
-            private List<PacketData> _snapshotInBuffs;
-            private int _snapshotInBuffCurrent = 0;
-            private int _snapshotInBytesUsed = 0;
-            private int _snapshotInBytesPacket = 0;
-            private bool _snapshotPendingData = false;
-            private bool _snapshotErrorTokenReceived = false;
-            private bool _snapshotHasOpenResult = false;
-            private bool _snapshotReceivedColumnMetadata = false;
-            private bool _snapshotAttentionReceived;
-            private byte _snapshotMessageStatus;
-
-            private NullBitmap _snapshotNullBitmapInfo;
-            private ulong _snapshotLongLen;
-            private ulong _snapshotLongLenLeft;
-            private _SqlMetaDataSet _snapshotCleanupMetaData;
-            private _SqlMetaDataSetCollection _snapshotCleanupAltMetaDataSetArray;
-
-            private readonly TdsParserStateObject _stateObj;
-
-            public StateSnapshot(TdsParserStateObject state)
+            private sealed class PLPData
             {
-                _snapshotInBuffs = new List<PacketData>();
-                _stateObj = state;
+                public readonly ulong SnapshotLongLen;
+                public readonly ulong SnapshotLongLenLeft;
+
+                public PLPData(ulong snapshotLongLen, ulong snapshotLongLenLeft)
+                {
+                    SnapshotLongLen = snapshotLongLen;
+                    SnapshotLongLenLeft = snapshotLongLenLeft;
+                }
+            }
+
+            private sealed partial class PacketData
+            {
+                public byte[] Buffer;
+                public int Read;
+                public PacketData Prev;
+
+                public void SetStack(string value)
+                {
+                    SetStackInternal(value);
+                }
+                partial void SetStackInternal(string value);
+
+                public void Clear()
+                {
+                    Buffer = null;
+                    Read = 0;
+                    Prev = null;
+                    SetStackInternal(null);
+                }
             }
 
 #if DEBUG
+            private sealed partial class PacketData
+            {
+                public string Stack;
+
+                partial void SetStackInternal(string value)
+                {
+                    Stack = value;
+                }
+            }
+
             private int _rollingPend = 0;
             private int _rollingPendCount = 0;
+#endif
+            private PacketData _snapshotInBuffList;
+            private PacketData _sparePacket;
+            private NullBitmap _snapshotNullBitmapInfo;
+            private _SqlMetaDataSet _snapshotCleanupMetaData;
+            private _SqlMetaDataSetCollection _snapshotCleanupAltMetaDataSetArray;
+            private PLPData _plpData;
+            private TdsParserStateObject _stateObj;
 
+            private int _snapshotInBuffCount;
+            private int _snapshotInBuffCurrent;
+            private int _snapshotInBytesUsed;
+            private int _snapshotInBytesPacket;
+            private SnapshottedStateFlags _state;
+            private byte _snapshotMessageStatus;
+
+#if DEBUG
             internal bool DoPend()
             {
                 if (_failAsyncPends || !_forceAllPends)
@@ -3878,8 +3969,25 @@ namespace Microsoft.Data.SqlClient
                 _rollingPendCount++;
                 return false;
             }
-#endif
 
+            internal void AssertCurrent()
+            {
+                Debug.Assert(_snapshotInBuffCurrent == _snapshotInBuffCount, "Should not be reading new packets when not replaying last packet");
+            }
+
+            internal void CheckStack(string trace)
+            {
+                PacketData prev = _snapshotInBuffList?.Prev;
+                if (prev.Stack == null)
+                {
+                    prev.Stack = trace;
+                }
+                else
+                {
+                    Debug.Assert(_stateObj._permitReplayStackTraceToDiffer || prev.Stack.ToString() == trace.ToString(), "The stack trace on subsequent replays should be the same");
+                }
+            }
+#endif
             internal void CloneNullBitmapInfo()
             {
                 if (_stateObj._nullBitmapInfo.ReferenceEquals(_snapshotNullBitmapInfo))
@@ -3898,42 +4006,45 @@ namespace Microsoft.Data.SqlClient
 
             internal void PushBuffer(byte[] buffer, int read)
             {
-                Debug.Assert(!_snapshotInBuffs.Any(b => object.ReferenceEquals(b.Buffer, buffer)));
-
-                PacketData packetData = new PacketData();
-                packetData.Buffer = buffer;
-                packetData.Read = read;
 #if DEBUG
-                packetData.Stack = _stateObj._lastStack;
+                for (PacketData current = _snapshotInBuffList; current != null; current = current.Prev)
+                {
+                    Debug.Assert(!object.ReferenceEquals(current.Buffer, buffer));
+                }
 #endif
 
-                _snapshotInBuffs.Add(packetData);
-            }
-
-#if DEBUG
-            internal void AssertCurrent()
-            {
-                Debug.Assert(_snapshotInBuffCurrent == _snapshotInBuffs.Count, "Should not be reading new packets when not replaying last packet");
-            }
-            internal void CheckStack(string trace)
-            {
-                PacketData prev = _snapshotInBuffs[_snapshotInBuffCurrent - 1];
-                if (prev.Stack == null)
+                PacketData packetData = _sparePacket;
+                if (packetData is null)
                 {
-                    prev.Stack = trace;
+                    packetData = new PacketData();
                 }
                 else
                 {
-                    Debug.Assert(_stateObj._permitReplayStackTraceToDiffer || prev.Stack.ToString() == trace.ToString(), "The stack trace on subsequent replays should be the same");
+                    _sparePacket = null;
                 }
-            }
+                packetData.Buffer = buffer;
+                packetData.Read = read;
+                packetData.Prev = _snapshotInBuffList;
+#if DEBUG
+                packetData.SetStack(_stateObj._lastStack);
 #endif
+                _snapshotInBuffList = packetData;
+                _snapshotInBuffCount++;
+            }
 
             internal bool Replay()
             {
-                if (_snapshotInBuffCurrent < _snapshotInBuffs.Count)
+                if (_snapshotInBuffCurrent < _snapshotInBuffCount)
                 {
-                    PacketData next = _snapshotInBuffs[_snapshotInBuffCurrent];
+                    PacketData next = _snapshotInBuffList;
+                    for (
+                        int position = (_snapshotInBuffCount - 1);
+                        position != _snapshotInBuffCurrent;
+                        position -= 1
+                    )
+                    {
+                        next = next.Prev;
+                    }
                     _stateObj._inBuff = next.Buffer;
                     _stateObj._inBytesUsed = 0;
                     _stateObj._inBytesRead = next.Read;
@@ -3944,25 +4055,27 @@ namespace Microsoft.Data.SqlClient
                 return false;
             }
 
-            internal void Snap()
+            internal void Snap(TdsParserStateObject state)
             {
-                _snapshotInBuffs.Clear();
+                _stateObj = state;
+                _snapshotInBuffList = null;
+                _snapshotInBuffCount = 0;
                 _snapshotInBuffCurrent = 0;
                 _snapshotInBytesUsed = _stateObj._inBytesUsed;
                 _snapshotInBytesPacket = _stateObj._inBytesPacket;
-                _snapshotPendingData = _stateObj._pendingData;
-                _snapshotErrorTokenReceived = _stateObj._errorTokenReceived;
+
                 _snapshotMessageStatus = _stateObj._messageStatus;
                 // _nullBitmapInfo must be cloned before it is updated
                 _snapshotNullBitmapInfo = _stateObj._nullBitmapInfo;
-                _snapshotLongLen = _stateObj._longlen;
-                _snapshotLongLenLeft = _stateObj._longlenleft;
+                if (_stateObj._longlen != 0 || _stateObj._longlenleft != 0)
+                {
+                    _plpData = new PLPData(_stateObj._longlen, _stateObj._longlenleft);
+                }
                 _snapshotCleanupMetaData = _stateObj._cleanupMetaData;
                 // _cleanupAltMetaDataSetArray must be cloned before it is updated
                 _snapshotCleanupAltMetaDataSetArray = _stateObj._cleanupAltMetaDataSetArray;
-                _snapshotHasOpenResult = _stateObj._hasOpenResult;
-                _snapshotReceivedColumnMetadata = _stateObj._receivedColMetaData;
-                _snapshotAttentionReceived = _stateObj._attentionReceived;
+
+                _state = _stateObj._snapshottedState;
 #if DEBUG
                 _rollingPend = 0;
                 _rollingPendCount = 0;
@@ -3983,23 +4096,21 @@ namespace Microsoft.Data.SqlClient
 
                 _stateObj._inBytesUsed = _snapshotInBytesUsed;
                 _stateObj._inBytesPacket = _snapshotInBytesPacket;
-                _stateObj._pendingData = _snapshotPendingData;
-                _stateObj._errorTokenReceived = _snapshotErrorTokenReceived;
+
                 _stateObj._messageStatus = _snapshotMessageStatus;
                 _stateObj._nullBitmapInfo = _snapshotNullBitmapInfo;
                 _stateObj._cleanupMetaData = _snapshotCleanupMetaData;
                 _stateObj._cleanupAltMetaDataSetArray = _snapshotCleanupAltMetaDataSetArray;
-                _stateObj._hasOpenResult = _snapshotHasOpenResult;
-                _stateObj._receivedColMetaData = _snapshotReceivedColumnMetadata;
-                _stateObj._attentionReceived = _snapshotAttentionReceived;
+
+                _stateObj._snapshottedState = _state;
 
                 // Reset partially read state (these only need to be maintained if doing async without snapshot)
                 _stateObj._bTmpRead = 0;
                 _stateObj._partialHeaderBytesRead = 0;
 
                 // reset plp state
-                _stateObj._longlen = _snapshotLongLen;
-                _stateObj._longlenleft = _snapshotLongLenLeft;
+                _stateObj._longlen = _plpData?.SnapshotLongLen ?? 0;
+                _stateObj._longlenleft = _plpData?.SnapshotLongLenLeft ?? 0;
 
                 _stateObj._snapshotReplay = true;
 
@@ -4010,6 +4121,32 @@ namespace Microsoft.Data.SqlClient
             {
                 ResetSnapshotState();
             }
+
+            internal void Clear()
+            {
+                PacketData packet = _snapshotInBuffList;
+                _snapshotInBuffList = null;
+                _snapshotInBuffCount = 0;
+                _snapshotInBuffCurrent = 0;
+                _snapshotInBytesUsed = 0;
+                _snapshotInBytesPacket = 0;
+                _snapshotMessageStatus = 0;
+                _snapshotNullBitmapInfo = default;
+                _plpData = null;
+                _snapshotCleanupMetaData = null;
+                _snapshotCleanupAltMetaDataSetArray = null;
+                _state = SnapshottedStateFlags.None;
+#if DEBUG
+                _rollingPend = 0;
+                _rollingPendCount = 0;
+                _stateObj._lastStack = null;
+#endif
+                _stateObj = null;
+
+                packet.Clear();
+                _sparePacket = packet;
+            }
+
         }
 
         /*

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -4146,7 +4146,6 @@ namespace Microsoft.Data.SqlClient
                 packet.Clear();
                 _sparePacket = packet;
             }
-
         }
 
         /*


### PR DESCRIPTION
Profiling the [DataAccessPerformance](https://github.com/aspnet/DataAccessPerformance) project which emulates the [TechEmpower fortunes benchmark](https://www.techempower.com/benchmarks/#section=data-r17&hw=ph&test=fortune) shows that a lot the work done by SqlClient is spent in managing state snapshots. The data returned to the user is all string instances which are placed in a Fortune object but these aren't the dominators in the memory profile.

This PR changes the implementation of the snapshot mechanisms used by `SqlDataReader` and `TdsStateParserObject` to:
- Keep track of a cached `SqlDataReader` snapshot object once one is created so that it can be efficiently reused. This is possible because a only a single async operation is permitted at any time. Access to the cached instance uses interlocked to take the instance so that it cannot ever be used twice and lazily returns the cleared object using standard assignment because creating a new one every now again again isn't a problem as long as it is usually reused. Under load one snapshot was created per reader and reused cleanly.

- Keep track of a cached `TdsStateParserObject` snapshot in a similar way to `SqlDataReader` but using interlocked for both rent and return to the cache variable. 

- Use slightly smaller data structures by compressing multiple boolean fields on `TdsParserStateObject` into a flags enumeration, this makes multiple flags copy and restore a single copy not 5. All access to the affected properties is now done through accessor functions.

- Introduce a small class `Snapshot.PLPData` to store any partially length prefixed data state if it is used, if it is not used the allocation object object and continual tracking of 128 bits of data it contains are avoided.

- Change `Snapshot.PacketData` to be a self assembling singly linked list. This removes `List<PacketData>` and linked `PacketData[]` allocations when taking snapshots and allows a cached PacketData link to be retained in the snapshot since one will always be required is a snapshot is used.

I also removed most of the setting of `TdsParserStateObject` variables to default values so it is now easier to tell when they are initialized to non-default values. The only exceptions are some variables which must be initialized to default because they are only touched through reflection in testing so the compiler will complain that it can't see them being set.

Profile results before, note that of the top 6 lines only the 4th is a result object we actually want:
![sqlclient snapshot master](https://user-images.githubusercontent.com/13322696/64914150-401f0200-d745-11e9-8f30-5c1f02446356.PNG)

After: 
![sqlclient snapshot branch](https://user-images.githubusercontent.com/13322696/64914158-6775cf00-d745-11e9-959b-25ef79699da7.PNG)

I have another branch which removes lines 3 4 and 5 intervening async machinery allocations which will give some more gains

Performance results are reasonable showing 8-10% throughput increase.

| name | sync | threads | TPS  | stdev | description |
| ---- | ---- | ------- | ---: | ----: | :---------- |
| ado-sqlclient+async+32 |async|32|62461|2411|mdsql snapshot master |
| ado-sqlclient+async+32|async|32|69154|2368|mdsql snapshot branch |
| ado-sqlclient+async+64|async|64|63023|1550|mdsql snapshot master |
| ado-sqlclient+async+64|async|64|68612|3114|mdsql snapshot branch |
| ado-sqlclient+async+128|async|128|59937|1640|mdsql snapshot master |
| ado-sqlclient+async+128|async|128|66253|1922|mdsql snapshot branch |

The function and manual tests pass. This work had already been done and tested on the corefx branch so it's had some scrutiny there as well. Coverage I can't tell about but the fact that I'm directly seeing the types being used to take them out of the profile indicates they're definitely being touched. The DataAccessPerformance benchmark is a reasonable stress test, and I've found race conditions with it before so getting through it repeatedly successfully for minutes at a time is an indicator of stability to me.

Note: if this is ported to netfx the snapshot enum comparison in TdsParserStateObject will need to be changed from using HasFlag to manual masking. On coreclr HasFlag was optimized to a jit primitive so it produces very simple and fast assembly instructions. On netfx HasFlag performance is notoriously poor and causes boxing of the argument.