### PR TITLE
Fix Tests to use connection string builder

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -392,8 +392,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
             InsertRows(tableName: tableName, numberofRows: numberOfRows, values: values);
 
-            //using (SqlConnection sqlConnection = new SqlConnection(string.Concat(DataTestUtility.TcpConnStr, " Column Encryption Setting = Enabled;")))
-            using (SqlConnection sqlConnection = new SqlConnection(string.Concat(DataTestUtility.TcpConnStr, " Column Encryption Setting = Enabled;")))
+            var encryptionEnabledConnectionString = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr)
+            {
+                ColumnEncryptionSetting = SqlConnectionColumnEncryptionSetting.Enabled
+            }.ConnectionString;
+
+            using (var sqlConnection = new SqlConnection(encryptionEnabledConnectionString))
             {
                 sqlConnection.Open();
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/BulkCopyAE.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/BulkCopyAE.cs
@@ -38,7 +38,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             dataTable.Rows.Add(dataRow);
             dataTable.AcceptChanges();
 
-            using (var connection = new SqlConnection(string.Concat(DataTestUtility.TcpConnStr, " Column Encryption Setting = Enabled;")))
+            var encryptionEnabledConnectionString = new SqlConnectionStringBuilder(DataTestUtility.TcpConnStr)
+            {
+                ColumnEncryptionSetting = SqlConnectionColumnEncryptionSetting.Enabled
+            }.ConnectionString;
+
+            using (var connection = new SqlConnection(encryptionEnabledConnectionString))
             using (var bulkCopy = new SqlBulkCopy(connection)
             {
                 EnableStreaming = true,


### PR DESCRIPTION
A couple of tests were using string concatenation to enable encryption on the connection string. This is ok unless your connection string isn't semicolon terminated, In that case the test fails with this sort of error:

```
  X Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.ApiShould.TestSqlDataAdapterFillDataTable [34ms]
  Error Message:
   System.ArgumentException : Invalid value for key 'connect timeout'.
---- System.FormatException : Input string was not in a correct format.
  Stack Trace:
```

This fixes the tests that do this by using a connection string builder as is used elsewhere in the tests to change connection properties.