### PR TITLE
Fix Cancel

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -283,39 +283,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        //[ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        //public static async Task CancelInInfiniteLoop()
-        //{
-        //    Exception exception = null;
-        //    DateTime started = DateTime.UtcNow;
-        //    using (var connection = new SqlConnection(s_connStr))
-        //    {
-        //        await connection.OpenAsync().ConfigureAwait(false);
-        //        using (var command = connection.CreateCommand())
-        //        {
-        //            command.CommandText = @"
-        //                WHILE 1 = 1
-        //                BEGIN
-        //                    DECLARE @x INT = 1
-        //                END
-        //            ";
-        //            command.CommandTimeout = 30;
-        //            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(1000);
-        //            try
-        //            {
-        //                await command.ExecuteNonQueryAsync(cancellationTokenSource.Token).ConfigureAwait(false);
-        //            }
-        //            catch (Exception ex)
-        //            {
-        //                exception = ex;
-        //            }
-        //        }
-        //    }
-        //    DateTime ended = DateTime.UtcNow;
-        //    Assert.InRange((ended - started).TotalSeconds, 1, 9);
-        //    Assert.NotNull(exception);
-        //}
-
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void CancelDoesNotWait()
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -282,5 +282,38 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 throw;
             }
         }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static async Task CancelInInfiniteLoop()
+        {
+            Exception exception = null;
+            DateTime started = DateTime.UtcNow;
+            using (var connection = new SqlConnection(s_connStr))
+            {
+                await connection.OpenAsync().ConfigureAwait(false);
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText = @"
+                        WHILE 1 = 1
+                        BEGIN
+                            DECLARE @x INT = 1
+                        END
+                    ";
+                    command.CommandTimeout = 30;
+                    CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(1000);
+                    try
+                    {
+                        await command.ExecuteNonQueryAsync(cancellationTokenSource.Token).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ex;
+                    }
+                }
+            }
+            DateTime ended = DateTime.UtcNow;
+            Assert.InRange((ended - started).TotalSeconds, 1, 9);
+            Assert.NotNull(exception);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/SqlClient/issues/44

Makes the parser lock in the internal Cancel method (called once from SqlCommand or SqlDataReader whichever is active) optional in the case of Cancel. This means that the send attention needed to cancel the running query is not blocked until the query completes. There's a new test to verify the behaviour derived from the bug report.