### PR TITLE
Fixing incorrect event id and opcode for the SqlEventSource.

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlEventSource.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data
         // the EventSource activity IDs (because they currently don't use tasks and this simply confuses the logic) and 
         // because of versioning requirements we don't have ActivityOptions capability (because mscorlib and System.Data version 
         // at different rates)  Sigh...
-        [Event(SqlEventSource.EndExecuteEventId, Keywords = Keywords.SqlClient, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Stop)]
+        [Event(SqlEventSource.BeginExecuteEventId, Keywords = Keywords.SqlClient, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Start)]
         public void BeginExecute(int objectId, string dataSource, string database, string commandText)
         {
             // we do not use unsafe code for better performance optization here because optimized helpers make the code unsafe where that would not be the case otherwise. 


### PR DESCRIPTION
Incorrect event ids are defined on the BeginExecuteEventId, resulting in in errors when WriteEvent is called for the Event Source. That again results in for example Application Insights being unable to properly track SQL dependency calls made with Microsoft.Data.SqlClient.

See this issue for reference: https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1282