### PR TITLE
Enable SQL Command text for non-stored procs in EventSource events for .NET Framework.

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -7464,8 +7464,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (SqlEventSource.Log.IsEnabled() && Connection != null)
             {
-                string commandText = CommandType == CommandType.StoredProcedure ? CommandText : string.Empty;
-                SqlEventSource.Log.BeginExecute(GetHashCode(), Connection.DataSource, Connection.Database, commandText);
+                SqlEventSource.Log.BeginExecute(GetHashCode(), Connection.DataSource, Connection.Database, CommandText);
             }
         }
 


### PR DESCRIPTION
When using System.Data.SqlClient, .NET Core provides the command text for all SQL operations but .NET Framework only does so for stored procedures in the EventSource events.

This has made it hard in the past to track down problematic SQL Statement by using the EventSource events, for example when using SQL dependency tracking in Application Insights in .NET Framework applications.

Since Microsoft.Data.SqlClient is a separate package, I think we have an excellent opportunity to change this behavior and bring .NET Framework up to speed with .NET Core, to more easily track SQL statements through the event source, without needing to install an additional profiler.

Would love to get input from @lmolkova and @cijothomas for this change as well, since they are familiar with the Application Insights side of things here.