### PR TITLE
Improve truncation error message

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1522,9 +1522,16 @@ namespace Microsoft.Data.SqlClient
                             int maxStringLength = length / 2;
                             if (str.Length > maxStringLength)
                             {
-                                // We truncate to at most 100 characters to match SQL Servers behavior as described in
-                                // https://blogs.msdn.microsoft.com/sql_server_team/string-or-binary-data-would-be-truncated-replacing-the-infamous-error-8152/
-                                str = str.Remove(Math.Min(maxStringLength, 100));
+                                if (metadata.isEncrypted)
+                                {
+                                    str = "<encrypted>";
+                                }
+                                else
+                                {
+                                    // We truncate to at most 100 characters to match SQL Servers behavior as described in
+                                    // https://blogs.msdn.microsoft.com/sql_server_team/string-or-binary-data-would-be-truncated-replacing-the-infamous-error-8152/
+                                    str = str.Remove(Math.Min(maxStringLength, 100));
+                                }
                                 throw SQL.BulkLoadStringTooLong(_destinationTableName, metadata.column, str);
                             }
                         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1518,10 +1518,14 @@ namespace Microsoft.Data.SqlClient
                         value = SqlParameter.CoerceValue(value, mt, out coercedToDataFeed, out typeChanged, false);
                         if (!coercedToDataFeed)
                         {   // We do not need to test for TextDataFeed as it is only assigned to (N)VARCHAR(MAX)
-                            int len = ((isSqlType) && (!typeChanged)) ? ((SqlString)value).Value.Length : ((string)value).Length;
-                            if (len > length / 2)
+                            string str = ((isSqlType) && (!typeChanged)) ? ((SqlString)value).Value : ((string)value);
+                            if (str.Length > length / 2)
                             {
-                                throw SQL.BulkLoadStringTooLong();
+                                if (str.Length > 100)
+                                {
+                                    str = str.Remove(100);
+                                }
+                                throw SQL.BulkLoadStringTooLong(_destinationTableName, metadata.column, str);
                             }
                         }
                         break;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1519,12 +1519,10 @@ namespace Microsoft.Data.SqlClient
                         if (!coercedToDataFeed)
                         {   // We do not need to test for TextDataFeed as it is only assigned to (N)VARCHAR(MAX)
                             string str = ((isSqlType) && (!typeChanged)) ? ((SqlString)value).Value : ((string)value);
-                            if (str.Length > length / 2)
+                            int maxStringLength = length / 2;
+                            if (str.Length > maxStringLength)
                             {
-                                if (str.Length > 100)
-                                {
-                                    str = str.Remove(100);
-                                }
+                                str = str.Remove(Math.Min(maxStringLength, 100));
                                 throw SQL.BulkLoadStringTooLong(_destinationTableName, metadata.column, str);
                             }
                         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1522,6 +1522,8 @@ namespace Microsoft.Data.SqlClient
                             int maxStringLength = length / 2;
                             if (str.Length > maxStringLength)
                             {
+                                // We truncate to at most 100 characters to match SQL Servers behavior as described in
+                                // https://blogs.msdn.microsoft.com/sql_server_team/string-or-binary-data-would-be-truncated-replacing-the-infamous-error-8152/
                                 str = str.Remove(Math.Min(maxStringLength, 100));
                                 throw SQL.BulkLoadStringTooLong(_destinationTableName, metadata.column, str);
                             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -822,9 +822,9 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.InvalidOperation(System.SRHelper.GetString(SR.SQL_BulkLoadNonMatchingColumnName, columnName), e);
         }
-        internal static Exception BulkLoadStringTooLong(string tableName, string columnName, string tuncatedValue)
+        internal static Exception BulkLoadStringTooLong(string tableName, string columnName, string truncatedValue)
         {
-            return ADP.InvalidOperation(System.SRHelper.GetString(SR.SQL_BulkLoadStringTooLong, tableName, columnName, tuncatedValue));
+            return ADP.InvalidOperation(System.SRHelper.GetString(SR.SQL_BulkLoadStringTooLong, tableName, columnName, truncatedValue));
         }
         internal static Exception BulkLoadInvalidVariantValue()
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -822,9 +822,9 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.InvalidOperation(System.SRHelper.GetString(SR.SQL_BulkLoadNonMatchingColumnName, columnName), e);
         }
-        internal static Exception BulkLoadStringTooLong()
+        internal static Exception BulkLoadStringTooLong(string tableName, string columnName, string tuncatedValue)
         {
-            return ADP.InvalidOperation(System.SRHelper.GetString(SR.SQL_BulkLoadStringTooLong));
+            return ADP.InvalidOperation(System.SRHelper.GetString(SR.SQL_BulkLoadStringTooLong, tableName, columnName, tuncatedValue));
         }
         internal static Exception BulkLoadInvalidVariantValue()
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/SR.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/SR.Designer.cs
@@ -2131,7 +2131,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to String or binary data would be truncated..
+        ///   Looks up a localized string similar to String or binary data would be truncated in table &apos;{0}&apos;, column &apos;{1}&apos;. Truncated value: &apos;{2}&apos;..
         /// </summary>
         internal static string SQL_BulkLoadStringTooLong {
             get {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/SR.resx
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/SR.resx
@@ -631,7 +631,7 @@
     <value>The given ColumnName '{0}' does not match up with any column in data source.</value>
   </data>
   <data name="SQL_BulkLoadStringTooLong" xml:space="preserve">
-    <value>String or binary data would be truncated.</value>
+    <value>String or binary data would be truncated in table '{0}', column '{1}'. Truncated value: '{2}'.</value>
   </data>
   <data name="SQL_BulkLoadInvalidTimeout" xml:space="preserve">
     <value>Timeout Value '{0}' is less than 0.</value>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1670,10 +1670,14 @@ namespace Microsoft.Data.SqlClient
                         value = SqlParameter.CoerceValue(value, mt, out coercedToDataFeed, out typeChanged, false);
                         if (!coercedToDataFeed)
                         { // We do not need to test for TextDataFeed as it is only assigned to (N)VARCHAR(MAX)
-                            int len = ((isSqlType) && (!typeChanged)) ? ((SqlString)value).Value.Length : ((string)value).Length;
-                            if (len > length / 2)
+                            string str = ((isSqlType) && (!typeChanged)) ? ((SqlString)value).Value : ((string)value);
+                            if (str.Length > length / 2)
                             {
-                                throw SQL.BulkLoadStringTooLong();
+                                if (str.Length > 100)
+                                {
+                                    str = str.Remove(100);
+                                }
+                                throw SQL.BulkLoadStringTooLong(_destinationTableName, metadata.column, str);
                             }
                         }
                         break;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1669,11 +1669,13 @@ namespace Microsoft.Data.SqlClient
                         mt = MetaType.GetMetaTypeFromSqlDbType(type.SqlDbType, false);
                         value = SqlParameter.CoerceValue(value, mt, out coercedToDataFeed, out typeChanged, false);
                         if (!coercedToDataFeed)
-                        { // We do not need to test for TextDataFeed as it is only assigned to (N)VARCHAR(MAX)
+                        {   // We do not need to test for TextDataFeed as it is only assigned to (N)VARCHAR(MAX)
                             string str = ((isSqlType) && (!typeChanged)) ? ((SqlString)value).Value : ((string)value);
                             int maxStringLength = length / 2;
                             if (str.Length > maxStringLength)
                             {
+                                // We truncate to at most 100 characters to match SQL Servers behavior as described in
+                                // https://blogs.msdn.microsoft.com/sql_server_team/string-or-binary-data-would-be-truncated-replacing-the-infamous-error-8152/
                                 str = str.Remove(Math.Min(maxStringLength, 100));
                                 throw SQL.BulkLoadStringTooLong(_destinationTableName, metadata.column, str);
                             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1671,12 +1671,10 @@ namespace Microsoft.Data.SqlClient
                         if (!coercedToDataFeed)
                         { // We do not need to test for TextDataFeed as it is only assigned to (N)VARCHAR(MAX)
                             string str = ((isSqlType) && (!typeChanged)) ? ((SqlString)value).Value : ((string)value);
-                            if (str.Length > length / 2)
+                            int maxStringLength = length / 2;
+                            if (str.Length > maxStringLength)
                             {
-                                if (str.Length > 100)
-                                {
-                                    str = str.Remove(100);
-                                }
+                                str = str.Remove(Math.Min(maxStringLength, 100));
                                 throw SQL.BulkLoadStringTooLong(_destinationTableName, metadata.column, str);
                             }
                         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1674,9 +1674,16 @@ namespace Microsoft.Data.SqlClient
                             int maxStringLength = length / 2;
                             if (str.Length > maxStringLength)
                             {
-                                // We truncate to at most 100 characters to match SQL Servers behavior as described in
-                                // https://blogs.msdn.microsoft.com/sql_server_team/string-or-binary-data-would-be-truncated-replacing-the-infamous-error-8152/
-                                str = str.Remove(Math.Min(maxStringLength, 100));
+                                if (metadata.isEncrypted)
+                                {
+                                    str = "<encrypted>";
+                                }
+                                else
+                                {
+                                    // We truncate to at most 100 characters to match SQL Servers behavior as described in
+                                    // https://blogs.msdn.microsoft.com/sql_server_team/string-or-binary-data-would-be-truncated-replacing-the-infamous-error-8152/
+                                    str = str.Remove(Math.Min(maxStringLength, 100));
+                                }
                                 throw SQL.BulkLoadStringTooLong(_destinationTableName, metadata.column, str);
                             }
                         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -975,9 +975,9 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_BulkLoadNonMatchingColumnName, columnName), e);
         }
-        static internal Exception BulkLoadStringTooLong()
+        static internal Exception BulkLoadStringTooLong(string tableName, string columnName, string tuncatedValue)
         {
-            return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_BulkLoadStringTooLong));
+            return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_BulkLoadStringTooLong, tableName, columnName, tuncatedValue));
         }
         static internal Exception BulkLoadInvalidVariantValue()
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -975,9 +975,9 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_BulkLoadNonMatchingColumnName, columnName), e);
         }
-        static internal Exception BulkLoadStringTooLong(string tableName, string columnName, string tuncatedValue)
+        static internal Exception BulkLoadStringTooLong(string tableName, string columnName, string truncatedValue)
         {
-            return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_BulkLoadStringTooLong, tableName, columnName, tuncatedValue));
+            return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_BulkLoadStringTooLong, tableName, columnName, truncatedValue));
         }
         static internal Exception BulkLoadInvalidVariantValue()
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
@@ -8857,7 +8857,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to String or binary data would be truncated..
+        ///   Looks up a localized string similar to String or binary data would be truncated in table &apos;{0}&apos;, column &apos;{1}&apos;. Truncated value: &apos;{2}&apos;..
         /// </summary>
         internal static string SQL_BulkLoadStringTooLong {
             get {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
@@ -2818,7 +2818,7 @@
     <value>The given ColumnName '{0}' does not match up with any column in data source.</value>
   </data>
   <data name="SQL_BulkLoadStringTooLong" xml:space="preserve">
-    <value>String or binary data would be truncated.</value>
+    <value>String or binary data would be truncated in table '{0}', column '{1}'. Truncated value: '{2}'.</value>
   </data>
   <data name="SQL_BulkLoadInvalidTimeout" xml:space="preserve">
     <value>Timeout Value '{0}' is less than 0.</value>


### PR DESCRIPTION
Brings the error message to parity with SQL Server 2016+ (trace flag) / 2019 (default).
fixes #256