### PR TITLE
Update 'minClientVersion' property for nuspec metadata

### DIFF
--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
-  <metadata minClientVersion="2.12">
+  <metadata minClientVersion="5.0">
     <id>Microsoft.Data.SqlClient</id>
     <version>1.0.0</version>
     <title>Microsoft.Data.SqlClient</title>


### PR DESCRIPTION
Suggestion from https://github.com/dotnet/SqlClient/issues/211#issuecomment-543093206
- Addresses issues with 'buildTransitive' not working properly due to old versions of Nuget.exe in use.