### PR TITLE
perf: Add multipacket async read target buffer caching

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -3967,8 +3967,8 @@ namespace Microsoft.Data.SqlClient
             private _SqlMetaDataSetCollection _snapshotCleanupAltMetaDataSetArray;
 
             internal byte[] _plpBuffer;
-
-            private readonly TdsParserStateObject _stateObj;
+            private PLPData _plpData;
+            private TdsParserStateObject _stateObj;
 
             private int _snapshotInBuffCount;
             private int _snapshotInBuffCurrent;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -1910,7 +1910,7 @@ namespace Microsoft.Data.SqlClient
         // Every time you call this method increment the offset and decrease len by the value of totalBytesRead
         internal bool TryReadPlpBytes(ref byte[] buff, int offset, int len, out int totalBytesRead)
         {
-            int bytesRead = 0;
+            int bytesRead;
             int bytesLeft;
             byte[] newbuf;
             ulong ignored;
@@ -1928,16 +1928,27 @@ namespace Microsoft.Data.SqlClient
                 return true;       // No data
             }
 
-            Debug.Assert((_longlen != TdsEnums.SQL_PLP_NULL),
-                    "Out of sync plp read request");
-
+            Debug.Assert(_longlen != TdsEnums.SQL_PLP_NULL, "Out of sync plp read request");
             Debug.Assert((buff == null && offset == 0) || (buff.Length >= offset + len), "Invalid length sent to ReadPlpBytes()!");
+
             bytesLeft = len;
 
             // If total length is known up front, allocate the whole buffer in one shot instead of realloc'ing and copying over each time
             if (buff == null && _longlen != TdsEnums.SQL_PLP_UNKNOWNLEN)
             {
-                buff = new byte[(int)Math.Min((int)_longlen, len)];
+                if (_snapshot != null)
+                {
+                    // if there is a snapshot and it contains a stored plp buffer take it
+                    // and try to use it if it is the right length
+                    buff = _snapshot._plpBuffer;
+                    _snapshot._plpBuffer = null;
+                }
+
+                if ((ulong)(buff?.Length ?? 0) != _longlen)
+                {
+                    // if the buffer is null or the wrong length create one to use
+                    buff = new byte[(int)Math.Min((int)_longlen, len)];
+                }
             }
 
             if (_longlenleft == 0)
@@ -1982,13 +1993,26 @@ namespace Microsoft.Data.SqlClient
                 _longlenleft -= (ulong)bytesRead;
                 if (!result)
                 {
+                    if (_snapshot != null)
+                    {
+                        // a partial read has happened so store the target buffer in the snapshot
+                        // so it can be re-used when another packet arrives and we read again
+                        _snapshot._plpBuffer = buff;
+                    }
                     return false;
                 }
 
                 if (_longlenleft == 0)
-                { // Read the next chunk or cleanup state if hit the end
+                { 
+                    // Read the next chunk or cleanup state if hit the end
                     if (!TryReadPlpLength(false, out ignored))
                     {
+                        if (_snapshot != null)
+                        {
+                            // a partial read has happened so store the target buffer in the snapshot
+                            // so it can be re-used when another packet arrives and we read again
+                            _snapshot._plpBuffer = buff;
+                        }
                         return false;
                     }
                 }
@@ -3941,8 +3965,10 @@ namespace Microsoft.Data.SqlClient
             private NullBitmap _snapshotNullBitmapInfo;
             private _SqlMetaDataSet _snapshotCleanupMetaData;
             private _SqlMetaDataSetCollection _snapshotCleanupAltMetaDataSetArray;
-            private PLPData _plpData;
-            private TdsParserStateObject _stateObj;
+
+            internal byte[] _plpBuffer;
+
+            private readonly TdsParserStateObject _stateObj;
 
             private int _snapshotInBuffCount;
             private int _snapshotInBuffCurrent;


### PR DESCRIPTION
closes https://github.com/dotnet/SqlClient/issues/245

Async reads that span multiple packets can allocate large target arrays and drop them repeatedly causing a large memory and cpu problem. This PR uses the async snapshot already present for all async calls to allow storing the presized target buffer between packet receipt decode attempts avoiding re-allocations.

Before:

| Method |         Behavior |      Mean |     Error |     StdDev |       Gen 0 |       Gen 1 |       Gen 2 |   Allocated |
|------- |----------------- |----------:|----------:|-----------:|------------:|------------:|------------:|------------:|
|  **Async** |          **Default** | **448.84 ms** | **8.9453 ms** |  **8.7855 ms** | **309000.0000** | **309000.0000** | **309000.0000** |     **3.98 KB** |
|   Sync |          Default |  17.46 ms | 0.1025 ms |  0.0959 ms |    406.2500 |    406.2500 |    406.2500 | 10244.82 KB |
|  **Async** | **SequentialAccess** | **458.23 ms** | **9.0577 ms** | **10.4309 ms** | **310000.0000** | **310000.0000** | **310000.0000** |     **3.98 KB** |
|   Sync | SequentialAccess |  17.38 ms | 0.0638 ms |  0.0596 ms |    406.2500 |    406.2500 |    406.2500 | 10244.82 KB |

After:

| Method |         Behavior |      Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |    Gen 2 |   Allocated |
|------- |----------------- |----------:|----------:|----------:|---------:|---------:|---------:|------------:|
|  **Async** |          **Default** | **124.68 ms** | **0.7149 ms** | **0.6687 ms** | **800.0000** | **400.0000** | **200.0000** |     **3.95 KB** |
|   Sync |          Default |  16.41 ms | 0.0898 ms | 0.0840 ms | 406.2500 | 406.2500 | 406.2500 | 10244.82 KB |
|  **Async** | **SequentialAccess** | **125.36 ms** | **1.3684 ms** | **1.2800 ms** | **750.0000** | **500.0000** | **250.0000** |     **3.95 KB** |
|   Sync | SequentialAccess |  16.48 ms | 0.0525 ms | 0.0491 ms | 406.2500 | 406.2500 | 406.2500 | 10244.82 KB |

BDN isn't showing LOH allocations which is why the memory numbers look odd. Using profiler results you can see the savings.

Before:
![beforePNG](https://user-images.githubusercontent.com/13322696/67527466-fc59d980-f6ae-11e9-86cf-4e68e699b101.PNG)

After:
![after](https://user-images.githubusercontent.com/13322696/67527475-ffed6080-f6ae-11e9-851a-309bcf1d25fb.PNG)

Overall 3x faster, 400 times less GC, 160 times less memory used on the benchmark provided in the report by @roji 