### PR TITLE
Fix SNIPacket.ReadFromStreamAsync to not consume same ValueTask twice

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.NetCoreApp.cs
@@ -58,6 +58,11 @@ namespace Microsoft.Data.SqlClient.SNI
                     // Completed
                     return;
                 }
+                else
+                {
+                    // Avoid consuming the same instance twice.
+                    vt = new ValueTask<int>(_length);
+                }
             }
 
             // Not complete or error call the async local function to complete


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/42338