### PR TITLE
Fix connection resiliency check

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1135,7 +1135,8 @@ namespace Microsoft.Data.SqlClient
                                             catch (SqlException)
                                             {
                                             }
-                                            runningReconnect = Task.Run(() => ReconnectAsync(timeout));
+                                            // use Task.Factory.StartNew with state overload instead of Task.Run to avoid anonymous closure context capture in method scope and avoid the unneeded allocation
+                                            runningReconnect = Task.Factory.StartNew(state => ReconnectAsync((int)state), timeout, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).Unwrap();
                                             // if current reconnect is not null, somebody already started reconnection task - some kind of race condition
                                             Debug.Assert(_currentReconnectionTask == null, "Duplicate reconnection tasks detected");
                                             _currentReconnectionTask = runningReconnect;
@@ -1160,7 +1161,7 @@ namespace Microsoft.Data.SqlClient
                                 OnError(SQL.CR_UnrecoverableServer(ClientConnectionId), true, null);
                             }
                         } // ValidateSNIConnection
-                    } // sessionRecoverySupported                  
+                    } // sessionRecoverySupported
                 } // connectRetryCount>0
             }
             else

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1135,8 +1135,7 @@ namespace Microsoft.Data.SqlClient
                                             catch (SqlException)
                                             {
                                             }
-                                            // use Task.Factory.StartNew with state overload instead of Task.Run to avoid anonymous closure context capture in method scope and avoid the unneeded allocation
-                                            runningReconnect = Task.Factory.StartNew(state => ReconnectAsync((int)state), timeout, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                                            runningReconnect = Task.Run(() => ReconnectAsync(timeout));
                                             // if current reconnect is not null, somebody already started reconnection task - some kind of race condition
                                             Debug.Assert(_currentReconnectionTask == null, "Duplicate reconnection tasks detected");
                                             _currentReconnectionTask = runningReconnect;


### PR DESCRIPTION
Fix for issue #304.

The connection resiliency check was broken in [corefx PR 34047](https://github.com/dotnet/corefx/pull/34047). Specifically, this change:
https://github.com/dotnet/corefx/pull/34047/files#diff-78c5752d4a8ee85fdc3593a8851c86e9L914

After my previous PR failed, I looked at other suspect changes in corefx PR 34047 and tried reverting them. This one line revert fixes my non-debug repro described in the issue. (I have not been able to repro this while debugging.) The original/working Task.Run call and the Task.Factory.StartNew call are almost functionally equivalent. After sprinkling some console messages throughout the reconnect path, I found that in SqlUtil.WaitForCompletion, [task.Wait](https://github.com/dotnet/SqlClient/blob/master/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs#L195) does not actually wait for the reconnect task from Task.Factory.StartNew ( a `System.Threading.Tasks.Task``1[System.Threading.Tasks.Task]`) to complete. So execution continues back up to the reader which hits a closed connection before the connection is actually reconnected. [task.Wait](https://github.com/dotnet/SqlClient/blob/master/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs#L195) does actually wait for the Task.Run generated task (a `System.Threading.Tasks.UnwrapPromise``1[System.Threading.Tasks.VoidTaskResult]`) to complete.

Update: The subtlety was the fact that Task.Run() is really an Unwrap()'ed Task.Factory.StartNew(). So simply adding .Unwrap() to the line also fixes the issue and preserves the previous perf benefit.