### PR TITLE
Test | Fix random test issues

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/ExceptionsAlgorithmErrors.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/ExceptionsAlgorithmErrors.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             // Zero out 4 bytes of authentication tag
             for (int i = 0; i < 4; i++)
             {
-                cipherText[1] = 0x00;
+                cipherText[i+1] = 0x00;
             }
             TargetInvocationException e = Assert.Throws<TargetInvocationException>(() => Utility.DecryptDataUsingAED(cipherText, CertFixture.cek, Utility.CColumnEncryptionType.Deterministic));
             Assert.Contains(expectedMessage, e.InnerException.Message);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -418,7 +418,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                     cmdText: $"select * from [{tableName}] where FirstName != {DummyParamName} and CustomerId = @CustomerId",
                     connection: sqlConnection))
                 {
-                    cmd.CommandTimeout = 90;
+                    if (DataTestUtility.EnclaveEnabled)
+                    {
+                        //Increase Time out for enclave-enabled server.
+                        cmd.CommandTimeout = 90;
+                    }
+
                     SqlParameter dummyParam = new SqlParameter(DummyParamName, SqlDbType.NVarChar, 150)
                     {
                         Value = "a"
@@ -538,7 +543,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                                 transaction: null,
                                 columnEncryptionSetting: SqlCommandColumnEncryptionSetting.Enabled))
                             {
-                                sqlCommand.CommandTimeout = 90;
+                                if (DataTestUtility.EnclaveEnabled)
+                                {
+                                    //Increase Time out for enclave-enabled server.
+                                    sqlCommand.CommandTimeout = 90;
+                                }
 
                                 sqlCommand.Parameters.AddWithValue(@"FirstName", string.Format(@"Microsoft{0}", i + 100));
                                 sqlCommand.Parameters.AddWithValue(@"CustomerId", values[0]);
@@ -1824,7 +1833,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                 // select the set of rows that were inserted just now.
                 using (SqlCommand sqlCommand = new SqlCommand($"SELECT LastName FROM [{tableName}] WHERE FirstName = @FirstName AND CustomerId = @CustomerId FOR XML AUTO;", sqlConnection, transaction: null, columnEncryptionSetting: SqlCommandColumnEncryptionSetting.Enabled))
                 {
-                    sqlCommand.CommandTimeout = 90;
+                    if (DataTestUtility.EnclaveEnabled)
+                    {
+                        //Increase Time out for enclave-enabled server.
+                        sqlCommand.CommandTimeout = 90;
+                    }
                     sqlCommand.Parameters.Add(@"CustomerId", SqlDbType.Int);
                     sqlCommand.Parameters.Add(@"FirstName", SqlDbType.NVarChar, ((string)values[1]).Length);
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CspProviderExt.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CspProviderExt.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         public void TestEncryptDecryptWithCSP(string connectionString)
         {
             string providerName = @"Microsoft Enhanced RSA and AES Cryptographic Provider";
-            string keyIdentifier = "BasicCMK";
+            string keyIdentifier = DataTestUtility.GetUniqueNameForSqlServer("CSP");
 
             try
             {


### PR DESCRIPTION
Fixes a few random failures:
- `TestEncryptDecryptWithCSP` to randomly generate CSP Key container name.
- `TestInvalidAuthenticationTag` to rightly replace bytes for test.
- `TestExecuteNonQuery` by trying again on a possible SQL Server deadlock