### PR TITLE
Tests | Fix random issues with CNG tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCngProviderShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCngProviderShould.cs
@@ -176,7 +176,8 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
 
         public void Dispose()
         {
-            RemoveKeyFromCng(providerName, containerName);
+            // Do Not remove Key for concurrency.
+            // RemoveKeyFromCng(providerName, containerName);
         }
 
         public static void AddKeyToCng(string providerName, string containerName)
@@ -184,12 +185,16 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             CngKeyCreationParameters keyParams = new CngKeyCreationParameters();
 
             keyParams.Provider = new CngProvider(providerName);
-            keyParams.KeyCreationOptions = CngKeyCreationOptions.OverwriteExistingKey;
+            keyParams.KeyCreationOptions = CngKeyCreationOptions.None;
 
             CngProperty keySizeProperty = new CngProperty("Length", BitConverter.GetBytes(2048), CngPropertyOptions.None);
             keyParams.Parameters.Add(keySizeProperty);
 
-            CngKey mycngKey = CngKey.Create(CngAlgorithm.Rsa, containerName, keyParams);
+            // Add Cng Key only if not exists.
+            if (!CngKey.Exists(containerName))
+            {
+                CngKey mycngKey = CngKey.Create(CngAlgorithm.Rsa, containerName, keyParams);
+            }
         }
 
         public static void RemoveKeyFromCng(string providerName, string containerName)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -1858,6 +1858,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             }
         }
 
+        [ActiveIssue("10620")] // Randomly hangs the process.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringSetupForAE))]
         [ClassData(typeof(AEConnectionStringProviderWithCommandBehaviorSet1))]
         public void TestBeginAndEndExecuteReaderWithAsyncCallback(string connection, CommandBehavior commandbehavior)
@@ -1894,6 +1895,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                 }
             }
         }
+
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringSetupForAE))]
         [ClassData(typeof(AEConnectionStringProviderWithExecutionMethod))]


### PR DESCRIPTION
- Fix randomly failing test: `SqlColumnEncryptionCngProviderWindowsShould` [Sample failing build](https://dev.azure.com/sqlclientdrivers-ci/sqlclient/_build/results?buildId=3081&view=ms.vss-test-web.build-test-results-tab)
- Skip randomly hanging test `TestBeginAndEndExecuteReaderWithAsyncCallback` with Active issue [Sample failing build](https://dev.azure.com/sqlclientdrivers-ci/sqlclient/_build/results?buildId=3059)