### PR TITLE
perf: Optimize async method allocations

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -70,6 +70,8 @@ namespace Microsoft.Data.SqlClient
         private static readonly DiagnosticListener _diagnosticListener = new DiagnosticListener(SqlClientDiagnosticListenerExtensions.DiagnosticListenerName);
         private bool _parentOperationStarted = false;
 
+        internal static readonly Action<object> s_cancelIgnoreFailure = CancelIgnoreFailureCallback;
+
         // Prepare
         // Against 7.0 Serve a prepare/unprepare requires an extra roundtrip to the server.
         //
@@ -2137,7 +2139,7 @@ namespace Microsoft.Data.SqlClient
                     source.SetCanceled();
                     return source.Task;
                 }
-                registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
+                registration = cancellationToken.Register(s_cancelIgnoreFailure, this);
             }
 
             Task<int> returnedTask = source.Task;
@@ -2225,7 +2227,7 @@ namespace Microsoft.Data.SqlClient
                     source.SetCanceled();
                     return source.Task;
                 }
-                registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
+                registration = cancellationToken.Register(s_cancelIgnoreFailure, this);
             }
 
             Task<SqlDataReader> returnedTask = source.Task;
@@ -2373,7 +2375,7 @@ namespace Microsoft.Data.SqlClient
                     source.SetCanceled();
                     return source.Task;
                 }
-                registration = cancellationToken.Register(s => ((SqlCommand)s).CancelIgnoreFailure(), this);
+                registration = cancellationToken.Register(s_cancelIgnoreFailure, this);
             }
 
             Task<XmlReader> returnedTask = source.Task;
@@ -5947,6 +5949,11 @@ namespace Microsoft.Data.SqlClient
             }
         }
 #endif
+        internal static void CancelIgnoreFailureCallback(object state)
+        {
+            SqlCommand command = (SqlCommand)state;
+            command.CancelIgnoreFailure();
+        }
 
         internal void CancelIgnoreFailure()
         {


### PR DESCRIPTION
This is a rework of a closed PR from corefx, https://github.com/dotnet/corefx/pull/37254 and I wrote a small essay explaining why it was a good idea in the initial post for that so it's worth clicking through and reading it.

Profiling the [DataAccessPerformance](https://github.com/aspnet/DataAccessPerformance) project which emulates the [TechEmpower fortunes benchmark](https://www.techempower.com/benchmarks/#section=data-r17&hw=ph&test=fortune) you can see that some of the top allocations are state closures for async methods like `ReadAsync` `GetFieldValueAsync`. Investigating this I found the code to be much more complex than I'd expected and quite confusing. In order to reduce the allocations I reworked the async infrastructure to use concrete classes and then cached some which are used repeatedly.

Before:
![master](https://user-images.githubusercontent.com/13322696/69499637-0f4d0d00-0eec-11ea-89cb-c26e81e61d80.PNG)

After:
![branch](https://user-images.githubusercontent.com/13322696/69499638-12e09400-0eec-11ea-8f68-cd951aacda7c.PNG)

DataAccessPerformance results:

| name | sync | threads | TPS  | stdev | description |
| ---- | ---- | ------- | ---: | ----: | :---------- |
|ado-sqlclient+async+128|async|128|64667|3262|master|
|ado-sqlclient+async+64|async|64|69262|1592|master|
|ado-sqlclient+async+32|async|32|68814|1918|master|
|ado-sqlclient+async+128|async|128|67288|1595|branch|
|ado-sqlclient+async+64|async|64|68870|2395|branch|
|ado-sqlclient+async+32|async|32|68311|1949|branch|


Which shows a ~5% throughput improvement in situations where CPU time is a limitation and less improvements where it isn't a limitation. I recommend reviewing manually because the diff makes the large number of changes and the extraction of lambdas look particularly confusing.