### PR TITLE
Allow large UDT buffers

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -739,6 +739,12 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.Argument(System.SRHelper.GetString(SR.SQLUDT_InvalidSqlType, typeName));
         }
+
+        internal static Exception UDTInvalidSize(int maxSize, int maxSupportedSize)
+        {
+            throw ADP.ArgumentOutOfRange(System.SRHelper.GetString(SR.SQLUDT_InvalidSize, maxSize, maxSupportedSize));
+        }
+
         internal static Exception InvalidSqlDbTypeForConstructor(SqlDbType type)
         {
             return ADP.Argument(System.SRHelper.GetString(SR.SqlMetaData_InvalidSqlDbTypeForConstructorFormat, type.ToString()));

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/SR.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/SR.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace System {
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,7 +19,7 @@ namespace System {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SR {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/SR.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/SR.Designer.cs
@@ -19,7 +19,7 @@ namespace System {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SR {
@@ -889,7 +889,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The validation of an attestation token failed. The token signature does not match the signature omputed using a public key retrieved from the attestation public key endpoint at &apos;{0}&apos;. Verify the DNS apping for the endpoint. If correct, contact Customer Support Services..
+        ///   Looks up a localized string similar to The validation of an attestation token failed. The token signature does not match the signature computed using a public key retrieved from the attestation public key endpoint at &apos;{0}&apos;. Verify the DNS mapping for the endpoint. If correct, contact Customer Support Services..
         /// </summary>
         internal static string AttestationTokenSignatureValidationFailed {
             get {
@@ -3994,6 +3994,15 @@ namespace System {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to UDT size must be less than {1}, size: {0}.
+        /// </summary>
+        internal static string SQLUDT_InvalidSize {
+            get {
+                return ResourceManager.GetString("SQLUDT_InvalidSize", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specified type is not registered on the target server. {0}..
         /// </summary>
         internal static string SQLUDT_InvalidSqlType {
@@ -4071,6 +4080,24 @@ namespace System {
         internal static string TCE_AttestationInfoNotReturnedFromSQLServer {
             get {
                 return ResourceManager.GetString("TCE_AttestationInfoNotReturnedFromSQLServer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error occured when generating enclave package. Attestation Protocol has not been specified in the connection string, but the query requires enclave computations..
+        /// </summary>
+        internal static string TCE_AttestationProtocolNotSpecifiedForGeneratingEnclavePackage {
+            get {
+                return ResourceManager.GetString("TCE_AttestationProtocolNotSpecifiedForGeneratingEnclavePackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to initialize connection. The attestation protocol &apos;{0}&apos; does not support the enclave type &apos;{1}&apos;..
+        /// </summary>
+        internal static string TCE_AttestationProtocolNotSupportEnclaveType {
+            get {
+                return ResourceManager.GetString("TCE_AttestationProtocolNotSupportEnclaveType", resourceCulture);
             }
         }
         
@@ -4179,6 +4206,15 @@ namespace System {
         internal static string TCE_ColumnMasterKeySignatureVerificationFailed {
             get {
                 return ResourceManager.GetString("TCE_ColumnMasterKeySignatureVerificationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specifies an attestation protocol for its corresponding enclave attestation service..
+        /// </summary>
+        internal static string TCE_DbConnectionString_AttestationProtocol {
+            get {
+                return ResourceManager.GetString("TCE_DbConnectionString_AttestationProtocol", resourceCulture);
             }
         }
         
@@ -4336,50 +4372,14 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No enclave provider found for enclave type &apos;{0}&apos;. Please specify the provider in the application configuration..
+        ///   Looks up a localized string similar to No enclave provider found for enclave type &apos;{0}&apos; and attestation protocol &apos;{1}&apos;. Please specify the correct attestation protocol in the connection string..
         /// </summary>
         internal static string TCE_EnclaveProviderNotFound {
             get {
                 return ResourceManager.GetString("TCE_EnclaveProviderNotFound", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Specifies an attestation protocol for its corresponding enclave attestation service.
-        /// </summary>
-        internal static string TCE_DbConnectionString_AttestationProtocol {
-            get {
-                return ResourceManager.GetString("TCE_DbConnectionString_AttestationProtocol", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        /// Looks up a localized string similar to The enclave type '{0}' returned from the server is not supported.
-        /// </summary>
-        internal static string TCE_EnclaveTypeNotSupported {
-            get {
-                return ResourceManager.GetString("TCE_EnclaveTypeNotSupported", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        /// Looks up a localized string similar to Failed to initialize connection. The attestation protocol '{0}' does not support the enclave type '{1}'.
-        /// </summary>
-        internal static string TCE_AttestationProtocolNotSupportEnclaveType {
-            get {
-                return ResourceManager.GetString("TCE_AttestationProtocolNotSupportEnclaveType", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        /// Looks up a localized string similar to Error occured when generating enclave package. Attestation Protocol has not been specified in the connection string, but the query requires enclave computations.
-        /// </summary>
-        internal static string TCE_AttestationProtocolNotSpecifiedForGeneratingEnclavePackage {
-            get {
-                return ResourceManager.GetString("TCE_AttestationProtocolNotSpecifiedForGeneratingEnclavePackage", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Executing a query requires enclave computations, but the application configuration is missing the enclave provider section..
         /// </summary>
@@ -4395,6 +4395,15 @@ namespace System {
         internal static string TCE_EnclaveTypeNotReturned {
             get {
                 return ResourceManager.GetString("TCE_EnclaveTypeNotReturned", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The enclave type &apos;{0}&apos; returned from the server is not supported..
+        /// </summary>
+        internal static string TCE_EnclaveTypeNotSupported {
+            get {
+                return ResourceManager.GetString("TCE_EnclaveTypeNotSupported", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/SR.resx
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/SR.resx
@@ -167,7 +167,7 @@
   </data>
   <data name="ADP_InvalidDataDirectory" xml:space="preserve">
     <value>The DataDirectory substitute is not a string.</value>
-  </data>  
+  </data>
   <data name="ADP_InvalidEnumerationValue" xml:space="preserve">
     <value>The {0} enumeration value, {1}, is invalid.</value>
   </data>
@@ -1850,5 +1850,8 @@
   </data>
   <data name="TCE_AttestationProtocolNotSpecifiedForGeneratingEnclavePackage" xml:space="preserve">
     <value>Error occured when generating enclave package. Attestation Protocol has not been specified in the connection string, but the query requires enclave computations.</value>
+  </data>
+  <data name="SQLUDT_InvalidSize" xml:space="preserve">
+    <value>UDT size must be less than {1}, size: {0}</value>
   </data>
 </root>


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/329

Changes the max size check so that it depends on the protocol version of the connection to the server. SQL Server 2008 and later use TDS verison >= 7.3 which can support large UDT types up to int.MaxValue not the previous short.MaxValue used. 

I removed n byte[] allocation which wasn't being used. I reordered the type name check so it occurs before all the work to get and check the value. I changed the exception type from IndexOutOfRange exception with the default message to ArgumentOutOfRange exception with an explanation containing the size and max supported size, this will need localizing.

I'm hoping someone can do the dance required to point EF core at the PR build nuget version and see if the original problem reported by @capeseanis removed. I'm finding it rather difficult to try and work through. If the method is valid the same work can be done on the desktop framework version.

/cc @ajcvickers @aprognimak