### PR TITLE
Test improvements

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Xunit;
@@ -445,14 +446,30 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return prefix + path;
         }
 
-        public static void RunNonQuery(string connectionString, string sql)
+        public static void RunNonQuery(string connectionString, string sql, int numberOfRetries = 0)
         {
-            using (SqlConnection connection = new SqlConnection(connectionString))
-            using (SqlCommand command = connection.CreateCommand())
+            int retries = 0;
+            while (true)
             {
-                connection.Open();
-                command.CommandText = sql;
-                command.ExecuteNonQuery();
+                try
+                {
+                    using (SqlConnection connection = new SqlConnection(connectionString))
+                    using (SqlCommand command = connection.CreateCommand())
+                    {
+                        connection.Open();
+                        command.CommandText = sql;
+                        command.ExecuteNonQuery();
+                    }
+                }
+                catch (Exception)
+                {
+                    if (retries >= numberOfRetries)
+                    {
+                        throw;
+                    }
+                    retries++;
+                    Thread.Sleep(1000);
+                }
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -459,6 +459,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         connection.Open();
                         command.CommandText = sql;
                         command.ExecuteNonQuery();
+                        break;
                     }
                 }
                 catch (Exception)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/InternalConnectionWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/InternalConnectionWrapper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// </summary>
         /// <param name="connection">Live outer connection to grab the inner connection from</param>
         /// <param name="supportKillByTSql">If true then we will query the server for this connection's SPID details (to be used in the KillConnectionByTSql method)</param>
-        public InternalConnectionWrapper(SqlConnection connection, bool supportKillByTSql = false)
+        public InternalConnectionWrapper(SqlConnection connection, bool supportKillByTSql = false, string originalConnectionString = "")
         {
             if (connection == null)
                 throw new ArgumentNullException(nameof(connection));
@@ -33,6 +33,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             if (supportKillByTSql)
             {
+                SqlConnectionStringBuilder csb = new SqlConnectionStringBuilder(ConnectionString);
+                if (!csb.IntegratedSecurity &&
+                    string.IsNullOrWhiteSpace(originalConnectionString))
+                {
+                    throw new ArgumentException("Must provide originalConnectionString if using supportKillByTSql and not using Integrated Security.");
+                }
+                else if (!string.IsNullOrWhiteSpace(originalConnectionString))
+                {
+                    ConnectionString = originalConnectionString;
+                }
+
                 // Save the SPID for later use
                 using (SqlCommand command = new SqlCommand("SELECT @@SPID", connection))
                 {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -207,9 +207,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 DataTestUtility.RunNonQuery(s_dbConnectionString, s_createTableCmd);
 
                 // Kill all the connections and set Database to SINGLE_USER Mode.
-                DataTestUtility.RunNonQuery(s_connectionString, s_alterDatabaseSingleCmd);
+                DataTestUtility.RunNonQuery(s_connectionString, s_alterDatabaseSingleCmd, 4);
                 // Set Database back to MULTI_USER Mode
-                DataTestUtility.RunNonQuery(s_connectionString, s_alterDatabaseMultiCmd);
+                DataTestUtility.RunNonQuery(s_connectionString, s_alterDatabaseMultiCmd, 4);
 
                 // Execute SELECT statement.
                 DataTestUtility.RunNonQuery(s_dbConnectionString, s_selectTableCmd);
@@ -222,8 +222,51 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             finally
             {
                 // Kill all the connections, set Database to SINGLE_USER Mode and drop Database
-                DataTestUtility.RunNonQuery(s_connectionString, s_alterDatabaseSingleCmd);
-                DataTestUtility.RunNonQuery(s_connectionString, s_dropDatabaseCmd);
+                DataTestUtility.RunNonQuery(s_connectionString, s_alterDatabaseSingleCmd, 4);
+                DataTestUtility.RunNonQuery(s_connectionString, s_dropDatabaseCmd, 4);
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void ConnectionResiliencyTest()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString);
+            builder.ConnectRetryCount = 0;
+            builder.ConnectRetryInterval = 5;
+
+            // No connection resiliency
+            using (SqlConnection conn = new SqlConnection(DataTestUtility.TCPConnectionString))
+            {
+                conn.Open();
+                InternalConnectionWrapper wrapper = new InternalConnectionWrapper(conn, true);
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    wrapper.KillConnectionByTSql();
+                    using (SqlDataReader reader = cmd.ExecuteReader())
+                    while (reader.Read())
+                    { }
+                }
+            }
+
+            builder.ConnectRetryCount = 2;
+            using (SqlConnection conn = new SqlConnection(DataTestUtility.TCPConnectionString))
+            {
+                conn.Open();
+                InternalConnectionWrapper wrapper = new InternalConnectionWrapper(conn, true);
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = "SELECT TOP 1 * FROM dbo.Employees";
+                    using (SqlDataReader reader = cmd.ExecuteReader())
+                        while (reader.Read())
+                        { }
+
+                    wrapper.KillConnectionByTSql();
+
+                    // Connection resiliency should reconnect transparently
+                    using (SqlDataReader reader = cmd.ExecuteReader())
+                        while (reader.Read())
+                        { }
+                }
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -228,20 +228,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
-        public static void ConnectionResiliencyTestUnix()
-        {
-            ConnectionResiliencyTest(typeof(AggregateException));
-        }
-
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public static void ConnectionResiliencyTestWindows()
-        {
-            ConnectionResiliencyTest(typeof(SqlException));
-        }
-
-        private static void ConnectionResiliencyTest(Type ExecuteExceptionType)
+        public static void ConnectionResiliencyTest()
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString);
             builder.ConnectRetryCount = 0;
@@ -256,7 +243,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 {
                     cmd.CommandText = "SELECT TOP 1 * FROM dbo.Employees";
                     wrapper.KillConnectionByTSql();
-                    Assert.Throws(ExecuteExceptionType, () => cmd.ExecuteReader());
+                    bool cmdSuccess = false;
+                    try
+                    {
+                        cmd.ExecuteScalar();
+                        cmdSuccess = true;
+                    }
+                    // Windows always throws SqlException. Unix sometimes throws AggregateException against Azure SQL DB.
+                    catch (Exception ex) when (ex is SqlException || ex is AggregateException) { }
+                    Assert.False(cmdSuccess);
                 }
             }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -228,7 +228,20 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        public static void ConnectionResiliencyTest()
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public static void ConnectionResiliencyTestUnix()
+        {
+            ConnectionResiliencyTest(typeof(AggregateException));
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public static void ConnectionResiliencyTestWindows()
+        {
+            ConnectionResiliencyTest(typeof(SqlException));
+        }
+
+        private static void ConnectionResiliencyTest(Type ExecuteExceptionType)
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString);
             builder.ConnectRetryCount = 0;
@@ -243,7 +256,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 {
                     cmd.CommandText = "SELECT TOP 1 * FROM dbo.Employees";
                     wrapper.KillConnectionByTSql();
-                    Assert.Throws<SqlException>(() => cmd.ExecuteReader());
+                    Assert.Throws(ExecuteExceptionType, () => cmd.ExecuteReader());
                 }
             }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             using (SqlConnection conn = new SqlConnection(builder.ConnectionString))
             {
                 conn.Open();
-                InternalConnectionWrapper wrapper = new InternalConnectionWrapper(conn, true);
+                InternalConnectionWrapper wrapper = new InternalConnectionWrapper(conn, true, builder.ConnectionString);
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT TOP 1 * FROM dbo.Employees";
@@ -251,7 +251,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             using (SqlConnection conn = new SqlConnection(builder.ConnectionString))
             {
                 conn.Open();
-                InternalConnectionWrapper wrapper = new InternalConnectionWrapper(conn, true);
+                InternalConnectionWrapper wrapper = new InternalConnectionWrapper(conn, true, builder.ConnectionString);
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = "SELECT TOP 1 * FROM dbo.Employees";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -235,21 +235,20 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             builder.ConnectRetryInterval = 5;
 
             // No connection resiliency
-            using (SqlConnection conn = new SqlConnection(DataTestUtility.TCPConnectionString))
+            using (SqlConnection conn = new SqlConnection(builder.ConnectionString))
             {
                 conn.Open();
                 InternalConnectionWrapper wrapper = new InternalConnectionWrapper(conn, true);
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
+                    cmd.CommandText = "SELECT TOP 1 * FROM dbo.Employees";
                     wrapper.KillConnectionByTSql();
-                    using (SqlDataReader reader = cmd.ExecuteReader())
-                    while (reader.Read())
-                    { }
+                    Assert.Throws<SqlException>(() => cmd.ExecuteReader());
                 }
             }
 
             builder.ConnectRetryCount = 2;
-            using (SqlConnection conn = new SqlConnection(DataTestUtility.TCPConnectionString))
+            using (SqlConnection conn = new SqlConnection(builder.ConnectionString))
             {
                 conn.Open();
                 InternalConnectionWrapper wrapper = new InternalConnectionWrapper(conn, true);


### PR DESCRIPTION
Targeting a couple of tests that fail intermittently and adding retries.

- ConnectivityTest
  - Add retries when changing the user mode of the database. I think with parallel jobs, the server may be objecting to simultaneously changing the mode of multiple databases at the same time.
  - Add a new test for connection resiliency. I wrote this for #304 and #310 but it would still pass, even before the fix, because the async reconnect task still ran with this particular bug and always beat the subsequent query in the context of the unit test. But the test could still catch other code errors which might break connection resiliency, so it will still be good to have.
- SqlCredentialTest: This test fails intermittently with the server somehow thinking the user is not allowed to change its own password. I suspect this might also be due to other jobs trying to change passwords at the same time and adding a brief wait on failure and retrying may make it pass more consistently.