### PR TITLE
Perf: Remove double fetch of domain name

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPoolIdentity.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPoolIdentity.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Data.ProviderBase
 
         internal static DbConnectionPoolIdentity GetCurrentManaged()
         {
-            string sidString = (!string.IsNullOrWhiteSpace(System.Environment.UserDomainName) ? System.Environment.UserDomainName + "\\" : "")
-                                + System.Environment.UserName;
+            string domainString = System.Environment.UserDomainName;
+            string sidString = (!string.IsNullOrWhiteSpace(domainString) ? domainString + "\\" : "") + System.Environment.UserName;
             bool isNetwork = false;
             bool isRestricted = false;
             return new DbConnectionPoolIdentity(sidString, isRestricted, isNetwork);


### PR DESCRIPTION
While profiling the managed SNI implementation I got distracted by the amount of time it takes to get a connection from the pool. I found this simple change which on windows removes 2 pinvokes and a string allocation by getting the user domain name only once and reusing it. 

 ![comparison](https://user-images.githubusercontent.com/13322696/71748008-30006f00-2e69-11ea-8ed8-54c252166eac.PNG)

If we were doing direct invokes instead of using System.Environment wrappers we could do it in 2-3 pinvokes and avoid a couple of string allocations. We would have to be platform specific though and I'd prefer to keep this implementation fully portable if possible. Note that the Environment.UserName and UseDomainName functions do not read environment variables the pinvoke directly so they are compatible with impersonation, any replacement would need to have the same property.