### PR TITLE
Perf: Make enclave key map lazy initialized

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Data.SqlClient
         // cached metadata
         private _SqlMetaDataSet _cachedMetaData;
 
-        private Dictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave = new Dictionary<int, SqlTceCipherInfoEntry>();
+        private Dictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave;
         private bool requiresEnclaveComputations = false;
         internal EnclavePackage enclavePackage = null;
         private SqlEnclaveAttestationParameters enclaveAttestationParameters = null;
@@ -2994,8 +2994,10 @@ namespace Microsoft.Data.SqlClient
                     _parameters[i].HasReceivedMetadata = false;
                 }
             }
-
-            keysToBeSentToEnclave.Clear();
+            if (keysToBeSentToEnclave != null)
+            {
+                keysToBeSentToEnclave.Clear();
+            }
             enclavePackage = null;
             requiresEnclaveComputations = false;
             enclaveAttestationParameters = null;
@@ -3728,10 +3730,14 @@ namespace Microsoft.Data.SqlClient
                         {
                             throw SQL.InvalidEncryptionKeyOrdinalEnclaveMetadata(requestedKey, columnEncryptionKeyTable.Count);
                         }
-
-                        if (!keysToBeSentToEnclave.ContainsKey(currentOrdinal))
+                        if (keysToBeSentToEnclave == null)
                         {
-                            this.keysToBeSentToEnclave.Add(currentOrdinal, cipherInfo);
+                            keysToBeSentToEnclave = new Dictionary<int, SqlTceCipherInfoEntry>();
+                            keysToBeSentToEnclave.Add(currentOrdinal, cipherInfo);
+                        } 
+                        else if (!keysToBeSentToEnclave.ContainsKey(currentOrdinal))
+                        {
+                            keysToBeSentToEnclave.Add(currentOrdinal, cipherInfo);
                         }
 
                         requiresEnclaveComputations = true;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Data.SqlClient
         // cached metadata
         private _SqlMetaDataSet _cachedMetaData;
 
-        private Dictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave = new Dictionary<int, SqlTceCipherInfoEntry>();
+        private Dictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave;
         private bool requiresEnclaveComputations = false;
         internal EnclaveDelegate.EnclavePackage enclavePackage = null;
         private SqlEnclaveAttestationParameters enclaveAttestationParameters = null;
@@ -3872,7 +3872,10 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            keysToBeSentToEnclave.Clear();
+            if (keysToBeSentToEnclave != null)
+            {
+                keysToBeSentToEnclave.Clear();
+            }
             enclavePackage = null;
             requiresEnclaveComputations = false;
             enclaveAttestationParameters = null;
@@ -4666,9 +4669,14 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.InvalidEncryptionKeyOrdinalEnclaveMetadata(requestedKey, columnEncryptionKeyTable.Count);
                         }
 
-                        if (!keysToBeSentToEnclave.ContainsKey(currentOrdinal))
+                        if (keysToBeSentToEnclave == null)
                         {
-                            this.keysToBeSentToEnclave.Add(currentOrdinal, cipherInfo);
+                            keysToBeSentToEnclave = new Dictionary<int, SqlTceCipherInfoEntry>();
+                            keysToBeSentToEnclave.Add(currentOrdinal, cipherInfo);
+                        }
+                        else if (!keysToBeSentToEnclave.ContainsKey(currentOrdinal))
+                        {
+                            keysToBeSentToEnclave.Add(currentOrdinal, cipherInfo);
                         }
 
                         requiresEnclaveComputations = true;


### PR DESCRIPTION
Just a small change. Makes the enclave key map be initialized when it is needed instead of always creating it and usually discarding it.