### PR TITLE
perf: Add invariant culture check result caching

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -27,6 +27,12 @@ namespace Microsoft.Data.SqlClient
     /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnection.xml' path='docs/members[@name="SqlConnection"]/SqlConnection/*' />
     public sealed partial class SqlConnection : DbConnection, ICloneable
     {
+        private enum CultureCheckState : uint
+        {
+            Unknown = 0,
+            Standard = 1,
+            Invariant = 2
+        }
 
         private bool _AsyncCommandInProgress;
 
@@ -72,7 +78,9 @@ namespace Microsoft.Data.SqlClient
                 };
 
         // Lock to control setting of _CustomColumnEncryptionKeyStoreProviders
-        private static readonly Object _CustomColumnEncryptionKeyProvidersLock = new Object();
+        private static readonly object _CustomColumnEncryptionKeyProvidersLock = new object();
+        // statuc of invariant culture environment check
+        private static CultureCheckState _cultureCheckState;
 
         /// <summary>
         /// Custom provider list should be provided by the user. We shallow copy the user supplied dictionary into a ReadOnlyDictionary.
@@ -1408,13 +1416,22 @@ namespace Microsoft.Data.SqlClient
         {
             SqlConnectionString connectionOptions = (SqlConnectionString)ConnectionOptions;
 
-            // .NET Core 2.0 and up supports a Globalization Invariant Mode to reduce the size of
-            // required libraries for applications which don't need globalization support. SqlClient
-            // requires those libraries for core functionality and will throw exceptions later if they
-            // are not present. Throwing on open with a meaningful message helps identify the issue.
-            if (CultureInfo.GetCultureInfo("en-US").EnglishName.Contains("Invariant"))
+            CultureCheckState cultureCheckState = _cultureCheckState;
+            if (cultureCheckState != CultureCheckState.Standard)
             {
-                throw SQL.GlobalizationInvariantModeNotSupported();
+                // .NET Core 2.0 and up supports a Globalization Invariant Mode to reduce the size of
+                // required libraries for applications which don't need globalization support. SqlClient
+                // requires those libraries for core functionality and will throw exceptions later if they
+                // are not present. Throwing on open with a meaningful message helps identify the issue.
+                if (cultureCheckState == CultureCheckState.Unknown)
+                {
+                    cultureCheckState = CultureInfo.GetCultureInfo("en-US").EnglishName.Contains("Invariant") ? CultureCheckState.Invariant : CultureCheckState.Standard;
+                    _cultureCheckState = cultureCheckState;
+                }
+                if (cultureCheckState == CultureCheckState.Invariant)
+                {
+                    throw SQL.GlobalizationInvariantModeNotSupported();
+                }
             }
 
             _applyTransientFaultHandling = (retry == null && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Data.SqlClient
 
         // Lock to control setting of _CustomColumnEncryptionKeyStoreProviders
         private static readonly object _CustomColumnEncryptionKeyProvidersLock = new object();
-        // statuc of invariant culture environment check
+        // status of invariant culture environment check
         private static CultureCheckState _cultureCheckState;
 
         /// <summary>
@@ -1416,19 +1416,17 @@ namespace Microsoft.Data.SqlClient
         {
             SqlConnectionString connectionOptions = (SqlConnectionString)ConnectionOptions;
 
-            CultureCheckState cultureCheckState = _cultureCheckState;
-            if (cultureCheckState != CultureCheckState.Standard)
+            if (_cultureCheckState != CultureCheckState.Standard)
             {
                 // .NET Core 2.0 and up supports a Globalization Invariant Mode to reduce the size of
                 // required libraries for applications which don't need globalization support. SqlClient
                 // requires those libraries for core functionality and will throw exceptions later if they
                 // are not present. Throwing on open with a meaningful message helps identify the issue.
-                if (cultureCheckState == CultureCheckState.Unknown)
+                if (_cultureCheckState == CultureCheckState.Unknown)
                 {
-                    cultureCheckState = CultureInfo.GetCultureInfo("en-US").EnglishName.Contains("Invariant") ? CultureCheckState.Invariant : CultureCheckState.Standard;
-                    _cultureCheckState = cultureCheckState;
+                    _cultureCheckState = CultureInfo.GetCultureInfo("en-US").EnglishName.Contains("Invariant") ? CultureCheckState.Invariant : CultureCheckState.Standard;
                 }
-                if (cultureCheckState == CultureCheckState.Invariant)
+                if (_cultureCheckState == CultureCheckState.Invariant)
                 {
                     throw SQL.GlobalizationInvariantModeNotSupported();
                 }


### PR DESCRIPTION
Every time SqlConnection.TryOpen is called the culture is checked to see if the runtime is in invariant mode and then throws because we can't run under culture invariant conditions. The culture object itself is cached so the check isn't too slow but in getting the cached object a string is allocated inside the runtime that can't be avoided. We can avoid most of this by caching the result of the first check because there is no way to change the invariant mode without restarting the runtime. 

The enum is uint because it's the fastest comparison for the runtime. The assignment back to the static cached value isn't interlocked and it isn't really necessary to do so because if a small number of opens happen at the same time the last assigner will win and all assigners will get the same value so nothing is confused or lost it'll just exhibit the same performance as the current master would.