### PR TITLE
perf: Strongly type lock token to avoid boxing

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -203,12 +203,12 @@ namespace Microsoft.Data.ProviderBase
             // By default, there is no preparation required
         }
 
-        virtual protected object ObtainAdditionalLocksForClose()
+        virtual protected bool ObtainAdditionalLocksForClose()
         {
-            return null; // no additional locks in default implementation
+            return false; // no additional locks in default implementation
         }
 
-        virtual protected void ReleaseAdditionalLocksForClose(object lockToken)
+        virtual protected void ReleaseAdditionalLocksForClose(bool lockToken)
         {
             // no additional locks in default implementation
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Data.ProviderBase
                 // Lock to prevent race condition with cancellation
                 lock (this)
                 {
-                    object lockToken = ObtainAdditionalLocksForClose();
+                    bool lockToken = ObtainAdditionalLocksForClose();
                     try
                     {
                         PrepareForCloseConnection();

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1758,7 +1758,7 @@ namespace Microsoft.Data.SqlClient
         // PREPARED COMMAND METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        protected override object ObtainAdditionalLocksForClose()
+        protected override bool ObtainAdditionalLocksForClose()
         {
             bool obtainParserLock = !ThreadHasParserLockForClose;
             Debug.Assert(obtainParserLock || _parserLock.ThreadMayHaveLock(), "Thread claims to have lock, but lock is not taken");
@@ -1770,10 +1770,9 @@ namespace Microsoft.Data.SqlClient
             return obtainParserLock;
         }
 
-        protected override void ReleaseAdditionalLocksForClose(object lockToken)
+        protected override void ReleaseAdditionalLocksForClose(bool lockToken)
         {
-            Debug.Assert(lockToken is bool, "Lock token should be boolean");
-            if ((bool)lockToken)
+            if (lockToken)
             {
                 ThreadHasParserLockForClose = false;
                 _parserLock.Release();


### PR DESCRIPTION
A tiny one. The lock token is only ever used as a Boolean but passing it as an object forces boxing to occur on each call. This just strongly types the methods that use it so they take bool.