### PR TITLE
perf: Lazy init reconnect lock when needed

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Data.SqlClient
         private string _accessToken; // Access Token to be used for token based authententication
 
         // connection resiliency
-        private object _reconnectLock = new object();
+        private object _reconnectLock;
         internal Task _currentReconnectionTask;
         private Task _asyncWaitingForReconnection; // current async task waiting for reconnection in non-MARS connections
         private Guid _originalConnectionId = Guid.Empty;
@@ -1116,6 +1116,12 @@ namespace Microsoft.Data.SqlClient
                             if (cData._unrecoverableStatesCount == 0)
                             {
                                 bool callDisconnect = false;
+
+                                if (_reconnectLock is null)
+                                {
+                                    Interlocked.CompareExchange(ref _reconnectLock, new object(), null);
+                                }
+
                                 lock (_reconnectLock)
                                 {
                                     tdsConn.CheckEnlistedTransactionBinding();


### PR DESCRIPTION
In ideal situations the reconnection lock isn't needed most of the time but it currently always allocated unused and then cleaned up by the GC. This PR defers the creation of the lock object used in reconnections until just before it is needed. It uses interlocked to ensure that only one concurrent call can assign to the variable and the semantics of compareexchange mean that all of them will observe the same value once one has assigned it.