### PR TITLE
perf: Add managed packet recycling

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -343,6 +343,8 @@
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIMarsQueuedPacket.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNINpHandle.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIPacket.cs" />
+    <Compile Include="Microsoft\Data\SqlClient\SNI\SNIPacketPool.cs" />
+    <Compile Include="Microsoft\Data\SqlClient\SNI\SNIPhysicalHandle.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIProxy.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNITcpHandle.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SslOverTdsStream.cs" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIHandle.cs
@@ -40,10 +40,9 @@ namespace Microsoft.Data.SqlClient.SNI
         /// Send a packet asynchronously
         /// </summary>
         /// <param name="packet">SNI packet</param>
-        /// <param name="disposePacketAfterSendAsync"></param>
         /// <param name="callback">Completion callback</param>
         /// <returns>SNI error code</returns>
-        public abstract uint SendAsync(SNIPacket packet, bool disposePacketAfterSendAsync, SNIAsyncCallback callback = null);
+        public abstract uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null);
 
         /// <summary>
         /// Receive a packet synchronously
@@ -87,6 +86,11 @@ namespace Microsoft.Data.SqlClient.SNI
         public abstract Guid ConnectionId { get; }
 
         public virtual int ReserveHeaderSize => 0;
+
+        public abstract SNIPacket RentPacket(int headerSize, int dataSize);
+
+        public abstract void ReturnPacket(SNIPacket packet);
+
 #if DEBUG
         /// <summary>
         /// Test handle for killing underlying connection

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -258,9 +258,9 @@ namespace Microsoft.Data.SqlClient.SNI
 
                             _currentHeader.Read(_headerBytes);
 
-                        _dataBytesLeft = (int)_currentHeader.length;
-                        _currentPacket = _lowerHandle.RentPacket(headerSize: 0, dataSize: (int)_currentHeader.length);
-                    }
+                            _dataBytesLeft = (int)_currentHeader.length;
+                            _currentPacket = _lowerHandle.RentPacket(headerSize: 0, dataSize: (int)_currentHeader.length);
+                        }
 
                         currentHeader = _currentHeader;
                         currentPacket = _currentPacket;
@@ -313,22 +313,22 @@ namespace Microsoft.Data.SqlClient.SNI
                         currentSession.HandleReceiveComplete(currentPacket, currentHeader);
                     }
 
-                if (_currentHeader.flags == (byte)SNISMUXFlags.SMUX_ACK)
-                {
-                    try
+                    if (_currentHeader.flags == (byte)SNISMUXFlags.SMUX_ACK)
                     {
-                        currentSession.HandleAck(currentHeader.highwater);
-                    }
-                    catch (Exception e)
-                    {
-                        SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, SNICommon.InternalExceptionError, e);
-                    }
+                        try
+                        {
+                            currentSession.HandleAck(currentHeader.highwater);
+                        }
+                        catch (Exception e)
+                        {
+                            SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, SNICommon.InternalExceptionError, e);
+                        }
 
-                    Debug.Assert(_currentPacket == currentPacket, "current and _current are not the same");
-                    ReturnPacket(currentPacket);
-                    currentPacket = null;
-                    _currentPacket = null;
-                }
+                        Debug.Assert(_currentPacket == currentPacket, "current and _current are not the same");
+                        ReturnPacket(currentPacket);
+                        currentPacket = null;
+                        _currentPacket = null;
+                    }
 
                     lock (this)
                     {
@@ -383,6 +383,16 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
+        }
+
+        public SNIPacket RentPacket(int headerSize, int dataSize)
+        {
+            return _lowerHandle.RentPacket(headerSize, dataSize);
+        }
+
+        public void ReturnPacket(SNIPacket packet)
+        {
+            _lowerHandle.ReturnPacket(packet);
         }
 
 #if DEBUG

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsQueuedPacket.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsQueuedPacket.cs
@@ -7,10 +7,10 @@ namespace Microsoft.Data.SqlClient.SNI
     /// <summary>
     /// Mars queued packet
     /// </summary>
-    internal class SNIMarsQueuedPacket
+    internal sealed class SNIMarsQueuedPacket
     {
-        private SNIPacket _packet;
-        private SNIAsyncCallback _callback;
+        private readonly SNIPacket _packet;
+        private readonly SNIAsyncCallback _callback;
 
         /// <summary>
         /// Constructor
@@ -23,36 +23,8 @@ namespace Microsoft.Data.SqlClient.SNI
             _callback = callback;
         }
 
-        /// <summary>
-        /// SNI packet
-        /// </summary>
-        public SNIPacket Packet
-        {
-            get
-            {
-                return _packet;
-            }
+        public SNIPacket Packet => _packet;
 
-            set
-            {
-                _packet = value;
-            }
-        }
-
-        /// <summary>
-        /// Completion callback
-        /// </summary>
-        public SNIAsyncCallback Callback
-        {
-            get
-            {
-                return _callback;
-            }
-
-            set
-            {
-                _callback = value;
-            }
-        }
+        public SNIAsyncCallback Callback => _callback;
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacketPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacketPool.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.Data.SqlClient.SNI
+{
+    // this is a very simple threadsafe pool derived from the aspnet/extensions default pool implementation
+    // https://github.com/aspnet/Extensions/blob/master/src/ObjectPool/src/DefaultObjectPool.cs
+    internal sealed class SNIPacketPool
+    {
+        private readonly PacketWrapper[] _items;
+        private SNIPacket _firstItem;
+
+        public SNIPacketPool(int maximumRetained)
+        {
+            // -1 due to _firstItem
+            _items = new PacketWrapper[maximumRetained - 1];
+        }
+
+        public bool TryGet(out SNIPacket packet)
+        {
+            packet = null;
+            SNIPacket item = _firstItem;
+            if (item != null && Interlocked.CompareExchange(ref _firstItem, null, item) == item)
+            {
+                // took first item
+                packet = item;
+                return true;
+            }
+            else
+            {
+                var items = _items;
+                for (var i = 0; i < items.Length; i++)
+                {
+                    item = items[i].Element;
+                    if (item != null && Interlocked.CompareExchange(ref items[i].Element, null, item) == item)
+                    {
+                        packet = item;
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public void Return(SNIPacket packet)
+        {
+            if (_firstItem != null || Interlocked.CompareExchange(ref _firstItem, packet, null) != null)
+            {
+                var items = _items;
+                for (var i = 0; i < items.Length && Interlocked.CompareExchange(ref items[i].Element, packet, null) != null; ++i)
+                {
+                }
+            }
+        }
+
+        // PERF: the struct wrapper avoids array-covariance-checks from the runtime when assigning to elements of the array.
+        [DebuggerDisplay("{Element}")]
+        private struct PacketWrapper
+        {
+            public SNIPacket Element;
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacketPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacketPool.cs
@@ -8,7 +8,7 @@ using System.Threading;
 namespace Microsoft.Data.SqlClient.SNI
 {
     // this is a very simple threadsafe pool derived from the aspnet/extensions default pool implementation
-    // https://github.com/aspnet/Extensions/blob/master/src/ObjectPool/src/DefaultObjectPool.cs
+    // https://github.com/dotnet/extensions/blob/release/3.1/src/ObjectPool/src/DefaultObjectPool.cs
     internal sealed class SNIPacketPool
     {
         private readonly PacketWrapper[] _items;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPhysicalHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPhysicalHandle.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Data.SqlClient.SNI
+{
+    internal abstract class SNIPhysicalHandle : SNIHandle
+    {
+        protected const int DefaultPoolSize = 4;
+#if DEBUG
+        private static int s_packetId;
+#endif
+        private SNIPacketPool _pool;
+
+        protected SNIPhysicalHandle(int poolSize = DefaultPoolSize)
+        {
+            _pool = new SNIPacketPool(poolSize);
+        }
+
+        public override SNIPacket RentPacket(int headerSize, int dataSize)
+        {
+            SNIPacket packet;
+            if (!_pool.TryGet(out packet))
+            {
+#if DEBUG
+                int id = Interlocked.Increment(ref s_packetId);
+                packet = new SNIPacket(this, id);
+#else
+                packet = new SNIPacket();
+#endif
+            }
+#if DEBUG
+            else
+            {
+                Debug.Assert(packet != null, "dequeue returned null SNIPacket");
+                Debug.Assert(!packet.IsActive, "SNIPacket _refcount must be 1 or a lifetime issue has occured, trace with the #TRACE_HISTORY define");
+                Debug.Assert(packet.IsInvalid, "dequeue returned valid packet");
+                GC.ReRegisterForFinalize(packet);
+            }
+            if (packet._history != null)
+            {
+                packet._history.Add(new SNIPacket.History { Action = SNIPacket.History.Direction.Rent, Stack = GetStackParts(), RefCount = packet._refCount });
+            }
+            Interlocked.Add(ref packet._refCount, 1);
+            Debug.Assert(packet.IsActive, "SNIPacket _refcount must be 1 or a lifetime issue has occured, trace with the #TRACE_HISTORY define");
+#endif
+            packet.Allocate(headerSize, dataSize);
+            return packet;
+        }
+
+        public override void ReturnPacket(SNIPacket packet)
+        {
+            Debug.Assert(packet != null, "releasing null SNIPacket");
+#if DEBUG
+            Debug.Assert(packet.IsActive, "SNIPacket _refcount must be 1 or a lifetime issue has occured, trace with the #TRACE_HISTORY define");
+            Debug.Assert(ReferenceEquals(packet._owner, this), "releasing SNIPacket that belongs to another physical handle");
+#endif
+            Debug.Assert(!packet.IsInvalid, "releasing already released SNIPacket");
+
+            packet.Release();
+#if DEBUG
+            Interlocked.Add(ref packet._refCount, -1);
+            packet._traceTag = null;
+            if (packet._history != null)
+            {
+                packet._history.Add(new SNIPacket.History { Action = SNIPacket.History.Direction.Return, Stack = GetStackParts(), RefCount = packet._refCount });
+            }
+            GC.SuppressFinalize(packet);
+#endif
+            _pool.Return(packet);
+        }
+
+#if DEBUG
+        
+        
+        private string GetStackParts()
+        {
+            return string.Join(Environment.NewLine,
+                Environment.StackTrace
+                .Split(new string[] { Environment.NewLine },StringSplitOptions.None)
+                .Skip(3) // trims off the common parts at the top of the stack so you can see what the actual caller was
+                .Take(7) // trims off most of the bottom of the stack because when running under xunit there's a lot of spam
+            );
+        }
+#endif
+    }
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPhysicalHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPhysicalHandle.cs
@@ -78,8 +78,6 @@ namespace Microsoft.Data.SqlClient.SNI
         }
 
 #if DEBUG
-        
-        
         private string GetStackParts()
         {
             return string.Join(Environment.NewLine,

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
@@ -240,11 +240,11 @@ namespace Microsoft.Data.SqlClient.SNI
             if (sync)
             {
                 result = handle.Send(packet);
-                packet.Release();
+                handle.ReturnPacket(packet);
             }
             else
             {
-                result = handle.SendAsync(packet, true);
+                result = handle.SendAsync(packet);
             }
 
             return result;
@@ -456,15 +456,6 @@ namespace Microsoft.Data.SqlClient.SNI
         public void PacketSetData(SNIPacket packet, byte[] data, int length)
         {
             packet.AppendData(data, length);
-        }
-
-        /// <summary>
-        /// Release packet
-        /// </summary>
-        /// <param name="packet">SNI packet</param>
-        public void PacketRelease(SNIPacket packet)
-        {
-            packet.Release();
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.SqlClient.SNI
     /// <summary>
     /// TCP connection handle
     /// </summary>
-    internal sealed class SNITCPHandle : SNIHandle
+    internal sealed class SNITCPHandle : SNIPhysicalHandle
     {
         private readonly string _targetServer;
         private readonly object _callbackObject;
@@ -513,7 +513,7 @@ namespace Microsoft.Data.SqlClient.SNI
                         return TdsEnums.SNI_WAIT_TIMEOUT;
                     }
 
-                    packet = new SNIPacket(headerSize: 0, dataSize: _bufferSize);
+                    packet = RentPacket(headerSize: 0, dataSize: _bufferSize);
                     packet.ReadFromStream(_stream);
 
                     if (packet.Length == 0)
@@ -572,15 +572,14 @@ namespace Microsoft.Data.SqlClient.SNI
         /// Send a packet asynchronously
         /// </summary>
         /// <param name="packet">SNI packet</param>
-        /// <param name="disposePacketAfterSendAsync"></param>
         /// <param name="callback">Completion callback</param>
         /// <returns>SNI error code</returns>
-        public override uint SendAsync(SNIPacket packet, bool disposePacketAfterSendAsync, SNIAsyncCallback callback = null)
+        public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
         {
             SNIAsyncCallback cb = callback ?? _sendCallback;
             lock (this)
             {
-                packet.WriteToStreamAsync(_stream, cb, SNIProviders.TCP_PROV, disposePacketAfterSendAsync);
+                packet.WriteToStreamAsync(_stream, cb, SNIProviders.TCP_PROV);
             }
             return TdsEnums.SNI_SUCCESS_IO_PENDING;
         }
@@ -593,7 +592,7 @@ namespace Microsoft.Data.SqlClient.SNI
         public override uint ReceiveAsync(ref SNIPacket packet)
         {
             SNIPacket errorPacket;
-            packet = new SNIPacket(headerSize: 0, dataSize: _bufferSize);
+            packet = RentPacket(headerSize: 0, dataSize: _bufferSize);
 
             try
             {
@@ -659,7 +658,7 @@ namespace Microsoft.Data.SqlClient.SNI
         {
             if (packet != null)
             {
-                packet.Release();
+                ReturnPacket(packet);
             }
             return ReportTcpSNIError(sniException);
         }
@@ -668,7 +667,7 @@ namespace Microsoft.Data.SqlClient.SNI
         {
             if (packet != null)
             {
-                packet.Release();
+                ReturnPacket(packet);
             }
             return ReportTcpSNIError(nativeError, sniError, errorMessage);
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -59,15 +59,21 @@ namespace Microsoft.Data.SqlClient.SNI
             else if (async)
             {
                 // Create call backs and allocate to the session handle
-                SNIAsyncCallback ReceiveAsyncCallbackDispatcher = new SNIAsyncCallback(ReadAsyncCallback);
-                SNIAsyncCallback SendAsyncCallbackDispatcher = new SNIAsyncCallback(WriteAsyncCallback);
-                _sessionHandle.SetAsyncCallbacks(ReceiveAsyncCallbackDispatcher, SendAsyncCallbackDispatcher);
+                _sessionHandle.SetAsyncCallbacks(ReadAsyncCallback, WriteAsyncCallback);
             }
         }
 
-        internal void ReadAsyncCallback(SNIPacket packet, uint error) => ReadAsyncCallback(IntPtr.Zero, PacketHandle.FromManagedPacket(packet), error);
+        internal void ReadAsyncCallback(SNIPacket packet, uint error)
+        {
+            ReadAsyncCallback(IntPtr.Zero, PacketHandle.FromManagedPacket(packet), error);
+            _sessionHandle.ReturnPacket(packet);
+        }
 
-        internal void WriteAsyncCallback(SNIPacket packet, uint sniError) => WriteAsyncCallback(IntPtr.Zero, PacketHandle.FromManagedPacket(packet), sniError);
+        internal void WriteAsyncCallback(SNIPacket packet, uint sniError)
+        {
+            WriteAsyncCallback(IntPtr.Zero, PacketHandle.FromManagedPacket(packet), sniError);
+            _sessionHandle.ReturnPacket(packet);
+        }
 
         protected override void RemovePacketFromPendingList(PacketHandle packet)
         {
@@ -109,8 +115,7 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 throw ADP.ClosedConnectionError();
             }
-            SNIPacket packet = null;
-            error = SNIProxy.Singleton.ReadSyncOverAsync(handle, out packet, timeoutRemaining);
+            error = SNIProxy.Singleton.ReadSyncOverAsync(handle, out SNIPacket packet, timeoutRemaining);
             return PacketHandle.FromManagedPacket(packet);
         }
 
@@ -118,7 +123,15 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal override bool IsPacketEmpty(PacketHandle packet) => packet.ManagedPacket == null;
 
-        internal override void ReleasePacket(PacketHandle syncReadPacket) => syncReadPacket.ManagedPacket?.Release();
+        internal override void ReleasePacket(PacketHandle syncReadPacket)
+        {
+            SNIPacket packet = syncReadPacket.ManagedPacket;
+            if (packet != null)
+            {
+                SNIHandle handle = Handle;
+                handle.ReturnPacket(packet);
+            }
+        }
 
         internal override uint CheckConnection()
         {
@@ -135,6 +148,9 @@ namespace Microsoft.Data.SqlClient.SNI
         internal override PacketHandle CreateAndSetAttentionPacket()
         {
             PacketHandle packetHandle = GetResetWritePacket(TdsEnums.HEADER_LEN);
+#if DEBUG
+            Debug.Assert(packetHandle.ManagedPacket.IsActive, "rental packet is not active a serious pooling error may have occured");
+#endif
             SetPacketData(packetHandle, SQL.AttentionHeader, TdsEnums.HEADER_LEN);
             packetHandle.ManagedPacket.IsOutOfBand = true;
             return packetHandle;
@@ -158,8 +174,12 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal override PacketHandle GetResetWritePacket(int dataSize)
         {
-            var packet = new SNIPacket(headerSize: _sessionHandle.ReserveHeaderSize, dataSize: dataSize);
-            Debug.Assert(packet.ReservedHeaderSize == _sessionHandle.ReserveHeaderSize, "failed to reserve header");
+            SNIHandle handle = Handle;
+            SNIPacket packet = handle.RentPacket(headerSize: handle.ReserveHeaderSize, dataSize: dataSize);
+#if DEBUG
+            Debug.Assert(packet.IsActive, "packet is not active, a serious pooling error may have occured");
+#endif
+            Debug.Assert(packet.ReservedHeaderSize == handle.ReserveHeaderSize, "failed to reserve header");
             return PacketHandle.FromManagedPacket(packet);
         }
 


### PR DESCRIPTION
When using the managed network interface `SNIPacket` instances are used to contain data being sent and received from the socket stream. These packets rent their buffers from the arraypool to try and make sure we aren't constantly allocating and discarding (by default 8K) large arrays, this isn't being particularly effective because a lot of packet instances are being dropped to the GC which loses the array to the GC as well. This isn't harmful it just isn't a good use of the arraypool. The arrays allocated are the most prevalent class in memory traces.

![packetrecycle-before](https://user-images.githubusercontent.com/13322696/72681576-d761e080-3abc-11ea-96e9-cea729913910.PNG)


This PR add a new class in the handle hierarchy, the `SNIPhysicalHandle` and adds a packet pool to it. The packet pool implementation is derived from a very simple one used and tested in the aspnet extensions repo. The physical handle is used as the base class for named pipe and tcp handles, mars handle composes those and defers to the physical connection for abstract members. The abstract members are used to rent and return packets to the pool. This means that each 'real' connection has a packet pool and that packets used to read and write from the physical connection will be served from that pool. The pool is small and I think that each pool should usually contain no more than 3 packets, 1 send, I receive, 1 attn but it can contain more. It isn't invalid to use more packets than are in the pool as long as they are created and disposed through the pool. Mars will need more packets for partial packet reconstruction.

In order to track the lifetime of packets and make sure they were always sourced and returned from the pool needed to add a lot of debugging infrastructure to the packet and pool. This allowed me to track down a subtle packet reuse bug that was fixed in https://github.com/dotnet/SqlClient/pull/350 This code is debug only mostly. There is some additional tracing put on a compiler #define in the packet to allow tracing of individual packets, this is very performance expensive but very valuable when you need to know what is really going on with a piece of data.

Reuse of packets cleans up quite a lot of lifetime handling code and means that read and write paths no longer need to care about who is responsible for cleaning up the packet, it's handled elsewhere. It also means that the allocation of the async read callback can be cached and reused which is another small memory save..

This has passed all the tests and I've put it through some pretty punishing benching with the DataAccessPerformance benchmark project used to test throughput performance. It's stable and roughly 7% faster on my configuration.

| Configuration | Throughput | StdDev | Name 
| --- | --- | --- | ---
| ado-sqlclient+async+32|31225|1798|managed master
| ado-sqlclient+async+32|33519|2059|managed recycle