### PR TITLE
Add Enclave Simulator for Internal Testing

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionAttestationProtocol.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionAttestationProtocol.xml
@@ -13,6 +13,10 @@
             <summary>Attestation portocol for Azure Attestation Service</summary>
             <value>1</value>
         </AAS>
+        <SIM>
+            <summary>Attestation protocol for Simulator</summary>
+            <value>2</value>
+        </SIM>
         <HGS>
             <summary>Attestation protocol for Host Guardian Service</summary>
              <value>3</value>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,6 +39,10 @@
     <DotNetCmd>$(DotNetRoot)dotnet</DotNetCmd>
     <DotNetCmd Condition="'$(OS)' == 'Windows_NT'">$(DotNetCmd).exe</DotNetCmd>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <BuildSimulator Condition="'$(BuildSimulator)' != 'true'">false</BuildSimulator>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BuildSimulator)' == 'true'">
+    <DefineConstants>$(DefineConstants);ENCLAVE_SIMULATOR</DefineConstants>
   </PropertyGroup>
 
   <!-- Provides Version properties -->

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.NetCoreApp.cs
@@ -113,6 +113,11 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/AAS/*' />
         AAS = 1,
 
+#if ENCLAVE_SIMULATOR
+        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/SIM/*' />
+        SIM = 2,
+#endif
+
         /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/HGS/*' />
         HGS = 3
     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -53,6 +53,9 @@
     <Compile Include="Microsoft\Data\SqlClient\EnclaveProviderBase.NetCoreApp.cs" />
     <Compile Include="Microsoft\Data\SqlClient\EnclaveSessionCache.NetCoreApp.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetGroup)' == 'netcoreapp' AND '$(BuildSimulator)' == 'true'">
+    <Compile Include="Microsoft\Data\SqlClient\SimulatorEnclaveProvider.NetCoreApp.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetGroup)' == 'netstandard'">
     <Compile Include="Microsoft\Data\SqlClient\SqlDelegatedTransaction.NetStandard.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParser.NetStandard.cs" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
@@ -221,6 +221,9 @@ namespace Microsoft.Data.Common
         /// </summary>
         const string AttestationProtocolHGS = "HGS";
         const string AttestationProtocolAAS = "AAS";
+#if ENCLAVE_SIMULATOR
+        const string AttestationProtocolSIM = "SIM";
+#endif
 
         /// <summary>
         ///  Convert a string value to the corresponding SqlConnectionAttestationProtocol
@@ -240,6 +243,13 @@ namespace Microsoft.Data.Common
                 result = SqlConnectionAttestationProtocol.AAS;
                 return true;
             }
+#if ENCLAVE_SIMULATOR
+            else if (StringComparer.InvariantCultureIgnoreCase.Equals(value, AttestationProtocolSIM))
+            {
+                result = SqlConnectionAttestationProtocol.SIM;
+                return true;
+            }
+#endif
             else
             {
                 result = DbConnectionStringDefaults.AttestationProtocol;
@@ -249,11 +259,18 @@ namespace Microsoft.Data.Common
 
         internal static bool IsValidAttestationProtocol(SqlConnectionAttestationProtocol value)
         {
+#if ENCLAVE_SIMULATOR
+            Debug.Assert(Enum.GetNames(typeof(SqlConnectionAttestationProtocol)).Length == 4, "SqlConnectionAttestationProtocol enum has changed, update needed");
+            return value == SqlConnectionAttestationProtocol.NotSpecified
+                || value == SqlConnectionAttestationProtocol.HGS
+                || value == SqlConnectionAttestationProtocol.AAS
+                || value == SqlConnectionAttestationProtocol.SIM;
+#else
             Debug.Assert(Enum.GetNames(typeof(SqlConnectionAttestationProtocol)).Length == 3, "SqlConnectionAttestationProtocol enum has changed, update needed");
             return value == SqlConnectionAttestationProtocol.NotSpecified
                 || value == SqlConnectionAttestationProtocol.HGS
                 || value == SqlConnectionAttestationProtocol.AAS;
-
+#endif
         }
 
         internal static string AttestationProtocolToString(SqlConnectionAttestationProtocol value)
@@ -266,6 +283,10 @@ namespace Microsoft.Data.Common
                     return AttestationProtocolHGS;
                 case SqlConnectionAttestationProtocol.AAS:
                     return AttestationProtocolAAS;
+#if ENCLAVE_SIMULATOR
+                case SqlConnectionAttestationProtocol.SIM:
+                    return AttestationProtocolSIM;
+#endif
                 default:
                     return null;
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetCoreApp.cs
@@ -166,6 +166,14 @@ namespace Microsoft.Data.SqlClient
                         sqlColumnEncryptionEnclaveProvider = EnclaveProviders[attestationProtocol];
                         break;
 
+#if ENCLAVE_SIMULATOR
+                    case SqlConnectionAttestationProtocol.SIM:
+                        SimulatorEnclaveProvider simulatorEnclaveProvider = new SimulatorEnclaveProvider();
+                        EnclaveProviders[attestationProtocol] = (SqlColumnEncryptionEnclaveProvider)simulatorEnclaveProvider;
+                        sqlColumnEncryptionEnclaveProvider = EnclaveProviders[attestationProtocol];
+                        break;
+#endif
+
                     default:
                         break;
                 }
@@ -188,6 +196,11 @@ namespace Microsoft.Data.SqlClient
 
                 case SqlConnectionAttestationProtocol.HGS:
                     return "HGS";
+
+#if ENCLAVE_SIMULATOR
+                case SqlConnectionAttestationProtocol.SIM:
+                    return "SIM";
+#endif
 
                 default:
                     return "NotSpecified";

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.NetCoreApp.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.Caching;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+
+namespace Microsoft.Data.SqlClient
+{
+    internal class SimulatorEnclaveProvider : EnclaveProviderBase
+    {
+        private static readonly int EnclaveSessionHandleSize = 8;
+
+        // When overridden in a derived class, looks up an existing enclave session information in the enclave session cache.
+        // If the enclave provider doesn't implement enclave session caching, this method is expected to return null in the sqlEnclaveSession parameter.
+        public override void GetEnclaveSession(string servername, string attestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
+        {
+            GetEnclaveSessionHelper(servername, attestationUrl, false, out sqlEnclaveSession, out counter, out customData, out customDataLength);
+        }
+
+        // Gets the information that SqlClient subsequently uses to initiate the process of attesting the enclave and to establish a secure session with the enclave.
+        // <returns>The information SqlClient subsequently uses to initiate the process of attesting the enclave and to establish a secure session with the enclave.</returns>
+        public override SqlEnclaveAttestationParameters GetAttestationParameters(string attestationUrl, byte[] customData, int customDataLength)
+        {
+            ECDiffieHellmanCng clientDHKey = new ECDiffieHellmanCng(384);
+            clientDHKey.KeyDerivationFunction = ECDiffieHellmanKeyDerivationFunction.Hash;
+            clientDHKey.HashAlgorithm = CngAlgorithm.Sha256;
+
+            return new SqlEnclaveAttestationParameters(2, new byte[] { }, clientDHKey);
+        }
+
+        // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
+        public override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        {
+            ////for simulator: enclave does not send public key, and sends an empty attestation info
+            //// The only non-trivial content it sends is the session setup info (DH pubkey of enclave)
+
+            sqlEnclaveSession = null;
+            counter = 0;
+            try
+            {
+                ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
+                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, out counter);
+
+                if (sqlEnclaveSession == null)
+                {
+                    if (!string.IsNullOrEmpty(attestationUrl))
+                    {
+                        ////Read AttestationInfo
+                        int attestationInfoOffset = 0;
+                        uint sizeOfTrustedModuleAttestationInfoBuffer = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
+                        attestationInfoOffset += sizeof(UInt32);
+                        int sizeOfTrustedModuleAttestationInfoBufferInt = checked((int)sizeOfTrustedModuleAttestationInfoBuffer);
+                        Debug.Assert(sizeOfTrustedModuleAttestationInfoBuffer == 0);
+
+                        ////read secure session info
+                        uint sizeOfSecureSessionInfoResponse = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
+                        attestationInfoOffset += sizeof(UInt32);
+
+                        byte[] enclaveSessionHandle = new byte[EnclaveSessionHandleSize];
+                        Buffer.BlockCopy(attestationInfo, attestationInfoOffset, enclaveSessionHandle, 0, EnclaveSessionHandleSize);
+                        attestationInfoOffset += EnclaveSessionHandleSize;
+
+                        uint sizeOfTrustedModuleDHPublicKeyBuffer = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
+                        attestationInfoOffset += sizeof(UInt32);
+                        uint sizeOfTrustedModuleDHPublicKeySignatureBuffer = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
+                        attestationInfoOffset += sizeof(UInt32);
+                        int sizeOfTrustedModuleDHPublicKeyBufferInt = checked((int)sizeOfTrustedModuleDHPublicKeyBuffer);
+
+                        byte[] trustedModuleDHPublicKey = new byte[sizeOfTrustedModuleDHPublicKeyBuffer];
+                        Buffer.BlockCopy(attestationInfo, attestationInfoOffset, trustedModuleDHPublicKey, 0,
+                            sizeOfTrustedModuleDHPublicKeyBufferInt);
+                        attestationInfoOffset += sizeOfTrustedModuleDHPublicKeyBufferInt;
+
+                        byte[] trustedModuleDHPublicKeySignature = new byte[sizeOfTrustedModuleDHPublicKeySignatureBuffer];
+                        Buffer.BlockCopy(attestationInfo, attestationInfoOffset, trustedModuleDHPublicKeySignature, 0,
+                            checked((int)sizeOfTrustedModuleDHPublicKeySignatureBuffer));
+
+                        CngKey k = CngKey.Import(trustedModuleDHPublicKey, CngKeyBlobFormat.EccPublicBlob);
+                        byte[] sharedSecret = clientDHKey.DeriveKeyMaterial(k);
+                        long sessionId = BitConverter.ToInt64(enclaveSessionHandle, 0);
+                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, sharedSecret, sessionId, out counter);
+                    }
+                    else
+                    {
+                        throw new AlwaysEncryptedAttestationException(SR.FailToCreateEnclaveSession);
+                    }
+                }
+            }
+            finally
+            {
+                UpdateEnclaveSessionLockStatus(sqlEnclaveSession);
+            }
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
+        /// </summary>
+        /// <param name="serverName">The name of the SQL Server instance containing the enclave.</param>
+        /// <param name="enclaveAttestationUrl">The endpoint of an attestation service, SqlClient contacts to attest the enclave.</param>
+        /// <param name="enclaveSessionToInvalidate">The session to be invalidated.</param>
+        public override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        {
+            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, enclaveSessionToInvalidate);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -983,6 +983,9 @@ namespace Microsoft.Data.SqlClient
         internal const int AEAD_AES_256_CBC_HMAC_SHA256 = 2;
         internal const string ENCLAVE_TYPE_VBS = "VBS";
         internal const string ENCLAVE_TYPE_SGX = "SGX";
+#if ENCLAVE_SIMULATOR
+        internal const string ENCLAVE_TYPE_SIMULATOR = "SIMULATOR";
+#endif
 
         // TCE Param names for exec handling
         internal const string TCE_PARAM_CIPHERTEXT = "cipherText";
@@ -1055,6 +1058,11 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/AAS/*' />
         AAS = 1,
+
+#if ENCLAVE_SIMULATOR
+        /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/SIM/*' />
+        SIM = 2,
+#endif
 
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/HGS/*' />
         HGS = 3
@@ -1159,4 +1167,3 @@ namespace Microsoft.Data.SqlClient
         AttestationInfo = 0,
     }
 }
-

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3017,23 +3017,41 @@ namespace Microsoft.Data.SqlClient
 
         private bool IsValidAttestationProtocol(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType)
         {
-            switch (enclaveType)
+            switch (enclaveType.ToUpper())
             {
                 case TdsEnums.ENCLAVE_TYPE_VBS:
                     if (attestationProtocol != SqlConnectionAttestationProtocol.AAS
+#if ENCLAVE_SIMULATOR
+                        && attestationProtocol != SqlConnectionAttestationProtocol.HGS
+                        && attestationProtocol != SqlConnectionAttestationProtocol.SIM)
+#else
                         && attestationProtocol != SqlConnectionAttestationProtocol.HGS)
+#endif
                     {
                         return false;
                     }
                     break;
 
                 case TdsEnums.ENCLAVE_TYPE_SGX:
+#if ENCLAVE_SIMULATOR
+                    if (attestationProtocol != SqlConnectionAttestationProtocol.AAS
+                        && attestationProtocol != SqlConnectionAttestationProtocol.SIM)
+#else
                     if (attestationProtocol != SqlConnectionAttestationProtocol.AAS)
+#endif
                     {
                         return false;
                     }
                     break;
 
+#if ENCLAVE_SIMULATOR
+                case TdsEnums.ENCLAVE_TYPE_SIMULATOR:
+                    if (attestationProtocol != SqlConnectionAttestationProtocol.SIM)
+                    {
+                        return false;
+                    }
+                    break;
+#endif
                 default:
                     // if we reach here, the enclave type is not supported
                     throw SQL.EnclaveTypeNotSupported(enclaveType);
@@ -3051,6 +3069,11 @@ namespace Microsoft.Data.SqlClient
 
                 case SqlConnectionAttestationProtocol.HGS:
                     return "HGS";
+
+#if ENCLAVE_SIMULATOR
+                case SqlConnectionAttestationProtocol.SIM:
+                    return "SIM";
+#endif
 
                 default:
                     return "NotSpecified";

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3022,11 +3022,9 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.ENCLAVE_TYPE_VBS:
                     if (attestationProtocol != SqlConnectionAttestationProtocol.AAS
 #if ENCLAVE_SIMULATOR
-                        && attestationProtocol != SqlConnectionAttestationProtocol.HGS
-                        && attestationProtocol != SqlConnectionAttestationProtocol.SIM)
-#else
-                        && attestationProtocol != SqlConnectionAttestationProtocol.HGS)
+                        && attestationProtocol != SqlConnectionAttestationProtocol.SIM
 #endif
+                        && attestationProtocol != SqlConnectionAttestationProtocol.HGS)
                     {
                         return false;
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -801,6 +801,11 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/AAS/*' />
         AAS = 1,
 
+#if ENCLAVE_SIMULATOR
+        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/SIM/*' />
+        SIM = 2,
+#endif
+
         /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/HGS/*' />
         HGS = 3
     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -309,6 +309,9 @@
     <Compile Include="Microsoft\Data\ProviderBase\FieldNameLookup.cs" />
     <Compile Include="Microsoft\Data\OperationAbortedException.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(BuildSimulator)' == 'true'">
+    <Compile Include="Microsoft\Data\SqlClient\SimulatorEnclaveProvider.cs" />
+  </ItemGroup>
   <!-- Resources  -->
   <ItemGroup>
     <Compile Include="Resources\$(ResxFileName).Designer.cs">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
@@ -822,6 +822,9 @@ namespace Microsoft.Data.Common
         /// </summary>
         const string AttestationProtocolHGS = "HGS";
         const string AttestationProtocolAAS = "AAS";
+#if ENCLAVE_SIMULATOR
+        const string AttestationProtocolSIM = "SIM";
+#endif
 
         /// <summary>
         ///  Convert a string value to the corresponding SqlConnectionAttestationProtocol
@@ -841,6 +844,13 @@ namespace Microsoft.Data.Common
                 result = SqlConnectionAttestationProtocol.AAS;
                 return true;
             }
+#if ENCLAVE_SIMULATOR
+            else if (StringComparer.InvariantCultureIgnoreCase.Equals(value, AttestationProtocolSIM))
+            {
+                result = SqlConnectionAttestationProtocol.SIM;
+                return true;
+            }
+#endif
             else
             {
                 result = DbConnectionStringDefaults.AttestationProtocol;
@@ -850,11 +860,18 @@ namespace Microsoft.Data.Common
 
         internal static bool IsValidAttestationProtocol(SqlConnectionAttestationProtocol value)
         {
+#if ENCLAVE_SIMULATOR
+            Debug.Assert(Enum.GetNames(typeof(SqlConnectionAttestationProtocol)).Length == 4, "SqlConnectionAttestationProtocol enum has changed, update needed");
+            return value == SqlConnectionAttestationProtocol.NotSpecified
+                || value == SqlConnectionAttestationProtocol.HGS
+                || value == SqlConnectionAttestationProtocol.AAS
+                || value == SqlConnectionAttestationProtocol.SIM;
+#else
             Debug.Assert(Enum.GetNames(typeof(SqlConnectionAttestationProtocol)).Length == 3, "SqlConnectionAttestationProtocol enum has changed, update needed");
             return value == SqlConnectionAttestationProtocol.NotSpecified
                 || value == SqlConnectionAttestationProtocol.HGS
                 || value == SqlConnectionAttestationProtocol.AAS;
-
+#endif
         }
 
         internal static string AttestationProtocolToString(SqlConnectionAttestationProtocol value)
@@ -867,6 +884,10 @@ namespace Microsoft.Data.Common
                     return AttestationProtocolHGS;
                 case SqlConnectionAttestationProtocol.AAS:
                     return AttestationProtocolAAS;
+#if ENCLAVE_SIMULATOR
+                case SqlConnectionAttestationProtocol.SIM:
+                    return AttestationProtocolSIM;
+#endif
                 default:
                     return null;
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
@@ -212,6 +212,14 @@ namespace Microsoft.Data.SqlClient
                         sqlColumnEncryptionEnclaveProvider = EnclaveProviders[attestationProtocol];
                         break;
 
+#if ENCLAVE_SIMULATOR
+                    case SqlConnectionAttestationProtocol.SIM:
+                        SimulatorEnclaveProvider simulatorEnclaveProvider = new SimulatorEnclaveProvider();
+                        EnclaveProviders[attestationProtocol] = (SqlColumnEncryptionEnclaveProvider)simulatorEnclaveProvider;
+                        sqlColumnEncryptionEnclaveProvider = EnclaveProviders[attestationProtocol];
+                        break;
+#endif
+
                     default:
                         break;
                 }
@@ -234,6 +242,11 @@ namespace Microsoft.Data.SqlClient
 
                 case SqlConnectionAttestationProtocol.HGS:
                     return "HGS";
+
+#if ENCLAVE_SIMULATOR
+                case SqlConnectionAttestationProtocol.SIM:
+                    return "SIM";
+#endif
 
                 default:
                     return "NotSpecified";

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.Caching;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+
+namespace Microsoft.Data.SqlClient
+{
+    internal class SimulatorEnclaveProvider : EnclaveProviderBase
+    {
+        private static readonly int EnclaveSessionHandleSize = 8;
+
+        // When overridden in a derived class, looks up an existing enclave session information in the enclave session cache.
+        // If the enclave provider doesn't implement enclave session caching, this method is expected to return null in the sqlEnclaveSession parameter.
+        public override void GetEnclaveSession(string servername, string attestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
+        {
+            GetEnclaveSessionHelper(servername, attestationUrl, false, out sqlEnclaveSession, out counter, out customData, out customDataLength);
+        }
+
+        // Gets the information that SqlClient subsequently uses to initiate the process of attesting the enclave and to establish a secure session with the enclave.
+        // <returns>The information SqlClient subsequently uses to initiate the process of attesting the enclave and to establish a secure session with the enclave.</returns>
+        public override SqlEnclaveAttestationParameters GetAttestationParameters(string attestationUrl, byte[] customData, int customDataLength)
+        {
+            ECDiffieHellmanCng clientDHKey = new ECDiffieHellmanCng(384);
+            clientDHKey.KeyDerivationFunction = ECDiffieHellmanKeyDerivationFunction.Hash;
+            clientDHKey.HashAlgorithm = CngAlgorithm.Sha256;
+
+            return new SqlEnclaveAttestationParameters(2, new byte[] { }, clientDHKey);
+        }
+
+        // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
+        public override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        {
+            ////for simulator: enclave does not send public key, and sends an empty attestation info
+            //// The only non-trivial content it sends is the session setup info (DH pubkey of enclave)
+
+            sqlEnclaveSession = null;
+            counter = 0;
+            try
+            {
+                ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
+                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, out counter);
+
+                if (sqlEnclaveSession == null)
+                {
+                    if (!string.IsNullOrEmpty(attestationUrl))
+                    {
+                        ////Read AttestationInfo
+                        int attestationInfoOffset = 0;
+                        uint sizeOfTrustedModuleAttestationInfoBuffer = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
+                        attestationInfoOffset += sizeof(UInt32);
+                        int sizeOfTrustedModuleAttestationInfoBufferInt = checked((int)sizeOfTrustedModuleAttestationInfoBuffer);
+                        Debug.Assert(sizeOfTrustedModuleAttestationInfoBuffer == 0);
+
+                        ////read secure session info
+                        uint sizeOfSecureSessionInfoResponse = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
+                        attestationInfoOffset += sizeof(UInt32);
+
+                        byte[] enclaveSessionHandle = new byte[EnclaveSessionHandleSize];
+                        Buffer.BlockCopy(attestationInfo, attestationInfoOffset, enclaveSessionHandle, 0, EnclaveSessionHandleSize);
+                        attestationInfoOffset += EnclaveSessionHandleSize;
+
+                        uint sizeOfTrustedModuleDHPublicKeyBuffer = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
+                        attestationInfoOffset += sizeof(UInt32);
+                        uint sizeOfTrustedModuleDHPublicKeySignatureBuffer = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
+                        attestationInfoOffset += sizeof(UInt32);
+                        int sizeOfTrustedModuleDHPublicKeyBufferInt = checked((int)sizeOfTrustedModuleDHPublicKeyBuffer);
+
+                        byte[] trustedModuleDHPublicKey = new byte[sizeOfTrustedModuleDHPublicKeyBuffer];
+                        Buffer.BlockCopy(attestationInfo, attestationInfoOffset, trustedModuleDHPublicKey, 0,
+                            sizeOfTrustedModuleDHPublicKeyBufferInt);
+                        attestationInfoOffset += sizeOfTrustedModuleDHPublicKeyBufferInt;
+
+                        byte[] trustedModuleDHPublicKeySignature = new byte[sizeOfTrustedModuleDHPublicKeySignatureBuffer];
+                        Buffer.BlockCopy(attestationInfo, attestationInfoOffset, trustedModuleDHPublicKeySignature, 0,
+                            checked((int)sizeOfTrustedModuleDHPublicKeySignatureBuffer));
+
+                        CngKey k = CngKey.Import(trustedModuleDHPublicKey, CngKeyBlobFormat.EccPublicBlob);
+                        byte[] sharedSecret = clientDHKey.DeriveKeyMaterial(k);
+                        long sessionId = BitConverter.ToInt64(enclaveSessionHandle, 0);
+                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, sharedSecret, sessionId, out counter);
+                    }
+                    else
+                    {
+                        throw new AlwaysEncryptedAttestationException(Strings.FailToCreateEnclaveSession);
+                    }
+                }
+            }
+            finally
+            {
+                UpdateEnclaveSessionLockStatus(sqlEnclaveSession);
+            }
+        }
+
+        /// <summary>
+        /// When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
+        /// </summary>
+        /// <param name="serverName">The name of the SQL Server instance containing the enclave.</param>
+        /// <param name="enclaveAttestationUrl">The endpoint of an attestation service, SqlClient contacts to attest the enclave.</param>
+        /// <param name="enclaveSessionToInvalidate">The session to be invalidated.</param>
+        public override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        {
+            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, enclaveSessionToInvalidate);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -947,7 +947,9 @@ namespace Microsoft.Data.SqlClient
         internal const int AEAD_AES_256_CBC_HMAC_SHA256 = 2;
         internal const string ENCLAVE_TYPE_VBS = "VBS";
         internal const string ENCLAVE_TYPE_SGX = "SGX";
-
+#if ENCLAVE_SIMULATOR
+        internal const string ENCLAVE_TYPE_SIMULATOR = "SIMULATOR";
+#endif
         // TCE Param names for exec handling
         internal const string TCE_PARAM_CIPHERTEXT = "cipherText";
         internal const string TCE_PARAM_CIPHER_ALGORITHM_ID = "cipherAlgorithmId";
@@ -1045,6 +1047,11 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/AAS/*' />
         AAS = 1,
+
+#if ENCLAVE_SIMULATOR
+        /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/SIM/*' />
+        SIM = 2,
+#endif
 
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/HGS/*' />
         HGS = 3

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3490,11 +3490,9 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.ENCLAVE_TYPE_VBS:
                     if (attestationProtocol != SqlConnectionAttestationProtocol.AAS
 #if ENCLAVE_SIMULATOR
-                        && attestationProtocol != SqlConnectionAttestationProtocol.HGS
-                        && attestationProtocol != SqlConnectionAttestationProtocol.SIM)
-#else
-                        && attestationProtocol != SqlConnectionAttestationProtocol.HGS)
+                        && attestationProtocol != SqlConnectionAttestationProtocol.SIM
 #endif
+                        && attestationProtocol != SqlConnectionAttestationProtocol.HGS)
                     {
                         return false;
                     }


### PR DESCRIPTION
- Added support for enclave simulator bypassing the actual attestation.
- Added `BuildSimulator` property to enable the simulator support.

How to use the enclave simulator: 

Given `Attestation Protocol = SIM` and `Enclave Attestation Url= dummyURL` in the connection string and run the AE enclave-enabled tests.

NOTE:  This change is for internal testing only. The simulator support should be disabled in the official nuget package releases.