### PR TITLE
Document exceptions SqlConnection constructors might throw

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml
@@ -115,12 +115,14 @@ using (SqlConnection connection = new SqlConnection(connectionString))
   
  ]]></format>
             </remarks>
+            <exception cref="T:System.ArgumentException">The supplied connection string argument failed <see cref="T:Microsoft.Data.SqlClient.SqlConnection.ConnectionString" /> validation.</exception>
         </ctorConnectionString>
         <ctorConnectionStringCredential>
             <param name="connectionString">A connection string that does not use any of the following connection string keywords: <see langword="Integrated Security = true" />, <see langword="UserId" />, or <see langword="Password" />; or that does not use <see langword="ContextConnection = true" />.</param>
             <param name="credential">A <see cref="T:Microsoft.Data.SqlClient.SqlCredential" /> object. If <paramref name="credential" /> is null, <see cref="M:Microsoft.Data.SqlClient.SqlConnection.#ctor(System.String,Microsoft.Data.SqlClient.SqlCredential)" /> is functionally equivalent to <see cref="M:Microsoft.Data.SqlClient.SqlConnection.#ctor(System.String)" />.</param>
             <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.SqlConnection" /> class given a connection string, that does not use <see langword="Integrated Security = true" /> and a <see cref="T:Microsoft.Data.SqlClient.SqlCredential" /> object that contains the user ID and password.</summary>
             <remarks>To be added.</remarks>
+            <exception cref="T:System.ArgumentException">The supplied arguments failed validation, including <see cref="T:Microsoft.Data.SqlClient.SqlConnection.ConnectionString" /> validation.</exception>
         </ctorConnectionStringCredential>
         <AccessToken>
             <summary>Gets or sets the access token for the connection.</summary>


### PR DESCRIPTION
This doc issue against S.D.SqlClient exists for M.D.SqlClient, too:
https://github.com/dotnet/dotnet-api-docs/issues/3468

Creating this PR so we don't miss it. Do we have documentation on how to validate doc edits? (I'm not 100% sure this change is syntactically correct.)