### PR TITLE
Fix access token behavior in connection pool

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Data.SqlClient
             SqlConnectionPoolKey key = obj as SqlConnectionPoolKey;
             return (key != null
                 && _credential == key._credential
-                && string.CompareOrdinal(ConnectionString, key.ConnectionString) == 0
+                && ConnectionString == key.ConnectionString
                 && string.CompareOrdinal(_accessToken, key._accessToken) == 0);
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.SqlClient
         public override bool Equals(object obj)
         {
             SqlConnectionPoolKey key = obj as SqlConnectionPoolKey;
-            return (key != null && _credential == key._credential && ConnectionString == key.ConnectionString && Object.ReferenceEquals(_accessToken, key._accessToken));
+            return (key != null && _credential == key._credential && ConnectionString == key.ConnectionString && _accessToken == key._accessToken);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
@@ -63,7 +63,10 @@ namespace Microsoft.Data.SqlClient
         public override bool Equals(object obj)
         {
             SqlConnectionPoolKey key = obj as SqlConnectionPoolKey;
-            return (key != null && _credential == key._credential && ConnectionString == key.ConnectionString && _accessToken == key._accessToken);
+            return (key != null
+                && _credential == key._credential
+                && string.CompareOrdinal(ConnectionString, key.ConnectionString) == 0
+                && string.CompareOrdinal(_accessToken, key._accessToken) == 0);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
@@ -109,8 +109,8 @@ namespace Microsoft.Data.SqlClient
 
             return (key != null &&
                     _credential == key._credential &&
-                    ConnectionString == key.ConnectionString &&
-                    _accessToken == key._accessToken &&
+                    string.CompareOrdinal(ConnectionString, key.ConnectionString) == 0 &&
+                    string.CompareOrdinal(_accessToken, key._accessToken) == 0 &&
                     _serverCertificateValidationCallback == key._serverCertificateValidationCallback &&
                     _clientCertificateRetrievalCallback == key._clientCertificateRetrievalCallback &&
                     _originalNetworkAddressInfo == key._originalNetworkAddressInfo);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Data.SqlClient
             return (key != null &&
                     _credential == key._credential &&
                     ConnectionString == key.ConnectionString &&
-                    Object.ReferenceEquals(_accessToken, key._accessToken) &&
+                    _accessToken == key._accessToken &&
                     _serverCertificateValidationCallback == key._serverCertificateValidationCallback &&
                     _clientCertificateRetrievalCallback == key._clientCertificateRetrievalCallback &&
                     _originalNetworkAddressInfo == key._originalNetworkAddressInfo);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionPoolKey.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Data.SqlClient
 
             return (key != null &&
                     _credential == key._credential &&
-                    string.CompareOrdinal(ConnectionString, key.ConnectionString) == 0 &&
+                    ConnectionString == key.ConnectionString &&
                     string.CompareOrdinal(_accessToken, key._accessToken) == 0 &&
                     _serverCertificateValidationCallback == key._serverCertificateValidationCallback &&
                     _clientCertificateRetrievalCallback == key._clientCertificateRetrievalCallback &&

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -11,9 +11,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -26,8 +28,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static readonly string TCPConnectionStringHGSVBS = null;
         public static readonly string TCPConnectionStringAASVBS = null;
         public static readonly string TCPConnectionStringAASSGX = null;
-        public static readonly string AADAccessToken = null;
+        public static readonly string AADAuthorityURL = null;
         public static readonly string AADPasswordConnectionString = null;
+        public static readonly string AADAccessToken = null;
         public static readonly string AKVBaseUrl = null;
         public static readonly string AKVUrl = null;
         public static readonly string AKVClientId = null;
@@ -60,7 +63,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             public string TCPConnectionStringHGSVBS = null;
             public string TCPConnectionStringAASVBS = null;
             public string TCPConnectionStringAASSGX = null;
-            public string AADAccessToken = null;
+            public string AADAuthorityURL = null;
             public string AADPasswordConnectionString = null;
             public string AzureKeyVaultURL = null;
             public string AzureKeyVaultClientId = null;
@@ -83,12 +86,19 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 TCPConnectionStringHGSVBS = c.TCPConnectionStringHGSVBS;
                 TCPConnectionStringAASVBS = c.TCPConnectionStringAASVBS;
                 TCPConnectionStringAASSGX = c.TCPConnectionStringAASSGX;
-                AADAccessToken = c.AADAccessToken;
+                AADAuthorityURL = c.AADAuthorityURL;
                 AADPasswordConnectionString = c.AADPasswordConnectionString;
                 SupportsLocalDb = c.SupportsLocalDb;
                 SupportsIntegratedSecurity = c.SupportsIntegratedSecurity;
                 SupportsFileStream = c.SupportsFileStream;
                 EnclaveEnabled = c.EnclaveEnabled;
+
+                if (IsAADPasswordConnStrSetup())
+                {
+                    string username = RetrieveValueFromConnStr(AADPasswordConnectionString, new string[] { "User ID", "UID" });
+                    string password = RetrieveValueFromConnStr(AADPasswordConnectionString, new string[] { "Password", "PWD" });
+                    AADAccessToken = GenerateAccessToken(AADAuthorityURL, username, password);
+                }
 
                 string url = c.AzureKeyVaultURL;
                 Uri AKVBaseUri = null;
@@ -133,6 +143,41 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 }
             }
         }
+
+        private static string GenerateAccessToken(string authorityURL, string aADAuthUserID, string aADAuthPassword)
+        {
+            return AcquireTokenAsync(authorityURL, aADAuthUserID, aADAuthPassword).Result;
+        }
+
+        private static Task<string> AcquireTokenAsync(string authorityURL, string userID, string password) => Task.Run(() =>
+        {
+            // The below properties are set specific to test configurations.
+            string scope = "https://database.windows.net/.default";
+            string applicationName = "Microsoft Data SqlClient Manual Tests";
+            string clientVersion = "1.0.0.0";
+            string adoClientId = "4d079b4c-cab7-4b7c-a115-8fd51b6f8239";
+
+            IPublicClientApplication app = PublicClientApplicationBuilder.Create(adoClientId)
+                .WithAuthority(authorityURL)
+                .WithClientName(applicationName)
+                .WithClientVersion(clientVersion)
+                .Build();
+            AuthenticationResult result;
+            string[] scopes = new string[] { scope };
+
+            // Note: CorrelationId, which existed in ADAL, can not be set in MSAL (yet?).
+            // parameter.ConnectionId was passed as the CorrelationId in ADAL to aid support in troubleshooting.
+            // If/When MSAL adds CorrelationId support, it should be passed from parameters here, too.
+
+            SecureString securePassword = new SecureString();
+
+            foreach (char c in password)
+                securePassword.AppendChar(c);
+            securePassword.MakeReadOnly();
+            result = app.AcquireTokenByUsernamePassword(scopes, userID, securePassword).ExecuteAsync().Result;
+
+            return result.AccessToken;
+        });
 
         public static bool IsDatabasePresent(string name)
         {
@@ -518,6 +563,28 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
 
             return paramValue.ToString();
+        }
+
+        public static string RetrieveValueFromConnStr(string connStr, string[] keywords)
+        {
+            // tokenize connection string and retrieve value for a specific key.
+            string res = "";
+            string[] keys = connStr.Split(';');
+            foreach (var key in keys)
+            {
+                foreach (var keyword in keywords)
+                {
+                    if (!string.IsNullOrEmpty(key.Trim()))
+                    {
+                        if (key.Trim().ToLower().StartsWith(keyword.Trim().ToLower()))
+                        {
+                            res = key.Substring(key.IndexOf('=') + 1).Trim();
+                            break;
+                        }
+                    }
+                }
+            }
+            return res;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/AADConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/AADConnectionTest.cs
@@ -21,33 +21,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        private static string RemoveKeysInConnStr(string connStr, string[] keysToRemove)
-        {
-            // tokenize connection string and remove input keys.
-            string res = "";
-            string[] keys = connStr.Split(';');
-            foreach (var key in keys)
-            {
-                if (!string.IsNullOrEmpty(key.Trim()))
-                {
-                    bool removeKey = false;
-                    foreach (var keyToRemove in keysToRemove)
-                    {
-                        if (key.Trim().ToLower().StartsWith(keyToRemove.Trim().ToLower()))
-                        {
-                            removeKey = true;
-                            break;
-                        }
-                    }
-                    if (!removeKey)
-                    {
-                        res += key + ";";
-                    }
-                }
-            }
-            return res;
-        }
-
         private static bool IsAccessTokenSetup() => DataTestUtility.IsAccessTokenSetup();
         private static bool IsAADConnStringsSetup() => DataTestUtility.IsAADPasswordConnStrSetup();
 
@@ -56,7 +29,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // Remove cred info and add invalid token
             string[] credKeys = { "User ID", "Password", "UID", "PWD", "Authentication" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
 
             using (SqlConnection connection = new SqlConnection(connStr))
             {
@@ -70,7 +43,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // Remove cred info and add invalid token
             string[] credKeys = { "User ID", "Password", "UID", "PWD", "Authentication" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
 
             using (SqlConnection connection = new SqlConnection(connStr))
             {
@@ -87,7 +60,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // Remove cred info and add invalid token
             string[] credKeys = { "User ID", "Password", "UID", "PWD" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
 
             using (SqlConnection connection = new SqlConnection(connStr))
             {
@@ -104,7 +77,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // Remove cred info and add invalid token
             string[] credKeys = { "Authentication" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
 
             using (SqlConnection connection = new SqlConnection(connStr))
             {
@@ -121,7 +94,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // Remove cred info and add invalid token
             string[] credKeys = { "User ID", "Password", "UID", "PWD", "Authentication" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
 
             using (SqlConnection connection = new SqlConnection(connStr))
             {
@@ -138,7 +111,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // Remove cred info and add invalid token
             string[] credKeys = { "User ID", "Password", "UID", "PWD", "Authentication" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys) + "Integrated Security=True;";
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys) + "Integrated Security=True;";
 
             using (SqlConnection connection = new SqlConnection(connStr))
             {
@@ -154,7 +127,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // Remove cred info and add invalid token
             string[] credKeys = { "Authentication" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys) + "Authentication=Active Directory Pass;";
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys) + "Authentication=Active Directory Pass;";
 
             ArgumentException e = Assert.Throws<ArgumentException>(() => ConnectAndDisconnect(connStr));
 
@@ -162,7 +135,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.Contains(expectedMessage, e.Message);
         }
 
-        [ConditionalFact(nameof(IsAccessTokenSetup), nameof(IsAADConnStringsSetup))]
+        [ConditionalFact(nameof(IsAADConnStringsSetup))]
         public static void AADPasswordWithIntegratedSecurityTrue()
         {
             string connStr = DataTestUtility.AADPasswordConnectionString + "Integrated Security=True;";
@@ -177,7 +150,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static void AADPasswordWithWrongPassword()
         {
             string[] credKeys = { "Password", "PWD" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys) + "Password=TestPassword;";
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys) + "Password=TestPassword;";
 
             AggregateException e = Assert.Throws<AggregateException>(() => ConnectAndDisconnect(connStr));
 
@@ -228,7 +201,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // connection fails with expected error message.
             string[] AuthKey = { "Authentication" };
-            string connStrWithNoAuthType = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, AuthKey);
+            string connStrWithNoAuthType = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, AuthKey);
             SqlException e = Assert.Throws<SqlException>(() => ConnectAndDisconnect(connStrWithNoAuthType));
 
             string expectedMessage = "Cannot open server \"microsoft.com\" requested by the login.  The login failed.";
@@ -241,7 +214,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // connection fails with expected error message.
             string[] AuthKey = { "Authentication" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, AuthKey) + "Authentication=Active Directory Integrated;";
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, AuthKey) + "Authentication=Active Directory Integrated;";
             ArgumentException e = Assert.Throws<ArgumentException>(() => ConnectAndDisconnect(connStr));
 
             string expectedMessage = "Cannot use 'Authentication=Active Directory Integrated' with 'User ID', 'UID', 'Password' or 'PWD' connection string keywords.";
@@ -254,7 +227,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // connection fails with expected error message.
             string[] AuthKey = { "Authentication" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, AuthKey) + "Authentication=Active Directory Interactive;";
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, AuthKey) + "Authentication=Active Directory Interactive;";
             ArgumentException e = Assert.Throws<ArgumentException>(() => ConnectAndDisconnect(connStr));
 
             string expectedMessage = "Cannot use 'Authentication=Active Directory Interactive' with 'User ID', 'UID', 'Password' or 'PWD' connection string keywords.";
@@ -266,7 +239,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // connection fails with expected error message.
             string[] pwdKey = { "Password", "PWD" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, pwdKey) + "Password=;";
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, pwdKey) + "Password=;";
             AggregateException e = Assert.Throws<AggregateException>(() => ConnectAndDisconnect(connStr));
 
             string expectedMessage = "ID3242: The security token could not be authenticated or authorized.";
@@ -279,7 +252,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // connection fails with expected error message.
             string[] removeKeys = { "User ID", "Password", "UID", "PWD" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, removeKeys) + "User ID=; Password=;";
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, removeKeys) + "User ID=; Password=;";
             AggregateException e = Assert.Throws<AggregateException>(() => ConnectAndDisconnect(connStr));
 
             string expectedMessage = "Failed to get user name";
@@ -293,7 +266,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // connection fails with expected error message.
             string[] removeKeys = { "User ID", "Password", "UID", "PWD" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, removeKeys) + "User ID=; Password=;";
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, removeKeys) + "User ID=; Password=;";
             AggregateException e = Assert.Throws<AggregateException>(() => ConnectAndDisconnect(connStr));
 
             string expectedMessage = "Could not identify the user logged into the OS";
@@ -306,7 +279,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // connection fails with expected error message.
             string[] removeKeys = { "User ID", "UID" };
-            string connStr = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, removeKeys) + "User ID=testdotnet@microsoft.com";
+            string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, removeKeys) + "User ID=testdotnet@microsoft.com";
             AggregateException e = Assert.Throws<AggregateException>(() => ConnectAndDisconnect(connStr));
 
             string expectedMessage = "ID3242: The security token could not be authenticated or authorized.";
@@ -321,7 +294,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             // connection fails with expected error message.
             string[] credKeys = { "User ID", "Password", "UID", "PWD" };
-            string connStrWithNoCred = RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
+            string connStrWithNoCred = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys);
             InvalidOperationException e = Assert.Throws<InvalidOperationException>(() => ConnectAndDisconnect(connStrWithNoCred));
 
             string expectedMessage = "Either Credential or both 'User ID' and 'Password' (or 'UID' and 'PWD') connection string keywords must be specified, if 'Authentication=Active Directory Password'.";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/config.default.json
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/config.default.json
@@ -5,7 +5,7 @@
     "TCPConnectionStringAASVBS": "",
     "TCPConnectionStringAASSGX": "",
     "EnclaveEnabled": false,
-    "AADAccessToken": "",
+    "AADAuthorityURL": "",
     "AADPasswordConnectionString": "",
     "AzureKeyVaultURL": "",
     "AzureKeyVaultClientId": "",


### PR DESCRIPTION
- Fixes #438 + tests added
- Modifies tests to dynamically generate Access Token for testing instead of specifying it in `config.json` file.