### PR TITLE
Remove sync over async in named pipe EnableSsl

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNINpHandle.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
             try
             {
-                _sslStream.AuthenticateAsClientAsync(_targetServer).GetAwaiter().GetResult();
+                _sslStream.AuthenticateAsClient(_targetServer);
                 _sslOverTdsStream.FinishHandshake();
             }
             catch (AuthenticationException aue)


### PR DESCRIPTION
This is a simple one line change that brings named pipe handle into line with the tcp version by removing a sync-over-async call in favour of using a sync call directly.