### PR TITLE
Enable Managed SNI on Windows with AppContext switch

### DIFF
--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -175,6 +175,6 @@ Tests can be built and run with custom Target Frameworks. See the below examples
 
 ## Using Managed SNI on Windows
 
-Managed SNI can be enabled on Windows by enabling below AppContext switch:
+Managed SNI can be enabled on Windows by enabling the below AppContext switch:
 
 **"Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows"**

--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -160,6 +160,7 @@ Tests can be built and run with custom Target Frameworks. See the below examples
 # Build the tests for custom TargetFramework (.NET Core)
 # Applicable values: netcoreapp2.1 | netcoreapp2.2 | netcoreapp3.0
 ```
+
 ### Running Tests:
 
 ```bash
@@ -171,3 +172,10 @@ Tests can be built and run with custom Target Frameworks. See the below examples
 # Use above property to run Functional Tests with custom TargetFramework (.NET Core)
 # Applicable values: netcoreapp2.1 | netcoreapp2.2 | netcoreapp3.0
 ```
+
+## Using Managed SNI on Windows
+
+Managed SNI can be enabled on Windows by setting any of the below two environment variables to 'True':
+
+- **Microsoft.Data.SqlClient.UseManagedSNIOnWindows** (Supported to respect namespace format)
+- **Microsoft_Data_SqlClient_UseManagedSNIOnWindows** (Supported for Azure Pipelines)

--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -175,7 +175,6 @@ Tests can be built and run with custom Target Frameworks. See the below examples
 
 ## Using Managed SNI on Windows
 
-Managed SNI can be enabled on Windows by setting any of the below two environment variables to 'True':
+Managed SNI can be enabled on Windows by enabling below AppContext switch:
 
-- **Microsoft.Data.SqlClient.UseManagedSNIOnWindows** (Supported to respect namespace format)
-- **Microsoft_Data_SqlClient_UseManagedSNIOnWindows** (Supported for Azure Pipelines)
+**"Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows"**

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -14,20 +14,15 @@ namespace Microsoft.Data.SqlClient
 
         public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
 
-
         // Temporary disabling App Context switching for managed SNI.
         // If the appcontext switch is set then Use Managed SNI based on the value. Otherwise Managed SNI should always be used.
         //private static bool shouldUseLegacyNetorking;
         //public static bool UseManagedSNI { get; } = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
 
-#if DEBUG
         private static Lazy<bool> useManagedSNIOnWindows = new Lazy<bool>(
             () => bool.TrueString.Equals(Environment.GetEnvironmentVariable("Microsoft.Data.SqlClient.UseManagedSNIOnWindows"), StringComparison.InvariantCultureIgnoreCase)
         );
         public static bool UseManagedSNI => useManagedSNIOnWindows.Value;
-#else
-         public static bool UseManagedSNI { get; } = false;
-#endif
 
         public EncryptionOptions EncryptionOptions
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -39,10 +39,14 @@ namespace Microsoft.Data.SqlClient
         {
             if (UseManagedSNI)
             {
+                SqlClientEventSource.Log.TraceEvent("<sc.TdsParserStateObjectFactory.CreateTdsParserStateObject|INFO> Found AppContext switch '{0}#' enabled, managed networking implementation will be used."
+                   , UseManagedNetworkingOnWindows);
                 return new TdsParserStateObjectManaged(parser);
             }
             else
             {
+                SqlClientEventSource.Log.TraceEvent("<sc.TdsParserStateObjectFactory.CreateTdsParserStateObject|INFO> AppContext switch '{0}#' not enabled, native networking implementation will be used."
+                   , UseManagedNetworkingOnWindows);
                 return new TdsParserStateObjectNative(parser);
             }
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -9,18 +9,17 @@ namespace Microsoft.Data.SqlClient
 {
     internal sealed class TdsParserStateObjectFactory
     {
-
-        private const string UseLegacyNetworkingOnWindows = "Microsoft.Data.SqlClient.UseLegacyNetworkingOnWindows";
-
         public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
 
-        // Temporary disabling App Context switching for managed SNI.
-        // If the appcontext switch is set then Use Managed SNI based on the value. Otherwise Managed SNI should always be used.
-        //private static bool shouldUseLegacyNetorking;
-        //public static bool UseManagedSNI { get; } = AppContext.TryGetSwitch(UseLegacyNetworkingOnWindows, out shouldUseLegacyNetorking) ? !shouldUseLegacyNetorking : true;
-
+        /* Managed SNI can be enabled on Windows by setting any of the below two environment variables to 'True':
+         * Microsoft.Data.SqlClient.UseManagedSNIOnWindows (Supported to respect namespace format)
+         * Microsoft_Data_SqlClient_UseManagedSNIOnWindows (Supported for Azure Pipelines)
+        **/
         private static Lazy<bool> useManagedSNIOnWindows = new Lazy<bool>(
-            () => bool.TrueString.Equals(Environment.GetEnvironmentVariable("Microsoft.Data.SqlClient.UseManagedSNIOnWindows"), StringComparison.InvariantCultureIgnoreCase)
+            () => bool.TrueString.Equals(Environment.GetEnvironmentVariable("Microsoft.Data.SqlClient.UseManagedSNIOnWindows"),
+                                        StringComparison.InvariantCultureIgnoreCase) ||
+                  bool.TrueString.Equals(Environment.GetEnvironmentVariable("Microsoft_Data_SqlClient_UseManagedSNIOnWindows"),
+                                        StringComparison.InvariantCultureIgnoreCase)
         );
         public static bool UseManagedSNI => useManagedSNIOnWindows.Value;
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -11,17 +11,13 @@ namespace Microsoft.Data.SqlClient
     {
         public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
 
-        /* Managed SNI can be enabled on Windows by setting any of the below two environment variables to 'True':
-         * Microsoft.Data.SqlClient.UseManagedSNIOnWindows (Supported to respect namespace format)
-         * Microsoft_Data_SqlClient_UseManagedSNIOnWindows (Supported for Azure Pipelines)
-        **/
-        private static Lazy<bool> useManagedSNIOnWindows = new Lazy<bool>(
-            () => bool.TrueString.Equals(Environment.GetEnvironmentVariable("Microsoft.Data.SqlClient.UseManagedSNIOnWindows"),
-                                        StringComparison.InvariantCultureIgnoreCase) ||
-                  bool.TrueString.Equals(Environment.GetEnvironmentVariable("Microsoft_Data_SqlClient_UseManagedSNIOnWindows"),
-                                        StringComparison.InvariantCultureIgnoreCase)
-        );
-        public static bool UseManagedSNI => useManagedSNIOnWindows.Value;
+        private const string UseManagedNetworkingOnWindows = "Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows";
+
+        private static bool shouldUseManagedSNI;
+
+        // If the appcontext switch is set then Use Managed SNI based on the value. Otherwise Native SNI.dll will be used by default.
+        public static bool UseManagedSNI { get; } =
+            AppContext.TryGetSwitch(UseManagedNetworkingOnWindows, out shouldUseManagedSNI) ? shouldUseManagedSNI : false;
 
         public EncryptionOptions EncryptionOptions
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -45,9 +45,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public const string UdtTestDbName = "UdtTestDb";
         public const string AKVKeyName = "TestSqlClientAzureKeyVaultProvider";
 
-        private static readonly Assembly MdsAssembly = typeof(Microsoft.Data.SqlClient.SqlConnection).GetTypeInfo().Assembly;
-        private static readonly Type TdsParserStateObjectFactoryInstance = MdsAssembly?.GetType("Microsoft.Data.SqlClient.TdsParserStateObjectFactory");
-        private static readonly PropertyInfo UseManagedSni = TdsParserStateObjectFactoryInstance?.GetProperty("UseManagedSNI", BindingFlags.Static | BindingFlags.Public);
+        private const string ManagedNetworkingAppContextSwitch = "Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows";
+
+        private static bool UseManagedSNI =
+            bool.TryParse(Environment.GetEnvironmentVariable("Microsoft_Data_SqlClient_UseManagedSniOnWindows"), out UseManagedSNI) ? UseManagedSNI : false;
 
         private static readonly string[] AzureSqlServerEndpoints = {".database.windows.net",
                                                                      ".database.cloudapi.de",
@@ -76,6 +77,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         static DataTestUtility()
         {
+            if (UseManagedSNI)
+            {
+                AppContext.SetSwitch(ManagedNetworkingAppContextSwitch, true);
+            }
+
             using (StreamReader r = new StreamReader("config.json"))
             {
                 string json = r.ReadToEnd();
@@ -231,7 +237,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return !string.IsNullOrEmpty(AKVUrl) && !string.IsNullOrEmpty(AKVClientId) && !string.IsNullOrEmpty(AKVClientSecret);
         }
 
-        public static bool IsUsingManagedSNI() => (bool)(UseManagedSni?.GetValue(null) ?? false);
+        public static bool IsUsingManagedSNI() => UseManagedSNI;
 
         public static bool IsUsingNativeSNI() => !IsUsingManagedSNI();
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             if (UseManagedSNI)
             {
                 AppContext.SetSwitch(ManagedNetworkingAppContextSwitch, true);
+                Console.WriteLine($"App Context switch {ManagedNetworkingAppContextSwitch} enabled on {Environment.OSVersion}");
             }
 
             using (StreamReader r = new StreamReader("config.json"))

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/IntegratedAuthenticationTest/IntegratedAuthenticationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/IntegratedAuthenticationTest/IntegratedAuthenticationTest.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private static bool AreConnectionStringsSetup() => DataTestUtility.AreConnStringsSetup();
 
-
         [ConditionalFact(nameof(IsIntegratedSecurityEnvironmentSet), nameof(AreConnectionStringsSetup))]
         public static void IntegratedAuthenticationTestWithConnectionPooling()
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/IntegratedAuthenticationTest/IntegratedAuthenticationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/IntegratedAuthenticationTest/IntegratedAuthenticationTest.cs
@@ -8,8 +8,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
     public static class IntegratedAuthenticationTest
     {
-        // Managed SNI does not support Windows Integrated Authentication, hence tests disabled for the same.
-        private static bool IsIntegratedSecurityEnvironmentSet() => DataTestUtility.IsIntegratedSecuritySetup() && DataTestUtility.IsUsingNativeSNI();
+        private static bool IsIntegratedSecurityEnvironmentSet() => DataTestUtility.IsIntegratedSecuritySetup();
 
         private static bool AreConnectionStringsSetup() => DataTestUtility.AreConnStringsSetup();
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/IntegratedAuthenticationTest/IntegratedAuthenticationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/IntegratedAuthenticationTest/IntegratedAuthenticationTest.cs
@@ -8,7 +8,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
     public static class IntegratedAuthenticationTest
     {
-        private static bool IsIntegratedSecurityEnvironmentSet() => DataTestUtility.IsIntegratedSecuritySetup();
+        // Managed SNI does not support Windows Integrated Authentication, hence tests disabled for the same.
+        private static bool IsIntegratedSecurityEnvironmentSet() => DataTestUtility.IsIntegratedSecuritySetup() && DataTestUtility.IsUsingNativeSNI();
+
         private static bool AreConnectionStringsSetup() => DataTestUtility.AreConnStringsSetup();
 
 


### PR DESCRIPTION
Enabling preview of Managed SNI on Windows for testing and debugging purposes.

With this change, users will be able to specify the below `AppContext` switch to toggle driver's behavior to use Managed SNI in .NET Core 2.1+ and .NET Standard 2.0+ projects on Windows.

**Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows**

```cs
AppContext.SetSwitch("Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", true);
```
**[NOTE]** Known differences when compared to Native SNI.dll:
- Managed SNI does not support non-domain Windows Authentication.