### PR TITLE
perf: Reduce tracing related allocations

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/ActivityCorrelator.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/ActivityCorrelator.cs
@@ -14,30 +14,15 @@ namespace Microsoft.Data.Common
 
     internal static class ActivityCorrelator
     {
-        internal class ActivityId
+        internal sealed class ActivityId
         {
-            internal Guid Id { get; private set; }
-            internal uint Sequence { get; private set; }
+            internal readonly Guid Id;
+            internal readonly uint Sequence;
 
-            internal ActivityId()
+            internal ActivityId(uint sequence)
             {
                 this.Id = Guid.NewGuid();
-                this.Sequence = 0; // the first event will start 1
-            }
-
-            // copy-constructor
-            internal ActivityId(ActivityId activity)
-            {
-                this.Id = activity.Id;
-                this.Sequence = activity.Sequence;
-            }
-
-            internal void Increment()
-            {
-                unchecked
-                {
-                    ++this.Sequence;
-                }
+                this.Sequence = sequence;
             }
 
             public override string ToString()
@@ -61,10 +46,9 @@ namespace Microsoft.Data.Common
             {
                 if (t_tlsActivity == null)
                 {
-                    t_tlsActivity = new ActivityId();
+                    t_tlsActivity = new ActivityId(1);
                 }
-
-                return new ActivityId(t_tlsActivity);
+                return t_tlsActivity;
             }
         }
 
@@ -74,14 +58,9 @@ namespace Microsoft.Data.Common
         /// <returns>ActivityId</returns>
         internal static ActivityId Next()
         {
-            if (t_tlsActivity == null)
-            {
-                t_tlsActivity = new ActivityId();
-            }
+            t_tlsActivity = new ActivityId( (t_tlsActivity?.Sequence ?? 0) + 1);
 
-            t_tlsActivity.Increment();
-
-            return new ActivityId(t_tlsActivity);
+            return t_tlsActivity;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -979,7 +979,10 @@ namespace Microsoft.Data.SqlClient
         {
             // Called when the connection that owns us is deactivated.
             SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.Deactivate|ADV> {0}# deactivating", ObjectID);
-            SqlClientEventSource.Log.StateDumpEvent("<sc.TdsParser.Deactivate|STATE> {0}# {1}", ObjectID, TraceString());
+            if (SqlClientEventSource.Log.IsStateDumpEnabled())
+            {
+                SqlClientEventSource.Log.StateDumpEvent("<sc.TdsParser.Deactivate|STATE> {0}# {1}", ObjectID, TraceString());
+            }
 
             if (MARSOn)
             {
@@ -12631,13 +12634,13 @@ namespace Microsoft.Data.SqlClient
                                        ;
         internal string TraceString()
         {
-            return String.Format(/*IFormatProvider*/ null,
+            return string.Format(/*IFormatProvider*/ null,
                            StateTraceFormatString,
-                           null == _physicalStateObj,
-                           null == _pMarsPhysicalConObj,
+                           null == _physicalStateObj ? bool.TrueString : bool.FalseString,
+                           null == _pMarsPhysicalConObj ? bool.TrueString : bool.FalseString,
                            _state,
                            _server,
-                           _fResetConnection,
+                           _fResetConnection ? bool.TrueString : bool.FalseString,
                            null == _defaultCollation ? "(null)" : _defaultCollation.TraceString(),
                            _defaultCodePage,
                            _defaultLCID,
@@ -12649,17 +12652,17 @@ namespace Microsoft.Data.SqlClient
                            _retainedTransactionId,
                            _nonTransactedOpenResultCount,
                            null == _connHandler ? "(null)" : _connHandler.ObjectID.ToString((IFormatProvider)null),
-                           _fMARS,
+                           _fMARS ? bool.TrueString : bool.FalseString,
                            null == _sessionPool ? "(null)" : _sessionPool.TraceString(),
-                           _isYukon,
+                           _isYukon ? bool.TrueString : bool.FalseString,
                            null == _sniSpnBuffer ? "(null)" : _sniSpnBuffer.Length.ToString((IFormatProvider)null),
                            _physicalStateObj != null ? "(null)" : _physicalStateObj.ErrorCount.ToString((IFormatProvider)null),
                            _physicalStateObj != null ? "(null)" : _physicalStateObj.WarningCount.ToString((IFormatProvider)null),
                            _physicalStateObj != null ? "(null)" : _physicalStateObj.PreAttentionErrorCount.ToString((IFormatProvider)null),
                            _physicalStateObj != null ? "(null)" : _physicalStateObj.PreAttentionWarningCount.ToString((IFormatProvider)null),
-                           null == _statistics,
-                           _statisticsIsInTransaction,
-                           _fPreserveTransaction,
+                           null == _statistics ? bool.TrueString : bool.FalseString,
+                           _statisticsIsInTransaction ? bool.TrueString : bool.FalseString,
+                           _fPreserveTransaction ? bool.TrueString : bool.FalseString,
                            null == _connHandler ? "(null)" : _connHandler.ConnectionOptions.MultiSubnetFailover.ToString((IFormatProvider)null));
         }
 


### PR DESCRIPTION
Now that tracing has been added to netcore I did a quick profile over the usual DataAccessPerformance benchmark app and investigated a few new hot allocation sources.

- ActivityCorrelator was creating a new copy of the current activity on every call. I've made the class effectively immutable so the current instance can be returned every time without danger and change the Next() implementation to correctly generate the next in sequence as before.
- TraceString() was being called unconditionally to pass into a method which wasn't going to use it. It's expensive so I added the check before the call, this means there are now two check but that should take less time than required for all the information generation and formatting.
- TraceString was passing a lot of bools in a params object array which causes them to be boxed, I simply did a ternary check and passed in the preallocated string version instead.
