### PR TITLE
Standardization of Event Source tracing + Improvements for readability

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Data.Common
         [System.Diagnostics.Conditional("DEBUG")]
         private static void DebugTraceKeyValuePair(string keyname, string keyvalue, Dictionary<string, string> synonyms)
         {
-            if (SqlClientEventSource.Log.IsAdvanceTraceOn())
+            if (SqlClientEventSource.Log.IsAdvancedTraceOn())
             {
                 Debug.Assert(string.Equals(keyname, keyname?.ToLower(), StringComparison.InvariantCulture), "missing ToLower");
                 string realkeyname = ((null != synonyms) ? (string)synonyms[keyname] : keyname);
@@ -171,11 +171,11 @@ namespace Microsoft.Data.Common
                     // don't trace passwords ever!
                     if (null != keyvalue)
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}', KeyValue='{1}'", keyname, keyvalue);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}', KeyValue='{1}'", keyname, keyvalue);
                     }
                     else
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}'", keyname);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}'", keyname);
                     }
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
@@ -171,11 +171,11 @@ namespace Microsoft.Data.Common
                     // don't trace passwords ever!
                     if (null != keyvalue)
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}', KeyValue='{1}'", keyname, keyvalue);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}#', KeyValue='{1}#'", keyname, keyvalue);
                     }
                     else
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}'", keyname);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}#'", keyname);
                     }
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
@@ -171,11 +171,11 @@ namespace Microsoft.Data.Common
                     // don't trace passwords ever!
                     if (null != keyvalue)
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}#', KeyValue='{1}#'", keyname, keyvalue);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}', KeyValue='{1}'", keyname, keyvalue);
                     }
                     else
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}#'", keyname);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}'", keyname);
                     }
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Data.ProviderBase
         private void PruneConnectionPoolGroups(object state)
         {
             // when debugging this method, expect multiple threads at the same time
-            SqlClientEventSource.Log.AdvanceTrace("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#", ObjectID);
             
             // First, walk the pool release list and attempt to clear each
             // pool, when the pool is finally empty, we dispose of it.  If the
@@ -323,7 +323,7 @@ namespace Microsoft.Data.ProviderBase
                             if (0 == pool.Count)
                             {
                                 _poolsToRelease.Remove(pool);
-                                SqlClientEventSource.Log.AdvanceTrace("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePool={1}#", ObjectID, pool.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePool={1}#", ObjectID, pool.ObjectID);
                             }
                         }
                     }
@@ -347,7 +347,7 @@ namespace Microsoft.Data.ProviderBase
                             if (0 == poolsLeft)
                             {
                                 _poolGroupsToRelease.Remove(poolGroup);
-                                SqlClientEventSource.Log.AdvanceTrace("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePoolGroup={1}#", ObjectID, poolGroup.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePoolGroup={1}#", ObjectID, poolGroup.ObjectID);
                             }
                         }
                     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Data.ProviderBase
         public void ClearPool(DbConnection connection)
         {
             ADP.CheckArgumentNull(connection, nameof(connection));
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.DbConnectionFactory.ClearPool|API> {0}#", GetObjectId(connection));
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.DbConnectionFactory.ClearPool|API> {0}", GetObjectId(connection));
             try
             {
                 DbConnectionPoolGroup poolGroup = GetConnectionPoolGroup(connection);
@@ -126,7 +126,7 @@ namespace Microsoft.Data.ProviderBase
             {
                 newConnection.MakeNonPooledObject(owningConnection);
             }
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.CreateNonPooledConnection|RES|CPOOL> {0}#, Non-pooled database connection created.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.CreateNonPooledConnection|RES|CPOOL> {0}, Non-pooled database connection created.", ObjectID);
             return newConnection;
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.Data.ProviderBase
             {
                 newConnection.MakePooledConnection(pool);
             }
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.CreatePooledConnection|RES|CPOOL> {0}#, Pooled database connection created.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.CreatePooledConnection|RES|CPOOL> {0}, Pooled database connection created.", ObjectID);
             return newConnection;
         }
 
@@ -195,7 +195,7 @@ namespace Microsoft.Data.ProviderBase
             // however, don't rebuild connectionOptions if no pooling is involved - let new connections do that work
             if (connectionPoolGroup.IsDisabled && (null != connectionPoolGroup.PoolGroupOptions))
             {
-                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnectionPool|RES|INFO|CPOOL> {0}#, DisabledPoolGroup={1}#", ObjectID, connectionPoolGroup.ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnectionPool|RES|INFO|CPOOL> {0}, DisabledPoolGroup={1}", ObjectID, connectionPoolGroup.ObjectID);
 
                 // reusing existing pool option in case user originally used SetConnectionPoolOptions
                 DbConnectionPoolGroupOptions poolOptions = connectionPoolGroup.PoolGroupOptions;
@@ -303,7 +303,7 @@ namespace Microsoft.Data.ProviderBase
         private void PruneConnectionPoolGroups(object state)
         {
             // when debugging this method, expect multiple threads at the same time
-            SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}", ObjectID);
             
             // First, walk the pool release list and attempt to clear each
             // pool, when the pool is finally empty, we dispose of it.  If the
@@ -323,7 +323,7 @@ namespace Microsoft.Data.ProviderBase
                             if (0 == pool.Count)
                             {
                                 _poolsToRelease.Remove(pool);
-                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePool={1}#", ObjectID, pool.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}, ReleasePool={1}", ObjectID, pool.ObjectID);
                             }
                         }
                     }
@@ -347,7 +347,7 @@ namespace Microsoft.Data.ProviderBase
                             if (0 == poolsLeft)
                             {
                                 _poolGroupsToRelease.Remove(poolGroup);
-                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePoolGroup={1}#", ObjectID, poolGroup.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}, ReleasePoolGroup={1}", ObjectID, poolGroup.ObjectID);
                             }
                         }
                     }
@@ -410,7 +410,7 @@ namespace Microsoft.Data.ProviderBase
         internal void QueuePoolGroupForRelease(DbConnectionPoolGroup poolGroup)
         {
             Debug.Assert(null != poolGroup, "null poolGroup?");
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.QueuePoolGroupForRelease|RES|INFO|CPOOL> {0}#, poolGroup={1}#", ObjectID, poolGroup.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.QueuePoolGroupForRelease|RES|INFO|CPOOL> {0}, poolGroup={1}", ObjectID, poolGroup.ObjectID);
 
             lock (_poolGroupsToRelease)
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Data.ProviderBase
 
         public void ClearAllPools()
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.DbConnectionFactory.ClearAllPools|{0}>", "API");
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.DbConnectionFactory.ClearAllPools|API");
             try
             {
                 Dictionary<DbConnectionPoolKey, DbConnectionPoolGroup> connectionPoolGroups = _connectionPoolGroups;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Data.ProviderBase
         {
             // Internal method called from the connection pooler so we don't expose
             // the Deactivate method publicly.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DeactivateConnection|RES|INFO|CPOOL> {0}#, Deactivating", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DeactivateConnection|RES|INFO|CPOOL> {0}, Deactivating", ObjectID);
 
 #if DEBUG
             int activateCount = Interlocked.Decrement(ref _activateCount);
@@ -249,14 +249,14 @@ namespace Microsoft.Data.ProviderBase
         protected internal void DoNotPoolThisConnection()
         {
             _cannotBePooled = true;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DoNotPoolThisConnection|RES|INFO|CPOOL> {0}#, Marking pooled object as non-poolable so it will be disposed", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DoNotPoolThisConnection|RES|INFO|CPOOL> {0}, Marking pooled object as non-poolable so it will be disposed", ObjectID);
         }
 
         /// <devdoc>Ensure that this connection cannot be put back into the pool.</devdoc>
         protected internal void DoomThisConnection()
         {
             _connectionIsDoomed = true;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DoomThisConnection|RES|INFO|CPOOL> {0}#, Dooming", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DoomThisConnection|RES|INFO|CPOOL> {0}, Dooming", ObjectID);
         }
 
         protected internal virtual DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
@@ -377,7 +377,7 @@ namespace Microsoft.Data.ProviderBase
                 throw ADP.InternalError(ADP.InternalErrorCode.PushingObjectSecondTime);         // pushing object onto stack a second time
             }
 
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.PrePush|RES|CPOOL> {0}#, Preparing to push into pool, owning connection {1}#, pooledCount={2}", ObjectID, 0, _pooledCount);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.PrePush|RES|CPOOL> {0}, Preparing to push into pool, owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
             _pooledCount++;
             _owningObject.Target = null; // NOTE: doing this and checking for InternalError.PooledObjectHasOwner degrades the close by 2%
         }
@@ -406,7 +406,7 @@ namespace Microsoft.Data.ProviderBase
             }
             _owningObject.Target = newOwner;
             _pooledCount--;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.PostPop|RES|CPOOL> {0}#, Preparing to pop from pool,  owning connection {1}#, pooledCount={2}", ObjectID, 0, _pooledCount);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.PostPop|RES|CPOOL> {0}, Preparing to pop from pool,  owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
 
             //3 // The following tests are retail assertions of things we can't allow to happen.
             if (null != Pool)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Data.ProviderBase
             if (PoolGroupStateIdle == _state)
             {
                 _state = PoolGroupStateActive;
-                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ClearInternal|RES|INFO|CPOOL> {0}#, Active", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ClearInternal|RES|INFO|CPOOL> {0}, Active", ObjectID);
             }
             return (PoolGroupStateActive == _state);
         }
@@ -281,12 +281,12 @@ namespace Microsoft.Data.ProviderBase
                     if (PoolGroupStateActive == _state)
                     {
                         _state = PoolGroupStateIdle;
-                        SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ClearInternal|RES|INFO|CPOOL> {0}#, Idle", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ClearInternal|RES|INFO|CPOOL> {0}, Idle", ObjectID);
                     }
                     else if (PoolGroupStateIdle == _state)
                     {
                         _state = PoolGroupStateDisabled;
-                        SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ReadyToRemove|RES|INFO|CPOOL> {0}#, Disabled", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ReadyToRemove|RES|INFO|CPOOL> {0}, Disabled", ObjectID);
                     }
                 }
                 return (PoolGroupStateDisabled == _state);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/DataException.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/DataException.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Data
             Debug.Assert(null != e, "TraceException: null Exception");
             if (null != e)
             {
-                SqlClientEventSource.Log.AdvanceTrace(trace, e.Message);
-                SqlClientEventSource.Log.AdvanceTrace("<comm.ADP.TraceException|ERR|ADV> Environment StackTrace = '{0}'", Environment.StackTrace);
+                SqlClientEventSource.Log.AdvancedTraceEvent(trace, e.Message);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<comm.ADP.TraceException|ERR|ADV> Environment StackTrace = '{0}'", Environment.StackTrace);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Data.ProviderBase
                         // connection creation failed on semaphore waiting or if max pool reached
                         if (connectionPool.IsRunning)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnection|RES|CPOOL> {0}#, GetConnection failed because a pool timeout occurred.", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnection|RES|CPOOL> {0}, GetConnection failed because a pool timeout occurred.", ObjectID);
                             // If GetConnection failed while the pool is running, the pool timeout occurred.
                             throw ADP.PooledOpenTimeout();
                         }
@@ -181,7 +181,7 @@ namespace Microsoft.Data.ProviderBase
 
             if (connection == null)
             {
-                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnection|RES|CPOOL> {0}#, GetConnection failed because a pool timeout occurred and all retries were exhausted.", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnection|RES|CPOOL> {0}, GetConnection failed because a pool timeout occurred and all retries were exhausted.", ObjectID);
                 // exhausted all retries or timed out - give up
                 throw ADP.PooledOpenTimeout();
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Data.ProviderBase
 
                     if (null != value)
                     {
-                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.set_EnlistedTransaction|RES|CPOOL> {0}#, Transaction {1}#, Enlisting.", ObjectID, value.GetHashCode());
+                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.set_EnlistedTransaction|RES|CPOOL> {0}, Transaction {1}, Enlisting.", ObjectID, value.GetHashCode());
                         TransactionOutcomeEnlist(value);
                     }
                 }
@@ -209,7 +209,7 @@ namespace Microsoft.Data.ProviderBase
         {
             // Internal method called from the connection pooler so we don't expose
             // the Activate method publicly.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.ActivateConnection|RES|INFO|CPOOL> {0}#, Activating", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.ActivateConnection|RES|INFO|CPOOL> {0}, Activating", ObjectID);
 
 #if DEBUG
             int activateCount = Interlocked.Increment(ref _activateCount);
@@ -259,7 +259,7 @@ namespace Microsoft.Data.ProviderBase
             ////////////////////////////////////////////////////////////////
             Debug.Assert(null != owningObject, "null owningObject");
             Debug.Assert(null != connectionFactory, "null connectionFactory");
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.CloseConnection|RES|CPOOL> {0}# Closing.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.CloseConnection|RES|CPOOL> {0} Closing.", ObjectID);
 
             // if an exception occurs after the state change but before the try block
             // the connection will be stuck in OpenBusy state.  The commented out try-catch
@@ -334,7 +334,7 @@ namespace Microsoft.Data.ProviderBase
             // IMPORTANT NOTE: You must have taken a lock on the object before
             // you call this method to prevent race conditions with Clear and
             // ReclaimEmancipatedObjects.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DelegatedTransactionEnded|RES|CPOOL> {0}#, Delegated Transaction Completed.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DelegatedTransactionEnded|RES|CPOOL> {0}, Delegated Transaction Completed.", ObjectID);
 
             if (1 == _pooledCount)
             {
@@ -426,7 +426,7 @@ namespace Microsoft.Data.ProviderBase
         // Detach transaction from connection.
         internal void DetachTransaction(Transaction transaction, bool isExplicitlyReleasing)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DetachTransaction|RES|CPOOL> {0}#, Transaction Completed. (pooledCount={1})", ObjectID, _pooledCount);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DetachTransaction|RES|CPOOL> {0}, Transaction Completed. (pooledCount={1})", ObjectID, _pooledCount);
 
             // potentially a multi-threaded event, so lock the connection to make sure we don't enlist in a new
             // transaction between compare and assignment. No need to short circuit outside of lock, since failed comparisons should
@@ -466,7 +466,7 @@ namespace Microsoft.Data.ProviderBase
         void TransactionCompletedEvent(object sender, TransactionEventArgs e)
         {
             Transaction transaction = e.Transaction;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TransactionCompletedEvent|RES|CPOOL> {0}#, Transaction Completed. (pooledCount = {1})", ObjectID, _pooledCount);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TransactionCompletedEvent|RES|CPOOL> {0}, Transaction Completed. (pooledCount = {1})", ObjectID, _pooledCount);
             CleanupTransactionOnCompletion(transaction);
             CleanupConnectionOnTransactionCompletion(transaction);
         }
@@ -479,18 +479,18 @@ namespace Microsoft.Data.ProviderBase
         internal void SetInStasis()
         {
             _isInStasis = true;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.SetInStasis|RES|CPOOL> {0}#, Non-Pooled Connection has Delegated Transaction, waiting to Dispose.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.SetInStasis|RES|CPOOL> {0}, Non-Pooled Connection has Delegated Transaction, waiting to Dispose.", ObjectID);
         }
 
         private void TerminateStasis(bool returningToPool)
         {
             if (returningToPool)
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TerminateStasis|RES|CPOOL> {0}#, Delegated Transaction has ended, connection is closed.  Returning to general pool.", ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TerminateStasis|RES|CPOOL> {0}, Delegated Transaction has ended, connection is closed.  Returning to general pool.", ObjectID);
             }
             else
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TerminateStasis|RES|CPOOL> {0}#, Delegated Transaction has ended, connection is closed/leaked.  Disposing.", ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TerminateStasis|RES|CPOOL> {0}, Delegated Transaction has ended, connection is closed/leaked.  Disposing.", ObjectID);
             }
             _isInStasis = false;
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -1273,7 +1273,7 @@ namespace Microsoft.Data.ProviderBase
                                 break;
 
                             default:
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, WaitForMultipleObjects={1}", ObjectID, waitResult);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, WaitForMultipleObjects={1}#", ObjectID, waitResult);
                                 Interlocked.Decrement(ref _waitCount);
                                 throw ADP.InternalError(ADP.InternalErrorCode.UnexpectedWaitAnyResult);
                         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Data.ProviderBase
 
                 _pool = pool;
                 _transactedCxns = new Dictionary<Transaction, TransactedConnectionList>();
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactedConnectionPool|RES|CPOOL> {0}#, Constructed for connection pool {1}#", ObjectID, _pool.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactedConnectionPool|RES|CPOOL> {0}, Constructed for connection pool {1}", ObjectID, _pool.ObjectID);
             }
 
             internal int ObjectID
@@ -133,7 +133,7 @@ namespace Microsoft.Data.ProviderBase
 
                 if (null != transactedObject)
                 {
-                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.GetTransactedObject|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Popped.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.GetTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Popped.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                 }
                 return transactedObject;
             }
@@ -160,7 +160,7 @@ namespace Microsoft.Data.ProviderBase
                         lock (connections)
                         {
                             Debug.Assert(0 > connections.IndexOf(transactedObject), "adding to pool a second time?");
-                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Pushing.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Pushing.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                             connections.Add(transactedObject);
                         }
                     }
@@ -195,13 +195,13 @@ namespace Microsoft.Data.ProviderBase
                                 lock (connections)
                                 {
                                     Debug.Assert(0 > connections.IndexOf(transactedObject), "adding to pool a second time?");
-                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Pushing.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Pushing.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                                     connections.Add(transactedObject);
                                 }
                             }
                             else
                             {
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Adding List to transacted pool.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Adding List to transacted pool.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
 
                                 // add the connection/transacted object to the list
                                 newConnections.Add(transactedObject);
@@ -229,13 +229,13 @@ namespace Microsoft.Data.ProviderBase
                             }
                         }
                     }
-                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Added.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Added.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                 }
             }
 
             internal void TransactionEnded(Transaction transaction, DbConnectionInternal transactedObject)
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Transaction Completed", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Transaction Completed", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                 TransactedConnectionList connections;
                 int entry = -1;
 
@@ -269,7 +269,7 @@ namespace Microsoft.Data.ProviderBase
                             // safely remove the list from the transacted pool.
                             if (0 >= connections.Count)
                             {
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}#, Transaction {1}#, Removing List from transacted pool.", ObjectID, transaction.GetHashCode());
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}, Transaction {1}, Removing List from transacted pool.", ObjectID, transaction.GetHashCode());
                                 _transactedCxns.Remove(transaction);
 
                                 // we really need to dispose our connection list; it may have 
@@ -285,7 +285,7 @@ namespace Microsoft.Data.ProviderBase
                     }
                     else
                     {
-                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Transacted pool not yet created prior to transaction completing. Connection may be leaked.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Transacted pool not yet created prior to transaction completing. Connection may be leaked.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                     }
                 }
 
@@ -443,7 +443,7 @@ namespace Microsoft.Data.ProviderBase
 
             _poolCreateRequest = new WaitCallback(PoolCreateRequest); // used by CleanupCallback
             _state = State.Running;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DbConnectionPool|RES|CPOOL> {0}#, Constructed.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DbConnectionPool|RES|CPOOL> {0}, Constructed.", ObjectID);
 
             //_cleanupTimer & QueuePoolCreateRequest is delayed until DbConnectionPoolGroup calls
             // StartBackgroundCallbacks after pool is actually in the collection
@@ -586,7 +586,7 @@ namespace Microsoft.Data.ProviderBase
             //
             // With this logic, objects are pruned from the pool if unused for
             // at least one period but not more than two periods.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CleanupCallback|RES|INFO|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CleanupCallback|RES|INFO|CPOOL> {0}", ObjectID);
 
             // Destroy free objects that put us above MinPoolSize from old stack.
             while (Count > MinPoolSize)
@@ -658,7 +658,7 @@ namespace Microsoft.Data.ProviderBase
                         break;
 
                     Debug.Assert(obj != null, "null connection is not expected");
-                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CleanupCallback|RES|INFO|CPOOL> {0}#, ChangeStacks={1}#", ObjectID, obj.ObjectID);
+                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CleanupCallback|RES|INFO|CPOOL> {0}, ChangeStacks={1}", ObjectID, obj.ObjectID);
                     Debug.Assert(!obj.IsEmancipated, "pooled object not in pool");
                     Debug.Assert(obj.CanBePooled, "pooled object is not poolable");
 
@@ -673,7 +673,7 @@ namespace Microsoft.Data.ProviderBase
 
         internal void Clear()
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Clear|RES|CPOOL> {0}#, Clearing.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Clear|RES|CPOOL> {0}, Clearing.", ObjectID);
             DbConnectionInternal obj;
 
             // First, quickly doom everything.
@@ -707,7 +707,7 @@ namespace Microsoft.Data.ProviderBase
             // Finally, reclaim everything that's emancipated (which, because
             // it's been doomed, will cause it to be disposed of as well)
             ReclaimEmancipatedObjects();
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Clear|RES|CPOOL> {0}#, Cleared.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Clear|RES|CPOOL> {0}, Cleared.", ObjectID);
         }
 
         private Timer CreateCleanupTimer() =>
@@ -758,7 +758,7 @@ namespace Microsoft.Data.ProviderBase
                         }
                     }
                 }
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CreateObject|RES|CPOOL> {0}#, Connection {1}#, Added to pool.", ObjectID, newObj != null ? newObj?.ObjectID.ToString() ?? "null" : "null");
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CreateObject|RES|CPOOL> {0}, Connection {1}, Added to pool.", ObjectID, newObj != null ? newObj?.ObjectID.ToString() ?? "null" : "null");
 
                 // Reset the error wait:
                 _errorWait = ERROR_WAIT_DEFAULT;
@@ -816,7 +816,7 @@ namespace Microsoft.Data.ProviderBase
 
         private void DeactivateObject(DbConnectionInternal obj)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DeactivateObject|RES|CPOOL> {0}#, Connection {1}#, Deactivating.", ObjectID, obj.ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DeactivateObject|RES|CPOOL> {0}, Connection {1}, Deactivating.", ObjectID, obj.ObjectID);
             obj.DeactivateConnection();
 
             bool returnToGeneralPool = false;
@@ -951,11 +951,11 @@ namespace Microsoft.Data.ProviderBase
             // again.
             if (obj.IsTxRootWaitingForTxEnd)
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}#, Connection {1}#, Has Delegated Transaction, waiting to Dispose.", ObjectID, obj.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}, Connection {1}, Has Delegated Transaction, waiting to Dispose.", ObjectID, obj.ObjectID);
             }
             else
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}#, Connection {1}#, Removing from pool.", ObjectID, obj.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}, Connection {1}, Removing from pool.", ObjectID, obj.ObjectID);
                 bool removed = false;
                 lock (_objectList)
                 {
@@ -966,16 +966,16 @@ namespace Microsoft.Data.ProviderBase
 
                 if (removed)
                 {
-                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}#, Connection {1}#, Removed from pool.", ObjectID, obj.ObjectID);
+                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}, Connection {1}, Removed from pool.", ObjectID, obj.ObjectID);
                 }
                 obj.Dispose();
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}#, Connection {1}#, Disposed.", ObjectID, obj.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}, Connection {1}, Disposed.", ObjectID, obj.ObjectID);
             }
         }
 
         private void ErrorCallback(object state)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ErrorCallback|RES|CPOOL> {0}#, Resetting Error handling.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ErrorCallback|RES|CPOOL> {0}, Resetting Error handling.", ObjectID);
             _errorOccurred = false;
             _waitHandles.ErrorEvent.Reset();
 
@@ -1106,7 +1106,7 @@ namespace Microsoft.Data.ProviderBase
 
             if (_state != State.Running)
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, DbConnectionInternal State != Running.", ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, DbConnectionInternal State != Running.", ObjectID);
                 connection = null;
                 return true;
             }
@@ -1146,7 +1146,7 @@ namespace Microsoft.Data.ProviderBase
         {
             DbConnectionInternal obj = null;
             Transaction transaction = null;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Getting connection.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Getting connection.", ObjectID);
 
             // If automatic transaction enlistment is required, then we try to
             // get the connection from the transacted connection pool first.
@@ -1181,19 +1181,19 @@ namespace Microsoft.Data.ProviderBase
                         switch (waitResult)
                         {
                             case WaitHandle.WaitTimeout:
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Wait timed out.", ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Wait timed out.", ObjectID);
                                 Interlocked.Decrement(ref _waitCount);
                                 connection = null;
                                 return false;
 
                             case ERROR_HANDLE:
                                 // Throw the error that PoolCreateRequest stashed.
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Errors are set.", ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Errors are set.", ObjectID);
                                 Interlocked.Decrement(ref _waitCount);
                                 throw TryCloneCachedException();
 
                             case CREATION_HANDLE:
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Creating new connection.", ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Creating new connection.", ObjectID);
                                 try
                                 {
                                     obj = UserCreateRequest(owningObject, userOptions);
@@ -1243,7 +1243,7 @@ namespace Microsoft.Data.ProviderBase
 
                                 if ((obj != null) && (!obj.IsConnectionAlive()))
                                 {
-                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Connection {1}#, found dead and removed.", ObjectID, obj.ObjectID);
+                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Connection {1}, found dead and removed.", ObjectID, obj.ObjectID);
                                     DestroyObject(obj);
                                     obj = null;     // Setting to null in case creating a new object fails
 
@@ -1253,7 +1253,7 @@ namespace Microsoft.Data.ProviderBase
                                         {
                                             try
                                             {
-                                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Creating new connection.", ObjectID);
+                                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Creating new connection.", ObjectID);
                                                 obj = UserCreateRequest(owningObject, userOptions);
                                             }
                                             finally
@@ -1264,7 +1264,7 @@ namespace Microsoft.Data.ProviderBase
                                         else
                                         {
                                             // Timeout waiting for creation semaphore - return null
-                                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Wait timed out.", ObjectID);
+                                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Wait timed out.", ObjectID);
                                             connection = null;
                                             return false;
                                         }
@@ -1273,7 +1273,7 @@ namespace Microsoft.Data.ProviderBase
                                 break;
 
                             default:
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, WaitForMultipleObjects={1}#", ObjectID, waitResult);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, WaitForMultipleObjects={1}", ObjectID, waitResult);
                                 Interlocked.Decrement(ref _waitCount);
                                 throw ADP.InternalError(ADP.InternalErrorCode.UnexpectedWaitAnyResult);
                         }
@@ -1325,7 +1325,7 @@ namespace Microsoft.Data.ProviderBase
         /// <returns>A new inner connection that is attached to the <paramref name="owningObject"/></returns>
         internal DbConnectionInternal ReplaceConnection(DbConnection owningObject, DbConnectionOptions userOptions, DbConnectionInternal oldConnection)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReplaceConnection|RES|CPOOL> {0}#, replacing connection.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReplaceConnection|RES|CPOOL> {0}, replacing connection.", ObjectID);
             DbConnectionInternal newConnection = UserCreateRequest(owningObject, userOptions, oldConnection);
 
             if (newConnection != null)
@@ -1366,7 +1366,7 @@ namespace Microsoft.Data.ProviderBase
 
             if (null != obj)
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromGeneralPool|RES|CPOOL> {0}#, Connection {1}#, Popped from general pool.", ObjectID, obj.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromGeneralPool|RES|CPOOL> {0}, Connection {1}, Popped from general pool.", ObjectID, obj.ObjectID);
             }
             return (obj);
         }
@@ -1382,7 +1382,7 @@ namespace Microsoft.Data.ProviderBase
 
                 if (null != obj)
                 {
-                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}#, Connection {1}#, Popped from transacted pool.", ObjectID, obj.ObjectID);
+                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, Popped from transacted pool.", ObjectID, obj.ObjectID);
 
                     if (obj.IsTransactionRoot)
                     {
@@ -1392,14 +1392,14 @@ namespace Microsoft.Data.ProviderBase
                         }
                         catch
                         {
-                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}#, Connection {1}#, found dead and removed.", ObjectID, obj.ObjectID);
+                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, found dead and removed.", ObjectID, obj.ObjectID);
                             DestroyObject(obj);
                             throw;
                         }
                     }
                     else if (!obj.IsConnectionAlive())
                     {
-                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}#, Connection {1}#, found dead and removed.", ObjectID, obj.ObjectID);
+                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, found dead and removed.", ObjectID, obj.ObjectID);
                         DestroyObject(obj);
                         obj = null;
                     }
@@ -1412,7 +1412,7 @@ namespace Microsoft.Data.ProviderBase
         {
             // called by pooler to ensure pool requests are currently being satisfied -
             // creation mutex has not been obtained
-            long scopeID = SqlClientEventSource.Log.PoolerScopeEnterEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|INFO|CPOOL> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.PoolerScopeEnterEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|INFO|CPOOL> {0}", ObjectID);
             try
             {
                 if (State.Running == _state)
@@ -1496,7 +1496,7 @@ namespace Microsoft.Data.ProviderBase
                                 }
                                 else
                                 {
-                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|CPOOL> {0}#, PoolCreateRequest called WaitForSingleObject failed {1}", ObjectID, waitResult);
+                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|CPOOL> {0}, PoolCreateRequest called WaitForSingleObject failed {1}", ObjectID, waitResult);
                                 }
                             }
                             catch (Exception e)
@@ -1509,7 +1509,7 @@ namespace Microsoft.Data.ProviderBase
                                 // Now that CreateObject can throw, we need to catch the exception and discard it.
                                 // There is no further action we can take beyond tracing.  The error will be 
                                 // thrown to the user the next time they request a connection.
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|CPOOL> {0}#, PoolCreateRequest called CreateConnection which threw an exception: {1}", ObjectID, e);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|CPOOL> {0}, PoolCreateRequest called CreateConnection which threw an exception: {1}", ObjectID, e);
                             }
                             finally
                             {
@@ -1533,7 +1533,7 @@ namespace Microsoft.Data.ProviderBase
         {
             Debug.Assert(null != obj, "why are we adding a null object to the pool?");
             // Debug.Assert(obj.CanBePooled,    "non-poolable object in pool");
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PutNewObject|RES|CPOOL> {0}#, Connection {1}#, Pushing to general pool.", ObjectID, obj.ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PutNewObject|RES|CPOOL> {0}, Connection {1}, Pushing to general pool.", ObjectID, obj.ObjectID);
 
             _stackNew.Push(obj);
             _waitHandles.PoolSemaphore.Release(1);
@@ -1577,7 +1577,7 @@ namespace Microsoft.Data.ProviderBase
             // method, we can safely presume that the caller is the only person
             // that is using the connection, and that all pre-push logic has been
             // done and all transactions are ended.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PutObjectFromTransactedPool|RES|CPOOL> {0}#, Connection {1}#, Transaction has ended.", ObjectID, obj.ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PutObjectFromTransactedPool|RES|CPOOL> {0}, Connection {1}, Transaction has ended.", ObjectID, obj.ObjectID);
 
             if (_state == State.Running && obj.CanBePooled)
             {
@@ -1602,7 +1602,7 @@ namespace Microsoft.Data.ProviderBase
         private bool ReclaimEmancipatedObjects()
         {
             bool emancipatedObjectFound = false;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReclaimEmancipatedObjects|RES|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReclaimEmancipatedObjects|RES|CPOOL> {0}", ObjectID);
             List<DbConnectionInternal> reclaimedObjects = new List<DbConnectionInternal>();
             int count;
 
@@ -1654,7 +1654,7 @@ namespace Microsoft.Data.ProviderBase
             for (int i = 0; i < count; ++i)
             {
                 DbConnectionInternal obj = reclaimedObjects[i];
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReclaimEmancipatedObjects|RES|CPOOL> {0}#, Connection {1}#, Reclaiming.", ObjectID, obj.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReclaimEmancipatedObjects|RES|CPOOL> {0}, Connection {1}, Reclaiming.", ObjectID, obj.ObjectID);
                 emancipatedObjectFound = true;
 
                 obj.DetachCurrentTransactionIfEnded();
@@ -1665,7 +1665,7 @@ namespace Microsoft.Data.ProviderBase
 
         internal void Startup()
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Startup|RES|INFO|CPOOL> {0}#, CleanupWait={1}", ObjectID, _cleanupWait);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Startup|RES|INFO|CPOOL> {0}, CleanupWait={1}", ObjectID, _cleanupWait);
             _cleanupTimer = CreateCleanupTimer();
             if (NeedToReplenish)
             {
@@ -1675,7 +1675,7 @@ namespace Microsoft.Data.ProviderBase
 
         internal void Shutdown()
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Shutdown|RES|INFO|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Shutdown|RES|INFO|CPOOL> {0}", ObjectID);
             _state = State.ShuttingDown;
 
             // deactivate timer callbacks
@@ -1697,7 +1697,7 @@ namespace Microsoft.Data.ProviderBase
             Debug.Assert(null != transactedObject, "null transactedObject?");
 
             // Note: connection may still be associated with transaction due to Explicit Unbinding requirement.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactionEnded|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Transaction Completed", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactionEnded|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Transaction Completed", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
 
             // called by the internal connection when it get's told that the
             // transaction is completed.  We tell the transacted pool to remove

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/LocalDBAPI.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/LocalDBAPI.Common.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data
                             {
                                 // SNI checks for LocalDBFormatMessage during DLL loading, so it is practically impossibe to get this error.
                                 int hResult = Marshal.GetLastWin32Error();
-                                SqlClientEventSource.Log.TraceEvent("<sc.LocalDBAPI.LocalDBFormatMessage> GetProcAddress for LocalDBFormatMessage error 0x{0}", hResult);
+                                SqlClientEventSource.Log.TraceEvent("<sc.LocalDBAPI.LocalDBFormatMessage> GetProcAddress for LocalDBFormatMessage error 0x{0}#", hResult);
                                 throw CreateLocalDBException(errorMessage: SR.LocalDB_MethodNotFound);
                             }
                             s_localDBFormatMessage = Marshal.GetDelegateForFunctionPointer<LocalDBFormatMessageDelegate>(functionAddr);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/LocalDBAPI.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/LocalDBAPI.Common.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data
                             {
                                 // SNI checks for LocalDBFormatMessage during DLL loading, so it is practically impossibe to get this error.
                                 int hResult = Marshal.GetLastWin32Error();
-                                SqlClientEventSource.Log.TraceEvent("<sc.LocalDBAPI.LocalDBFormatMessage> GetProcAddress for LocalDBFormatMessage error 0x{0}#", hResult);
+                                SqlClientEventSource.Log.TraceEvent("<sc.LocalDBAPI.LocalDBFormatMessage> GetProcAddress for LocalDBFormatMessage error 0x{0}", hResult);
                                 throw CreateLocalDBException(errorMessage: SR.LocalDB_MethodNotFound);
                             }
                             s_localDBFormatMessage = Marshal.GetDelegateForFunctionPointer<LocalDBFormatMessageDelegate>(functionAddr);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/LocalDB.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/LocalDB.Windows.cs
@@ -64,26 +64,26 @@ namespace Microsoft.Data.SqlClient.SNI
             switch (errorState)
             {
                 case LocalDBErrorState.NO_INSTALLATION:
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.MapLocalDBErrorStateToCode |SNI|ERR > LocalDB is not installed. Error State ={0}", errorState);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.MapLocalDBErrorStateToCode |SNI|ERR > LocalDB is not installed. Error State ={0}", errorState);
                     return SNICommon.LocalDBNoInstallation;
 
                 case LocalDBErrorState.INVALID_CONFIG:
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.MapLocalDBErrorStateToCode |SNI|ERR > Invalid configuration. Error State ={0}", errorState);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.MapLocalDBErrorStateToCode |SNI|ERR > Invalid configuration. Error State ={0}", errorState);
                     return SNICommon.LocalDBInvalidConfig;
 
                 case LocalDBErrorState.NO_SQLUSERINSTANCEDLL_PATH:
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.MapLocalDBErrorStateToCode |SNI|ERR > No SQL user instance path. Error State ={0}", errorState);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.MapLocalDBErrorStateToCode |SNI|ERR > No SQL user instance path. Error State ={0}", errorState);
                     return SNICommon.LocalDBNoSqlUserInstanceDllPath;
 
                 case LocalDBErrorState.INVALID_SQLUSERINSTANCEDLL_PATH:
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.MapLocalDBErrorStateToCode |SNI|ERR > Invalid SQL user instance path. Error State ={0}", errorState);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.MapLocalDBErrorStateToCode |SNI|ERR > Invalid SQL user instance path. Error State ={0}", errorState);
                     return SNICommon.LocalDBInvalidSqlUserInstanceDllPath;
 
                 case LocalDBErrorState.NONE:
                     return 0;
 
                 default:
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.MapLocalDBErrorStateToCode |SNI|ERR > Invalid configuration. Error State ={0}", errorState);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.MapLocalDBErrorStateToCode |SNI|ERR > Invalid configuration. Error State ={0}", errorState);
                     return SNICommon.LocalDBInvalidConfig;
             }
         }
@@ -93,7 +93,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         private bool LoadUserInstanceDll()
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI>");
             try
             {
                 // Check in a non thread-safe way if the handle is already set for performance.
@@ -126,7 +126,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     if (string.IsNullOrWhiteSpace(dllPath))
                     {
                         SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.INVALID_PROV, 0, SNICommon.LocalDBInvalidSqlUserInstanceDllPath, string.Empty);
-                        SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI|ERR > User instance DLL path is invalid. DLL path ={0}", dllPath);
+                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI|ERR > User instance DLL path is invalid. DLL path ={0}", dllPath);
                         return false;
                     }
 
@@ -181,7 +181,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns></returns>
         private string GetUserInstanceDllPath(out LocalDBErrorState errorState)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|SCOPE|INFO > GetUserInstanceDllPath");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|SCOPE|INFO > GetUserInstanceDllPath");
             try
             {
                 string dllPath = null;
@@ -190,7 +190,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     if (key == null)
                     {
                         errorState = LocalDBErrorState.NO_INSTALLATION;
-                        SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|ERR > not installed. Error state ={0}.", errorState);
+                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|ERR > not installed. Error state ={0}.", errorState);
                         return null;
                     }
 
@@ -205,7 +205,7 @@ namespace Microsoft.Data.SqlClient.SNI
                         if (!Version.TryParse(subKey, out currentKeyVersion))
                         {
                             errorState = LocalDBErrorState.INVALID_CONFIG;
-                            SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|ERR > Invalid Configuration. state ={0}.", errorState);
+                            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|ERR > Invalid Configuration. state ={0}.", errorState);
                             return null;
                         }
 
@@ -219,7 +219,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     if (latestVersion.Equals(zeroVersion))
                     {
                         errorState = LocalDBErrorState.INVALID_CONFIG;
-                        SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|ERR > Invalid Configuration. state ={0}.", errorState);
+                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|ERR > Invalid Configuration. state ={0}.", errorState);
                         return null;
                     }
 
@@ -232,7 +232,7 @@ namespace Microsoft.Data.SqlClient.SNI
                         if (instanceAPIPathRegistryObject == null)
                         {
                             errorState = LocalDBErrorState.NO_SQLUSERINSTANCEDLL_PATH;
-                            SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|ERR > No SQL user instance DLL. Instance API Path REgistry Object Error. state ={0}.", errorState);
+                            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|ERR > No SQL user instance DLL. Instance API Path REgistry Object Error. state ={0}.", errorState);
                             return null;
                         }
 
@@ -241,7 +241,7 @@ namespace Microsoft.Data.SqlClient.SNI
                         if (valueKind != RegistryValueKind.String)
                         {
                             errorState = LocalDBErrorState.INVALID_SQLUSERINSTANCEDLL_PATH;
-                            SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|ERR > No SQL user instance DLL. state ={0}. Registry value kind error.", errorState);
+                            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.GetUserInstanceDllPath |SNI|ERR > No SQL user instance DLL. state ={0}. Registry value kind error.", errorState);
                             return null;
                         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/LocalDB.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/LocalDB.Windows.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -254,7 +254,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/LocalDB.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/LocalDB.Windows.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     if (dllPath == null)
                     {
                         SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.INVALID_PROV, 0, MapLocalDBErrorStateToCode(registryQueryErrorState), string.Empty);
-                        SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI|ERR >User instance DLL path is null.");
+                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI|ERR >User instance DLL path is null.");
                         return false;
                     }
 
@@ -136,7 +136,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     if (libraryHandle.IsInvalid)
                     {
                         SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.INVALID_PROV, 0, SNICommon.LocalDBFailedToLoadDll, string.Empty);
-                        SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI|ERR > Library Handle is invalid. Could not load the dll.");
+                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI|ERR > Library Handle is invalid. Could not load the dll.");
                         libraryHandle.Dispose();
                         return false;
                     }
@@ -147,7 +147,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     if (_startInstanceHandle == IntPtr.Zero)
                     {
                         SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.INVALID_PROV, 0, SNICommon.LocalDBBadRuntime, string.Empty);
-                        SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI|ERR > Was not able to load the PROC from DLL. Bad Runtime.");
+                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI|ERR > Was not able to load the PROC from DLL. Bad Runtime.");
                         libraryHandle.Dispose();
                         return false;
                     }
@@ -164,13 +164,13 @@ namespace Microsoft.Data.SqlClient.SNI
                     }
 
                     _sqlUserInstanceLibraryHandle = libraryHandle;
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI|INFO > User Instance DLL was loaded successfully.");
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.LocalDB.Windows.LoadUserInstanceDll |SNI|INFO > User Instance DLL was loaded successfully.");
                     return true;
                 }
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -254,7 +254,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>True if certificate is valid</returns>
         internal static bool ValidateSslServerCertificate(string targetServerName, object sender, X509Certificate cert, X509Chain chain, SslPolicyErrors policyErrors)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNICommon.ValidateSslServerCertificate |SNI|SCOPE|INFO >");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNICommon.ValidateSslServerCertificate |SNI|SCOPE|INFO >");
             try
             {
                 if (policyErrors == SslPolicyErrors.None)
@@ -203,7 +203,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns></returns>
         internal static uint ReportSNIError(SNIProviders provider, uint nativeError, uint sniError, string errorMessage)
         {
-            SqlClientEventSource.Log.SNITrace("<sc.SNI.SNICommon. ReportSNIError |SNI|ERR > Provider ={0}, native Error ={1}, SNI Error ={2}, Error Message ={3}", provider, nativeError, sniError, errorMessage);
+            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNICommon. ReportSNIError |SNI|ERR > Provider ={0}, native Error ={1}, SNI Error ={2}, Error Message ={3}", provider, nativeError, sniError, errorMessage);
             return ReportSNIError(new SNIError(provider, nativeError, sniError, errorMessage));
         }
 
@@ -216,7 +216,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns></returns>
         internal static uint ReportSNIError(SNIProviders provider, uint sniError, Exception sniException)
         {
-            SqlClientEventSource.Log.SNITrace("<sc.SNI.SNICommon. ReportSNIError |SNI|ERR > Provider ={0}, SNI Error ={2}, Exception ={3}", provider, sniError, sniException.Message);
+            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNICommon. ReportSNIError |SNI|ERR > Provider ={0}, SNI Error ={2}, Exception ={3}", provider, sniError, sniException.Message);
             return ReportSNIError(new SNIError(provider, sniError, sniException));
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -203,7 +203,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns></returns>
         internal static uint ReportSNIError(SNIProviders provider, uint nativeError, uint sniError, string errorMessage)
         {
-            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNICommon. ReportSNIError |SNI|ERR > Provider ={0}, native Error ={1}, SNI Error ={2}, Error Message ={3}", provider, nativeError, sniError, errorMessage);
+            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNICommon. ReportSNIError |SNI|ERR > Provider ={0}#, native Error ={1}#, SNI Error ={2}#, Error Message ={3}#", provider, nativeError, sniError, errorMessage);
             return ReportSNIError(new SNIError(provider, nativeError, sniError, errorMessage));
         }
 
@@ -216,7 +216,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns></returns>
         internal static uint ReportSNIError(SNIProviders provider, uint sniError, Exception sniException)
         {
-            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNICommon. ReportSNIError |SNI|ERR > Provider ={0}, SNI Error ={2}, Exception ={3}", provider, sniError, sniException.Message);
+            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNICommon. ReportSNIError |SNI|ERR > Provider ={0}, SNI Error ={1}, Exception ={2}", provider, sniError, sniException.Message);
             return ReportSNIError(new SNIError(provider, sniError, sniException));
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
@@ -141,13 +141,13 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 if (policyErrors == SslPolicyErrors.None)
                 {
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNICommon.ValidateSslServerCertificate |SNI|INFO > SSL Server certificate validated.");
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNICommon.ValidateSslServerCertificate |SNI|INFO > SSL Server certificate validated.");
                     return true;
                 }
 
                 if ((policyErrors & SslPolicyErrors.RemoteCertificateNameMismatch) != 0)
                 {
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNICommon.ValidateSslServerCertificate |SNI|ERR > SSL Remote certificate name mismatched.");
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNICommon.ValidateSslServerCertificate |SNI|ERR > SSL Remote certificate name mismatched.");
                     string certServerName = cert.Subject.Substring(cert.Subject.IndexOf('=') + 1);
 
                     // Verify that target server name matches subject in the certificate
@@ -189,7 +189,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -203,7 +203,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns></returns>
         internal static uint ReportSNIError(SNIProviders provider, uint nativeError, uint sniError, string errorMessage)
         {
-            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNICommon. ReportSNIError |SNI|ERR > Provider ={0}#, native Error ={1}#, SNI Error ={2}#, Error Message ={3}#", provider, nativeError, sniError, errorMessage);
+            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNICommon. ReportSNIError |SNI|ERR > Provider ={0}, native Error ={1}, SNI Error ={2}, Error Message ={3}", provider, nativeError, sniError, errorMessage);
             return ReportSNIError(new SNIError(provider, nativeError, sniError, errorMessage));
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNILoadHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNILoadHandle.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
             set
             {
-                SqlClientEventSource.Log.SNITrace("<sc.SNI.SNILoadHandle.LastError |SNI|INFO|SETTER > Last Error Value = {0}", value);
+                SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNILoadHandle.LastError |SNI|INFO|SETTER > Last Error Value = {0}", value);
                 _lastError.Value = value;
             }
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -69,15 +69,15 @@ namespace Microsoft.Data.SqlClient.SNI
 
                 if (ReceiveAsync(ref packet) == TdsEnums.SNI_SUCCESS_IO_PENDING)
                 {
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNIMarsConnection.StartReceive |SNI|INFO|Trace> Success IO pending.");
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNIMarsConnection.StartReceive |SNI|INFO|Trace> Success IO pending.");
                     return TdsEnums.SNI_SUCCESS_IO_PENDING;
                 }
-                SqlClientEventSource.Log.SNITrace("<sc.SNI.SNIMarsConnection.StartReceive |SNI|ERR> Connection not useable.");
+                SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNIMarsConnection.StartReceive |SNI|ERR> Connection not useable.");
                 return SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, 0, SNICommon.ConnNotUsableError, string.Empty);
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -98,7 +98,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -147,7 +147,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -167,7 +167,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -179,7 +179,7 @@ namespace Microsoft.Data.SqlClient.SNI
             Debug.Assert(Monitor.IsEntered(this), "HandleReceiveError was called without being locked.");
             if (!Monitor.IsEntered(this))
             {
-                SqlClientEventSource.Log.SNITrace("<sc.SNI.SNIMarsConnection.HandleReceiveError |SNI|ERR> HandleReceiveError was called without being locked.");
+                SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNIMarsConnection.HandleReceiveError |SNI|ERR> HandleReceiveError was called without being locked.");
             }
             foreach (SNIMarsHandle handle in _sessions.Values)
             {
@@ -220,7 +220,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     lock (this)
                     {
                         HandleReceiveError(packet);
-                        SqlClientEventSource.Log.SNITrace("<sc.SNI.SNIMarsConnection.HandleReceiveComplete |SNI|ERR> not successfull.");
+                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNIMarsConnection.HandleReceiveComplete |SNI|ERR> not successfull.");
                         return;
                     }
                 }
@@ -246,7 +246,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
                                     if (sniErrorCode == TdsEnums.SNI_SUCCESS_IO_PENDING)
                                     {
-                                        SqlClientEventSource.Log.SNITrace("<sc.SNI.SNIMarsConnection.HandleReceiveComplete |SNI|ERR> not successfull.");
+                                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNIMarsConnection.HandleReceiveComplete |SNI|ERR> not successfull.");
                                         return;
                                     }
 
@@ -343,7 +343,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -359,7 +359,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -375,7 +375,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -392,7 +392,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 #endif

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns></returns>
         public uint StartReceive()
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsConnection.StartReceive |SNI|INFO|SCOPE> StartReceive");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsConnection.StartReceive |SNI|INFO|SCOPE> StartReceive");
             try
             {
                 SNIPacket packet = null;
@@ -88,7 +88,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public uint Send(SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsConnection.Send |SNI|INFO|SCOPE> Send");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsConnection.Send |SNI|INFO|SCOPE> Send");
             try
             {
                 lock (this)
@@ -110,7 +110,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public uint SendAsync(SNIPacket packet, SNIAsyncCallback callback)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsConnection.SendAsync |SNI|INFO|SCOPE> SendAsync");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsConnection.SendAsync |SNI|INFO|SCOPE> SendAsync");
             try
             {
                 lock (this)
@@ -131,7 +131,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public uint ReceiveAsync(ref SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsConnection.SendAsync |SNI|INFO|SCOPE> SendAsync");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsConnection.SendAsync |SNI|INFO|SCOPE> SendAsync");
             try
             {
                 if (packet != null)
@@ -157,7 +157,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error status</returns>
         public uint CheckConnection()
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsConnection.CheckConnection |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsConnection.CheckConnection |SNI|INFO|SCOPE>");
             try
             {
                 lock (this)
@@ -208,7 +208,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="sniErrorCode">SNI error code</param>
         public void HandleReceiveComplete(SNIPacket packet, uint sniErrorCode)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsConnection.HandleReceiveComplete |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsConnection.HandleReceiveComplete |SNI|INFO|SCOPE>");
             try
             {
                 SNISMUXHeader currentHeader = null;
@@ -352,7 +352,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public uint EnableSsl(uint options)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsConnection.EnableSsl |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsConnection.EnableSsl |SNI|INFO|SCOPE>");
             try
             {
                 return _lowerHandle.EnableSsl(options);
@@ -368,7 +368,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public void DisableSsl()
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsConnection.EnableSsl |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsConnection.EnableSsl |SNI|INFO|SCOPE>");
             try
             {
                 _lowerHandle.DisableSsl();
@@ -385,7 +385,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public void KillConnection()
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsConnection.KillConnection |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsConnection.KillConnection |SNI|INFO|SCOPE>");
             try
             {
                 _lowerHandle.KillConnection();

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -98,7 +98,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -147,7 +147,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -167,7 +167,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -343,7 +343,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -359,7 +359,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -375,7 +375,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -392,7 +392,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 #endif

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -51,14 +51,14 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public override void Dispose()
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.Dispose |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.Dispose |SNI|INFO|SCOPE>");
             try
             {
                 SendControlPacket(SNISMUXFlags.SMUX_FIN);
             }
             catch (Exception e)
             {
-                SqlClientEventSource.Log.SNITrace("<sc.SNI.SNIMarsHandle.Dispose |SNI|ERR> internal exception error = {0}, Member Name={1}", e.Message, e.GetType().Name);
+                SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNIMarsHandle.Dispose |SNI|ERR> internal exception error = {0}, Member Name={1}", e.Message, e.GetType().Name);
                 SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, SNICommon.InternalExceptionError, e);
             }
             finally
@@ -89,7 +89,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="flags">SMUX header flags</param>
         private void SendControlPacket(SNISMUXFlags flags)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.SendControlPacket |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.SendControlPacket |SNI|INFO|SCOPE>");
             try
             {
                 SNIPacket packet = new SNIPacket(headerSize: SNISMUXHeader.HEADER_LENGTH, dataSize: 0);
@@ -146,7 +146,7 @@ namespace Microsoft.Data.SqlClient.SNI
         public override uint Send(SNIPacket packet)
         {
             Debug.Assert(packet.ReservedHeaderSize == SNISMUXHeader.HEADER_LENGTH, "mars handle attempting to send muxed packet without mux reservation in Send");
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.Send |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.Send |SNI|INFO|SCOPE>");
             try
             {
                 while (true)
@@ -189,7 +189,7 @@ namespace Microsoft.Data.SqlClient.SNI
         private uint InternalSendAsync(SNIPacket packet, SNIAsyncCallback callback)
         {
             Debug.Assert(packet.ReservedHeaderSize == SNISMUXHeader.HEADER_LENGTH, "mars handle attempting to send muxed packet without mux reservation in InternalSendAsync");
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.InternalSendAsync |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.InternalSendAsync |SNI|INFO|SCOPE>");
             try
             {
                 lock (this)
@@ -217,7 +217,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         private uint SendPendingPackets()
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.SendPendingPackets |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.SendPendingPackets |SNI|INFO|SCOPE>");
             SNIMarsQueuedPacket packet = null;
             try
             {
@@ -268,7 +268,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint SendAsync(SNIPacket packet, bool disposePacketAfterSendAsync, SNIAsyncCallback callback = null)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.SendAsync |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.SendAsync |SNI|INFO|SCOPE>");
             try
             {
                 lock (this)
@@ -292,7 +292,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint ReceiveAsync(ref SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.SendAsync |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.SendAsync |SNI|INFO|SCOPE>");
             try
             {
                 lock (_receivedPacketQueue)
@@ -337,7 +337,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public void HandleReceiveError(SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.HandleReceiveError |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.HandleReceiveError |SNI|INFO|SCOPE>");
             try
             {
                 lock (_receivedPacketQueue)
@@ -361,7 +361,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="sniErrorCode">SNI error code</param>
         public void HandleSendComplete(SNIPacket packet, uint sniErrorCode)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.HandleSendComplete |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.HandleSendComplete |SNI|INFO|SCOPE>");
             try
             {
                 lock (this)
@@ -383,7 +383,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="highwater">Send highwater mark</param>
         public void HandleAck(uint highwater)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.HandleAck |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.HandleAck |SNI|INFO|SCOPE>");
             try
             {
                 lock (this)
@@ -408,7 +408,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="header">SMUX header</param>
         public void HandleReceiveComplete(SNIPacket packet, SNISMUXHeader header)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.HandleReceiveComplete |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.HandleReceiveComplete |SNI|INFO|SCOPE>");
             try
             {
                 lock (this)
@@ -475,7 +475,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint Receive(out SNIPacket packet, int timeoutInMilliseconds)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNIMarsHandle.Receive |SNI|INFO|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNIMarsHandle.Receive |SNI|INFO|SCOPE>");
             try
             {
                 packet = null;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -105,7 +105,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -207,7 +207,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -255,7 +255,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -281,7 +281,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -328,7 +328,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -350,7 +350,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -373,7 +373,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -397,7 +397,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -443,7 +443,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -526,7 +526,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -105,7 +105,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -196,7 +196,7 @@ namespace Microsoft.Data.SqlClient.SNI
                 {
                     if (_sequenceNumber >= _sendHighwater)
                     {
-                        SqlClientEventSource.Log.SNITrace("<sc.SNI.SNIMarsHandle.InternalSendAsync |SNI|INFO|> SNI Queue is full");
+                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNIMarsHandle.InternalSendAsync |SNI|INFO|> SNI Queue is full");
                         return TdsEnums.SNI_QUEUE_FULL;
                     }
 
@@ -207,7 +207,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -234,7 +234,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
                                 if (result != TdsEnums.SNI_SUCCESS && result != TdsEnums.SNI_SUCCESS_IO_PENDING)
                                 {
-                                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNIMarsHandle.SendPendingPackets |SNI|ERR> InternalSendAsync result is not SNI_SUCCESS and is not SNI_SUCCESS_IO_PENDING");
+                                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNIMarsHandle.SendPendingPackets |SNI|ERR> InternalSendAsync result is not SNI_SUCCESS and is not SNI_SUCCESS_IO_PENDING");
                                     return result;
                                 }
 
@@ -255,7 +255,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -281,7 +281,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -328,7 +328,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -350,7 +350,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -373,7 +373,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -397,7 +397,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -443,7 +443,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -526,7 +526,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNINpHandle.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Data.SqlClient.SNI
                 {
                     SNICommon.ReportSNIError(SNIProviders.NP_PROV, 0, SNICommon.ConnOpenFailedError, string.Empty);
                     _status = TdsEnums.SNI_ERROR;
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.SNINpHandle |SNI|ERR> Pipe stream is not connected or cannot write or read to/from it.");
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.SNINpHandle |SNI|ERR> Pipe stream is not connected or cannot write or read to/from it.");
                     return;
                 }
 
@@ -100,7 +100,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -127,7 +127,7 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 if (!_stream.CanWrite || !_stream.CanRead)
                 {
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.CheckConnection |SNI|ERR> cannot wite or read to/from the stream");
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.CheckConnection |SNI|ERR> cannot wite or read to/from the stream");
                     return TdsEnums.SNI_ERROR;
                 }
                 else
@@ -137,7 +137,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -187,7 +187,7 @@ namespace Microsoft.Data.SqlClient.SNI
                             errorPacket = packet;
                             packet = null;
                             var e = new Win32Exception();
-                            SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.Receive |SNI|ERR> packet length is 0.");
+                            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.Receive |SNI|ERR> packet length is 0.");
                             return ReportErrorAndReleasePacket(errorPacket, (uint)e.NativeErrorCode, 0, e.Message);
                         }
                     }
@@ -210,7 +210,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -244,7 +244,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -303,7 +303,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -318,7 +318,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -354,7 +354,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -390,7 +390,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNINpHandle.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -137,7 +137,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -210,7 +210,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -244,7 +244,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -303,7 +303,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -318,7 +318,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -354,7 +354,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -390,7 +390,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNINpHandle.cs
@@ -40,8 +40,8 @@ namespace Microsoft.Data.SqlClient.SNI
 
         public SNINpHandle(string serverName, string pipeName, long timerExpire, object callbackObject)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNINpHandle.SNINpHandle |SNI|INFO|SCOPE> Constructor");
-            SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.SNINpHandle |SNI|INFO> Constructor. server name = {0}, pipe name = {1}", serverName, pipeName);
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNINpHandle.SNINpHandle |SNI|INFO|SCOPE> Constructor");
+            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.SNINpHandle |SNI|INFO> Constructor. server name = {0}, pipe name = {1}", serverName, pipeName);
             try
             {
                 _sendSync = new object();
@@ -73,14 +73,14 @@ namespace Microsoft.Data.SqlClient.SNI
                 {
                     SNICommon.ReportSNIError(SNIProviders.NP_PROV, SNICommon.ConnOpenFailedError, te);
                     _status = TdsEnums.SNI_ERROR;
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.SNINpHandle |SNI|ERR> Timed out. Exception = {0}", te.Message);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.SNINpHandle |SNI|ERR> Timed out. Exception = {0}", te.Message);
                     return;
                 }
                 catch (IOException ioe)
                 {
                     SNICommon.ReportSNIError(SNIProviders.NP_PROV, SNICommon.ConnOpenFailedError, ioe);
                     _status = TdsEnums.SNI_ERROR;
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.SNINpHandle |SNI|ERR> IOException = {0}", ioe.Message);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.SNINpHandle |SNI|ERR> IOException = {0}", ioe.Message);
                     return;
                 }
 
@@ -122,7 +122,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
         public override uint CheckConnection()
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNINpHandle.CheckConnection |SNI|INFO>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNINpHandle.CheckConnection |SNI|INFO>");
             try
             {
                 if (!_stream.CanWrite || !_stream.CanRead)
@@ -170,7 +170,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
         public override uint Receive(out SNIPacket packet, int timeout)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNINpHandle.Receive |SNI|INFO>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNINpHandle.Receive |SNI|INFO>");
             try
             {
                 SNIPacket errorPacket;
@@ -195,14 +195,14 @@ namespace Microsoft.Data.SqlClient.SNI
                     {
                         errorPacket = packet;
                         packet = null;
-                        SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.Receive |SNI|ERR> ObjectDisposedException message = {0}.", ode.Message);
+                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.Receive |SNI|ERR> ObjectDisposedException message = {0}.", ode.Message);
                         return ReportErrorAndReleasePacket(errorPacket, ode);
                     }
                     catch (IOException ioe)
                     {
                         errorPacket = packet;
                         packet = null;
-                        SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.Receive |SNI|ERR> IOException message = {0}.", ioe.Message);
+                        SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.Receive |SNI|ERR> IOException message = {0}.", ioe.Message);
                         return ReportErrorAndReleasePacket(errorPacket, ioe);
                     }
                     return TdsEnums.SNI_SUCCESS;
@@ -216,7 +216,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
         public override uint ReceiveAsync(ref SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNINpHandle.ReceiveAsync |SNI|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNINpHandle.ReceiveAsync |SNI|SCOPE>");
             try
             {
                 SNIPacket errorPacket;
@@ -231,14 +231,14 @@ namespace Microsoft.Data.SqlClient.SNI
                 {
                     errorPacket = packet;
                     packet = null;
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.ReceiveAsync |SNI|ERR> ObjectDisposedException message = {0}.", ode.Message);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.ReceiveAsync |SNI|ERR> ObjectDisposedException message = {0}.", ode.Message);
                     return ReportErrorAndReleasePacket(errorPacket, ode);
                 }
                 catch (IOException ioe)
                 {
                     errorPacket = packet;
                     packet = null;
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.ReceiveAsync |SNI|ERR> IOException message = {0}.", ioe.Message);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.ReceiveAsync |SNI|ERR> IOException message = {0}.", ioe.Message);
                     return ReportErrorAndReleasePacket(errorPacket, ioe);
                 }
             }
@@ -250,7 +250,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
         public override uint Send(SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNINpHandle.Send |SNI|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNINpHandle.Send |SNI|SCOPE>");
             try
             {
                 bool releaseLock = false;
@@ -282,12 +282,12 @@ namespace Microsoft.Data.SqlClient.SNI
                         }
                         catch (ObjectDisposedException ode)
                         {
-                            SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.Send |SNI|ERR> ObjectDisposedException message = {0}.", ode.Message);
+                            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.Send |SNI|ERR> ObjectDisposedException message = {0}.", ode.Message);
                             return ReportErrorAndReleasePacket(packet, ode);
                         }
                         catch (IOException ioe)
                         {
-                            SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.Send |SNI|ERR> IOException message = {0}.", ioe.Message);
+                            SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.Send |SNI|ERR> IOException message = {0}.", ioe.Message);
 
                             return ReportErrorAndReleasePacket(packet, ioe);
                         }
@@ -309,7 +309,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
         public override uint SendAsync(SNIPacket packet, bool disposePacketAfterSendAsync, SNIAsyncCallback callback = null)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNINpHandle.SendAsync |SNI|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNINpHandle.SendAsync |SNI|SCOPE>");
             try
             {
                 SNIAsyncCallback cb = callback ?? _sendCallback;
@@ -330,7 +330,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
         public override uint EnableSsl(uint options)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNINpHandle.EnableSsl |SNI|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNINpHandle.EnableSsl |SNI|SCOPE>");
             try
             {
                 _validateCert = (options & TdsEnums.SNI_SSL_VALIDATE_CERTIFICATE) != 0;
@@ -341,12 +341,12 @@ namespace Microsoft.Data.SqlClient.SNI
                 }
                 catch (AuthenticationException aue)
                 {
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.EnableSsl |SNI|ERR> AuthenticationException message = {0}.", aue.Message);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.EnableSsl |SNI|ERR> AuthenticationException message = {0}.", aue.Message);
                     return SNICommon.ReportSNIError(SNIProviders.NP_PROV, SNICommon.InternalExceptionError, aue);
                 }
                 catch (InvalidOperationException ioe)
                 {
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SNINpHandle.EnableSsl |SNI|ERR>InvalidOperationExceptionn message = {0}.", ioe.Message);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SNINpHandle.EnableSsl |SNI|ERR>InvalidOperationExceptionn message = {0}.", ioe.Message);
                     return SNICommon.ReportSNIError(SNIProviders.NP_PROV, SNICommon.InternalExceptionError, ioe);
                 }
                 _stream = _sslStream;
@@ -378,7 +378,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>true if valid</returns>
         private bool ValidateServerCertificate(object sender, X509Certificate cert, X509Chain chain, SslPolicyErrors policyErrors)
         {
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SNINpHandle.ValidateServerCertificate |SNI|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SNINpHandle.ValidateServerCertificate |SNI|SCOPE>");
             try
             {
                 if (!_validateCert)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SSRP.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SSRP.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.SqlClient.SNI
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(browserHostName), "browserHostName should not be null, empty, or whitespace");
             Debug.Assert(!string.IsNullOrWhiteSpace(instanceName), "instanceName should not be null, empty, or whitespace");
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SSRP.GetPortByInstanceName |SNI|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SSRP.GetPortByInstanceName |SNI|SCOPE>");
             try
             {
                 byte[] instanceInfoRequest = CreateInstanceInfoRequest(instanceName);
@@ -37,7 +37,7 @@ namespace Microsoft.Data.SqlClient.SNI
                 }
                 catch (SocketException se)
                 {
-                    SqlClientEventSource.Log.SNITrace("<sc.SNI.SSRP.GetPortByInstanceName |SNI|ERR> SocketException Message = {0}", se.Message);
+                    SqlClientEventSource.Log.SNITraceEvent("<sc.SNI.SSRP.GetPortByInstanceName |SNI|ERR> SocketException Message = {0}", se.Message);
                     throw new Exception(SQLMessage.SqlServerBrowserNotAccessible(), se);
                 }
 
@@ -73,7 +73,7 @@ namespace Microsoft.Data.SqlClient.SNI
         private static byte[] CreateInstanceInfoRequest(string instanceName)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(instanceName), "instanceName should not be null, empty, or whitespace");
-            long scopeID = SqlClientEventSource.Log.SNIScopeEnter("<sc.SNI.SSRP.CreateInstanceInfoRequest |SNI|SCOPE>");
+            long scopeID = SqlClientEventSource.Log.SNIScopeEnterEvent("<sc.SNI.SSRP.CreateInstanceInfoRequest |SNI|SCOPE>");
             try
             {
                 const byte ClntUcastInst = 0x04;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SSRP.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SSRP.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SSRP.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SSRP.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             finally
             {
-                SqlClientEventSource.Log.SNIScopeLeave(scopeID);
+                SqlClientEventSource.Log.SNIScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -545,8 +545,8 @@ namespace Microsoft.Data.SqlClient
         private Task<BulkCopySimpleResultSet> CreateAndExecuteInitialQueryAsync(out BulkCopySimpleResultSet result)
         {
             string TDSCommand = CreateInitialQuery();
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|INFO> Initial Query: '{0}#'", TDSCommand);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|Info|Correlation> ObjectID {0}#, ActivityID {1}#", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|INFO> Initial Query: '{0}'", TDSCommand);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|Info|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             Task executeTask = _parser.TdsExecuteSQLBatch(TDSCommand, this.BulkCopyTimeout, null, _stateObj, sync: !_isAsyncBulkCopy, callerHasConnectionLock: true);
 
             if (executeTask == null)
@@ -811,7 +811,7 @@ namespace Microsoft.Data.SqlClient
 
         private Task SubmitUpdateBulkCommand(string TDSCommand)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.SubmitUpdateBulkCommand|Info|Correlation> ObjectID{0}#, ActivityID {1}#", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.SubmitUpdateBulkCommand|Info|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             Task executeTask = _parser.TdsExecuteSQLBatch(TDSCommand, this.BulkCopyTimeout, null, _stateObj, sync: !_isAsyncBulkCopy, callerHasConnectionLock: true);
 
             if (executeTask == null)
@@ -2318,7 +2318,7 @@ namespace Microsoft.Data.SqlClient
                             // It's also the user's chance to cause an exception.
                             _stateObj.BcpLock = true;
                             abortOperation = FireRowsCopiedEvent(_rowsCopied);
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlBulkCopy.WriteToServerInternal|{0}#>", "INFO");
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlBulkCopy.WriteToServerInternal|{0}>", "INFO");
 
                             // In case the target connection is closed accidentally.
                             if (ConnectionState.Open != _connection.State)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -545,8 +545,8 @@ namespace Microsoft.Data.SqlClient
         private Task<BulkCopySimpleResultSet> CreateAndExecuteInitialQueryAsync(out BulkCopySimpleResultSet result)
         {
             string TDSCommand = CreateInitialQuery();
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|INFO> Initial Query: '{0}'", TDSCommand);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|Info|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|INFO> Initial Query: '{0}#'", TDSCommand);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|Info|Correlation> ObjectID {0}#, ActivityID {1}#", ObjectID, ActivityCorrelator.Current.ToString());
             Task executeTask = _parser.TdsExecuteSQLBatch(TDSCommand, this.BulkCopyTimeout, null, _stateObj, sync: !_isAsyncBulkCopy, callerHasConnectionLock: true);
 
             if (executeTask == null)
@@ -811,7 +811,7 @@ namespace Microsoft.Data.SqlClient
 
         private Task SubmitUpdateBulkCommand(string TDSCommand)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.SubmitUpdateBulkCommand|Info|Correlation> ObjectID{0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.SubmitUpdateBulkCommand|Info|Correlation> ObjectID{0}#, ActivityID {1}#", ObjectID, ActivityCorrelator.Current.ToString());
             Task executeTask = _parser.TdsExecuteSQLBatch(TDSCommand, this.BulkCopyTimeout, null, _stateObj, sync: !_isAsyncBulkCopy, callerHasConnectionLock: true);
 
             if (executeTask == null)
@@ -2318,7 +2318,7 @@ namespace Microsoft.Data.SqlClient
                             // It's also the user's chance to cause an exception.
                             _stateObj.BcpLock = true;
                             abortOperation = FireRowsCopiedEvent(_rowsCopied);
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlBulkCopy.WriteToServerInternal|{0}>", "INFO");
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlBulkCopy.WriteToServerInternal|{0}#>", "INFO");
 
                             // In case the target connection is closed accidentally.
                             if (ConnectionState.Open != _connection.State)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Data.SqlClient
 
         #region Notification Scope
         [NonEvent]
-        internal long notificationScopeEnterEvent<T0>(string message, T0 args0)
+        internal long NotificationScopeEnterEvent<T0>(string message, T0 args0)
         {
             if (Log.IsNotificationScopeEnabled())
             {
@@ -438,7 +438,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         [NonEvent]
-        internal long notificationScopeEnterEvent<T0, T1>(string message, T0 args0, T1 args1)
+        internal long NotificationScopeEnterEvent<T0, T1>(string message, T0 args0, T1 args1)
         {
             if (Log.IsNotificationScopeEnabled())
             {
@@ -448,7 +448,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         [NonEvent]
-        internal long notificationScopeEnterEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
+        internal long NotificationScopeEnterEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
         {
             if (Log.IsNotificationScopeEnabled())
             {
@@ -458,7 +458,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         [NonEvent]
-        internal long notificationScopeEnterEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
+        internal long NotificationScopeEnterEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
         {
             if (Log.IsNotificationScopeEnabled())
             {
@@ -468,7 +468,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         [NonEvent]
-        internal void notificationScopeLeaveEvent(long scopeId)
+        internal void NotificationScopeLeaveEvent(long scopeId)
         {
             if (Log.IsNotificationScopeEnabled())
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -96,29 +96,34 @@ namespace Microsoft.Data.SqlClient
         private const int AdvancedTraceBinId = 15;
 
         /// <summary>
+        /// Defines EventId for AdvancedTraceError() events
+        /// </summary>
+        private const int AdvancedTraceErrorId = 16;
+
+        /// <summary>
         /// Defines EventId for CorrelationTrace() events
         /// </summary>
-        private const int CorrelationTraceId = 16;
+        private const int CorrelationTraceId = 17;
 
         /// <summary>
         /// Defines EventId for StateDump() events
         /// </summary>
-        private const int StateDumpEventId = 17;
+        private const int StateDumpEventId = 18;
 
         /// <summary>
         /// Defines EventId for SNITrace() events
         /// </summary>
-        private const int SNITraceEventId = 18;
+        private const int SNITraceEventId = 19;
 
         /// <summary>
         /// Defines EventId for SNIEnterScope() events
         /// </summary>
-        private const int SNIScopeEnterId = 19;
+        private const int SNIScopeEnterId = 20;
 
         /// <summary>
         /// Defines EventId for SNIExitScope() events
         /// </summary>
-        private const int SNIScopeExitId = 20;
+        private const int SNIScopeExitId = 21;
         #endregion
 
         /// <summary>
@@ -873,13 +878,13 @@ namespace Microsoft.Data.SqlClient
         [Event(PoolerScopeExitId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Keywords = Keywords.PoolerScope)]
         internal void PoolerScopeLeave(long scopeId)
         {
-            WriteEvent(ScopeExitId, scopeId);
+            WriteEvent(PoolerScopeExitId, scopeId);
         }
 
         [Event(AdvancedTraceId, Level = EventLevel.Verbose, Keywords = Keywords.AdvancedTrace)]
         internal void AdvancedTrace(string message)
         {
-            WriteEvent(TraceEventId, message);
+            WriteEvent(AdvancedTraceId, message);
         }
 
         [Event(AdvancedScopeEnterId, Level = EventLevel.Verbose, Opcode = EventOpcode.Start, Keywords = Keywords.AdvancedTrace)]
@@ -902,10 +907,10 @@ namespace Microsoft.Data.SqlClient
             WriteEvent(AdvancedTraceBinId, message);
         }
 
-        [Event(AdvancedTraceId, Level = EventLevel.Error, Keywords = Keywords.AdvancedTrace)]
+        [Event(AdvancedTraceErrorId, Level = EventLevel.Error, Keywords = Keywords.AdvancedTrace)]
         internal void AdvancedTraceError(string message)
         {
-            WriteEvent(TraceEventId, message);
+            WriteEvent(AdvancedTraceErrorId, message);
         }
 
         [Event(CorrelationTraceId, Level = EventLevel.Informational, Keywords = Keywords.CorrelationTrace, Opcode = EventOpcode.Start)]

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -226,37 +226,37 @@ namespace Microsoft.Data.SqlClient
         internal bool IsExecutionTraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.ExecutionTrace);
 
         [NonEvent]
-        internal bool IsTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Trace);
+        internal bool IsTraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.Trace);
 
         [NonEvent]
-        internal bool IsScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Scope);
+        internal bool IsScopeEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.Scope);
 
         [NonEvent]
-        internal bool IsNotificationTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.NotificationTrace);
+        internal bool IsNotificationTraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.NotificationTrace);
 
         [NonEvent]
-        internal bool IsNotificationScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.NotificationScope);
+        internal bool IsNotificationScopeEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.NotificationScope);
 
         [NonEvent]
-        internal bool IsPoolerTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.PoolerTrace);
+        internal bool IsPoolerTraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.PoolerTrace);
 
         [NonEvent]
-        internal bool IsPoolerScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.PoolerScope);
+        internal bool IsPoolerScopeEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.PoolerScope);
 
         [NonEvent]
-        internal bool IsAdvancedTraceOn() => SqlClientEventSource.Log.IsEnabled(EventLevel.Verbose, Keywords.AdvancedTrace);
+        internal bool IsAdvancedTraceOn() => Log.IsEnabled(EventLevel.Verbose, Keywords.AdvancedTrace);
 
         [NonEvent]
-        internal bool IsCorrelationEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.CorrelationTrace);
+        internal bool IsCorrelationEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.CorrelationTrace);
 
         [NonEvent]
-        internal bool IsStateDumpEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.StateDump);
+        internal bool IsStateDumpEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.StateDump);
 
         [NonEvent]
-        internal bool IsSNITraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.SNITrace);
+        internal bool IsSNITraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.SNITrace);
 
         [NonEvent]
-        internal bool IsSNIScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.SNIScope);
+        internal bool IsSNIScopeEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.SNIScope);
         #endregion
 
         #region overloads

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text;
 using System.Diagnostics.Tracing;
 using System.Threading;
 
@@ -14,9 +13,12 @@ namespace Microsoft.Data.SqlClient
         // Defines the singleton instance for the Resources ETW provider
         internal static readonly SqlClientEventSource Log = new SqlClientEventSource();
 
+        #region Event IDs
+        // Initialized static Scope IDs
         private static long s_nextScopeId = 0;
         private static long s_nextNotificationScopeId = 0;
         private static long s_nextPoolerScopeId = 0;
+        private static long s_nextSNIScopeId = 0;
 
         /// <summary>
         /// Defines EventId for BeginExecute (Reader, Scalar, NonQuery, XmlReader).
@@ -27,157 +29,246 @@ namespace Microsoft.Data.SqlClient
         /// Defines EventId for EndExecute (Reader, Scalar, NonQuery, XmlReader).
         /// </summary>
         private const int EndExecuteEventId = 2;
+
+        /// <summary>
+        /// Defines EventId for Trace() events
+        /// </summary>
         private const int TraceEventId = 3;
-        private const int EnterScopeId = 4;
-        private const int ExitScopeId = 5;
-        private const int TraceBinId = 6;
-        private const int CorrelationTraceId = 7;
-        private const int NotificationsScopeEnterId = 8;
-        private const int NotificationsTraceId = 9;
-        private const int PoolerScopeEnterId = 10;
+
+        /// <summary>
+        /// Defines EventId for ScopeEnter() events
+        /// </summary>
+        private const int ScopeEnterId = 4;
+
+        /// <summary>
+        /// Defines EventId for ScopeLeave() events
+        /// </summary>
+        private const int ScopeExitId = 5;
+
+        /// <summary>
+        /// Defines EventId for notificationScopeEnter() events
+        /// </summary>
+        private const int NotificationScopeEnterId = 6;
+
+        /// <summary>
+        /// Defines EventId for notificationScopeLeave() events
+        /// </summary>
+        private const int NotificationScopeExitId = 7;
+
+        /// <summary>
+        /// Defines EventId for notificationScopeTrace() events
+        /// </summary>
+        private const int NotificationTraceId = 8;
+
+        /// <summary>
+        /// Defines EventId for PoolerScopeEnter() events
+        /// </summary>
+        private const int PoolerScopeEnterId = 9;
+
+        /// <summary>
+        /// Defines EventId for PoolerScopeLeave() events
+        /// </summary>
+        private const int PoolerScopeExitId = 10;
+
+        /// <summary>
+        /// Defines EventId for PoolerTrace() events
+        /// </summary>
         private const int PoolerTraceId = 11;
 
         /// <summary>
-        /// Keyword definitions.  These represent logical groups of events that can be turned on and off independently
-        /// Often each task has a keyword, but where tasks are determined by subsystem, keywords are determined by
-        /// usefulness to end users to filter.  Generally users don't mind extra events if they are not high volume
-        /// so grouping low volume events together in a single keywords is OK (users can post-filter by task if desired)
+        /// Defines EventId for AdvancedTrace() events
+        /// </summary>
+        private const int AdvancedTraceId = 12;
+
+        /// <summary>
+        /// Defines EventId for AdvancedScopeEnter() events
+        /// </summary>
+        private const int AdvancedScopeEnterId = 13;
+
+        /// <summary>
+        /// Defines EventId for AdvancedScopeLeave() events
+        /// </summary>
+        private const int AdvancedScopeExitId = 14;
+
+        /// <summary>
+        /// Defines EventId for AdvancedTraceBin() events
+        /// </summary>
+        private const int AdvancedTraceBinId = 15;
+
+        /// <summary>
+        /// Defines EventId for CorrelationTrace() events
+        /// </summary>
+        private const int CorrelationTraceId = 16;
+
+        /// <summary>
+        /// Defines EventId for StateDump() events
+        /// </summary>
+        private const int StateDumpEventId = 17;
+
+        /// <summary>
+        /// Defines EventId for SNITrace() events
+        /// </summary>
+        private const int SNITraceEventId = 18;
+
+        /// <summary>
+        /// Defines EventId for SNIEnterScope() events
+        /// </summary>
+        private const int SNIScopeEnterId = 19;
+
+        /// <summary>
+        /// Defines EventId for SNIExitScope() events
+        /// </summary>
+        private const int SNIScopeExitId = 20;
+        #endregion
+
+        /// <summary>
+        /// These represent logical groups of events that can be turned on and off independently
+        /// Often each task has a keyword, but where tasks are determined by subsystem, keywords
+        /// are determined by usefulness to end users to filter.
+        /// 
+        /// Generally users don't mind extra events if they are not high volume, so grouping low 
+        /// volume events together in a single keywords is OK (users can post-filter by task if desired)
+        /// 
         /// <remarks>
-        /// The visibility of the enum has to be public, otherwise there will be an ArgumentException on calling related WriteEvent method. the Keywords class has to be a nested class.
+        /// The visibility of the enum has to be public, otherwise there will be an ArgumentException 
+        /// on calling related WriteEvent() method.
+        /// 
+        /// The Keywords class has to be a nested class.
         /// Each keyword must be a power of 2.
         /// </remarks>
+        /// 
         /// </summary>
         #region Keywords
         public class Keywords
         {
-            internal const EventKeywords SqlClient = 0;
+            /// <summary>
+            /// Captures Start/Stop events before and after command execution.
+            /// </summary>
+            internal const EventKeywords ExecutionTrace = (EventKeywords)1;
 
-            internal const EventKeywords Trace = (EventKeywords)1;
+            /// <summary>
+            /// Captures basic application flow trace events.
+            /// </summary>
+            internal const EventKeywords Trace = (EventKeywords)2;
 
-            internal const EventKeywords TraceBin = (EventKeywords)2;
-
+            /// <summary>
+            /// Captures basic application scope entering and exiting events.
+            /// </summary>
             internal const EventKeywords Scope = (EventKeywords)4;
 
+            /// <summary>
+            /// Captures `SqlNotification` flow trace events.
+            /// </summary>
             internal const EventKeywords NotificationTrace = (EventKeywords)8;
 
-            internal const EventKeywords Pooling = (EventKeywords)16;
+            /// <summary>
+            /// Captures `SqlNotification` scope entering and exiting events.
+            /// </summary>
+            internal const EventKeywords NotificationScope = (EventKeywords)16;
 
-            internal const EventKeywords Correlation = (EventKeywords)32;
+            /// <summary>
+            /// Captures connection pooling flow trace events.
+            /// </summary>
+            internal const EventKeywords PoolerTrace = (EventKeywords)32;
 
-            internal const EventKeywords NotificationScope = (EventKeywords)64;
+            /// <summary>
+            /// Captures connection pooling scope trace events.
+            /// </summary>
+            internal const EventKeywords PoolerScope = (EventKeywords)64;
 
-            internal const EventKeywords PoolerScope = (EventKeywords)128;
+            /// <summary>
+            /// Captures advanced flow trace events.
+            /// </summary>
+            internal const EventKeywords AdvancedTrace = (EventKeywords)128;
 
-            internal const EventKeywords PoolerTrace = (EventKeywords)256;
+            /// <summary>
+            /// Captures advanced flow trace events with additional information.
+            /// </summary>
+            internal const EventKeywords AdvancedTraceBin = (EventKeywords)256;
 
-            internal const EventKeywords Advanced = (EventKeywords)512;
+            /// <summary>
+            /// Captures correlation flow trace events.
+            /// </summary>
+            internal const EventKeywords CorrelationTrace = (EventKeywords)512;
 
+            /// <summary>
+            /// Captures full state dump of `SqlConnection`
+            /// </summary>
             internal const EventKeywords StateDump = (EventKeywords)1024;
 
+            /// <summary>
+            /// Captures application flow traces from Managed networking implementation
+            /// </summary>
             internal const EventKeywords SNITrace = (EventKeywords)2048;
+
+            /// <summary>
+            /// Captures scope trace events from Managed networking implementation
+            /// </summary>
+            internal const EventKeywords SNIScope = (EventKeywords)4096;
         }
         #endregion
 
-        public static class Tasks // this name is important for EventSource
+        #region Tasks
+        /// <summary>
+        /// Tasks supported by SqlClient's EventSource implementation
+        /// </summary>
+        public static class Tasks
         {
-            /// <summary>Task that tracks sql command execute.</summary>
+            /// <summary>
+            /// Task that tracks SqlCommand execution.
+            /// </summary>
             public const EventTask ExecuteCommand = (EventTask)1;
         }
+        #endregion
 
         #region Enable/Disable Events
         [NonEvent]
-        internal bool IsTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Trace);
+        internal bool IsExecutionTraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.ExecutionTrace);
 
         [NonEvent]
-        internal bool IsTraceBinEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.TraceBin);
+        internal bool IsTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Trace);
 
         [NonEvent]
         internal bool IsScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Scope);
 
         [NonEvent]
-        internal bool IsPoolerScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.PoolerScope);
-
-        [NonEvent]
-        internal bool IsCorrelationEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Correlation);
+        internal bool IsNotificationTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.NotificationTrace);
 
         [NonEvent]
         internal bool IsNotificationScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.NotificationScope);
 
         [NonEvent]
-        internal bool IsPoolingEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Pooling);
-
-        [NonEvent]
-        internal bool IsNotificationTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.NotificationTrace);
-
-        [NonEvent]
         internal bool IsPoolerTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.PoolerTrace);
 
         [NonEvent]
-        internal bool IsAdvanceTraceOn() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Advanced);
+        internal bool IsPoolerScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.PoolerScope);
+
+        [NonEvent]
+        internal bool IsAdvancedTraceOn() => SqlClientEventSource.Log.IsEnabled(EventLevel.Verbose, Keywords.AdvancedTrace);
+
+        [NonEvent]
+        internal bool IsCorrelationEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.CorrelationTrace);
 
         [NonEvent]
         internal bool IsStateDumpEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.StateDump);
 
         [NonEvent]
-        internal bool IsSqlClientEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.SqlClient);
+        internal bool IsSNITraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.SNITrace);
 
         [NonEvent]
-        internal bool IsSNITraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.SNITrace);
+        internal bool IsSNIScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.SNIScope);
         #endregion
 
         #region overloads
         //Never use event writer directly as they are not checking for enabled/disabled situations. Always use overloads.
-        [NonEvent]
-        internal void SNITrace(string message)
-        {
-            if (Log.IsSNITraceEnabled())
-            {
-                Trace(string.Format(message));
-            }
-        }
 
+        #region Trace
         [NonEvent]
-        internal void SNITrace<T0>(string message, T0 args0)
+        internal void TraceEvent(string message)
         {
-            if (Log.IsSNITraceEnabled())
+            if (Log.IsTraceEnabled())
             {
-                Trace(string.Format(message, args0));
-            }
-        }
-
-        [NonEvent]
-        internal void SNITrace<T0, T1>(string message, T0 args0, T1 args1)
-        {
-            if (Log.IsSNITraceEnabled())
-            {
-                Trace(string.Format(message, args0, args1));
-            }
-        }
-
-        [NonEvent]
-        internal void SNITrace<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
-        {
-            if (Log.IsSNITraceEnabled())
-            {
-                Trace(string.Format(message, args0, args1, args2));
-            }
-        }
-
-        [NonEvent]
-        internal void SNITrace<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
-        {
-            if (Log.IsSNITraceEnabled())
-            {
-                Trace(string.Format(message, args0, args1, args2, args3));
-            }
-        }
-
-        [NonEvent]
-        internal void SNITrace<T0, T1, T2, T3, T4>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4)
-        {
-            if (Log.IsSNITraceEnabled())
-            {
-                Trace(string.Format(message, args0, args1, args2, args3, args4));
+                Trace(message);
             }
         }
 
@@ -186,16 +277,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (Log.IsTraceEnabled())
             {
-                Trace(string.Format(message, args0?.ToString()));
-            }
-        }
-
-        [NonEvent]
-        internal void TraceEvent(string message)
-        {
-            if (Log.IsTraceEnabled())
-            {
-                Trace(message);
+                Trace(string.Format(message, args0?.ToString() ?? "Null"));
             }
         }
 
@@ -213,7 +295,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (Log.IsTraceEnabled())
             {
-                Trace(string.Format(message, args0?.ToString() ?? "Null", args1?.ToString() ?? "Null", args2?.ToString() ?? "Null"));
+                Trace(string.Format(message, args0, args1, args2));
             }
         }
 
@@ -234,85 +316,17 @@ namespace Microsoft.Data.SqlClient
                 Trace(string.Format(message, args0, args1, args2, args3, args4, args5));
             }
         }
+        #endregion
 
+        #region Scope
         [NonEvent]
-        internal void AdvanceTrace(string message)
+        internal long ScopeEnterEvent(string message)
         {
-            if (Log.IsAdvanceTraceOn())
+            if (Log.IsScopeEnabled())
             {
-                Trace(message);
+                return ScopeEnter(message);
             }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0>(string message, T0 args0)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1>(string message, T0 args0, T1 args1)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1, args2));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1, args2, args3));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1, T2, T3, T4>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1, args2, args3, args4));
-            }
-        }
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1, T2, T3, T4, T5>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4, T5 args5)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1, args2, args3, args4, args5));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1, T2, T3, T4, T5, T6, T7>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4, T5 args5, T6 args6, T7 args7)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1, args2, args3, args4, args5, args6, args7));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTraceBin<T0, T1>(string message, T0 args0, T1 args1)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                TraceBin(string.Format(message, args0, args1));
-            }
+            return 0;
         }
 
         [NonEvent]
@@ -320,27 +334,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (Log.IsScopeEnabled())
             {
-                return SNIScopeEnter(string.Format(message, args0));
-            }
-            return 0;
-        }
-
-        [NonEvent]
-        internal long AdvanceScopeEnter<T0>(string message, T0 args0)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                return SNIScopeEnter(string.Format(message, args0));
-            }
-            return 0;
-        }
-
-        [NonEvent]
-        internal long ScopeEnterEvent(string message)
-        {
-            if (Log.IsScopeEnabled())
-            {
-                return SNIScopeEnter(message);
+                return ScopeEnter(string.Format(message, args0));
             }
             return 0;
         }
@@ -350,7 +344,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (Log.IsScopeEnabled())
             {
-                return SNIScopeEnter(string.Format(message, args0, args1));
+                return ScopeEnter(string.Format(message, args0, args1));
             }
             return 0;
         }
@@ -360,7 +354,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (Log.IsScopeEnabled())
             {
-                return SNIScopeEnter(string.Format(message, args0, args1, args2));
+                return ScopeEnter(string.Format(message, args0, args1, args2));
             }
             return 0;
         }
@@ -370,61 +364,120 @@ namespace Microsoft.Data.SqlClient
         {
             if (Log.IsScopeEnabled())
             {
-                return SNIScopeEnter(string.Format(message, args0, args1, args2, args3));
+                return ScopeEnter(string.Format(message, args0, args1, args2, args3));
             }
             return 0;
         }
 
         [NonEvent]
-        internal long PoolerScopeEnterEvent<T0>(string message, T0 args0)
+        internal void ScopeLeaveEvent(long scopeId)
         {
-            if (Log.IsPoolerScopeEnabled())
+            if (Log.IsScopeEnabled())
             {
-                return PoolerScopeEnter(string.Format(message, args0));
+                ScopeLeave(scopeId);
             }
-            return 0;
+        }
+        #endregion
+
+        #region Notification Trace
+        [NonEvent]
+        internal void NotificationTraceEvent(string message)
+        {
+            if (Log.IsNotificationTraceEnabled())
+            {
+                NotificationTrace(message);
+            }
         }
 
         [NonEvent]
-        internal long NotificationsScopeEnterEvent<T0>(string message, T0 args0)
+        internal void NotificationTraceEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsNotificationTraceEnabled())
+            {
+                NotificationTrace(string.Format(message, args0));
+            }
+        }
+
+        [NonEvent]
+        internal void NotificationTraceEvent<T0, T1>(string message, T0 args0, T1 args1)
+        {
+            if (Log.IsNotificationTraceEnabled())
+            {
+                NotificationTrace(string.Format(message, args0, args1));
+            }
+        }
+
+        [NonEvent]
+        internal void NotificationTraceEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
+        {
+            if (Log.IsNotificationTraceEnabled())
+            {
+                NotificationTrace(string.Format(message, args0, args1, args2));
+            }
+        }
+
+        [NonEvent]
+        internal void NotificationTraceEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
+        {
+            if (Log.IsNotificationTraceEnabled())
+            {
+                NotificationTrace(string.Format(message, args0, args1, args2, args3));
+            }
+        }
+        #endregion
+
+        #region Notification Scope
+        [NonEvent]
+        internal long notificationScopeEnterEvent<T0>(string message, T0 args0)
         {
             if (Log.IsNotificationScopeEnabled())
             {
-                return NotificationsScopeEnter(string.Format(message, args0));
+                return NotificationScopeEnter(string.Format(message, args0));
             }
             return 0;
         }
 
         [NonEvent]
-        internal long NotificationsScopeEnterEvent<T0, T1>(string message, T0 args0, T1 args1)
+        internal long notificationScopeEnterEvent<T0, T1>(string message, T0 args0, T1 args1)
         {
             if (Log.IsNotificationScopeEnabled())
             {
-                return NotificationsScopeEnter(string.Format(message, args0, args1));
+                return NotificationScopeEnter(string.Format(message, args0, args1));
             }
             return 0;
         }
 
         [NonEvent]
-        internal long NotificationsScopeEnterEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
+        internal long notificationScopeEnterEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
         {
             if (Log.IsNotificationScopeEnabled())
             {
-                return NotificationsScopeEnter(string.Format(message, args0, args1, args2));
+                return NotificationScopeEnter(string.Format(message, args0, args1, args2));
             }
             return 0;
         }
 
         [NonEvent]
-        internal long NotificationsScopeEnterEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
+        internal long notificationScopeEnterEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
         {
             if (Log.IsNotificationScopeEnabled())
             {
-                return NotificationsScopeEnter(string.Format(message, args0, args1, args2, args3));
+                return NotificationScopeEnter(string.Format(message, args0, args1, args2, args3));
             }
             return 0;
         }
 
+        [NonEvent]
+        internal void notificationScopeLeaveEvent(long scopeId)
+        {
+            if (Log.IsNotificationScopeEnabled())
+            {
+                NotificationScopeLeave(scopeId);
+            }
+        }
+        #endregion
+
+        #region Pooler Trace
         [NonEvent]
         internal void PoolerTraceEvent<T0>(string message, T0 args0)
         {
@@ -460,7 +513,132 @@ namespace Microsoft.Data.SqlClient
                 PoolerTrace(string.Format(message, args0, args1, args2, args3));
             }
         }
+        #endregion
 
+        #region Pooler Scope
+        [NonEvent]
+        internal long PoolerScopeEnterEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsPoolerScopeEnabled())
+            {
+                return PoolerScopeEnter(string.Format(message, args0));
+            }
+            return 0;
+        }
+
+        [NonEvent]
+        internal void PoolerScopeLeaveEvent(long scopeId)
+        {
+            if (Log.IsPoolerScopeEnabled())
+            {
+                PoolerScopeLeave(scopeId);
+            }
+        }
+        #endregion
+
+        #region AdvancedTrace
+        [NonEvent]
+        internal void AdvancedTraceEvent(string message)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(message);
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0, T1>(string message, T0 args0, T1 args1)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0, args1));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0, args1, args2));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0, args1, args2, args3));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0, T1, T2, T3, T4, T5>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4, T5 args5)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0, args1, args2, args3, args4, args5));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0, T1, T2, T3, T4, T5, T6, T7>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4, T5 args5, T6 args6, T7 args7)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0, args1, args2, args3, args4, args5, args6, args7));
+            }
+        }
+
+        [NonEvent]
+        internal long AdvancedScopeEnterEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                return AdvancedScopeEnter(string.Format(message, args0));
+            }
+            return 0;
+        }
+
+        [NonEvent]
+        internal void AdvanceScopeLeave(long scopeId)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedScopeLeave(scopeId);
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceBinEvent<T0, T1>(string message, T0 args0, T1 args1)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTraceBin(string.Format(message, args0, args1));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceErrorEvent<T0, T1, T2, T3, T4>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTraceError(string.Format(message, args0, args1, args2, args3, args4));
+            }
+        }
+        #endregion
+
+        #region Correlation Trace
         [NonEvent]
         internal void CorrelationTraceEvent<T0>(string message, T0 args0)
         {
@@ -475,7 +653,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (Log.IsCorrelationEnabled())
             {
-                CorrelationTrace(string.Format(message, args0, args1?.ToString() ?? "Null"));
+                CorrelationTrace(string.Format(message, args0?.ToString() ?? "Null", args1?.ToString() ?? "Null"));
             }
         }
 
@@ -487,146 +665,201 @@ namespace Microsoft.Data.SqlClient
                 CorrelationTrace(string.Format(message, args0?.ToString() ?? "Null", args1?.ToString() ?? "Null", args2?.ToString() ?? "Null"));
             }
         }
+        #endregion
 
-        [NonEvent]
-        internal void NotificationsTraceEvent(string message)
-        {
-            if (Log.IsNotificationTraceEnabled())
-            {
-                NotificationsTrace(message);
-            }
-        }
-
-        [NonEvent]
-        internal void NotificationsTraceEvent<T0>(string message, T0 args0)
-        {
-            if (Log.IsNotificationTraceEnabled())
-            {
-                NotificationsTrace(string.Format(message, args0));
-            }
-        }
-
-        [NonEvent]
-        internal void NotificationsTraceEvent<T0, T1>(string message, T0 args0, T1 args1)
-        {
-            if (Log.IsNotificationTraceEnabled())
-            {
-                NotificationsTrace(string.Format(message, args0, args1));
-            }
-        }
-
-        [NonEvent]
-        internal void NotificationsTraceEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
-        {
-            if (Log.IsNotificationTraceEnabled())
-            {
-                NotificationsTrace(string.Format(message, args0, args1, args2));
-            }
-        }
-
-        [NonEvent]
-        internal void NotificationsTraceEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
-        {
-            if (Log.IsNotificationTraceEnabled())
-            {
-                NotificationsTrace(string.Format(message, args0, args1, args2, args3));
-            }
-        }
-
-        [NonEvent]
-        internal void TraceBinEvent<T0, T1>(string message, T0 args0, T1 args1)
-        {
-            if (Log.IsTraceBinEnabled())
-            {
-                TraceBin(string.Format(message, args0, args1));
-            }
-        }
-
+        #region State Dump
         [NonEvent]
         internal void StateDumpEvent<T0, T1>(string message, T0 args0, T1 args1)
         {
             if (Log.IsStateDumpEnabled())
             {
-                Trace(string.Format(message, args0, args1));
-            }
-        }
-
-        [NonEvent]
-        internal void ScopeLeaveEvent(long scopeId)
-        {
-            if (Log.IsScopeEnabled())
-            {
-                ScopeLeave(scopeId);
-            }
-        }
-
-        [NonEvent]
-        internal void NotificationsScopeLeaveEvent(long scopeId)
-        {
-            if (Log.IsNotificationScopeEnabled())
-            {
-                ScopeLeave(scopeId);
-            }
-        }
-
-        [NonEvent]
-        internal void PoolerScopeLeaveEvent(long scopeId)
-        {
-            if (Log.IsPoolerScopeEnabled())
-            {
-                ScopeLeave(scopeId);
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceScopeLeave(long scopeId)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                ScopeLeave(scopeId);
+                StateDump(string.Format(message, args0, args1));
             }
         }
         #endregion
 
-        #region Events
+        #region SNI Trace
+        [NonEvent]
+        internal void SNITraceEvent(string message)
+        {
+            if (Log.IsSNITraceEnabled())
+            {
+                SNITrace(string.Format(message));
+            }
+        }
+
+        [NonEvent]
+        internal void SNITraceEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsSNITraceEnabled())
+            {
+                SNITrace(string.Format(message, args0));
+            }
+        }
+
+        [NonEvent]
+        internal void SNITraceEvent<T0, T1>(string message, T0 args0, T1 args1)
+        {
+            if (Log.IsSNITraceEnabled())
+            {
+                SNITrace(string.Format(message, args0, args1));
+            }
+        }
+
+        [NonEvent]
+        internal void SNITraceEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
+        {
+            if (Log.IsSNITraceEnabled())
+            {
+                SNITrace(string.Format(message, args0, args1, args2));
+            }
+        }
+
+        [NonEvent]
+        internal void SNITraceEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
+        {
+            if (Log.IsSNITraceEnabled())
+            {
+                SNITrace(string.Format(message, args0, args1, args2, args3));
+            }
+        }
+
+        [NonEvent]
+        internal void SNITraceEvent<T0, T1, T2, T3, T4>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4)
+        {
+            if (Log.IsSNITraceEnabled())
+            {
+                SNITrace(string.Format(message, args0, args1, args2, args3, args4));
+            }
+        }
+        #endregion
+
+        #region SNI Scope
+        [NonEvent]
+        internal long SNIScopeEnterEvent(string message)
+        {
+            if (Log.IsSNIScopeEnabled())
+            {
+                return SNIScopeEnter(message);
+            }
+            return 0;
+        }
+
+        [NonEvent]
+        internal long SNIScopeEnterEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsSNIScopeEnabled())
+            {
+                return SNIScopeEnter(string.Format(message, args0));
+            }
+            return 0;
+        }
+
+        [NonEvent]
+        internal long SNIScopeEnterEvent<T0, T1>(string message, T0 args0, T1 args1)
+        {
+            if (Log.IsSNIScopeEnabled())
+            {
+                return SNIScopeEnter(string.Format(message, args0, args1));
+            }
+            return 0;
+        }
+
+        [NonEvent]
+        internal long SNIScopeEnterEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
+        {
+            if (Log.IsSNIScopeEnabled())
+            {
+                return SNIScopeEnter(string.Format(message, args0, args1, args2));
+            }
+            return 0;
+        }
+
+        [NonEvent]
+        internal long SNIScopeEnterEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
+        {
+            if (Log.IsSNIScopeEnabled())
+            {
+                return SNIScopeEnter(string.Format(message, args0, args1, args2, args3));
+            }
+            return 0;
+        }
+
+        [NonEvent]
+        internal void SNIScopeLeaveEvent(long scopeId)
+        {
+            if (Log.IsSNIScopeEnabled())
+            {
+                SNIScopeLeave(scopeId);
+            }
+        }
+        #endregion
+
+        #endregion
+
+        #region Write Events
+        [Event(BeginExecuteEventId, Keywords = Keywords.ExecutionTrace, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Start)]
+        internal void BeginExecute(int objectId, string dataSource, string database, string commandText)
+        {
+            if (Log.IsExecutionTraceEnabled())
+            {
+                WriteEvent(BeginExecuteEventId, objectId, dataSource, database, commandText);
+            }
+        }
+
+        [Event(EndExecuteEventId, Keywords = Keywords.ExecutionTrace, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Stop)]
+        internal void EndExecute(int objectId, int compositeState, int sqlExceptionNumber)
+        {
+            if (Log.IsExecutionTraceEnabled())
+            {
+                WriteEvent(EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
+            }
+        }
+
         [Event(TraceEventId, Level = EventLevel.Informational, Keywords = Keywords.Trace)]
         internal void Trace(string message)
         {
             WriteEvent(TraceEventId, message);
         }
 
-        [Event(EnterScopeId, Level = EventLevel.Verbose, Keywords = Keywords.Scope)]
-        internal long SNIScopeEnter(string message)
+        [Event(ScopeEnterId, Level = EventLevel.Informational, Opcode = EventOpcode.Start, Keywords = Keywords.Scope)]
+        internal long ScopeEnter(string message)
         {
             long scopeId = Interlocked.Increment(ref s_nextScopeId);
-            WriteEvent(EnterScopeId, message);
+            WriteEvent(ScopeEnterId, message);
             return scopeId;
         }
 
-        [Event(ExitScopeId, Level = EventLevel.Verbose, Keywords = Keywords.Scope)]
+        [Event(ScopeExitId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Keywords = Keywords.Scope)]
         internal void ScopeLeave(long scopeId)
         {
-            WriteEvent(ExitScopeId, scopeId);
+            WriteEvent(ScopeExitId, scopeId);
         }
 
-        [Event(TraceBinId, Level = EventLevel.Informational, Keywords = Keywords.Trace)]
-        internal void TraceBin(string message)
+        [Event(NotificationTraceId, Level = EventLevel.Informational, Keywords = Keywords.NotificationTrace)]
+        internal void NotificationTrace(string message)
         {
-            WriteEvent(TraceBinId, message);
+            WriteEvent(NotificationTraceId, message);
         }
 
-        [Event(CorrelationTraceId, Level = EventLevel.Informational, Keywords = Keywords.Correlation, Opcode = EventOpcode.Start)]
-        internal void CorrelationTrace(string message)
-        {
-            WriteEvent(CorrelationTraceId, message);
-        }
-
-        [Event(NotificationsScopeEnterId, Level = EventLevel.Informational, Opcode = EventOpcode.Start, Keywords = Keywords.NotificationScope)]
-        internal long NotificationsScopeEnter(string message)
+        [Event(NotificationScopeEnterId, Level = EventLevel.Informational, Opcode = EventOpcode.Start, Keywords = Keywords.NotificationScope)]
+        internal long NotificationScopeEnter(string message)
         {
             long scopeId = Interlocked.Increment(ref s_nextNotificationScopeId);
-            WriteEvent(NotificationsScopeEnterId, message);
+            WriteEvent(NotificationScopeEnterId, message);
             return scopeId;
+        }
+
+        [Event(NotificationScopeExitId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Keywords = Keywords.NotificationScope)]
+        internal void NotificationScopeLeave(long scopeId)
+        {
+            WriteEvent(NotificationScopeExitId, scopeId);
+        }
+
+        [Event(PoolerTraceId, Level = EventLevel.Informational, Keywords = Keywords.PoolerTrace)]
+        internal void PoolerTrace(string message)
+        {
+            WriteEvent(PoolerTraceId, message);
         }
 
         [Event(PoolerScopeEnterId, Level = EventLevel.Informational, Opcode = EventOpcode.Start, Keywords = Keywords.PoolerScope)]
@@ -637,44 +870,74 @@ namespace Microsoft.Data.SqlClient
             return scopeId;
         }
 
-        [Event(NotificationsTraceId, Level = EventLevel.Informational, Keywords = Keywords.Trace)]
-        internal void NotificationsTrace(string message)
+        [Event(PoolerScopeExitId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Keywords = Keywords.PoolerScope)]
+        internal void PoolerScopeLeave(long scopeId)
         {
-            WriteEvent(NotificationsTraceId, message);
+            WriteEvent(ScopeExitId, scopeId);
         }
 
-        [Event(PoolerTraceId, Level = EventLevel.Informational, Keywords = Keywords.PoolerTrace)]
-        internal void PoolerTrace(string message)
+        [Event(AdvancedTraceId, Level = EventLevel.Verbose, Keywords = Keywords.AdvancedTrace)]
+        internal void AdvancedTrace(string message)
         {
-            WriteEvent(PoolerTraceId, message);
+            WriteEvent(TraceEventId, message);
         }
 
-        // unfortunately these are not marked as Start/Stop opcodes.  The reason is that we dont want them to participate in 
-        // the EventSource activity IDs (because they currently don't use tasks and this simply confuses the logic) and 
-        // because of versioning requirements we don't have ActivityOptions capability (because mscorlib and System.Data version 
-        // at different rates)  Sigh...
-        [Event(BeginExecuteEventId, Keywords = Keywords.SqlClient, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Start)]
-        public void BeginExecute(int objectId, string dataSource, string database, string commandText)
+        [Event(AdvancedScopeEnterId, Level = EventLevel.Verbose, Opcode = EventOpcode.Start, Keywords = Keywords.AdvancedTrace)]
+        internal long AdvancedScopeEnter(string message)
         {
-            // we do not use unsafe code for better performance optization here because optimized helpers make the code unsafe where that would not be the case otherwise. 
-            // This introduces the question of partial trust, which is complex in the SQL case (there are a lot of scenarios and SQL has special security support).   
-            if (Log.IsSqlClientEnabled())
-            {
-                WriteEvent(BeginExecuteEventId, objectId, dataSource, database, commandText);
-            }
+            long scopeId = Interlocked.Increment(ref s_nextScopeId);
+            WriteEvent(AdvancedScopeEnterId, message);
+            return scopeId;
         }
 
-        // unfortunately these are not marked as Start/Stop opcodes.  The reason is that we dont want them to participate in 
-        // the EventSource activity IDs (because they currently don't use tasks and this simply confuses the logic) and 
-        // because of versioning requirements we don't have ActivityOptions capability (because mscorlib and System.Data version 
-        // at different rates)  Sigh...
-        [Event(EndExecuteEventId, Keywords = Keywords.SqlClient, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Stop)]
-        public void EndExecute(int objectId, int compositeState, int sqlExceptionNumber)
+        [Event(AdvancedScopeExitId, Level = EventLevel.Verbose, Opcode = EventOpcode.Stop, Keywords = Keywords.AdvancedTrace)]
+        internal void AdvancedScopeLeave(long scopeId)
         {
-            if (Log.IsSqlClientEnabled())
-            {
-                WriteEvent(EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
-            }
+            WriteEvent(AdvancedScopeExitId, scopeId);
+        }
+
+        [Event(AdvancedTraceBinId, Level = EventLevel.Verbose, Keywords = Keywords.AdvancedTraceBin)]
+        internal void AdvancedTraceBin(string message)
+        {
+            WriteEvent(AdvancedTraceBinId, message);
+        }
+
+        [Event(AdvancedTraceId, Level = EventLevel.Error, Keywords = Keywords.AdvancedTrace)]
+        internal void AdvancedTraceError(string message)
+        {
+            WriteEvent(TraceEventId, message);
+        }
+
+        [Event(CorrelationTraceId, Level = EventLevel.Informational, Keywords = Keywords.CorrelationTrace, Opcode = EventOpcode.Start)]
+        internal void CorrelationTrace(string message)
+        {
+            WriteEvent(CorrelationTraceId, message);
+        }
+
+        [Event(StateDumpEventId, Level = EventLevel.Verbose, Keywords = Keywords.StateDump)]
+        internal void StateDump(string message)
+        {
+            WriteEvent(StateDumpEventId, message);
+        }
+
+        [Event(SNITraceEventId, Level = EventLevel.Informational, Keywords = Keywords.SNITrace)]
+        internal void SNITrace(string message)
+        {
+            WriteEvent(SNITraceEventId, message);
+        }
+
+        [Event(SNIScopeEnterId, Level = EventLevel.Informational, Opcode = EventOpcode.Start, Keywords = Keywords.SNIScope)]
+        internal long SNIScopeEnter(string message)
+        {
+            long scopeId = Interlocked.Increment(ref s_nextSNIScopeId);
+            WriteEvent(SNIScopeEnterId, message);
+            return scopeId;
+        }
+
+        [Event(SNIScopeExitId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Keywords = Keywords.SNIScope)]
+        internal void SNIScopeLeave(long scopeId)
+        {
+            WriteEvent(SNIScopeExitId, scopeId);
         }
         #endregion
     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientLogger.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientLogger.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientLogger.xml' path='docs/members[@name="SqlClientLogger"]/LogInfo/*'/>
         public void LogInfo(string type, string method, string message)
         {
-            SqlClientEventSource.Log.TraceEvent("<sc|{0}|{1}|{2}>{3}", type, method, LogLevel.Info, message);
+            SqlClientEventSource.Log.TraceEvent("<sc|{0}#|{1}#|{2}#>{3}#", type, method, LogLevel.Info, message);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientLogger.xml' path='docs/members[@name="SqlClientLogger"]/LogError/*'/>
         public void LogError(string type, string method, string message)
         {
-            SqlClientEventSource.Log.TraceEvent("<sc|{0}|{1}|{2}>{3}", type, method, LogLevel.Info, message);
+            SqlClientEventSource.Log.TraceEvent("<sc|{0}#|{1}#|{2}#>{3}#", type, method, LogLevel.Info, message);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientLogger.xml' path='docs/members[@name="SqlClientLogger"]/LogAssert/*'/>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientLogger.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientLogger.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientLogger.xml' path='docs/members[@name="SqlClientLogger"]/LogInfo/*'/>
         public void LogInfo(string type, string method, string message)
         {
-            SqlClientEventSource.Log.TraceEvent("<sc|{0}#|{1}#|{2}#>{3}#", type, method, LogLevel.Info, message);
+            SqlClientEventSource.Log.TraceEvent("<sc|{0}|{1}|{2}>{3}", type, method, LogLevel.Info, message);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientLogger.xml' path='docs/members[@name="SqlClientLogger"]/LogError/*'/>
         public void LogError(string type, string method, string message)
         {
-            SqlClientEventSource.Log.TraceEvent("<sc|{0}#|{1}#|{2}#>{3}#", type, method, LogLevel.Info, message);
+            SqlClientEventSource.Log.TraceEvent("<sc|{0}|{1}|{2}>{3}", type, method, LogLevel.Info, message);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientLogger.xml' path='docs/members[@name="SqlClientLogger"]/LogAssert/*'/>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 _activeConnection = value;
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Connection|API> {0}#, {1}#", ObjectID, (null != value) ? value.ObjectID : -1);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Connection|API> {0}, {1}", ObjectID, (null != value) ? value.ObjectID : -1);
             }
         }
 
@@ -448,7 +448,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Notification|API> {0}#", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Notification|API> {0}", ObjectID);
                 _sqlDep = null;
                 _notification = value;
             }
@@ -492,7 +492,7 @@ namespace Microsoft.Data.SqlClient
                         throw SQL.CannotModifyPropertyAsyncOperationInProgress();
                     }
                 }
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Transaction|API> {0}#", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Transaction|API> {0}", ObjectID);
                 _transaction = value;
             }
         }
@@ -520,7 +520,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandText|API> {0}#, String Value = '{1}#'", ObjectID, value);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandText|API> {0}, String Value = '{1}'", ObjectID, value);
                 if (_commandText != value)
                 {
                     PropertyChanging();
@@ -541,7 +541,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandTimeout|API> {0}#, {1}#", ObjectID, value);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandTimeout|API> {0}, {1}", ObjectID, value);
                 if (value < 0)
                 {
                     throw ADP.InvalidCommandTimeout(value);
@@ -574,7 +574,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandType|API> {0}#, {1}#{2}#", ObjectID, (int)value, _commandType);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandType|API> {0}, {1}{2}", ObjectID, (int)value, _commandType);
                 if (_commandType != value)
                 {
                     switch (value)
@@ -679,7 +679,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     try
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.OnStatementCompleted|INFO> {0}#, recordCount={1}#", ObjectID, recordCount);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.OnStatementCompleted|INFO> {0}, recordCount={1}", ObjectID, recordCount);
                         handler(this, new StatementCompletedEventArgs(recordCount));
                     }
                     catch (Exception e)
@@ -706,8 +706,8 @@ namespace Microsoft.Data.SqlClient
             _pendingCancel = false;
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.Prepare|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.Prepare|API|Correlation> ObjectID {0}#, ActivityID {1}#", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.Prepare|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.Prepare|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -821,7 +821,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             _cachedMetaData = null;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.Prepare|INFO> {0}#, Command unprepared.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.Prepare|INFO> {0}, Command unprepared.", ObjectID);
         }
 
         // Cancel is supposed to be multi-thread safe.
@@ -831,8 +831,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Cancel/*'/>
         override public void Cancel()
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.Cancel | API > {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.Cancel|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.Cancel | API > {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.Cancel|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             SqlStatistics statistics = null;
             try
             {
@@ -947,8 +947,8 @@ namespace Microsoft.Data.SqlClient
 
             SqlStatistics statistics = null;
 
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteScalar|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteScalar|API|Correlation> ObjectID{0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteScalar|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteScalar|API|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
             Exception e = null;
             bool success = false;
@@ -1031,8 +1031,8 @@ namespace Microsoft.Data.SqlClient
 
             SqlStatistics statistics = null;
 
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteNonQuery|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQuery|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteNonQuery|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQuery|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             Exception e = null;
             try
             {
@@ -1070,7 +1070,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteNonQuery[@name="AsyncCallbackAndStateObject"]/*'/>
         public IAsyncResult BeginExecuteNonQuery(AsyncCallback callback, object stateObject)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteNonQuery|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteNonQuery|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             return BeginExecuteNonQueryInternal(0, callback, stateObject, 0, inRetry: false);
         }
 
@@ -1267,7 +1267,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteNonQuery|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteNonQuery|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             }
         }
 
@@ -1286,7 +1286,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/EndExecuteNonQueryAsync[@name="IAsyncResult"]/*'/>
         public int EndExecuteNonQueryAsync(IAsyncResult asyncResult)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteNonQueryAsync|Info|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteNonQueryAsync|Info|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             Debug.Assert(!_internalEndExecuteInitiated || _stateObj == null);
 
             Exception asyncException = ((Task)asyncResult).Exception;
@@ -1486,7 +1486,7 @@ namespace Microsoft.Data.SqlClient
             {
                 // otherwise, use a full-fledged execute that can handle params and stored procs
                 Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteNonQuery|INFO> {0}#, Command executed as RPC.", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteNonQuery|INFO> {0}, Command executed as RPC.", ObjectID);
 
                 SqlDataReader reader = RunExecuteReader(0, RunBehavior.UntilDone, false, completion, timeout, out task, out usedCache, asyncWrite, inRetry, methodName);
                 if (null != reader)
@@ -1520,8 +1520,8 @@ namespace Microsoft.Data.SqlClient
             Guid operationId = _diagnosticListener.WriteCommandBefore(this);
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteXmlReader|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReader|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteXmlReader|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             int? sqlExceptionNumber = null;
 
             Exception e = null;
@@ -1572,7 +1572,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteXmlReader[@name="AsyncCallbackAndstateObject"]/*'/>
         public IAsyncResult BeginExecuteXmlReader(AsyncCallback callback, object stateObject)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteXmlReader|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteXmlReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             return BeginExecuteXmlReaderInternal(CommandBehavior.SequentialAccess, callback, stateObject, 0, inRetry: false);
         }
 
@@ -1695,13 +1695,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteXmlReader|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteXmlReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             }
         }
 
         private XmlReader EndExecuteXmlReaderAsync(IAsyncResult asyncResult)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteXmlReaderAsync|Info|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteXmlReaderAsync|Info|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             Debug.Assert(!_internalEndExecuteInitiated || _stateObj == null);
 
             Exception asyncException = ((Task)asyncResult).Exception;
@@ -1808,14 +1808,14 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteReader[@name="AsyncCallbackAndstateObjectAndCommandBehavior"]/*'/>
         public IAsyncResult BeginExecuteReader(AsyncCallback callback, object stateObject, CommandBehavior behavior)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteReader|API|Correlation> ObjectID{0}#, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteReader|API|Correlation> ObjectID{0}, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
             return BeginExecuteReaderInternal(behavior, callback, stateObject, 0, inRetry: false);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteDbDataReader[@name="CommandBehavior"]/*'/>
         override protected DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteDbDataReader|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteDbDataReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             return ExecuteReader(behavior);
         }
 
@@ -1823,8 +1823,8 @@ namespace Microsoft.Data.SqlClient
         new public SqlDataReader ExecuteReader()
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteReader|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReader|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteReader|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -1891,14 +1891,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteReader|API|Correlation> ObjectID{0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteReader|API|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             }
         }
 
 
         internal SqlDataReader EndExecuteReaderAsync(IAsyncResult asyncResult)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteReaderAsync|Info|Correlation> ObjectID{0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteReaderAsync|Info|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             Debug.Assert(!_internalEndExecuteInitiated || _stateObj == null);
 
             Exception asyncException = ((Task)asyncResult).Exception;
@@ -2247,7 +2247,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteNonQueryAsync[@name="CancellationToken"]/*'/>
         public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQueryAsync|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQueryAsync|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             Guid operationId = _diagnosticListener.WriteCommandBefore(this);
 
             TaskCompletionSource<int> source = new TaskCompletionSource<int>();
@@ -2334,7 +2334,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="commandBehaviorAndCancellationToken"]/*'/>
         new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReaderAsync|API|Correlation> ObjectID {0}#, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReaderAsync|API|Correlation> ObjectID {0}, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
             Guid operationId = default(Guid);
             if (!_parentOperationStarted)
                 operationId = _diagnosticListener.WriteCommandBefore(this);
@@ -2485,7 +2485,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteXmlReaderAsync[@name="CancellationToken"]/*'/>
         public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReaderAsync|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReaderAsync|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             Guid operationId = _diagnosticListener.WriteCommandBefore(this);
 
             TaskCompletionSource<XmlReader> source = new TaskCompletionSource<XmlReader>();
@@ -3027,7 +3027,7 @@ namespace Microsoft.Data.SqlClient
                 // no parameters are sent over
                 // no data reader is returned
                 // use this overload for "batch SQL" tds token type
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteNonQuery|INFO> {0}#, Command executed as SQLBATCH.", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteNonQuery|INFO> {0}, Command executed as SQLBATCH.", ObjectID);
                 Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(this.CommandText, timeout, this.Notification, _stateObj, sync: true);
                 Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
 
@@ -4377,7 +4377,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (returnStream)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}#, Command executed as SQLBATCH.", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}, Command executed as SQLBATCH.", ObjectID);
                     }
                     string text = GetCommandText(cmdBehavior) + GetResetOptionsString(cmdBehavior);
                     //If the query requires enclave computations, pass the enclavepackage in the SQLBatch TDS stream
@@ -4438,7 +4438,7 @@ namespace Microsoft.Data.SqlClient
                     rpc.options = TdsEnums.RPC_NOMETADATA;
                     if (returnStream)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}#, Command executed as RPC.", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}, Command executed as RPC.", ObjectID);
                     }
 
                     Debug.Assert(_rpcArrayOf1[0] == rpc);
@@ -4456,7 +4456,7 @@ namespace Microsoft.Data.SqlClient
                     optionSettings = GetSetOptionsString(cmdBehavior);
                     if (returnStream)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}#, Command executed as RPC.", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}, Command executed as RPC.", ObjectID);
                     }
 
                     // turn set options ON
@@ -6121,7 +6121,7 @@ namespace Microsoft.Data.SqlClient
         public SqlCommand Clone()
         {
             SqlCommand clone = new SqlCommand(this);
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.Clone|API> {0}#, clone={1}#", ObjectID, clone.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.Clone|API> {0}, clone={1}", ObjectID, clone.ObjectID);
             return clone;
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -520,7 +520,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandText|API> {0}#, String Value = '{1}'", ObjectID, value);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandText|API> {0}#, String Value = '{1}#'", ObjectID, value);
                 if (_commandText != value)
                 {
                     PropertyChanging();
@@ -541,7 +541,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandTimeout|API> {0}#, {1}", ObjectID, value);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandTimeout|API> {0}#, {1}#", ObjectID, value);
                 if (value < 0)
                 {
                     throw ADP.InvalidCommandTimeout(value);
@@ -574,7 +574,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandType|API> {0}#, {1}{2}", ObjectID, (int)value, _commandType);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandType|API> {0}#, {1}#{2}#", ObjectID, (int)value, _commandType);
                 if (_commandType != value)
                 {
                     switch (value)
@@ -679,7 +679,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     try
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.OnStatementCompleted|INFO> {0}#, recordCount={1}", ObjectID, recordCount);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.OnStatementCompleted|INFO> {0}#, recordCount={1}#", ObjectID, recordCount);
                         handler(this, new StatementCompletedEventArgs(recordCount));
                     }
                     catch (Exception e)
@@ -707,7 +707,7 @@ namespace Microsoft.Data.SqlClient
 
             SqlStatistics statistics = null;
             long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.Prepare|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.Prepare|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.Prepare|API|Correlation> ObjectID {0}#, ActivityID {1}#", ObjectID, ActivityCorrelator.Current);
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -6127,7 +6127,7 @@ namespace Microsoft.Data.SqlClient
 
         private void WriteEndExecuteEvent(bool success, int? sqlExceptionNumber, bool synchronous)
         {
-            if (SqlClientEventSource.Log.IsSqlClientEnabled())
+            if (SqlClientEventSource.Log.IsExecutionTraceEnabled())
             {
                 // SqlEventSource.WriteEvent(int, int, int, int) is faster than provided overload SqlEventSource.WriteEvent(int, object[]).
                 // that's why trying to fit several booleans in one integer value

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Data.SqlClient
         internal void Append(SqlCommand command)
         {
             ADP.CheckArgumentNull(command, nameof(command));
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Append|API> {0}#, command={1}, parameterCount={2}", ObjectID, command.ObjectID, command.Parameters.Count);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Append|API> {0}, command={1}, parameterCount={2}", ObjectID, command.ObjectID, command.Parameters.Count);
             string cmdText = command.CommandText;
             if (string.IsNullOrEmpty(cmdText))
             {
@@ -248,7 +248,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Clear()
         {
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Clear|API> {0}#", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Clear|API> {0}", ObjectID);
             DbCommand batchCommand = BatchCommand;
             if (null != batchCommand)
             {
@@ -264,7 +264,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Dispose()
         {
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Dispose|API> {0}#", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Dispose|API> {0}", ObjectID);
             SqlCommand command = _batchCommand;
             _commandList = null;
             _batchCommand = null;
@@ -278,7 +278,7 @@ namespace Microsoft.Data.SqlClient
         internal int ExecuteNonQuery()
         {
             ValidateCommandBehavior(nameof(ExecuteNonQuery), CommandBehavior.Default);
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommandSet.ExecuteNonQuery|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommandSet.ExecuteNonQuery|API> {0}", ObjectID);
 
             try
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -782,7 +782,7 @@ namespace Microsoft.Data.SqlClient
         [SuppressMessage("Microsoft.Reliability", "CA2004:RemoveCallsToGCKeepAlive")]
         override protected DbTransaction BeginDbTransaction(System.Data.IsolationLevel isolationLevel)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.SqlConnection.BeginDbTransaction|API> {0}#, isolationLevel={1}", ObjectID, (int)isolationLevel);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.SqlConnection.BeginDbTransaction|API> {0}, isolationLevel={1}", ObjectID, (int)isolationLevel);
             try
             {
                 DbTransaction transaction = BeginTransaction(isolationLevel);
@@ -806,7 +806,7 @@ namespace Microsoft.Data.SqlClient
         {
             WaitForPendingReconnection();
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlConnection.BeginTransaction|API> {0}#, iso={1}, transactionName='{2}'", ObjectID, (int)iso, (string.IsNullOrEmpty(transactionName) ? "None" : transactionName));
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlConnection.BeginTransaction|API> {0}, iso={1}, transactionName='{2}'", ObjectID, (int)iso, (string.IsNullOrEmpty(transactionName) ? "None" : transactionName));
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -840,7 +840,7 @@ namespace Microsoft.Data.SqlClient
         {
             SqlStatistics statistics = null;
             RepairInnerConnection();
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.ChangeDatabase|API|Correlation> ObjectID{0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.ChangeDatabase|API|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -885,8 +885,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/Close/*' />
         public override void Close()
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlConnection.Close|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.Close|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlConnection.Close|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.Close|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             try
             {
                 ConnectionState previousState = State;
@@ -1000,7 +1000,7 @@ namespace Microsoft.Data.SqlClient
         public override void Open()
         {
             long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlConnection.Open|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.Open|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.Open|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             try
             {
                 Guid operationId = s_diagnosticListener.WriteConnectionOpenBefore(this);
@@ -1267,8 +1267,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OpenAsync/*' />
         public override Task OpenAsync(CancellationToken cancellationToken)
         {
-            long scopeID = SqlClientEventSource.Log.PoolerScopeEnterEvent("<sc.SqlConnection.OpenAsync|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.OpenAsync|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            long scopeID = SqlClientEventSource.Log.PoolerScopeEnterEvent("<sc.SqlConnection.OpenAsync|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.OpenAsync|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             try
             {
                 Guid operationId = s_diagnosticListener.WriteConnectionOpenBefore(this);
@@ -1395,7 +1395,7 @@ namespace Microsoft.Data.SqlClient
 
             internal void Retry(Task<DbConnectionInternal> retryTask)
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OpenAsyncRetry|Info> {0}#", _parent.ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OpenAsyncRetry|Info> {0}", _parent.ObjectID);
                 _registration.Dispose();
                 try
                 {
@@ -1653,7 +1653,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         if (capturedCloseCount == _closeCount)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnError|INFO> {0}#, Connection broken.", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnError|INFO> {0}, Connection broken.", ObjectID);
                             Close();
                         }
                     };
@@ -1662,7 +1662,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnError|INFO> {0}#, Connection broken.", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnError|INFO> {0}, Connection broken.", ObjectID);
                     Close();
                 }
             }
@@ -1713,7 +1713,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void OnInfoMessage(SqlInfoMessageEventArgs imevent, out bool notified)
         {
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnInfoMessage|API|INFO> {0}#, Message='{1}'", ObjectID, (null != imevent) ? imevent.Message : "");
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnInfoMessage|API|INFO> {0}, Message='{1}'", ObjectID, (null != imevent) ? imevent.Message : "");
             SqlInfoMessageEventHandler handler = InfoMessage;
             if (null != handler)
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Data.SqlClient
 
         private string ConnectionString_Get()
         {
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Get|API> {0}#", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Get|API> {0}", ObjectID);
             bool hidePassword = InnerConnection.ShouldHidePassword;
             DbConnectionOptions connectionOptions = UserConnectionOptions;
             return ((null != connectionOptions) ? connectionOptions.UsersConnectionString(hidePassword) : "");
@@ -87,7 +87,7 @@ namespace Microsoft.Data.SqlClient
                 throw ADP.OpenConnectionPropertySet(nameof(ConnectionString), connectionInternal.State);
             }
             string cstr = ((null != connectionOptions) ? connectionOptions.UsersConnectionStringForTrace() : "");
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Set|API> {0}#, '{1}'", ObjectID, cstr);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Set|API> {0}, '{1}'", ObjectID, cstr);
         }
 
         internal DbConnectionInternal InnerConnection
@@ -135,11 +135,11 @@ namespace Microsoft.Data.SqlClient
             // will end the reliable try...
             if (e is OutOfMemoryException)
             {
-                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.Abort|RES|INFO|CPOOL> {0}#, Aborting operation due to asynchronous exception: {'OutOfMemory'}", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.Abort|RES|INFO|CPOOL> {0}, Aborting operation due to asynchronous exception: {'OutOfMemory'}", ObjectID);
             }
             else
             {
-                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.Abort|RES|INFO|CPOOL> {0}#, Aborting operation due to asynchronous exception: {1}", ObjectID, e);
+                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.Abort|RES|INFO|CPOOL> {0}, Aborting operation due to asynchronous exception: {1}", ObjectID, e);
             }
         }
 
@@ -151,7 +151,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/CreateDbCommand/*' />
         override protected DbCommand CreateDbCommand()
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.DbConnectionHelper.CreateDbCommand|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.DbConnectionHelper.CreateDbCommand|API> {0}", ObjectID);
             try
             {
                 DbCommand command = null;
@@ -184,7 +184,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/EnlistTransaction/*' />
         public override void EnlistTransaction(Transaction transaction)
         {
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.EnlistTransaction|RES|TRAN> {0}#, Connection enlisting in a transaction.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.EnlistTransaction|RES|TRAN> {0}, Connection enlisting in a transaction.", ObjectID);
 
             // If we're currently enlisted in a transaction and we were called
             // on the EnlistTransaction method (Whidbey) we're not allowed to

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.ArgumentOutOfRange(nameof(UpdateBatchSize));
                 }
                 _updateBatchSize = value;
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlDataAdapter.set_UpdateBatchSize|API> {0}#, {1}", ObjectID, value);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDataAdapter.set_UpdateBatchSize|API> {0}, {1}", ObjectID, value);
             }
         }
 
@@ -149,7 +149,7 @@ namespace Microsoft.Data.SqlClient
         protected override int ExecuteBatch()
         {
             Debug.Assert(null != _commandSet && (0 < _commandSet.CommandCount), "no commands");
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlDataAdapter.ExecuteBatch|Info|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlDataAdapter.ExecuteBatch|Info|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             return _commandSet.ExecuteNonQuery();
         }
 
@@ -172,7 +172,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataAdapter.xml' path='docs/members[@name="SqlDataAdapter"]/InitializeBatching/*' />
         protected override void InitializeBatching()
         {
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDataAdapter.InitializeBatching|API> {0}#", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlDataAdapter.InitializeBatching|API> {0}", ObjectID);
             _commandSet = new SqlCommandSet();
             SqlCommand command = SelectCommand;
             if (null == command)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -844,7 +844,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Close/*' />
         public override void Close()
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.Close|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.Close|API> {0}", ObjectID);
             SqlStatistics statistics = null;
             try
             {
@@ -1467,7 +1467,7 @@ namespace Microsoft.Data.SqlClient
         public override DataTable GetSchemaTable()
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.GetSchemaTable|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.GetSchemaTable|API> {0}", ObjectID);
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -3261,7 +3261,7 @@ namespace Microsoft.Data.SqlClient
         private bool TryNextResult(out bool more)
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.NextResult|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.NextResult|API> {0}", ObjectID);
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -3422,7 +3422,7 @@ namespace Microsoft.Data.SqlClient
         private bool TryReadInternal(bool setTimeout, out bool more)
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.Read|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.Read|API> {0}", ObjectID);
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -3953,7 +3953,7 @@ namespace Microsoft.Data.SqlClient
                 // broken connection, so check state first.
                 if (parser.State == TdsParserState.OpenLoggedIn)
                 {
-                    SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlDataReader.RestoreServerSettings|Info|Correlation> ObjectID {0}#, ActivityID '{1}'", ObjectID, ActivityCorrelator.Current.ToString());
+                    SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlDataReader.RestoreServerSettings|Info|Correlation> ObjectID {0}, ActivityID '{1}'", ObjectID, ActivityCorrelator.Current.ToString());
                     Task executeTask = parser.TdsExecuteSQLBatch(_resetOptionsString, (_command != null) ? _command.CommandTimeout : 0, null, stateObj, sync: true);
                     Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
 
@@ -4258,7 +4258,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/NextResultAsync/*' />
         public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.NextResultAsync|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.NextResultAsync|API> {0}", ObjectID);
             try
             {
                 TaskCompletionSource<bool> source = new TaskCompletionSource<bool>();
@@ -4308,7 +4308,7 @@ namespace Microsoft.Data.SqlClient
             HasNextResultAsyncCallContext context = (HasNextResultAsyncCallContext)state;
             if (task != null)
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlDataReader.NextResultAsync> attempt retry {0}#", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDataReader.NextResultAsync> attempt retry {0}", ObjectID);
                 context._reader.PrepareForAsyncContinuation();
             }
 
@@ -4584,7 +4584,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/ReadAsync/*' />
         public override Task<bool> ReadAsync(CancellationToken cancellationToken)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.ReadAsync|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.ReadAsync|API> {0}", ObjectID);
             try
             {
                 if (IsClosed)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -80,13 +80,13 @@ namespace Microsoft.Data.SqlClient
             // transaction.
             SqlInternalConnection connection = _connection;
             SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Initialize|RES|CPOOL> {0}#, Connection {1}#, delegating transaction.", ObjectID, connection.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Initialize|RES|CPOOL> {0}, Connection {1}, delegating transaction.", ObjectID, connection.ObjectID);
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
                 if (connection.IsEnlistedInTransaction)
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Initialize|RES|CPOOL> {0}#, Connection {1}#, was enlisted, now defecting.", ObjectID, connection.ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Initialize|RES|CPOOL> {0}, Connection {1}, was enlisted, now defecting.", ObjectID, connection.ObjectID);
 
                     // defect first
                     connection.EnlistNull();
@@ -141,7 +141,7 @@ namespace Microsoft.Data.SqlClient
             Exception promoteException;
             byte[] returnValue = null;
             SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}#, Connection {1}#, promoting transaction.", ObjectID, connection.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}, Connection {1}, promoting transaction.", ObjectID, connection.ObjectID);
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
@@ -220,7 +220,7 @@ namespace Microsoft.Data.SqlClient
 
             SqlInternalConnection connection = GetValidConnection();
             SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Rollback|RES|CPOOL> {0}#, Connection {1}#, aborting transaction.", ObjectID, connection.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Rollback|RES|CPOOL> {0}, Connection {1}, aborting transaction.", ObjectID, connection.ObjectID);
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
@@ -293,7 +293,7 @@ namespace Microsoft.Data.SqlClient
 
             SqlInternalConnection connection = GetValidConnection();
             SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.SinglePhaseCommit|RES|CPOOL> {0}#, Connection {1}#, committing transaction.", ObjectID, connection.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.SinglePhaseCommit|RES|CPOOL> {0}, Connection {1}, committing transaction.", ObjectID, connection.ObjectID);
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
@@ -404,7 +404,7 @@ namespace Microsoft.Data.SqlClient
 
             if (connection != null)
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.TransactionEnded|RES|CPOOL> {0}#, Connection {1}#, transaction completed externally.", ObjectID, connection.ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.TransactionEnded|RES|CPOOL> {0}, Connection {1}, transaction completed externally.", ObjectID, connection.ObjectID);
                 lock (connection)
                 {
                     if (_atomicTransaction.Equals(transaction))

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDependency.xml' path='docs/members[@name="SqlDependency"]/ctorCommandOptionsTimeout/*' />
         public SqlDependency(SqlCommand command, string options, int timeout)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency|DEP> {0}#, options: '{1}', timeout: '{2}'", ObjectID, options, timeout);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency|DEP> {0}#, options: '{1}', timeout: '{2}'", ObjectID, options, timeout);
             try
             {
                 if (timeout < 0)
@@ -264,7 +264,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -294,7 +294,7 @@ namespace Microsoft.Data.SqlClient
             // EventHandlers to be fired when dependency is notified.
             add
             {
-                long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.OnChange-Add|DEP> {0}#", ObjectID);
+                long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.OnChange-Add|DEP> {0}#", ObjectID);
                 try
                 {
                     if (null != value)
@@ -329,12 +329,12 @@ namespace Microsoft.Data.SqlClient
                 }
                 finally
                 {
-                    SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                    SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
                 }
             }
             remove
             {
-                long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.OnChange-Remove|DEP> {0}#", ObjectID);
+                long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.OnChange-Remove|DEP> {0}#", ObjectID);
                 try
                 {
                     if (null != value)
@@ -352,7 +352,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 finally
                 {
-                    SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                    SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
                 }
             }
         }
@@ -362,7 +362,7 @@ namespace Microsoft.Data.SqlClient
         public void AddCommandDependency(SqlCommand command)
         {
             // Adds command to dependency collection so we automatically create the SqlNotificationsRequest object
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.AddCommandDependency|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.AddCommandDependency|DEP> {0}#", ObjectID);
             try
             {
                 // and listen for a notification for the added commands.
@@ -375,7 +375,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -396,7 +396,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static bool Start(string connectionString, string queue, bool useDefaults)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.Start|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.Start|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
             try
             {
                 if (string.IsNullOrEmpty(connectionString))
@@ -455,7 +455,7 @@ namespace Microsoft.Data.SqlClient
                                         SqlDependencyPerAppDomainDispatcher.SingletonInstance,
                                     out errorOccurred,
                                     out appDomainStart);
-                                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.Start|DEP> Start (defaults) returned: '{0}', with service: '{1}', server: '{2}', database: '{3}'", result, service, server, database);
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Start|DEP> Start (defaults) returned: '{0}', with service: '{1}', server: '{2}', database: '{3}'", result, service, server, database);
                             }
                             finally
                             {
@@ -477,7 +477,7 @@ namespace Microsoft.Data.SqlClient
                                             }
 
                                             ADP.TraceExceptionWithoutRethrow(e); // Discard failure, but trace for now.
-                                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from Stop() after duplicate was found on Start().");
+                                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from Stop() after duplicate was found on Start().");
                                         }
                                         throw SQL.SqlDependencyDuplicateStart();
                                     }
@@ -491,7 +491,7 @@ namespace Microsoft.Data.SqlClient
                                 queue,
                                 s_appDomainKey,
                                 SqlDependencyPerAppDomainDispatcher.SingletonInstance);
-                            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.Start|DEP> Start (user provided queue) returned: '{0}'", result);
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Start|DEP> Start (user provided queue) returned: '{0}'", result);
 
                             // No need to call AddToServerDatabaseHash since if not using default queue user is required
                             // to provide options themselves.
@@ -505,7 +505,7 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         ADP.TraceExceptionWithoutRethrow(e); // Discard failure, but trace for now.
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from _processDispatcher.Start(...), calling Invalidate(...).");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from _processDispatcher.Start(...), calling Invalidate(...).");
                         throw;
                     }
                 }
@@ -514,7 +514,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -532,7 +532,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static bool Stop(string connectionString, string queue, bool useDefaults, bool startFailed)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.Stop|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.Stop|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
             try
             {
                 if (string.IsNullOrEmpty(connectionString))
@@ -628,7 +628,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -636,7 +636,7 @@ namespace Microsoft.Data.SqlClient
 
         private static bool AddToServerUserHash(string server, IdentityUserNamePair identityUser, DatabaseServicePair databaseService)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.AddToServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.AddToServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
             try
             {
                 bool result = false;
@@ -647,7 +647,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (!s_serverUserHash.ContainsKey(server))
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash did not contain server, adding.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash did not contain server, adding.");
                         identityDatabaseHash = new Dictionary<IdentityUserNamePair, List<DatabaseServicePair>>();
                         s_serverUserHash.Add(server, identityDatabaseHash);
                     }
@@ -660,7 +660,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (!identityDatabaseHash.ContainsKey(identityUser))
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash contained server but not user, adding user.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash contained server but not user, adding user.");
                         databaseServiceList = new List<DatabaseServicePair>();
                         identityDatabaseHash.Add(identityUser, databaseServiceList);
                     }
@@ -671,13 +671,13 @@ namespace Microsoft.Data.SqlClient
 
                     if (!databaseServiceList.Contains(databaseService))
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Adding database.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Adding database.");
                         databaseServiceList.Add(databaseService);
                         result = true;
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddToServerUserHash|DEP|ERR> ERROR - hash already contained server, user, and database - we will throw!.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP|ERR> ERROR - hash already contained server, user, and database - we will throw!.");
                     }
                 }
 
@@ -685,13 +685,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         private static void RemoveFromServerUserHash(string server, IdentityUserNamePair identityUser, DatabaseServicePair databaseService)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
             try
             {
                 lock (s_serverUserHash)
@@ -711,43 +711,43 @@ namespace Microsoft.Data.SqlClient
                             int index = databaseServiceList.IndexOf(databaseService);
                             if (index >= 0)
                             {
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> Hash contained server, user, and database - removing database.");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> Hash contained server, user, and database - removing database.");
                                 databaseServiceList.RemoveAt(index);
 
                                 if (databaseServiceList.Count == 0)
                                 {
-                                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> databaseServiceList count 0, removing the list for this server and user.");
+                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> databaseServiceList count 0, removing the list for this server and user.");
                                     identityDatabaseHash.Remove(identityUser);
 
                                     if (identityDatabaseHash.Count == 0)
                                     {
-                                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> identityDatabaseHash count 0, removing the hash for this server.");
+                                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> identityDatabaseHash count 0, removing the hash for this server.");
                                         s_serverUserHash.Remove(server);
                                     }
                                 }
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server and user but not database!");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server and user but not database!");
                                 Debug.Fail("Unexpected state - hash did not contain database!");
                             }
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server but not user!");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server but not user!");
                             Debug.Fail("Unexpected state - hash did not contain user!");
                         }
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash did not contain server!");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash did not contain server!");
                         Debug.Fail("Unexpected state - hash did not contain server!");
                     }
                 }
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -755,7 +755,7 @@ namespace Microsoft.Data.SqlClient
         {
             // Server must be an exact match, but user and database only needs to match exactly if there is more than one 
             // for the given user or database passed.  That is ambiguious and we must fail.
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> server: '{0}', failoverServer: '{1}', database: '{2}'", server, failoverServer, database);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> server: '{0}', failoverServer: '{1}', database: '{2}'", server, failoverServer, database);
             try
             {
                 string result;
@@ -767,17 +767,17 @@ namespace Microsoft.Data.SqlClient
                         if (0 == s_serverUserHash.Count)
                         {
                             // Special error for no calls to start.
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - no start calls have been made, about to throw.");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - no start calls have been made, about to throw.");
                             throw SQL.SqlDepDefaultOptionsButNoStart();
                         }
                         else if (!string.IsNullOrEmpty(failoverServer) && s_serverUserHash.ContainsKey(failoverServer))
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP> using failover server instead\n");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP> using failover server instead\n");
                             server = failoverServer;
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening to this server, about to throw.");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening to this server, about to throw.");
                             throw SQL.SqlDependencyNoMatchingServerStart();
                         }
                     }
@@ -790,7 +790,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         if (identityDatabaseHash.Count > 1)
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening for this user, " +
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening for this user, " +
                                                           "but listening to more than one other user, about to throw.");
                             throw SQL.SqlDependencyNoMatchingServerStart();
                         }
@@ -839,19 +839,19 @@ namespace Microsoft.Data.SqlClient
                         else
                         {
                             // More than one database for given server, ambiguous - fail the default case!
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - SqlDependency.Start called multiple times for this server/user, but no matching database.");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - SqlDependency.Start called multiple times for this server/user, but no matching database.");
                             throw SQL.SqlDependencyNoMatchingServerDatabaseStart();
                         }
                     }
                 }
 
                 Debug.Assert(!string.IsNullOrEmpty(result), "GetDefaultComposedOptions should never return null or empty string!");
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> resulting options: '{0}'.", result);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> resulting options: '{0}'.", result);
                 return result;
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -861,7 +861,7 @@ namespace Microsoft.Data.SqlClient
         // use this list for a reverse lookup based on server.
         internal void AddToServerList(string server)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.AddToServerList|DEP> {0}#, server: '{1}'", ObjectID, server);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.AddToServerList|DEP> {0}#, server: '{1}'", ObjectID, server);
             try
             {
                 lock (_serverList)
@@ -877,7 +877,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -891,7 +891,7 @@ namespace Microsoft.Data.SqlClient
 
         internal string ComputeHashAndAddToDispatcher(SqlCommand command)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
             try
             {
                 // Create a string representing the concatenation of the connection string, command text and .ToString on all parameter values.
@@ -903,18 +903,18 @@ namespace Microsoft.Data.SqlClient
                 string commandHash = ComputeCommandHash(command.Connection.ConnectionString, command); // calculate the string representation of command
 
                 string idString = SqlDependencyPerAppDomainDispatcher.SingletonInstance.AddCommandEntry(commandHash, this); // Add to map.
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> computed id string: '{0}'.", idString);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> computed id string: '{0}'.", idString);
                 return idString;
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         internal void Invalidate(SqlNotificationType type, SqlNotificationInfo info, SqlNotificationSource source)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.Invalidate|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.Invalidate|DEP> {0}#", ObjectID);
             try
             {
                 List<EventContextPair> eventList = null;
@@ -928,7 +928,7 @@ namespace Microsoft.Data.SqlClient
 
                         if (ExpirationTime >= DateTime.UtcNow)
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.Invalidate|DEP|ERR> ERROR - notification received twice - we should never enter this state!");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP|ERR> ERROR - notification received twice - we should never enter this state!");
                             Debug.Fail("Received notification twice - we should never enter this state!");
                         }
                         else
@@ -937,7 +937,7 @@ namespace Microsoft.Data.SqlClient
                             // raises Timeout event but before removing this event from the list. If notification is received from
                             // server in this case, we will hit this code path.
                             // It is safe to ignore this race condition because no event is sent to user and no leak happens.
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.Invalidate|DEP> ignore notification received after timeout!");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP> ignore notification received after timeout!");
                         }
                     }
                     else
@@ -951,7 +951,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (eventList != null)
                 {
-                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.Invalidate|DEP> Firing events.");
+                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP> Firing events.");
                     foreach (EventContextPair pair in eventList)
                     {
                         pair.Invoke(new SqlNotificationEventArgs(type, info, source));
@@ -960,14 +960,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is used by SqlCommand.
         internal void StartTimer(SqlNotificationRequest notificationRequest)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.StartTimer|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.StartTimer|DEP> {0}#", ObjectID);
             try
             {
                 if (_expirationTime == DateTime.MaxValue)
@@ -989,7 +989,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -1000,7 +1000,7 @@ namespace Microsoft.Data.SqlClient
             if (cmd != null)
             {
                 // Don't bother with EventSource if command null.
-                long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.AddCommandInternal|DEP> {0}#, SqlCommand: {1}#", ObjectID, cmd.ObjectID);
+                long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.AddCommandInternal|DEP> {0}#, SqlCommand: {1}#", ObjectID, cmd.ObjectID);
                 try
                 {
                     SqlConnection connection = cmd.Connection;
@@ -1010,7 +1010,7 @@ namespace Microsoft.Data.SqlClient
                         // Fail if cmd has notification that is not already associated with this dependency.
                         if (cmd._sqlDep == null || cmd._sqlDep != this)
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - throwing command has existing SqlNotificationRequest exception.");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - throwing command has existing SqlNotificationRequest exception.");
                             throw SQL.SqlCommandHasExistingSqlNotificationRequest();
                         }
                     }
@@ -1044,7 +1044,7 @@ namespace Microsoft.Data.SqlClient
                                 if (0 == _eventList.Count)
                                 {
                                     // Keep logic just in case.
-                                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - firing events, though it is unexpected we have events at this point.");
+                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - firing events, though it is unexpected we have events at this point.");
                                     needToInvalidate = true; // Delay invalidation until outside of lock.
                                 }
                             }
@@ -1058,14 +1058,14 @@ namespace Microsoft.Data.SqlClient
                 }
                 finally
                 {
-                    SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                    SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
                 }
             }
         }
 
         private string ComputeCommandHash(string connectionString, SqlCommand command)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.ComputeCommandHash|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.ComputeCommandHash|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
             try
             {
                 // Create a string representing the concatenation of the connection string, the command text and .ToString on all its parameter values.
@@ -1121,12 +1121,12 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 string result = builder.ToString();
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.ComputeCommandHash|DEP> ComputeCommandHash result: '{0}'.", result);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ComputeCommandHash|DEP> ComputeCommandHash result: '{0}'.", result);
                 return result;
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDependency.xml' path='docs/members[@name="SqlDependency"]/ctorCommandOptionsTimeout/*' />
         public SqlDependency(SqlCommand command, string options, int timeout)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency|DEP> {0}#, options: '{1}', timeout: '{2}'", ObjectID, options, timeout);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency|DEP> {0}#, options: '{1}', timeout: '{2}'", ObjectID, options, timeout);
             try
             {
                 if (timeout < 0)
@@ -264,7 +264,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -294,7 +294,7 @@ namespace Microsoft.Data.SqlClient
             // EventHandlers to be fired when dependency is notified.
             add
             {
-                long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.OnChange-Add|DEP> {0}#", ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Add|DEP> {0}#", ObjectID);
                 try
                 {
                     if (null != value)
@@ -329,12 +329,12 @@ namespace Microsoft.Data.SqlClient
                 }
                 finally
                 {
-                    SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                    SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
                 }
             }
             remove
             {
-                long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.OnChange-Remove|DEP> {0}#", ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Remove|DEP> {0}#", ObjectID);
                 try
                 {
                     if (null != value)
@@ -352,7 +352,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 finally
                 {
-                    SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                    SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
                 }
             }
         }
@@ -362,7 +362,7 @@ namespace Microsoft.Data.SqlClient
         public void AddCommandDependency(SqlCommand command)
         {
             // Adds command to dependency collection so we automatically create the SqlNotificationsRequest object
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.AddCommandDependency|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandDependency|DEP> {0}#", ObjectID);
             try
             {
                 // and listen for a notification for the added commands.
@@ -375,7 +375,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -396,7 +396,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static bool Start(string connectionString, string queue, bool useDefaults)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.Start|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.Start|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
             try
             {
                 if (string.IsNullOrEmpty(connectionString))
@@ -514,7 +514,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -532,7 +532,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static bool Stop(string connectionString, string queue, bool useDefaults, bool startFailed)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.Stop|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.Stop|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
             try
             {
                 if (string.IsNullOrEmpty(connectionString))
@@ -628,7 +628,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -636,7 +636,7 @@ namespace Microsoft.Data.SqlClient
 
         private static bool AddToServerUserHash(string server, IdentityUserNamePair identityUser, DatabaseServicePair databaseService)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.AddToServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddToServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
             try
             {
                 bool result = false;
@@ -685,13 +685,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private static void RemoveFromServerUserHash(string server, IdentityUserNamePair identityUser, DatabaseServicePair databaseService)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
             try
             {
                 lock (s_serverUserHash)
@@ -747,7 +747,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -755,7 +755,7 @@ namespace Microsoft.Data.SqlClient
         {
             // Server must be an exact match, but user and database only needs to match exactly if there is more than one 
             // for the given user or database passed.  That is ambiguious and we must fail.
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> server: '{0}', failoverServer: '{1}', database: '{2}'", server, failoverServer, database);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> server: '{0}', failoverServer: '{1}', database: '{2}'", server, failoverServer, database);
             try
             {
                 string result;
@@ -851,7 +851,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -861,7 +861,7 @@ namespace Microsoft.Data.SqlClient
         // use this list for a reverse lookup based on server.
         internal void AddToServerList(string server)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.AddToServerList|DEP> {0}#, server: '{1}'", ObjectID, server);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddToServerList|DEP> {0}#, server: '{1}'", ObjectID, server);
             try
             {
                 lock (_serverList)
@@ -877,7 +877,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -891,7 +891,7 @@ namespace Microsoft.Data.SqlClient
 
         internal string ComputeHashAndAddToDispatcher(SqlCommand command)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
             try
             {
                 // Create a string representing the concatenation of the connection string, command text and .ToString on all parameter values.
@@ -908,13 +908,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         internal void Invalidate(SqlNotificationType type, SqlNotificationInfo info, SqlNotificationSource source)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.Invalidate|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.Invalidate|DEP> {0}#", ObjectID);
             try
             {
                 List<EventContextPair> eventList = null;
@@ -960,14 +960,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is used by SqlCommand.
         internal void StartTimer(SqlNotificationRequest notificationRequest)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.StartTimer|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.StartTimer|DEP> {0}#", ObjectID);
             try
             {
                 if (_expirationTime == DateTime.MaxValue)
@@ -989,7 +989,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -1000,7 +1000,7 @@ namespace Microsoft.Data.SqlClient
             if (cmd != null)
             {
                 // Don't bother with EventSource if command null.
-                long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.AddCommandInternal|DEP> {0}#, SqlCommand: {1}#", ObjectID, cmd.ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandInternal|DEP> {0}#, SqlCommand: {1}#", ObjectID, cmd.ObjectID);
                 try
                 {
                     SqlConnection connection = cmd.Connection;
@@ -1058,14 +1058,14 @@ namespace Microsoft.Data.SqlClient
                 }
                 finally
                 {
-                    SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                    SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
                 }
             }
         }
 
         private string ComputeCommandHash(string connectionString, SqlCommand command)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependency.ComputeCommandHash|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeCommandHash|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
             try
             {
                 // Create a string representing the concatenation of the connection string, the command text and .ToString on all its parameter values.
@@ -1126,7 +1126,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDependency.xml' path='docs/members[@name="SqlDependency"]/ctorCommandOptionsTimeout/*' />
         public SqlDependency(SqlCommand command, string options, int timeout)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency|DEP> {0}#, options: '{1}', timeout: '{2}'", ObjectID, options, timeout);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency|DEP> {0}, options: '{1}', timeout: '{2}'", ObjectID, options, timeout);
             try
             {
                 if (timeout < 0)
@@ -294,7 +294,7 @@ namespace Microsoft.Data.SqlClient
             // EventHandlers to be fired when dependency is notified.
             add
             {
-                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Add|DEP> {0}#", ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Add|DEP> {0}", ObjectID);
                 try
                 {
                     if (null != value)
@@ -334,7 +334,7 @@ namespace Microsoft.Data.SqlClient
             }
             remove
             {
-                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Remove|DEP> {0}#", ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Remove|DEP> {0}", ObjectID);
                 try
                 {
                     if (null != value)
@@ -362,7 +362,7 @@ namespace Microsoft.Data.SqlClient
         public void AddCommandDependency(SqlCommand command)
         {
             // Adds command to dependency collection so we automatically create the SqlNotificationsRequest object
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandDependency|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandDependency|DEP> {0}", ObjectID);
             try
             {
                 // and listen for a notification for the added commands.
@@ -477,7 +477,7 @@ namespace Microsoft.Data.SqlClient
                                             }
 
                                             ADP.TraceExceptionWithoutRethrow(e); // Discard failure, but trace for now.
-                                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from Stop() after duplicate was found on Start().");
+                                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from Stop() after duplicate was found on Start().");
                                         }
                                         throw SQL.SqlDependencyDuplicateStart();
                                     }
@@ -647,7 +647,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (!s_serverUserHash.ContainsKey(server))
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash did not contain server, adding.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddToServerUserHash|DEP> Hash did not contain server, adding.");
                         identityDatabaseHash = new Dictionary<IdentityUserNamePair, List<DatabaseServicePair>>();
                         s_serverUserHash.Add(server, identityDatabaseHash);
                     }
@@ -660,7 +660,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (!identityDatabaseHash.ContainsKey(identityUser))
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash contained server but not user, adding user.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddToServerUserHash|DEP> Hash contained server but not user, adding user.");
                         databaseServiceList = new List<DatabaseServicePair>();
                         identityDatabaseHash.Add(identityUser, databaseServiceList);
                     }
@@ -671,13 +671,13 @@ namespace Microsoft.Data.SqlClient
 
                     if (!databaseServiceList.Contains(databaseService))
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Adding database.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddToServerUserHash|DEP> Adding database.");
                         databaseServiceList.Add(databaseService);
                         result = true;
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP|ERR> ERROR - hash already contained server, user, and database - we will throw!.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddToServerUserHash|DEP|ERR> ERROR - hash already contained server, user, and database - we will throw!.");
                     }
                 }
 
@@ -711,36 +711,36 @@ namespace Microsoft.Data.SqlClient
                             int index = databaseServiceList.IndexOf(databaseService);
                             if (index >= 0)
                             {
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> Hash contained server, user, and database - removing database.");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> Hash contained server, user, and database - removing database.");
                                 databaseServiceList.RemoveAt(index);
 
                                 if (databaseServiceList.Count == 0)
                                 {
-                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> databaseServiceList count 0, removing the list for this server and user.");
+                                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> databaseServiceList count 0, removing the list for this server and user.");
                                     identityDatabaseHash.Remove(identityUser);
 
                                     if (identityDatabaseHash.Count == 0)
                                     {
-                                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> identityDatabaseHash count 0, removing the hash for this server.");
+                                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> identityDatabaseHash count 0, removing the hash for this server.");
                                         s_serverUserHash.Remove(server);
                                     }
                                 }
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server and user but not database!");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server and user but not database!");
                                 Debug.Fail("Unexpected state - hash did not contain database!");
                             }
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server but not user!");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server but not user!");
                             Debug.Fail("Unexpected state - hash did not contain user!");
                         }
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash did not contain server!");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash did not contain server!");
                         Debug.Fail("Unexpected state - hash did not contain server!");
                     }
                 }
@@ -767,17 +767,17 @@ namespace Microsoft.Data.SqlClient
                         if (0 == s_serverUserHash.Count)
                         {
                             // Special error for no calls to start.
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - no start calls have been made, about to throw.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - no start calls have been made, about to throw.");
                             throw SQL.SqlDepDefaultOptionsButNoStart();
                         }
                         else if (!string.IsNullOrEmpty(failoverServer) && s_serverUserHash.ContainsKey(failoverServer))
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP> using failover server instead\n");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> using failover server instead\n");
                             server = failoverServer;
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening to this server, about to throw.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening to this server, about to throw.");
                             throw SQL.SqlDependencyNoMatchingServerStart();
                         }
                     }
@@ -790,7 +790,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         if (identityDatabaseHash.Count > 1)
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening for this user, " +
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening for this user, " +
                                                           "but listening to more than one other user, about to throw.");
                             throw SQL.SqlDependencyNoMatchingServerStart();
                         }
@@ -839,7 +839,7 @@ namespace Microsoft.Data.SqlClient
                         else
                         {
                             // More than one database for given server, ambiguous - fail the default case!
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - SqlDependency.Start called multiple times for this server/user, but no matching database.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - SqlDependency.Start called multiple times for this server/user, but no matching database.");
                             throw SQL.SqlDependencyNoMatchingServerDatabaseStart();
                         }
                     }
@@ -861,7 +861,7 @@ namespace Microsoft.Data.SqlClient
         // use this list for a reverse lookup based on server.
         internal void AddToServerList(string server)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddToServerList|DEP> {0}#, server: '{1}'", ObjectID, server);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddToServerList|DEP> {0}, server: '{1}'", ObjectID, server);
             try
             {
                 lock (_serverList)
@@ -891,7 +891,7 @@ namespace Microsoft.Data.SqlClient
 
         internal string ComputeHashAndAddToDispatcher(SqlCommand command)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> {0}, SqlCommand: {1}", ObjectID, command.ObjectID);
             try
             {
                 // Create a string representing the concatenation of the connection string, command text and .ToString on all parameter values.
@@ -914,7 +914,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Invalidate(SqlNotificationType type, SqlNotificationInfo info, SqlNotificationSource source)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.Invalidate|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.Invalidate|DEP> {0}", ObjectID);
             try
             {
                 List<EventContextPair> eventList = null;
@@ -928,7 +928,7 @@ namespace Microsoft.Data.SqlClient
 
                         if (ExpirationTime >= DateTime.UtcNow)
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP|ERR> ERROR - notification received twice - we should never enter this state!");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Invalidate|DEP|ERR> ERROR - notification received twice - we should never enter this state!");
                             Debug.Fail("Received notification twice - we should never enter this state!");
                         }
                         else
@@ -937,7 +937,7 @@ namespace Microsoft.Data.SqlClient
                             // raises Timeout event but before removing this event from the list. If notification is received from
                             // server in this case, we will hit this code path.
                             // It is safe to ignore this race condition because no event is sent to user and no leak happens.
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP> ignore notification received after timeout!");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Invalidate|DEP> ignore notification received after timeout!");
                         }
                     }
                     else
@@ -951,7 +951,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (eventList != null)
                 {
-                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP> Firing events.");
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Invalidate|DEP> Firing events.");
                     foreach (EventContextPair pair in eventList)
                     {
                         pair.Invoke(new SqlNotificationEventArgs(type, info, source));
@@ -967,7 +967,7 @@ namespace Microsoft.Data.SqlClient
         // This method is used by SqlCommand.
         internal void StartTimer(SqlNotificationRequest notificationRequest)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.StartTimer|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.StartTimer|DEP> {0}", ObjectID);
             try
             {
                 if (_expirationTime == DateTime.MaxValue)
@@ -1000,7 +1000,7 @@ namespace Microsoft.Data.SqlClient
             if (cmd != null)
             {
                 // Don't bother with EventSource if command null.
-                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandInternal|DEP> {0}#, SqlCommand: {1}#", ObjectID, cmd.ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandInternal|DEP> {0}, SqlCommand: {1}", ObjectID, cmd.ObjectID);
                 try
                 {
                     SqlConnection connection = cmd.Connection;
@@ -1010,7 +1010,7 @@ namespace Microsoft.Data.SqlClient
                         // Fail if cmd has notification that is not already associated with this dependency.
                         if (cmd._sqlDep == null || cmd._sqlDep != this)
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - throwing command has existing SqlNotificationRequest exception.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - throwing command has existing SqlNotificationRequest exception.");
                             throw SQL.SqlCommandHasExistingSqlNotificationRequest();
                         }
                     }
@@ -1044,7 +1044,7 @@ namespace Microsoft.Data.SqlClient
                                 if (0 == _eventList.Count)
                                 {
                                     // Keep logic just in case.
-                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - firing events, though it is unexpected we have events at this point.");
+                                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - firing events, though it is unexpected we have events at this point.");
                                     needToInvalidate = true; // Delay invalidation until outside of lock.
                                 }
                             }
@@ -1065,7 +1065,7 @@ namespace Microsoft.Data.SqlClient
 
         private string ComputeCommandHash(string connectionString, SqlCommand command)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeCommandHash|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeCommandHash|DEP> {0}, SqlCommand: {1}", ObjectID, command.ObjectID);
             try
             {
                 // Create a string representing the concatenation of the connection string, the command text and .ToString on all its parameter values.

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -55,7 +55,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         internal SqlConnectionContainer(SqlConnectionContainerHashHelper hashHelper, string appDomainKey, bool useDefaults)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer|DEP> {0}#, queue: '{1}'", ObjectID, HashHelper?.Queue);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer|DEP> {0}#, queue: '{1}'", ObjectID, HashHelper?.Queue);
             bool setupCompleted = false;
             try
             {
@@ -76,7 +76,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 }
 #if DEBUG
                 SqlConnectionString connectionStringOptions = new SqlConnectionString(_hashHelper.ConnectionStringBuilder.ConnectionString);
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
 #endif
 
                 // Always use ConnectionStringBuilder since in default case it is different from the 
@@ -175,7 +175,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -207,7 +207,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         // SqlDependencyProcessDispatcher.QueueAppDomainUnload on AppDomain.Unload.
         internal bool AppDomainUnload(string appDomainKey)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> {0}#, AppDomainKey: '{1}'", ObjectID, appDomainKey);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> {0}#, AppDomainKey: '{1}'", ObjectID, appDomainKey);
             try
             {
                 Debug.Assert(!string.IsNullOrEmpty(appDomainKey), "Unexpected empty appDomainKey!");
@@ -219,9 +219,9 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     if (_appDomainKeyHash.ContainsKey(appDomainKey))
                     {
                         // Do nothing if AppDomain did not call Start!
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash contained AppDomainKey: '{0}'.", appDomainKey);
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash contained AppDomainKey: '{0}'.", appDomainKey);
                         int value = _appDomainKeyHash[appDomainKey];
-                        SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash for AppDomainKey: '{0}' count: '{1}'.", appDomainKey, value);
+                        SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash for AppDomainKey: '{0}' count: '{1}'.", appDomainKey, value);
                         Debug.Assert(value > 0, "Why is value 0 or less?");
 
                         bool ignored = false;
@@ -238,26 +238,26 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
                         if (_appDomainKeyHash.ContainsKey(appDomainKey))
                         {
-                            SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP|ERR> ERROR - after the Stop() loop, _appDomainKeyHash for AppDomainKey: '{0}' entry not removed from hash.  Count: {1}'", appDomainKey, _appDomainKeyHash[appDomainKey]);
+                            SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP|ERR> ERROR - after the Stop() loop, _appDomainKeyHash for AppDomainKey: '{0}' entry not removed from hash.  Count: {1}'", appDomainKey, _appDomainKeyHash[appDomainKey]);
                         }
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash did not contain AppDomainKey: '{0}'.", appDomainKey);
+                        SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash did not contain AppDomainKey: '{0}'.", appDomainKey);
                     }
                 }
-                SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> Exiting, _stopped: '{0}'.", _stopped);
+                SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> Exiting, _stopped: '{0}'.", _stopped);
                 return _stopped;
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void AsynchronouslyQueryServiceBrokerQueue()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.AsynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.AsynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
             try
             {
                 AsyncCallback callback = new AsyncCallback(AsyncResultCallback);
@@ -265,13 +265,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void AsyncResultCallback(IAsyncResult asyncResult)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> {0}#", ObjectID);
             try
             {
                 using (SqlDataReader reader = _com.EndExecuteReader(asyncResult))
@@ -297,7 +297,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     _errorState = true;
                     throw;
                 }
-                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> Exception occurred.");
+                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> Exception occurred.");
 
                 if (!_stop)
                 { // Only assert if not in cancel path.
@@ -317,13 +317,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void CreateQueueAndService(bool restart)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.CreateQueueAndService|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.CreateQueueAndService|DEP> {0}#", ObjectID);
             try
             {
                 SqlCommand com = new SqlCommand()
@@ -457,18 +457,18 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         internal void IncrementStartCount(string appDomainKey, out bool appDomainStart)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> {0}#", ObjectID);
             try
             {
                 appDomainStart = false; // Reset out param.
                 int result = Interlocked.Increment(ref _startCount); // Add to refCount.
-                SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.IncrementStartCount|DEP> {0}#, incremented _startCount: {1}", s_staticInstance.ObjectID, result);
+                SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.IncrementStartCount|DEP> {0}#, incremented _startCount: {1}", s_staticInstance.ObjectID, result);
 
                 // Dictionary used to track how many times start has been called per app domain.
                 // For each increment, add to count, and create entry if not present.
@@ -477,25 +477,25 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     if (_appDomainKeyHash.ContainsKey(appDomainKey))
                     {
                         _appDomainKeyHash[appDomainKey] = _appDomainKeyHash[appDomainKey] + 1;
-                        SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.IncrementStartCount|DEP> _appDomainKeyHash contained AppDomainKey: '{0}', incremented count: '{1}'.", appDomainKey, _appDomainKeyHash[appDomainKey]);
+                        SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.IncrementStartCount|DEP> _appDomainKeyHash contained AppDomainKey: '{0}', incremented count: '{1}'.", appDomainKey, _appDomainKeyHash[appDomainKey]);
                     }
                     else
                     {
                         _appDomainKeyHash[appDomainKey] = 1;
                         appDomainStart = true;
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> _appDomainKeyHash did not contain AppDomainKey: '{0}', added to hashtable and value set to 1.", appDomainKey);
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> _appDomainKeyHash did not contain AppDomainKey: '{0}', added to hashtable and value set to 1.", appDomainKey);
                     }
                 }
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void ProcessNotificationResults(SqlDataReader reader)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> {0}#", ObjectID);
             Guid handle = Guid.Empty; // Conversation_handle.  Always close this!
             try
             {
@@ -503,18 +503,18 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 {
                     while (reader.Read())
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Row read.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Row read.");
 #if DEBUG
                         if (SqlClientEventSource.Log.IsNotificationTraceEnabled())
                         {
                             for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> column: {0}, value: {1}", reader.GetName(i), reader.GetValue(i).ToString());
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> column: {0}, value: {1}", reader.GetName(i), reader.GetValue(i).ToString());
                             }
                         }
 #endif
                         string msgType = reader.GetString(0);
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> msgType: '{0}'", msgType);
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> msgType: '{0}'", msgType);
                         handle = reader.GetGuid(1);
 
                         // Only process QueryNotification messages.
@@ -527,7 +527,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                 if (null != notification)
                                 {
                                     string key = notification.Key;
-                                    SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Key: '{0}'", key);
+                                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Key: '{0}'", key);
                                     int index = key.IndexOf(';'); // Our format is simple: "AppDomainKey;commandHash"
 
                                     if (index >= 0)
@@ -556,31 +556,31 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                         else
                                         {
                                             Debug.Fail("Received notification but do not have an associated PerAppDomainDispatcher!");
-                                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Received notification but do not have an associated PerAppDomainDispatcher!");
+                                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Received notification but do not have an associated PerAppDomainDispatcher!");
                                         }
                                     }
                                     else
                                     {
                                         Debug.Fail("Unexpected ID format received!");
-                                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Unexpected ID format received!");
+                                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Unexpected ID format received!");
                                     }
                                 }
                                 else
                                 {
                                     Debug.Fail("Null notification returned from ProcessMessage!");
-                                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null notification returned from ProcessMessage!");
+                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null notification returned from ProcessMessage!");
                                 }
                             }
                             else
                             {
                                 Debug.Fail("Null payload for QN notification type!");
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null payload for QN notification type!");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null payload for QN notification type!");
                             }
                         }
                         else
                         {
                             handle = Guid.Empty;
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Unexpected message format received!");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Unexpected message format received!");
                         }
                     }
                 }
@@ -608,13 +608,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     }
                     Debug.Assert(_com.Parameters.Count == 2, "Unexpected number of parameters!");
                 }
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void Restart(object unused)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.Restart|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.Restart|DEP> {0}#", ObjectID);
             try
             {
                 // Unused arg required by TimerCallback.
@@ -762,13 +762,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         internal bool Stop(string appDomainKey, out bool appDomainStop)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.Stop|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.Stop|DEP> {0}#", ObjectID);
             try
             {
                 appDomainStop = false;
@@ -786,7 +786,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                             int value = _appDomainKeyHash[appDomainKey];
 
                             Debug.Assert(value > 0, "Unexpected count for appDomainKey");
-                            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> _appDomainKeyHash contained AppDomainKey: '{0}', pre-decrement Count: '{1}'.", appDomainKey, value);
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> _appDomainKeyHash contained AppDomainKey: '{0}', pre-decrement Count: '{1}'.", appDomainKey, value);
 
                             if (value > 0)
                             {
@@ -794,7 +794,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR pre-decremented count <= 0!");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR pre-decremented count <= 0!");
                                 Debug.Fail("Unexpected AppDomainKey count in Stop()");
                             }
 
@@ -806,7 +806,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR appDomainKey not null and not found in hash!");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR appDomainKey not null and not found in hash!");
                             Debug.Fail("Unexpected state on Stop() - no AppDomainKey entry in hashtable!");
                         }
                     }
@@ -819,7 +819,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 {
                     // If we've reached refCount 0, destroy.
                     // Lock to ensure Cancel() complete prior to other thread calling TearDown.
-                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.Stop|DEP> Reached 0 count, cancelling and waiting.");
+                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP> Reached 0 count, cancelling and waiting.");
 
                     lock (this)
                     {
@@ -862,7 +862,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                             // TearDownAndDispose in the maximum retry period case as well as in the _errorState case.
                             if (_errorState || retryStopwatch.Elapsed.Seconds >= 30)
                             {
-                                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.Stop|DEP|ERR> forcing cleanup. elapsedSeconds: '{0}', _errorState: '{1}'.", retryStopwatch.Elapsed.Seconds, _errorState);
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP|ERR> forcing cleanup. elapsedSeconds: '{0}', _errorState: '{1}'.", retryStopwatch.Elapsed.Seconds, _errorState);
                                 Timer retryTimer = _retryTimer;
                                 _retryTimer = null;
                                 if (retryTimer != null)
@@ -881,7 +881,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 }
                 else
                 {
-                    SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> _startCount not 0 after decrement.  _startCount: '{0}'.", _startCount);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> _startCount not 0 after decrement.  _startCount: '{0}'.", _startCount);
                 }
 
                 Debug.Assert(0 <= _startCount, "Invalid start count state");
@@ -890,13 +890,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void SynchronouslyQueryServiceBrokerQueue()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.SynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.SynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
             try
             {
                 using (SqlDataReader reader = _com.ExecuteReader())
@@ -906,14 +906,14 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         [SuppressMessage("Microsoft.Security", "CA2100:ReviewSqlQueriesForSecurityVulnerabilities")]
         private void TearDownAndDispose()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.TearDownAndDispose|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.TearDownAndDispose|DEP> {0}#", ObjectID);
             try
             {
                 lock (this)
@@ -981,7 +981,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
     }
@@ -1310,19 +1310,19 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     private SqlDependencyProcessDispatcher(object dummyVariable)
     {
         Debug.Assert(null == s_staticInstance, "Real constructor called with static instance already created!");
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
         try
         {
 #if DEBUG
             // Possibly expensive, limit to debug.
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
 #endif
             _connectionContainers = new Dictionary<SqlConnectionContainerHashHelper, SqlConnectionContainer>();
             _sqlDependencyPerAppDomainDispatchers = new Dictionary<string, SqlDependencyPerAppDomainDispatcher>();
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1331,17 +1331,17 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     public SqlDependencyProcessDispatcher()
     {
         // Empty constructor and object - dummy to obtain singleton.
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
         try
         {
 #if DEBUG
             // Possibly expensive, limit to debug.
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
 #endif
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1358,7 +1358,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         out string user,
             string queue)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.GetHashString|DEP> {0}#, queue: {1}", s_staticInstance.ObjectID, queue);
+        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.GetHashString|DEP> {0}#, queue: {1}", s_staticInstance.ObjectID, queue);
         try
         {
             // Force certain connection string properties to be used by SqlDependencyProcessDispatcher.  
@@ -1392,7 +1392,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1404,7 +1404,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
     private void Invalidate(string server, SqlNotification sqlNotification)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Invalidate|DEP> {0}#, server: {1}", ObjectID, server);
+        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Invalidate|DEP> {0}#, server: {1}", ObjectID, server);
         try
         {
             Debug.Assert(this == s_staticInstance, "Instance method called on non _staticInstance instance!");
@@ -1436,7 +1436,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1451,7 +1451,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     // This method is only called by queued work-items from the method above.
     private void AppDomainUnloading(object state)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.AppDomainUnloading|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.AppDomainUnloading|DEP> {0}#", ObjectID);
         try
         {
             string appDomainKey = (string)state;
@@ -1483,7 +1483,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1553,7 +1553,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             bool useDefaults)
     {
         Debug.Assert(this == s_staticInstance, "Instance method called on non _staticInstance instance!");
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, queue: '{1}', appDomainKey: '{2}', perAppDomainDispatcher ID: '{3}'", ObjectID, queueService, appDomainKey, dispatcher.ObjectID);
+        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, queue: '{1}', appDomainKey: '{2}', perAppDomainDispatcher ID: '{3}'", ObjectID, queueService, appDomainKey, dispatcher.ObjectID);
         try
         {
             server = null;  // Reset out params.
@@ -1578,7 +1578,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                                                     queueService);
 #if DEBUG
             SqlConnectionString connectionStringOptions = new SqlConnectionString(connectionStringBuilder.ConnectionString);
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
 #endif
 
             bool started = false;
@@ -1588,7 +1588,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             {
                 if (!_connectionContainers.ContainsKey(hashHelper))
                 {
-                    SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, hashtable miss, creating new container.", ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, hashtable miss, creating new container.", ObjectID);
                     container = new SqlConnectionContainer(hashHelper, appDomainKey, useDefaults);
                     _connectionContainers.Add(hashHelper, container);
                     started = true;
@@ -1597,10 +1597,10 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 else
                 {
                     container = _connectionContainers[hashHelper];
-                    SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, hashtable hit, container: {1}", ObjectID, container.ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, hashtable hit, container: {1}", ObjectID, container.ObjectID);
                     if (container.InErrorState)
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, container: {1} is in error state!", ObjectID, container.ObjectID);
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, container: {1} is in error state!", ObjectID, container.ObjectID);
                         errorOccurred = true; // Set outparam errorOccurred true so we invalidate on Start().
                     }
                     else
@@ -1615,14 +1615,14 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 server = container.Server;
                 database = container.Database;
                 queueService = container.Queue;
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, default service: '{1}', server: '{2}', database: '{3}'", ObjectID, queueService, server, database);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, default service: '{1}', server: '{2}', database: '{3}'", ObjectID, queueService, server, database);
             }
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, started: {1}", ObjectID, started);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, started: {1}", ObjectID, started);
             return started;
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1638,7 +1638,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             string appDomainKey,
         out bool appDomainStop)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, queue: '{1}'", ObjectID, queueService);
+        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, queue: '{1}'", ObjectID, queueService);
         Debug.Assert(this == s_staticInstance, "Instance method called on non _staticInstance instance!");
         try
         {
@@ -1655,7 +1655,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                                                   queueService);
 #if DEBUG
             SqlConnectionString connectionStringOptions = new SqlConnectionString(connectionStringBuilder.ConnectionString);
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
 #endif
 
             bool stopped = false;
@@ -1665,7 +1665,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 if (_connectionContainers.ContainsKey(hashHelper))
                 {
                     SqlConnectionContainer container = _connectionContainers[hashHelper];
-                    SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, hashtable hit, container: {1}", ObjectID, container.ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, hashtable hit, container: {1}", ObjectID, container.ObjectID);
                     server = container.Server;   // Return server, database, and queue info for use by calling SqlDependency.
                     database = container.Database;
                     queueService = container.Queue;
@@ -1678,15 +1678,15 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 }
                 else
                 {
-                    SqlClientEventSource.Log.NotificationsTraceEvent("<Sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, hashtable miss.", ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<Sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, hashtable miss.", ObjectID);
                 }
             }
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, stopped: {1}", ObjectID, stopped);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, stopped: {1}", ObjectID, stopped);
             return stopped;
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -55,7 +55,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         internal SqlConnectionContainer(SqlConnectionContainerHashHelper hashHelper, string appDomainKey, bool useDefaults)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer|DEP> {0}#, queue: '{1}'", ObjectID, HashHelper?.Queue);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer|DEP> {0}, queue: '{1}'", ObjectID, HashHelper?.Queue);
             bool setupCompleted = false;
             try
             {
@@ -207,7 +207,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         // SqlDependencyProcessDispatcher.QueueAppDomainUnload on AppDomain.Unload.
         internal bool AppDomainUnload(string appDomainKey)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> {0}#, AppDomainKey: '{1}'", ObjectID, appDomainKey);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> {0}, AppDomainKey: '{1}'", ObjectID, appDomainKey);
             try
             {
                 Debug.Assert(!string.IsNullOrEmpty(appDomainKey), "Unexpected empty appDomainKey!");
@@ -257,7 +257,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void AsynchronouslyQueryServiceBrokerQueue()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsynchronouslyQueryServiceBrokerQueue|DEP> {0}", ObjectID);
             try
             {
                 AsyncCallback callback = new AsyncCallback(AsyncResultCallback);
@@ -271,7 +271,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void AsyncResultCallback(IAsyncResult asyncResult)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> {0}", ObjectID);
             try
             {
                 using (SqlDataReader reader = _com.EndExecuteReader(asyncResult))
@@ -297,7 +297,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     _errorState = true;
                     throw;
                 }
-                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> Exception occurred.");
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> Exception occurred.");
 
                 if (!_stop)
                 { // Only assert if not in cancel path.
@@ -323,7 +323,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void CreateQueueAndService(bool restart)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.CreateQueueAndService|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.CreateQueueAndService|DEP> {0}", ObjectID);
             try
             {
                 SqlCommand com = new SqlCommand()
@@ -463,12 +463,12 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         internal void IncrementStartCount(string appDomainKey, out bool appDomainStart)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> {0}", ObjectID);
             try
             {
                 appDomainStart = false; // Reset out param.
                 int result = Interlocked.Increment(ref _startCount); // Add to refCount.
-                SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.IncrementStartCount|DEP> {0}#, incremented _startCount: {1}", s_staticInstance.ObjectID, result);
+                SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.IncrementStartCount|DEP> {0}, incremented _startCount: {1}", s_staticInstance.ObjectID, result);
 
                 // Dictionary used to track how many times start has been called per app domain.
                 // For each increment, add to count, and create entry if not present.
@@ -495,7 +495,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void ProcessNotificationResults(SqlDataReader reader)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> {0}", ObjectID);
             Guid handle = Guid.Empty; // Conversation_handle.  Always close this!
             try
             {
@@ -503,7 +503,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 {
                     while (reader.Read())
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Row read.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Row read.");
 #if DEBUG
                         if (SqlClientEventSource.Log.IsNotificationTraceEnabled())
                         {
@@ -556,31 +556,31 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                         else
                                         {
                                             Debug.Fail("Received notification but do not have an associated PerAppDomainDispatcher!");
-                                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Received notification but do not have an associated PerAppDomainDispatcher!");
+                                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Received notification but do not have an associated PerAppDomainDispatcher!");
                                         }
                                     }
                                     else
                                     {
                                         Debug.Fail("Unexpected ID format received!");
-                                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Unexpected ID format received!");
+                                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Unexpected ID format received!");
                                     }
                                 }
                                 else
                                 {
                                     Debug.Fail("Null notification returned from ProcessMessage!");
-                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null notification returned from ProcessMessage!");
+                                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null notification returned from ProcessMessage!");
                                 }
                             }
                             else
                             {
                                 Debug.Fail("Null payload for QN notification type!");
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null payload for QN notification type!");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null payload for QN notification type!");
                             }
                         }
                         else
                         {
                             handle = Guid.Empty;
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Unexpected message format received!");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Unexpected message format received!");
                         }
                     }
                 }
@@ -614,7 +614,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void Restart(object unused)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Restart|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Restart|DEP> {0}", ObjectID);
             try
             {
                 // Unused arg required by TimerCallback.
@@ -768,7 +768,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         internal bool Stop(string appDomainKey, out bool appDomainStop)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Stop|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Stop|DEP> {0}", ObjectID);
             try
             {
                 appDomainStop = false;
@@ -794,7 +794,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR pre-decremented count <= 0!");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR pre-decremented count <= 0!");
                                 Debug.Fail("Unexpected AppDomainKey count in Stop()");
                             }
 
@@ -806,7 +806,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR appDomainKey not null and not found in hash!");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR appDomainKey not null and not found in hash!");
                             Debug.Fail("Unexpected state on Stop() - no AppDomainKey entry in hashtable!");
                         }
                     }
@@ -819,7 +819,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 {
                     // If we've reached refCount 0, destroy.
                     // Lock to ensure Cancel() complete prior to other thread calling TearDown.
-                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP> Reached 0 count, cancelling and waiting.");
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> Reached 0 count, cancelling and waiting.");
 
                     lock (this)
                     {
@@ -896,7 +896,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void SynchronouslyQueryServiceBrokerQueue()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.SynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.SynchronouslyQueryServiceBrokerQueue|DEP> {0}", ObjectID);
             try
             {
                 using (SqlDataReader reader = _com.ExecuteReader())
@@ -913,7 +913,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         [SuppressMessage("Microsoft.Security", "CA2100:ReviewSqlQueriesForSecurityVulnerabilities")]
         private void TearDownAndDispose()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.TearDownAndDispose|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.TearDownAndDispose|DEP> {0}", ObjectID);
             try
             {
                 lock (this)
@@ -1310,12 +1310,12 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     private SqlDependencyProcessDispatcher(object dummyVariable)
     {
         Debug.Assert(null == s_staticInstance, "Real constructor called with static instance already created!");
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}", ObjectID);
         try
         {
 #if DEBUG
             // Possibly expensive, limit to debug.
-            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
 #endif
             _connectionContainers = new Dictionary<SqlConnectionContainerHashHelper, SqlConnectionContainer>();
             _sqlDependencyPerAppDomainDispatchers = new Dictionary<string, SqlDependencyPerAppDomainDispatcher>();
@@ -1331,12 +1331,12 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     public SqlDependencyProcessDispatcher()
     {
         // Empty constructor and object - dummy to obtain singleton.
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}", ObjectID);
         try
         {
 #if DEBUG
             // Possibly expensive, limit to debug.
-            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
 #endif
         }
         finally
@@ -1358,7 +1358,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         out string user,
             string queue)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.GetHashString|DEP> {0}#, queue: {1}", s_staticInstance.ObjectID, queue);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.GetHashString|DEP> {0}, queue: {1}", s_staticInstance.ObjectID, queue);
         try
         {
             // Force certain connection string properties to be used by SqlDependencyProcessDispatcher.  
@@ -1404,7 +1404,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
     private void Invalidate(string server, SqlNotification sqlNotification)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Invalidate|DEP> {0}#, server: {1}", ObjectID, server);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Invalidate|DEP> {0}, server: {1}", ObjectID, server);
         try
         {
             Debug.Assert(this == s_staticInstance, "Instance method called on non _staticInstance instance!");
@@ -1451,7 +1451,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     // This method is only called by queued work-items from the method above.
     private void AppDomainUnloading(object state)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.AppDomainUnloading|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.AppDomainUnloading|DEP> {0}", ObjectID);
         try
         {
             string appDomainKey = (string)state;
@@ -1553,7 +1553,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             bool useDefaults)
     {
         Debug.Assert(this == s_staticInstance, "Instance method called on non _staticInstance instance!");
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, queue: '{1}', appDomainKey: '{2}', perAppDomainDispatcher ID: '{3}'", ObjectID, queueService, appDomainKey, dispatcher.ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, queue: '{1}', appDomainKey: '{2}', perAppDomainDispatcher ID: '{3}'", ObjectID, queueService, appDomainKey, dispatcher.ObjectID);
         try
         {
             server = null;  // Reset out params.
@@ -1588,7 +1588,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             {
                 if (!_connectionContainers.ContainsKey(hashHelper))
                 {
-                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, hashtable miss, creating new container.", ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, hashtable miss, creating new container.", ObjectID);
                     container = new SqlConnectionContainer(hashHelper, appDomainKey, useDefaults);
                     _connectionContainers.Add(hashHelper, container);
                     started = true;
@@ -1597,10 +1597,10 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 else
                 {
                     container = _connectionContainers[hashHelper];
-                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, hashtable hit, container: {1}", ObjectID, container.ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, hashtable hit, container: {1}", ObjectID, container.ObjectID);
                     if (container.InErrorState)
                     {
-                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, container: {1} is in error state!", ObjectID, container.ObjectID);
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, container: {1} is in error state!", ObjectID, container.ObjectID);
                         errorOccurred = true; // Set outparam errorOccurred true so we invalidate on Start().
                     }
                     else
@@ -1615,9 +1615,9 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 server = container.Server;
                 database = container.Database;
                 queueService = container.Queue;
-                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, default service: '{1}', server: '{2}', database: '{3}'", ObjectID, queueService, server, database);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, default service: '{1}', server: '{2}', database: '{3}'", ObjectID, queueService, server, database);
             }
-            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, started: {1}", ObjectID, started);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, started: {1}", ObjectID, started);
             return started;
         }
         finally
@@ -1638,7 +1638,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             string appDomainKey,
         out bool appDomainStop)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, queue: '{1}'", ObjectID, queueService);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}, queue: '{1}'", ObjectID, queueService);
         Debug.Assert(this == s_staticInstance, "Instance method called on non _staticInstance instance!");
         try
         {
@@ -1665,7 +1665,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 if (_connectionContainers.ContainsKey(hashHelper))
                 {
                     SqlConnectionContainer container = _connectionContainers[hashHelper];
-                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, hashtable hit, container: {1}", ObjectID, container.ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}, hashtable hit, container: {1}", ObjectID, container.ObjectID);
                     server = container.Server;   // Return server, database, and queue info for use by calling SqlDependency.
                     database = container.Database;
                     queueService = container.Queue;
@@ -1678,10 +1678,10 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 }
                 else
                 {
-                    SqlClientEventSource.Log.NotificationTraceEvent("<Sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, hashtable miss.", ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<Sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}, hashtable miss.", ObjectID);
                 }
             }
-            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, stopped: {1}", ObjectID, stopped);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}, stopped: {1}", ObjectID, stopped);
             return stopped;
         }
         finally

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -55,7 +55,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         internal SqlConnectionContainer(SqlConnectionContainerHashHelper hashHelper, string appDomainKey, bool useDefaults)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer|DEP> {0}#, queue: '{1}'", ObjectID, HashHelper?.Queue);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer|DEP> {0}#, queue: '{1}'", ObjectID, HashHelper?.Queue);
             bool setupCompleted = false;
             try
             {
@@ -175,7 +175,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -207,7 +207,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         // SqlDependencyProcessDispatcher.QueueAppDomainUnload on AppDomain.Unload.
         internal bool AppDomainUnload(string appDomainKey)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> {0}#, AppDomainKey: '{1}'", ObjectID, appDomainKey);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> {0}#, AppDomainKey: '{1}'", ObjectID, appDomainKey);
             try
             {
                 Debug.Assert(!string.IsNullOrEmpty(appDomainKey), "Unexpected empty appDomainKey!");
@@ -251,13 +251,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void AsynchronouslyQueryServiceBrokerQueue()
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.AsynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
             try
             {
                 AsyncCallback callback = new AsyncCallback(AsyncResultCallback);
@@ -265,13 +265,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void AsyncResultCallback(IAsyncResult asyncResult)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> {0}#", ObjectID);
             try
             {
                 using (SqlDataReader reader = _com.EndExecuteReader(asyncResult))
@@ -317,13 +317,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void CreateQueueAndService(bool restart)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.CreateQueueAndService|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.CreateQueueAndService|DEP> {0}#", ObjectID);
             try
             {
                 SqlCommand com = new SqlCommand()
@@ -457,13 +457,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         internal void IncrementStartCount(string appDomainKey, out bool appDomainStart)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> {0}#", ObjectID);
             try
             {
                 appDomainStart = false; // Reset out param.
@@ -489,13 +489,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void ProcessNotificationResults(SqlDataReader reader)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> {0}#", ObjectID);
             Guid handle = Guid.Empty; // Conversation_handle.  Always close this!
             try
             {
@@ -608,13 +608,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     }
                     Debug.Assert(_com.Parameters.Count == 2, "Unexpected number of parameters!");
                 }
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void Restart(object unused)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.Restart|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Restart|DEP> {0}#", ObjectID);
             try
             {
                 // Unused arg required by TimerCallback.
@@ -762,13 +762,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         internal bool Stop(string appDomainKey, out bool appDomainStop)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.Stop|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Stop|DEP> {0}#", ObjectID);
             try
             {
                 appDomainStop = false;
@@ -890,13 +890,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void SynchronouslyQueryServiceBrokerQueue()
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.SynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.SynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
             try
             {
                 using (SqlDataReader reader = _com.ExecuteReader())
@@ -906,14 +906,14 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         [SuppressMessage("Microsoft.Security", "CA2100:ReviewSqlQueriesForSecurityVulnerabilities")]
         private void TearDownAndDispose()
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlConnectionContainer.TearDownAndDispose|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.TearDownAndDispose|DEP> {0}#", ObjectID);
             try
             {
                 lock (this)
@@ -981,7 +981,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
     }
@@ -1310,7 +1310,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     private SqlDependencyProcessDispatcher(object dummyVariable)
     {
         Debug.Assert(null == s_staticInstance, "Real constructor called with static instance already created!");
-        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
         try
         {
 #if DEBUG
@@ -1322,7 +1322,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1331,7 +1331,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     public SqlDependencyProcessDispatcher()
     {
         // Empty constructor and object - dummy to obtain singleton.
-        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
         try
         {
 #if DEBUG
@@ -1341,7 +1341,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1358,7 +1358,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         out string user,
             string queue)
     {
-        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.GetHashString|DEP> {0}#, queue: {1}", s_staticInstance.ObjectID, queue);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.GetHashString|DEP> {0}#, queue: {1}", s_staticInstance.ObjectID, queue);
         try
         {
             // Force certain connection string properties to be used by SqlDependencyProcessDispatcher.  
@@ -1392,7 +1392,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1404,7 +1404,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
     private void Invalidate(string server, SqlNotification sqlNotification)
     {
-        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Invalidate|DEP> {0}#, server: {1}", ObjectID, server);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Invalidate|DEP> {0}#, server: {1}", ObjectID, server);
         try
         {
             Debug.Assert(this == s_staticInstance, "Instance method called on non _staticInstance instance!");
@@ -1436,7 +1436,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1451,7 +1451,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     // This method is only called by queued work-items from the method above.
     private void AppDomainUnloading(object state)
     {
-        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.AppDomainUnloading|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.AppDomainUnloading|DEP> {0}#", ObjectID);
         try
         {
             string appDomainKey = (string)state;
@@ -1483,7 +1483,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1553,7 +1553,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             bool useDefaults)
     {
         Debug.Assert(this == s_staticInstance, "Instance method called on non _staticInstance instance!");
-        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, queue: '{1}', appDomainKey: '{2}', perAppDomainDispatcher ID: '{3}'", ObjectID, queueService, appDomainKey, dispatcher.ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, queue: '{1}', appDomainKey: '{2}', perAppDomainDispatcher ID: '{3}'", ObjectID, queueService, appDomainKey, dispatcher.ObjectID);
         try
         {
             server = null;  // Reset out params.
@@ -1622,7 +1622,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1638,7 +1638,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             string appDomainKey,
         out bool appDomainStop)
     {
-        long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, queue: '{1}'", ObjectID, queueService);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, queue: '{1}'", ObjectID, queueService);
         Debug.Assert(this == s_staticInstance, "Instance method called on non _staticInstance instance!");
         try
         {
@@ -1686,7 +1686,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.AppDomain.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.AppDomain.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient
 
         private void UnloadEventHandler(object sender, EventArgs e)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.UnloadEventHandler|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.UnloadEventHandler|DEP> {0}#", ObjectID);
             try
             {
                 // Make non-blocking call to ProcessDispatcher to ThreadPool.QueueUserWorkItem to complete 
@@ -31,7 +31,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.AppDomain.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.AppDomain.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient
 
         private void UnloadEventHandler(object sender, EventArgs e)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.UnloadEventHandler|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.UnloadEventHandler|DEP> {0}#", ObjectID);
             try
             {
                 // Make non-blocking call to ProcessDispatcher to ThreadPool.QueueUserWorkItem to complete 
@@ -31,7 +31,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.AppDomain.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.AppDomain.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient
 
         private void UnloadEventHandler(object sender, EventArgs e)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.UnloadEventHandler|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.UnloadEventHandler|DEP> {0}", ObjectID);
             try
             {
                 // Make non-blocking call to ProcessDispatcher to ThreadPool.QueueUserWorkItem to complete 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Data.SqlClient
 
         private SqlDependencyPerAppDomainDispatcher()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher|DEP> {0}#", ObjectID);
             try
             {
                 _dependencyIdToDependencyHash = new Dictionary<string, SqlDependency>();
@@ -97,7 +97,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -113,7 +113,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called upon SqlDependency constructor.
         internal void AddDependencyEntry(SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddDependencyEntry|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddDependencyEntry|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
             try
             {
                 lock (_instanceLock)
@@ -123,14 +123,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is called upon Execute of a command associated with a SqlDependency object.
         internal string AddCommandEntry(string commandHash, SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> {0}#, commandHash: '{1}', SqlDependency: {2}#", ObjectID, commandHash, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> {0}#, commandHash: '{1}', SqlDependency: {2}#", ObjectID, commandHash, dep.ObjectID);
             string notificationId = string.Empty;
             try
             {
@@ -139,7 +139,7 @@ namespace Microsoft.Data.SqlClient
                     if (!_dependencyIdToDependencyHash.ContainsKey(dep.Id))
                     {
                         // Determine if depId->dep hashtable contains dependency.  If not, it's been invalidated.
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present in depId->dep hash, must have been invalidated.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present in depId->dep hash, must have been invalidated.");
                     }
                     else
                     {
@@ -160,12 +160,12 @@ namespace Microsoft.Data.SqlClient
                             // join the new dependency to the list
                             if (!dependencyList.Contains(dep))
                             {
-                                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present for commandHash, adding.");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present for commandHash, adding.");
                                 dependencyList.Add(dep);
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency already present for commandHash.");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency already present for commandHash.");
                             }
                         }
                         else
@@ -179,7 +179,7 @@ namespace Microsoft.Data.SqlClient
                                 SqlDependency.AppDomainKey, // must be first
                                 Guid.NewGuid().ToString("D", System.Globalization.CultureInfo.InvariantCulture)
                                 );
-                            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Creating new Dependencies list for commandHash.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Creating new Dependencies list for commandHash.");
                             DependencyList dependencyList = new DependencyList(commandHash);
                             dependencyList.Add(dep);
 
@@ -196,14 +196,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is called by the ProcessDispatcher upon a notification for this AppDomain.
         internal void InvalidateCommandID(SqlNotification sqlNotification)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> {0}#, commandHash: '{1}'", ObjectID, sqlNotification.Key);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> {0}#, commandHash: '{1}'", ObjectID, sqlNotification.Key);
             try
             {
                 List<SqlDependency> dependencyList = null;
@@ -214,7 +214,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (null != dependencyList)
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash found in hashtable.");
                         foreach (SqlDependency dependency in dependencyList)
                         {
                             // Ensure we remove from process static app domain hash for dependency initiated invalidates.
@@ -226,7 +226,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash NOT found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash NOT found in hashtable.");
                     }
                 }
 
@@ -235,7 +235,7 @@ namespace Microsoft.Data.SqlClient
                     // After removal from hashtables, invalidate.
                     foreach (SqlDependency dependency in dependencyList)
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> Dependency found in commandHash dependency ArrayList - calling invalidate.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> Dependency found in commandHash dependency ArrayList - calling invalidate.");
                         try
                         {
                             dependency.Invalidate(sqlNotification.Type, sqlNotification.Info, sqlNotification.Source);
@@ -256,14 +256,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is called when a connection goes down or other unknown error occurs in the ProcessDispatcher.
         internal void InvalidateServer(string server, SqlNotification sqlNotification)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.Invalidate|DEP> {0}#, server: '{1}'", ObjectID, server);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.Invalidate|DEP> {0}#, server: '{1}'", ObjectID, server);
             try
             {
                 List<SqlDependency> dependencies = new List<SqlDependency>();
@@ -310,14 +310,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is called by SqlCommand to enable ASP.NET scenarios - map from ID to Dependency.
         internal SqlDependency LookupDependencyEntry(string id)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}#, Key: '{1}'", ObjectID, id);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}#, Key: '{1}'", ObjectID, id);
             try
             {
                 if (null == id)
@@ -339,7 +339,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP|ERR> ERROR - dependency ID mismatch - not throwing.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP|ERR> ERROR - dependency ID mismatch - not throwing.");
                     }
                 }
 
@@ -347,21 +347,21 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         // Remove the dependency from the hashtable with the passed id.
         private void LookupDependencyEntryWithRemove(string id)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> {0}#, id: '{1}'", ObjectID, id);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> {0}#, id: '{1}'", ObjectID, id);
             try
             {
                 lock (_instanceLock)
                 {
                     if (_dependencyIdToDependencyHash.ContainsKey(id))
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry found in hashtable - removing.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry found in hashtable - removing.");
                         _dependencyIdToDependencyHash.Remove(id);
 
                         // if there are no more dependencies then we can dispose the timer.
@@ -373,20 +373,20 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry NOT found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry NOT found in hashtable.");
                     }
                 }
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         // Find and return arraylist, and remove passed hash value.
         private List<SqlDependency> LookupCommandEntryWithRemove(string notificationId)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupCommandEntryWithRemove|DEP> {0}#, commandHash: '{1}'", ObjectID, notificationId);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupCommandEntryWithRemove|DEP> {0}#, commandHash: '{1}'", ObjectID, notificationId);
             try
             {
                 DependencyList entry = null;
@@ -395,7 +395,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (_notificationIdToDependenciesHash.TryGetValue(notificationId, out entry))
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries found in hashtable - removing.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries found in hashtable - removing.");
 
                         // update the tables
                         _notificationIdToDependenciesHash.Remove(notificationId);
@@ -404,7 +404,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries NOT found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries NOT found in hashtable.");
                     }
 
                     Debug.Assert(_notificationIdToDependenciesHash.Count == _commandHashToNotificationId.Count, "always keep these maps in sync!");
@@ -414,14 +414,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         // Remove from commandToDependenciesHash all references to the passed dependency.
         private void RemoveDependencyFromCommandToDependenciesHash(SqlDependency dependency)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> {0}#, SqlDependency: {1}#", ObjectID, dependency.ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> {0}#, SqlDependency: {1}#", ObjectID, dependency.ObjectID);
             try
             {
                 lock (_instanceLock)
@@ -434,7 +434,7 @@ namespace Microsoft.Data.SqlClient
                         DependencyList dependencies = entry.Value;
                         if (dependencies.Remove(dependency))
                         {
-                            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> Removed SqlDependency: {0}#, with ID: '{1}'.", dependency.ObjectID, dependency.Id);
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> Removed SqlDependency: {0}#, with ID: '{1}'.", dependency.ObjectID, dependency.Id);
                             if (dependencies.Count == 0)
                             {
                                 // this dependency was the last associated with this notification ID, remove the entry
@@ -461,7 +461,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -469,7 +469,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void StartTimer(SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
             try
             {
                 // If this dependency expires sooner than the current next timeout, change
@@ -480,7 +480,7 @@ namespace Microsoft.Data.SqlClient
                     // Enable the timer if needed (disable when empty, enable on the first addition).
                     if (!_sqlDependencyTimeOutTimerStarted)
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> Timer not yet started, starting.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> Timer not yet started, starting.");
                         _timeoutTimer.Change(15000 /* 15 secs */, 15000 /* 15 secs */);
 
                         // Save this as the earlier timeout to come.
@@ -489,7 +489,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else if (_nextTimeout > dep.ExpirationTime)
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> Timer already started, resetting time.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> Timer already started, resetting time.");
 
                         // Save this as the earlier timeout to come.
                         _nextTimeout = dep.ExpirationTime;
@@ -498,13 +498,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
 
         private static void TimeoutTimerCallback(object state)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> AppDomainKey: '{0}'", SqlDependency.AppDomainKey);
+            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> AppDomainKey: '{0}'", SqlDependency.AppDomainKey);
             try
             {
                 SqlDependency[] dependencies;
@@ -516,14 +516,14 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (0 == SingletonInstance._dependencyIdToDependencyHash.Count)
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No dependencies, exiting.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No dependencies, exiting.");
 
                         // Nothing to check.
                         return;
                     }
                     if (SingletonInstance._nextTimeout > DateTime.UtcNow)
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No timeouts expired, exiting.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No timeouts expired, exiting.");
 
                         // No dependency timed-out yet.
                         return;
@@ -594,7 +594,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Data.SqlClient
 
         private SqlDependencyPerAppDomainDispatcher()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher|DEP> {0}", ObjectID);
             try
             {
                 _dependencyIdToDependencyHash = new Dictionary<string, SqlDependency>();
@@ -113,7 +113,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called upon SqlDependency constructor.
         internal void AddDependencyEntry(SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddDependencyEntry|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddDependencyEntry|DEP> {0}, SqlDependency: {1}", ObjectID, dep.ObjectID);
             try
             {
                 lock (_instanceLock)
@@ -130,7 +130,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called upon Execute of a command associated with a SqlDependency object.
         internal string AddCommandEntry(string commandHash, SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> {0}#, commandHash: '{1}', SqlDependency: {2}#", ObjectID, commandHash, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> {0}, commandHash: '{1}', SqlDependency: {2}", ObjectID, commandHash, dep.ObjectID);
             string notificationId = string.Empty;
             try
             {
@@ -203,7 +203,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called by the ProcessDispatcher upon a notification for this AppDomain.
         internal void InvalidateCommandID(SqlNotification sqlNotification)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> {0}#, commandHash: '{1}'", ObjectID, sqlNotification.Key);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> {0}, commandHash: '{1}'", ObjectID, sqlNotification.Key);
             try
             {
                 List<SqlDependency> dependencyList = null;
@@ -263,7 +263,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called when a connection goes down or other unknown error occurs in the ProcessDispatcher.
         internal void InvalidateServer(string server, SqlNotification sqlNotification)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.Invalidate|DEP> {0}#, server: '{1}'", ObjectID, server);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.Invalidate|DEP> {0}, server: '{1}'", ObjectID, server);
             try
             {
                 List<SqlDependency> dependencies = new List<SqlDependency>();
@@ -317,7 +317,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called by SqlCommand to enable ASP.NET scenarios - map from ID to Dependency.
         internal SqlDependency LookupDependencyEntry(string id)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}#, Key: '{1}'", ObjectID, id);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}, Key: '{1}'", ObjectID, id);
             try
             {
                 if (null == id)
@@ -354,7 +354,7 @@ namespace Microsoft.Data.SqlClient
         // Remove the dependency from the hashtable with the passed id.
         private void LookupDependencyEntryWithRemove(string id)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> {0}#, id: '{1}'", ObjectID, id);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> {0}, id: '{1}'", ObjectID, id);
             try
             {
                 lock (_instanceLock)
@@ -386,7 +386,7 @@ namespace Microsoft.Data.SqlClient
         // Find and return arraylist, and remove passed hash value.
         private List<SqlDependency> LookupCommandEntryWithRemove(string notificationId)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupCommandEntryWithRemove|DEP> {0}#, commandHash: '{1}'", ObjectID, notificationId);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupCommandEntryWithRemove|DEP> {0}, commandHash: '{1}'", ObjectID, notificationId);
             try
             {
                 DependencyList entry = null;
@@ -421,7 +421,7 @@ namespace Microsoft.Data.SqlClient
         // Remove from commandToDependenciesHash all references to the passed dependency.
         private void RemoveDependencyFromCommandToDependenciesHash(SqlDependency dependency)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> {0}#, SqlDependency: {1}#", ObjectID, dependency.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> {0}, SqlDependency: {1}", ObjectID, dependency.ObjectID);
             try
             {
                 lock (_instanceLock)
@@ -434,7 +434,7 @@ namespace Microsoft.Data.SqlClient
                         DependencyList dependencies = entry.Value;
                         if (dependencies.Remove(dependency))
                         {
-                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> Removed SqlDependency: {0}#, with ID: '{1}'.", dependency.ObjectID, dependency.Id);
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> Removed SqlDependency: {0}, with ID: '{1}'.", dependency.ObjectID, dependency.Id);
                             if (dependencies.Count == 0)
                             {
                                 // this dependency was the last associated with this notification ID, remove the entry
@@ -469,7 +469,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void StartTimer(SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> {0}, SqlDependency: {1}", ObjectID, dep.ObjectID);
             try
             {
                 // If this dependency expires sooner than the current next timeout, change
@@ -516,14 +516,14 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (0 == SingletonInstance._dependencyIdToDependencyHash.Count)
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No dependencies, exiting.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No dependencies, exiting.");
 
                         // Nothing to check.
                         return;
                     }
                     if (SingletonInstance._nextTimeout > DateTime.UtcNow)
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No timeouts expired, exiting.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No timeouts expired, exiting.");
 
                         // No dependency timed-out yet.
                         return;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Data.SqlClient
 
         private SqlDependencyPerAppDomainDispatcher()
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher|DEP> {0}#", ObjectID);
             try
             {
                 _dependencyIdToDependencyHash = new Dictionary<string, SqlDependency>();
@@ -97,7 +97,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -113,7 +113,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called upon SqlDependency constructor.
         internal void AddDependencyEntry(SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddDependencyEntry|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddDependencyEntry|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
             try
             {
                 lock (_instanceLock)
@@ -123,14 +123,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is called upon Execute of a command associated with a SqlDependency object.
         internal string AddCommandEntry(string commandHash, SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> {0}#, commandHash: '{1}', SqlDependency: {2}#", ObjectID, commandHash, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> {0}#, commandHash: '{1}', SqlDependency: {2}#", ObjectID, commandHash, dep.ObjectID);
             string notificationId = string.Empty;
             try
             {
@@ -196,14 +196,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is called by the ProcessDispatcher upon a notification for this AppDomain.
         internal void InvalidateCommandID(SqlNotification sqlNotification)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> {0}#, commandHash: '{1}'", ObjectID, sqlNotification.Key);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> {0}#, commandHash: '{1}'", ObjectID, sqlNotification.Key);
             try
             {
                 List<SqlDependency> dependencyList = null;
@@ -256,14 +256,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is called when a connection goes down or other unknown error occurs in the ProcessDispatcher.
         internal void InvalidateServer(string server, SqlNotification sqlNotification)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.Invalidate|DEP> {0}#, server: '{1}'", ObjectID, server);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.Invalidate|DEP> {0}#, server: '{1}'", ObjectID, server);
             try
             {
                 List<SqlDependency> dependencies = new List<SqlDependency>();
@@ -310,14 +310,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is called by SqlCommand to enable ASP.NET scenarios - map from ID to Dependency.
         internal SqlDependency LookupDependencyEntry(string id)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}#, Key: '{1}'", ObjectID, id);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}#, Key: '{1}'", ObjectID, id);
             try
             {
                 if (null == id)
@@ -347,14 +347,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // Remove the dependency from the hashtable with the passed id.
         private void LookupDependencyEntryWithRemove(string id)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> {0}#, id: '{1}'", ObjectID, id);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> {0}#, id: '{1}'", ObjectID, id);
             try
             {
                 lock (_instanceLock)
@@ -379,14 +379,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // Find and return arraylist, and remove passed hash value.
         private List<SqlDependency> LookupCommandEntryWithRemove(string notificationId)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupCommandEntryWithRemove|DEP> {0}#, commandHash: '{1}'", ObjectID, notificationId);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupCommandEntryWithRemove|DEP> {0}#, commandHash: '{1}'", ObjectID, notificationId);
             try
             {
                 DependencyList entry = null;
@@ -414,14 +414,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // Remove from commandToDependenciesHash all references to the passed dependency.
         private void RemoveDependencyFromCommandToDependenciesHash(SqlDependency dependency)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> {0}#, SqlDependency: {1}#", ObjectID, dependency.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> {0}#, SqlDependency: {1}#", ObjectID, dependency.ObjectID);
             try
             {
                 lock (_instanceLock)
@@ -461,7 +461,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -469,7 +469,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void StartTimer(SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
             try
             {
                 // If this dependency expires sooner than the current next timeout, change
@@ -498,13 +498,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private static void TimeoutTimerCallback(object state)
         {
-            long scopeID = SqlClientEventSource.Log.notificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> AppDomainKey: '{0}'", SqlDependency.AppDomainKey);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> AppDomainKey: '{0}'", SqlDependency.AppDomainKey);
             try
             {
                 SqlDependency[] dependencies;
@@ -594,7 +594,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.notificationScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Data.SqlClient
         {
             try
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.Deactivate|ADV> {0}# deactivating", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.Deactivate|ADV> {0}# deactivating", ObjectID);
                 SqlReferenceCollection referenceCollection = (SqlReferenceCollection)ReferenceCollection;
                 if (null != referenceCollection)
                 {
@@ -329,12 +329,12 @@ namespace Microsoft.Data.SqlClient
         private void EnlistNonNull(Transaction tx)
         {
             Debug.Assert(null != tx, "null transaction?");
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, transaction {1}#.", ObjectID, tx.GetHashCode());
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, transaction {1}#.", ObjectID, tx.GetHashCode());
             bool hasDelegatedTransaction = false;
 
             // Promotable transactions are only supported on Yukon
             // servers or newer.
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, attempting to delegate", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, attempting to delegate", ObjectID);
             SqlDelegatedTransaction delegatedTransaction = new SqlDelegatedTransaction(this, tx);
 
             try
@@ -398,7 +398,7 @@ namespace Microsoft.Data.SqlClient
                 if (hasDelegatedTransaction)
                 {
                     this.DelegatedTransaction = delegatedTransaction;
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegated to transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegated to transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
                 }
             }
             catch (SqlException e)
@@ -428,7 +428,7 @@ namespace Microsoft.Data.SqlClient
 
             if (!hasDelegatedTransaction)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegation not possible, enlisting.", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegation not possible, enlisting.", ObjectID);
                 byte[] cookie = null;
 
                 if (_isGlobalTransaction)
@@ -459,7 +459,7 @@ namespace Microsoft.Data.SqlClient
                 PropagateTransactionCookie(cookie);
 
                 _isEnlistedInTransaction = true;
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, enlisted with transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, enlisted with transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
             }
 
             EnlistedTransaction = tx; // Tell the base class about our enlistment
@@ -483,7 +483,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void EnlistNull()
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisting.", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisting.", ObjectID);
             // We were in a transaction, but now we are not - so send
             // message to server with empty transaction - confirmed proper
             // behavior from Sameet Agarwal
@@ -501,7 +501,7 @@ namespace Microsoft.Data.SqlClient
             _isEnlistedInTransaction = false;
             EnlistedTransaction = null; // Tell the base class about our enlistment
 
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisted.", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisted.", ObjectID);
 
             // The EnlistTransaction above will return an TransactionEnded event, 
             // which causes the TdsParser or SmiEventSink should to clear the

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Data.SqlClient
         {
             try
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.Deactivate|ADV> {0}# deactivating", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.Deactivate|ADV> {0} deactivating", ObjectID);
                 SqlReferenceCollection referenceCollection = (SqlReferenceCollection)ReferenceCollection;
                 if (null != referenceCollection)
                 {
@@ -329,12 +329,12 @@ namespace Microsoft.Data.SqlClient
         private void EnlistNonNull(Transaction tx)
         {
             Debug.Assert(null != tx, "null transaction?");
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, transaction {1}#.", ObjectID, tx.GetHashCode());
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, transaction {1}.", ObjectID, tx.GetHashCode());
             bool hasDelegatedTransaction = false;
 
             // Promotable transactions are only supported on Yukon
             // servers or newer.
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, attempting to delegate", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, attempting to delegate", ObjectID);
             SqlDelegatedTransaction delegatedTransaction = new SqlDelegatedTransaction(this, tx);
 
             try
@@ -398,7 +398,7 @@ namespace Microsoft.Data.SqlClient
                 if (hasDelegatedTransaction)
                 {
                     this.DelegatedTransaction = delegatedTransaction;
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegated to transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, delegated to transaction {1} with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
                 }
             }
             catch (SqlException e)
@@ -428,7 +428,7 @@ namespace Microsoft.Data.SqlClient
 
             if (!hasDelegatedTransaction)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegation not possible, enlisting.", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, delegation not possible, enlisting.", ObjectID);
                 byte[] cookie = null;
 
                 if (_isGlobalTransaction)
@@ -459,7 +459,7 @@ namespace Microsoft.Data.SqlClient
                 PropagateTransactionCookie(cookie);
 
                 _isEnlistedInTransaction = true;
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, enlisted with transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, enlisted with transaction {1} with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
             }
 
             EnlistedTransaction = tx; // Tell the base class about our enlistment
@@ -483,7 +483,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void EnlistNull()
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisting.", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}, unenlisting.", ObjectID);
             // We were in a transaction, but now we are not - so send
             // message to server with empty transaction - confirmed proper
             // behavior from Sameet Agarwal
@@ -501,7 +501,7 @@ namespace Microsoft.Data.SqlClient
             _isEnlistedInTransaction = false;
             EnlistedTransaction = null; // Tell the base class about our enlistment
 
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisted.", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}, unenlisted.", ObjectID);
 
             // The EnlistTransaction above will return an TransactionEnded event, 
             // which causes the TdsParser or SmiEventSink should to clear the

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -462,7 +462,7 @@ namespace Microsoft.Data.SqlClient
                 ThreadHasParserLockForClose = false;
                 _parserLock.Release();
             }
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.ctor|ADV> {0}#, constructed new TDS internal connection", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.ctor|ADV> {0}#, constructed new TDS internal connection", ObjectID);
         }
 
         // Returns true if the Sql error is a transient.
@@ -646,7 +646,7 @@ namespace Microsoft.Data.SqlClient
 
         public override void Dispose()
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.Dispose|ADV> {0}# disposing", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.Dispose|ADV> {0}# disposing", ObjectID);
             try
             {
                 TdsParser parser = Interlocked.Exchange(ref _parser, null);  // guard against multiple concurrent dispose calls -- Delegated Transactions might cause this.
@@ -1136,7 +1136,7 @@ namespace Microsoft.Data.SqlClient
             _parser.EnableMars();
 
             _fConnectionOpen = true; // mark connection as open
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.CompleteLogin|ADV> Post-Login Phase: Server connection obtained.");
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.CompleteLogin|ADV> Post-Login Phase: Server connection obtained.");
 
             // for non-pooled connections, enlist in a distributed transaction
             // if present - and user specified to enlist
@@ -1367,7 +1367,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(object.ReferenceEquals(connectionOptions, this.ConnectionOptions), "ConnectionOptions argument and property must be the same"); // consider removing the argument
             int routingAttempts = 0;
             ServerInfo originalServerInfo = serverInfo; // serverInfo may end up pointing to new object due to routing, original object is used to set CurrentDatasource
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, host={1}", ObjectID, serverInfo.UserServerName);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, host={1}", ObjectID, serverInfo.UserServerName);
             int sleepInterval = 100;  //milliseconds to sleep (back off) between attempts.
 
             ResolveExtendedServerName(serverInfo, !redirectedUserInstance, connectionOptions);
@@ -1517,7 +1517,7 @@ namespace Microsoft.Data.SqlClient
 
                 // Sleep for a bit to prevent clogging the network with requests, 
                 //  then update sleep interval for next iteration (max 1 second interval)
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
                 Thread.Sleep(sleepInterval);
                 sleepInterval = (sleepInterval < 500) ? sleepInterval * 2 : 1000;
             }
@@ -1561,7 +1561,7 @@ namespace Microsoft.Data.SqlClient
             )
         {
             Debug.Assert(!connectionOptions.MultiSubnetFailover, "MultiSubnetFailover should not be set if failover partner is used");
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, useFailover={1}[bool], primary={2}, failover={3}", ObjectID, useFailoverHost, primaryServerInfo.UserServerName, failoverHost ?? "null");
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, useFailover={1}[bool], primary={2}, failover={3}", ObjectID, useFailoverHost, primaryServerInfo.UserServerName, failoverHost ?? "null");
 
             int sleepInterval = 100;  //milliseconds to sleep (back off) between attempts.
             long timeoutUnitInterval;
@@ -1620,7 +1620,7 @@ namespace Microsoft.Data.SqlClient
                     // Primary server may give us a different failover partner than the connection string indicates.  Update it
                     if (null != ServerProvidedFailOverPartner && failoverServerInfo.ResolvedServerName != ServerProvidedFailOverPartner)
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, new failover partner={1}", ObjectID, ServerProvidedFailOverPartner);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, new failover partner={1}", ObjectID, ServerProvidedFailOverPartner);
                         failoverServerInfo.SetDerivedNames(string.Empty, ServerProvidedFailOverPartner);
                     }
                     currentServerInfo = failoverServerInfo;
@@ -1685,7 +1685,7 @@ namespace Microsoft.Data.SqlClient
                 //  the network with requests, then update sleep interval for next iteration (max 1 second interval)
                 if (1 == attemptNumber % 2)
                 {
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
                     Thread.Sleep(sleepInterval);
                     sleepInterval = (sleepInterval < 500) ? sleepInterval * 2 : 1000;
                 }
@@ -1740,7 +1740,7 @@ namespace Microsoft.Data.SqlClient
                                 TimeoutTimer timeout,
                                 bool withFailover = false)
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.AttemptOneLogin|ADV> {0}#, timout={1}[msec], server={2}", ObjectID, timeout.MillisecondsRemaining, serverInfo.ExtendedServerName);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.AttemptOneLogin|ADV> {0}#, timout={1}[msec], server={2}", ObjectID, timeout.MillisecondsRemaining, serverInfo.ExtendedServerName);
             RoutingInfo = null; // forget routing information 
 
             _parser._physicalStateObj.SniContext = SniContext.Snix_Connect;
@@ -1949,7 +1949,7 @@ namespace Microsoft.Data.SqlClient
                     break;
 
                 case TdsEnums.ENV_ROUTING:
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnEnvChange|ADV> {0}#, Received routing info", ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnEnvChange|ADV> {0}#, Received routing info", ObjectID);
                     if (string.IsNullOrEmpty(rec.newRoutingInfo.ServerName) || rec.newRoutingInfo.Protocol != 0 || rec.newRoutingInfo.Port == 0)
                     {
                         throw SQL.ROR_InvalidRoutingInfo(this);
@@ -2045,7 +2045,7 @@ namespace Microsoft.Data.SqlClient
                     // If a thread is already doing the refresh, just use the existing token in the cache and proceed.
                     else if (contextValidity <= _dbAuthenticationContextLockedRefreshTimeSpan)
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFedAuthInfo|ADV> {0}#, " +
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo|ADV> {0}#, " +
                             "The authentication context needs a refresh.The expiration time is {1}. " +
                             "Current Time is {2}.", ObjectID, dbConnectionPoolAuthenticationContext.ExpirationTime.ToLongTimeString(), DateTime.UtcNow.ToLongTimeString());
 
@@ -2064,7 +2064,7 @@ namespace Microsoft.Data.SqlClient
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, The attempt to get a new access token succeeded under the locked mode.", ObjectID);
                         }
                     }
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, Found an authentication context in the cache that does not need a refresh at this time. Re-using the cached token.", ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, Found an authentication context in the cache that does not need a refresh at this time. Re-using the cached token.", ObjectID);
                 }
             }
 
@@ -2307,8 +2307,8 @@ namespace Microsoft.Data.SqlClient
                         throw exc;
                     }
 
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, sleeping {1}[Milliseconds]", ObjectID, sleepInterval);
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, remaining {1}[Milliseconds]", ObjectID, _timeout.MillisecondsRemaining);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, sleeping {1}[Milliseconds]", ObjectID, sleepInterval);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, remaining {1}[Milliseconds]", ObjectID, _timeout.MillisecondsRemaining);
 
                     Thread.Sleep(sleepInterval);
                     sleepInterval *= 2;
@@ -2388,7 +2388,7 @@ namespace Microsoft.Data.SqlClient
 
                 case TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
                         if (data.Length < 1)
                         {
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown version number for GlobalTransactions", ObjectID);
@@ -2404,7 +2404,7 @@ namespace Microsoft.Data.SqlClient
                     }
                 case TdsEnums.FEATUREEXT_FEDAUTH:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for federated authentication", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for federated authentication", ObjectID);
                         if (!_federatedAuthenticationRequested)
                         {
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Did not request federated authentication", ObjectID);
@@ -2459,7 +2459,7 @@ namespace Microsoft.Data.SqlClient
                     }
                 case TdsEnums.FEATUREEXT_TCE:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for TCE", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for TCE", ObjectID);
                         if (data.Length < 1)
                         {
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown version number for TCE", ObjectID);
@@ -2488,7 +2488,7 @@ namespace Microsoft.Data.SqlClient
 
                 case TdsEnums.FEATUREEXT_UTF8SUPPORT:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for UTF8 support", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for UTF8 support", ObjectID);
                         if (data.Length < 1)
                         {
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown value for UTF8 support", ObjectID);
@@ -2498,7 +2498,7 @@ namespace Microsoft.Data.SqlClient
                     }
                 case TdsEnums.FEATUREEXT_DATACLASSIFICATION:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for DATACLASSIFICATION", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for DATACLASSIFICATION", ObjectID);
                         if (data.Length < 1)
                         {
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown token for DATACLASSIFICATION", ObjectID);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -462,7 +462,7 @@ namespace Microsoft.Data.SqlClient
                 ThreadHasParserLockForClose = false;
                 _parserLock.Release();
             }
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.ctor|ADV> {0}#, constructed new TDS internal connection", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.ctor|ADV> {0}, constructed new TDS internal connection", ObjectID);
         }
 
         // Returns true if the Sql error is a transient.
@@ -646,7 +646,7 @@ namespace Microsoft.Data.SqlClient
 
         public override void Dispose()
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.Dispose|ADV> {0}# disposing", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.Dispose|ADV> {0} disposing", ObjectID);
             try
             {
                 TdsParser parser = Interlocked.Exchange(ref _parser, null);  // guard against multiple concurrent dispose calls -- Delegated Transactions might cause this.
@@ -1094,12 +1094,12 @@ namespace Microsoft.Data.SqlClient
                 // ROR should not affect state of connection recovery
                 if (_federatedAuthenticationRequested && !_federatedAuthenticationAcknowledged)
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.CompleteLogin|ERR> {0}#, Server did not acknowledge the federated authentication request", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.CompleteLogin|ERR> {0}, Server did not acknowledge the federated authentication request", ObjectID);
                     throw SQL.ParsingError(ParsingErrorState.FedAuthNotAcknowledged);
                 }
                 if (_federatedAuthenticationInfoRequested && !_federatedAuthenticationInfoReceived)
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.CompleteLogin|ERR> {0}#, Server never sent the requested federated authentication info", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.CompleteLogin|ERR> {0}, Server never sent the requested federated authentication info", ObjectID);
                     throw SQL.ParsingError(ParsingErrorState.FedAuthInfoNotReceived);
                 }
                 if (!_sessionRecoveryAcknowledged)
@@ -1251,7 +1251,7 @@ namespace Microsoft.Data.SqlClient
 
         private void LoginFailure()
         {
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.LoginFailure|RES|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.LoginFailure|RES|CPOOL> {0}", ObjectID);
 
             // If the parser was allocated and we failed, then we must have failed on
             // either the Connect or Login, either way we should call Disconnect.
@@ -1367,7 +1367,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(object.ReferenceEquals(connectionOptions, this.ConnectionOptions), "ConnectionOptions argument and property must be the same"); // consider removing the argument
             int routingAttempts = 0;
             ServerInfo originalServerInfo = serverInfo; // serverInfo may end up pointing to new object due to routing, original object is used to set CurrentDatasource
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, host={1}", ObjectID, serverInfo.UserServerName);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}, host={1}", ObjectID, serverInfo.UserServerName);
             int sleepInterval = 100;  //milliseconds to sleep (back off) between attempts.
 
             ResolveExtendedServerName(serverInfo, !redirectedUserInstance, connectionOptions);
@@ -1517,7 +1517,7 @@ namespace Microsoft.Data.SqlClient
 
                 // Sleep for a bit to prevent clogging the network with requests, 
                 //  then update sleep interval for next iteration (max 1 second interval)
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}, sleeping {1}[milisec]", ObjectID, sleepInterval);
                 Thread.Sleep(sleepInterval);
                 sleepInterval = (sleepInterval < 500) ? sleepInterval * 2 : 1000;
             }
@@ -1561,7 +1561,7 @@ namespace Microsoft.Data.SqlClient
             )
         {
             Debug.Assert(!connectionOptions.MultiSubnetFailover, "MultiSubnetFailover should not be set if failover partner is used");
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, useFailover={1}[bool], primary={2}, failover={3}", ObjectID, useFailoverHost, primaryServerInfo.UserServerName, failoverHost ?? "null");
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}, useFailover={1}[bool], primary={2}, failover={3}", ObjectID, useFailoverHost, primaryServerInfo.UserServerName, failoverHost ?? "null");
 
             int sleepInterval = 100;  //milliseconds to sleep (back off) between attempts.
             long timeoutUnitInterval;
@@ -1620,7 +1620,7 @@ namespace Microsoft.Data.SqlClient
                     // Primary server may give us a different failover partner than the connection string indicates.  Update it
                     if (null != ServerProvidedFailOverPartner && failoverServerInfo.ResolvedServerName != ServerProvidedFailOverPartner)
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, new failover partner={1}", ObjectID, ServerProvidedFailOverPartner);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}, new failover partner={1}", ObjectID, ServerProvidedFailOverPartner);
                         failoverServerInfo.SetDerivedNames(string.Empty, ServerProvidedFailOverPartner);
                     }
                     currentServerInfo = failoverServerInfo;
@@ -1685,7 +1685,7 @@ namespace Microsoft.Data.SqlClient
                 //  the network with requests, then update sleep interval for next iteration (max 1 second interval)
                 if (1 == attemptNumber % 2)
                 {
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}, sleeping {1}[milisec]", ObjectID, sleepInterval);
                     Thread.Sleep(sleepInterval);
                     sleepInterval = (sleepInterval < 500) ? sleepInterval * 2 : 1000;
                 }
@@ -1740,7 +1740,7 @@ namespace Microsoft.Data.SqlClient
                                 TimeoutTimer timeout,
                                 bool withFailover = false)
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.AttemptOneLogin|ADV> {0}#, timout={1}[msec], server={2}", ObjectID, timeout.MillisecondsRemaining, serverInfo.ExtendedServerName);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.AttemptOneLogin|ADV> {0}, timout={1}[msec], server={2}", ObjectID, timeout.MillisecondsRemaining, serverInfo.ExtendedServerName);
             RoutingInfo = null; // forget routing information 
 
             _parser._physicalStateObj.SniContext = SniContext.Snix_Connect;
@@ -1843,7 +1843,7 @@ namespace Microsoft.Data.SqlClient
         internal void BreakConnection()
         {
             var connection = Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.BreakConnection|RES|CPOOL> {0}#, Breaking connection.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.BreakConnection|RES|CPOOL> {0}, Breaking connection.", ObjectID);
             DoomThisConnection();   // Mark connection as unusable, so it will be destroyed
             if (null != connection)
             {
@@ -1949,7 +1949,7 @@ namespace Microsoft.Data.SqlClient
                     break;
 
                 case TdsEnums.ENV_ROUTING:
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnEnvChange|ADV> {0}#, Received routing info", ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnEnvChange|ADV> {0}, Received routing info", ObjectID);
                     if (string.IsNullOrEmpty(rec.newRoutingInfo.ServerName) || rec.newRoutingInfo.Protocol != 0 || rec.newRoutingInfo.Port == 0)
                     {
                         throw SQL.ROR_InvalidRoutingInfo(this);
@@ -1992,7 +1992,7 @@ namespace Microsoft.Data.SqlClient
                          "Credentials aren't provided for calling MSAL");
             Debug.Assert(fedAuthInfo != null, "info should not be null.");
             Debug.Assert(_dbConnectionPoolAuthenticationContextKey == null, "_dbConnectionPoolAuthenticationContextKey should be null.");
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, Generating federated authentication token", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}, Generating federated authentication token", ObjectID);
             DbConnectionPoolAuthenticationContext dbConnectionPoolAuthenticationContext = null;
 
             // We want to refresh the token without taking a lock on the context, allowed when the access token is expiring within the next 10 mins.
@@ -2023,7 +2023,7 @@ namespace Microsoft.Data.SqlClient
                     // And on successful login, try to update the cache with the new token.
                     if (contextValidity <= _dbAuthenticationContextUnLockedRefreshTimeSpan)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, " +
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}, " +
                            "The expiration time is less than 10 mins, so trying to get new access token regardless of if an other thread is also trying to update it." +
                            "The expiration time is {1}. Current Time is {2}.", ObjectID, dbConnectionPoolAuthenticationContext.ExpirationTime.ToLongTimeString(), DateTime.UtcNow.ToLongTimeString());
                         attemptRefreshTokenUnLocked = true;
@@ -2045,7 +2045,7 @@ namespace Microsoft.Data.SqlClient
                     // If a thread is already doing the refresh, just use the existing token in the cache and proceed.
                     else if (contextValidity <= _dbAuthenticationContextLockedRefreshTimeSpan)
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo|ADV> {0}#, " +
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo|ADV> {0}, " +
                             "The authentication context needs a refresh.The expiration time is {1}. " +
                             "Current Time is {2}.", ObjectID, dbConnectionPoolAuthenticationContext.ExpirationTime.ToLongTimeString(), DateTime.UtcNow.ToLongTimeString());
 
@@ -2061,10 +2061,10 @@ namespace Microsoft.Data.SqlClient
                         // Indicate in EventSource Trace that we are successful with the update.
                         if (attemptRefreshTokenLocked)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, The attempt to get a new access token succeeded under the locked mode.", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}, The attempt to get a new access token succeeded under the locked mode.", ObjectID);
                         }
                     }
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, Found an authentication context in the cache that does not need a refresh at this time. Re-using the cached token.", ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}, Found an authentication context in the cache that does not need a refresh at this time. Re-using the cached token.", ObjectID);
                 }
             }
 
@@ -2124,14 +2124,14 @@ namespace Microsoft.Data.SqlClient
                 // Else some other thread is already updating it, so just proceed forward with the existing token in the cache.
                 if (dbConnectionPoolAuthenticationContext.LockToUpdate())
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.TryGetFedAuthTokenLocked> {0}#, " +
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.TryGetFedAuthTokenLocked> {0}, " +
                                         "Acquired the lock to update the authentication context.The expiration time is {1}. " +
                                         "Current Time is {2}.", ObjectID, dbConnectionPoolAuthenticationContext.ExpirationTime.ToLongTimeString(), DateTime.UtcNow.ToLongTimeString());
                     authenticationContextLocked = true;
                 }
                 else
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.TryGetFedAuthTokenLocked> {0}#, Refreshing the context is already in progress by another thread.", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.TryGetFedAuthTokenLocked> {0}, Refreshing the context is already in progress by another thread.", ObjectID);
                 }
 
                 if (authenticationContextLocked)
@@ -2289,7 +2289,7 @@ namespace Microsoft.Data.SqlClient
                         || _timeout.IsExpired
                         || _timeout.MillisecondsRemaining <= sleepInterval)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken.MSALException error:> {0}#", msalException.ErrorCode);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken.MSALException error:> {0}", msalException.ErrorCode);
                         // Error[0]
                         SqlErrorCollection sqlErs = new SqlErrorCollection();
                         sqlErs.Add(new SqlError(0, (byte)0x00, (byte)TdsEnums.MIN_ERROR_CLASS, ConnectionOptions.DataSource, SRHelper.GetString(SR.SQL_MSALFailure, username, ConnectionOptions.Authentication.ToString("G")), ActiveDirectoryAuthentication.MSALGetAccessTokenFunctionName, 0));
@@ -2307,8 +2307,8 @@ namespace Microsoft.Data.SqlClient
                         throw exc;
                     }
 
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, sleeping {1}[Milliseconds]", ObjectID, sleepInterval);
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, remaining {1}[Milliseconds]", ObjectID, _timeout.MillisecondsRemaining);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}, sleeping {1}[Milliseconds]", ObjectID, sleepInterval);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}, remaining {1}[Milliseconds]", ObjectID, _timeout.MillisecondsRemaining);
 
                     Thread.Sleep(sleepInterval);
                     sleepInterval *= 2;
@@ -2324,7 +2324,7 @@ namespace Microsoft.Data.SqlClient
                 DateTime expirationTime = DateTime.FromFileTimeUtc(fedAuthToken.expirationFileTime);
                 _newDbConnectionPoolAuthenticationContext = new DbConnectionPoolAuthenticationContext(fedAuthToken.accessToken, expirationTime);
             }
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken> {0}#, Finished generating federated authentication token.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken> {0}, Finished generating federated authentication token.", ObjectID);
             return fedAuthToken;
         }
 
@@ -2388,10 +2388,10 @@ namespace Microsoft.Data.SqlClient
 
                 case TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
                         if (data.Length < 1)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown version number for GlobalTransactions", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown version number for GlobalTransactions", ObjectID);
                             throw SQL.ParsingError();
                         }
 
@@ -2404,10 +2404,10 @@ namespace Microsoft.Data.SqlClient
                     }
                 case TdsEnums.FEATUREEXT_FEDAUTH:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for federated authentication", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for federated authentication", ObjectID);
                         if (!_federatedAuthenticationRequested)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Did not request federated authentication", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Did not request federated authentication", ObjectID);
                             throw SQL.ParsingErrorFeatureId(ParsingErrorState.UnrequestedFeatureAckReceived, featureId);
                         }
 
@@ -2420,14 +2420,14 @@ namespace Microsoft.Data.SqlClient
                                 // The server shouldn't have sent any additional data with the ack (like a nonce)
                                 if (data.Length != 0)
                                 {
-                                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Federated authentication feature extension ack for MSAL and Security Token includes extra data", ObjectID);
+                                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Federated authentication feature extension ack for MSAL and Security Token includes extra data", ObjectID);
                                     throw SQL.ParsingError(ParsingErrorState.FedAuthFeatureAckContainsExtraData);
                                 }
                                 break;
 
                             default:
                                 Debug.Fail("Unknown _fedAuthLibrary type");
-                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Attempting to use unknown federated authentication library", ObjectID);
+                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Attempting to use unknown federated authentication library", ObjectID);
                                 throw SQL.ParsingErrorLibraryType(ParsingErrorState.FedAuthFeatureAckUnknownLibraryType, (int)_fedAuthFeatureExtensionData.Value.libraryType);
                         }
                         _federatedAuthenticationAcknowledged = true;
@@ -2446,11 +2446,11 @@ namespace Microsoft.Data.SqlClient
                             // For debug purposes, assert and trace if we ended up updating the cache with the new one or some other thread's context won the expiration race.
                             if (newAuthenticationContextInCacheAfterAddOrUpdate == _newDbConnectionPoolAuthenticationContext)
                             {
-                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Updated the new dbAuthenticationContext in the _dbConnectionPool.AuthenticationContexts.", ObjectID);
+                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Updated the new dbAuthenticationContext in the _dbConnectionPool.AuthenticationContexts.", ObjectID);
                             }
                             else
                             {
-                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, AddOrUpdate attempted on _dbConnectionPool.AuthenticationContexts, but it did not update the new value.", ObjectID);
+                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, AddOrUpdate attempted on _dbConnectionPool.AuthenticationContexts, but it did not update the new value.", ObjectID);
                             }
 #endif
                         }
@@ -2459,17 +2459,17 @@ namespace Microsoft.Data.SqlClient
                     }
                 case TdsEnums.FEATUREEXT_TCE:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for TCE", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for TCE", ObjectID);
                         if (data.Length < 1)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown version number for TCE", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown version number for TCE", ObjectID);
                             throw SQL.ParsingError(ParsingErrorState.TceUnknownVersion);
                         }
 
                         byte supportedTceVersion = data[0];
                         if (0 == supportedTceVersion || supportedTceVersion > TdsEnums.MAX_SUPPORTED_TCE_VERSION)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Invalid version number for TCE", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for TCE", ObjectID);
                             throw SQL.ParsingErrorValue(ParsingErrorState.TceInvalidVersion, supportedTceVersion);
                         }
 
@@ -2488,32 +2488,32 @@ namespace Microsoft.Data.SqlClient
 
                 case TdsEnums.FEATUREEXT_UTF8SUPPORT:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for UTF8 support", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for UTF8 support", ObjectID);
                         if (data.Length < 1)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown value for UTF8 support", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown value for UTF8 support", ObjectID);
                             throw SQL.ParsingError();
                         }
                         break;
                     }
                 case TdsEnums.FEATUREEXT_DATACLASSIFICATION:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for DATACLASSIFICATION", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for DATACLASSIFICATION", ObjectID);
                         if (data.Length < 1)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown token for DATACLASSIFICATION", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown token for DATACLASSIFICATION", ObjectID);
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         byte supportedDataClassificationVersion = data[0];
                         if ((0 == supportedDataClassificationVersion) || (supportedDataClassificationVersion > TdsEnums.MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION))
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Invalid version number for DATACLASSIFICATION", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for DATACLASSIFICATION", ObjectID);
                             throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, supportedDataClassificationVersion);
                         }
 
                         if (data.Length != 2)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown token for DATACLASSIFICATION", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown token for DATACLASSIFICATION", ObjectID);
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         byte enabled = data[1];

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -432,7 +432,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Rollback(string transactionName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}#, transactionName='{transactionName}'", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}#, transactionName='{1}#'", ObjectID, transactionName);
             if (_innerConnection.IsLockedForBulkCopy)
             {
                 throw SQL.ConnectionLockedForBcpEvent();
@@ -468,7 +468,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Save(string savePointName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}#, savePointName='{savePointName}'", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}#, savePointName='{1}#'", ObjectID, savePointName);
             _innerConnection.ValidateConnectionForExecute(null);
 
             // ROLLBACK takes either a save point name or a transaction name.  It will rollback the

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -432,7 +432,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Rollback(string transactionName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}#, transactionName='{1}#'", ObjectID, transactionName);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}#, transactionName='{1}'", ObjectID, transactionName);
             if (_innerConnection.IsLockedForBulkCopy)
             {
                 throw SQL.ConnectionLockedForBcpEvent();
@@ -468,7 +468,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Save(string savePointName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}#, savePointName='{1}#'", ObjectID, savePointName);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}#, savePointName='{1}'", ObjectID, savePointName);
             _innerConnection.ValidateConnectionForExecute(null);
 
             // ROLLBACK takes either a save point name or a transaction name.  It will rollback the

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -432,7 +432,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Rollback(string transactionName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}#, transactionName='{1}'", ObjectID, transactionName);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}#, transactionName={1}#", ObjectID, transactionName);
             if (_innerConnection.IsLockedForBulkCopy)
             {
                 throw SQL.ConnectionLockedForBcpEvent();
@@ -468,7 +468,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Save(string savePointName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}#, savePointName='{1}'", ObjectID, savePointName);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}#, savePointName={1}#", ObjectID, savePointName);
             _innerConnection.ValidateConnectionForExecute(null);
 
             // ROLLBACK takes either a save point name or a transaction name.  It will rollback the

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.SqlClient
 
         internal SqlInternalTransaction(SqlInternalConnection innerConnection, TransactionType type, SqlTransaction outerTransaction, long transactionId)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInternalTransaction.ctor|RES|CPOOL> {0}#, Created for connection {1}#, outer transaction {2}#, Type {3}", ObjectID, innerConnection.ObjectID, (null != outerTransaction) ? outerTransaction.ObjectID : -1, (int)type);
+            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInternalTransaction.ctor|RES|CPOOL> {0}, Created for connection {1}, outer transaction {2}, Type {3}", ObjectID, innerConnection.ObjectID, (null != outerTransaction) ? outerTransaction.ObjectID : -1, (int)type);
             _innerConnection = innerConnection;
             _transactionType = type;
 
@@ -254,7 +254,7 @@ namespace Microsoft.Data.SqlClient
             SqlInternalConnection innerConnection = _innerConnection;
 
             Debug.Assert(innerConnection != null, "How can we be here if the connection is null?");
-            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInteralTransaction.CloseFromConnection|RES|CPOOL> {0}#, Closing", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInteralTransaction.CloseFromConnection|RES|CPOOL> {0}, Closing", ObjectID);
             bool processFinallyBlock = true;
             try
             {
@@ -280,7 +280,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Commit()
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Commit|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Commit|API> {0}", ObjectID);
 
             if (_innerConnection.IsLockedForBulkCopy)
             {
@@ -339,7 +339,7 @@ namespace Microsoft.Data.SqlClient
 
         private /*protected override*/ void Dispose(bool disposing)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInteralTransaction.Dispose|RES|CPOOL> {0}#, Disposing", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInteralTransaction.Dispose|RES|CPOOL> {0}, Disposing", ObjectID);
             if (disposing)
             {
                 if (null != _innerConnection)
@@ -390,7 +390,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Rollback()
         {
-            var scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}#", ObjectID);
+            var scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}", ObjectID);
             if (_innerConnection.IsLockedForBulkCopy)
             {
                 throw SQL.ConnectionLockedForBcpEvent();
@@ -432,7 +432,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Rollback(string transactionName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}#, transactionName={1}#", ObjectID, transactionName);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}, transactionName={1}", ObjectID, transactionName);
             if (_innerConnection.IsLockedForBulkCopy)
             {
                 throw SQL.ConnectionLockedForBcpEvent();
@@ -468,7 +468,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Save(string savePointName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}#, savePointName={1}#", ObjectID, savePointName);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}, savePointName={1}", ObjectID, savePointName);
             _innerConnection.ValidateConnectionForExecute(null);
 
             // ROLLBACK takes either a save point name or a transaction name.  It will rollback the

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -142,8 +142,8 @@ namespace Microsoft.Data.SqlClient
             ZombieCheck();
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Commit|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlTransaction.Commit|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Commit|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlTransaction.Commit|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -209,7 +209,7 @@ namespace Microsoft.Data.SqlClient
             if (IsYukonPartialZombie)
             {
                 // Put something in the trace in case a customer has an issue
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Rollback|ADV> {0}# partial zombie no rollback required", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Rollback|ADV> {0} partial zombie no rollback required", ObjectID);
                 _internalTransaction = null; // yukon zombification
             }
             else
@@ -217,8 +217,8 @@ namespace Microsoft.Data.SqlClient
                 ZombieCheck();
 
                 SqlStatistics statistics = null;
-                long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Rollback|API> {0}#", ObjectID);
-                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlTransaction.Rollback|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+                long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Rollback|API> {0}", ObjectID);
+                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlTransaction.Rollback|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
                 try
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
@@ -256,7 +256,7 @@ namespace Microsoft.Data.SqlClient
             Guid operationId = s_diagnosticListener.WriteTransactionRollbackBefore(_isolationLevel, _connection, transactionName);
 
             ZombieCheck();
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Rollback|API> {0}# transactionName='{1}'", ObjectID, transactionName);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Rollback|API> {0} transactionName='{1}'", ObjectID, transactionName);
             SqlStatistics statistics = null;
             try
             {
@@ -295,7 +295,7 @@ namespace Microsoft.Data.SqlClient
             ZombieCheck();
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Save|API> {0}# savePointName='{1}'", ObjectID, savePointName);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Save|API> {0} savePointName='{1}'", ObjectID, savePointName);
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -323,7 +323,7 @@ namespace Microsoft.Data.SqlClient
             SqlInternalConnection internalConnection = (_connection.InnerConnection as SqlInternalConnection);
             if (null != internalConnection && !_isFromAPI)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Zombie|ADV> {0}# yukon deferred zombie", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Zombie|ADV> {0} yukon deferred zombie", ObjectID);
             }
             else
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Data.SqlClient
             if (IsYukonPartialZombie)
             {
                 // Put something in the trace in case a customer has an issue
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlTransaction.Rollback|ADV> {0}# partial zombie no rollback required", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Rollback|ADV> {0}# partial zombie no rollback required", ObjectID);
                 _internalTransaction = null; // yukon zombification
             }
             else
@@ -323,7 +323,7 @@ namespace Microsoft.Data.SqlClient
             SqlInternalConnection internalConnection = (_connection.InnerConnection as SqlInternalConnection);
             if (null != internalConnection && !_isFromAPI)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlTransaction.Zombie|ADV> {0}# yukon deferred zombie", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Zombie|ADV> {0}# yukon deferred zombie", ObjectID);
             }
             else
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Data.SqlClient
         internal TdsParserStateObject CreateSession()
         {
             TdsParserStateObject session = TdsParserStateObjectFactory.Singleton.CreateSessionObject(this, _pMarsPhysicalConObj, true);
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.CreateSession|ADV> {0}# created session {1}", ObjectID, session.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.CreateSession|ADV> {0} created session {1}", ObjectID, session.ObjectID);
             return session;
         }
 
@@ -544,12 +544,12 @@ namespace Microsoft.Data.SqlClient
                 session = _sessionPool.GetSession(owner);
 
                 Debug.Assert(!session.HasPendingData, "pending data on a pooled MARS session");
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0}# getting session {1} from pool", ObjectID, session.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0} getting session {1} from pool", ObjectID, session.ObjectID);
             }
             else
             {
                 session = _physicalStateObj;
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0}# getting physical session {1}", ObjectID, session.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0} getting physical session {1}", ObjectID, session.ObjectID);
             }
             Debug.Assert(session._outputPacketNumber == 1, "The packet number is expected to be 1");
             return session;
@@ -941,7 +941,7 @@ namespace Microsoft.Data.SqlClient
                         // Only 0x00 and 0x01 are accepted values from the server.
                         if (payload[payloadOffset] != 0x00 && payload[payloadOffset] != 0x01)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.ConsumePreLoginHandshake|ERR> {0}#, " +
+                            SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.ConsumePreLoginHandshake|ERR> {0}, " +
                                 "Server sent an unexpected value for FedAuthRequired PreLogin Option. Value was {1}.", ObjectID, (int)payload[payloadOffset]);
                             throw SQL.ParsingErrorValue(ParsingErrorState.FedAuthRequiredPreLoginResponseInvalidValue, (int)payload[payloadOffset]);
                         }
@@ -978,10 +978,10 @@ namespace Microsoft.Data.SqlClient
         internal void Deactivate(bool connectionIsDoomed)
         {
             // Called when the connection that owns us is deactivated.
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.Deactivate|ADV> {0}# deactivating", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.Deactivate|ADV> {0} deactivating", ObjectID);
             if (SqlClientEventSource.Log.IsStateDumpEnabled())
             {
-                SqlClientEventSource.Log.StateDumpEvent("<sc.TdsParser.Deactivate|STATE> {0}# {1}", ObjectID, TraceString());
+                SqlClientEventSource.Log.StateDumpEvent("<sc.TdsParser.Deactivate|STATE> {0} {1}", ObjectID, TraceString());
             }
 
             if (MARSOn)
@@ -1142,7 +1142,7 @@ namespace Microsoft.Data.SqlClient
 
             if (temp.Count == 0)
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.ThrowExceptionAndWarning|ERR> Potential multi-threaded misuse of connection, unexpectedly empty warnings/errors under lock {0}#", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.ThrowExceptionAndWarning|ERR> Potential multi-threaded misuse of connection, unexpectedly empty warnings/errors under lock {0}", ObjectID);
             }
             Debug.Assert(temp != null, "TdsParser::ThrowExceptionAndWarning: null errors collection!");
             Debug.Assert(temp.Count > 0, "TdsParser::ThrowExceptionAndWarning called with no exceptions or warnings!");
@@ -1862,7 +1862,7 @@ namespace Microsoft.Data.SqlClient
                     Debug.Fail($"unexpected token; token = {token,-2:X2}");
                     _state = TdsParserState.Broken;
                     _connHandler.BreakConnection();
-                    SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.Run|ERR> Potential multi-threaded misuse of connection, unexpected TDS token found {0}#", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.Run|ERR> Potential multi-threaded misuse of connection, unexpected TDS token found {0}", ObjectID);
                     throw SQL.ParsingError();
                 }
 
@@ -8013,7 +8013,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 WriteInt(log7Flags, _physicalStateObj);
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TdsLogin|ADV> {0}#, TDS Login7 flags = {1}:", ObjectID, log7Flags);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TdsLogin|ADV> {0}, TDS Login7 flags = {1}:", ObjectID, log7Flags);
 
                 WriteInt(0, _physicalStateObj);  // ClientTimeZone is not used
                 WriteInt(0, _physicalStateObj);  // LCID is unused by server
@@ -8685,7 +8685,7 @@ namespace Microsoft.Data.SqlClient
 
                 if ((!_fMARS) && (_physicalStateObj.HasOpenResult))
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.TdsExecuteSQLBatch|ERR> Potential multi-threaded misuse of connection, non-MARs connection with an open result {0}#", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.TdsExecuteSQLBatch|ERR> Potential multi-threaded misuse of connection, non-MARs connection with an open result {0}", ObjectID);
                 }
                 stateObj.SniContext = SniContext.Snix_Execute;
 
@@ -8814,7 +8814,7 @@ namespace Microsoft.Data.SqlClient
 
                         if ((!_fMARS) && (_physicalStateObj.HasOpenResult))
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.TdsExecuteRPC|ERR> Potential multi-threaded misuse of connection, non-MARs connection with an open result {0}#", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.TdsExecuteRPC|ERR> Potential multi-threaded misuse of connection, non-MARs connection with an open result {0}", ObjectID);
                         }
 
                         stateObj.SniContext = SniContext.Snix_Execute;
@@ -9635,7 +9635,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             var sendDefaultValue = sendDefault ? 1 : 0;
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.WriteSmiParameter|ADV> {0}#, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData.TraceString(3));
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.WriteSmiParameter|ADV> {0}, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData.TraceString(3));
 
             //
             // Write parameter metadata

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Data.SqlClient
         internal TdsParserStateObject CreateSession()
         {
             TdsParserStateObject session = TdsParserStateObjectFactory.Singleton.CreateSessionObject(this, _pMarsPhysicalConObj, true);
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.CreateSession|ADV> {0}# created session {1}", ObjectID, session.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.CreateSession|ADV> {0}# created session {1}", ObjectID, session.ObjectID);
             return session;
         }
 
@@ -544,12 +544,12 @@ namespace Microsoft.Data.SqlClient
                 session = _sessionPool.GetSession(owner);
 
                 Debug.Assert(!session.HasPendingData, "pending data on a pooled MARS session");
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.GetSession|ADV> {0}# getting session {1} from pool", ObjectID, session.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0}# getting session {1} from pool", ObjectID, session.ObjectID);
             }
             else
             {
                 session = _physicalStateObj;
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.GetSession|ADV> {0}# getting physical session {1}", ObjectID, session.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0}# getting physical session {1}", ObjectID, session.ObjectID);
             }
             Debug.Assert(session._outputPacketNumber == 1, "The packet number is expected to be 1");
             return session;
@@ -978,7 +978,7 @@ namespace Microsoft.Data.SqlClient
         internal void Deactivate(bool connectionIsDoomed)
         {
             // Called when the connection that owns us is deactivated.
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.Deactivate|ADV> {0}# deactivating", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.Deactivate|ADV> {0}# deactivating", ObjectID);
             SqlClientEventSource.Log.StateDumpEvent("<sc.TdsParser.Deactivate|STATE> {0}# {1}", ObjectID, TraceString());
 
             if (MARSOn)
@@ -1252,7 +1252,7 @@ namespace Microsoft.Data.SqlClient
 #if DEBUG
                 // There is an exception here for MARS as its possible that another thread has closed the connection just as we see an error
                 Debug.Assert(SniContext.Undefined != stateObj.DebugOnlyCopyOfSniContext || ((_fMARS) && ((_state == TdsParserState.Closed) || (_state == TdsParserState.Broken))), "SniContext must not be None");
-                SqlClientEventSource.Log.SNITrace("<sc.TdsParser.ProcessSNIError|ERR> SNIContext must not be None = {0}, _fMARS = {1}, TDS Parser State = {2}", stateObj.DebugOnlyCopyOfSniContext, _fMARS, _state);
+                SqlClientEventSource.Log.SNITraceEvent("<sc.TdsParser.ProcessSNIError|ERR> SNIContext must not be None = {0}, _fMARS = {1}, TDS Parser State = {2}", stateObj.DebugOnlyCopyOfSniContext, _fMARS, _state);
 
 #endif
                 SNIErrorDetails details = GetSniErrorDetails();
@@ -1264,17 +1264,17 @@ namespace Microsoft.Data.SqlClient
                     {
                         case (int)SNINativeMethodWrapper.SniSpecialErrors.MultiSubnetFailoverWithMoreThan64IPs:
                             // Connecting with the MultiSubnetFailover connection option to a SQL Server instance configured with more than 64 IP addresses is not supported.
-                            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.ProcessSNIError|ERR|ADV> Connecting with the MultiSubnetFailover connection option to a SQL Server instance configured with more than 64 IP addresses is not supported.");
+                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.ProcessSNIError|ERR|ADV> Connecting with the MultiSubnetFailover connection option to a SQL Server instance configured with more than 64 IP addresses is not supported.");
                             throw SQL.MultiSubnetFailoverWithMoreThan64IPs();
 
                         case (int)SNINativeMethodWrapper.SniSpecialErrors.MultiSubnetFailoverWithInstanceSpecified:
                             // Connecting to a named SQL Server instance using the MultiSubnetFailover connection option is not supported.
-                            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.ProcessSNIError|ERR|ADV> Connecting to a named SQL Server instance using the MultiSubnetFailover connection option is not supported.");
+                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.ProcessSNIError|ERR|ADV> Connecting to a named SQL Server instance using the MultiSubnetFailover connection option is not supported.");
                             throw SQL.MultiSubnetFailoverWithInstanceSpecified();
 
                         case (int)SNINativeMethodWrapper.SniSpecialErrors.MultiSubnetFailoverWithNonTcpProtocol:
                             // Connecting to a SQL Server instance using the MultiSubnetFailover connection option is only supported when using the TCP protocol.
-                            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.ProcessSNIError|ERR|ADV> Connecting to a SQL Server instance using the MultiSubnetFailover connection option is only supported when using the TCP protocol.");
+                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.ProcessSNIError|ERR|ADV> Connecting to a SQL Server instance using the MultiSubnetFailover connection option is only supported when using the TCP protocol.");
                             throw SQL.MultiSubnetFailoverWithNonTcpProtocol();
                             // continue building SqlError instance
                     }
@@ -1282,7 +1282,7 @@ namespace Microsoft.Data.SqlClient
                 // PInvoke code automatically sets the length of the string for us
                 // So no need to look for \0
                 string errorMessage = details.errorMessage;
-                SqlClientEventSource.Log.AdvanceTrace("< sc.TdsParser.ProcessSNIError |ERR|ADV > Error message Detail: {0}", details.errorMessage);
+                SqlClientEventSource.Log.AdvancedTraceEvent("< sc.TdsParser.ProcessSNIError |ERR|ADV > Error message Detail: {0}", details.errorMessage);
 
                 //  Format SNI errors and add Context Information
                 //
@@ -1300,12 +1300,12 @@ namespace Microsoft.Data.SqlClient
                 if (TdsParserStateObjectFactory.UseManagedSNI)
                 {
                     Debug.Assert(!string.IsNullOrEmpty(details.errorMessage) || details.sniErrorNumber != 0, "Empty error message received from SNI");
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}, SNI Error Number ={1}", details.errorMessage, details.sniErrorNumber);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}, SNI Error Number ={1}", details.errorMessage, details.sniErrorNumber);
                 }
                 else
                 {
                     Debug.Assert(!string.IsNullOrEmpty(details.errorMessage), "Empty error message received from SNI");
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}", details.errorMessage);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}", details.errorMessage);
                 }
 
                 string sniContextEnumName = TdsEnums.GetSniContextEnumName(stateObj.SniContext);
@@ -1315,7 +1315,7 @@ namespace Microsoft.Data.SqlClient
                 string providerName = SRHelper.GetResourceString(providerRid);
                 Debug.Assert(!string.IsNullOrEmpty(providerName), $"invalid providerResourceId '{providerRid}'");
                 uint win32ErrorCode = details.nativeError;
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.ProcessSNIError |ERR|ADV > SNI Native Error Code = {0}", win32ErrorCode);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > SNI Native Error Code = {0}", win32ErrorCode);
                 if (details.sniErrorNumber == 0)
                 {
                     // Provider error. The message from provider is preceded with non-localizable info from SNI
@@ -1323,9 +1323,9 @@ namespace Microsoft.Data.SqlClient
                     //
                     int iColon = errorMessage.IndexOf(':');
                     Debug.Assert(0 <= iColon, "':' character missing in sni errorMessage");
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.ProcessSNIError |ERR|ADV > ':' character missing in sni errorMessage. Error Mesage index of ':' = {0}", iColon);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > ':' character missing in sni errorMessage. Error Mesage index of ':' = {0}", iColon);
                     Debug.Assert(errorMessage.Length > iColon + 1 && errorMessage[iColon + 1] == ' ', "Expecting a space after the ':' character");
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.ProcessSNIError |ERR|ADV > Expecting a space after the ':' character. Error Mesage Length = {0}", errorMessage.Length);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Expecting a space after the ':' character. Error Mesage Length = {0}", errorMessage.Length);
                     // extract the message excluding the colon and trailing cr/lf chars
                     if (0 <= iColon)
                     {
@@ -1373,7 +1373,10 @@ namespace Microsoft.Data.SqlClient
                 }
                 errorMessage = string.Format("{0} (provider: {1}, error: {2} - {3})",
                     sqlContextInfo, providerName, (int)details.sniErrorNumber, errorMessage);
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.ProcessSNIError |ERR|ADV > SNI Error Message. Native Error = {0}, Line Number ={1}, Function ={2}, Exception ={3}, Server = {4}", (int)details.nativeError, (int)details.lineNumber, details.function, details.exception, _server);
+                
+                SqlClientEventSource.Log.AdvancedTraceErrorEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > SNI Error Message. Native Error = {0}, Line Number ={1}, Function ={2}, Exception ={3}, Server = {4}", 
+                    (int)details.nativeError, (int)details.lineNumber, details.function, details.exception, _server);
+
                 return new SqlError((int)details.nativeError, 0x00, TdsEnums.FATAL_ERROR_CLASS,
                                     _server, errorMessage, details.function, (int)details.lineNumber, details.nativeError, details.exception);
             }
@@ -3577,7 +3580,7 @@ namespace Microsoft.Data.SqlClient
             SqlFedAuthInfo tempFedAuthInfo = new SqlFedAuthInfo();
 
             // Skip reading token length, since it has already been read in caller
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo> FEDAUTHINFO token stream length = {0}", tokenLen);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo> FEDAUTHINFO token stream length = {0}", tokenLen);
             if (tokenLen < sizeof(uint))
             {
                 // the token must at least contain a DWORD indicating the number of info IDs
@@ -3593,14 +3596,14 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.ParsingError(ParsingErrorState.FedAuthInfoFailedToReadCountOfInfoIds);
             }
             tokenLen -= sizeof(uint); // remaining length is shortened since we read optCount
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo|ADV> CountOfInfoIDs = {0}", optionsCount.ToString(CultureInfo.InvariantCulture));
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|ADV> CountOfInfoIDs = {0}", optionsCount.ToString(CultureInfo.InvariantCulture));
             if (tokenLen > 0)
             {
                 // read the rest of the token
                 byte[] tokenData = new byte[tokenLen];
                 int totalRead = 0;
                 bool successfulRead = stateObj.TryReadByteArray(tokenData, tokenLen, out totalRead);
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo|ADV> Read rest of FEDAUTHINFO token stream: {0}", BitConverter.ToString(tokenData, 0, totalRead));
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|ADV> Read rest of FEDAUTHINFO token stream: {0}", BitConverter.ToString(tokenData, 0, totalRead));
 
                 if (!successfulRead || totalRead != tokenLen)
                 {
@@ -3625,7 +3628,7 @@ namespace Microsoft.Data.SqlClient
                     byte id = tokenData[currentOptionOffset];
                     uint dataLen = BitConverter.ToUInt32(tokenData, checked((int)(currentOptionOffset + 1)));
                     uint dataOffset = BitConverter.ToUInt32(tokenData, checked((int)(currentOptionOffset + 5)));
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo> FedAuthInfoOpt: ID={0}, DataLen={1}, Offset={2}", id, dataLen.ToString(CultureInfo.InvariantCulture), dataOffset.ToString(CultureInfo.InvariantCulture));
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo> FedAuthInfoOpt: ID={0}, DataLen={1}, Offset={2}", id, dataLen.ToString(CultureInfo.InvariantCulture), dataOffset.ToString(CultureInfo.InvariantCulture));
 
                     // offset is measured from optCount, so subtract to make offset measured
                     // from the beginning of tokenData
@@ -3657,7 +3660,7 @@ namespace Microsoft.Data.SqlClient
                         SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|{0}> FedAuthInfoData is not in unicode format.", "ERR");
                         throw SQL.ParsingError(ParsingErrorState.FedAuthInfoDataNotUnicode, e);
                     }
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo|ADV> FedAuthInfoData: {0}", data);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|ADV> FedAuthInfoData: {0}", data);
 
                     // store data in tempFedAuthInfo
                     switch ((TdsEnums.FedAuthInfoId)id)
@@ -3671,7 +3674,7 @@ namespace Microsoft.Data.SqlClient
                             break;
 
                         default:
-                            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo|ADV> Ignoring unknown federated authentication info option: {0}", id);
+                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|ADV> Ignoring unknown federated authentication info option: {0}", id);
                             break;
                     }
                 }
@@ -8007,7 +8010,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 WriteInt(log7Flags, _physicalStateObj);
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TdsLogin|ADV> {0}#, TDS Login7 flags = {1}:", ObjectID, log7Flags);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TdsLogin|ADV> {0}#, TDS Login7 flags = {1}:", ObjectID, log7Flags);
 
                 WriteInt(0, _physicalStateObj);  // ClientTimeZone is not used
                 WriteInt(0, _physicalStateObj);  // LCID is unused by server
@@ -9629,7 +9632,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             var sendDefaultValue = sendDefault ? 1 : 0;
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.WriteSmiParameter|ADV> {0}#, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData.TraceString(3));
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.WriteSmiParameter|ADV> {0}#, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData.TraceString(3));
 
             //
             // Write parameter metadata
@@ -10668,7 +10671,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(ushort.MaxValue >= service.Length, "Service length is out of range");
             Debug.Assert(-1 <= timeout, "Timeout");
 
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.TdsParser.WriteQueryNotificationHeader|DEP> NotificationRequest: userData: '{0}', options: '{1}', timeout: '{2}'", notificationRequest.UserData, notificationRequest.Options, notificationRequest.Timeout);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.TdsParser.WriteQueryNotificationHeader|DEP> NotificationRequest: userData: '{0}', options: '{1}', timeout: '{2}'", notificationRequest.UserData, notificationRequest.Options, notificationRequest.Timeout);
             WriteShort(TdsEnums.HEADERTYPE_QNOTIFICATION, stateObj);      // Query notifications Type
 
             WriteShort(callbackId.Length * 2, stateObj); // Length in bytes

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1287,18 +1287,18 @@ namespace Microsoft.Data.SqlClient
                 string errorMessage = details.errorMessage;
                 SqlClientEventSource.Log.AdvancedTraceEvent("< sc.TdsParser.ProcessSNIError |ERR|ADV > Error message Detail: {0}", details.errorMessage);
 
-                //  Format SNI errors and add Context Information
-                //
-                //  General syntax is:
-                //  <sqlclient message>
-                //  (provider:<SNIx provider>, error: <SNIx error code> - <SNIx error message>)
-                //
-                // errorMessage | sniError |
-                // -------------------------------------------
-                // ==null       | x        | must never happen
-                // !=null       | != 0     | retrieve corresponding errorMessage from resources
-                // !=null       | == 0     | replace text left of errorMessage
-                //
+                /*  Format SNI errors and add Context Information
+                 *
+                 *  General syntax is:
+                 *  <sqlclient message>
+                 *  (provider:<SNIx provider>, error: <SNIx error code> - <SNIx error message>)
+                 *
+                 * errorMessage | sniError |
+                 * -------------------------------------------
+                 * ==null       | x        | must never happen
+                 * !=null       | != 0     | retrieve corresponding errorMessage from resources
+                 * !=null       | == 0     | replace text left of errorMessage
+                 */
 
                 if (TdsParserStateObjectFactory.UseManagedSNI)
                 {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient
             _cache = new List<TdsParserStateObject>();
             _freeStateObjects = new TdsParserStateObject[MaxInactiveCount];
             _freeStateObjectCount = 0;
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.ctor|ADV> {0}# created session pool for parser {1}", ObjectID, parser.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.ctor|ADV> {0}# created session pool for parser {1}", ObjectID, parser.ObjectID);
         }
 
         private bool IsDisposed
@@ -79,7 +79,7 @@ namespace Microsoft.Data.SqlClient
                             if (session.IsOrphaned)
                             {
                                 // TODO: consider adding a performance counter for the number of sessions we reclaim
-                                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.Deactivate|ADV> {0}# reclaiming session {1}", ObjectID, session.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0}# reclaiming session {1}", ObjectID, session.ObjectID);
                                 PutSession(session);
                             }
                         }
@@ -96,7 +96,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Dispose()
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.Dispose|ADV> {0}# disposing cachedCount={1}", ObjectID, _cachedCount);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Dispose|ADV> {0}# disposing cachedCount={1}", ObjectID, _cachedCount);
             lock (_cache)
             {
                 // Dispose free sessions
@@ -154,7 +154,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // No free objects, create a new one
                     session = _parser.CreateSession();
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.CreateSession|ADV> {0}# adding session {1} to pool", ObjectID, session.ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.CreateSession|ADV> {0}# adding session {1} to pool", ObjectID, session.ObjectID);
 
                     _cache.Add(session);
                     _cachedCount = _cache.Count;
@@ -163,7 +163,7 @@ namespace Microsoft.Data.SqlClient
                 session.Activate(owner);
             }
 
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.GetSession|ADV> {0}# using session {1}", ObjectID, session.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.GetSession|ADV> {0}# using session {1}", ObjectID, session.ObjectID);
             return session;
         }
 
@@ -185,7 +185,7 @@ namespace Microsoft.Data.SqlClient
                 else if ((okToReuse) && (_freeStateObjectCount < MaxInactiveCount))
                 {
                     // Session is good to re-use and our cache has space
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.PutSession|ADV> {0}# keeping session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0}# keeping session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
                     Debug.Assert(!session.HasPendingData, "pending data on a pooled session?");
 
                     _freeStateObjects[_freeStateObjectCount] = session;
@@ -194,7 +194,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     // Either the session is bad, or we have no cache space - so dispose the session and remove it
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.PutSession|ADV> {0}# disposing session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0}# disposing session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
 
                     bool removed = _cache.Remove(session);
                     Debug.Assert(removed, "session not in pool?");

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient
             _cache = new List<TdsParserStateObject>();
             _freeStateObjects = new TdsParserStateObject[MaxInactiveCount];
             _freeStateObjectCount = 0;
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.ctor|ADV> {0}# created session pool for parser {1}", ObjectID, parser.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.ctor|ADV> {0} created session pool for parser {1}", ObjectID, parser.ObjectID);
         }
 
         private bool IsDisposed
@@ -60,7 +60,7 @@ namespace Microsoft.Data.SqlClient
             // When being deactivated, we check all the sessions in the
             // cache to make sure they're cleaned up and then we dispose of
             // sessions that are past what we want to keep around.
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0}# deactivating cachedCount={1}", ObjectID, _cachedCount);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0} deactivating cachedCount={1}", ObjectID, _cachedCount);
             try
             {
                 lock (_cache)
@@ -79,7 +79,7 @@ namespace Microsoft.Data.SqlClient
                             if (session.IsOrphaned)
                             {
                                 // TODO: consider adding a performance counter for the number of sessions we reclaim
-                                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0}# reclaiming session {1}", ObjectID, session.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0} reclaiming session {1}", ObjectID, session.ObjectID);
                                 PutSession(session);
                             }
                         }
@@ -96,7 +96,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Dispose()
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Dispose|ADV> {0}# disposing cachedCount={1}", ObjectID, _cachedCount);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Dispose|ADV> {0} disposing cachedCount={1}", ObjectID, _cachedCount);
             lock (_cache)
             {
                 // Dispose free sessions
@@ -154,7 +154,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // No free objects, create a new one
                     session = _parser.CreateSession();
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.CreateSession|ADV> {0}# adding session {1} to pool", ObjectID, session.ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.CreateSession|ADV> {0} adding session {1} to pool", ObjectID, session.ObjectID);
 
                     _cache.Add(session);
                     _cachedCount = _cache.Count;
@@ -163,7 +163,7 @@ namespace Microsoft.Data.SqlClient
                 session.Activate(owner);
             }
 
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.GetSession|ADV> {0}# using session {1}", ObjectID, session.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.GetSession|ADV> {0} using session {1}", ObjectID, session.ObjectID);
             return session;
         }
 
@@ -185,7 +185,7 @@ namespace Microsoft.Data.SqlClient
                 else if ((okToReuse) && (_freeStateObjectCount < MaxInactiveCount))
                 {
                     // Session is good to re-use and our cache has space
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0}# keeping session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0} keeping session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
                     Debug.Assert(!session.HasPendingData, "pending data on a pooled session?");
 
                     _freeStateObjects[_freeStateObjectCount] = session;
@@ -194,7 +194,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     // Either the session is bad, or we have no cache space - so dispose the session and remove it
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0}# disposing session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0} disposing session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
 
                     bool removed = _cache.Remove(session);
                     Debug.Assert(removed, "session not in pool?");

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -540,8 +540,8 @@ namespace Microsoft.Data.SqlClient
                     return false;
                 }
 
-                SqlClientEventSource.Log.TraceEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> {0}#, NBCROW bitmap received, column count = {1}", stateObj.ObjectID, columnsCount);
-                SqlClientEventSource.Log.TraceBinEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> NBCROW bitmap data: ", _nullBitmap, (ushort)_nullBitmap.Length);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> {0}#, NBCROW bitmap received, column count = {1}", stateObj.ObjectID, columnsCount);
+                SqlClientEventSource.Log.AdvancedTraceBinEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> NBCROW bitmap data: ", _nullBitmap, (ushort)_nullBitmap.Length);
                 return true;
             }
 
@@ -869,7 +869,7 @@ namespace Microsoft.Data.SqlClient
         internal int DecrementPendingCallbacks(bool release)
         {
             int remaining = Interlocked.Decrement(ref _pendingCallbacks);
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}#, after decrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}#, after decrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
             FreeGcHandle(remaining, release);
             // NOTE: TdsParserSessionPool may call DecrementPendingCallbacks on a TdsParserStateObject which is already disposed
             // This is not dangerous (since the stateObj is no longer in use), but we need to add a workaround in the assert for it

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -540,7 +540,7 @@ namespace Microsoft.Data.SqlClient
                     return false;
                 }
 
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> {0}#, NBCROW bitmap received, column count = {1}", stateObj.ObjectID, columnsCount);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> {0}, NBCROW bitmap received, column count = {1}", stateObj.ObjectID, columnsCount);
                 SqlClientEventSource.Log.AdvancedTraceBinEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> NBCROW bitmap data: ", _nullBitmap, (ushort)_nullBitmap.Length);
                 return true;
             }
@@ -869,7 +869,7 @@ namespace Microsoft.Data.SqlClient
         internal int DecrementPendingCallbacks(bool release)
         {
             int remaining = Interlocked.Decrement(ref _pendingCallbacks);
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}#, after decrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}, after decrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
             FreeGcHandle(remaining, release);
             // NOTE: TdsParserSessionPool may call DecrementPendingCallbacks on a TdsParserStateObject which is already disposed
             // This is not dangerous (since the stateObj is no longer in use), but we need to add a workaround in the assert for it

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -39,13 +39,13 @@ namespace Microsoft.Data.SqlClient
         {
             if (UseManagedSNI)
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.TdsParserStateObjectFactory.CreateTdsParserStateObject|INFO> Found AppContext switch '{0}#' enabled, managed networking implementation will be used."
+                SqlClientEventSource.Log.TraceEvent("<sc.TdsParserStateObjectFactory.CreateTdsParserStateObject|INFO> Found AppContext switch '{0}' enabled, managed networking implementation will be used."
                    , UseManagedNetworkingOnWindows);
                 return new TdsParserStateObjectManaged(parser);
             }
             else
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.TdsParserStateObjectFactory.CreateTdsParserStateObject|INFO> AppContext switch '{0}#' not enabled, native networking implementation will be used."
+                SqlClientEventSource.Log.TraceEvent("<sc.TdsParserStateObjectFactory.CreateTdsParserStateObject|INFO> AppContext switch '{0}' not enabled, native networking implementation will be used."
                    , UseManagedNetworkingOnWindows);
                 return new TdsParserStateObjectNative(parser);
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlFileStream.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlFileStream.Windows.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Data.SqlTypes
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/ctor2/*' />
         public SqlFileStream(string path, byte[] transactionContext, FileAccess access, FileOptions options, long allocationSize)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlFileStream.ctor|API> {0}# access={1} options={2} path='{3}'", ObjectID, (int)access, (int)options, path);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlFileStream.ctor|API> {0} access={1} options={2} path='{3}'", ObjectID, (int)access, (int)options, path);
             try
             {
                 //-----------------------------------------------------------------
@@ -599,7 +599,7 @@ namespace Microsoft.Data.SqlTypes
                                                                                 eaBuffer: b,
                                                                                 eaLength: (uint)fullSize);
 
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlFileStream.OpenSqlFileStream|ADV> {0}#, desiredAccess=0x{1}, allocationSize={2}, " +
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlFileStream.OpenSqlFileStream|ADV> {0}, desiredAccess=0x{1}, allocationSize={2}, " +
                        "fileAttributes=0x{3}, shareAccess=0x{4}, dwCreateDisposition=0x{5}, createOptions=0x{ dwCreateOptions}", ObjectID, (int)nDesiredAccess, allocationSize, 0, (int)nShareAccess, dwCreateDisposition);
 
                         retval = status;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlFileStream.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlFileStream.Windows.cs
@@ -599,7 +599,7 @@ namespace Microsoft.Data.SqlTypes
                                                                                 eaBuffer: b,
                                                                                 eaLength: (uint)fullSize);
 
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlFileStream.OpenSqlFileStream|ADV> {0}#, desiredAccess=0x{1}, allocationSize={2}, " +
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlFileStream.OpenSqlFileStream|ADV> {0}#, desiredAccess=0x{1}, allocationSize={2}, " +
                        "fileAttributes=0x{3}, shareAccess=0x{4}, dwCreateDisposition=0x{5}, createOptions=0x{ dwCreateOptions}", ObjectID, (int)nDesiredAccess, allocationSize, 0, (int)nShareAccess, dwCreateDisposition);
 
                         retval = status;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Data.Common
         private static string[] ParseRestrictions(string restrictions, Hashtable synonyms)
         {
 #if DEBUG
-            SqlClientEventSource.Log.AdvanceTrace("<comm.DBConnectionString|INFO|ADV> Restrictions='{0}'", restrictions);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DBConnectionString|INFO|ADV> Restrictions='{0}'", restrictions);
 #endif
             List<string> restrictionValues = new List<string>();
             StringBuilder buffer = new StringBuilder(restrictions.Length);
@@ -486,7 +486,7 @@ namespace Microsoft.Data.Common
                 if (!ADP.IsEmpty(keyname))
                 {
 #if DEBUG
-                    SqlClientEventSource.Log.AdvanceTrace("<comm.DBConnectionString|INFO|ADV> KeyName='{0}'", keyname);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DBConnectionString|INFO|ADV> KeyName='{0}'", keyname);
 #endif
                     string realkeyname = ((null != synonyms) ? (string)synonyms[keyname] : keyname); // MDAC 85144
                     if (ADP.IsEmpty(realkeyname))

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DbConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DbConnectionOptions.cs
@@ -627,7 +627,7 @@ namespace Microsoft.Data.Common
         [System.Diagnostics.Conditional("DEBUG")]
         private static void DebugTraceKeyValuePair(string keyname, string keyvalue, Hashtable synonyms)
         {
-            if (SqlClientEventSource.Log.IsAdvanceTraceOn())
+            if (SqlClientEventSource.Log.IsAdvancedTraceOn())
             {
                 Debug.Assert(keyname == keyname.ToLower(CultureInfo.InvariantCulture), "missing ToLower");
                 string realkeyname = ((null != synonyms) ? (string)synonyms[keyname] : keyname);
@@ -637,11 +637,11 @@ namespace Microsoft.Data.Common
                     // don't trace passwords ever!
                     if (null != keyvalue)
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}', KeyValue='{1}'", keyname, keyvalue);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}', KeyValue='{1}'", keyname, keyvalue);
                     }
                     else
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}'", keyname);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<comm.DbConnectionOptions|INFO|ADV> KeyName='{0}'", keyname);
                     }
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/DataException.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/DataException.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Data
             Debug.Assert(null != e, "TraceException: null Exception");
             if (null != e)
             {
-                SqlClientEventSource.Log.AdvanceTrace(trace, e.Message);
+                SqlClientEventSource.Log.AdvancedTraceEvent(trace, e.Message);
                 try
                 {
-                    SqlClientEventSource.Log.AdvanceTrace("<comm.ADP.TraceException|ERR|ADV> Environment StackTrace = '{0}'", Environment.StackTrace);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<comm.ADP.TraceException|ERR|ADV> Environment StackTrace = '{0}'", Environment.StackTrace);
                 }
                 catch (System.Security.SecurityException)
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -539,7 +539,7 @@ namespace Microsoft.Data.ProviderBase
         private void PruneConnectionPoolGroups(object state)
         {
             // when debugging this method, expect multiple threads at the same time
-            SqlClientEventSource.Log.AdvanceTrace("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#", ObjectID);
 
             // First, walk the pool release list and attempt to clear each
             // pool, when the pool is finally empty, we dispose of it.  If the
@@ -559,7 +559,7 @@ namespace Microsoft.Data.ProviderBase
                             if (0 == pool.Count)
                             {
                                 _poolsToRelease.Remove(pool);
-                                SqlClientEventSource.Log.AdvanceTrace("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePool={1}#", ObjectID, pool.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePool={1}#", ObjectID, pool.ObjectID);
                                 PerformanceCounters.NumberOfInactiveConnectionPools.Decrement();
                             }
                         }
@@ -584,7 +584,7 @@ namespace Microsoft.Data.ProviderBase
                             if (0 == poolsLeft)
                             {
                                 _poolGroupsToRelease.Remove(poolGroup);
-                                SqlClientEventSource.Log.AdvanceTrace("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePoolGroup={1}#", ObjectID, poolGroup.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePoolGroup={1}#", ObjectID, poolGroup.ObjectID);
                                 PerformanceCounters.NumberOfInactiveConnectionPoolGroups.Decrement();
                             }
                         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Data.ProviderBase
         public void ClearPool(DbConnection connection)
         {
             ADP.CheckArgumentNull(connection, "connection");
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.DbConnectionFactory.ClearPool|API> {0}#", GetObjectId(connection));
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.DbConnectionFactory.ClearPool|API> {0}", GetObjectId(connection));
             try
             {
                 DbConnectionPoolGroup poolGroup = GetConnectionPoolGroup(connection);
@@ -151,7 +151,7 @@ namespace Microsoft.Data.ProviderBase
                 PerformanceCounters.HardConnectsPerSecond.Increment();
                 newConnection.MakeNonPooledObject(owningConnection, PerformanceCounters);
             }
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.CreateNonPooledConnection|RES|CPOOL> {0}#, Non-pooled database connection created.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.CreateNonPooledConnection|RES|CPOOL> {0}, Non-pooled database connection created.", ObjectID);
             return newConnection;
         }
 
@@ -167,7 +167,7 @@ namespace Microsoft.Data.ProviderBase
                 PerformanceCounters.HardConnectsPerSecond.Increment();
                 newConnection.MakePooledConnection(pool);
             }
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.CreatePooledConnection|RES|CPOOL> {0}#, Pooled database connection created.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.CreatePooledConnection|RES|CPOOL> {0}, Pooled database connection created.", ObjectID);
             return newConnection;
         }
 
@@ -362,7 +362,7 @@ namespace Microsoft.Data.ProviderBase
                         // connection creation failed on semaphore waiting or if max pool reached
                         if (connectionPool.IsRunning)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnection|RES|CPOOL> {0}#, GetConnection failed because a pool timeout occurred.", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnection|RES|CPOOL> {0}, GetConnection failed because a pool timeout occurred.", ObjectID);
 
                             // If GetConnection failed while the pool is running, the pool timeout occurred.
                             throw ADP.PooledOpenTimeout();
@@ -381,7 +381,7 @@ namespace Microsoft.Data.ProviderBase
 
             if (connection == null)
             {
-                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnection|RES|CPOOL> {0}#, GetConnection failed because a pool timeout occurred and all retries were exhausted.", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnection|RES|CPOOL> {0}, GetConnection failed because a pool timeout occurred and all retries were exhausted.", ObjectID);
 
                 // exhausted all retries or timed out - give up
                 throw ADP.PooledOpenTimeout();
@@ -408,7 +408,7 @@ namespace Microsoft.Data.ProviderBase
             // however, don't rebuild connectionOptions if no pooling is involved - let new connections do that work
             if (connectionPoolGroup.IsDisabled && (null != connectionPoolGroup.PoolGroupOptions))
             {
-                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnectionPool|RES|INFO|CPOOL> {0}#, DisabledPoolGroup={1}#", ObjectID, connectionPoolGroup.ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.GetConnectionPool|RES|INFO|CPOOL> {0}, DisabledPoolGroup={1}", ObjectID, connectionPoolGroup.ObjectID);
 
                 // reusing existing pool option in case user originally used SetConnectionPoolOptions
                 DbConnectionPoolGroupOptions poolOptions = connectionPoolGroup.PoolGroupOptions;
@@ -539,7 +539,7 @@ namespace Microsoft.Data.ProviderBase
         private void PruneConnectionPoolGroups(object state)
         {
             // when debugging this method, expect multiple threads at the same time
-            SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}", ObjectID);
 
             // First, walk the pool release list and attempt to clear each
             // pool, when the pool is finally empty, we dispose of it.  If the
@@ -559,7 +559,7 @@ namespace Microsoft.Data.ProviderBase
                             if (0 == pool.Count)
                             {
                                 _poolsToRelease.Remove(pool);
-                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePool={1}#", ObjectID, pool.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}, ReleasePool={1}", ObjectID, pool.ObjectID);
                                 PerformanceCounters.NumberOfInactiveConnectionPools.Decrement();
                             }
                         }
@@ -584,7 +584,7 @@ namespace Microsoft.Data.ProviderBase
                             if (0 == poolsLeft)
                             {
                                 _poolGroupsToRelease.Remove(poolGroup);
-                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}#, ReleasePoolGroup={1}#", ObjectID, poolGroup.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}, ReleasePoolGroup={1}", ObjectID, poolGroup.ObjectID);
                                 PerformanceCounters.NumberOfInactiveConnectionPoolGroups.Decrement();
                             }
                         }
@@ -650,7 +650,7 @@ namespace Microsoft.Data.ProviderBase
         internal void QueuePoolGroupForRelease(DbConnectionPoolGroup poolGroup)
         {
             Debug.Assert(null != poolGroup, "null poolGroup?");
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.QueuePoolGroupForRelease|RES|INFO|CPOOL> {0}#, poolGroup={1}#", ObjectID, poolGroup.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionFactory.QueuePoolGroupForRelease|RES|INFO|CPOOL> {0}, poolGroup={1}", ObjectID, poolGroup.ObjectID);
 
             lock (_poolGroupsToRelease)
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Data.ProviderBase
 
                     if (null != value)
                     {
-                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.set_EnlistedTransaction|RES|CPOOL> {0}#, Transaction {1}#, Enlisting.", ObjectID, value.GetHashCode());
+                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.set_EnlistedTransaction|RES|CPOOL> {0}, Transaction {1}, Enlisting.", ObjectID, value.GetHashCode());
                         TransactionOutcomeEnlist(value);
                     }
                 }
@@ -388,7 +388,7 @@ namespace Microsoft.Data.ProviderBase
         {
             // Internal method called from the connection pooler so we don't expose
             // the Activate method publicly.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.ActivateConnection|RES|INFO|CPOOL> {0}#, Activating", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.ActivateConnection|RES|INFO|CPOOL> {0}, Activating", ObjectID);
 #if DEBUG
             int activateCount = Interlocked.Increment(ref _activateCount);
             Debug.Assert(1 == activateCount, "activated multiple times?");
@@ -459,7 +459,7 @@ namespace Microsoft.Data.ProviderBase
             ////////////////////////////////////////////////////////////////
             Debug.Assert(null != owningObject, "null owningObject");
             Debug.Assert(null != connectionFactory, "null connectionFactory");
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.CloseConnection|RES|CPOOL> {0}# Closing.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.CloseConnection|RES|CPOOL> {0} Closing.", ObjectID);
 
             // if an exception occurs after the state change but before the try block
             // the connection will be stuck in OpenBusy state.  The commented out try-catch
@@ -564,7 +564,7 @@ namespace Microsoft.Data.ProviderBase
         {
             // Internal method called from the connection pooler so we don't expose
             // the Deactivate method publicly.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DeactivateConnection|RES|INFO|CPOOL> {0}#, Deactivating", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DeactivateConnection|RES|INFO|CPOOL> {0}, Deactivating", ObjectID);
 #if DEBUG
             int activateCount = Interlocked.Decrement(ref _activateCount);
             Debug.Assert(0 == activateCount, "activated multiple times?");
@@ -598,7 +598,7 @@ namespace Microsoft.Data.ProviderBase
             // IMPORTANT NOTE: You must have taken a lock on the object before
             // you call this method to prevent race conditions with Clear and
             // ReclaimEmancipatedObjects.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DelegatedTransactionEnded|RES|CPOOL> {0}#, Delegated Transaction Completed.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DelegatedTransactionEnded|RES|CPOOL> {0}, Delegated Transaction Completed.", ObjectID);
 
             if (1 == _pooledCount)
             {
@@ -661,7 +661,7 @@ namespace Microsoft.Data.ProviderBase
         protected internal void DoNotPoolThisConnection()
         {
             _cannotBePooled = true;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DoNotPoolThisConnection|RES|INFO|CPOOL> {0}#, Marking pooled object as non-poolable so it will be disposed", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DoNotPoolThisConnection|RES|INFO|CPOOL> {0}, Marking pooled object as non-poolable so it will be disposed", ObjectID);
         }
 
         /// <devdoc>Ensure that this connection cannot be put back into the pool.</devdoc>
@@ -669,7 +669,7 @@ namespace Microsoft.Data.ProviderBase
         protected internal void DoomThisConnection()
         {
             _connectionIsDoomed = true;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DoomThisConnection|RES|INFO|CPOOL> {0}#, Dooming", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DoomThisConnection|RES|INFO|CPOOL> {0}, Dooming", ObjectID);
         }
 
         // Reset connection doomed status so it can be re-connected and pooled.
@@ -803,7 +803,7 @@ namespace Microsoft.Data.ProviderBase
             }
 
             //DbConnection x = (expectedOwner as DbConnection);
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.PrePush|RES|CPOOL> {0}#, Preparing to push into pool, owning connection {1}#, pooledCount={2}", ObjectID, 0, _pooledCount);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.PrePush|RES|CPOOL> {0}, Preparing to push into pool, owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
 
             _pooledCount++;
             _owningObject.Target = null; // NOTE: doing this and checking for InternalError.PooledObjectHasOwner degrades the close by 2%
@@ -835,7 +835,7 @@ namespace Microsoft.Data.ProviderBase
             _pooledCount--;
 
             //DbConnection x = (newOwner as DbConnection);
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.PostPop|RES|CPOOL> {0}#, Preparing to pop from pool,  owning connection {1}#, pooledCount={2}", ObjectID, 0, _pooledCount);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.PostPop|RES|CPOOL> {0}, Preparing to pop from pool,  owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
 
             //3 // The following tests are retail assertions of things we can't allow to happen.
             if (null != Pool)
@@ -892,7 +892,7 @@ namespace Microsoft.Data.ProviderBase
         // Detach transaction from connection.
         internal void DetachTransaction(SysTx.Transaction transaction, bool isExplicitlyReleasing)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DetachTransaction|RES|CPOOL> {0}#, Transaction Completed. (pooledCount={1})", ObjectID, _pooledCount);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.DetachTransaction|RES|CPOOL> {0}, Transaction Completed. (pooledCount={1})", ObjectID, _pooledCount);
 
             // potentially a multi-threaded event, so lock the connection to make sure we don't enlist in a new
             // transaction between compare and assignment. No need to short circuit outside of lock, since failed comparisons should
@@ -933,7 +933,7 @@ namespace Microsoft.Data.ProviderBase
         void TransactionCompletedEvent(object sender, SysTx.TransactionEventArgs e)
         {
             SysTx.Transaction transaction = e.Transaction;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TransactionCompletedEvent|RES|CPOOL> {0}#, Transaction Completed. (pooledCount = {1})", ObjectID, _pooledCount);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TransactionCompletedEvent|RES|CPOOL> {0}, Transaction Completed. (pooledCount = {1})", ObjectID, _pooledCount);
 
             CleanupTransactionOnCompletion(transaction);
             CleanupConnectionOnTransactionCompletion(transaction);
@@ -950,7 +950,7 @@ namespace Microsoft.Data.ProviderBase
         internal void SetInStasis()
         {
             _isInStasis = true;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.SetInStasis|RES|CPOOL> {0}#, Non-Pooled Connection has Delegated Transaction, waiting to Dispose.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.SetInStasis|RES|CPOOL> {0}, Non-Pooled Connection has Delegated Transaction, waiting to Dispose.", ObjectID);
             PerformanceCounters.NumberOfStasisConnections.Increment();
         }
 
@@ -958,11 +958,11 @@ namespace Microsoft.Data.ProviderBase
         {
             if (returningToPool)
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TerminateStasis|RES|CPOOL> {0}#, Delegated Transaction has ended, connection is closed.  Returning to general pool.", ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TerminateStasis|RES|CPOOL> {0}, Delegated Transaction has ended, connection is closed.  Returning to general pool.", ObjectID);
             }
             else
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TerminateStasis|RES|CPOOL> {0}#, Delegated Transaction has ended, connection is closed/leaked.  Disposing.", ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionInternal.TerminateStasis|RES|CPOOL> {0}, Delegated Transaction has ended, connection is closed/leaked.  Disposing.", ObjectID);
             }
 
             PerformanceCounters.NumberOfStasisConnections.Decrement();

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Data.ProviderBase
                 Debug.Assert(null != pool, "null pool?");
                 _pool = pool;
                 _transactedCxns = new Dictionary<SysTx.Transaction, TransactedConnectionList>();
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactedConnectionPool|RES|CPOOL> {0}#, Constructed for connection pool {1}#", ObjectID, _pool.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactedConnectionPool|RES|CPOOL> {0}, Constructed for connection pool {1}", ObjectID, _pool.ObjectID);
             }
 
             internal int ObjectID
@@ -140,7 +140,7 @@ namespace Microsoft.Data.ProviderBase
 
                 if (null != transactedObject)
                 {
-                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.GetTransactedObject|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Popped.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.GetTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Popped.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                 }
                 return transactedObject;
             }
@@ -167,7 +167,7 @@ namespace Microsoft.Data.ProviderBase
                         lock (connections)
                         {
                             Debug.Assert(0 > connections.IndexOf(transactedObject), "adding to pool a second time?");
-                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Pushing.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Pushing.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                             connections.Add(transactedObject);
                         }
                     }
@@ -202,13 +202,13 @@ namespace Microsoft.Data.ProviderBase
                                 lock (connections)
                                 {
                                     Debug.Assert(0 > connections.IndexOf(transactedObject), "adding to pool a second time?");
-                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Pushing.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Pushing.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                                     connections.Add(transactedObject);
                                 }
                             }
                             else
                             {
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Adding List to transacted pool.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Adding List to transacted pool.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
 
                                 // add the connection/transacted object to the list
                                 newConnections.Add(transactedObject);
@@ -236,7 +236,7 @@ namespace Microsoft.Data.ProviderBase
                             }
                         }
                     }
-                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Added.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Added.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                 }
 
                 Pool.PerformanceCounters.NumberOfFreeConnections.Increment();
@@ -245,7 +245,7 @@ namespace Microsoft.Data.ProviderBase
 
             internal void TransactionEnded(SysTx.Transaction transaction, DbConnectionInternal transactedObject)
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Transaction Completed", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Transaction Completed", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                 TransactedConnectionList connections;
                 int entry = -1;
 
@@ -279,7 +279,7 @@ namespace Microsoft.Data.ProviderBase
                             // safely remove the list from the transacted pool.
                             if (0 >= connections.Count)
                             {
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}#, Transaction {1}#, Removing List from transacted pool.", ObjectID, transaction.GetHashCode());
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}, Transaction {1}, Removing List from transacted pool.", ObjectID, transaction.GetHashCode());
                                 _transactedCxns.Remove(transaction);
 
                                 // we really need to dispose our connection list; it may have 
@@ -296,7 +296,7 @@ namespace Microsoft.Data.ProviderBase
                     else
                     {
                         //Debug.Assert ( false, "TransactionCompletedEvent fired before PutTransactedObject put the connection in the transacted pool." );
-                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Transacted pool not yet created prior to transaction completing. Connection may be leaked.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Transacted pool not yet created prior to transaction completing. Connection may be leaked.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                     }
                 }
 
@@ -523,7 +523,7 @@ namespace Microsoft.Data.ProviderBase
 
             _poolCreateRequest = new WaitCallback(PoolCreateRequest); // used by CleanupCallback
             _state = State.Running;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DbConnectionPool|RES|CPOOL> {0}#, Constructed.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DbConnectionPool|RES|CPOOL> {0}, Constructed.", ObjectID);
 
             //_cleanupTimer & QueuePoolCreateRequest is delayed until DbConnectionPoolGroup calls
             // StartBackgroundCallbacks after pool is actually in the collection
@@ -671,7 +671,7 @@ namespace Microsoft.Data.ProviderBase
             //
             // With this logic, objects are pruned from the pool if unused for
             // at least one period but not more than two periods.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CleanupCallback|RES|INFO|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CleanupCallback|RES|INFO|CPOOL> {0}", ObjectID);
 
             // Destroy free objects that put us above MinPoolSize from old stack.
             while (Count > MinPoolSize)
@@ -745,7 +745,7 @@ namespace Microsoft.Data.ProviderBase
                         break;
 
                     Debug.Assert(obj != null, "null connection is not expected");
-                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CleanupCallback|RES|INFO|CPOOL> {0}#, ChangeStacks={1}#", ObjectID, obj.ObjectID);
+                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CleanupCallback|RES|INFO|CPOOL> {0}, ChangeStacks={1}", ObjectID, obj.ObjectID);
                     Debug.Assert(!obj.IsEmancipated, "pooled object not in pool");
                     Debug.Assert(obj.CanBePooled, "pooled object is not poolable");
 
@@ -760,7 +760,7 @@ namespace Microsoft.Data.ProviderBase
 
         internal void Clear()
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Clear|RES|CPOOL> {0}#, Clearing.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Clear|RES|CPOOL> {0}, Clearing.", ObjectID);
             DbConnectionInternal obj;
 
             // First, quickly doom everything.
@@ -796,7 +796,7 @@ namespace Microsoft.Data.ProviderBase
             // Finally, reclaim everything that's emancipated (which, because
             // it's been doomed, will cause it to be disposed of as well)
             ReclaimEmancipatedObjects();
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Clear|RES|CPOOL> {0}#, Cleared.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Clear|RES|CPOOL> {0}, Cleared.", ObjectID);
         }
 
         private Timer CreateCleanupTimer()
@@ -886,7 +886,7 @@ namespace Microsoft.Data.ProviderBase
                         }
                     }
                 }
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CreateObject|RES|CPOOL> {0}#, Connection {1}#, Added to pool.", ObjectID, newObj != null ? newObj?.ObjectID.ToString() ?? "null" : "null");
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.CreateObject|RES|CPOOL> {0}, Connection {1}, Added to pool.", ObjectID, newObj != null ? newObj?.ObjectID.ToString() ?? "null" : "null");
 
                 // Reset the error wait:
                 _errorWait = ERROR_WAIT_DEFAULT;
@@ -947,7 +947,7 @@ namespace Microsoft.Data.ProviderBase
 
         private void DeactivateObject(DbConnectionInternal obj)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DeactivateObject|RES|CPOOL> {0}#, Connection {1}#, Deactivating.", ObjectID, obj.ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DeactivateObject|RES|CPOOL> {0}, Connection {1}, Deactivating.", ObjectID, obj.ObjectID);
             obj.DeactivateConnection(); // we presume this operation is safe outside of a lock...
 
             bool returnToGeneralPool = false;
@@ -1087,11 +1087,11 @@ namespace Microsoft.Data.ProviderBase
             // again.
             if (obj.IsTxRootWaitingForTxEnd)
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}#, Connection {1}#, Has Delegated Transaction, waiting to Dispose.", ObjectID, obj.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}, Connection {1}, Has Delegated Transaction, waiting to Dispose.", ObjectID, obj.ObjectID);
             }
             else
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}#, Connection {1}#, Removing from pool.", ObjectID, obj.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}, Connection {1}, Removing from pool.", ObjectID, obj.ObjectID);
                 bool removed = false;
                 lock (_objectList)
                 {
@@ -1102,18 +1102,18 @@ namespace Microsoft.Data.ProviderBase
 
                 if (removed)
                 {
-                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}#, Connection {1}#, Removed from pool.", ObjectID, obj.ObjectID);
+                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}, Connection {1}, Removed from pool.", ObjectID, obj.ObjectID);
                     PerformanceCounters.NumberOfPooledConnections.Decrement();
                 }
                 obj.Dispose();
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}#, Connection {1}#, Disposed.", ObjectID, obj.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.DestroyObject|RES|CPOOL> {0}, Connection {1}, Disposed.", ObjectID, obj.ObjectID);
                 PerformanceCounters.HardDisconnectsPerSecond.Increment();
             }
         }
 
         private void ErrorCallback(Object state)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ErrorCallback|RES|CPOOL> {0}#, Resetting Error handling.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ErrorCallback|RES|CPOOL> {0}, Resetting Error handling.", ObjectID);
             _errorOccurred = false;
             _waitHandles.ErrorEvent.Reset();
 
@@ -1287,7 +1287,7 @@ namespace Microsoft.Data.ProviderBase
 
             if (_state != State.Running)
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, DbConnectionInternal State != Running.", ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, DbConnectionInternal State != Running.", ObjectID);
                 connection = null;
                 return true;
             }
@@ -1332,7 +1332,7 @@ namespace Microsoft.Data.ProviderBase
             SysTx.Transaction transaction = null;
 
             PerformanceCounters.SoftConnectsPerSecond.Increment();
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Getting connection.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Getting connection.", ObjectID);
 
             // If automatic transaction enlistment is required, then we try to
             // get the connection from the transacted connection pool first.
@@ -1385,7 +1385,7 @@ namespace Microsoft.Data.ProviderBase
                         switch (waitResult)
                         {
                             case WAIT_TIMEOUT:
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Wait timed out.", ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Wait timed out.", ObjectID);
                                 Interlocked.Decrement(ref _waitCount);
                                 connection = null;
                                 return false;
@@ -1393,12 +1393,12 @@ namespace Microsoft.Data.ProviderBase
                             case ERROR_HANDLE:
 
                                 // Throw the error that PoolCreateRequest stashed.
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Errors are set.", ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Errors are set.", ObjectID);
                                 Interlocked.Decrement(ref _waitCount);
                                 throw TryCloneCachedException();
 
                             case CREATION_HANDLE:
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Creating new connection.", ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Creating new connection.", ObjectID);
                                 try
                                 {
                                     obj = UserCreateRequest(owningObject, userOptions);
@@ -1451,7 +1451,7 @@ namespace Microsoft.Data.ProviderBase
 
                                 if ((obj != null) && (!obj.IsConnectionAlive()))
                                 {
-                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Connection {1}#, found dead and removed.", ObjectID, obj.ObjectID);
+                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Connection {1}, found dead and removed.", ObjectID, obj.ObjectID);
                                     DestroyObject(obj);
                                     obj = null;     // Setting to null in case creating a new object fails
 
@@ -1462,7 +1462,7 @@ namespace Microsoft.Data.ProviderBase
                                             RuntimeHelpers.PrepareConstrainedRegions();
                                             try
                                             {
-                                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Creating new connection.", ObjectID);
+                                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Creating new connection.", ObjectID);
                                                 obj = UserCreateRequest(owningObject, userOptions);
                                             }
                                             finally
@@ -1473,7 +1473,7 @@ namespace Microsoft.Data.ProviderBase
                                         else
                                         {
                                             // Timeout waiting for creation semaphore - return null
-                                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Wait timed out.", ObjectID);
+                                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Wait timed out.", ObjectID);
                                             connection = null;
                                             return false;
                                         }
@@ -1483,28 +1483,28 @@ namespace Microsoft.Data.ProviderBase
 
                             case WAIT_FAILED:
                                 Debug.Assert(waitForMultipleObjectsExHR != 0, "WaitForMultipleObjectsEx failed but waitForMultipleObjectsExHR remained 0");
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Wait failed.", ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Wait failed.", ObjectID);
                                 Interlocked.Decrement(ref _waitCount);
                                 Marshal.ThrowExceptionForHR(waitForMultipleObjectsExHR);
                                 goto default; // if ThrowExceptionForHR didn't throw for some reason
 
                             case (WAIT_ABANDONED + SEMAPHORE_HANDLE):
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Semaphore handle abandonded.", ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Semaphore handle abandonded.", ObjectID);
                                 Interlocked.Decrement(ref _waitCount);
                                 throw new AbandonedMutexException(SEMAPHORE_HANDLE, _waitHandles.PoolSemaphore);
 
                             case (WAIT_ABANDONED + ERROR_HANDLE):
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Error handle abandonded.", ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Error handle abandonded.", ObjectID);
                                 Interlocked.Decrement(ref _waitCount);
                                 throw new AbandonedMutexException(ERROR_HANDLE, _waitHandles.ErrorEvent);
 
                             case (WAIT_ABANDONED + CREATION_HANDLE):
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, Creation handle abandoned.", ObjectID);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Creation handle abandoned.", ObjectID);
                                 Interlocked.Decrement(ref _waitCount);
                                 throw new AbandonedMutexException(CREATION_HANDLE, _waitHandles.CreationSemaphore);
 
                             default:
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}#, WaitForMultipleObjects={1}", ObjectID, waitResult);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, WaitForMultipleObjects={1}", ObjectID, waitResult);
                                 Interlocked.Decrement(ref _waitCount);
                                 throw ADP.InternalError(ADP.InternalErrorCode.UnexpectedWaitAnyResult);
                         }
@@ -1569,7 +1569,7 @@ namespace Microsoft.Data.ProviderBase
         internal DbConnectionInternal ReplaceConnection(DbConnection owningObject, DbConnectionOptions userOptions, DbConnectionInternal oldConnection)
         {
             PerformanceCounters.SoftConnectsPerSecond.Increment();
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReplaceConnection|RES|CPOOL> {0}#, replacing connection.", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReplaceConnection|RES|CPOOL> {0}, replacing connection.", ObjectID);
             DbConnectionInternal newConnection = UserCreateRequest(owningObject, userOptions, oldConnection);
 
             if (newConnection != null)
@@ -1611,7 +1611,7 @@ namespace Microsoft.Data.ProviderBase
 
             if (null != obj)
             {
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromGeneralPool|RES|CPOOL> {0}#, Connection {1}#, Popped from general pool.", ObjectID, obj.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromGeneralPool|RES|CPOOL> {0}, Connection {1}, Popped from general pool.", ObjectID, obj.ObjectID);
                 PerformanceCounters.NumberOfFreeConnections.Decrement();
             }
             return (obj);
@@ -1628,7 +1628,7 @@ namespace Microsoft.Data.ProviderBase
 
                 if (null != obj)
                 {
-                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}#, Connection {1}#, Popped from transacted pool.", ObjectID, obj.ObjectID);
+                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, Popped from transacted pool.", ObjectID, obj.ObjectID);
                     PerformanceCounters.NumberOfFreeConnections.Decrement();
 
                     if (obj.IsTransactionRoot)
@@ -1639,14 +1639,14 @@ namespace Microsoft.Data.ProviderBase
                         }
                         catch
                         {
-                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}#, Connection {1}#, found dead and removed.", ObjectID, obj.ObjectID);
+                            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, found dead and removed.", ObjectID, obj.ObjectID);
                             DestroyObject(obj);
                             throw;
                         }
                     }
                     else if (!obj.IsConnectionAlive())
                     {
-                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}#, Connection {1}#, found dead and removed.", ObjectID, obj.ObjectID);
+                        SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.GetFromTransactedPool|RES|CPOOL> {0}, Connection {1}, found dead and removed.", ObjectID, obj.ObjectID);
                         DestroyObject(obj);
                         obj = null;
                     }
@@ -1661,7 +1661,7 @@ namespace Microsoft.Data.ProviderBase
         {
             // called by pooler to ensure pool requests are currently being satisfied -
             // creation mutex has not been obtained
-            long scopeID = SqlClientEventSource.Log.PoolerScopeEnterEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|INFO|CPOOL> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.PoolerScopeEnterEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|INFO|CPOOL> {0}", ObjectID);
             try
             {
                 if (State.Running == _state)
@@ -1746,7 +1746,7 @@ namespace Microsoft.Data.ProviderBase
                                 else
                                 {
                                     // trace waitResult and ignore the failure
-                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|CPOOL> {0}#, PoolCreateRequest called WaitForSingleObject failed {1}", ObjectID, waitResult);
+                                    SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|CPOOL> {0}, PoolCreateRequest called WaitForSingleObject failed {1}", ObjectID, waitResult);
                                 }
                             }
                             catch (Exception e)
@@ -1760,7 +1760,7 @@ namespace Microsoft.Data.ProviderBase
                                 // Now that CreateObject can throw, we need to catch the exception and discard it.
                                 // There is no further action we can take beyond tracing.  The error will be 
                                 // thrown to the user the next time they request a connection.
-                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|CPOOL> {0}#, PoolCreateRequest called CreateConnection which threw an exception: {1}", ObjectID, e);
+                                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PoolCreateRequest|RES|CPOOL> {0}, PoolCreateRequest called CreateConnection which threw an exception: {1}", ObjectID, e);
                             }
                             finally
                             {
@@ -1793,7 +1793,7 @@ namespace Microsoft.Data.ProviderBase
             // causes the following assert to fire, which really mucks up stress
             // against checked bits.
             // Debug.Assert(obj.CanBePooled,    "non-poolable object in pool");
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PutNewObject|RES|CPOOL> {0}#, Connection {1}#, Pushing to general pool.", ObjectID, obj.ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PutNewObject|RES|CPOOL> {0}, Connection {1}, Pushing to general pool.", ObjectID, obj.ObjectID);
 
             _stackNew.Push(obj);
             _waitHandles.PoolSemaphore.Release(1);
@@ -1842,7 +1842,7 @@ namespace Microsoft.Data.ProviderBase
             // method, we can safely presume that the caller is the only person
             // that is using the connection, and that all pre-push logic has been
             // done and all transactions are ended.
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PutObjectFromTransactedPool|RES|CPOOL> {0}#, Connection {1}#, Transaction has ended.", ObjectID, obj.ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.PutObjectFromTransactedPool|RES|CPOOL> {0}, Connection {1}, Transaction has ended.", ObjectID, obj.ObjectID);
 
             if (_state == State.Running && obj.CanBePooled)
             {
@@ -1867,7 +1867,7 @@ namespace Microsoft.Data.ProviderBase
         private bool ReclaimEmancipatedObjects()
         {
             bool emancipatedObjectFound = false;
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReclaimEmancipatedObjects|RES|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReclaimEmancipatedObjects|RES|CPOOL> {0}", ObjectID);
             List<DbConnectionInternal> reclaimedObjects = new List<DbConnectionInternal>();
             int count;
 
@@ -1919,7 +1919,7 @@ namespace Microsoft.Data.ProviderBase
             for (int i = 0; i < count; ++i)
             {
                 DbConnectionInternal obj = reclaimedObjects[i];
-                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReclaimEmancipatedObjects|RES|CPOOL> {0}#, Connection {1}#, Reclaiming.", ObjectID, obj.ObjectID);
+                SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.ReclaimEmancipatedObjects|RES|CPOOL> {0}, Connection {1}, Reclaiming.", ObjectID, obj.ObjectID);
                 PerformanceCounters.NumberOfReclaimedConnections.Increment();
 
                 emancipatedObjectFound = true;
@@ -1932,7 +1932,7 @@ namespace Microsoft.Data.ProviderBase
 
         internal void Startup()
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Startup|RES|INFO|CPOOL> {0}#, CleanupWait={1}", ObjectID, _cleanupWait);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Startup|RES|INFO|CPOOL> {0}, CleanupWait={1}", ObjectID, _cleanupWait);
             _cleanupTimer = CreateCleanupTimer();
 
             if (NeedToReplenish)
@@ -1943,7 +1943,7 @@ namespace Microsoft.Data.ProviderBase
 
         internal void Shutdown()
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Shutdown|RES|INFO|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.Shutdown|RES|INFO|CPOOL> {0}", ObjectID);
             _state = State.ShuttingDown;
 
             // deactivate timer callbacks
@@ -1965,7 +1965,7 @@ namespace Microsoft.Data.ProviderBase
             Debug.Assert(null != transactedObject, "null transactedObject?");
 
             // Note: connection may still be associated with transaction due to Explicit Unbinding requirement.          
-            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactionEnded|RES|CPOOL> {0}#, Transaction {1}#, Connection {2}#, Transaction Completed", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<prov.DbConnectionPool.TransactionEnded|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Transaction Completed", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
 
             // called by the internal connection when it get's told that the
             // transaction is completed.  We tell the transacted pool to remove

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Data.ProviderBase
             if (PoolGroupStateIdle == _state)
             {
                 _state = PoolGroupStateActive;
-                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ClearInternal|RES|INFO|CPOOL> {0}#, Active", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ClearInternal|RES|INFO|CPOOL> {0}, Active", ObjectID);
             }
             return (PoolGroupStateActive == _state);
         }
@@ -335,12 +335,12 @@ namespace Microsoft.Data.ProviderBase
                     if (PoolGroupStateActive == _state)
                     {
                         _state = PoolGroupStateIdle;
-                        SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ClearInternal|RES|INFO|CPOOL> {0}#, Idle", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ClearInternal|RES|INFO|CPOOL> {0}, Idle", ObjectID);
                     }
                     else if (PoolGroupStateIdle == _state)
                     {
                         _state = PoolGroupStateDisabled;
-                        SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ReadyToRemove|RES|INFO|CPOOL> {0}#, Disabled", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionPoolGroup.ReadyToRemove|RES|INFO|CPOOL> {0}, Disabled", ObjectID);
                     }
                 }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/SqlConnectionHelper.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Data.SqlClient
 
         private string ConnectionString_Get()
         {
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Get|API> {0}#", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Get|API> {0}", ObjectID);
             bool hidePassword = InnerConnection.ShouldHidePassword;
             DbConnectionOptions connectionOptions = UserConnectionOptions;
             return ((null != connectionOptions) ? connectionOptions.UsersConnectionString(hidePassword) : "");
@@ -132,7 +132,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             string cstr = ((null != connectionOptions) ? connectionOptions.UsersConnectionStringForTrace() : "");
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Set|API> {0}#, '{1}'", ObjectID, cstr);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Set|API> {0}, '{1}'", ObjectID, cstr);
         }
 
         internal DbConnectionInternal InnerConnection
@@ -182,11 +182,11 @@ namespace Microsoft.Data.SqlClient
             // will end the reliable try...
             if (e is OutOfMemoryException)
             {
-                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.Abort|RES|INFO|CPOOL> {0}#, Aborting operation due to asynchronous exception: {'OutOfMemory'}", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.Abort|RES|INFO|CPOOL> {0}, Aborting operation due to asynchronous exception: {'OutOfMemory'}", ObjectID);
             }
             else
             {
-                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.Abort|RES|INFO|CPOOL> {0}#, Aborting operation due to asynchronous exception: {1}", ObjectID, e.ToString());
+                SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.Abort|RES|INFO|CPOOL> {0}, Aborting operation due to asynchronous exception: {1}", ObjectID, e.ToString());
             }
         }
 
@@ -199,7 +199,7 @@ namespace Microsoft.Data.SqlClient
         override protected DbCommand CreateDbCommand()
         {
             DbCommand command = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.DbConnectionHelper.CreateDbCommand|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.DbConnectionHelper.CreateDbCommand|API> {0}", ObjectID);
             try
             {
                 DbProviderFactory providerFactory = ConnectionFactory.ProviderFactory;
@@ -245,7 +245,7 @@ namespace Microsoft.Data.SqlClient
             permissionSet.AddPermission(new System.Security.Permissions.SecurityPermission(System.Security.Permissions.SecurityPermissionFlag.UnmanagedCode));
             permissionSet.Demand();
 
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.EnlistDistributedTransactionHelper|RES|TRAN> {0}#, Connection enlisting in a transaction.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.EnlistDistributedTransactionHelper|RES|TRAN> {0}, Connection enlisting in a transaction.", ObjectID);
             SysTx.Transaction indigoTransaction = null;
 
             if (null != transaction)
@@ -270,7 +270,7 @@ namespace Microsoft.Data.SqlClient
         override public void EnlistTransaction(SysTx.Transaction transaction)
         {
             SqlConnection.ExecutePermission.Demand();
-            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.EnlistTransaction|RES|TRAN> {0}#, Connection enlisting in a transaction.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.EnlistTransaction|RES|TRAN> {0}, Connection enlisting in a transaction.", ObjectID);
 
             // If we're currently enlisted in a transaction and we were called
             // on the EnlistTransaction method (Whidbey) we're not allowed to

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiEventSink_Default.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiEventSink_Default.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (null == _parent)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SmiEventSink_Default.MessagePosted|ADV> {0}#, number={1} state={2} errorClass={3} server='{4}' message='{5}' procedure='{6}' linenumber={7}.", 0, number, state, errorClass, server ?? "<null>", message ?? "<null>", procedure ?? "<null>", lineNumber);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SmiEventSink_Default.MessagePosted|ADV> {0}#, number={1} state={2} errorClass={3} server='{4}' message='{5}' procedure='{6}' linenumber={7}.", 0, number, state, errorClass, server ?? "<null>", message ?? "<null>", procedure ?? "<null>", lineNumber);
                 SqlError error = new SqlError(number, state, errorClass, server, message, procedure, lineNumber);
 
                 if (error.Class < TdsEnums.MIN_ERROR_CLASS)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiEventSink_Default.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiEventSink_Default.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (null == _parent)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SmiEventSink_Default.MessagePosted|ADV> {0}#, number={1} state={2} errorClass={3} server='{4}' message='{5}' procedure='{6}' linenumber={7}.", 0, number, state, errorClass, server ?? "<null>", message ?? "<null>", procedure ?? "<null>", lineNumber);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SmiEventSink_Default.MessagePosted|ADV> {0}, number={1} state={2} errorClass={3} server='{4}' message='{5}' procedure='{6}' linenumber={7}.", 0, number, state, errorClass, server ?? "<null>", message ?? "<null>", procedure ?? "<null>", lineNumber);
                 SqlError error = new SqlError(number, state, errorClass, server, message, procedure, lineNumber);
 
                 if (error.Class < TdsEnums.MIN_ERROR_CLASS)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -625,7 +625,7 @@ namespace Microsoft.Data.SqlClient
         {
             string TDSCommand = CreateInitialQuery();
             SqlClientEventSource.Log.TraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|INFO> Initial Query: '{0}'", TDSCommand);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|Info|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.CreateAndExecuteInitialQueryAsync|Info|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             Task executeTask = _parser.TdsExecuteSQLBatch(TDSCommand, this.BulkCopyTimeout, null, _stateObj, sync: !_isAsyncBulkCopy, callerHasConnectionLock: true);
 
             if (executeTask == null)
@@ -915,7 +915,7 @@ namespace Microsoft.Data.SqlClient
         //
         private Task SubmitUpdateBulkCommand(string TDSCommand)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.SubmitUpdateBulkCommand|Info|Correlation> ObjectID{0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlBulkCopy.SubmitUpdateBulkCommand|Info|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             Task executeTask = _parser.TdsExecuteSQLBatch(TDSCommand, this.BulkCopyTimeout, null, _stateObj, sync: !_isAsyncBulkCopy, callerHasConnectionLock: true);
 
             if (executeTask == null)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         private const int StateDumpEventId = 17;
         #endregion
+
         /// <summary>
         /// These represent logical groups of events that can be turned on and off independently
         /// Often each task has a keyword, but where tasks are determined by subsystem, keywords

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -199,31 +199,31 @@ namespace Microsoft.Data.SqlClient
         internal bool IsExecutionTraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.ExecutionTrace);
 
         [NonEvent]
-        internal bool IsTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Trace);
+        internal bool IsTraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.Trace);
 
         [NonEvent]
-        internal bool IsScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Scope);
+        internal bool IsScopeEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.Scope);
 
         [NonEvent]
-        internal bool IsNotificationTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.NotificationTrace);
+        internal bool IsNotificationTraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.NotificationTrace);
 
         [NonEvent]
-        internal bool IsNotificationScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.NotificationScope);
+        internal bool IsNotificationScopeEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.NotificationScope);
 
         [NonEvent]
-        internal bool IsPoolerTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.PoolerTrace);
+        internal bool IsPoolerTraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.PoolerTrace);
 
         [NonEvent]
-        internal bool IsPoolerScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.PoolerScope);
+        internal bool IsPoolerScopeEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.PoolerScope);
 
         [NonEvent]
-        internal bool IsAdvancedTraceOn() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.AdvancedTrace);
+        internal bool IsAdvancedTraceOn() => Log.IsEnabled(EventLevel.Informational, Keywords.AdvancedTrace);
 
         [NonEvent]
-        internal bool IsCorrelationEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.CorrelationTrace);
+        internal bool IsCorrelationEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.CorrelationTrace);
 
         [NonEvent]
-        internal bool IsStateDumpEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.StateDump);
+        internal bool IsStateDumpEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.StateDump);
 
         #endregion
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Data.SqlClient
 
         #region Notification Trace
         [NonEvent]
-        internal void NotificationsTraceEvent(string message)
+        internal void NotificationTraceEvent(string message)
         {
             if (Log.IsNotificationTraceEnabled())
             {
@@ -358,7 +358,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         [NonEvent]
-        internal void NotificationsTraceEvent<T0>(string message, T0 args0)
+        internal void NotificationTraceEvent<T0>(string message, T0 args0)
         {
             if (Log.IsNotificationTraceEnabled())
             {
@@ -367,7 +367,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         [NonEvent]
-        internal void NotificationsTraceEvent<T0, T1>(string message, T0 args0, T1 args1)
+        internal void NotificationTraceEvent<T0, T1>(string message, T0 args0, T1 args1)
         {
             if (Log.IsNotificationTraceEnabled())
             {
@@ -376,7 +376,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         [NonEvent]
-        internal void NotificationsTraceEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
+        internal void NotificationTraceEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
         {
             if (Log.IsNotificationTraceEnabled())
             {
@@ -385,7 +385,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         [NonEvent]
-        internal void NotificationsTraceEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
+        internal void NotificationTraceEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
         {
             if (Log.IsNotificationTraceEnabled())
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -715,13 +715,13 @@ namespace Microsoft.Data.SqlClient
         [Event(PoolerScopeExitId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Keywords = Keywords.PoolerScope)]
         internal void PoolerScopeLeave(long scopeId)
         {
-            WriteEvent(ScopeExitId, scopeId);
+            WriteEvent(PoolerScopeExitId, scopeId);
         }
 
         [Event(AdvancedTraceId, Level = EventLevel.Verbose, Keywords = Keywords.AdvancedTrace)]
         internal void AdvancedTrace(string message)
         {
-            WriteEvent(TraceEventId, message);
+            WriteEvent(AdvancedTraceId, message);
         }
 
         [Event(AdvancedScopeEnterId, Level = EventLevel.Verbose, Opcode = EventOpcode.Start, Keywords = Keywords.AdvancedTrace)]

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text;
 using System.Diagnostics.Tracing;
 using System.Threading;
 
@@ -14,6 +13,8 @@ namespace Microsoft.Data.SqlClient
         // Defines the singleton instance for the Resources ETW provider
         internal static readonly SqlClientEventSource Log = new SqlClientEventSource();
 
+        #region Event IDs
+        // Initialized static Scope IDs
         private static long s_nextScopeId = 0;
         private static long s_nextNotificationScopeId = 0;
         private static long s_nextPoolerScopeId = 0;
@@ -27,116 +28,224 @@ namespace Microsoft.Data.SqlClient
         /// Defines EventId for EndExecute (Reader, Scalar, NonQuery, XmlReader).
         /// </summary>
         private const int EndExecuteEventId = 2;
+
+        /// <summary>
+        /// Defines EventId for Trace() events
+        /// </summary>
         private const int TraceEventId = 3;
-        private const int EnterScopeId = 4;
-        private const int ExitScopeId = 5;
-        private const int TraceBinId = 6;
-        private const int CorrelationTraceId = 7;
-        private const int NotificationsScopeEnterId = 8;
-        private const int NotificationsTraceId = 9;
-        private const int PoolerScopeEnterId = 10;
+
+        /// <summary>
+        /// Defines EventId for ScopeEnter() events
+        /// </summary>
+        private const int ScopeEnterId = 4;
+
+        /// <summary>
+        /// Defines EventId for ScopeLeave() events
+        /// </summary>
+        private const int ScopeExitId = 5;
+
+        /// <summary>
+        /// Defines EventId for NotificationScopeEnter() events
+        /// </summary>
+        private const int NotificationScopeEnterId = 6;
+
+        /// <summary>
+        /// Defines EventId for NotificationScopeLeave() events
+        /// </summary>
+        private const int NotificationScopeExitId = 7;
+
+        /// <summary>
+        /// Defines EventId for NotificationScopeTrace() events
+        /// </summary>
+        private const int NotificationTraceId = 8;
+
+        /// <summary>
+        /// Defines EventId for PoolerScopeEnter() events
+        /// </summary>
+        private const int PoolerScopeEnterId = 9;
+
+        /// <summary>
+        /// Defines EventId for PoolerScopeLeave() events
+        /// </summary>
+        private const int PoolerScopeExitId = 10;
+
+        /// <summary>
+        /// Defines EventId for PoolerTrace() events
+        /// </summary>
         private const int PoolerTraceId = 11;
 
         /// <summary>
-        /// Keyword definitions.  These represent logical groups of events that can be turned on and off independently
-        /// Often each task has a keyword, but where tasks are determined by subsystem, keywords are determined by
-        /// usefulness to end users to filter.  Generally users don't mind extra events if they are not high volume
-        /// so grouping low volume events together in a single keywords is OK (users can post-filter by task if desired)
+        /// Defines EventId for AdvancedTrace() events
+        /// </summary>
+        private const int AdvancedTraceId = 12;
+
+        /// <summary>
+        /// Defines EventId for AdvancedScopeEnter() events
+        /// </summary>
+        private const int AdvancedScopeEnterId = 13;
+
+        /// <summary>
+        /// Defines EventId for AdvancedScopeLeave() events
+        /// </summary>
+        private const int AdvancedScopeExitId = 14;
+
+        /// <summary>
+        /// Defines EventId for AdvancedTraceBin() events
+        /// </summary>
+        private const int AdvancedTraceBinId = 15;
+
+        /// <summary>
+        /// Defines EventId for CorrelationTrace() events
+        /// </summary>
+        private const int CorrelationTraceId = 16;
+
+        /// <summary>
+        /// Defines EventId for StateDump() events
+        /// </summary>
+        private const int StateDumpEventId = 17;
+        #endregion
+        /// <summary>
+        /// These represent logical groups of events that can be turned on and off independently
+        /// Often each task has a keyword, but where tasks are determined by subsystem, keywords
+        /// are determined by usefulness to end users to filter.
+        /// 
+        /// Generally users don't mind extra events if they are not high volume, so grouping low 
+        /// volume events together in a single keywords is OK (users can post-filter by task if desired)
+        /// 
         /// <remarks>
-        /// The visibility of the enum has to be public, otherwise there will be an ArgumentException on calling related WriteEvent method. the Keywords class has to be a nested class.
+        /// The visibility of the enum has to be public, otherwise there will be an ArgumentException 
+        /// on calling related WriteEvent() method.
+        /// 
+        /// The Keywords class has to be a nested class.
         /// Each keyword must be a power of 2.
         /// </remarks>
+        /// 
         /// </summary>
         #region Keywords
         public class Keywords
         {
-            internal const EventKeywords SqlClient = 0;
+            /// <summary>
+            /// Captures Start/Stop events before and after command execution.
+            /// </summary>
+            internal const EventKeywords ExecutionTrace = (EventKeywords)1;
 
-            internal const EventKeywords Trace = (EventKeywords)1;
+            /// <summary>
+            /// Captures basic application flow trace events.
+            /// </summary>
+            internal const EventKeywords Trace = (EventKeywords)2;
 
-            internal const EventKeywords TraceBin = (EventKeywords)2;
-
+            /// <summary>
+            /// Captures basic application scope entering and exiting events.
+            /// </summary>
             internal const EventKeywords Scope = (EventKeywords)4;
 
+            /// <summary>
+            /// Captures `SqlNotification` flow trace events.
+            /// </summary>
             internal const EventKeywords NotificationTrace = (EventKeywords)8;
 
-            internal const EventKeywords Pooling = (EventKeywords)16;
+            /// <summary>
+            /// Captures `SqlNotification` scope entering and exiting events.
+            /// </summary>
+            internal const EventKeywords NotificationScope = (EventKeywords)16;
 
-            internal const EventKeywords Correlation = (EventKeywords)32;
+            /// <summary>
+            /// Captures connection pooling flow trace events.
+            /// </summary>
+            internal const EventKeywords PoolerTrace = (EventKeywords)32;
 
-            internal const EventKeywords NotificationScope = (EventKeywords)64;
+            /// <summary>
+            /// Captures connection pooling scope trace events.
+            /// </summary>
+            internal const EventKeywords PoolerScope = (EventKeywords)64;
 
-            internal const EventKeywords PoolerScope = (EventKeywords)128;
+            /// <summary>
+            /// Captures advanced flow trace events.
+            /// </summary>
+            internal const EventKeywords AdvancedTrace = (EventKeywords)128;
 
-            internal const EventKeywords PoolerTrace = (EventKeywords)256;
+            /// <summary>
+            /// Captures advanced flow trace events with additional information.
+            /// </summary>
+            internal const EventKeywords AdvancedTraceBin = (EventKeywords)256;
 
-            internal const EventKeywords Advanced = (EventKeywords)512;
+            /// <summary>
+            /// Captures correlation flow trace events.
+            /// </summary>
+            internal const EventKeywords CorrelationTrace = (EventKeywords)512;
 
+            /// <summary>
+            /// Captures full state dump of `SqlConnection`
+            /// </summary>
             internal const EventKeywords StateDump = (EventKeywords)1024;
         }
         #endregion
 
-        public static class Tasks // this name is important for EventSource
+        #region Tasks
+        /// <summary>
+        /// Tasks supported by SqlClient's EventSource implementation
+        /// </summary>
+        public static class Tasks
         {
-            /// <summary>Task that tracks sql command execute.</summary>
+            /// <summary>
+            /// Task that tracks SqlCommand execution.
+            /// </summary>
             public const EventTask ExecuteCommand = (EventTask)1;
         }
+        #endregion
 
         #region Enable/Disable Events
         [NonEvent]
-        internal bool IsTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Trace);
+        internal bool IsExecutionTraceEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.ExecutionTrace);
 
         [NonEvent]
-        internal bool IsTraceBinEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.TraceBin);
+        internal bool IsTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Trace);
 
         [NonEvent]
         internal bool IsScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Scope);
 
         [NonEvent]
-        internal bool IsPoolerScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.PoolerScope);
-
-        [NonEvent]
-        internal bool IsCorrelationEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Correlation);
+        internal bool IsNotificationTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.NotificationTrace);
 
         [NonEvent]
         internal bool IsNotificationScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.NotificationScope);
 
         [NonEvent]
-        internal bool IsPoolingEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Pooling);
-
-        [NonEvent]
-        internal bool IsNotificationTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.NotificationTrace);
-
-        [NonEvent]
         internal bool IsPoolerTraceEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.PoolerTrace);
 
         [NonEvent]
-        internal bool IsAdvanceTraceOn() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.Advanced);
+        internal bool IsPoolerScopeEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.PoolerScope);
+
+        [NonEvent]
+        internal bool IsAdvancedTraceOn() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.AdvancedTrace);
+
+        [NonEvent]
+        internal bool IsCorrelationEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.CorrelationTrace);
 
         [NonEvent]
         internal bool IsStateDumpEnabled() => SqlClientEventSource.Log.IsEnabled(EventLevel.Informational, Keywords.StateDump);
 
-        [NonEvent]
-        internal bool IsSqlClientEnabled() => Log.IsEnabled(EventLevel.Informational, Keywords.SqlClient);
         #endregion
 
         #region overloads
         //Never use event writer directly as they are not checking for enabled/disabled situations. Always use overloads.
-        [NonEvent]
-        internal void TraceEvent<T0>(string message, T0 args0)
-        {
-            if (Log.IsTraceEnabled())
-            {
-                TraceEvent(string.Format(message, args0?.ToString() ?? "Null"));
-            }
-        }
 
+        #region Trace
         [NonEvent]
         internal void TraceEvent(string message)
         {
             if (Log.IsTraceEnabled())
             {
                 Trace(message);
+            }
+        }
+
+        [NonEvent]
+        internal void TraceEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsTraceEnabled())
+            {
+                Trace(string.Format(message, args0?.ToString() ?? "Null"));
             }
         }
 
@@ -175,77 +284,17 @@ namespace Microsoft.Data.SqlClient
                 Trace(string.Format(message, args0, args1, args2, args3, args4, args5));
             }
         }
+        #endregion
 
+        #region Scope
         [NonEvent]
-        internal void AdvanceTrace(string message)
+        internal long ScopeEnterEvent(string message)
         {
-            if (Log.IsAdvanceTraceOn())
+            if (Log.IsScopeEnabled())
             {
-                Trace(message);
+                return ScopeEnter(message);
             }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0>(string message, T0 args0)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1>(string message, T0 args0, T1 args1)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1, args2));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1, args2, args3));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1, T2, T3, T4, T5>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4, T5 args5)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1, args2, args3, args4, args5));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTrace<T0, T1, T2, T3, T4, T5, T6, T7>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4, T5 args5, T6 args6, T7 args7)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                Trace(string.Format(message, args0, args1, args2, args3, args4, args5, args6, args7));
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceTraceBin<T0, T1>(string message, T0 args0, T1 args1)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                TraceBin(string.Format(message, args0, args1));
-            }
+            return 0;
         }
 
         [NonEvent]
@@ -254,26 +303,6 @@ namespace Microsoft.Data.SqlClient
             if (Log.IsScopeEnabled())
             {
                 return ScopeEnter(string.Format(message, args0));
-            }
-            return 0;
-        }
-
-        [NonEvent]
-        internal long AdvanceScopeEnter<T0>(string message, T0 args0)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                return ScopeEnter(string.Format(message, args0));
-            }
-            return 0;
-        }
-
-        [NonEvent]
-        internal long ScopeEnterEvent(string message)
-        {
-            if (Log.IsScopeEnabled())
-            {
-                return ScopeEnter(message);
             }
             return 0;
         }
@@ -309,55 +338,114 @@ namespace Microsoft.Data.SqlClient
         }
 
         [NonEvent]
-        internal long PoolerScopeEnterEvent<T0>(string message, T0 args0)
+        internal void ScopeLeaveEvent(long scopeId)
         {
-            if (Log.IsPoolerScopeEnabled())
+            if (Log.IsScopeEnabled())
             {
-                return PoolerScopeEnter(string.Format(message, args0));
+                ScopeLeave(scopeId);
+            }
+        }
+        #endregion
+
+        #region Notification Trace
+        [NonEvent]
+        internal void NotificationsTraceEvent(string message)
+        {
+            if (Log.IsNotificationTraceEnabled())
+            {
+                NotificationTrace(message);
+            }
+        }
+
+        [NonEvent]
+        internal void NotificationsTraceEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsNotificationTraceEnabled())
+            {
+                NotificationTrace(string.Format(message, args0));
+            }
+        }
+
+        [NonEvent]
+        internal void NotificationsTraceEvent<T0, T1>(string message, T0 args0, T1 args1)
+        {
+            if (Log.IsNotificationTraceEnabled())
+            {
+                NotificationTrace(string.Format(message, args0, args1));
+            }
+        }
+
+        [NonEvent]
+        internal void NotificationsTraceEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
+        {
+            if (Log.IsNotificationTraceEnabled())
+            {
+                NotificationTrace(string.Format(message, args0, args1, args2));
+            }
+        }
+
+        [NonEvent]
+        internal void NotificationsTraceEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
+        {
+            if (Log.IsNotificationTraceEnabled())
+            {
+                NotificationTrace(string.Format(message, args0, args1, args2, args3));
+            }
+        }
+        #endregion
+
+        #region Notification Scope
+        [NonEvent]
+        internal long NotificationScopeEnterEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsNotificationScopeEnabled())
+            {
+                return NotificationScopeEnter(string.Format(message, args0));
             }
             return 0;
         }
 
         [NonEvent]
-        internal long NotificationsScopeEnterEvent<T0>(string message, T0 args0)
+        internal long NotificationScopeEnterEvent<T0, T1>(string message, T0 args0, T1 args1)
         {
             if (Log.IsNotificationScopeEnabled())
             {
-                return NotificationsScopeEnter(string.Format(message, args0));
+                return NotificationScopeEnter(string.Format(message, args0, args1));
             }
             return 0;
         }
 
         [NonEvent]
-        internal long NotificationsScopeEnterEvent<T0, T1>(string message, T0 args0, T1 args1)
+        internal long NotificationScopeEnterEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
         {
             if (Log.IsNotificationScopeEnabled())
             {
-                return NotificationsScopeEnter(string.Format(message, args0, args1));
+                return NotificationScopeEnter(string.Format(message, args0, args1, args2));
             }
             return 0;
         }
 
         [NonEvent]
-        internal long NotificationsScopeEnterEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
+        internal long NotificationScopeEnterEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
         {
             if (Log.IsNotificationScopeEnabled())
             {
-                return NotificationsScopeEnter(string.Format(message, args0, args1, args2));
+                return NotificationScopeEnter(string.Format(message, args0, args1, args2, args3));
             }
             return 0;
         }
 
         [NonEvent]
-        internal long NotificationsScopeEnterEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
+        internal void NotificationScopeLeaveEvent(long scopeId)
         {
             if (Log.IsNotificationScopeEnabled())
             {
-                return NotificationsScopeEnter(string.Format(message, args0, args1, args2, args3));
+                NotificationScopeLeave(scopeId);
             }
-            return 0;
         }
+        #endregion
 
+        #region Pooler Trace
         [NonEvent]
         internal void PoolerTraceEvent<T0>(string message, T0 args0)
         {
@@ -393,7 +481,123 @@ namespace Microsoft.Data.SqlClient
                 PoolerTrace(string.Format(message, args0, args1, args2, args3));
             }
         }
+        #endregion
 
+        #region Pooler Scope
+        [NonEvent]
+        internal long PoolerScopeEnterEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsPoolerScopeEnabled())
+            {
+                return PoolerScopeEnter(string.Format(message, args0));
+            }
+            return 0;
+        }
+
+        [NonEvent]
+        internal void PoolerScopeLeaveEvent(long scopeId)
+        {
+            if (Log.IsPoolerScopeEnabled())
+            {
+                PoolerScopeLeave(scopeId);
+            }
+        }
+        #endregion
+
+        #region AdvancedTrace
+        [NonEvent]
+        internal void AdvancedTraceEvent(string message)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(message);
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0, T1>(string message, T0 args0, T1 args1)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0, args1));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0, args1, args2));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0, args1, args2, args3));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0, T1, T2, T3, T4, T5>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4, T5 args5)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0, args1, args2, args3, args4, args5));
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceEvent<T0, T1, T2, T3, T4, T5, T6, T7>(string message, T0 args0, T1 args1, T2 args2, T3 args3, T4 args4, T5 args5, T6 args6, T7 args7)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTrace(string.Format(message, args0, args1, args2, args3, args4, args5, args6, args7));
+            }
+        }
+
+        [NonEvent]
+        internal long AdvancedScopeEnterEvent<T0>(string message, T0 args0)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                return AdvancedScopeEnter(string.Format(message, args0));
+            }
+            return 0;
+        }
+
+        [NonEvent]
+        internal void AdvanceScopeLeave(long scopeId)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedScopeLeave(scopeId);
+            }
+        }
+
+        [NonEvent]
+        internal void AdvancedTraceBinEvent<T0, T1>(string message, T0 args0, T1 args1)
+        {
+            if (Log.IsAdvancedTraceOn())
+            {
+                AdvancedTraceBin(string.Format(message, args0, args1));
+            }
+        }
+        #endregion
+
+        #region Correlation Trace
         [NonEvent]
         internal void CorrelationTraceEvent<T0>(string message, T0 args0)
         {
@@ -420,146 +624,84 @@ namespace Microsoft.Data.SqlClient
                 CorrelationTrace(string.Format(message, args0?.ToString() ?? "Null", args1?.ToString() ?? "Null", args2?.ToString() ?? "Null"));
             }
         }
+        #endregion
 
-        [NonEvent]
-        internal void NotificationsTraceEvent(string message)
-        {
-            if (Log.IsNotificationTraceEnabled())
-            {
-                NotificationsTrace(message);
-            }
-        }
-
-        [NonEvent]
-        internal void NotificationsTraceEvent<T0>(string message, T0 args0)
-        {
-            if (Log.IsNotificationTraceEnabled())
-            {
-                NotificationsTrace(string.Format(message, args0));
-            }
-        }
-
-        [NonEvent]
-        internal void NotificationsTraceEvent<T0, T1>(string message, T0 args0, T1 args1)
-        {
-            if (Log.IsNotificationTraceEnabled())
-            {
-                NotificationsTrace(string.Format(message, args0, args1));
-            }
-        }
-
-        [NonEvent]
-        internal void NotificationsTraceEvent<T0, T1, T2>(string message, T0 args0, T1 args1, T2 args2)
-        {
-            if (Log.IsNotificationTraceEnabled())
-            {
-                NotificationsTrace(string.Format(message, args0, args1, args2));
-            }
-        }
-
-        [NonEvent]
-        internal void NotificationsTraceEvent<T0, T1, T2, T3>(string message, T0 args0, T1 args1, T2 args2, T3 args3)
-        {
-            if (Log.IsNotificationTraceEnabled())
-            {
-                NotificationsTrace(string.Format(message, args0, args1, args2, args3));
-            }
-        }
-
-        [NonEvent]
-        internal void TraceBinEvent<T0, T1>(string message, T0 args0, T1 args1)
-        {
-            if (Log.IsTraceBinEnabled())
-            {
-                TraceBin(string.Format(message, args0, args1));
-            }
-        }
-
+        #region State Dump
         [NonEvent]
         internal void StateDumpEvent<T0, T1>(string message, T0 args0, T1 args1)
         {
             if (Log.IsStateDumpEnabled())
             {
-                Trace(string.Format(message, args0, args1));
-            }
-        }
-
-        [NonEvent]
-        internal void ScopeLeaveEvent(long scopeId)
-        {
-            if (Log.IsScopeEnabled())
-            {
-                ScopeLeave(scopeId);
-            }
-        }
-
-        [NonEvent]
-        internal void NotificationsScopeLeaveEvent(long scopeId)
-        {
-            if (Log.IsNotificationScopeEnabled())
-            {
-                ScopeLeave(scopeId);
-            }
-        }
-
-        [NonEvent]
-        internal void PoolerScopeLeaveEvent(long scopeId)
-        {
-            if (Log.IsPoolerScopeEnabled())
-            {
-                ScopeLeave(scopeId);
-            }
-        }
-
-        [NonEvent]
-        internal void AdvanceScopeLeave(long scopeId)
-        {
-            if (Log.IsAdvanceTraceOn())
-            {
-                ScopeLeave(scopeId);
+                StateDump(string.Format(message, args0, args1));
             }
         }
         #endregion
 
-        #region Events
+        #endregion
+
+        #region Write Events
+        [Event(BeginExecuteEventId, Keywords = Keywords.ExecutionTrace, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Start)]
+        internal void BeginExecute(int objectId, string dataSource, string database, string commandText)
+        {
+            if (Log.IsExecutionTraceEnabled())
+            {
+                WriteEvent(BeginExecuteEventId, objectId, dataSource, database, commandText);
+            }
+        }
+
+        [Event(EndExecuteEventId, Keywords = Keywords.ExecutionTrace, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Stop)]
+        internal void EndExecute(int objectId, int compositeState, int sqlExceptionNumber)
+        {
+            if (Log.IsExecutionTraceEnabled())
+            {
+                WriteEvent(EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
+            }
+        }
+
         [Event(TraceEventId, Level = EventLevel.Informational, Keywords = Keywords.Trace)]
         internal void Trace(string message)
         {
             WriteEvent(TraceEventId, message);
         }
 
-        [Event(EnterScopeId, Level = EventLevel.Verbose, Keywords = Keywords.Scope)]
+        [Event(ScopeEnterId, Level = EventLevel.Informational, Opcode = EventOpcode.Start, Keywords = Keywords.Scope)]
         internal long ScopeEnter(string message)
         {
             long scopeId = Interlocked.Increment(ref s_nextScopeId);
-            WriteEvent(EnterScopeId, message);
+            WriteEvent(ScopeEnterId, message);
             return scopeId;
         }
 
-        [Event(ExitScopeId, Level = EventLevel.Verbose, Keywords = Keywords.Scope)]
+        [Event(ScopeExitId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Keywords = Keywords.Scope)]
         internal void ScopeLeave(long scopeId)
         {
-            WriteEvent(ExitScopeId, scopeId);
+            WriteEvent(ScopeExitId, scopeId);
         }
 
-        [Event(TraceBinId, Level = EventLevel.Informational, Keywords = Keywords.Trace)]
-        internal void TraceBin(string message)
+        [Event(NotificationTraceId, Level = EventLevel.Informational, Keywords = Keywords.NotificationTrace)]
+        internal void NotificationTrace(string message)
         {
-            WriteEvent(TraceBinId, message);
+            WriteEvent(NotificationTraceId, message);
         }
 
-        [Event(CorrelationTraceId, Level = EventLevel.Informational, Keywords = Keywords.Correlation, Opcode = EventOpcode.Start)]
-        internal void CorrelationTrace(string message)
-        {
-            WriteEvent(CorrelationTraceId, message);
-        }
-
-        [Event(NotificationsScopeEnterId, Level = EventLevel.Informational, Opcode = EventOpcode.Start, Keywords = Keywords.NotificationScope)]
-        internal long NotificationsScopeEnter(string message)
+        [Event(NotificationScopeEnterId, Level = EventLevel.Informational, Opcode = EventOpcode.Start, Keywords = Keywords.NotificationScope)]
+        internal long NotificationScopeEnter(string message)
         {
             long scopeId = Interlocked.Increment(ref s_nextNotificationScopeId);
-            WriteEvent(NotificationsScopeEnterId, message);
+            WriteEvent(NotificationScopeEnterId, message);
             return scopeId;
+        }
+
+        [Event(NotificationScopeExitId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Keywords = Keywords.NotificationScope)]
+        internal void NotificationScopeLeave(long scopeId)
+        {
+            WriteEvent(NotificationScopeExitId, scopeId);
+        }
+
+        [Event(PoolerTraceId, Level = EventLevel.Informational, Keywords = Keywords.PoolerTrace)]
+        internal void PoolerTrace(string message)
+        {
+            WriteEvent(PoolerTraceId, message);
         }
 
         [Event(PoolerScopeEnterId, Level = EventLevel.Informational, Opcode = EventOpcode.Start, Keywords = Keywords.PoolerScope)]
@@ -570,44 +712,48 @@ namespace Microsoft.Data.SqlClient
             return scopeId;
         }
 
-        [Event(NotificationsTraceId, Level = EventLevel.Informational, Keywords = Keywords.Trace)]
-        internal void NotificationsTrace(string message)
+        [Event(PoolerScopeExitId, Level = EventLevel.Informational, Opcode = EventOpcode.Stop, Keywords = Keywords.PoolerScope)]
+        internal void PoolerScopeLeave(long scopeId)
         {
-            WriteEvent(NotificationsTraceId, message);
+            WriteEvent(ScopeExitId, scopeId);
         }
 
-        [Event(PoolerTraceId, Level = EventLevel.Informational, Keywords = Keywords.PoolerTrace)]
-        internal void PoolerTrace(string message)
+        [Event(AdvancedTraceId, Level = EventLevel.Verbose, Keywords = Keywords.AdvancedTrace)]
+        internal void AdvancedTrace(string message)
         {
-            WriteEvent(PoolerTraceId, message);
+            WriteEvent(TraceEventId, message);
         }
 
-        // unfortunately these are not marked as Start/Stop opcodes.  The reason is that we dont want them to participate in 
-        // the EventSource activity IDs (because they currently don't use tasks and this simply confuses the logic) and 
-        // because of versioning requirements we don't have ActivityOptions capability (because mscorlib and System.Data version 
-        // at different rates)  Sigh...
-        [Event(BeginExecuteEventId, Keywords = Keywords.SqlClient, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Start)]
-        public void BeginExecute(int objectId, string dataSource, string database, string commandText)
+        [Event(AdvancedScopeEnterId, Level = EventLevel.Verbose, Opcode = EventOpcode.Start, Keywords = Keywords.AdvancedTrace)]
+        internal long AdvancedScopeEnter(string message)
         {
-            // we do not use unsafe code for better performance optization here because optimized helpers make the code unsafe where that would not be the case otherwise. 
-            // This introduces the question of partial trust, which is complex in the SQL case (there are a lot of scenarios and SQL has special security support).   
-            if (Log.IsSqlClientEnabled())
-            {
-                WriteEvent(BeginExecuteEventId, objectId, dataSource, database, commandText);
-            }
+            long scopeId = Interlocked.Increment(ref s_nextScopeId);
+            WriteEvent(AdvancedScopeEnterId, message);
+            return scopeId;
         }
 
-        // unfortunately these are not marked as Start/Stop opcodes.  The reason is that we dont want them to participate in 
-        // the EventSource activity IDs (because they currently don't use tasks and this simply confuses the logic) and 
-        // because of versioning requirements we don't have ActivityOptions capability (because mscorlib and System.Data version 
-        // at different rates)  Sigh...
-        [Event(EndExecuteEventId, Keywords = Keywords.SqlClient, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Stop)]
-        public void EndExecute(int objectId, int compositeState, int sqlExceptionNumber)
+        [Event(AdvancedScopeExitId, Level = EventLevel.Verbose, Opcode = EventOpcode.Stop, Keywords = Keywords.AdvancedTrace)]
+        internal void AdvancedScopeLeave(long scopeId)
         {
-            if (Log.IsSqlClientEnabled())
-            {
-                WriteEvent(EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
-            }
+            WriteEvent(AdvancedScopeExitId, scopeId);
+        }
+
+        [Event(AdvancedTraceBinId, Level = EventLevel.Informational, Keywords = Keywords.AdvancedTraceBin)]
+        internal void AdvancedTraceBin(string message)
+        {
+            WriteEvent(AdvancedTraceBinId, message);
+        }
+
+        [Event(CorrelationTraceId, Level = EventLevel.Informational, Keywords = Keywords.CorrelationTrace, Opcode = EventOpcode.Start)]
+        internal void CorrelationTrace(string message)
+        {
+            WriteEvent(CorrelationTraceId, message);
+        }
+
+        [Event(StateDumpEventId, Level = EventLevel.Verbose, Keywords = Keywords.StateDump)]
+        internal void StateDump(string message)
+        {
+            WriteEvent(StateDumpEventId, message);
         }
         #endregion
     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Data.SqlClient
 
             internal override void StatementCompleted(int rowsAffected)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlCommand.CommandEventSink.StatementCompleted|ADV> {0}#, rowsAffected={1}.", _command.ObjectID, rowsAffected);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.StatementCompleted|ADV> {0}#, rowsAffected={1}.", _command.ObjectID, rowsAffected);
                 _command.InternalRecordsAffected = rowsAffected;
 
                 // UNDONE: need to fire events back to user code, but this may be called
@@ -355,20 +355,20 @@ namespace Microsoft.Data.SqlClient
 
             internal override void BatchCompleted()
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlCommand.CommandEventSink.BatchCompleted|ADV> {0}#.", _command.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.BatchCompleted|ADV> {0}#.", _command.ObjectID);
             }
 
             internal override void ParametersAvailable(SmiParameterMetaData[] metaData, ITypedGettersV3 parameterValues)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlCommand.CommandEventSink.ParametersAvailable|ADV> {0}# metaData.Length={1}.", _command.ObjectID, (null != metaData) ? metaData.Length : -1);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.ParametersAvailable|ADV> {0}# metaData.Length={1}.", _command.ObjectID, (null != metaData) ? metaData.Length : -1);
 
-                if (SqlClientEventSource.Log.IsAdvanceTraceOn())
+                if (SqlClientEventSource.Log.IsAdvancedTraceOn())
                 {
                     if (null != metaData)
                     {
                         for (int i = 0; i < metaData.Length; i++)
                         {
-                            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlCommand.CommandEventSink.ParametersAvailable|ADV> {0}#, metaData[{1}] is {2}{3}", _command.ObjectID, i, metaData[i].GetType().ToString(), metaData[i].TraceString());
+                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.ParametersAvailable|ADV> {0}#, metaData[{1}] is {2}{3}", _command.ObjectID, i, metaData[i].GetType().ToString(), metaData[i].TraceString());
                         }
                     }
                 }
@@ -379,7 +379,7 @@ namespace Microsoft.Data.SqlClient
 
             internal override void ParameterAvailable(SmiParameterMetaData metaData, SmiTypedGetterSetter parameterValues, int ordinal)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlCommand.CommandEventSink.ParameterAvailable|ADV> {0}#, metaData[{1}] is {2}{ 3}", _command.ObjectID, ordinal, metaData.GetType().ToString(), metaData.TraceString());
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.ParameterAvailable|ADV> {0}#, metaData[{1}] is {2}{ 3}", _command.ObjectID, ordinal, metaData.GetType().ToString(), metaData.TraceString());
                 Debug.Assert(SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.KatmaiVersion);
                 _command.OnParameterAvailableSmi(metaData, parameterValues, ordinal);
             }
@@ -3767,7 +3767,7 @@ namespace Microsoft.Data.SqlClient
                     SysTx.Transaction transaction;
                     innerConnection.GetCurrentTransactionPair(out transactionId, out transaction);
 
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlCommand.RunExecuteNonQuerySmi|ADV> {0}#, innerConnection={1}#, transactionId=0x{2}, cmdBehavior={3}.", ObjectID, innerConnection.ObjectID, transactionId, (int)CommandBehavior.Default);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.RunExecuteNonQuerySmi|ADV> {0}#, innerConnection={1}#, transactionId=0x{2}, cmdBehavior={3}.", ObjectID, innerConnection.ObjectID, transactionId, (int)CommandBehavior.Default);
 
                     if (SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.KatmaiVersion)
                     {
@@ -5429,7 +5429,7 @@ namespace Microsoft.Data.SqlClient
                 long transactionId;
                 SysTx.Transaction transaction;
                 innerConnection.GetCurrentTransactionPair(out transactionId, out transaction);
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlCommand.RunExecuteReaderSmi|ADV> {0}#, innerConnection={1}#, transactionId=0x{2}, commandBehavior={(int)cmdBehavior}.", ObjectID, innerConnection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.RunExecuteReaderSmi|ADV> {0}#, innerConnection={1}#, transactionId=0x{2}, commandBehavior={(int)cmdBehavior}.", ObjectID, innerConnection.ObjectID, transactionId);
 
                 if (SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.KatmaiVersion)
                 {
@@ -7450,7 +7450,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="synchronous">True if SQL command was executed synchronously, otherwise false.</param>
         private void WriteEndExecuteEvent(bool success, int? sqlExceptionNumber, bool synchronous)
         {
-            if (SqlClientEventSource.Log.IsSqlClientEnabled())
+            if (SqlClientEventSource.Log.IsExecutionTraceEnabled())
             {
                 // SqlEventSource.WriteEvent(int, int, int, int) is faster than provided overload SqlEventSource.WriteEvent(int, object[]).
                 // that's why trying to fit several booleans in one integer value

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Data.SqlClient
 
             internal override void StatementCompleted(int rowsAffected)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.StatementCompleted|ADV> {0}#, rowsAffected={1}.", _command.ObjectID, rowsAffected);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.StatementCompleted|ADV> {0}, rowsAffected={1}.", _command.ObjectID, rowsAffected);
                 _command.InternalRecordsAffected = rowsAffected;
 
                 // UNDONE: need to fire events back to user code, but this may be called
@@ -355,12 +355,12 @@ namespace Microsoft.Data.SqlClient
 
             internal override void BatchCompleted()
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.BatchCompleted|ADV> {0}#.", _command.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.BatchCompleted|ADV> {0}.", _command.ObjectID);
             }
 
             internal override void ParametersAvailable(SmiParameterMetaData[] metaData, ITypedGettersV3 parameterValues)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.ParametersAvailable|ADV> {0}# metaData.Length={1}.", _command.ObjectID, (null != metaData) ? metaData.Length : -1);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.ParametersAvailable|ADV> {0} metaData.Length={1}.", _command.ObjectID, (null != metaData) ? metaData.Length : -1);
 
                 if (SqlClientEventSource.Log.IsAdvancedTraceOn())
                 {
@@ -368,7 +368,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         for (int i = 0; i < metaData.Length; i++)
                         {
-                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.ParametersAvailable|ADV> {0}#, metaData[{1}] is {2}{3}", _command.ObjectID, i, metaData[i].GetType().ToString(), metaData[i].TraceString());
+                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.ParametersAvailable|ADV> {0}, metaData[{1}] is {2}{3}", _command.ObjectID, i, metaData[i].GetType().ToString(), metaData[i].TraceString());
                         }
                     }
                 }
@@ -379,7 +379,7 @@ namespace Microsoft.Data.SqlClient
 
             internal override void ParameterAvailable(SmiParameterMetaData metaData, SmiTypedGetterSetter parameterValues, int ordinal)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.ParameterAvailable|ADV> {0}#, metaData[{1}] is {2}{ 3}", _command.ObjectID, ordinal, metaData.GetType().ToString(), metaData.TraceString());
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.ParameterAvailable|ADV> {0}, metaData[{1}] is {2}{ 3}", _command.ObjectID, ordinal, metaData.GetType().ToString(), metaData.TraceString());
                 Debug.Assert(SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.KatmaiVersion);
                 _command.OnParameterAvailableSmi(metaData, parameterValues, ordinal);
             }
@@ -562,7 +562,7 @@ namespace Microsoft.Data.SqlClient
                     }
                 }
                 _activeConnection = value; // UNDONE: Designers need this setter.  Should we block other scenarios?
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Connection|API> {0}#, {1}#", ObjectID, (null != value) ? value.ObjectID : -1);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Connection|API> {0}, {1}", ObjectID, (null != value) ? value.ObjectID : -1);
             }
         }
 
@@ -640,7 +640,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Notification|API> {0}#", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Notification|API> {0}", ObjectID);
                 _sqlDep = null;
                 _notification = value;
             }
@@ -690,7 +690,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // TODO: Add objid here
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Transaction|API> {0}#", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_Transaction|API> {0}", ObjectID);
                 _transaction = value;
             }
         }
@@ -725,7 +725,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandText|API> {0}#, String Value = '{1}'", ObjectID, value);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandText|API> {0}, String Value = '{1}'", ObjectID, value);
 
                 if (0 != ADP.SrcCompare(_commandText, value))
                 {
@@ -763,7 +763,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandTimeout|API> {0}#, {1}", ObjectID, value);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandTimeout|API> {0}, {1}", ObjectID, value);
                 if (value < 0)
                 {
                     throw ADP.InvalidCommandTimeout(value);
@@ -808,7 +808,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandType|API> {0}#, {1}{2}", ObjectID, (int)value, _commandType);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.set_CommandType|API> {0}, {1}{2}", ObjectID, (int)value, _commandType);
                 if (_commandType != value)
                 {
                     switch (value)
@@ -951,7 +951,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     try
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.OnStatementCompleted|INFO> {0}#, recordCount={1}", ObjectID, recordCount);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.OnStatementCompleted|INFO> {0}, recordCount={1}", ObjectID, recordCount);
                         handler(this, new StatementCompletedEventArgs(recordCount));
                     }
                     catch (Exception e)
@@ -989,8 +989,8 @@ namespace Microsoft.Data.SqlClient
             }
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.Prepare|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.Prepare|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.Prepare|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.Prepare|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
             statistics = SqlStatistics.StartTimer(Statistics);
 
@@ -1156,7 +1156,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             _cachedMetaData = null;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.Prepare|INFO> {0}#, Command unprepared.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.Prepare|INFO> {0}, Command unprepared.", ObjectID);
         }
 
         // Cancel is supposed to be multi-thread safe.
@@ -1166,8 +1166,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Cancel/*'/>
         override public void Cancel()
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.Cancel | API > {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.Cancel|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.Cancel | API > {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.Cancel|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
             SqlStatistics statistics = null;
             try
@@ -1329,8 +1329,8 @@ namespace Microsoft.Data.SqlClient
             _pendingCancel = false;
             SqlStatistics statistics = null;
 
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteScalar|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteScalar|API|Correlation> ObjectID{0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteScalar|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteScalar|API|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
             bool success = false;
             int? sqlExceptionNumber = null;
@@ -1399,8 +1399,8 @@ namespace Microsoft.Data.SqlClient
 
             SqlStatistics statistics = null;
 
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteNonQuery|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQuery|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteNonQuery|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQuery|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
             bool success = false;
             int? sqlExceptionNumber = null;
@@ -1437,7 +1437,7 @@ namespace Microsoft.Data.SqlClient
             _pendingCancel = false;
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteToPipe|INFO> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteToPipe|INFO> {0}", ObjectID);
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -1463,7 +1463,7 @@ namespace Microsoft.Data.SqlClient
         [System.Security.Permissions.HostProtectionAttribute(ExternalThreading = true)]
         public IAsyncResult BeginExecuteNonQuery(AsyncCallback callback, object stateObject)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteNonQuery|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteNonQuery|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             SqlConnection.ExecutePermission.Demand();
             return BeginExecuteNonQueryInternal(0, callback, stateObject, 0, inRetry: false);
         }
@@ -1689,7 +1689,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteNonQuery|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteNonQuery|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             }
         }
 
@@ -1707,7 +1707,7 @@ namespace Microsoft.Data.SqlClient
 
         private int EndExecuteNonQueryAsync(IAsyncResult asyncResult)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteNonQueryAsync|Info|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteNonQueryAsync|Info|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             Debug.Assert(!_internalEndExecuteInitiated || _stateObj == null);
 
             Exception asyncException = ((Task)asyncResult).Exception;
@@ -1969,7 +1969,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         // otherwise, use a full-fledged execute that can handle params and stored procs
                         Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteNonQuery|INFO> {0}#, Command executed as RPC.", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteNonQuery|INFO> {0}, Command executed as RPC.", ObjectID);
 
                         SqlDataReader reader = RunExecuteReader(0, RunBehavior.UntilDone, false, methodName, completion, timeout, out task, out usedCache, asyncWrite, inRetry);
                         if (null != reader)
@@ -2023,8 +2023,8 @@ namespace Microsoft.Data.SqlClient
 
             SqlStatistics statistics = null;
 
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteXmlReader|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReader|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteXmlReader|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
             bool success = false;
             int? sqlExceptionNumber = null;
@@ -2065,7 +2065,7 @@ namespace Microsoft.Data.SqlClient
         [System.Security.Permissions.HostProtectionAttribute(ExternalThreading = true)]
         public IAsyncResult BeginExecuteXmlReader(AsyncCallback callback, object stateObject)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteXmlReader|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteXmlReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             SqlConnection.ExecutePermission.Demand();
             return BeginExecuteXmlReaderInternal(CommandBehavior.SequentialAccess, callback, stateObject, 0, inRetry: false);
         }
@@ -2218,13 +2218,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteXmlReader|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteXmlReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             }
         }
 
         private XmlReader EndExecuteXmlReaderAsync(IAsyncResult asyncResult)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteXmlReaderAsync|Info|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteXmlReaderAsync|Info|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             Debug.Assert(!_internalEndExecuteInitiated || _stateObj == null);
 
             Exception asyncException = ((Task)asyncResult).Exception;
@@ -2343,7 +2343,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteDbDataReader[@name="CommandBehavior"]/*'/>
         override protected DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteDbDataReader|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteDbDataReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             return ExecuteReader(behavior, ADP.ExecuteReader);
         }
 
@@ -2351,8 +2351,8 @@ namespace Microsoft.Data.SqlClient
         new public SqlDataReader ExecuteReader()
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteReader|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReader|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteReader|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
@@ -2368,8 +2368,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReader[@name="CommandBehavior"]/*'/>
         new public SqlDataReader ExecuteReader(CommandBehavior behavior)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteReader|API> {0}#, behavior={1}", ObjectID, (int)behavior);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReader|API|Correlation> ObjectID {0}#, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteReader|API> {0}, behavior={1}", ObjectID, (int)behavior);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReader|API|Correlation> ObjectID {0}, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
 
             try
             {
@@ -2392,7 +2392,7 @@ namespace Microsoft.Data.SqlClient
         [System.Security.Permissions.HostProtectionAttribute(ExternalThreading = true)]
         public IAsyncResult BeginExecuteReader(AsyncCallback callback, object stateObject, CommandBehavior behavior)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteReader|API|Correlation> ObjectID{0}#, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.BeginExecuteReader|API|Correlation> ObjectID{0}, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
             SqlConnection.ExecutePermission.Demand();
             return BeginExecuteReaderInternal(behavior, callback, stateObject, 0, inRetry: false);
         }
@@ -2473,13 +2473,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteReader|API|Correlation> ObjectID{0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteReader|API|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             }
         }
 
         private SqlDataReader EndExecuteReaderAsync(IAsyncResult asyncResult)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteReaderAsync|Info|Correlation> ObjectID{0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.EndExecuteReaderAsync|Info|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             Debug.Assert(!_internalEndExecuteInitiated || _stateObj == null);
 
             Exception asyncException = ((Task)asyncResult).Exception;
@@ -2880,7 +2880,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteNonQueryAsync[@name="CancellationToken"]/*'/>
         public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQueryAsync|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQueryAsync|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             SqlConnection.ExecutePermission.Demand();
 
             TaskCompletionSource<int> source = new TaskCompletionSource<int>();
@@ -2965,7 +2965,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="commandBehaviorAndCancellationToken"]/*'/>
         new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReaderAsync|API|Correlation> ObjectID {0}#, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReaderAsync|API|Correlation> ObjectID {0}, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
             SqlConnection.ExecutePermission.Demand();
 
             TaskCompletionSource<SqlDataReader> source = new TaskCompletionSource<SqlDataReader>();
@@ -3099,7 +3099,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteXmlReaderAsync[@name="CancellationToken"]/*'/>
         public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken)
         {
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReaderAsync|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReaderAsync|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             SqlConnection.ExecutePermission.Demand();
 
             TaskCompletionSource<XmlReader> source = new TaskCompletionSource<XmlReader>();
@@ -3705,7 +3705,7 @@ namespace Microsoft.Data.SqlClient
                 // no parameters are sent over
                 // no data reader is returned
                 // use this overload for "batch SQL" tds token type
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteNonQuery|INFO> {0}#, Command executed as SQLBATCH.", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteNonQuery|INFO> {0}, Command executed as SQLBATCH.", ObjectID);
                 Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(this.CommandText, timeout, this.Notification, _stateObj, sync: true);
                 Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
 
@@ -3767,7 +3767,7 @@ namespace Microsoft.Data.SqlClient
                     SysTx.Transaction transaction;
                     innerConnection.GetCurrentTransactionPair(out transactionId, out transaction);
 
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.RunExecuteNonQuerySmi|ADV> {0}#, innerConnection={1}#, transactionId=0x{2}, cmdBehavior={3}.", ObjectID, innerConnection.ObjectID, transactionId, (int)CommandBehavior.Default);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.RunExecuteNonQuerySmi|ADV> {0}, innerConnection={1}, transactionId=0x{2}, cmdBehavior={3}.", ObjectID, innerConnection.ObjectID, transactionId, (int)CommandBehavior.Default);
 
                     if (SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.KatmaiVersion)
                     {
@@ -5246,7 +5246,7 @@ namespace Microsoft.Data.SqlClient
                     Debug.Assert(!IsUserPrepared, "CommandType.Text with no params should not be prepared!");
                     if (returnStream)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}#, Command executed as SQLBATCH.", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}, Command executed as SQLBATCH.", ObjectID);
                     }
                     string text = GetCommandText(cmdBehavior) + GetResetOptionsString(cmdBehavior);
 
@@ -5311,7 +5311,7 @@ namespace Microsoft.Data.SqlClient
                         rpc.options = TdsEnums.RPC_NOMETADATA;
                     if (returnStream)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}#, Command executed as RPC.", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}, Command executed as RPC.", ObjectID);
                     }
 
                     // TODO: Medusa: Unprepare only happens for SQL 7.0 which may be broken anyway (it's not re-prepared). Consider removing the reset here if we're really dropping 7.0 support.
@@ -5334,7 +5334,7 @@ namespace Microsoft.Data.SqlClient
                     optionSettings = GetSetOptionsString(cmdBehavior);
                     if (returnStream)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}#, Command executed as RPC.", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.ExecuteReader|INFO> {0}, Command executed as RPC.", ObjectID);
                     }
 
                     // turn set options ON
@@ -5429,7 +5429,7 @@ namespace Microsoft.Data.SqlClient
                 long transactionId;
                 SysTx.Transaction transaction;
                 innerConnection.GetCurrentTransactionPair(out transactionId, out transaction);
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.RunExecuteReaderSmi|ADV> {0}#, innerConnection={1}#, transactionId=0x{2}, commandBehavior={(int)cmdBehavior}.", ObjectID, innerConnection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.RunExecuteReaderSmi|ADV> {0}, innerConnection={1}, transactionId=0x{2}, commandBehavior={(int)cmdBehavior}.", ObjectID, innerConnection.ObjectID, transactionId);
 
                 if (SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.KatmaiVersion)
                 {
@@ -5649,7 +5649,7 @@ namespace Microsoft.Data.SqlClient
         public SqlCommand Clone()
         {
             SqlCommand clone = new SqlCommand(this);
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.Clone|API> {0}#, clone={1}#", ObjectID, clone.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommand.Clone|API> {0}, clone={1}", ObjectID, clone.ObjectID);
             return clone;
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Data.SqlClient
         internal void Append(SqlCommand command)
         {
             ADP.CheckArgumentNull(command, "command");
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Append|API> {0}#, command={1}, parameterCount={2}", ObjectID, command.ObjectID, command.Parameters.Count);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Append|API> {0}, command={1}, parameterCount={2}", ObjectID, command.ObjectID, command.Parameters.Count);
             string cmdText = command.CommandText;
 
             if (ADP.IsEmpty(cmdText))
@@ -264,7 +264,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Clear()
         {
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Clear|API> {0}#", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Clear|API> {0}", ObjectID);
             DbCommand batchCommand = BatchCommand;
             if (null != batchCommand)
             {
@@ -280,7 +280,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Dispose()
         {
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Dispose|API> {0}#", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlCommandSet.Dispose|API> {0}", ObjectID);
             SqlCommand command = _batchCommand;
             _commandList = null;
             _batchCommand = null;
@@ -294,7 +294,7 @@ namespace Microsoft.Data.SqlClient
         internal int ExecuteNonQuery()
         {
             SqlConnection.ExecutePermission.Demand();
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommandSet.ExecuteNonQuery|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommandSet.ExecuteNonQuery|API> {0}", ObjectID);
 
             try
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1101,7 +1101,7 @@ namespace Microsoft.Data.SqlClient
         [SuppressMessage("Microsoft.Reliability", "CA2004:RemoveCallsToGCKeepAlive")]
         override protected DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.SqlConnection.BeginDbTransaction|API> {0}#, isolationLevel={1}", ObjectID, (int)isolationLevel);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<prov.SqlConnection.BeginDbTransaction|API> {0}, isolationLevel={1}", ObjectID, (int)isolationLevel);
             try
             {
 
@@ -1126,7 +1126,7 @@ namespace Microsoft.Data.SqlClient
         {
             WaitForPendingReconnection();
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlConnection.BeginTransaction|API> {0}#, iso={1}, transactionName='{2}'", ObjectID, (int)iso, (ADP.IsEmpty(transactionName) ? "None" : transactionName));
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlConnection.BeginTransaction|API> {0}, iso={1}, transactionName='{2}'", ObjectID, (int)iso, (ADP.IsEmpty(transactionName) ? "None" : transactionName));
 
             try
             {
@@ -1164,7 +1164,7 @@ namespace Microsoft.Data.SqlClient
         {
             SqlStatistics statistics = null;
             RepairInnerConnection();
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.ChangeDatabase|API|Correlation> ObjectID{0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.ChangeDatabase|API|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
             TdsParser bestEffortCleanupTarget = null;
             RuntimeHelpers.PrepareConstrainedRegions();
 
@@ -1258,8 +1258,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnection.xml' path='docs/members[@name="SqlConnection"]/Close/*' />
         override public void Close()
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlConnection.Close|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.Close|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlConnection.Close|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.Close|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
 
             try
             {
@@ -1398,7 +1398,7 @@ namespace Microsoft.Data.SqlClient
         override public void Open()
         {
             long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlConnection.Open|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.Open|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.Open|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
 
             try
             {
@@ -1656,8 +1656,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OpenAsync/*' />
         public override Task OpenAsync(CancellationToken cancellationToken)
         {
-            long scopeID = SqlClientEventSource.Log.PoolerScopeEnterEvent("<sc.SqlConnection.OpenAsync|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.OpenAsync|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            long scopeID = SqlClientEventSource.Log.PoolerScopeEnterEvent("<sc.SqlConnection.OpenAsync|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlConnection.OpenAsync|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
 
             try
             {
@@ -1755,7 +1755,7 @@ namespace Microsoft.Data.SqlClient
 
             internal void Retry(Task<DbConnectionInternal> retryTask)
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OpenAsyncRetry|Info> {0}#", _parent.ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OpenAsyncRetry|Info> {0}", _parent.ObjectID);
                 _registration.Dispose();
 
                 try
@@ -2102,7 +2102,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         if (capturedCloseCount == _closeCount)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnError|INFO> {0}#, Connection broken.", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnError|INFO> {0}, Connection broken.", ObjectID);
                             Close();
                         }
                     };
@@ -2111,7 +2111,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnError|INFO> {0}#, Connection broken.", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnError|INFO> {0}, Connection broken.", ObjectID);
                     Close();
                 }
             }
@@ -2219,7 +2219,7 @@ namespace Microsoft.Data.SqlClient
 
             Debug.Assert(null != imevent, "null SqlInfoMessageEventArgs");
             var imeventValue = (null != imevent) ? imevent.Message : "";
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnInfoMessage|API|INFO> {0}#, Message='{1}'", ObjectID, imeventValue);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlConnection.OnInfoMessage|API|INFO> {0}, Message='{1}'", ObjectID, imeventValue);
             SqlInfoMessageEventHandler handler = (SqlInfoMessageEventHandler)Events[EventInfoMessage];
 
             if (null != handler)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2500,7 +2500,6 @@ namespace Microsoft.Data.SqlClient
                 if (newSecurePassword == null || newSecurePassword.Length == 0)
                 {
                     throw SQL.ChangePasswordArgumentMissing("newSecurePassword");
-                    ;
                 }
 
                 if (!newSecurePassword.IsReadOnly())

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.ArgumentOutOfRange("UpdateBatchSize");
                 }
                 _updateBatchSize = value;
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlDataAdapter.set_UpdateBatchSize|API> {0}#, {1}", ObjectID, value);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDataAdapter.set_UpdateBatchSize|API> {0}, {1}", ObjectID, value);
             }
         }
 
@@ -249,7 +249,7 @@ namespace Microsoft.Data.SqlClient
         override protected int ExecuteBatch()
         {
             Debug.Assert(null != _commandSet && (0 < _commandSet.CommandCount), "no commands");
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlDataAdapter.ExecuteBatch|Info|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlDataAdapter.ExecuteBatch|Info|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
 
             return _commandSet.ExecuteNonQuery();
         }
@@ -273,7 +273,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlDataAdapter.xml' path='docs/members[@name="SqlDataAdapter"]/InitializeBatching/*' />
         override protected void InitializeBatching()
         {
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDataAdapter.InitializeBatching|API> {0}#", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlDataAdapter.InitializeBatching|API> {0}", ObjectID);
             _commandSet = new SqlCommandSet();
             SqlCommand command = SelectCommand;
             if (null == command)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -939,7 +939,7 @@ namespace Microsoft.Data.SqlClient
         override public void Close()
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.Close|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.Close|API> {0}", ObjectID);
 
             try
             {
@@ -1670,7 +1670,7 @@ namespace Microsoft.Data.SqlClient
         override public DataTable GetSchemaTable()
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.GetSchemaTable|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.GetSchemaTable|API> {0}", ObjectID);
 
             try
             {
@@ -3597,7 +3597,7 @@ namespace Microsoft.Data.SqlClient
         private bool TryNextResult(out bool more)
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.NextResult|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.NextResult|API> {0}", ObjectID);
             RuntimeHelpers.PrepareConstrainedRegions();
 
             try
@@ -3803,7 +3803,7 @@ namespace Microsoft.Data.SqlClient
         private bool TryReadInternal(bool setTimeout, out bool more)
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.Read|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.Read|API> {0}", ObjectID);
             RuntimeHelpers.PrepareConstrainedRegions();
 
             try
@@ -4470,7 +4470,7 @@ namespace Microsoft.Data.SqlClient
                 // broken connection, so check state first.
                 if (parser.State == TdsParserState.OpenLoggedIn)
                 {
-                    SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlDataReader.RestoreServerSettings|Info|Correlation> ObjectID {0}#, ActivityID '{1}'", ObjectID, ActivityCorrelator.Current.ToString());
+                    SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlDataReader.RestoreServerSettings|Info|Correlation> ObjectID {0}, ActivityID '{1}'", ObjectID, ActivityCorrelator.Current.ToString());
                     Task executeTask = parser.TdsExecuteSQLBatch(_resetOptionsString, (_command != null) ? _command.CommandTimeout : 0, null, stateObj, sync: true);
                     Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
 
@@ -4782,7 +4782,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/NextResultAsync/*' />
         public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.NextResultAsync|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.NextResultAsync|API> {0}", ObjectID);
 
             try
             {
@@ -4828,7 +4828,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (t != null)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDataReader.NextResultAsync> attempt retry {0}#", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDataReader.NextResultAsync> attempt retry {0}", ObjectID);
                         PrepareForAsyncContinuation();
                     }
 
@@ -4910,7 +4910,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (t != null)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDataReader.GetBytesAsync> attempt retry {0}#", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDataReader.GetBytesAsync> attempt retry {0}", ObjectID);
                         PrepareForAsyncContinuation();
                     }
 
@@ -5081,7 +5081,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/ReadAsync/*' />
         public override Task<bool> ReadAsync(CancellationToken cancellationToken)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.ReadAsync|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReader.ReadAsync|API> {0}", ObjectID);
             try
             {
                 if (IsClosed)
@@ -5201,7 +5201,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (t != null)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDataReader.ReadAsync> attempt retry {0}#", ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDataReader.ReadAsync> attempt retry {0}", ObjectID);
                         PrepareForAsyncContinuation();
                     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReaderSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReaderSmi.cs
@@ -374,7 +374,7 @@ namespace Microsoft.Data.SqlClient
 
         private void CloseInternal(bool closeConnection)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReaderSmi.Close|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlDataReaderSmi.Close|API> {0}", ObjectID);
             bool processFinallyBlock = true;
             try
             {
@@ -433,7 +433,7 @@ namespace Microsoft.Data.SqlClient
 
         internal unsafe bool InternalNextResult(bool ignoreNonFatalMessages)
         {
-            long scopeID = SqlClientEventSource.Log.AdvancedScopeEnterEvent("<sc.SqlDataReaderSmi.InternalNextResult|ADV> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.AdvancedScopeEnterEvent("<sc.SqlDataReaderSmi.InternalNextResult|ADV> {0}", ObjectID);
             try
             {
                 _hasRows = false;
@@ -486,7 +486,7 @@ namespace Microsoft.Data.SqlClient
 
         internal unsafe bool InternalRead(bool ignoreNonFatalErrors)
         {
-            long scopeID = SqlClientEventSource.Log.AdvancedScopeEnterEvent("<sc.SqlDataReaderSmi.InternalRead|ADV> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.AdvancedScopeEnterEvent("<sc.SqlDataReaderSmi.InternalRead|ADV> {0}", ObjectID);
             try
             {
                 // Don't move unless currently in results.
@@ -1316,7 +1316,7 @@ namespace Microsoft.Data.SqlClient
             internal override void MetaDataAvailable(SmiQueryMetaData[] md, bool nextEventIsRow)
             {
                 var mdLength = (null != md) ? md.Length : -1;
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.MetaDataAvailable|ADV> {0}#, md.Length={1} nextEventIsRow={2}.", reader.ObjectID, mdLength, nextEventIsRow);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.MetaDataAvailable|ADV> {0}, md.Length={1} nextEventIsRow={2}.", reader.ObjectID, mdLength, nextEventIsRow);
 
                 if (SqlClientEventSource.Log.IsAdvancedTraceOn())
                 {
@@ -1324,7 +1324,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         for (int i = 0; i < md.Length; i++)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.MetaDataAvailable|ADV> {0}#, metaData[{1}] is {2}{3}", reader.ObjectID, i, md[i].GetType().ToString(), md[i].TraceString());
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.MetaDataAvailable|ADV> {0}, metaData[{1}] is {2}{3}", reader.ObjectID, i, md[i].GetType().ToString(), md[i].TraceString());
                         }
                     }
                 }
@@ -1334,25 +1334,25 @@ namespace Microsoft.Data.SqlClient
             // Obsolete V2- method
             internal override void RowAvailable(ITypedGetters row)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0}# (v2).", reader.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0} (v2).", reader.ObjectID);
                 this.reader.RowAvailable(row);
             }
 
             internal override void RowAvailable(ITypedGettersV3 row)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0}# (ITypedGettersV3).", reader.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0} (ITypedGettersV3).", reader.ObjectID);
                 this.reader.RowAvailable(row);
             }
 
             internal override void RowAvailable(SmiTypedGetterSetter rowData)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0}# (SmiTypedGetterSetter).", reader.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0} (SmiTypedGetterSetter).", reader.ObjectID);
                 this.reader.RowAvailable(rowData);
             }
 
             internal override void StatementCompleted(int recordsAffected)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.StatementCompleted|ADV> {0}# recordsAffected= {1}.", reader.ObjectID, recordsAffected);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.StatementCompleted|ADV> {0} recordsAffected= {1}.", reader.ObjectID, recordsAffected);
 
                 // devnote: relies on SmiEventSink_Default to pass event to parent
                 // Both command and reader care about StatementCompleted, but for different reasons.
@@ -1362,7 +1362,7 @@ namespace Microsoft.Data.SqlClient
 
             internal override void BatchCompleted()
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.BatchCompleted|ADV> {0}#.", reader.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.BatchCompleted|ADV> {0}.", reader.ObjectID);
 
                 // devnote: relies on SmiEventSink_Default to pass event to parent
                 //  parent's callback *MUST* come before reader's BatchCompleted, since

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReaderSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReaderSmi.cs
@@ -433,7 +433,7 @@ namespace Microsoft.Data.SqlClient
 
         internal unsafe bool InternalNextResult(bool ignoreNonFatalMessages)
         {
-            long scopeID = SqlClientEventSource.Log.AdvanceScopeEnter("<sc.SqlDataReaderSmi.InternalNextResult|ADV> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.AdvancedScopeEnterEvent("<sc.SqlDataReaderSmi.InternalNextResult|ADV> {0}#", ObjectID);
             try
             {
                 _hasRows = false;
@@ -486,7 +486,7 @@ namespace Microsoft.Data.SqlClient
 
         internal unsafe bool InternalRead(bool ignoreNonFatalErrors)
         {
-            long scopeID = SqlClientEventSource.Log.AdvanceScopeEnter("<sc.SqlDataReaderSmi.InternalRead|ADV> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.AdvancedScopeEnterEvent("<sc.SqlDataReaderSmi.InternalRead|ADV> {0}#", ObjectID);
             try
             {
                 // Don't move unless currently in results.
@@ -1316,9 +1316,9 @@ namespace Microsoft.Data.SqlClient
             internal override void MetaDataAvailable(SmiQueryMetaData[] md, bool nextEventIsRow)
             {
                 var mdLength = (null != md) ? md.Length : -1;
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlDataReaderSmi.ReaderEventSink.MetaDataAvailable|ADV> {0}#, md.Length={1} nextEventIsRow={2}.", reader.ObjectID, mdLength, nextEventIsRow);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.MetaDataAvailable|ADV> {0}#, md.Length={1} nextEventIsRow={2}.", reader.ObjectID, mdLength, nextEventIsRow);
 
-                if (SqlClientEventSource.Log.IsAdvanceTraceOn())
+                if (SqlClientEventSource.Log.IsAdvancedTraceOn())
                 {
                     if (null != md)
                     {
@@ -1334,25 +1334,25 @@ namespace Microsoft.Data.SqlClient
             // Obsolete V2- method
             internal override void RowAvailable(ITypedGetters row)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0}# (v2).", reader.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0}# (v2).", reader.ObjectID);
                 this.reader.RowAvailable(row);
             }
 
             internal override void RowAvailable(ITypedGettersV3 row)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0}# (ITypedGettersV3).", reader.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0}# (ITypedGettersV3).", reader.ObjectID);
                 this.reader.RowAvailable(row);
             }
 
             internal override void RowAvailable(SmiTypedGetterSetter rowData)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0}# (SmiTypedGetterSetter).", reader.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.RowAvailable|ADV> {0}# (SmiTypedGetterSetter).", reader.ObjectID);
                 this.reader.RowAvailable(rowData);
             }
 
             internal override void StatementCompleted(int recordsAffected)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlDataReaderSmi.ReaderEventSink.StatementCompleted|ADV> {0}# recordsAffected= {1}.", reader.ObjectID, recordsAffected);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.StatementCompleted|ADV> {0}# recordsAffected= {1}.", reader.ObjectID, recordsAffected);
 
                 // devnote: relies on SmiEventSink_Default to pass event to parent
                 // Both command and reader care about StatementCompleted, but for different reasons.
@@ -1362,7 +1362,7 @@ namespace Microsoft.Data.SqlClient
 
             internal override void BatchCompleted()
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlDataReaderSmi.ReaderEventSink.BatchCompleted|ADV> {0}#.", reader.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlDataReaderSmi.ReaderEventSink.BatchCompleted|ADV> {0}#.", reader.ObjectID);
 
                 // devnote: relies on SmiEventSink_Default to pass event to parent
                 //  parent's callback *MUST* come before reader's BatchCompleted, since

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Data.SqlClient
             // transaction.
             SqlInternalConnection connection = _connection;
             SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Initialize|RES|CPOOL> {0}#, Connection {1}#, delegating transaction.", ObjectID, connection.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Initialize|RES|CPOOL> {0}, Connection {1}, delegating transaction.", ObjectID, connection.ObjectID);
             RuntimeHelpers.PrepareConstrainedRegions();
 
             try
@@ -106,7 +106,7 @@ namespace Microsoft.Data.SqlClient
 #endif //DEBUG
                     if (connection.IsEnlistedInTransaction)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Initialize|RES|CPOOL> {0}#, Connection {1}#, was enlisted, now defecting.", ObjectID, connection.ObjectID);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Initialize|RES|CPOOL> {0}, Connection {1}, was enlisted, now defecting.", ObjectID, connection.ObjectID);
 
                         // defect first
                         connection.EnlistNull();
@@ -168,7 +168,7 @@ namespace Microsoft.Data.SqlClient
             Exception promoteException;
             byte[] returnValue = null;
             SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}#, Connection {1}#, promoting transaction.", ObjectID, connection.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}, Connection {1}, promoting transaction.", ObjectID, connection.ObjectID);
             RuntimeHelpers.PrepareConstrainedRegions();
 
             try
@@ -268,7 +268,7 @@ namespace Microsoft.Data.SqlClient
 
             SqlInternalConnection connection = GetValidConnection();
             SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Rollback|RES|CPOOL> {0}#, Connection {1}#, aborting transaction.", ObjectID, connection.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Rollback|RES|CPOOL> {0}, Connection {1}, aborting transaction.", ObjectID, connection.ObjectID);
             RuntimeHelpers.PrepareConstrainedRegions();
 
             try
@@ -362,7 +362,7 @@ namespace Microsoft.Data.SqlClient
 
             SqlInternalConnection connection = GetValidConnection();
             SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.SinglePhaseCommit|RES|CPOOL> {0}#, Connection {1}#, committing transaction.", ObjectID, connection.ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.SinglePhaseCommit|RES|CPOOL> {0}, Connection {1}, committing transaction.", ObjectID, connection.ObjectID);
             RuntimeHelpers.PrepareConstrainedRegions();
 
             try
@@ -494,7 +494,7 @@ namespace Microsoft.Data.SqlClient
 
             if (connection != null)
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.TransactionEnded|RES|CPOOL> {0}#, Connection {1}#, transaction completed externally.", ObjectID, connection.ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.TransactionEnded|RES|CPOOL> {0}, Connection {1}, transaction completed externally.", ObjectID, connection.ObjectID);
 
                 lock (connection)
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Data.SqlClient
         [System.Security.Permissions.HostProtectionAttribute(ExternalThreading = true)]
         public SqlDependency(SqlCommand command, string options, int timeout)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency|DEP> {0}#, options: '{1}', timeout: '{2}'", ObjectID, options, timeout);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency|DEP> {0}#, options: '{1}', timeout: '{2}'", ObjectID, options, timeout);
             try
             {
                 if (InOutOfProcHelper.InProc)
@@ -339,7 +339,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -436,7 +436,7 @@ namespace Microsoft.Data.SqlClient
             // EventHandlers to be fired when dependency is notified.
             add
             {
-                long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.OnChange-Add|DEP> {0}#", ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Add|DEP> {0}#", ObjectID);
 
                 try
                 {
@@ -449,12 +449,12 @@ namespace Microsoft.Data.SqlClient
                             if (_dependencyFired)
                             {
                                 // If fired, fire the new event immediately.
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.OnChange-Add|DEP> Dependency already fired, firing new event.");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.OnChange-Add|DEP> Dependency already fired, firing new event.");
                                 sqlNotificationEvent = new SqlNotificationEventArgs(SqlNotificationType.Subscribe, SqlNotificationInfo.AlreadyChanged, SqlNotificationSource.Client);
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.OnChange-Add|DEP> Dependency has not fired, adding new event.");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.OnChange-Add|DEP> Dependency has not fired, adding new event.");
                                 EventContextPair pair = new EventContextPair(value, this);
                                 if (!_eventList.Contains(pair))
                                 {
@@ -475,12 +475,12 @@ namespace Microsoft.Data.SqlClient
                 }
                 finally
                 {
-                    SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                    SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
                 }
             }
             remove
             {
-                long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.OnChange-Remove|DEP> {0}#", ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Remove|DEP> {0}#", ObjectID);
                 try
                 {
                     if (null != value)
@@ -498,7 +498,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 finally
                 {
-                    SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                    SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
                 }
             }
         }
@@ -515,7 +515,7 @@ namespace Microsoft.Data.SqlClient
         {
             // Adds command to dependency collection so we automatically create the SqlNotificationsRequest object
             // and listen for a notification for the added commands.
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.AddCommandDependency|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandDependency|DEP> {0}#", ObjectID);
             try
             {
                 if (command == null)
@@ -527,7 +527,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -553,7 +553,7 @@ namespace Microsoft.Data.SqlClient
 
             if (nativeStorage == null)
             {
-                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP> nativeStorage null, obtaining dispatcher AppDomain and creating ProcessDispatcher.");
+                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP> nativeStorage null, obtaining dispatcher AppDomain and creating ProcessDispatcher.");
 
 #if DEBUG       // Possibly expensive, limit to debug.
                 SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> AppDomain.CurrentDomain.FriendlyName: {0}", AppDomain.CurrentDomain.FriendlyName);
@@ -582,25 +582,25 @@ namespace Microsoft.Data.SqlClient
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - ObjectHandle.Unwrap returned null!");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - ObjectHandle.Unwrap returned null!");
                             throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyObtainProcessDispatcherFailureObjectHandle);
                         }
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - AppDomain.CreateInstance returned null!");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - AppDomain.CreateInstance returned null!");
                         throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyProcessDispatcherFailureCreateInstance);
                     }
                 }
                 else
                 {
-                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - unable to obtain default AppDomain!");
+                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - unable to obtain default AppDomain!");
                     throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyProcessDispatcherFailureAppDomain);
                 }
             }
             else
             {
-                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP> nativeStorage not null, obtaining existing dispatcher AppDomain and ProcessDispatcher.");
+                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP> nativeStorage not null, obtaining existing dispatcher AppDomain and ProcessDispatcher.");
 
 #if DEBUG       // Possibly expensive, limit to debug.
                 SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> AppDomain.CurrentDomain.FriendlyName: {0}", AppDomain.CurrentDomain.FriendlyName);
@@ -655,7 +655,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static bool Start(string connectionString, string queue, bool useDefaults)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.Start|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.Start|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
             try
             {
                 // The following code exists in Stop as well.  It exists here to demand permissions as high in the stack
@@ -751,7 +751,7 @@ namespace Microsoft.Data.SqlClient
                                             }
 
                                             ADP.TraceExceptionWithoutRethrow(e); // Discard failure, but trace for now.
-                                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from Stop() after duplicate was found on Start().");
+                                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from Stop() after duplicate was found on Start().");
                                         }
                                         throw SQL.SqlDependencyDuplicateStart();
                                     }
@@ -788,7 +788,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -808,7 +808,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static bool Stop(string connectionString, string queue, bool useDefaults, bool startFailed)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.Stop|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.Stop|DEP> AppDomainKey: '{0}', queue: '{1}'", AppDomainKey, queue);
             try
             {
                 // The following code exists in Stop as well.  It exists here to demand permissions as high in the stack
@@ -918,7 +918,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -928,7 +928,7 @@ namespace Microsoft.Data.SqlClient
 
         private static bool AddToServerUserHash(string server, IdentityUserNamePair identityUser, DatabaseServicePair databaseService)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.AddToServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddToServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
             try
             {
                 bool result = false;
@@ -939,7 +939,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (!_serverUserHash.ContainsKey(server))
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash did not contain server, adding.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash did not contain server, adding.");
                         identityDatabaseHash = new Dictionary<IdentityUserNamePair, List<DatabaseServicePair>>();
                         _serverUserHash.Add(server, identityDatabaseHash);
                     }
@@ -952,7 +952,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (!identityDatabaseHash.ContainsKey(identityUser))
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash contained server but not user, adding user.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash contained server but not user, adding user.");
                         databaseServiceList = new List<DatabaseServicePair>();
                         identityDatabaseHash.Add(identityUser, databaseServiceList);
                     }
@@ -963,13 +963,13 @@ namespace Microsoft.Data.SqlClient
 
                     if (!databaseServiceList.Contains(databaseService))
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Adding database.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Adding database.");
                         databaseServiceList.Add(databaseService);
                         result = true;
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddToServerUserHash|DEP|ERR> ERROR - hash already contained server, user, and database - we will throw!.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP|ERR> ERROR - hash already contained server, user, and database - we will throw!.");
                     }
                 }
 
@@ -977,13 +977,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private static void RemoveFromServerUserHash(string server, IdentityUserNamePair identityUser, DatabaseServicePair databaseService)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> server: '{0}', database: '{1}', service: '{2}'", server, databaseService.Database, databaseService.Service);
             try
             {
                 lock (_serverUserHash)
@@ -1003,43 +1003,43 @@ namespace Microsoft.Data.SqlClient
                             int index = databaseServiceList.IndexOf(databaseService);
                             if (index >= 0)
                             {
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> Hash contained server, user, and database - removing database.");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> Hash contained server, user, and database - removing database.");
                                 databaseServiceList.RemoveAt(index);
 
                                 if (databaseServiceList.Count == 0)
                                 {
-                                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> databaseServiceList count 0, removing the list for this server and user.");
+                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> databaseServiceList count 0, removing the list for this server and user.");
                                     identityDatabaseHash.Remove(identityUser);
 
                                     if (identityDatabaseHash.Count == 0)
                                     {
-                                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> identityDatabaseHash count 0, removing the hash for this server.");
+                                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> identityDatabaseHash count 0, removing the hash for this server.");
                                         _serverUserHash.Remove(server);
                                     }
                                 }
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server and user but not database!");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server and user but not database!");
                                 Debug.Assert(false, "Unexpected state - hash did not contain database!");
                             }
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server but not user!");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server but not user!");
                             Debug.Assert(false, "Unexpected state - hash did not contain user!");
                         }
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash did not contain server!");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash did not contain server!");
                         Debug.Assert(false, "Unexpected state - hash did not contain server!");
                     }
                 }
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -1047,7 +1047,7 @@ namespace Microsoft.Data.SqlClient
         {
             // Server must be an exact match, but user and database only needs to match exactly if there is more than one 
             // for the given user or database passed.  That is ambiguious and we must fail.
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> server: '{0}', failoverServer: '{1}', database: '{2}'", server, failoverServer, database);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> server: '{0}', failoverServer: '{1}', database: '{2}'", server, failoverServer, database);
 
             try
             {
@@ -1060,17 +1060,17 @@ namespace Microsoft.Data.SqlClient
                         if (0 == _serverUserHash.Count)
                         {
                             // Special error for no calls to start.
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - no start calls have been made, about to throw.");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - no start calls have been made, about to throw.");
                             throw SQL.SqlDepDefaultOptionsButNoStart();
                         }
                         else if (!ADP.IsEmpty(failoverServer) && _serverUserHash.ContainsKey(failoverServer))
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP> using failover server instead\n");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP> using failover server instead\n");
                             server = failoverServer;
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening to this server, about to throw.");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening to this server, about to throw.");
                             throw SQL.SqlDependencyNoMatchingServerStart();
                         }
                     }
@@ -1083,7 +1083,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         if (identityDatabaseHash.Count > 1)
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening for this user, " +
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening for this user, " +
                                "but listening to more than one other user, about to throw.");
                             throw SQL.SqlDependencyNoMatchingServerStart();
                         }
@@ -1131,7 +1131,7 @@ namespace Microsoft.Data.SqlClient
                         else
                         {
                             // More than one database for given server, ambiguous - fail the default case!
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - SqlDependency.Start called multiple times for this server/user, but no matching database.");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - SqlDependency.Start called multiple times for this server/user, but no matching database.");
                             throw SQL.SqlDependencyNoMatchingServerDatabaseStart();
                         }
                     }
@@ -1143,7 +1143,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -1155,7 +1155,7 @@ namespace Microsoft.Data.SqlClient
         // use this list for a reverse lookup based on server.
         internal void AddToServerList(string server)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.AddToServerList|DEP> {0}#, server: '{1}'", ObjectID, server);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddToServerList|DEP> {0}#, server: '{1}'", ObjectID, server);
             try
             {
                 lock (_serverList)
@@ -1172,7 +1172,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -1186,7 +1186,7 @@ namespace Microsoft.Data.SqlClient
 
         internal string ComputeHashAndAddToDispatcher(SqlCommand command)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
             try
             {
                 // Create a string representing the concatenation of the connection string, command text and .ToString on all parameter values.
@@ -1206,13 +1206,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         internal void Invalidate(SqlNotificationType type, SqlNotificationInfo info, SqlNotificationSource source)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.Invalidate|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.Invalidate|DEP> {0}#", ObjectID);
             try
             {
                 List<EventContextPair> eventList = null;
@@ -1230,12 +1230,12 @@ namespace Microsoft.Data.SqlClient
                             // raises Timeout event but before removing this event from the list. If notification is received from
                             // server in this case, we will hit this code path.
                             // It is safe to ignore this race condition because no event is sent to user and no leak happens.
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.Invalidate|DEP> ignore notification received after timeout!");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP> ignore notification received after timeout!");
                         }
                         else
                         {
                             Debug.Assert(false, "Received notification twice - we should never enter this state!");
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.Invalidate|DEP|ERR> ERROR - notification received twice - we should never enter this state!");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP|ERR> ERROR - notification received twice - we should never enter this state!");
                         }
                     }
                     else
@@ -1249,7 +1249,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (eventList != null)
                 {
-                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.Invalidate|DEP> Firing events.");
+                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP> Firing events.");
                     foreach (EventContextPair pair in eventList)
                     {
                         pair.Invoke(new SqlNotificationEventArgs(type, info, source));
@@ -1258,19 +1258,19 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is used by SqlCommand.
         internal void StartTimer(SqlNotificationRequest notificationRequest)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.StartTimer|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.StartTimer|DEP> {0}#", ObjectID);
             try
             {
                 if (_expirationTime == DateTime.MaxValue)
                 {
-                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.StartTimer|DEP> We've timed out, executing logic.");
+                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.StartTimer|DEP> We've timed out, executing logic.");
                     int seconds = SQL.SqlDependencyServerTimeout;
                     if (0 != _timeout)
                     {
@@ -1288,7 +1288,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -1301,7 +1301,7 @@ namespace Microsoft.Data.SqlClient
             if (cmd != null)
             {
                 // Don't bother with BID if command null.
-                long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.AddCommandInternal|DEP> {0}#, SqlCommand: {1}#", ObjectID, cmd.ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandInternal|DEP> {0}#, SqlCommand: {1}#", ObjectID, cmd.ObjectID);
                 try
                 {
                     SqlConnection connection = cmd.Connection;
@@ -1311,7 +1311,7 @@ namespace Microsoft.Data.SqlClient
                         // Fail if cmd has notification that is not already associated with this dependency.
                         if (cmd._sqlDep == null || cmd._sqlDep != this)
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - throwing command has existing SqlNotificationRequest exception.");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - throwing command has existing SqlNotificationRequest exception.");
                             throw SQL.SqlCommandHasExistingSqlNotificationRequest();
                         }
                     }
@@ -1343,7 +1343,7 @@ namespace Microsoft.Data.SqlClient
                                 if (0 == _eventList.Count)
                                 {
                                     // Keep logic just in case.
-                                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - firing events, though it is unexpected we have events at this point.");
+                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - firing events, though it is unexpected we have events at this point.");
                                     needToInvalidate = true; // Delay invalidation until outside of lock.
                                 }
                             }
@@ -1357,14 +1357,14 @@ namespace Microsoft.Data.SqlClient
                 }
                 finally
                 {
-                    SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                    SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
                 }
             }
         }
 
         private string ComputeCommandHash(string connectionString, SqlCommand command)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependency.ComputeCommandHash|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeCommandHash|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
             try
             {
                 // Create a string representing the concatenation of the connection string, the command text and .ToString on all its parameter values.
@@ -1426,7 +1426,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Data.SqlClient
         [System.Security.Permissions.HostProtectionAttribute(ExternalThreading = true)]
         public SqlDependency(SqlCommand command, string options, int timeout)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency|DEP> {0}#, options: '{1}', timeout: '{2}'", ObjectID, options, timeout);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency|DEP> {0}, options: '{1}', timeout: '{2}'", ObjectID, options, timeout);
             try
             {
                 if (InOutOfProcHelper.InProc)
@@ -436,7 +436,7 @@ namespace Microsoft.Data.SqlClient
             // EventHandlers to be fired when dependency is notified.
             add
             {
-                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Add|DEP> {0}#", ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Add|DEP> {0}", ObjectID);
 
                 try
                 {
@@ -449,12 +449,12 @@ namespace Microsoft.Data.SqlClient
                             if (_dependencyFired)
                             {
                                 // If fired, fire the new event immediately.
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.OnChange-Add|DEP> Dependency already fired, firing new event.");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.OnChange-Add|DEP> Dependency already fired, firing new event.");
                                 sqlNotificationEvent = new SqlNotificationEventArgs(SqlNotificationType.Subscribe, SqlNotificationInfo.AlreadyChanged, SqlNotificationSource.Client);
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.OnChange-Add|DEP> Dependency has not fired, adding new event.");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.OnChange-Add|DEP> Dependency has not fired, adding new event.");
                                 EventContextPair pair = new EventContextPair(value, this);
                                 if (!_eventList.Contains(pair))
                                 {
@@ -480,7 +480,7 @@ namespace Microsoft.Data.SqlClient
             }
             remove
             {
-                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Remove|DEP> {0}#", ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.OnChange-Remove|DEP> {0}", ObjectID);
                 try
                 {
                     if (null != value)
@@ -515,7 +515,7 @@ namespace Microsoft.Data.SqlClient
         {
             // Adds command to dependency collection so we automatically create the SqlNotificationsRequest object
             // and listen for a notification for the added commands.
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandDependency|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandDependency|DEP> {0}", ObjectID);
             try
             {
                 if (command == null)
@@ -553,10 +553,10 @@ namespace Microsoft.Data.SqlClient
 
             if (nativeStorage == null)
             {
-                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP> nativeStorage null, obtaining dispatcher AppDomain and creating ProcessDispatcher.");
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> nativeStorage null, obtaining dispatcher AppDomain and creating ProcessDispatcher.");
 
 #if DEBUG       // Possibly expensive, limit to debug.
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> AppDomain.CurrentDomain.FriendlyName: {0}", AppDomain.CurrentDomain.FriendlyName);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> AppDomain.CurrentDomain.FriendlyName: {0}", AppDomain.CurrentDomain.FriendlyName);
 
 #endif
                 _AppDomain masterDomain = SNINativeMethodWrapper.GetDefaultAppDomain();
@@ -582,33 +582,33 @@ namespace Microsoft.Data.SqlClient
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - ObjectHandle.Unwrap returned null!");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - ObjectHandle.Unwrap returned null!");
                             throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyObtainProcessDispatcherFailureObjectHandle);
                         }
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - AppDomain.CreateInstance returned null!");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - AppDomain.CreateInstance returned null!");
                         throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyProcessDispatcherFailureCreateInstance);
                     }
                 }
                 else
                 {
-                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - unable to obtain default AppDomain!");
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - unable to obtain default AppDomain!");
                     throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyProcessDispatcherFailureAppDomain);
                 }
             }
             else
             {
-                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.ObtainProcessDispatcher|DEP> nativeStorage not null, obtaining existing dispatcher AppDomain and ProcessDispatcher.");
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> nativeStorage not null, obtaining existing dispatcher AppDomain and ProcessDispatcher.");
 
 #if DEBUG       // Possibly expensive, limit to debug.
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> AppDomain.CurrentDomain.FriendlyName: {0}", AppDomain.CurrentDomain.FriendlyName);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> AppDomain.CurrentDomain.FriendlyName: {0}", AppDomain.CurrentDomain.FriendlyName);
 #endif
                 BinaryFormatter formatter = new BinaryFormatter();
                 MemoryStream stream = new MemoryStream(nativeStorage);
                 _processDispatcher = GetDeserializedObject(formatter, stream); // Deserialize and set for appdomain.
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> processDispatcher obtained, ID: {0}", _processDispatcher.ObjectID);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> processDispatcher obtained, ID: {0}", _processDispatcher.ObjectID);
             }
         }
 
@@ -729,7 +729,7 @@ namespace Microsoft.Data.SqlClient
                                                                              out errorOccurred,
                                                                              out appDomainStart);
 
-                                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.Start|DEP> Start (defaults) returned: '{0}', with service: '{1}', server: '{2}', database: '{3}'", result, service, server, database);
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Start|DEP> Start (defaults) returned: '{0}', with service: '{1}', server: '{2}', database: '{3}'", result, service, server, database);
                             }
                             finally
                             {
@@ -751,7 +751,7 @@ namespace Microsoft.Data.SqlClient
                                             }
 
                                             ADP.TraceExceptionWithoutRethrow(e); // Discard failure, but trace for now.
-                                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from Stop() after duplicate was found on Start().");
+                                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from Stop() after duplicate was found on Start().");
                                         }
                                         throw SQL.SqlDependencyDuplicateStart();
                                     }
@@ -764,7 +764,7 @@ namespace Microsoft.Data.SqlClient
                                                               queue,
                                                               _appDomainKey,
                                                               SqlDependencyPerAppDomainDispatcher.SingletonInstance);
-                            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.Start|DEP> Start (user provided queue) returned: '{0}'", result);
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Start|DEP> Start (user provided queue) returned: '{0}'", result);
 
                             // No need to call AddToServerDatabaseHash since if not using default queue user is required
                             // to provide options themselves.
@@ -779,7 +779,7 @@ namespace Microsoft.Data.SqlClient
 
                         ADP.TraceExceptionWithoutRethrow(e); // Discard failure, but trace for now.
 
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from _processDispatcher.Start(...), calling Invalidate(...).");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Start|DEP|ERR> Exception occurred from _processDispatcher.Start(...), calling Invalidate(...).");
                         throw;
                     }
                 }
@@ -939,7 +939,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (!_serverUserHash.ContainsKey(server))
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash did not contain server, adding.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddToServerUserHash|DEP> Hash did not contain server, adding.");
                         identityDatabaseHash = new Dictionary<IdentityUserNamePair, List<DatabaseServicePair>>();
                         _serverUserHash.Add(server, identityDatabaseHash);
                     }
@@ -952,7 +952,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (!identityDatabaseHash.ContainsKey(identityUser))
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Hash contained server but not user, adding user.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddToServerUserHash|DEP> Hash contained server but not user, adding user.");
                         databaseServiceList = new List<DatabaseServicePair>();
                         identityDatabaseHash.Add(identityUser, databaseServiceList);
                     }
@@ -963,13 +963,13 @@ namespace Microsoft.Data.SqlClient
 
                     if (!databaseServiceList.Contains(databaseService))
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP> Adding database.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddToServerUserHash|DEP> Adding database.");
                         databaseServiceList.Add(databaseService);
                         result = true;
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddToServerUserHash|DEP|ERR> ERROR - hash already contained server, user, and database - we will throw!.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddToServerUserHash|DEP|ERR> ERROR - hash already contained server, user, and database - we will throw!.");
                     }
                 }
 
@@ -1003,36 +1003,36 @@ namespace Microsoft.Data.SqlClient
                             int index = databaseServiceList.IndexOf(databaseService);
                             if (index >= 0)
                             {
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> Hash contained server, user, and database - removing database.");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> Hash contained server, user, and database - removing database.");
                                 databaseServiceList.RemoveAt(index);
 
                                 if (databaseServiceList.Count == 0)
                                 {
-                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> databaseServiceList count 0, removing the list for this server and user.");
+                                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> databaseServiceList count 0, removing the list for this server and user.");
                                     identityDatabaseHash.Remove(identityUser);
 
                                     if (identityDatabaseHash.Count == 0)
                                     {
-                                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP> identityDatabaseHash count 0, removing the hash for this server.");
+                                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP> identityDatabaseHash count 0, removing the hash for this server.");
                                         _serverUserHash.Remove(server);
                                     }
                                 }
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server and user but not database!");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server and user but not database!");
                                 Debug.Assert(false, "Unexpected state - hash did not contain database!");
                             }
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server but not user!");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash contained server but not user!");
                             Debug.Assert(false, "Unexpected state - hash did not contain user!");
                         }
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash did not contain server!");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.RemoveFromServerUserHash|DEP|ERR> ERROR - hash did not contain server!");
                         Debug.Assert(false, "Unexpected state - hash did not contain server!");
                     }
                 }
@@ -1060,17 +1060,17 @@ namespace Microsoft.Data.SqlClient
                         if (0 == _serverUserHash.Count)
                         {
                             // Special error for no calls to start.
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - no start calls have been made, about to throw.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - no start calls have been made, about to throw.");
                             throw SQL.SqlDepDefaultOptionsButNoStart();
                         }
                         else if (!ADP.IsEmpty(failoverServer) && _serverUserHash.ContainsKey(failoverServer))
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP> using failover server instead\n");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> using failover server instead\n");
                             server = failoverServer;
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening to this server, about to throw.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening to this server, about to throw.");
                             throw SQL.SqlDependencyNoMatchingServerStart();
                         }
                     }
@@ -1083,7 +1083,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         if (identityDatabaseHash.Count > 1)
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening for this user, " +
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - not listening for this user, " +
                                "but listening to more than one other user, about to throw.");
                             throw SQL.SqlDependencyNoMatchingServerStart();
                         }
@@ -1131,14 +1131,14 @@ namespace Microsoft.Data.SqlClient
                         else
                         {
                             // More than one database for given server, ambiguous - fail the default case!
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - SqlDependency.Start called multiple times for this server/user, but no matching database.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - SqlDependency.Start called multiple times for this server/user, but no matching database.");
                             throw SQL.SqlDependencyNoMatchingServerDatabaseStart();
                         }
                     }
                 }
 
                 Debug.Assert(!ADP.IsEmpty(result), "GetDefaultComposedOptions should never return null or empty string!");
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> resulting options: '{0}'.", result);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP> resulting options: '{0}'.", result);
                 return result;
             }
             finally
@@ -1155,7 +1155,7 @@ namespace Microsoft.Data.SqlClient
         // use this list for a reverse lookup based on server.
         internal void AddToServerList(string server)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddToServerList|DEP> {0}#, server: '{1}'", ObjectID, server);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddToServerList|DEP> {0}, server: '{1}'", ObjectID, server);
             try
             {
                 lock (_serverList)
@@ -1164,7 +1164,7 @@ namespace Microsoft.Data.SqlClient
                     if (0 > index)
                     {
                         // If less than 0, item was not found in list.
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.AddToServerList|DEP> Server not present in hashtable, adding server: '{0}'.", server);
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddToServerList|DEP> Server not present in hashtable, adding server: '{0}'.", server);
                         index = ~index; // BinarySearch returns the 2's compliment of where the item should be inserted to preserver a sorted list after insertion.
                         _serverList.Insert(index, server);
                     }
@@ -1186,7 +1186,7 @@ namespace Microsoft.Data.SqlClient
 
         internal string ComputeHashAndAddToDispatcher(SqlCommand command)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> {0}, SqlCommand: {1}", ObjectID, command.ObjectID);
             try
             {
                 // Create a string representing the concatenation of the connection string, command text and .ToString on all parameter values.
@@ -1201,7 +1201,7 @@ namespace Microsoft.Data.SqlClient
                 string commandHash = ComputeCommandHash(command.Connection.ConnectionString, command); // calculate the string representation of command
 
                 string idString = SqlDependencyPerAppDomainDispatcher.SingletonInstance.AddCommandEntry(commandHash, this); // Add to map.
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> computed id string: '{0}'.", idString);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ComputeHashAndAddToDispatcher|DEP> computed id string: '{0}'.", idString);
                 return idString;
             }
             finally
@@ -1212,7 +1212,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Invalidate(SqlNotificationType type, SqlNotificationInfo info, SqlNotificationSource source)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.Invalidate|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.Invalidate|DEP> {0}", ObjectID);
             try
             {
                 List<EventContextPair> eventList = null;
@@ -1230,12 +1230,12 @@ namespace Microsoft.Data.SqlClient
                             // raises Timeout event but before removing this event from the list. If notification is received from
                             // server in this case, we will hit this code path.
                             // It is safe to ignore this race condition because no event is sent to user and no leak happens.
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP> ignore notification received after timeout!");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Invalidate|DEP> ignore notification received after timeout!");
                         }
                         else
                         {
                             Debug.Assert(false, "Received notification twice - we should never enter this state!");
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP|ERR> ERROR - notification received twice - we should never enter this state!");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Invalidate|DEP|ERR> ERROR - notification received twice - we should never enter this state!");
                         }
                     }
                     else
@@ -1249,7 +1249,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (eventList != null)
                 {
-                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.Invalidate|DEP> Firing events.");
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.Invalidate|DEP> Firing events.");
                     foreach (EventContextPair pair in eventList)
                     {
                         pair.Invoke(new SqlNotificationEventArgs(type, info, source));
@@ -1265,12 +1265,12 @@ namespace Microsoft.Data.SqlClient
         // This method is used by SqlCommand.
         internal void StartTimer(SqlNotificationRequest notificationRequest)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.StartTimer|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.StartTimer|DEP> {0}", ObjectID);
             try
             {
                 if (_expirationTime == DateTime.MaxValue)
                 {
-                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.StartTimer|DEP> We've timed out, executing logic.");
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.StartTimer|DEP> We've timed out, executing logic.");
                     int seconds = SQL.SqlDependencyServerTimeout;
                     if (0 != _timeout)
                     {
@@ -1301,7 +1301,7 @@ namespace Microsoft.Data.SqlClient
             if (cmd != null)
             {
                 // Don't bother with BID if command null.
-                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandInternal|DEP> {0}#, SqlCommand: {1}#", ObjectID, cmd.ObjectID);
+                long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.AddCommandInternal|DEP> {0}, SqlCommand: {1}", ObjectID, cmd.ObjectID);
                 try
                 {
                     SqlConnection connection = cmd.Connection;
@@ -1311,7 +1311,7 @@ namespace Microsoft.Data.SqlClient
                         // Fail if cmd has notification that is not already associated with this dependency.
                         if (cmd._sqlDep == null || cmd._sqlDep != this)
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - throwing command has existing SqlNotificationRequest exception.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - throwing command has existing SqlNotificationRequest exception.");
                             throw SQL.SqlCommandHasExistingSqlNotificationRequest();
                         }
                     }
@@ -1343,7 +1343,7 @@ namespace Microsoft.Data.SqlClient
                                 if (0 == _eventList.Count)
                                 {
                                     // Keep logic just in case.
-                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - firing events, though it is unexpected we have events at this point.");
+                                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - firing events, though it is unexpected we have events at this point.");
                                     needToInvalidate = true; // Delay invalidation until outside of lock.
                                 }
                             }
@@ -1364,7 +1364,7 @@ namespace Microsoft.Data.SqlClient
 
         private string ComputeCommandHash(string connectionString, SqlCommand command)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeCommandHash|DEP> {0}#, SqlCommand: {1}#", ObjectID, command.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependency.ComputeCommandHash|DEP> {0}, SqlCommand: {1}", ObjectID, command.ObjectID);
             try
             {
                 // Create a string representing the concatenation of the connection string, the command text and .ToString on all its parameter values.
@@ -1421,7 +1421,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 string result = builder.ToString();
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependency.ComputeCommandHash|DEP> ComputeCommandHash result: '{0}'.", result);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependency.ComputeCommandHash|DEP> ComputeCommandHash result: '{0}'.", result);
                 return result;
             }
             finally

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -78,7 +78,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         // -----------
         internal SqlConnectionContainer(SqlConnectionContainerHashHelper hashHelper, string appDomainKey, bool useDefaults)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer|DEP> {0}#, queue: '{1}'", ObjectID, HashHelper?.Queue);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer|DEP> {0}, queue: '{1}'", ObjectID, HashHelper?.Queue);
             bool setupCompleted = false;
 
             try
@@ -101,7 +101,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
 #if DEBUG
                 SqlConnectionString connectionStringOptions = new SqlConnectionString(_hashHelper.ConnectionStringBuilder.ConnectionString);
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
 #endif
 
                 // Always use ConnectionStringBuilder since in default case it is different from the 
@@ -276,7 +276,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         // SqlDependencyProcessDispatcher.QueueAppDomainUnload on AppDomain.Unload.
         internal bool AppDomainUnload(string appDomainKey)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> {0}#, AppDomainKey: '{1}'", ObjectID, appDomainKey);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> {0}, AppDomainKey: '{1}'", ObjectID, appDomainKey);
             try
             {
                 Debug.Assert(!ADP.IsEmpty(appDomainKey), "Unexpected empty appDomainKey!");
@@ -288,9 +288,9 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     if (_appDomainKeyHash.ContainsKey(appDomainKey))
                     {
                         // Do nothing if AppDomain did not call Start!
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash contained AppDomainKey: '{0}'.", appDomainKey);
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash contained AppDomainKey: '{0}'.", appDomainKey);
                         int value = _appDomainKeyHash[appDomainKey];
-                        SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash for AppDomainKey: '{0}' count: '{1}'.", appDomainKey, value);
+                        SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash for AppDomainKey: '{0}' count: '{1}'.", appDomainKey, value);
                         Debug.Assert(value > 0, "Why is value 0 or less?");
 
                         bool ignored = false;
@@ -307,15 +307,15 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
                         if (_appDomainKeyHash.ContainsKey(appDomainKey))
                         {
-                            SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP|ERR> ERROR - after the Stop() loop, _appDomainKeyHash for AppDomainKey: '{0}' entry not removed from hash.  Count: {1}'", appDomainKey, _appDomainKeyHash[appDomainKey]);
+                            SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP|ERR> ERROR - after the Stop() loop, _appDomainKeyHash for AppDomainKey: '{0}' entry not removed from hash.  Count: {1}'", appDomainKey, _appDomainKeyHash[appDomainKey]);
                         }
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash did not contain AppDomainKey: '{0}'.", appDomainKey);
+                        SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> _appDomainKeyHash did not contain AppDomainKey: '{0}'.", appDomainKey);
                     }
                 }
-                SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> Exiting, _stopped: '{0}'.", _stopped);
+                SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.AppDomainUnload|DEP> Exiting, _stopped: '{0}'.", _stopped);
                 return _stopped;
             }
             finally
@@ -326,7 +326,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void AsynchronouslyQueryServiceBrokerQueue()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsynchronouslyQueryServiceBrokerQueue|DEP> {0}", ObjectID);
             try
             {
                 AsyncCallback callback = new AsyncCallback(AsyncResultCallback);
@@ -340,7 +340,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void AsyncResultCallback(IAsyncResult asyncResult)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> {0}", ObjectID);
             try
             {
                 using (SqlDataReader reader = _com.EndExecuteReader(asyncResult))
@@ -366,7 +366,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     _errorState = true;
                     throw;
                 }
-                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> Exception occurred.");
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> Exception occurred.");
 
                 if (!_stop)
                 { // Only assert if not in cancel path.
@@ -392,7 +392,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void CreateQueueAndService(bool restart)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.CreateQueueAndService|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.CreateQueueAndService|DEP> {0}", ObjectID);
             try
             {
                 SqlCommand com = new SqlCommand();
@@ -528,12 +528,12 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         internal void IncrementStartCount(string appDomainKey, out bool appDomainStart)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> {0}", ObjectID);
             try
             {
                 appDomainStart = false; // Reset out param.
                 int result = Interlocked.Increment(ref _startCount); // Add to refCount.
-                SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.IncrementStartCount|DEP> {0}#, incremented _startCount: {1}", _staticInstance.ObjectID, result);
+                SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.IncrementStartCount|DEP> {0}, incremented _startCount: {1}", _staticInstance.ObjectID, result);
 
                 // Dictionary used to track how many times start has been called per app domain.
                 // For each increment, add to count, and create entry if not present.
@@ -542,13 +542,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     if (_appDomainKeyHash.ContainsKey(appDomainKey))
                     {
                         _appDomainKeyHash[appDomainKey] = _appDomainKeyHash[appDomainKey] + 1;
-                        SqlClientEventSource.Log.NotificationsTraceEvent("SqlConnectionContainer.IncrementStartCount|DEP> _appDomainKeyHash contained AppDomainKey: '{0}', incremented count: '{1}'.", appDomainKey, _appDomainKeyHash[appDomainKey]);
+                        SqlClientEventSource.Log.NotificationTraceEvent("SqlConnectionContainer.IncrementStartCount|DEP> _appDomainKeyHash contained AppDomainKey: '{0}', incremented count: '{1}'.", appDomainKey, _appDomainKeyHash[appDomainKey]);
                     }
                     else
                     {
                         _appDomainKeyHash[appDomainKey] = 1;
                         appDomainStart = true;
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> _appDomainKeyHash did not contain AppDomainKey: '{0}', added to hashtable and value set to 1.", appDomainKey);
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> _appDomainKeyHash did not contain AppDomainKey: '{0}', added to hashtable and value set to 1.", appDomainKey);
                     }
                 }
             }
@@ -560,7 +560,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void ProcessNotificationResults(SqlDataReader reader)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> {0}", ObjectID);
             try
             {
                 Guid handle = Guid.Empty; // Conversation_handle.  Always close this!
@@ -570,18 +570,18 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     {
                         while (reader.Read())
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Row read.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Row read.");
 #if DEBUG
                             if (SqlClientEventSource.Log.IsNotificationTraceEnabled())
                             {
                                 for (int i = 0; i < reader.FieldCount; i++)
                                 {
-                                    SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> column: {0}, value: {1}", reader.GetName(i), reader.GetValue(i).ToString());
+                                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> column: {0}, value: {1}", reader.GetName(i), reader.GetValue(i).ToString());
                                 }
                             }
 #endif
                             string msgType = reader.GetString(0);
-                            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> msgType: '{0}'", msgType);
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> msgType: '{0}'", msgType);
                             handle = reader.GetGuid(1);
 
                             // Only process QueryNotification messages.
@@ -594,7 +594,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                     if (null != notification)
                                     {
                                         string key = notification.Key;
-                                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Key: '{0}'", key);
+                                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Key: '{0}'", key);
                                         int index = key.IndexOf(';'); // Our format is simple: "AppDomainKey;commandHash"
 
                                         if (index >= 0)
@@ -623,25 +623,25 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                             else
                                             {
                                                 Debug.Assert(false, "Received notification but do not have an associated PerAppDomainDispatcher!");
-                                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Received notification but do not have an associated PerAppDomainDispatcher!");
+                                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Received notification but do not have an associated PerAppDomainDispatcher!");
                                             }
                                         }
                                         else
                                         {
                                             Debug.Assert(false, "Unexpected ID format received!");
-                                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Unexpected ID format received!");
+                                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Unexpected ID format received!");
                                         }
                                     }
                                     else
                                     {
                                         Debug.Assert(false, "Null notification returned from ProcessMessage!");
-                                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null notification returned from ProcessMessage!");
+                                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null notification returned from ProcessMessage!");
                                     }
                                 }
                                 else
                                 {
                                     Debug.Assert(false, "Null payload for QN notification type!");
-                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null payload for QN notification type!");
+                                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null payload for QN notification type!");
                                 }
                             }
                             else
@@ -649,7 +649,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                 handle = Guid.Empty;
                                 // VSDD 546707: this assert was hit by SQL Notification fuzzing tests, disable it to let these tests run on Debug bits
                                 // Debug.Assert(false, "Unexpected message format received!");
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Unexpected message format received!");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Unexpected message format received!");
                             }
                         }
                     }
@@ -692,7 +692,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         private void Restart(object unused)
         {
             // Unused arg required by TimerCallback.
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Restart|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Restart|DEP> {0}", ObjectID);
             try
             {
                 try
@@ -860,7 +860,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         internal bool Stop(string appDomainKey, out bool appDomainStop)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Stop|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Stop|DEP> {0}", ObjectID);
             try
             {
                 appDomainStop = false;
@@ -880,7 +880,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                             int value = _appDomainKeyHash[appDomainKey];
 
                             Debug.Assert(value > 0, "Unexpected count for appDomainKey");
-                            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> _appDomainKeyHash contained AppDomainKey: '{0}', pre-decrement Count: '{1}'.", appDomainKey, value);
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> _appDomainKeyHash contained AppDomainKey: '{0}', pre-decrement Count: '{1}'.", appDomainKey, value);
 
                             if (value > 0)
                             {
@@ -888,7 +888,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR pre-decremented count <= 0!");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR pre-decremented count <= 0!");
                                 Debug.Assert(false, "Unexpected AppDomainKey count in Stop()");
                             }
 
@@ -900,7 +900,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR appDomainKey not null and not found in hash!");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR appDomainKey not null and not found in hash!");
                             Debug.Assert(false, "Unexpected state on Stop() - no AppDomainKey entry in hashtable!");
                         }
                     }
@@ -913,7 +913,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 {
                     // If we've reached refCount 0, destroy.
                     // Lock to ensure Cancel() complete prior to other thread calling TearDown.
-                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP> Reached 0 count, cancelling and waiting.");
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> Reached 0 count, cancelling and waiting.");
 
                     lock (this)
                     {
@@ -957,7 +957,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                             // TearDownAndDispose in the maximum retry period case as well as in the _errorState case.
                             if (_errorState || retryStopwatch.Elapsed.Seconds >= 30)
                             {
-                                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.Stop|DEP|ERR> forcing cleanup. elapsedSeconds: '{0}', _errorState: '{1}'.", retryStopwatch.Elapsed.Seconds, _errorState);
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP|ERR> forcing cleanup. elapsedSeconds: '{0}', _errorState: '{1}'.", retryStopwatch.Elapsed.Seconds, _errorState);
                                 Timer retryTimer = _retryTimer;
                                 _retryTimer = null;
                                 if (retryTimer != null)
@@ -976,7 +976,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 }
                 else
                 {
-                    SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> _startCount not 0 after decrement.  _startCount: '{0}'.", _startCount);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> _startCount not 0 after decrement.  _startCount: '{0}'.", _startCount);
                 }
 
                 Debug.Assert(0 <= _startCount, "Invalid start count state");
@@ -991,7 +991,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
         private void SynchronouslyQueryServiceBrokerQueue()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.SynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.SynchronouslyQueryServiceBrokerQueue|DEP> {0}", ObjectID);
 
             try
             {
@@ -1009,7 +1009,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         [SuppressMessage("Microsoft.Security", "CA2100:ReviewSqlQueriesForSecurityVulnerabilities")]
         private void TearDownAndDispose()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.TearDownAndDispose|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.TearDownAndDispose|DEP> {0}", ObjectID);
 
             try
             {
@@ -1227,42 +1227,42 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                         catch (ArgumentException e)
                         {
                             ADP.TraceExceptionWithoutRethrow(e); // Discard failure, but trace.
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> Exception thrown - Enum.Parse failed to parse the value '{0}' of the attribute '{1}'.", xmlReader.Value, xmlReader.LocalName);
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> Exception thrown - Enum.Parse failed to parse the value '{0}' of the attribute '{1}'.", xmlReader.Value, xmlReader.LocalName);
                             return null;
                         }
                     }
 
                     if (MessageAttributes.All != messageAttributes)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> Not all expected attributes in Message; messageAttributes = '{0}'.", (int)messageAttributes);
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> Not all expected attributes in Message; messageAttributes = '{0}'.", (int)messageAttributes);
                         return null;
                     }
 
                     // Proceed to the "Message" node.
                     if (!xmlReader.Read())
                     {
-                        SqlClientEventSource.Log.TraceEvent("<Sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<Sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
                         return null;
                     }
 
                     // Verify state after Read().
                     if ((XmlNodeType.Element != xmlReader.NodeType) || (0 != string.Compare(xmlReader.LocalName, MessageNode, StringComparison.OrdinalIgnoreCase)))
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
                         return null;
                     }
 
                     // Proceed to the Text Node.
                     if (!xmlReader.Read())
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
                         return null;
                     }
 
                     // Verify state after Read().
                     if (xmlReader.NodeType != XmlNodeType.Text)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
                         return null;
                     }
 
@@ -1272,7 +1272,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                         // Proceed to the Text Node.
                         if (!xmlMessageReader.Read())
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
                             return null;
                         }
 
@@ -1283,7 +1283,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                         }
                         else
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
                             return null;
                         }
                     }
@@ -1292,7 +1292,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 }
                 else
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
                     return null; // failure
                 }
             }
@@ -1472,12 +1472,12 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     private SqlDependencyProcessDispatcher(object dummyVariable)
     {
         Debug.Assert(null == _staticInstance, "Real constructor called with static instance already created!");
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}", ObjectID);
         try
         {
 #if DEBUG
             // Possibly expensive, limit to debug.
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
 #endif
             _connectionContainers = new Dictionary<SqlConnectionContainerHashHelper, SqlConnectionContainer>();
             _sqlDependencyPerAppDomainDispatchers = new Dictionary<string, SqlDependencyPerAppDomainDispatcher>();
@@ -1492,13 +1492,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     // Required to be public, even on internal class, for Remoting infrastructure.
     public SqlDependencyProcessDispatcher()
     {
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}", ObjectID);
         try
         {
             // Empty constructor and object - dummy to obtain singleton.
 #if DEBUG
             // Possibly expensive, limit to debug.
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}, AppDomain.CurrentDomain.FriendlyName: {1}", ObjectID, AppDomain.CurrentDomain.FriendlyName);
 #endif
         }
         finally
@@ -1529,7 +1529,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                                                   out string user,
                                                                       string queue)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.GetHashString|DEP> {0}#, queue: {1}", _staticInstance.ObjectID, queue);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.GetHashString|DEP> {0}, queue: {1}", _staticInstance.ObjectID, queue);
         try
         {
             // Force certain connection string properties to be used by SqlDependencyProcessDispatcher.  
@@ -1574,7 +1574,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
     private void Invalidate(string server, SqlNotification sqlNotification)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Invalidate|DEP> {0}#, server: {1}", ObjectID, server);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Invalidate|DEP> {0}, server: {1}", ObjectID, server);
         try
         {
             Debug.Assert(this == _staticInstance, "Instance method called on non _staticInstance instance!");
@@ -1623,7 +1623,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     // This method is only called by queued work-items from the method above.
     private void AppDomainUnloading(object state)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.AppDomainUnloading|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.AppDomainUnloading|DEP> {0}", ObjectID);
         try
         {
             string appDomainKey = (string)state;
@@ -1722,7 +1722,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                        out bool appDomainStart,
                            bool useDefaults)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, queue: '{1}', appDomainKey: '{2}', perAppDomainDispatcher ID: '{3}'", ObjectID, queueService, appDomainKey, dispatcher.ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, queue: '{1}', appDomainKey: '{2}', perAppDomainDispatcher ID: '{3}'", ObjectID, queueService, appDomainKey, dispatcher.ObjectID);
         try
         {
             Debug.Assert(this == _staticInstance, "Instance method called on non _staticInstance instance!");
@@ -1749,7 +1749,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                                                                          queueService);
 #if DEBUG
             SqlConnectionString connectionStringOptions = new SqlConnectionString(connectionStringBuilder.ConnectionString);
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
 #endif
 
             bool started = false;
@@ -1759,7 +1759,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             {
                 if (!_connectionContainers.ContainsKey(hashHelper))
                 {
-                    SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, hashtable miss, creating new container.", ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, hashtable miss, creating new container.", ObjectID);
                     container = new SqlConnectionContainer(hashHelper, appDomainKey, useDefaults);
                     _connectionContainers.Add(hashHelper, container);
                     started = true;
@@ -1768,10 +1768,10 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 else
                 {
                     container = _connectionContainers[hashHelper];
-                    SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, hashtable hit, container: {1}", ObjectID, container.ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, hashtable hit, container: {1}", ObjectID, container.ObjectID);
                     if (container.InErrorState)
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, container: {1} is in error state!", ObjectID, container.ObjectID);
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, container: {1} is in error state!", ObjectID, container.ObjectID);
                         errorOccurred = true; // Set outparam errorOccurred true so we invalidate on Start().
                     }
                     else
@@ -1786,10 +1786,10 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 server = container.Server;
                 database = container.Database;
                 queueService = container.Queue;
-                SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, default service: '{1}', server: '{2}', database: '{3}'", ObjectID, queueService, server, database);
+                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, default service: '{1}', server: '{2}', database: '{3}'", ObjectID, queueService, server, database);
             }
 
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, started: {1}", ObjectID, started);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}, started: {1}", ObjectID, started);
             return started;
         }
         finally
@@ -1811,7 +1811,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                            string appDomainKey,
                        out bool appDomainStop)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, queue: '{1}'", ObjectID, queueService);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}, queue: '{1}'", ObjectID, queueService);
         try
         {
             Debug.Assert(this == _staticInstance, "Instance method called on non _staticInstance instance!");
@@ -1829,7 +1829,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                                                                          queueService);
 #if DEBUG
             SqlConnectionString connectionStringOptions = new SqlConnectionString(connectionStringBuilder.ConnectionString);
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> Modified connection string: '{0}'", connectionStringOptions.UsersConnectionStringForTrace());
 #endif
 
             bool stopped = false;
@@ -1839,7 +1839,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 if (_connectionContainers.ContainsKey(hashHelper))
                 {
                     SqlConnectionContainer container = _connectionContainers[hashHelper];
-                    SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, hashtable hit, container: {1}", ObjectID, container.ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}, hashtable hit, container: {1}", ObjectID, container.ObjectID);
 
                     server = container.Server;   // Return server, database, and queue info for use by calling SqlDependency.
                     database = container.Database;
@@ -1852,11 +1852,11 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 }
                 else
                 {
-                    SqlClientEventSource.Log.NotificationsTraceEvent("<Sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, hashtable miss.", ObjectID);
+                    SqlClientEventSource.Log.NotificationTraceEvent("<Sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}, hashtable miss.", ObjectID);
                 }
             }
 
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, stopped: {1}", ObjectID, stopped);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}, stopped: {1}", ObjectID, stopped);
             return stopped;
         }
         finally

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -78,7 +78,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         // -----------
         internal SqlConnectionContainer(SqlConnectionContainerHashHelper hashHelper, string appDomainKey, bool useDefaults)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer|DEP> {0}#, queue: '{1}'", ObjectID, HashHelper?.Queue);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer|DEP> {0}#, queue: '{1}'", ObjectID, HashHelper?.Queue);
             bool setupCompleted = false;
 
             try
@@ -216,7 +216,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -276,7 +276,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         // SqlDependencyProcessDispatcher.QueueAppDomainUnload on AppDomain.Unload.
         internal bool AppDomainUnload(string appDomainKey)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> {0}#, AppDomainKey: '{1}'", ObjectID, appDomainKey);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AppDomainUnload|DEP> {0}#, AppDomainKey: '{1}'", ObjectID, appDomainKey);
             try
             {
                 Debug.Assert(!ADP.IsEmpty(appDomainKey), "Unexpected empty appDomainKey!");
@@ -320,13 +320,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void AsynchronouslyQueryServiceBrokerQueue()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.AsynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
             try
             {
                 AsyncCallback callback = new AsyncCallback(AsyncResultCallback);
@@ -334,13 +334,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void AsyncResultCallback(IAsyncResult asyncResult)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> {0}#", ObjectID);
             try
             {
                 using (SqlDataReader reader = _com.EndExecuteReader(asyncResult))
@@ -366,7 +366,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     _errorState = true;
                     throw;
                 }
-                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> Exception occurred.");
+                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.AsyncResultCallback|DEP> Exception occurred.");
 
                 if (!_stop)
                 { // Only assert if not in cancel path.
@@ -386,13 +386,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void CreateQueueAndService(bool restart)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.CreateQueueAndService|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.CreateQueueAndService|DEP> {0}#", ObjectID);
             try
             {
                 SqlCommand com = new SqlCommand();
@@ -522,13 +522,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         internal void IncrementStartCount(string appDomainKey, out bool appDomainStart)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.IncrementStartCount|DEP> {0}#", ObjectID);
             try
             {
                 appDomainStart = false; // Reset out param.
@@ -554,13 +554,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void ProcessNotificationResults(SqlDataReader reader)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> {0}#", ObjectID);
             try
             {
                 Guid handle = Guid.Empty; // Conversation_handle.  Always close this!
@@ -570,7 +570,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     {
                         while (reader.Read())
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Row read.");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Row read.");
 #if DEBUG
                             if (SqlClientEventSource.Log.IsNotificationTraceEnabled())
                             {
@@ -623,25 +623,25 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                             else
                                             {
                                                 Debug.Assert(false, "Received notification but do not have an associated PerAppDomainDispatcher!");
-                                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Received notification but do not have an associated PerAppDomainDispatcher!");
+                                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Received notification but do not have an associated PerAppDomainDispatcher!");
                                             }
                                         }
                                         else
                                         {
                                             Debug.Assert(false, "Unexpected ID format received!");
-                                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Unexpected ID format received!");
+                                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Unexpected ID format received!");
                                         }
                                     }
                                     else
                                     {
                                         Debug.Assert(false, "Null notification returned from ProcessMessage!");
-                                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null notification returned from ProcessMessage!");
+                                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null notification returned from ProcessMessage!");
                                     }
                                 }
                                 else
                                 {
                                     Debug.Assert(false, "Null payload for QN notification type!");
-                                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null payload for QN notification type!");
+                                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP|ERR> Null payload for QN notification type!");
                                 }
                             }
                             else
@@ -649,7 +649,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                 handle = Guid.Empty;
                                 // VSDD 546707: this assert was hit by SQL Notification fuzzing tests, disable it to let these tests run on Debug bits
                                 // Debug.Assert(false, "Unexpected message format received!");
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Unexpected message format received!");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.ProcessNotificationResults|DEP> Unexpected message format received!");
                             }
                         }
                     }
@@ -681,7 +681,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -692,7 +692,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         private void Restart(object unused)
         {
             // Unused arg required by TimerCallback.
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.Restart|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Restart|DEP> {0}#", ObjectID);
             try
             {
                 try
@@ -854,13 +854,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         internal bool Stop(string appDomainKey, out bool appDomainStop)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.Stop|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.Stop|DEP> {0}#", ObjectID);
             try
             {
                 appDomainStop = false;
@@ -888,7 +888,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR pre-decremented count <= 0!");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR pre-decremented count <= 0!");
                                 Debug.Assert(false, "Unexpected AppDomainKey count in Stop()");
                             }
 
@@ -900,7 +900,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                         }
                         else
                         {
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR appDomainKey not null and not found in hash!");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP|ERR> ERROR appDomainKey not null and not found in hash!");
                             Debug.Assert(false, "Unexpected state on Stop() - no AppDomainKey entry in hashtable!");
                         }
                     }
@@ -913,7 +913,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 {
                     // If we've reached refCount 0, destroy.
                     // Lock to ensure Cancel() complete prior to other thread calling TearDown.
-                    SqlClientEventSource.Log.NotificationsTrace("<sc.SqlConnectionContainer.Stop|DEP> Reached 0 count, cancelling and waiting.");
+                    SqlClientEventSource.Log.NotificationTrace("<sc.SqlConnectionContainer.Stop|DEP> Reached 0 count, cancelling and waiting.");
 
                     lock (this)
                     {
@@ -985,13 +985,13 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private void SynchronouslyQueryServiceBrokerQueue()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.SynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.SynchronouslyQueryServiceBrokerQueue|DEP> {0}#", ObjectID);
 
             try
             {
@@ -1002,14 +1002,14 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         [SuppressMessage("Microsoft.Security", "CA2100:ReviewSqlQueriesForSecurityVulnerabilities")]
         private void TearDownAndDispose()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlConnectionContainer.TearDownAndDispose|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlConnectionContainer.TearDownAndDispose|DEP> {0}#", ObjectID);
 
             try
             {
@@ -1083,7 +1083,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
     }
@@ -1472,7 +1472,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     private SqlDependencyProcessDispatcher(object dummyVariable)
     {
         Debug.Assert(null == _staticInstance, "Real constructor called with static instance already created!");
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
         try
         {
 #if DEBUG
@@ -1484,7 +1484,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1492,7 +1492,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     // Required to be public, even on internal class, for Remoting infrastructure.
     public SqlDependencyProcessDispatcher()
     {
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}#", ObjectID);
         try
         {
             // Empty constructor and object - dummy to obtain singleton.
@@ -1503,7 +1503,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1529,7 +1529,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                                                   out string user,
                                                                       string queue)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.GetHashString|DEP> {0}#, queue: {1}", _staticInstance.ObjectID, queue);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.GetHashString|DEP> {0}#, queue: {1}", _staticInstance.ObjectID, queue);
         try
         {
             // Force certain connection string properties to be used by SqlDependencyProcessDispatcher.  
@@ -1562,7 +1562,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1574,7 +1574,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
     private void Invalidate(string server, SqlNotification sqlNotification)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Invalidate|DEP> {0}#, server: {1}", ObjectID, server);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Invalidate|DEP> {0}#, server: {1}", ObjectID, server);
         try
         {
             Debug.Assert(this == _staticInstance, "Instance method called on non _staticInstance instance!");
@@ -1606,7 +1606,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1623,7 +1623,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     // This method is only called by queued work-items from the method above.
     private void AppDomainUnloading(object state)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.AppDomainUnloading|DEP> {0}#", ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.AppDomainUnloading|DEP> {0}#", ObjectID);
         try
         {
             string appDomainKey = (string)state;
@@ -1655,7 +1655,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1722,7 +1722,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                        out bool appDomainStart,
                            bool useDefaults)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, queue: '{1}', appDomainKey: '{2}', perAppDomainDispatcher ID: '{3}'", ObjectID, queueService, appDomainKey, dispatcher.ObjectID);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Start|DEP> {0}#, queue: '{1}', appDomainKey: '{2}', perAppDomainDispatcher ID: '{3}'", ObjectID, queueService, appDomainKey, dispatcher.ObjectID);
         try
         {
             Debug.Assert(this == _staticInstance, "Instance method called on non _staticInstance instance!");
@@ -1794,7 +1794,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 
@@ -1811,7 +1811,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                            string appDomainKey,
                        out bool appDomainStop)
     {
-        long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, queue: '{1}'", ObjectID, queueService);
+        long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher.Stop|DEP> {0}#, queue: '{1}'", ObjectID, queueService);
         try
         {
             Debug.Assert(this == _staticInstance, "Instance method called on non _staticInstance instance!");
@@ -1861,7 +1861,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
         }
         finally
         {
-            SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+            SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
         }
     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Data.SqlClient
 
         private SqlDependencyPerAppDomainDispatcher()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher|DEP> {0}#", ObjectID);
             try
             {
                 _dependencyIdToDependencyHash = new Dictionary<string, SqlDependency>();
@@ -106,7 +106,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Data.SqlClient
 
         private void UnloadEventHandler(object sender, EventArgs e)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.UnloadEventHandler|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.UnloadEventHandler|DEP> {0}#", ObjectID);
             try
             {
                 // Make non-blocking call to ProcessDispatcher to ThreadPool.QueueUserWorkItem to complete 
@@ -139,7 +139,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -150,7 +150,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called upon SqlDependency constructor.
         internal void AddDependencyEntry(SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddDependencyEntry|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddDependencyEntry|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
             try
             {
                 lock (this)
@@ -160,7 +160,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.Data.SqlClient
         internal string AddCommandEntry(string commandHash, SqlDependency dep)
         {
             string notificationId = string.Empty;
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> {0}#, commandHash: '{1}', SqlDependency: {2}#", ObjectID, commandHash, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> {0}#, commandHash: '{1}', SqlDependency: {2}#", ObjectID, commandHash, dep.ObjectID);
             try
             {
                 lock (this)
@@ -176,7 +176,7 @@ namespace Microsoft.Data.SqlClient
                     if (!_dependencyIdToDependencyHash.ContainsKey(dep.Id))
                     {
                         // Determine if depId->dep hashtable contains dependency.  If not, it's been invalidated.
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present in depId->dep hash, must have been invalidated.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present in depId->dep hash, must have been invalidated.");
                     }
                     else
                     {
@@ -197,12 +197,12 @@ namespace Microsoft.Data.SqlClient
                             // join the new dependency to the list
                             if (!dependencyList.Contains(dep))
                             {
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present for commandHash, adding.");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present for commandHash, adding.");
                                 dependencyList.Add(dep);
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency already present for commandHash.");
+                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency already present for commandHash.");
                             }
                         }
                         else
@@ -216,7 +216,7 @@ namespace Microsoft.Data.SqlClient
                                 SqlDependency.AppDomainKey, // must be first
                                 Guid.NewGuid().ToString("D", System.Globalization.CultureInfo.InvariantCulture)
                                 );
-                            SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Creating new Dependencies list for commandHash.");
+                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Creating new Dependencies list for commandHash.");
                             DependencyList dependencyList = new DependencyList(commandHash);
                             dependencyList.Add(dep);
 
@@ -238,7 +238,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
 
             return notificationId;
@@ -247,7 +247,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called by the ProcessDispatcher upon a notification for this AppDomain.
         internal void InvalidateCommandID(SqlNotification sqlNotification)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> {0}#, commandHash: '{1}'", ObjectID, sqlNotification.Key);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> {0}#, commandHash: '{1}'", ObjectID, sqlNotification.Key);
             try
             {
                 List<SqlDependency> dependencyList = null;
@@ -258,7 +258,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (null != dependencyList)
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash found in hashtable.");
                         foreach (SqlDependency dependency in dependencyList)
                         {
                             // Ensure we remove from process static app domain hash for dependency initiated invalidates.
@@ -270,7 +270,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash NOT found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash NOT found in hashtable.");
                     }
                 }
 
@@ -279,7 +279,7 @@ namespace Microsoft.Data.SqlClient
                     // After removal from hashtables, invalidate.
                     foreach (SqlDependency dependency in dependencyList)
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> Dependency found in commandHash dependency ArrayList - calling invalidate.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> Dependency found in commandHash dependency ArrayList - calling invalidate.");
                         try
                         {
                             dependency.Invalidate(sqlNotification.Type, sqlNotification.Info, sqlNotification.Source);
@@ -300,14 +300,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is called when a connection goes down or other unknown error occurs in the ProcessDispatcher.
         internal void InvalidateServer(string server, SqlNotification sqlNotification)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.Invalidate|DEP> {0}#, server: '{1}'", ObjectID, server);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.Invalidate|DEP> {0}#, server: '{1}'", ObjectID, server);
             try
             {
                 List<SqlDependency> dependencies = new List<SqlDependency>();
@@ -354,14 +354,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // This method is called by SqlCommand to enable ASP.NET scenarios - map from ID to Dependency.
         internal SqlDependency LookupDependencyEntry(string id)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}#, Key: '{1}'", ObjectID, id);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}#, Key: '{1}'", ObjectID, id);
             try
             {
                 if (null == id)
@@ -383,7 +383,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP|ERR> ERROR - dependency ID mismatch - not throwing.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP|ERR> ERROR - dependency ID mismatch - not throwing.");
                     }
                 }
 
@@ -391,21 +391,21 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // Remove the dependency from the hashtable with the passed id.
         private void LookupDependencyEntryWithRemove(string id)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> {0}#, id: '{1}'", ObjectID, id);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> {0}#, id: '{1}'", ObjectID, id);
             try
             {
                 lock (this)
                 {
                     if (_dependencyIdToDependencyHash.ContainsKey(id))
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry found in hashtable - removing.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry found in hashtable - removing.");
                         _dependencyIdToDependencyHash.Remove(id);
 
                         // if there are no more dependencies then we can dispose the timer.
@@ -417,20 +417,20 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry NOT found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry NOT found in hashtable.");
                     }
                 }
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // Find and return arraylist, and remove passed hash value.
         private List<SqlDependency> LookupCommandEntryWithRemove(string notificationId)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupCommandEntryWithRemove|DEP> {0}#, commandHash: '{1}'", ObjectID, notificationId);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupCommandEntryWithRemove|DEP> {0}#, commandHash: '{1}'", ObjectID, notificationId);
             try
             {
                 DependencyList entry = null;
@@ -439,7 +439,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (_notificationIdToDependenciesHash.TryGetValue(notificationId, out entry))
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries found in hashtable - removing.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries found in hashtable - removing.");
 
                         // update the tables - do it inside finally block to avoid ThreadAbort exception interrupt this operation
                         try
@@ -453,7 +453,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries NOT found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries NOT found in hashtable.");
                     }
 
                     Debug.Assert(_notificationIdToDependenciesHash.Count == _commandHashToNotificationId.Count, "always keep these maps in sync!");
@@ -463,14 +463,14 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         // Remove from commandToDependenciesHash all references to the passed dependency.
         private void RemoveDependencyFromCommandToDependenciesHash(SqlDependency dependency)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> {0}#, SqlDependency: {1}#", ObjectID, dependency.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> {0}#, SqlDependency: {1}#", ObjectID, dependency.ObjectID);
             try
             {
                 lock (this)
@@ -516,7 +516,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
@@ -526,7 +526,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void StartTimer(SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
             try
             {
                 // If this dependency expires sooner than the current next timeout, change
@@ -555,13 +555,13 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
 
         private static void TimeoutTimerCallback(object state)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationsScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> AppDomainKey: '{0}'", SqlDependency.AppDomainKey);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> AppDomainKey: '{0}'", SqlDependency.AppDomainKey);
             try
             {
                 SqlDependency[] dependencies;
@@ -574,12 +574,12 @@ namespace Microsoft.Data.SqlClient
                     if (0 == SingletonInstance._dependencyIdToDependencyHash.Count)
                     {
                         // Nothing to check.
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No dependencies, exiting.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No dependencies, exiting.");
                         return;
                     }
                     if (SingletonInstance._nextTimeout > DateTime.UtcNow)
                     {
-                        SqlClientEventSource.Log.NotificationsTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No timeouts expired, exiting.");
+                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No timeouts expired, exiting.");
 
                         // No dependency timed-out yet.
                         return;
@@ -650,7 +650,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                SqlClientEventSource.Log.NotificationsScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.NotificationScopeLeaveEvent(scopeID);
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Data.SqlClient
 
         private SqlDependencyPerAppDomainDispatcher()
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher|DEP> {0}", ObjectID);
             try
             {
                 _dependencyIdToDependencyHash = new Dictionary<string, SqlDependency>();
@@ -124,7 +124,7 @@ namespace Microsoft.Data.SqlClient
 
         private void UnloadEventHandler(object sender, EventArgs e)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.UnloadEventHandler|DEP> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.UnloadEventHandler|DEP> {0}", ObjectID);
             try
             {
                 // Make non-blocking call to ProcessDispatcher to ThreadPool.QueueUserWorkItem to complete 
@@ -150,7 +150,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called upon SqlDependency constructor.
         internal void AddDependencyEntry(SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddDependencyEntry|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddDependencyEntry|DEP> {0}, SqlDependency: {1}", ObjectID, dep.ObjectID);
             try
             {
                 lock (this)
@@ -168,7 +168,7 @@ namespace Microsoft.Data.SqlClient
         internal string AddCommandEntry(string commandHash, SqlDependency dep)
         {
             string notificationId = string.Empty;
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> {0}#, commandHash: '{1}', SqlDependency: {2}#", ObjectID, commandHash, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> {0}, commandHash: '{1}', SqlDependency: {2}", ObjectID, commandHash, dep.ObjectID);
             try
             {
                 lock (this)
@@ -176,7 +176,7 @@ namespace Microsoft.Data.SqlClient
                     if (!_dependencyIdToDependencyHash.ContainsKey(dep.Id))
                     {
                         // Determine if depId->dep hashtable contains dependency.  If not, it's been invalidated.
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present in depId->dep hash, must have been invalidated.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present in depId->dep hash, must have been invalidated.");
                     }
                     else
                     {
@@ -197,12 +197,12 @@ namespace Microsoft.Data.SqlClient
                             // join the new dependency to the list
                             if (!dependencyList.Contains(dep))
                             {
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present for commandHash, adding.");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency not present for commandHash, adding.");
                                 dependencyList.Add(dep);
                             }
                             else
                             {
-                                SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency already present for commandHash.");
+                                SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Dependency already present for commandHash.");
                             }
                         }
                         else
@@ -216,7 +216,7 @@ namespace Microsoft.Data.SqlClient
                                 SqlDependency.AppDomainKey, // must be first
                                 Guid.NewGuid().ToString("D", System.Globalization.CultureInfo.InvariantCulture)
                                 );
-                            SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Creating new Dependencies list for commandHash.");
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.AddCommandEntry|DEP> Creating new Dependencies list for commandHash.");
                             DependencyList dependencyList = new DependencyList(commandHash);
                             dependencyList.Add(dep);
 
@@ -247,7 +247,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called by the ProcessDispatcher upon a notification for this AppDomain.
         internal void InvalidateCommandID(SqlNotification sqlNotification)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> {0}#, commandHash: '{1}'", ObjectID, sqlNotification.Key);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> {0}, commandHash: '{1}'", ObjectID, sqlNotification.Key);
             try
             {
                 List<SqlDependency> dependencyList = null;
@@ -258,7 +258,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (null != dependencyList)
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash found in hashtable.");
                         foreach (SqlDependency dependency in dependencyList)
                         {
                             // Ensure we remove from process static app domain hash for dependency initiated invalidates.
@@ -270,7 +270,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash NOT found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> commandHash NOT found in hashtable.");
                     }
                 }
 
@@ -279,7 +279,7 @@ namespace Microsoft.Data.SqlClient
                     // After removal from hashtables, invalidate.
                     foreach (SqlDependency dependency in dependencyList)
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> Dependency found in commandHash dependency ArrayList - calling invalidate.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.InvalidateCommandID|DEP> Dependency found in commandHash dependency ArrayList - calling invalidate.");
                         try
                         {
                             dependency.Invalidate(sqlNotification.Type, sqlNotification.Info, sqlNotification.Source);
@@ -307,7 +307,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called when a connection goes down or other unknown error occurs in the ProcessDispatcher.
         internal void InvalidateServer(string server, SqlNotification sqlNotification)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.Invalidate|DEP> {0}#, server: '{1}'", ObjectID, server);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.Invalidate|DEP> {0}, server: '{1}'", ObjectID, server);
             try
             {
                 List<SqlDependency> dependencies = new List<SqlDependency>();
@@ -361,7 +361,7 @@ namespace Microsoft.Data.SqlClient
         // This method is called by SqlCommand to enable ASP.NET scenarios - map from ID to Dependency.
         internal SqlDependency LookupDependencyEntry(string id)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}#, Key: '{1}'", ObjectID, id);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}, Key: '{1}'", ObjectID, id);
             try
             {
                 if (null == id)
@@ -383,7 +383,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP|ERR> ERROR - dependency ID mismatch - not throwing.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP|ERR> ERROR - dependency ID mismatch - not throwing.");
                     }
                 }
 
@@ -398,14 +398,14 @@ namespace Microsoft.Data.SqlClient
         // Remove the dependency from the hashtable with the passed id.
         private void LookupDependencyEntryWithRemove(string id)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> {0}#, id: '{1}'", ObjectID, id);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> {0}, id: '{1}'", ObjectID, id);
             try
             {
                 lock (this)
                 {
                     if (_dependencyIdToDependencyHash.ContainsKey(id))
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry found in hashtable - removing.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry found in hashtable - removing.");
                         _dependencyIdToDependencyHash.Remove(id);
 
                         // if there are no more dependencies then we can dispose the timer.
@@ -417,7 +417,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry NOT found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntryWithRemove|DEP> Entry NOT found in hashtable.");
                     }
                 }
             }
@@ -430,7 +430,7 @@ namespace Microsoft.Data.SqlClient
         // Find and return arraylist, and remove passed hash value.
         private List<SqlDependency> LookupCommandEntryWithRemove(string notificationId)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupCommandEntryWithRemove|DEP> {0}#, commandHash: '{1}'", ObjectID, notificationId);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupCommandEntryWithRemove|DEP> {0}, commandHash: '{1}'", ObjectID, notificationId);
             try
             {
                 DependencyList entry = null;
@@ -439,7 +439,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (_notificationIdToDependenciesHash.TryGetValue(notificationId, out entry))
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries found in hashtable - removing.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries found in hashtable - removing.");
 
                         // update the tables - do it inside finally block to avoid ThreadAbort exception interrupt this operation
                         try
@@ -453,7 +453,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries NOT found in hashtable.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntriesWithRemove|DEP> Entries NOT found in hashtable.");
                     }
 
                     Debug.Assert(_notificationIdToDependenciesHash.Count == _commandHashToNotificationId.Count, "always keep these maps in sync!");
@@ -470,7 +470,7 @@ namespace Microsoft.Data.SqlClient
         // Remove from commandToDependenciesHash all references to the passed dependency.
         private void RemoveDependencyFromCommandToDependenciesHash(SqlDependency dependency)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> {0}#, SqlDependency: {1}#", ObjectID, dependency.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> {0}, SqlDependency: {1}", ObjectID, dependency.ObjectID);
             try
             {
                 lock (this)
@@ -483,7 +483,7 @@ namespace Microsoft.Data.SqlClient
                         DependencyList dependencies = entry.Value;
                         if (dependencies.Remove(dependency))
                         {
-                            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> Removed SqlDependency: {0}#, with ID: '{1}'.", dependency.ObjectID, dependency.Id);
+                            SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.RemoveDependencyFromCommandToDependenciesHash|DEP> Removed SqlDependency: {0}, with ID: '{1}'.", dependency.ObjectID, dependency.Id);
                             if (dependencies.Count == 0)
                             {
                                 // this dependency was the last associated with this notification ID, remove the entry
@@ -526,7 +526,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void StartTimer(SqlDependency dep)
         {
-            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> {0}#, SqlDependency: {1}#", ObjectID, dep.ObjectID);
+            long scopeID = SqlClientEventSource.Log.NotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> {0}, SqlDependency: {1}", ObjectID, dep.ObjectID);
             try
             {
                 // If this dependency expires sooner than the current next timeout, change
@@ -537,7 +537,7 @@ namespace Microsoft.Data.SqlClient
                     // Enable the timer if needed (disable when empty, enable on the first addition).
                     if (!_SqlDependencyTimeOutTimerStarted)
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> Timer not yet started, starting.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> Timer not yet started, starting.");
                         _timeoutTimer.Change(15000 /* 15 secs */, 15000 /* 15 secs */);
 
                         // Save this as the earlier timeout to come.
@@ -546,7 +546,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else if (_nextTimeout > dep.ExpirationTime)
                     {
-                        SqlClientEventSource.Log.NotificationsTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> Timer already started, resetting time.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.StartTimer|DEP> Timer already started, resetting time.");
 
                         // Save this as the earlier timeout to come.
                         _nextTimeout = dep.ExpirationTime;
@@ -574,12 +574,12 @@ namespace Microsoft.Data.SqlClient
                     if (0 == SingletonInstance._dependencyIdToDependencyHash.Count)
                     {
                         // Nothing to check.
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No dependencies, exiting.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No dependencies, exiting.");
                         return;
                     }
                     if (SingletonInstance._nextTimeout > DateTime.UtcNow)
                     {
-                        SqlClientEventSource.Log.NotificationTrace("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No timeouts expired, exiting.");
+                        SqlClientEventSource.Log.NotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No timeouts expired, exiting.");
 
                         // No dependency timed-out yet.
                         return;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Data.SqlClient
 
         override protected void Deactivate()
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.Deactivate|ADV> {0}# deactivating", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.Deactivate|ADV> {0} deactivating", ObjectID);
             TdsParser bestEffortCleanupTarget = null;
             RuntimeHelpers.PrepareConstrainedRegions();
             try
@@ -435,12 +435,12 @@ namespace Microsoft.Data.SqlClient
         private void EnlistNonNull(SysTx.Transaction tx)
         {
             Debug.Assert(null != tx, "null transaction?");
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, transaction {1}#.", ObjectID, tx.GetHashCode());
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, transaction {1}.", ObjectID, tx.GetHashCode());
             bool hasDelegatedTransaction = false;
 
             if (IsYukonOrNewer)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, attempting to delegate", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, attempting to delegate", ObjectID);
 
                 // Promotable transactions are only supported on Yukon
                 // servers or newer.
@@ -507,7 +507,7 @@ namespace Microsoft.Data.SqlClient
                     if (hasDelegatedTransaction)
                     {
                         this.DelegatedTransaction = delegatedTransaction;
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegated to transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, delegated to transaction {1} with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
                     }
                 }
                 catch (SqlException e)
@@ -540,7 +540,7 @@ namespace Microsoft.Data.SqlClient
 
             if (!hasDelegatedTransaction)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegation not possible, enlisting.", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, delegation not possible, enlisting.", ObjectID);
                 byte[] cookie = null;
 
                 if (_isGlobalTransaction)
@@ -570,7 +570,7 @@ namespace Microsoft.Data.SqlClient
                 // send cookie to server to finish enlistment
                 PropagateTransactionCookie(cookie);
                 _isEnlistedInTransaction = true;
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, enlisted with transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, enlisted with transaction {1} with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
             }
 
             EnlistedTransaction = tx; // Tell the base class about our enlistment
@@ -593,7 +593,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void EnlistNull()
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisting.", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}, unenlisting.", ObjectID);
 
             // We were in a transaction, but now we are not - so send
             // message to server with empty transaction - confirmed proper
@@ -611,7 +611,7 @@ namespace Microsoft.Data.SqlClient
             _isEnlistedInTransaction = false;
             EnlistedTransaction = null; // Tell the base class about our enlistment
 
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisted.", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}, unenlisted.", ObjectID);
 
             // The EnlistTransaction above will return an TransactionEnded event, 
             // which causes the TdsParser or SmiEventSink should to clear the

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Data.SqlClient
 
         override protected void Deactivate()
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.Deactivate|ADV> {0}# deactivating", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.Deactivate|ADV> {0}# deactivating", ObjectID);
             TdsParser bestEffortCleanupTarget = null;
             RuntimeHelpers.PrepareConstrainedRegions();
             try
@@ -435,12 +435,12 @@ namespace Microsoft.Data.SqlClient
         private void EnlistNonNull(SysTx.Transaction tx)
         {
             Debug.Assert(null != tx, "null transaction?");
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, transaction {1}#.", ObjectID, tx.GetHashCode());
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, transaction {1}#.", ObjectID, tx.GetHashCode());
             bool hasDelegatedTransaction = false;
 
             if (IsYukonOrNewer)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, attempting to delegate", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, attempting to delegate", ObjectID);
 
                 // Promotable transactions are only supported on Yukon
                 // servers or newer.
@@ -507,7 +507,7 @@ namespace Microsoft.Data.SqlClient
                     if (hasDelegatedTransaction)
                     {
                         this.DelegatedTransaction = delegatedTransaction;
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegated to transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegated to transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
                     }
                 }
                 catch (SqlException e)
@@ -540,7 +540,7 @@ namespace Microsoft.Data.SqlClient
 
             if (!hasDelegatedTransaction)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegation not possible, enlisting.", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, delegation not possible, enlisting.", ObjectID);
                 byte[] cookie = null;
 
                 if (_isGlobalTransaction)
@@ -570,7 +570,7 @@ namespace Microsoft.Data.SqlClient
                 // send cookie to server to finish enlistment
                 PropagateTransactionCookie(cookie);
                 _isEnlistedInTransaction = true;
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, enlisted with transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}#, enlisted with transaction {1}# with transactionId=0x{2}", ObjectID, null != CurrentTransaction ? CurrentTransaction.ObjectID : 0, null != CurrentTransaction ? CurrentTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
             }
 
             EnlistedTransaction = tx; // Tell the base class about our enlistment
@@ -593,7 +593,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void EnlistNull()
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisting.", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisting.", ObjectID);
 
             // We were in a transaction, but now we are not - so send
             // message to server with empty transaction - confirmed proper
@@ -611,7 +611,7 @@ namespace Microsoft.Data.SqlClient
             _isEnlistedInTransaction = false;
             EnlistedTransaction = null; // Tell the base class about our enlistment
 
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisted.", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNull|ADV> {0}#, unenlisted.", ObjectID);
 
             // The EnlistTransaction above will return an TransactionEnded event, 
             // which causes the TdsParser or SmiEventSink should to clear the

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
@@ -65,37 +65,37 @@ namespace Microsoft.Data.SqlClient
 
             internal override void DefaultDatabaseChanged(string databaseName)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.DefaultDatabaseChanged|ADV> {0}#, databaseName='{1}'.", _connection.ObjectID, databaseName);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.DefaultDatabaseChanged|ADV> {0}, databaseName='{1}'.", _connection.ObjectID, databaseName);
                 _connection.CurrentDatabase = databaseName;
             }
 
             internal override void TransactionCommitted(long transactionId)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionCommitted|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionCommitted|ADV> {0}, transactionId=0x{1}.", _connection.ObjectID, transactionId);
                 _connection.TransactionEnded(transactionId, TransactionState.Committed);
             }
 
             internal override void TransactionDefected(long transactionId)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionDefected|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionDefected|ADV> {0}, transactionId=0x{1}.", _connection.ObjectID, transactionId);
                 _connection.TransactionEnded(transactionId, TransactionState.Unknown);
             }
 
             internal override void TransactionEnlisted(long transactionId)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionEnlisted|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionEnlisted|ADV> {0}, transactionId=0x{1}.", _connection.ObjectID, transactionId);
                 _connection.TransactionStarted(transactionId, true); // distributed;
             }
 
             internal override void TransactionEnded(long transactionId)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionEnded|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionEnded|ADV> {0}, transactionId=0x{1}.", _connection.ObjectID, transactionId);
                 _connection.TransactionEndedByServer(transactionId, TransactionState.Unknown);
             }
 
             internal override void TransactionRolledBack(long transactionId)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionRolledBack|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionRolledBack|ADV> {0}, transactionId=0x{1}.", _connection.ObjectID, transactionId);
 
                 // Dev11 1066: ensure delegated transaction is rolled back
                 _connection.TransactionEndedByServer(transactionId, TransactionState.Aborted);
@@ -103,7 +103,7 @@ namespace Microsoft.Data.SqlClient
 
             internal override void TransactionStarted(long transactionId)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionStarted|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionStarted|ADV> {0}, transactionId=0x{1}.", _connection.ObjectID, transactionId);
                 _connection.TransactionStarted(transactionId, false); // not distributed;
             }
         }
@@ -119,7 +119,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(null != _smiConnection, "null SmiContext.ContextConnection?");
 
             _smiEventSink = new EventSink(this);
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.ctor|ADV> {0}#, constructed new SMI internal connection", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.ctor|ADV> {0}, constructed new SMI internal connection", ObjectID);
         }
 
         internal SmiContext InternalContext
@@ -269,7 +269,7 @@ namespace Microsoft.Data.SqlClient
             SysTx.Transaction currentSystemTransaction = ADP.GetCurrentTransaction();      // NOTE: Must be first to ensure _smiContext.ContextTransaction is set!
             SysTx.Transaction contextTransaction = _smiContext.ContextTransaction; // returns the transaction that was handed to SysTx that wraps the ContextTransactionId.
             long contextTransactionId = _smiContext.ContextTransactionId;
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}#, contextTransactionId=0x{1}, contextTransaction={2}#, currentSystemTransaction={3}#.", ObjectID, contextTransactionId, (null != contextTransaction) ? contextTransaction.GetHashCode() : 0, (null != currentSystemTransaction) ? currentSystemTransaction.GetHashCode() : 0);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}, contextTransactionId=0x{1}, contextTransaction={2}, currentSystemTransaction={3}.", ObjectID, contextTransactionId, (null != contextTransaction) ? contextTransaction.GetHashCode() : 0, (null != currentSystemTransaction) ? currentSystemTransaction.GetHashCode() : 0);
 
             if (SqlInternalTransaction.NullTransactionId != contextTransactionId)
             {
@@ -278,18 +278,18 @@ namespace Microsoft.Data.SqlClient
                     throw SQL.NestedTransactionScopesNotSupported();    // can't use TransactionScope(RequiresNew) inside a Sql Transaction.
                 }
 
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}#, using context transaction with transactionId=0x{1}", ObjectID, contextTransactionId);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}, using context transaction with transactionId=0x{1}", ObjectID, contextTransactionId);
                 _currentTransaction = new SqlInternalTransaction(this, TransactionType.Context, null, contextTransactionId);
                 ContextTransaction = contextTransaction;
             }
             else if (null == currentSystemTransaction)
             {
                 _currentTransaction = null;  // there really isn't a transaction.
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}#, no transaction.", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}, no transaction.", ObjectID);
             }
             else
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}#, using current System.Transaction.", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}, using current System.Transaction.", ObjectID);
                 base.Enlist(currentSystemTransaction);
             }
         }
@@ -302,7 +302,7 @@ namespace Microsoft.Data.SqlClient
 
         override protected void InternalDeactivate()
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.Deactivate|ADV> {0}#, Deactivating.", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.Deactivate|ADV> {0}, Deactivating.", ObjectID);
 
             // When we put this to bed, we should not hold on to the transaction
             // or any activity (commit/rollback) may cause it to stop responding.
@@ -331,13 +331,13 @@ namespace Microsoft.Data.SqlClient
         override internal void DelegatedTransactionEnded()
         {
             base.DelegatedTransactionEnded();
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.DelegatedTransactionEnded|ADV> {0}#, cleaning up after Delegated Transaction Completion", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.DelegatedTransactionEnded|ADV> {0}, cleaning up after Delegated Transaction Completion", ObjectID);
             _currentTransaction = null;           // clean up our current transaction too
         }
 
         override internal void DisconnectTransaction(SqlInternalTransaction internalTransaction)
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.DisconnectTransaction|ADV> {0}#, Disconnecting Transaction {1}#.", ObjectID, internalTransaction.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.DisconnectTransaction|ADV> {0}, Disconnecting Transaction {1}.", ObjectID, internalTransaction.ObjectID);
 
             // VSTS 215465/15029: allow _currentTransaction to be null - it can be cleared before by server's callback
             Debug.Assert(_currentTransaction == null || _currentTransaction == internalTransaction, "disconnecting different transaction");
@@ -361,7 +361,7 @@ namespace Microsoft.Data.SqlClient
                     SqlInternalTransaction internalTransaction,
                     bool isDelegateControlRequest)
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.ExecuteTransaction|ADV> {0}#, transactionRequest={1}, " +
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.ExecuteTransaction|ADV> {0}, transactionRequest={1}, " +
                 "transactionName='{2}', isolationLevel={3}, internalTransaction=#{4} transactionId=0x{5}.", ObjectID, transactionRequest.ToString(), transactionName ?? "null", iso.ToString(), (null != internalTransaction) ? internalTransaction.ObjectID : 0, (null != internalTransaction) ? internalTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
 
             switch (transactionRequest)
@@ -449,7 +449,7 @@ namespace Microsoft.Data.SqlClient
             // Called whenever the context goes out of scope, we need to make
             // sure that we close the connection, or the next person that uses
             // the context may appear to have the connection in use.
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.OutOfScope|ADV> {0}# context is out of scope", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.OutOfScope|ADV> {0} context is out of scope", ObjectID);
 
             // TODO: This is suspect to me -- if I go out of scope, who will commit the transaction?
             DelegatedTransaction = null;     // we don't want to hold this over to the next usage; it will automatically be reused as the context transaction...

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
@@ -65,37 +65,37 @@ namespace Microsoft.Data.SqlClient
 
             internal override void DefaultDatabaseChanged(string databaseName)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.EventSink.DefaultDatabaseChanged|ADV> {0}#, databaseName='{1}'.", _connection.ObjectID, databaseName);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.DefaultDatabaseChanged|ADV> {0}#, databaseName='{1}'.", _connection.ObjectID, databaseName);
                 _connection.CurrentDatabase = databaseName;
             }
 
             internal override void TransactionCommitted(long transactionId)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.EventSink.TransactionCommitted|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionCommitted|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
                 _connection.TransactionEnded(transactionId, TransactionState.Committed);
             }
 
             internal override void TransactionDefected(long transactionId)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.EventSink.TransactionDefected|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionDefected|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
                 _connection.TransactionEnded(transactionId, TransactionState.Unknown);
             }
 
             internal override void TransactionEnlisted(long transactionId)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.EventSink.TransactionEnlisted|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionEnlisted|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
                 _connection.TransactionStarted(transactionId, true); // distributed;
             }
 
             internal override void TransactionEnded(long transactionId)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.EventSink.TransactionEnded|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionEnded|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
                 _connection.TransactionEndedByServer(transactionId, TransactionState.Unknown);
             }
 
             internal override void TransactionRolledBack(long transactionId)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.EventSink.TransactionRolledBack|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionRolledBack|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
 
                 // Dev11 1066: ensure delegated transaction is rolled back
                 _connection.TransactionEndedByServer(transactionId, TransactionState.Aborted);
@@ -103,7 +103,7 @@ namespace Microsoft.Data.SqlClient
 
             internal override void TransactionStarted(long transactionId)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.EventSink.TransactionStarted|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.EventSink.TransactionStarted|ADV> {0}#, transactionId=0x{1}.", _connection.ObjectID, transactionId);
                 _connection.TransactionStarted(transactionId, false); // not distributed;
             }
         }
@@ -119,7 +119,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(null != _smiConnection, "null SmiContext.ContextConnection?");
 
             _smiEventSink = new EventSink(this);
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.ctor|ADV> {0}#, constructed new SMI internal connection", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.ctor|ADV> {0}#, constructed new SMI internal connection", ObjectID);
         }
 
         internal SmiContext InternalContext
@@ -269,7 +269,7 @@ namespace Microsoft.Data.SqlClient
             SysTx.Transaction currentSystemTransaction = ADP.GetCurrentTransaction();      // NOTE: Must be first to ensure _smiContext.ContextTransaction is set!
             SysTx.Transaction contextTransaction = _smiContext.ContextTransaction; // returns the transaction that was handed to SysTx that wraps the ContextTransactionId.
             long contextTransactionId = _smiContext.ContextTransactionId;
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}#, contextTransactionId=0x{1}, contextTransaction={2}#, currentSystemTransaction={3}#.", ObjectID, contextTransactionId, (null != contextTransaction) ? contextTransaction.GetHashCode() : 0, (null != currentSystemTransaction) ? currentSystemTransaction.GetHashCode() : 0);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}#, contextTransactionId=0x{1}, contextTransaction={2}#, currentSystemTransaction={3}#.", ObjectID, contextTransactionId, (null != contextTransaction) ? contextTransaction.GetHashCode() : 0, (null != currentSystemTransaction) ? currentSystemTransaction.GetHashCode() : 0);
 
             if (SqlInternalTransaction.NullTransactionId != contextTransactionId)
             {
@@ -285,11 +285,11 @@ namespace Microsoft.Data.SqlClient
             else if (null == currentSystemTransaction)
             {
                 _currentTransaction = null;  // there really isn't a transaction.
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}#, no transaction.", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}#, no transaction.", ObjectID);
             }
             else
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}#, using current System.Transaction.", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}#, using current System.Transaction.", ObjectID);
                 base.Enlist(currentSystemTransaction);
             }
         }
@@ -302,7 +302,7 @@ namespace Microsoft.Data.SqlClient
 
         override protected void InternalDeactivate()
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.Deactivate|ADV> {0}#, Deactivating.", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.Deactivate|ADV> {0}#, Deactivating.", ObjectID);
 
             // When we put this to bed, we should not hold on to the transaction
             // or any activity (commit/rollback) may cause it to stop responding.
@@ -331,13 +331,13 @@ namespace Microsoft.Data.SqlClient
         override internal void DelegatedTransactionEnded()
         {
             base.DelegatedTransactionEnded();
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.DelegatedTransactionEnded|ADV> {0}#, cleaning up after Delegated Transaction Completion", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.DelegatedTransactionEnded|ADV> {0}#, cleaning up after Delegated Transaction Completion", ObjectID);
             _currentTransaction = null;           // clean up our current transaction too
         }
 
         override internal void DisconnectTransaction(SqlInternalTransaction internalTransaction)
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.DisconnectTransaction|ADV> {0}#, Disconnecting Transaction {1}#.", ObjectID, internalTransaction.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.DisconnectTransaction|ADV> {0}#, Disconnecting Transaction {1}#.", ObjectID, internalTransaction.ObjectID);
 
             // VSTS 215465/15029: allow _currentTransaction to be null - it can be cleared before by server's callback
             Debug.Assert(_currentTransaction == null || _currentTransaction == internalTransaction, "disconnecting different transaction");
@@ -361,7 +361,7 @@ namespace Microsoft.Data.SqlClient
                     SqlInternalTransaction internalTransaction,
                     bool isDelegateControlRequest)
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.ExecuteTransaction|ADV> {0}#, transactionRequest={1}, " +
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.ExecuteTransaction|ADV> {0}#, transactionRequest={1}, " +
                 "transactionName='{2}', isolationLevel={3}, internalTransaction=#{4} transactionId=0x{5}.", ObjectID, transactionRequest.ToString(), transactionName ?? "null", iso.ToString(), (null != internalTransaction) ? internalTransaction.ObjectID : 0, (null != internalTransaction) ? internalTransaction.TransactionId : SqlInternalTransaction.NullTransactionId);
 
             switch (transactionRequest)
@@ -419,11 +419,11 @@ namespace Microsoft.Data.SqlClient
 
             if (null != whereAbouts)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.GetDTCAddress|ADV> whereAbouts = {0}, Length = {1}", whereAbouts, (ushort)whereAbouts.Length);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.GetDTCAddress|ADV> whereAbouts = {0}, Length = {1}", whereAbouts, (ushort)whereAbouts.Length);
             }
             else
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.GetDTCAddress|ADV> whereAbouts=null");
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.GetDTCAddress|ADV> whereAbouts=null");
             }
 
             return whereAbouts;
@@ -449,7 +449,7 @@ namespace Microsoft.Data.SqlClient
             // Called whenever the context goes out of scope, we need to make
             // sure that we close the connection, or the next person that uses
             // the context may appear to have the connection in use.
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.OutOfScope|ADV> {0}# context is out of scope", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.OutOfScope|ADV> {0}# context is out of scope", ObjectID);
 
             // TODO: This is suspect to me -- if I go out of scope, who will commit the transaction?
             DelegatedTransaction = null;     // we don't want to hold this over to the next usage; it will automatically be reused as the context transaction...
@@ -480,11 +480,11 @@ namespace Microsoft.Data.SqlClient
 
             if (null != transactionCookie)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.PropagateTransactionCookie|ADV> transactionCookie", transactionCookie, (UInt16)transactionCookie.Length);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.PropagateTransactionCookie|ADV> transactionCookie", transactionCookie, (UInt16)transactionCookie.Length);
             }
             else
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionSmi.PropagateTransactionCookie|ADV> null");
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionSmi.PropagateTransactionCookie|ADV> null");
             }
 
             // Propagate the transaction cookie to the server

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -516,7 +516,7 @@ namespace Microsoft.Data.SqlClient
                 ThreadHasParserLockForClose = false;
                 _parserLock.Release();
             }
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.ctor|ADV> {0}#, constructed new TDS internal connection", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.ctor|ADV> {0}#, constructed new TDS internal connection", ObjectID);
         }
 
         // The erros in the transient error set are contained in
@@ -771,7 +771,7 @@ namespace Microsoft.Data.SqlClient
 
         override public void Dispose()
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.Dispose|ADV> {0}# disposing", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.Dispose|ADV> {0}# disposing", ObjectID);
             try
             {
                 TdsParser parser = Interlocked.Exchange(ref _parser, null);  // guard against multiple concurrent dispose calls -- Delegated Transactions might cause this.
@@ -1406,7 +1406,7 @@ namespace Microsoft.Data.SqlClient
             _parser.EnableMars();
 
             _fConnectionOpen = true; // mark connection as open
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.CompleteLogin|ADV> Post-Login Phase: Server connection obtained.");
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.CompleteLogin|ADV> Post-Login Phase: Server connection obtained.");
 
             // for non-pooled connections, enlist in a distributed transaction
             // if present - and user specified to enlist
@@ -1661,7 +1661,7 @@ namespace Microsoft.Data.SqlClient
             int routingAttempts = 0;
             ServerInfo originalServerInfo = serverInfo; // serverInfo may end up pointing to new object due to routing, original object is used to set CurrentDatasource
 
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, host={1}", ObjectID, serverInfo.UserServerName);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, host={1}", ObjectID, serverInfo.UserServerName);
 
             int sleepInterval = 100;  //milliseconds to sleep (back off) between attempts.
 
@@ -1856,7 +1856,7 @@ namespace Microsoft.Data.SqlClient
 
                 // Sleep for a bit to prevent clogging the network with requests,
                 //  then update sleep interval for next iteration (max 1 second interval)
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
 
                 Thread.Sleep(sleepInterval);
                 sleepInterval = (sleepInterval < 500) ? sleepInterval * 2 : 1000;
@@ -1938,7 +1938,7 @@ namespace Microsoft.Data.SqlClient
         {
 
             Debug.Assert(!connectionOptions.MultiSubnetFailover, "MultiSubnetFailover should not be set if failover partner is used");
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, useFailover={1}[bool], primary={2}, failover={3}", ObjectID, useFailoverHost, primaryServerInfo.UserServerName, failoverHost ?? "null");
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, useFailover={1}[bool], primary={2}, failover={3}", ObjectID, useFailoverHost, primaryServerInfo.UserServerName, failoverHost ?? "null");
 
             int sleepInterval = 100;  //milliseconds to sleep (back off) between attempts.
             long timeoutUnitInterval;
@@ -2006,7 +2006,7 @@ namespace Microsoft.Data.SqlClient
                     // Primary server may give us a different failover partner than the connection string indicates.  Update it
                     if (null != ServerProvidedFailOverPartner && failoverServerInfo.ResolvedServerName != ServerProvidedFailOverPartner)
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, new failover partner={1}", ObjectID, ServerProvidedFailOverPartner);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, new failover partner={1}", ObjectID, ServerProvidedFailOverPartner);
                         failoverServerInfo.SetDerivedNames(protocol, ServerProvidedFailOverPartner);
                     }
                     currentServerInfo = failoverServerInfo;
@@ -2108,7 +2108,7 @@ namespace Microsoft.Data.SqlClient
                 //  the network with requests, then update sleep interval for next iteration (max 1 second interval)
                 if (1 == attemptNumber % 2)
                 {
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
                     Thread.Sleep(sleepInterval);
                     sleepInterval = (sleepInterval < 500) ? sleepInterval * 2 : 1000;
                 }
@@ -2183,7 +2183,7 @@ namespace Microsoft.Data.SqlClient
         // Common code path for making one attempt to establish a connection and log in to server.
         private void AttemptOneLogin(ServerInfo serverInfo, string newPassword, SecureString newSecurePassword, bool ignoreSniOpenTimeout, TimeoutTimer timeout, bool withFailover = false, bool isFirstTransparentAttempt = true, bool disableTnir = false)
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.AttemptOneLogin|ADV> {0}#, timout={1}[msec], server={2}", ObjectID, timeout.MillisecondsRemaining, serverInfo.ExtendedServerName);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.AttemptOneLogin|ADV> {0}#, timout={1}[msec], server={2}", ObjectID, timeout.MillisecondsRemaining, serverInfo.ExtendedServerName);
 
             _routingInfo = null; // forget routing information
 
@@ -2427,7 +2427,7 @@ namespace Microsoft.Data.SqlClient
                     break;
 
                 case TdsEnums.ENV_ROUTING:
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnEnvChange|ADV> {0}#, Received routing info", ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnEnvChange|ADV> {0}#, Received routing info", ObjectID);
                     if (string.IsNullOrEmpty(rec.newRoutingInfo.ServerName) || rec.newRoutingInfo.Protocol != 0 || rec.newRoutingInfo.Port == 0)
                     {
                         throw SQL.ROR_InvalidRoutingInfo(this);
@@ -2525,7 +2525,7 @@ namespace Microsoft.Data.SqlClient
                     // If a thread is already doing the refresh, just use the existing token in the cache and proceed.
                     else if (contextValidity <= _dbAuthenticationContextLockedRefreshTimeSpan)
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFedAuthInfo|ADV> {0}#, " +
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo|ADV> {0}#, " +
                             "The authentication context needs a refresh.The expiration time is {1}. " +
                             "Current Time is {2}.", ObjectID, dbConnectionPoolAuthenticationContext.ExpirationTime.ToLongTimeString(), DateTime.UtcNow.ToLongTimeString());
 
@@ -2544,7 +2544,7 @@ namespace Microsoft.Data.SqlClient
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, The attempt to get a new access token succeeded under the locked mode.", ObjectID);
                         }
                     }
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, Found an authentication context in the cache that does not need a refresh at this time. Re-using the cached token.", ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, Found an authentication context in the cache that does not need a refresh at this time. Re-using the cached token.", ObjectID);
                 }
             }
 
@@ -2789,8 +2789,8 @@ namespace Microsoft.Data.SqlClient
                         throw exc;
                     }
 
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, sleeping {1}[Milliseconds]", ObjectID, sleepInterval);
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, remaining {1}[Milliseconds]", ObjectID, _timeout.MillisecondsRemaining);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, sleeping {1}[Milliseconds]", ObjectID, sleepInterval);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, remaining {1}[Milliseconds]", ObjectID, _timeout.MillisecondsRemaining);
 
                     Thread.Sleep(sleepInterval);
                     sleepInterval *= 2;
@@ -2869,7 +2869,7 @@ namespace Microsoft.Data.SqlClient
                     }
                 case TdsEnums.FEATUREEXT_FEDAUTH:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for federated authentication", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for federated authentication", ObjectID);
 
                         if (!_federatedAuthenticationRequested)
                         {
@@ -2926,7 +2926,7 @@ namespace Microsoft.Data.SqlClient
                     }
                 case TdsEnums.FEATUREEXT_TCE:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for TCE", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for TCE", ObjectID);
                         if (data.Length < 1)
                         {
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown version number for TCE", ObjectID);
@@ -2955,7 +2955,7 @@ namespace Microsoft.Data.SqlClient
 
                 case TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
 
                         if (data.Length < 1)
                         {
@@ -2973,7 +2973,7 @@ namespace Microsoft.Data.SqlClient
 
                 case TdsEnums.FEATUREEXT_AZURESQLSUPPORT:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for AzureSQLSupport", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for AzureSQLSupport", ObjectID);
 
                         if (data.Length < 1)
                         {
@@ -2985,14 +2985,14 @@ namespace Microsoft.Data.SqlClient
                         //  Bit 0 for RO/FP support
                         if ((data[0] & 1) == 1 && SqlClientEventSource.Log.IsTraceEnabled())
                         {
-                            SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, FailoverPartner enabled with Readonly intent for AzureSQL DB", ObjectID);
+                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, FailoverPartner enabled with Readonly intent for AzureSQL DB", ObjectID);
                         }
                         break;
                     }
 
                 case TdsEnums.FEATUREEXT_DATACLASSIFICATION:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for DATACLASSIFICATION", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for DATACLASSIFICATION", ObjectID);
 
                         if (data.Length < 1)
                         {
@@ -3019,7 +3019,7 @@ namespace Microsoft.Data.SqlClient
 
                 case TdsEnums.FEATUREEXT_UTF8SUPPORT:
                     {
-                        SqlClientEventSource.Log.AdvanceTrace("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for UTF8 support", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for UTF8 support", ObjectID);
 
                         if (data.Length < 1)
                         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -516,7 +516,7 @@ namespace Microsoft.Data.SqlClient
                 ThreadHasParserLockForClose = false;
                 _parserLock.Release();
             }
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.ctor|ADV> {0}#, constructed new TDS internal connection", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.ctor|ADV> {0}, constructed new TDS internal connection", ObjectID);
         }
 
         // The erros in the transient error set are contained in
@@ -771,7 +771,7 @@ namespace Microsoft.Data.SqlClient
 
         override public void Dispose()
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.Dispose|ADV> {0}# disposing", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.Dispose|ADV> {0} disposing", ObjectID);
             try
             {
                 TdsParser parser = Interlocked.Exchange(ref _parser, null);  // guard against multiple concurrent dispose calls -- Delegated Transactions might cause this.
@@ -1363,12 +1363,12 @@ namespace Microsoft.Data.SqlClient
                 // ROR should not affect state of connection recovery
                 if (_federatedAuthenticationRequested && !_federatedAuthenticationAcknowledged)
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.CompleteLogin|ERR> {0}#, Server did not acknowledge the federated authentication request", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.CompleteLogin|ERR> {0}, Server did not acknowledge the federated authentication request", ObjectID);
                     throw SQL.ParsingError(ParsingErrorState.FedAuthNotAcknowledged);
                 }
                 if (_federatedAuthenticationInfoRequested && !_federatedAuthenticationInfoReceived)
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.CompleteLogin|ERR> {0}#, Server never sent the requested federated authentication info", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.CompleteLogin|ERR> {0}, Server never sent the requested federated authentication info", ObjectID);
                     throw SQL.ParsingError(ParsingErrorState.FedAuthInfoNotReceived);
                 }
 
@@ -1535,7 +1535,7 @@ namespace Microsoft.Data.SqlClient
 
         private void LoginFailure()
         {
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.LoginFailure|RES|CPOOL> {0}#", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.LoginFailure|RES|CPOOL> {0}", ObjectID);
 
             // If the parser was allocated and we failed, then we must have failed on
             // either the Connect or Login, either way we should call Disconnect.
@@ -1661,7 +1661,7 @@ namespace Microsoft.Data.SqlClient
             int routingAttempts = 0;
             ServerInfo originalServerInfo = serverInfo; // serverInfo may end up pointing to new object due to routing, original object is used to set CurrentDatasource
 
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, host={1}", ObjectID, serverInfo.UserServerName);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}, host={1}", ObjectID, serverInfo.UserServerName);
 
             int sleepInterval = 100;  //milliseconds to sleep (back off) between attempts.
 
@@ -1856,7 +1856,7 @@ namespace Microsoft.Data.SqlClient
 
                 // Sleep for a bit to prevent clogging the network with requests,
                 //  then update sleep interval for next iteration (max 1 second interval)
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover|ADV> {0}, sleeping {1}[milisec]", ObjectID, sleepInterval);
 
                 Thread.Sleep(sleepInterval);
                 sleepInterval = (sleepInterval < 500) ? sleepInterval * 2 : 1000;
@@ -1938,7 +1938,7 @@ namespace Microsoft.Data.SqlClient
         {
 
             Debug.Assert(!connectionOptions.MultiSubnetFailover, "MultiSubnetFailover should not be set if failover partner is used");
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, useFailover={1}[bool], primary={2}, failover={3}", ObjectID, useFailoverHost, primaryServerInfo.UserServerName, failoverHost ?? "null");
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}, useFailover={1}[bool], primary={2}, failover={3}", ObjectID, useFailoverHost, primaryServerInfo.UserServerName, failoverHost ?? "null");
 
             int sleepInterval = 100;  //milliseconds to sleep (back off) between attempts.
             long timeoutUnitInterval;
@@ -2006,7 +2006,7 @@ namespace Microsoft.Data.SqlClient
                     // Primary server may give us a different failover partner than the connection string indicates.  Update it
                     if (null != ServerProvidedFailOverPartner && failoverServerInfo.ResolvedServerName != ServerProvidedFailOverPartner)
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, new failover partner={1}", ObjectID, ServerProvidedFailOverPartner);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}, new failover partner={1}", ObjectID, ServerProvidedFailOverPartner);
                         failoverServerInfo.SetDerivedNames(protocol, ServerProvidedFailOverPartner);
                     }
                     currentServerInfo = failoverServerInfo;
@@ -2108,7 +2108,7 @@ namespace Microsoft.Data.SqlClient
                 //  the network with requests, then update sleep interval for next iteration (max 1 second interval)
                 if (1 == attemptNumber % 2)
                 {
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}#, sleeping {1}[milisec]", ObjectID, sleepInterval);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}, sleeping {1}[milisec]", ObjectID, sleepInterval);
                     Thread.Sleep(sleepInterval);
                     sleepInterval = (sleepInterval < 500) ? sleepInterval * 2 : 1000;
                 }
@@ -2183,7 +2183,7 @@ namespace Microsoft.Data.SqlClient
         // Common code path for making one attempt to establish a connection and log in to server.
         private void AttemptOneLogin(ServerInfo serverInfo, string newPassword, SecureString newSecurePassword, bool ignoreSniOpenTimeout, TimeoutTimer timeout, bool withFailover = false, bool isFirstTransparentAttempt = true, bool disableTnir = false)
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.AttemptOneLogin|ADV> {0}#, timout={1}[msec], server={2}", ObjectID, timeout.MillisecondsRemaining, serverInfo.ExtendedServerName);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.AttemptOneLogin|ADV> {0}, timout={1}[msec], server={2}", ObjectID, timeout.MillisecondsRemaining, serverInfo.ExtendedServerName);
 
             _routingInfo = null; // forget routing information
 
@@ -2335,7 +2335,7 @@ namespace Microsoft.Data.SqlClient
         internal void BreakConnection()
         {
             SqlConnection connection = Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.BreakConnection|RES|CPOOL> {0}#, Breaking connection.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.BreakConnection|RES|CPOOL> {0}, Breaking connection.", ObjectID);
             DoomThisConnection();   // Mark connection as unusable, so it will be destroyed
 
             if (null != connection)
@@ -2427,7 +2427,7 @@ namespace Microsoft.Data.SqlClient
                     break;
 
                 case TdsEnums.ENV_ROUTING:
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnEnvChange|ADV> {0}#, Received routing info", ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnEnvChange|ADV> {0}, Received routing info", ObjectID);
                     if (string.IsNullOrEmpty(rec.newRoutingInfo.ServerName) || rec.newRoutingInfo.Protocol != 0 || rec.newRoutingInfo.Port == 0)
                     {
                         throw SQL.ROR_InvalidRoutingInfo(this);
@@ -2471,7 +2471,7 @@ namespace Microsoft.Data.SqlClient
                          "Credentials aren't provided for calling MSAL");
             Debug.Assert(fedAuthInfo != null, "info should not be null.");
             Debug.Assert(_dbConnectionPoolAuthenticationContextKey == null, "_dbConnectionPoolAuthenticationContextKey should be null.");
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, Generating federated authentication token", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}, Generating federated authentication token", ObjectID);
             DbConnectionPoolAuthenticationContext dbConnectionPoolAuthenticationContext = null;
 
             // We want to refresh the token without taking a lock on the context, allowed when the access token is expiring within the next 10 mins.
@@ -2502,7 +2502,7 @@ namespace Microsoft.Data.SqlClient
                     // And on successful login, try to update the cache with the new token.
                     if (contextValidity <= _dbAuthenticationContextUnLockedRefreshTimeSpan)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, " +
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}, " +
                             "The expiration time is less than 10 mins, so trying to get new access token regardless of if an other thread is also trying to update it." +
                             "The expiration time is {1}. Current Time is {2}.", ObjectID, dbConnectionPoolAuthenticationContext.ExpirationTime.ToLongTimeString(), DateTime.UtcNow.ToLongTimeString());
 
@@ -2525,7 +2525,7 @@ namespace Microsoft.Data.SqlClient
                     // If a thread is already doing the refresh, just use the existing token in the cache and proceed.
                     else if (contextValidity <= _dbAuthenticationContextLockedRefreshTimeSpan)
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo|ADV> {0}#, " +
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo|ADV> {0}, " +
                             "The authentication context needs a refresh.The expiration time is {1}. " +
                             "Current Time is {2}.", ObjectID, dbConnectionPoolAuthenticationContext.ExpirationTime.ToLongTimeString(), DateTime.UtcNow.ToLongTimeString());
 
@@ -2541,10 +2541,10 @@ namespace Microsoft.Data.SqlClient
                         // Indicate in Bid Trace that we are successful with the update.
                         if (attemptRefreshTokenLocked)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, The attempt to get a new access token succeeded under the locked mode.", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}, The attempt to get a new access token succeeded under the locked mode.", ObjectID);
                         }
                     }
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}#, Found an authentication context in the cache that does not need a refresh at this time. Re-using the cached token.", ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFedAuthInfo> {0}, Found an authentication context in the cache that does not need a refresh at this time. Re-using the cached token.", ObjectID);
                 }
             }
 
@@ -2604,7 +2604,7 @@ namespace Microsoft.Data.SqlClient
                 // Else some other thread is already updating it, so just proceed forward with the existing token in the cache.
                 if (dbConnectionPoolAuthenticationContext.LockToUpdate())
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.TryGetFedAuthTokenLocked> {0}#, " +
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.TryGetFedAuthTokenLocked> {0}, " +
                     "Acquired the lock to update the authentication context.The expiration time is {1}. " +
                     "Current Time is {2}.", ObjectID, dbConnectionPoolAuthenticationContext.ExpirationTime.ToLongTimeString(), DateTime.UtcNow.ToLongTimeString());
 
@@ -2612,7 +2612,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.TryGetFedAuthTokenLocked> {0}#, Refreshing the context is already in progress by another thread.", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.TryGetFedAuthTokenLocked> {0}, Refreshing the context is already in progress by another thread.", ObjectID);
                 }
 
                 if (authenticationContextLocked)
@@ -2770,7 +2770,7 @@ namespace Microsoft.Data.SqlClient
                         || _timeout.IsExpired
                         || _timeout.MillisecondsRemaining <= sleepInterval)
                     {
-                        SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken.MSALException error:> {0}#", msalException.ErrorCode);
+                        SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken.MSALException error:> {0}", msalException.ErrorCode);
 
                         // Error[0]
                         SqlErrorCollection sqlErs = new SqlErrorCollection();
@@ -2789,8 +2789,8 @@ namespace Microsoft.Data.SqlClient
                         throw exc;
                     }
 
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, sleeping {1}[Milliseconds]", ObjectID, sleepInterval);
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}#, remaining {1}[Milliseconds]", ObjectID, _timeout.MillisecondsRemaining);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}, sleeping {1}[Milliseconds]", ObjectID, sleepInterval);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken|ADV> {0}, remaining {1}[Milliseconds]", ObjectID, _timeout.MillisecondsRemaining);
 
                     Thread.Sleep(sleepInterval);
                     sleepInterval *= 2;
@@ -2806,7 +2806,7 @@ namespace Microsoft.Data.SqlClient
                 DateTime expirationTime = DateTime.FromFileTimeUtc(fedAuthToken.expirationFileTime);
                 _newDbConnectionPoolAuthenticationContext = new DbConnectionPoolAuthenticationContext(fedAuthToken.accessToken, expirationTime);
             }
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken> {0}#, Finished generating federated authentication token.", ObjectID);
+            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken> {0}, Finished generating federated authentication token.", ObjectID);
             return fedAuthToken;
         }
 
@@ -2869,11 +2869,11 @@ namespace Microsoft.Data.SqlClient
                     }
                 case TdsEnums.FEATUREEXT_FEDAUTH:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for federated authentication", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for federated authentication", ObjectID);
 
                         if (!_federatedAuthenticationRequested)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Did not request federated authentication", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Did not request federated authentication", ObjectID);
                             throw SQL.ParsingErrorFeatureId(ParsingErrorState.UnrequestedFeatureAckReceived, featureId);
                         }
 
@@ -2886,7 +2886,7 @@ namespace Microsoft.Data.SqlClient
                                 // The server shouldn't have sent any additional data with the ack (like a nonce)
                                 if (data.Length != 0)
                                 {
-                                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Federated authentication feature extension ack for MSAL and Security Token includes extra data", ObjectID);
+                                    SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Federated authentication feature extension ack for MSAL and Security Token includes extra data", ObjectID);
                                     throw SQL.ParsingError(ParsingErrorState.FedAuthFeatureAckContainsExtraData);
                                 }
                                 break;
@@ -2894,7 +2894,7 @@ namespace Microsoft.Data.SqlClient
                             default:
                                 Debug.Fail("Unknown _fedAuthLibrary type");
 
-                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Attempting to use unknown federated authentication library", ObjectID);
+                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Attempting to use unknown federated authentication library", ObjectID);
                                 throw SQL.ParsingErrorLibraryType(ParsingErrorState.FedAuthFeatureAckUnknownLibraryType, (int)_fedAuthFeatureExtensionData.Value.libraryType);
                         }
                         _federatedAuthenticationAcknowledged = true;
@@ -2913,11 +2913,11 @@ namespace Microsoft.Data.SqlClient
                             // For debug purposes, assert and trace if we ended up updating the cache with the new one or some other thread's context won the expiration race.
                             if (newAuthenticationContextInCacheAfterAddOrUpdate == _newDbConnectionPoolAuthenticationContext)
                             {
-                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Updated the new dbAuthenticationContext in the _dbConnectionPool.AuthenticationContexts.", ObjectID);
+                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Updated the new dbAuthenticationContext in the _dbConnectionPool.AuthenticationContexts.", ObjectID);
                             }
                             else
                             {
-                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, AddOrUpdate attempted on _dbConnectionPool.AuthenticationContexts, but it did not update the new value.", ObjectID);
+                                SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, AddOrUpdate attempted on _dbConnectionPool.AuthenticationContexts, but it did not update the new value.", ObjectID);
                             }
 #endif
                         }
@@ -2926,17 +2926,17 @@ namespace Microsoft.Data.SqlClient
                     }
                 case TdsEnums.FEATUREEXT_TCE:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for TCE", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for TCE", ObjectID);
                         if (data.Length < 1)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown version number for TCE", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown version number for TCE", ObjectID);
                             throw SQL.ParsingError(ParsingErrorState.TceUnknownVersion);
                         }
 
                         byte supportedTceVersion = data[0];
                         if (0 == supportedTceVersion || supportedTceVersion > TdsEnums.MAX_SUPPORTED_TCE_VERSION)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Invalid version number for TCE", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for TCE", ObjectID);
                             throw SQL.ParsingErrorValue(ParsingErrorState.TceInvalidVersion, supportedTceVersion);
                         }
 
@@ -2955,11 +2955,11 @@ namespace Microsoft.Data.SqlClient
 
                 case TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
 
                         if (data.Length < 1)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown version number for GlobalTransactions", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown version number for GlobalTransactions", ObjectID);
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
 
@@ -2973,7 +2973,7 @@ namespace Microsoft.Data.SqlClient
 
                 case TdsEnums.FEATUREEXT_AZURESQLSUPPORT:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for AzureSQLSupport", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for AzureSQLSupport", ObjectID);
 
                         if (data.Length < 1)
                         {
@@ -2985,31 +2985,31 @@ namespace Microsoft.Data.SqlClient
                         //  Bit 0 for RO/FP support
                         if ((data[0] & 1) == 1 && SqlClientEventSource.Log.IsTraceEnabled())
                         {
-                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, FailoverPartner enabled with Readonly intent for AzureSQL DB", ObjectID);
+                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, FailoverPartner enabled with Readonly intent for AzureSQL DB", ObjectID);
                         }
                         break;
                     }
 
                 case TdsEnums.FEATUREEXT_DATACLASSIFICATION:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for DATACLASSIFICATION", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for DATACLASSIFICATION", ObjectID);
 
                         if (data.Length < 1)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown token for DATACLASSIFICATION", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown token for DATACLASSIFICATION", ObjectID);
 
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         byte supportedDataClassificationVersion = data[0];
                         if ((0 == supportedDataClassificationVersion) || (supportedDataClassificationVersion > TdsEnums.MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION))
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Invalid version number for DATACLASSIFICATION", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for DATACLASSIFICATION", ObjectID);
                             throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, supportedDataClassificationVersion);
                         }
 
                         if (data.Length != 2)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown token for DATACLASSIFICATION", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown token for DATACLASSIFICATION", ObjectID);
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         byte enabled = data[1];
@@ -3019,11 +3019,11 @@ namespace Microsoft.Data.SqlClient
 
                 case TdsEnums.FEATUREEXT_UTF8SUPPORT:
                     {
-                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}#, Received feature extension acknowledgement for UTF8 support", ObjectID);
+                        SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for UTF8 support", ObjectID);
 
                         if (data.Length < 1)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}#, Unknown value for UTF8 support", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown value for UTF8 support", ObjectID);
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         break;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -142,8 +142,8 @@ namespace Microsoft.Data.SqlClient
             ZombieCheck();
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Commit|API> {0}#", ObjectID);
-            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlTransaction.Commit|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Commit|API> {0}", ObjectID);
+            SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlTransaction.Commit|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
 
             TdsParser bestEffortCleanupTarget = null;
             RuntimeHelpers.PrepareConstrainedRegions();
@@ -268,7 +268,7 @@ namespace Microsoft.Data.SqlClient
             if (IsYukonPartialZombie)
             {
                 // Put something in the trace in case a customer has an issue
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Rollback|ADV> {0}# partial zombie no rollback required", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Rollback|ADV> {0} partial zombie no rollback required", ObjectID);
 
                 _internalTransaction = null; // yukon zombification
             }
@@ -277,8 +277,8 @@ namespace Microsoft.Data.SqlClient
                 ZombieCheck();
 
                 SqlStatistics statistics = null;
-                long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Rollback|API> {0}#", ObjectID);
-                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlTransaction.Rollback|API|Correlation> ObjectID {0}#, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
+                long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Rollback|API> {0}", ObjectID);
+                SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlTransaction.Rollback|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current.ToString());
 
                 TdsParser bestEffortCleanupTarget = null;
                 RuntimeHelpers.PrepareConstrainedRegions();
@@ -342,7 +342,7 @@ namespace Microsoft.Data.SqlClient
             ZombieCheck();
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Rollback|API> {0}# transactionName='{1}'", ObjectID, transactionName);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Rollback|API> {0} transactionName='{1}'", ObjectID, transactionName);
             TdsParser bestEffortCleanupTarget = null;
             RuntimeHelpers.PrepareConstrainedRegions();
             try
@@ -404,7 +404,7 @@ namespace Microsoft.Data.SqlClient
             ZombieCheck();
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Save|API> {0}# savePointName='{1}'", ObjectID, savePointName);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Save|API> {0} savePointName='{1}'", ObjectID, savePointName);
 
             TdsParser bestEffortCleanupTarget = null;
             RuntimeHelpers.PrepareConstrainedRegions();
@@ -470,7 +470,7 @@ namespace Microsoft.Data.SqlClient
 
             if (null != internalConnection && internalConnection.IsYukonOrNewer && !_isFromAPI)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Zombie|ADV> {0}# yukon deferred zombie", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Zombie|ADV> {0} yukon deferred zombie", ObjectID);
             }
             else
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Data.SqlClient
             if (IsYukonPartialZombie)
             {
                 // Put something in the trace in case a customer has an issue
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlTransaction.Rollback|ADV> {0}# partial zombie no rollback required", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Rollback|ADV> {0}# partial zombie no rollback required", ObjectID);
 
                 _internalTransaction = null; // yukon zombification
             }
@@ -470,7 +470,7 @@ namespace Microsoft.Data.SqlClient
 
             if (null != internalConnection && internalConnection.IsYukonOrNewer && !_isFromAPI)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.SqlTransaction.Zombie|ADV> {0}# yukon deferred zombie", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlTransaction.Zombie|ADV> {0}# yukon deferred zombie", ObjectID);
             }
             else
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -726,7 +726,7 @@ namespace Microsoft.Data.SqlClient
         internal TdsParserStateObject CreateSession()
         {
             TdsParserStateObject session = new TdsParserStateObject(this, (SNIHandle)_pMarsPhysicalConObj.Handle, true);
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.CreateSession|ADV> {0}# created session {1}", ObjectID, session.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.CreateSession|ADV> {0} created session {1}", ObjectID, session.ObjectID);
             return session;
         }
 
@@ -741,12 +741,12 @@ namespace Microsoft.Data.SqlClient
                 session = _sessionPool.GetSession(owner);
 
                 Debug.Assert(!session._pendingData, "pending data on a pooled MARS session");
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0}# getting session {1} from pool", ObjectID, session.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0} getting session {1} from pool", ObjectID, session.ObjectID);
             }
             else
             {
                 session = _physicalStateObj;
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0}# getting physical session {1}", ObjectID, session.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0} getting physical session {1}", ObjectID, session.ObjectID);
             }
             Debug.Assert(session._outputPacketNumber == 1, "The packet number is expected to be 1");
             return session;
@@ -1270,7 +1270,7 @@ namespace Microsoft.Data.SqlClient
                         // Only 0x00 and 0x01 are accepted values from the server.
                         if (payload[payloadOffset] != 0x00 && payload[payloadOffset] != 0x01)
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.ConsumePreLoginHandshake|ERR> {0}#, " +
+                            SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.ConsumePreLoginHandshake|ERR> {0}, " +
                             "Server sent an unexpected value for FedAuthRequired PreLogin Option. Value was {1}.", ObjectID, (int)payload[payloadOffset]);
 
                             throw SQL.ParsingErrorValue(ParsingErrorState.FedAuthRequiredPreLoginResponseInvalidValue, (int)payload[payloadOffset]);
@@ -1313,10 +1313,10 @@ namespace Microsoft.Data.SqlClient
         {
             // Called when the connection that owns us is deactivated.
 
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.Deactivate|ADV> {0}# deactivating", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.Deactivate|ADV> {0} deactivating", ObjectID);
             if (SqlClientEventSource.Log.IsStateDumpEnabled())
             {
-                SqlClientEventSource.Log.StateDumpEvent("<sc.TdsParser.Deactivate|STATE> {0}#, {1}", ObjectID, TraceString());
+                SqlClientEventSource.Log.StateDumpEvent("<sc.TdsParser.Deactivate|STATE> {0}, {1}", ObjectID, TraceString());
             }
 
             if (MARSOn)
@@ -1473,7 +1473,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(temp.Count > 0, "TdsParser::ThrowExceptionAndWarning called with no exceptions or warnings!");
             if (temp.Count == 0)
             {
-                SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.ThrowExceptionAndWarning|ERR> Potential multi-threaded misuse of connection, unexpectedly empty warnings/errors under lock {0}#", ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.ThrowExceptionAndWarning|ERR> Potential multi-threaded misuse of connection, unexpectedly empty warnings/errors under lock {0}", ObjectID);
             }
             Debug.Assert(_connHandler != null, "TdsParser::ThrowExceptionAndWarning called with null connectionHandler!");
 
@@ -2192,7 +2192,7 @@ namespace Microsoft.Data.SqlClient
                     Debug.Fail($"unexpected token; token = {token,-2:X2}");
                     _state = TdsParserState.Broken;
                     _connHandler.BreakConnection();
-                    SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.Run|ERR> Potential multi-threaded misuse of connection, unexpected TDS token found {0}#", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.Run|ERR> Potential multi-threaded misuse of connection, unexpected TDS token found {0}", ObjectID);
                     throw SQL.ParsingErrorToken(ParsingErrorState.InvalidTdsTokenReceived, token); // MDAC 82443
                 }
 
@@ -8793,7 +8793,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 WriteInt(log7Flags, _physicalStateObj);
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TdsLogin|ADV> {0}#, TDS Login7 flags = {1}:", ObjectID, log7Flags);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TdsLogin|ADV> {0}, TDS Login7 flags = {1}:", ObjectID, log7Flags);
 
                 WriteInt(0, _physicalStateObj);  // ClientTimeZone is not used
                 WriteInt(0, _physicalStateObj);  // LCID is unused by server
@@ -9505,7 +9505,7 @@ namespace Microsoft.Data.SqlClient
                 stateObj.SetTimeoutSeconds(timeout);
                 if ((!_fMARS) && (_physicalStateObj.HasOpenResult))
                 {
-                    SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.TdsExecuteSQLBatch|ERR> Potential multi-threaded misuse of connection, non-MARs connection with an open result {0}#", ObjectID);
+                    SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.TdsExecuteSQLBatch|ERR> Potential multi-threaded misuse of connection, non-MARs connection with an open result {0}", ObjectID);
                 }
                 stateObj.SniContext = SniContext.Snix_Execute;
 
@@ -9634,7 +9634,7 @@ namespace Microsoft.Data.SqlClient
                         stateObj.SetTimeoutSeconds(timeout);
                         if ((!_fMARS) && (_physicalStateObj.HasOpenResult))
                         {
-                            SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.TdsExecuteRPC|ERR> Potential multi-threaded misuse of connection, non-MARs connection with an open result {0}#", ObjectID);
+                            SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.TdsExecuteRPC|ERR> Potential multi-threaded misuse of connection, non-MARs connection with an open result {0}", ObjectID);
                         }
                         stateObj.SniContext = SniContext.Snix_Execute;
 
@@ -10498,7 +10498,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             var sendDefaultValue = sendDefault ? 1 : 0;
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.WriteSmiParameter|ADV> {0}#, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData.TraceString(3));
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.WriteSmiParameter|ADV> {0}, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData.TraceString(3));
 
             //
             // Write parameter metadata
@@ -11554,7 +11554,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(-1 <= timeout, "Timeout");
 
 
-            SqlClientEventSource.Log.NotificationsTraceEvent("<sc.TdsParser.WriteQueryNotificationHeader|DEP> NotificationRequest: userData: '{0}', options: '{1}', timeout: '{2}'", notificationRequest.UserData, notificationRequest.Options, notificationRequest.Timeout);
+            SqlClientEventSource.Log.NotificationTraceEvent("<sc.TdsParser.WriteQueryNotificationHeader|DEP> NotificationRequest: userData: '{0}', options: '{1}', timeout: '{2}'", notificationRequest.UserData, notificationRequest.Options, notificationRequest.Timeout);
 
             WriteShort(TdsEnums.HEADERTYPE_QNOTIFICATION, stateObj);      // Query notifications Type
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -726,7 +726,7 @@ namespace Microsoft.Data.SqlClient
         internal TdsParserStateObject CreateSession()
         {
             TdsParserStateObject session = new TdsParserStateObject(this, (SNIHandle)_pMarsPhysicalConObj.Handle, true);
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.CreateSession|ADV> {0}# created session {1}", ObjectID, session.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.CreateSession|ADV> {0}# created session {1}", ObjectID, session.ObjectID);
             return session;
         }
 
@@ -741,12 +741,12 @@ namespace Microsoft.Data.SqlClient
                 session = _sessionPool.GetSession(owner);
 
                 Debug.Assert(!session._pendingData, "pending data on a pooled MARS session");
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.GetSession|ADV> {0}# getting session {1} from pool", ObjectID, session.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0}# getting session {1} from pool", ObjectID, session.ObjectID);
             }
             else
             {
                 session = _physicalStateObj;
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.GetSession|ADV> {0}# getting physical session {1}", ObjectID, session.ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0}# getting physical session {1}", ObjectID, session.ObjectID);
             }
             Debug.Assert(session._outputPacketNumber == 1, "The packet number is expected to be 1");
             return session;
@@ -1315,7 +1315,7 @@ namespace Microsoft.Data.SqlClient
         {
             // Called when the connection that owns us is deactivated.
 
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.Deactivate|ADV> {0}# deactivating", ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.Deactivate|ADV> {0}# deactivating", ObjectID);
             SqlClientEventSource.Log.StateDumpEvent("<sc.TdsParser.Deactivate|STATE> {0}#, {1}", ObjectID, TraceString());
 
             if (MARSOn)
@@ -3984,7 +3984,7 @@ namespace Microsoft.Data.SqlClient
             SqlFedAuthInfo tempFedAuthInfo = new SqlFedAuthInfo();
 
             // Skip reading token length, since it has already been read in caller
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo> FEDAUTHINFO token stream length = {0}", tokenLen);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo> FEDAUTHINFO token stream length = {0}", tokenLen);
 
             if (tokenLen < sizeof(uint))
             {
@@ -4003,7 +4003,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             tokenLen -= sizeof(uint); // remaining length is shortened since we read optCount
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo|ADV> CountOfInfoIDs = {0}", optionsCount.ToString(CultureInfo.InvariantCulture));
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|ADV> CountOfInfoIDs = {0}", optionsCount.ToString(CultureInfo.InvariantCulture));
 
             if (tokenLen > 0)
             {
@@ -4012,7 +4012,7 @@ namespace Microsoft.Data.SqlClient
                 int totalRead = 0;
                 bool successfulRead = stateObj.TryReadByteArray(tokenData, 0, tokenLen, out totalRead);
 
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo|ADV> Read rest of FEDAUTHINFO token stream: {0}", BitConverter.ToString(tokenData, 0, totalRead));
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|ADV> Read rest of FEDAUTHINFO token stream: {0}", BitConverter.ToString(tokenData, 0, totalRead));
 
                 if (!successfulRead || totalRead != tokenLen)
                 {
@@ -4037,7 +4037,7 @@ namespace Microsoft.Data.SqlClient
                     byte id = tokenData[currentOptionOffset];
                     uint dataLen = BitConverter.ToUInt32(tokenData, checked((int)(currentOptionOffset + 1)));
                     uint dataOffset = BitConverter.ToUInt32(tokenData, checked((int)(currentOptionOffset + 5)));
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo> FedAuthInfoOpt: ID={0}, DataLen={1}, Offset={2}", id, dataLen.ToString(CultureInfo.InvariantCulture), dataOffset.ToString(CultureInfo.InvariantCulture));
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo> FedAuthInfoOpt: ID={0}, DataLen={1}, Offset={2}", id, dataLen.ToString(CultureInfo.InvariantCulture), dataOffset.ToString(CultureInfo.InvariantCulture));
 
                     // offset is measured from optCount, so subtract to make offset measured
                     // from the beginning of tokenData
@@ -4069,7 +4069,7 @@ namespace Microsoft.Data.SqlClient
                         SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|{0}> FedAuthInfoData is not in unicode format.", "ERR");
                         throw SQL.ParsingError(ParsingErrorState.FedAuthInfoDataNotUnicode, e);
                     }
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo|ADV> FedAuthInfoData: {0}", data);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|ADV> FedAuthInfoData: {0}", data);
 
                     // store data in tempFedAuthInfo
                     switch ((TdsEnums.FedAuthInfoId)id)
@@ -4081,7 +4081,7 @@ namespace Microsoft.Data.SqlClient
                             tempFedAuthInfo.stsurl = data;
                             break;
                         default:
-                            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TryProcessFedAuthInfo|ADV> Ignoring unknown federated authentication info option: {0}", id);
+                            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|ADV> Ignoring unknown federated authentication info option: {0}", id);
                             break;
                     }
                 }
@@ -8792,7 +8792,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 WriteInt(log7Flags, _physicalStateObj);
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.TdsLogin|ADV> {0}#, TDS Login7 flags = {1}:", ObjectID, log7Flags);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.TdsLogin|ADV> {0}#, TDS Login7 flags = {1}:", ObjectID, log7Flags);
 
                 WriteInt(0, _physicalStateObj);  // ClientTimeZone is not used
                 WriteInt(0, _physicalStateObj);  // LCID is unused by server
@@ -10497,7 +10497,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             var sendDefaultValue = sendDefault ? 1 : 0;
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParser.WriteSmiParameter|ADV> {0}#, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData.TraceString(3));
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.WriteSmiParameter|ADV> {0}#, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData.TraceString(3));
 
             //
             // Write parameter metadata

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient
             _cache = new List<TdsParserStateObject>();
             _freeStateObjects = new TdsParserStateObject[MaxInactiveCount];
             _freeStateObjectCount = 0;
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.ctor|ADV> {0}# created session pool for parser {1}", ObjectID, parser.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.ctor|ADV> {0} created session pool for parser {1}", ObjectID, parser.ObjectID);
         }
 
         private bool IsDisposed
@@ -60,7 +60,7 @@ namespace Microsoft.Data.SqlClient
             // When being deactivated, we check all the sessions in the
             // cache to make sure they're cleaned up and then we dispose of
             // sessions that are past what we want to keep around.
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0}# deactivating cachedCount={1}", ObjectID, _cachedCount);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0} deactivating cachedCount={1}", ObjectID, _cachedCount);
             try
             {
                 lock (_cache)
@@ -79,7 +79,7 @@ namespace Microsoft.Data.SqlClient
                             if (session.IsOrphaned)
                             {
                                 // TODO: consider adding a performance counter for the number of sessions we reclaim
-                                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0}# reclaiming session {1}", ObjectID, session.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0} reclaiming session {1}", ObjectID, session.ObjectID);
                                 PutSession(session);
                             }
                         }
@@ -113,7 +113,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Dispose()
         {
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Dispose|ADV> {0}# disposing cachedCount={1}", ObjectID, _cachedCount);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Dispose|ADV> {0} disposing cachedCount={1}", ObjectID, _cachedCount);
             lock (_cache)
             {
                 // Dispose free sessions
@@ -172,7 +172,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // No free objects, create a new one
                     session = _parser.CreateSession();
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.CreateSession|ADV> {0}# adding session {1} to pool", ObjectID, session.ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.CreateSession|ADV> {0} adding session {1} to pool", ObjectID, session.ObjectID);
 
                     _cache.Add(session);
                     _cachedCount = _cache.Count;
@@ -180,7 +180,7 @@ namespace Microsoft.Data.SqlClient
 
                 session.Activate(owner);
             }
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.GetSession|ADV> {0}# using session {1}", ObjectID, session.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.GetSession|ADV> {0} using session {1}", ObjectID, session.ObjectID);
             return session;
         }
 
@@ -202,7 +202,7 @@ namespace Microsoft.Data.SqlClient
                 else if ((okToReuse) && (_freeStateObjectCount < MaxInactiveCount))
                 {
                     // Session is good to re-use and our cache has space
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0}# keeping session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0} keeping session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
                     Debug.Assert(!session._pendingData, "pending data on a pooled session?");
 
                     _freeStateObjects[_freeStateObjectCount] = session;
@@ -211,7 +211,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     // Either the session is bad, or we have no cache space - so dispose the session and remove it
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0}# disposing session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0} disposing session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
 
                     bool removed = _cache.Remove(session);
                     Debug.Assert(removed, "session not in pool?");

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient
             _cache = new List<TdsParserStateObject>();
             _freeStateObjects = new TdsParserStateObject[MaxInactiveCount];
             _freeStateObjectCount = 0;
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.ctor|ADV> {0}# created session pool for parser {1}", ObjectID, parser.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.ctor|ADV> {0}# created session pool for parser {1}", ObjectID, parser.ObjectID);
         }
 
         private bool IsDisposed
@@ -79,7 +79,7 @@ namespace Microsoft.Data.SqlClient
                             if (session.IsOrphaned)
                             {
                                 // TODO: consider adding a performance counter for the number of sessions we reclaim
-                                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.Deactivate|ADV> {0}# reclaiming session {1}", ObjectID, session.ObjectID);
+                                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0}# reclaiming session {1}", ObjectID, session.ObjectID);
                                 PutSession(session);
                             }
                         }
@@ -113,7 +113,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Dispose()
         {
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.Dispose|ADV> {0}# disposing cachedCount={1}", ObjectID, _cachedCount);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.Dispose|ADV> {0}# disposing cachedCount={1}", ObjectID, _cachedCount);
             lock (_cache)
             {
                 // Dispose free sessions
@@ -172,7 +172,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // No free objects, create a new one
                     session = _parser.CreateSession();
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.CreateSession|ADV> {0}# adding session {1} to pool", ObjectID, session.ObjectID);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.CreateSession|ADV> {0}# adding session {1} to pool", ObjectID, session.ObjectID);
 
                     _cache.Add(session);
                     _cachedCount = _cache.Count;
@@ -180,7 +180,7 @@ namespace Microsoft.Data.SqlClient
 
                 session.Activate(owner);
             }
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.GetSession|ADV> {0}# using session {1}", ObjectID, session.ObjectID);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.GetSession|ADV> {0}# using session {1}", ObjectID, session.ObjectID);
             return session;
         }
 
@@ -202,7 +202,7 @@ namespace Microsoft.Data.SqlClient
                 else if ((okToReuse) && (_freeStateObjectCount < MaxInactiveCount))
                 {
                     // Session is good to re-use and our cache has space
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.PutSession|ADV> {0}# keeping session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0}# keeping session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
                     Debug.Assert(!session._pendingData, "pending data on a pooled session?");
 
                     _freeStateObjects[_freeStateObjectCount] = session;
@@ -211,7 +211,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     // Either the session is bad, or we have no cache space - so dispose the session and remove it
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserSessionPool.PutSession|ADV> {0}# disposing session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0}# disposing session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
 
                     bool removed = _cache.Remove(session);
                     Debug.Assert(removed, "session not in pool?");

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -558,8 +558,8 @@ namespace Microsoft.Data.SqlClient
                 {
                     return false;
                 }
-                SqlClientEventSource.Log.TraceEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> {0}#, NBCROW bitmap received, column count = {1}", stateObj.ObjectID, columnsCount);
-                SqlClientEventSource.Log.TraceBinEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> NBCROW bitmap data: ", _nullBitmap, (ushort)_nullBitmap.Length);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> {0}#, NBCROW bitmap received, column count = {1}", stateObj.ObjectID, columnsCount);
+                SqlClientEventSource.Log.AdvancedTraceBinEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> NBCROW bitmap data: ", _nullBitmap, (ushort)_nullBitmap.Length);
 
                 return true;
             }
@@ -912,11 +912,11 @@ namespace Microsoft.Data.SqlClient
         internal int DecrementPendingCallbacks(bool release)
         {
             int remaining = Interlocked.Decrement(ref _pendingCallbacks);
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}#, after decrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}#, after decrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
 
             if ((0 == remaining || release) && _gcHandle.IsAllocated)
             {
-                SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}#, FREEING HANDLE!", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}#, FREEING HANDLE!", ObjectID);
                 _gcHandle.Free();
             }
 
@@ -1025,7 +1025,7 @@ namespace Microsoft.Data.SqlClient
         {
             int remaining = Interlocked.Increment(ref _pendingCallbacks);
 
-            SqlClientEventSource.Log.AdvanceTrace("<sc.TdsParserStateObject.IncrementPendingCallbacks|ADV> {0}#, after incrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.IncrementPendingCallbacks|ADV> {0}#, after incrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
             Debug.Assert(0 < remaining && remaining <= 3, $"_pendingCallbacks values is invalid after incrementing: {remaining}");
             return remaining;
         }
@@ -2795,7 +2795,7 @@ namespace Microsoft.Data.SqlClient
                         }
                     }
                     SniReadStatisticsAndTracing();
-                    SqlClientEventSource.Log.AdvanceTraceBin("<sc.TdsParser.ReadNetworkPacketAsyncCallback|INFO|ADV> Packet read", _inBuff, (ushort)_inBytesRead);
+                    SqlClientEventSource.Log.AdvancedTraceBinEvent("<sc.TdsParser.ReadNetworkPacketAsyncCallback|INFO|ADV> Packet read", _inBuff, (ushort)_inBytesRead);
                     AssertValidState();
                 }
                 else
@@ -3541,7 +3541,7 @@ namespace Microsoft.Data.SqlClient
                     _attentionSending = false;
                 }
 
-                SqlClientEventSource.Log.AdvanceTraceBin("<sc.TdsParser.WritePacket|INFO|ADV>  Packet sent", _outBuff, (ushort)_outBytesUsed);
+                SqlClientEventSource.Log.AdvancedTraceBinEvent("<sc.TdsParser.WritePacket|INFO|ADV>  Packet sent", _outBuff, (ushort)_outBytesUsed);
                 SqlClientEventSource.Log.TraceEvent("<sc.TdsParser.SendAttention|{0}> Attention sent to the server.", "Info");
 
                 AssertValidState();
@@ -3698,7 +3698,7 @@ namespace Microsoft.Data.SqlClient
                 statistics.SafeAdd(ref statistics._bytesSent, _outBytesUsed);
                 statistics.RequestNetworkServerTimer();
             }
-            if (SqlClientEventSource.Log.IsAdvanceTraceOn())
+            if (SqlClientEventSource.Log.IsAdvancedTraceOn())
             {
                 // If we have tracePassword variables set, we are flushing TDSLogin and so we need to
                 // blank out password in buffer.  Buffer has already been sent to netlib, so no danger
@@ -3728,7 +3728,7 @@ namespace Microsoft.Data.SqlClient
                     _traceChangePasswordLength = 0;
                 }
             }
-            SqlClientEventSource.Log.AdvanceTraceBin("<sc.TdsParser.WritePacket|INFO|ADV>  Packet sent", _outBuff, (ushort)_outBytesUsed);
+            SqlClientEventSource.Log.AdvancedTraceBinEvent("<sc.TdsParser.WritePacket|INFO|ADV>  Packet sent", _outBuff, (ushort)_outBytesUsed);
         }
 
         [Conditional("DEBUG")]

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     return false;
                 }
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> {0}#, NBCROW bitmap received, column count = {1}", stateObj.ObjectID, columnsCount);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> {0}, NBCROW bitmap received, column count = {1}", stateObj.ObjectID, columnsCount);
                 SqlClientEventSource.Log.AdvancedTraceBinEvent("<sc.TdsParserStateObject.NullBitmap.Initialize|INFO|ADV> NBCROW bitmap data: ", _nullBitmap, (ushort)_nullBitmap.Length);
 
                 return true;
@@ -912,11 +912,11 @@ namespace Microsoft.Data.SqlClient
         internal int DecrementPendingCallbacks(bool release)
         {
             int remaining = Interlocked.Decrement(ref _pendingCallbacks);
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}#, after decrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}, after decrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
 
             if ((0 == remaining || release) && _gcHandle.IsAllocated)
             {
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}#, FREEING HANDLE!", ObjectID);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.DecrementPendingCallbacks|ADV> {0}, FREEING HANDLE!", ObjectID);
                 _gcHandle.Free();
             }
 
@@ -1025,7 +1025,7 @@ namespace Microsoft.Data.SqlClient
         {
             int remaining = Interlocked.Increment(ref _pendingCallbacks);
 
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.IncrementPendingCallbacks|ADV> {0}#, after incrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
+            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParserStateObject.IncrementPendingCallbacks|ADV> {0}, after incrementing _pendingCallbacks: {1}", ObjectID, _pendingCallbacks);
             Debug.Assert(0 < remaining && remaining <= 3, $"_pendingCallbacks values is invalid after incrementing: {remaining}");
             return remaining;
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Data.SqlClient
 
         internal SqlInternalTransaction(SqlInternalConnection innerConnection, TransactionType type, SqlTransaction outerTransaction, long transactionId)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInternalTransaction.ctor|RES|CPOOL> {0}#, Created for connection {1}#, outer transaction {2}#, Type {3}", ObjectID, innerConnection.ObjectID, (null != outerTransaction) ? outerTransaction.ObjectID : -1, (int)type);
+            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInternalTransaction.ctor|RES|CPOOL> {0}, Created for connection {1}, outer transaction {2}, Type {3}", ObjectID, innerConnection.ObjectID, (null != outerTransaction) ? outerTransaction.ObjectID : -1, (int)type);
 
             _innerConnection = innerConnection;
             _transactionType = type;
@@ -268,7 +268,7 @@ namespace Microsoft.Data.SqlClient
             SqlInternalConnection innerConnection = _innerConnection;
 
             Debug.Assert(innerConnection != null, "How can we be here if the connection is null?");
-            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInteralTransaction.CloseFromConnection|RES|CPOOL> {0}#, Closing", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInteralTransaction.CloseFromConnection|RES|CPOOL> {0}, Closing", ObjectID);
 
             bool processFinallyBlock = true;
             try
@@ -296,7 +296,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Commit()
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Commit|API> {0}#", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Commit|API> {0}", ObjectID);
             if (_innerConnection.IsLockedForBulkCopy)
             {
                 throw SQL.ConnectionLockedForBcpEvent();
@@ -369,7 +369,7 @@ namespace Microsoft.Data.SqlClient
 
         private /*protected override*/ void Dispose(bool disposing)
         {
-            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInteralTransaction.Dispose|RES|CPOOL> {0}#, Disposing", ObjectID);
+            SqlClientEventSource.Log.PoolerTraceEvent("<sc.SqlInteralTransaction.Dispose|RES|CPOOL> {0}, Disposing", ObjectID);
 
             if (disposing)
             {
@@ -425,7 +425,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Rollback()
         {
-            var scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}#", ObjectID);
+            var scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}", ObjectID);
 
             if (_innerConnection.IsLockedForBulkCopy)
             {
@@ -472,7 +472,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Rollback(string transactionName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}#, transactionName='{transactionName}'", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}, transactionName='{transactionName}'", ObjectID);
 
             if (_innerConnection.IsLockedForBulkCopy)
             {
@@ -521,7 +521,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Save(string savePointName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}#, savePointName='{savePointName}'", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}, savePointName='{savePointName}'", ObjectID);
             _innerConnection.ValidateConnectionForExecute(null);
 
             try

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Rollback(string transactionName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}, transactionName='{transactionName}'", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}, transactionName='{1}'", ObjectID, transactionName);
 
             if (_innerConnection.IsLockedForBulkCopy)
             {
@@ -521,7 +521,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Save(string savePointName)
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}, savePointName='{savePointName}'", ObjectID);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}, savePointName='{1}'", ObjectID, savePointName);
             _innerConnection.ValidateConnectionForExecute(null);
 
             try

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
@@ -713,7 +713,7 @@ namespace Microsoft.Data.SqlTypes
                 UnsafeNativeMethods.SetErrorModeWrapper(UnsafeNativeMethods.SEM_FAILCRITICALERRORS, out oldMode);
                 try
                 {
-                    SqlClientEventSource.Log.AdvanceTrace("<sc.SqlFileStream.OpenSqlFileStream|ADV> {0}#, desiredAccess=0x{1}, allocationSize={2}, " +
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlFileStream.OpenSqlFileStream|ADV> {0}#, desiredAccess=0x{1}, allocationSize={2}, " +
                        "fileAttributes=0x{3}, shareAccess=0x{4}, dwCreateDisposition=0x{5}, createOptions=0x{ dwCreateOptions}", ObjectID, (int)nDesiredAccess, allocationSize, 0, (int)shareAccess, dwCreateDisposition);
 
                     retval = UnsafeNativeMethods.NtCreateFile(out hFile, nDesiredAccess,

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Data.SqlTypes
                 Int64 allocationSize
             )
         {
-            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlFileStream.ctor|API> {0}# access={1} options={2} path='{3}'", ObjectID, (int)access, (int)options, path);
+            long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlFileStream.ctor|API> {0} access={1} options={2} path='{3}'", ObjectID, (int)access, (int)options, path);
             try
             {
                 //-----------------------------------------------------------------
@@ -713,7 +713,7 @@ namespace Microsoft.Data.SqlTypes
                 UnsafeNativeMethods.SetErrorModeWrapper(UnsafeNativeMethods.SEM_FAILCRITICALERRORS, out oldMode);
                 try
                 {
-                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlFileStream.OpenSqlFileStream|ADV> {0}#, desiredAccess=0x{1}, allocationSize={2}, " +
+                    SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlFileStream.OpenSqlFileStream|ADV> {0}, desiredAccess=0x{1}, allocationSize={2}, " +
                        "fileAttributes=0x{3}, shareAccess=0x{4}, dwCreateDisposition=0x{5}, createOptions=0x{ dwCreateOptions}", ObjectID, (int)nDesiredAccess, allocationSize, 0, (int)shareAccess, dwCreateDisposition);
 
                     retval = UnsafeNativeMethods.NtCreateFile(out hFile, nDesiredAccess,

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -3,16 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlTypes;
+using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Security;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
@@ -38,6 +35,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static List<string> AEConnStrings = new List<string>();
         public static List<string> AEConnStringsSetup = new List<string>();
         public static readonly bool EnclaveEnabled = false;
+        public static readonly bool TracingEnabled = false;
         public static readonly bool SupportsIntegratedSecurity = false;
         public static readonly bool SupportsLocalDb = false;
         public static readonly bool SupportsFileStream = false;
@@ -56,6 +54,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                                                                      ".database.chinacloudapi.cn"};
 
         private static Dictionary<string, bool> AvailableDatabases;
+        private static TraceEventListener TraceListener;
 
         private class Config
         {
@@ -70,6 +69,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             public string AzureKeyVaultClientId = null;
             public string AzureKeyVaultClientSecret = null;
             public bool EnclaveEnabled = false;
+            public bool TracingEnabled = false;
             public bool SupportsIntegratedSecurity = false;
             public bool SupportsLocalDb = false;
             public bool SupportsFileStream = false;
@@ -99,6 +99,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 SupportsIntegratedSecurity = c.SupportsIntegratedSecurity;
                 SupportsFileStream = c.SupportsFileStream;
                 EnclaveEnabled = c.EnclaveEnabled;
+                TracingEnabled = c.TracingEnabled;
+
+                if(TracingEnabled)
+                {
+                    TraceListener = new DataTestUtility.TraceEventListener();
+                }
 
                 if (IsAADPasswordConnStrSetup() && IsAADAuthorityURLSetup())
                 {
@@ -636,6 +642,25 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 }
             }
             return res;
+        }
+
+        public class TraceEventListener : EventListener
+        {
+            public List<int> IDs = new List<int>();
+
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                if (eventSource.Name.Equals("Microsoft.Data.SqlClient.EventSource"))
+                {
+                    // Collect all traces for better code coverage
+                    EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
+                }
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData)
+            {
+                IDs.Add(eventData.EventId);
+            }
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -39,14 +39,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static readonly bool SupportsIntegratedSecurity = false;
         public static readonly bool SupportsLocalDb = false;
         public static readonly bool SupportsFileStream = false;
+        public static readonly bool UseManagedSNIOnWindows = false;
 
         public const string UdtTestDbName = "UdtTestDb";
         public const string AKVKeyName = "TestSqlClientAzureKeyVaultProvider";
-
         private const string ManagedNetworkingAppContextSwitch = "Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows";
-
-        private static bool UseManagedSNI =
-            bool.TryParse(Environment.GetEnvironmentVariable("Microsoft_Data_SqlClient_UseManagedSniOnWindows"), out UseManagedSNI) ? UseManagedSNI : false;
 
         private static readonly string[] AzureSqlServerEndpoints = {".database.windows.net",
                                                                      ".database.cloudapi.de",
@@ -73,16 +70,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             public bool SupportsIntegratedSecurity = false;
             public bool SupportsLocalDb = false;
             public bool SupportsFileStream = false;
+            public bool UseManagedSNIOnWindows = false;
         }
 
         static DataTestUtility()
         {
-            if (UseManagedSNI)
-            {
-                AppContext.SetSwitch(ManagedNetworkingAppContextSwitch, true);
-                Console.WriteLine($"App Context switch {ManagedNetworkingAppContextSwitch} enabled on {Environment.OSVersion}");
-            }
-
             using (StreamReader r = new StreamReader("config.json"))
             {
                 string json = r.ReadToEnd();
@@ -100,10 +92,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 SupportsFileStream = c.SupportsFileStream;
                 EnclaveEnabled = c.EnclaveEnabled;
                 TracingEnabled = c.TracingEnabled;
+                UseManagedSNIOnWindows = c.UseManagedSNIOnWindows;
 
-                if(TracingEnabled)
+                if (TracingEnabled)
                 {
                     TraceListener = new DataTestUtility.TraceEventListener();
+                }
+
+                if (UseManagedSNIOnWindows)
+                {
+                    AppContext.SetSwitch(ManagedNetworkingAppContextSwitch, true);
+                    Console.WriteLine($"App Context switch {ManagedNetworkingAppContextSwitch} enabled on {Environment.OSVersion}");
                 }
 
                 if (IsAADPasswordConnStrSetup() && IsAADAuthorityURLSetup())
@@ -244,7 +243,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return !string.IsNullOrEmpty(AKVUrl) && !string.IsNullOrEmpty(AKVClientId) && !string.IsNullOrEmpty(AKVClientSecret);
         }
 
-        public static bool IsUsingManagedSNI() => UseManagedSNI;
+        public static bool IsUsingManagedSNI() => UseManagedSNIOnWindows;
 
         public static bool IsUsingNativeSNI() => !IsUsingManagedSNI();
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/EventSource/EventSourceTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/EventSource/EventSourceTest.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using System.Linq;
 using Xunit;
 
@@ -16,7 +12,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public void EventSourceTestAll()
         {
-            using (var TraceListener = new TraceEventListener())
+            using (var TraceListener = new DataTestUtility.TraceEventListener())
             {
                 using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
                 {
@@ -36,25 +32,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 Assert.All(TraceListener.IDs, item => { Assert.Contains(item, Enumerable.Range(1, 21)); });
             }
-        }
-    }
-
-    public class TraceEventListener : EventListener
-    {
-        public List<int> IDs = new List<int>();
-
-        protected override void OnEventSourceCreated(EventSource eventSource)
-        {
-            if (eventSource.Name.Equals("Microsoft.Data.SqlClient.EventSource"))
-            {
-                // Collect all traces for better code coverage
-                // EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
-            }
-        }
-
-        protected override void OnEventWritten(EventWrittenEventArgs eventData)
-        {
-            IDs.Add(eventData.EventId);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/EventSource/EventSourceTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/EventSource/EventSourceTest.cs
@@ -34,11 +34,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 // Need to investigate better way of collecting traces in sequential runs, 
                 // For now we're collecting all traces to improve code coverage.
 #if NETCOREAPP
+#if unix
+                Assert.Equal(211, TraceListener.IDs.Count);
+#else
                 Assert.Equal(226, TraceListener.IDs.Count);
+#endif
 #elif NETFX
                 Assert.Equal(250, TraceListener.IDs.Count);
-#elif UNIX
-                Assert.Equal(211, TraceListener.IDs.Count);
 #endif
                 Assert.All(TraceListener.IDs, item => { Assert.Contains(item, Enumerable.Range(1, 21)); });
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/EventSource/EventSourceTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/EventSource/EventSourceTest.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 #elif NETFX
                 Assert.Equal(250, TraceListener.IDs.Count);
 #elif UNIX
-                Assert.Equal(226, TraceListener.IDs.Count);
+                Assert.Equal(211, TraceListener.IDs.Count);
 #endif
                 Assert.All(TraceListener.IDs, item => { Assert.Contains(item, Enumerable.Range(1, 21)); });
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/EventSource/EventSourceTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/EventSource/EventSourceTest.cs
@@ -30,12 +30,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         }
                     }
                 }
+
                 // Need to investigate better way of collecting traces in sequential runs, 
                 // For now we're collecting all traces to improve code coverage.
 #if NETCOREAPP
-                Assert.True(TraceListener.IDs.Count == 226);
-#else
-                Assert.True(TraceListener.IDs.Count == 250);
+                Assert.Equal(226, TraceListener.IDs.Count);
+#elif NETFX
+                Assert.Equal(250, TraceListener.IDs.Count);
+#elif UNIX
+                Assert.Equal(226, TraceListener.IDs.Count);
 #endif
                 Assert.All(TraceListener.IDs, item => { Assert.Contains(item, Enumerable.Range(1, 21)); });
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/EventSource/EventSourceTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/EventSource/EventSourceTest.cs
@@ -31,17 +31,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     }
                 }
 
-                // Need to investigate better way of collecting traces in sequential runs, 
+                // Need to investigate better way of validating traces in sequential runs, 
                 // For now we're collecting all traces to improve code coverage.
-#if NETCOREAPP
-#if unix
-                Assert.Equal(211, TraceListener.IDs.Count);
-#else
-                Assert.Equal(226, TraceListener.IDs.Count);
-#endif
-#elif NETFX
-                Assert.Equal(250, TraceListener.IDs.Count);
-#endif
+
                 Assert.All(TraceListener.IDs, item => { Assert.Contains(item, Enumerable.Range(1, 21)); });
             }
         }
@@ -56,7 +48,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             if (eventSource.Name.Equals("Microsoft.Data.SqlClient.EventSource"))
             {
                 // Collect all traces for better code coverage
-                EnableEvents(eventSource, EventLevel.Informational, 0);
+                // EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -7,7 +7,8 @@
     <CodeAnalysisRuleSet>Microsoft.Data.SqlClient.ManualTesting.Tests.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;net46-Release;net46-Debug;netcoreapp2.1-Debug;netcoreapp2.1-Release;netcoreapp3.1-Debug;netcoreapp3.1-Release</Configurations>
     <Platforms>AnyCPU;x86;x64</Platforms>
-    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);NETCOREAPP</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netfx'">$(DefineConstants);NETFX</DefineConstants>
     <IntermediateOutputPath>$(ObjFolder)$(Configuration).ManualTests</IntermediateOutputPath>
     <OutputPath>$(BinFolder)$(Configuration).ManualTests</OutputPath>
   </PropertyGroup>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -7,8 +7,8 @@
     <CodeAnalysisRuleSet>Microsoft.Data.SqlClient.ManualTesting.Tests.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;net46-Release;net46-Debug;netcoreapp2.1-Debug;netcoreapp2.1-Release;netcoreapp3.1-Debug;netcoreapp3.1-Release</Configurations>
     <Platforms>AnyCPU;x86;x64</Platforms>
-    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);NETCOREAPP</DefineConstants>
-    <DefineConstants Condition="'$(TargetGroup)'=='netfx'">$(DefineConstants);NETFX</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netfx'">$(DefineConstants);netfx</DefineConstants>
     <IntermediateOutputPath>$(ObjFolder)$(Configuration).ManualTests</IntermediateOutputPath>
     <OutputPath>$(BinFolder)$(Configuration).ManualTests</OutputPath>
   </PropertyGroup>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/config.default.json
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/config.default.json
@@ -5,6 +5,7 @@
     "TCPConnectionStringAASVBS": "",
     "TCPConnectionStringAASSGX": "",
     "EnclaveEnabled": false,
+    "TracingEnabled": false,
     "AADAuthorityURL": "",
     "AADPasswordConnectionString": "",
     "AzureKeyVaultURL": "",

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/config.default.json
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/config.default.json
@@ -13,5 +13,6 @@
     "AzureKeyVaultClientSecret": "",
     "SupportsIntegratedSecurity": true,
     "SupportsLocalDb": false,
-    "SupportsFileStream": false
+    "SupportsFileStream": false,
+    "UseManagedSNIOnWindows": false
 }


### PR DESCRIPTION
Updates in EventSource tracing implementation:
- Re-ordered Keywords
- Code Organization for readability
- Standardization of method names
- Inline documentations
- SNI Trace + Scope segregation
- Event proofing
- Adds support in ManualTests to enable tracing for all tests from pipeline.
- Modifies enabling "UseManagedSNIOnWindows" from config.json instead of Env variable.

Also to mention:
* This change also makes EventSource traces all disabled by default.
End users would have to enable "_ExecutionTrace_" to continue to capture Begin/End execute commands.
* Keeping this trace enabled by default does not seem appropriate when comparing with other EventSource implementations. As we head to 2.0 (major), we are making amendments to set things right.