### PR TITLE
[Release 1.1] Fixed the ConnectionString's password persistence in NetCore.

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
@@ -101,7 +101,6 @@ namespace Microsoft.Data.Common
         private readonly string _usersConnectionString;
         private readonly Dictionary<string, string> _parsetable;
         internal readonly NameValuePair _keyChain;
-        internal readonly bool _hasPasswordKeyword;
 
         internal Dictionary<string, string> Parsetable
         {
@@ -114,14 +113,14 @@ namespace Microsoft.Data.Common
         private string UsersConnectionString(bool hidePassword, bool forceHidePassword)
         {
             string connectionString = _usersConnectionString;
-            if (_hasPasswordKeyword && (forceHidePassword || (hidePassword && !HasPersistablePassword)))
+            if (HasPasswordKeyword && (forceHidePassword || (hidePassword && !HasPersistablePassword)))
             {
                 ReplacePasswordPwd(out connectionString, false);
             }
             return connectionString ?? string.Empty;
         }
 
-        internal bool HasPersistablePassword => _hasPasswordKeyword ?
+        internal bool HasPersistablePassword => HasPasswordKeyword ?
             ConvertValueToBoolean(KEY.Persist_Security_Info, false) :
             true; // no password means persistable password so we don't have to munge
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionOptions.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Data.Common
         protected DbConnectionOptions(DbConnectionOptions connectionOptions)
         { // Clone used by SqlConnectionString
             _usersConnectionString = connectionOptions._usersConnectionString;
-            _hasPasswordKeyword = connectionOptions._hasPasswordKeyword;
             _parsetable = connectionOptions._parsetable;
             _keyChain = connectionOptions._keyChain;
             HasPasswordKeyword = connectionOptions.HasPasswordKeyword;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -208,6 +208,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return retval;
         }
 
+        public static bool IsTCPConnectionStringPasswordIncluded()
+        {
+            return RetrieveValueFromConnStr(TCPConnectionString, new string[] { "Password", "PWD" }) != string.Empty;
+        }
+
         // the name length will be no more then (16 + prefix.Length + escapeLeft.Length + escapeRight.Length)
         // some providers does not support names (Oracle supports up to 30)
         public static string GetUniqueName(string prefix)
@@ -481,6 +486,31 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 cmd.ExecuteNonQuery();
             }
+        }
+
+        public static string RetrieveValueFromConnStr(string connStr, string[] keywords)
+        {
+            // tokenize connection string and retrieve value for a specific key.
+            string res = "";
+            if (connStr != null && keywords != null)
+            {
+                string[] keys = connStr.Split(';');
+                foreach (var key in keys)
+                {
+                    foreach (var keyword in keywords)
+                    {
+                        if (!string.IsNullOrEmpty(key.Trim()))
+                        {
+                            if (key.Trim().ToLower().StartsWith(keyword.Trim().ToLower()))
+                            {
+                                res = key.Substring(key.IndexOf('=') + 1).Trim();
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            return res;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
-    public static class ConnectivityParametersTest
+    public static class ConnectivityTest
     {
         private const string COL_SPID = "SPID";
         private const string COL_PROGRAM_NAME = "ProgramName";
@@ -224,6 +224,34 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 // Kill all the connections, set Database to SINGLE_USER Mode and drop Database
                 DataTestUtility.RunNonQuery(s_connectionString, s_alterDatabaseSingleCmd);
                 DataTestUtility.RunNonQuery(s_connectionString, s_dropDatabaseCmd);
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnectionStringPasswordIncluded))]
+        public static void ConnectionStringPersistantInfoTest()
+        {
+            SqlConnectionStringBuilder connectionStringBuilder = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString);
+            connectionStringBuilder.PersistSecurityInfo = false;
+            string cnnString = connectionStringBuilder.ConnectionString;
+
+            connectionStringBuilder.Clear();
+            using (SqlConnection sqlCnn = new SqlConnection(cnnString))
+            {
+                sqlCnn.Open();
+                connectionStringBuilder.ConnectionString = sqlCnn.ConnectionString;
+                Assert.True(connectionStringBuilder.Password == string.Empty, "Password must not persist according to set the PersistSecurityInfo by false!");
+            }
+
+            connectionStringBuilder.ConnectionString = DataTestUtility.TCPConnectionString;
+            connectionStringBuilder.PersistSecurityInfo = true;
+            cnnString = connectionStringBuilder.ConnectionString;
+
+            connectionStringBuilder.Clear();
+            using (SqlConnection sqlCnn = new SqlConnection(cnnString))
+            {
+                sqlCnn.Open();
+                connectionStringBuilder.ConnectionString = sqlCnn.ConnectionString;
+                Assert.True(connectionStringBuilder.Password != string.Empty, "Password must persist according to set the PersistSecurityInfo by true!");
             }
         }
     }


### PR DESCRIPTION
Ports changes from #453 to 1.1-servicing.

If PersistSecurityInfo = false be set in a ConnectionString, we should not get the password in an open sqlConnection's ConnectionString property.