### PR TITLE
Allow username with Active Directory Interactive Authentication (NetFx)

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/ActiveDirectoryNativeAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/ActiveDirectoryNativeAuthenticationProvider.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Data.SqlClient
             {
                 result = await app.AcquireTokenInteractive(scopes)
                   .WithUseEmbeddedWebView(true)
+                  .WithLoginHint(parameters.UserId)
                   .ExecuteAsync();
             }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -530,9 +530,9 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.IntegratedWithUserIDAndPassword();
             }
 
-            if (Authentication == SqlAuthenticationMethod.ActiveDirectoryInteractive && (HasUserIdKeyword || HasPasswordKeyword))
+            if (Authentication == SqlAuthenticationMethod.ActiveDirectoryInteractive && (HasPasswordKeyword))
             {
-                throw SQL.InteractiveWithUserIDAndPassword();
+                throw SQL.InteractiveWithPassword();
             }
 
 #if ADONET_CERT_AUTH

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -326,9 +326,9 @@ namespace Microsoft.Data.SqlClient
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_IntegratedWithUserIDAndPassword));
         }
 
-        static internal Exception InteractiveWithUserIDAndPassword()
+        static internal Exception InteractiveWithPassword()
         {
-            return ADP.Argument(StringsHelper.GetString(Strings.SQL_InteractiveWithUserIDAndPassword));
+            return ADP.Argument(StringsHelper.GetString(Strings.SQL_InteractiveWithPassword));
         }
 
         static internal Exception SettingIntegratedWithCredential()

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
@@ -9379,11 +9379,11 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot use &apos;Authentication=Active Directory Interactive&apos; with &apos;User ID&apos;, &apos;UID&apos;, &apos;Password&apos; or &apos;PWD&apos; connection string keywords..
+        ///   Looks up a localized string similar to Cannot use &apos;Authentication=Active Directory Interactive&apos; with &apos;Password&apos; or &apos;PWD&apos; connection string keywords..
         /// </summary>
-        internal static string SQL_InteractiveWithUserIDAndPassword {
+        internal static string SQL_InteractiveWithPassword {
             get {
-                return ResourceManager.GetString("SQL_InteractiveWithUserIDAndPassword", resourceCulture);
+                return ResourceManager.GetString("SQL_InteractiveWithPassword", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
@@ -2496,8 +2496,8 @@
   <data name="SQL_IntegratedWithUserIDAndPassword" xml:space="preserve">
     <value>Cannot use 'Authentication=Active Directory Integrated' with 'User ID', 'UID', 'Password' or 'PWD' connection string keywords.</value>
   </data>
-  <data name="SQL_InteractiveWithUserIDAndPassword" xml:space="preserve">
-    <value>Cannot use 'Authentication=Active Directory Interactive' with 'User ID', 'UID', 'Password' or 'PWD' connection string keywords.</value>
+  <data name="SQL_InteractiveWithPassword" xml:space="preserve">
+    <value>Cannot use 'Authentication=Active Directory Interactive' with 'Password' or 'PWD' connection string keywords.</value>
   </data>
   <data name="SQL_SettingIntegratedWithCredential" xml:space="preserve">
     <value>Cannot use 'Authentication=Active Directory Integrated', if the Credential property has been set.</value>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/AADConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/AADConnectionTest.cs
@@ -224,14 +224,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         [ConditionalFact(nameof(IsAADConnStringsSetup))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
-        public static void MFAAuthWithCred()
+        public static void MFAAuthWithPassword()
         {
             // connection fails with expected error message.
             string[] AuthKey = { "Authentication" };
             string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, AuthKey) + "Authentication=Active Directory Interactive;";
             ArgumentException e = Assert.Throws<ArgumentException>(() => ConnectAndDisconnect(connStr));
 
-            string expectedMessage = "Cannot use 'Authentication=Active Directory Interactive' with 'User ID', 'UID', 'Password' or 'PWD' connection string keywords.";
+            string expectedMessage = "Cannot use 'Authentication=Active Directory Interactive' with 'Password' or 'PWD' connection string keywords.";
             Assert.Contains(expectedMessage, e.Message);
         }
 


### PR DESCRIPTION

This PR adds support for specifying "User ID" or "UID" (optionally) with "Active Directory Interactive" authentication mode in Connection String.

* It does not break existing behavior of Microsoft.Data.SqlClient.
* Also makes the driver backwards compatible with System.Data.SqlClient.

Dev NuGet Package for testing:
[Microsoft.Data.SqlClient.2.0.0-dev.nupkg.zip](https://github.com/dotnet/SqlClient/files/4389268/Microsoft.Data.SqlClient.2.0.0-dev.nupkg.zip)

Connection Strings acceptable:
"Server={servername}; Authentication=Active Directory Interactive;"
"Server={servername}; Authentication=Active Directory Interactive; User Id={username};"