### PR TITLE
Fixed command's parameters' insert in NetFx [issue #478]

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/SqlParameterCollectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/SqlParameterCollectionHelper.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Data.SqlClient
         {
             OnChange();  // fire event before value is validated
             ValidateType(value);
-            Validate(-1, (SqlParameterCollection)value);
+            Validate(-1, (SqlParameter)value);
             InnerList.Insert(index, (SqlParameter)value);
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlCommandTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlCommandTest.cs
@@ -555,8 +555,15 @@ namespace Microsoft.Data.SqlClient.Tests
         [Fact]
         public void ParameterCollectionTest()
         {
-            SqlCommand cmd = new SqlCommand();
-            cmd.Parameters.AddRange(new SqlParameter[] { });
+            using (var cmd = new SqlCommand())
+            {
+                cmd.Parameters.Add(new SqlParameter());
+                cmd.Parameters.AddRange(new SqlParameter[] { });
+                cmd.Parameters.Insert(0, new SqlParameter());                
+                cmd.Parameters.Insert(1, new SqlParameter());                
+                cmd.Parameters.RemoveAt(0);
+                cmd.Parameters.Remove(cmd.Parameters[0]);
+            }
         }
     }
 }


### PR DESCRIPTION
The issue [#478](https://github.com/dotnet/SqlClient/issues/440) pertained to explicit type conversion on validate the input parameter for prevention of type misusing in **SqlParameterCollection** class.
This exception found in **.NetFx** , and **.NetCore** does not reproduce the problem.