### PR TITLE
Attempt to fix Promote Transaction issue

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -137,79 +137,92 @@ namespace Microsoft.Data.SqlClient
             //  from an operational standpoint (i.e. logging connection's ObjectID should be fine,
             //  but the PromotedDTCToken can change over calls. so that must be protected).
             SqlInternalConnection connection = GetValidConnection();
-
             Exception promoteException;
             byte[] returnValue = null;
-            SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}, Connection {1}, promoting transaction.", ObjectID, connection.ObjectID);
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
+
+            if (null != connection)
             {
-                lock (connection)
+                SqlConnection usersConnection = connection.Connection;
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}, Connection {1}, promoting transaction.", ObjectID, connection.ObjectID);
+                RuntimeHelpers.PrepareConstrainedRegions();
+                try
                 {
-                    try
+                    lock (connection)
                     {
-                        // Now that we've acquired the lock, make sure we still have valid state for this operation.
-                        ValidateActiveOnConnection(connection);
-
-                        connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Promote, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
-                        returnValue = _connection.PromotedDTCToken;
-
-                        // For Global Transactions, we need to set the Transaction Id since we use a Non-MSDTC Promoter type.
-                        if (_connection.IsGlobalTransaction)
+                        try
                         {
-                            if (SysTxForGlobalTransactions.SetDistributedTransactionIdentifier == null)
+                            // Now that we've acquired the lock, make sure we still have valid state for this operation.
+                            ValidateActiveOnConnection(connection);
+
+                            connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Promote, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
+                            returnValue = _connection.PromotedDTCToken;
+
+                            // For Global Transactions, we need to set the Transaction Id since we use a Non-MSDTC Promoter type.
+                            if (_connection.IsGlobalTransaction)
                             {
-                                throw SQL.UnsupportedSysTxForGlobalTransactions();
+                                if (SysTxForGlobalTransactions.SetDistributedTransactionIdentifier == null)
+                                {
+                                    throw SQL.UnsupportedSysTxForGlobalTransactions();
+                                }
+
+                                if (!_connection.IsGlobalTransactionsEnabledForServer)
+                                {
+                                    throw SQL.GlobalTransactionsNotEnabled();
+                                }
+
+                                SysTxForGlobalTransactions.SetDistributedTransactionIdentifier.Invoke(_atomicTransaction, new object[] { this, GetGlobalTxnIdentifierFromToken() });
                             }
 
-                            if (!_connection.IsGlobalTransactionsEnabledForServer)
-                            {
-                                throw SQL.GlobalTransactionsNotEnabled();
-                            }
-
-                            SysTxForGlobalTransactions.SetDistributedTransactionIdentifier.Invoke(_atomicTransaction, new object[] { this, GetGlobalTxnIdentifierFromToken() });
+                            promoteException = null;
                         }
+                        catch (SqlException e)
+                        {
+                            promoteException = e;
 
-                        promoteException = null;
-                    }
-                    catch (SqlException e)
-                    {
-                        promoteException = e;
-
-                        // Doom the connection, to make sure that the transaction is
-                        // eventually rolled back.
-                        // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
-                        connection.DoomThisConnection();
-                    }
-                    catch (InvalidOperationException e)
-                    {
-                        promoteException = e;
-                        connection.DoomThisConnection();
+                            // Doom the connection, to make sure that the transaction is
+                            // eventually rolled back.
+                            // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
+                            connection.DoomThisConnection();
+                        }
+                        catch (InvalidOperationException e)
+                        {
+                            promoteException = e;
+                            connection.DoomThisConnection();
+                        }
                     }
                 }
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                usersConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                usersConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                usersConnection.Abort(e);
-                throw;
-            }
+                catch (System.OutOfMemoryException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
+                catch (System.StackOverflowException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
+                catch (System.Threading.ThreadAbortException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
 
-            if (promoteException != null)
-            {
-                throw SQL.PromotionFailed(promoteException);
+                //Throw exception only if Transaction is till active and not yet aborted.
+                if (promoteException != null && Transaction.TransactionInformation.Status != TransactionStatus.Aborted)
+                {
+                    throw SQL.PromotionFailed(promoteException);
+                }
+                else
+                {
+                    // The transaction was aborted externally, since it's already doomed above, we only log the same.
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}, Connection {1}, aborted during promotion.", ObjectID, connection.ObjectID);
+                }
             }
-
+            else
+            {
+                // The transaction was aborted externally, doom the connection to make sure it's eventually rolled back and log the same.
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}, Connection {1}, aborted before promoting.", ObjectID, connection.ObjectID);
+            }
             return returnValue;
         }
 
@@ -217,13 +230,12 @@ namespace Microsoft.Data.SqlClient
         public void Rollback(SinglePhaseEnlistment enlistment)
         {
             Debug.Assert(null != enlistment, "null enlistment?");
-            SqlInternalConnection connection = null;
+            SqlInternalConnection connection = GetValidConnection();
 
-            try
+            if (null != connection)
             {
-                connection = GetValidConnection();
                 SqlConnection usersConnection = connection.Connection;
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Rollback|RES|CPOOL> {0}, Connection {1}, aborting transaction.", ObjectID, connection.ObjectID);
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Rollback|RES|CPOOL> {0}, Connection {1}, rolling back transaction.", ObjectID, connection.ObjectID);
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
@@ -288,14 +300,11 @@ namespace Microsoft.Data.SqlClient
                     throw;
                 }
             }
-            catch (ObjectDisposedException)
+            else
             {
-                if (_atomicTransaction.TransactionInformation.Status == TransactionStatus.Active)
-                {
-                    throw;
-                }
-                // Do not throw exception if connection is already aborted/ended from another thread,
-                // replicate as done in TransactionEnded event handler.
+                // The transaction was aborted, report that to SysTx and log the same.
+                enlistment.Aborted();
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Rollback|RES|CPOOL> {0}, Connection {1}, aborted before rollback.", ObjectID, connection.ObjectID);
             }
         }
 
@@ -303,107 +312,116 @@ namespace Microsoft.Data.SqlClient
         public void SinglePhaseCommit(SinglePhaseEnlistment enlistment)
         {
             Debug.Assert(null != enlistment, "null enlistment?");
-
             SqlInternalConnection connection = GetValidConnection();
-            SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.SinglePhaseCommit|RES|CPOOL> {0}, Connection {1}, committing transaction.", ObjectID, connection.ObjectID);
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
+
+            if (null != connection)
             {
-                // If the connection is dooomed, we can be certain that the
-                // transaction will eventually be rolled back, and we shouldn't
-                // attempt to commit it.
-                if (connection.IsConnectionDoomed)
+                SqlConnection usersConnection = connection.Connection;
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.SinglePhaseCommit|RES|CPOOL> {0}, Connection {1}, committing transaction.", ObjectID, connection.ObjectID);
+                RuntimeHelpers.PrepareConstrainedRegions();
+                try
                 {
-                    lock (connection)
+                    // If the connection is dooomed, we can be certain that the
+                    // transaction will eventually be rolled back, and we shouldn't
+                    // attempt to commit it.
+                    if (connection.IsConnectionDoomed)
                     {
-                        _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
-                        _connection = null;
-                    }
-
-                    enlistment.Aborted(SQL.ConnectionDoomed());
-                }
-                else
-                {
-                    Exception commitException;
-                    lock (connection)
-                    {
-                        try
+                        lock (connection)
                         {
-                            // Now that we've acquired the lock, make sure we still have valid state for this operation.
-                            ValidateActiveOnConnection(connection);
-
                             _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
-                            _connection = null;   // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
+                            _connection = null;
+                        }
 
-                            connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
-                            commitException = null;
-                        }
-                        catch (SqlException e)
-                        {
-                            commitException = e;
-
-                            // Doom the connection, to make sure that the transaction is
-                            // eventually rolled back.
-                            // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
-                            connection.DoomThisConnection();
-                        }
-                        catch (InvalidOperationException e)
-                        {
-                            commitException = e;
-                            connection.DoomThisConnection();
-                        }
+                        enlistment.Aborted(SQL.ConnectionDoomed());
                     }
-                    if (commitException != null)
+                    else
                     {
-                        // connection.ExecuteTransaction failed with exception
-                        if (_internalTransaction.IsCommitted)
+                        Exception commitException;
+                        lock (connection)
                         {
-                            // Even though we got an exception, the transaction
-                            // was committed by the server.
+                            try
+                            {
+                                // Now that we've acquired the lock, make sure we still have valid state for this operation.
+                                ValidateActiveOnConnection(connection);
+
+                                _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
+                                _connection = null;   // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
+
+                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
+                                commitException = null;
+                            }
+                            catch (SqlException e)
+                            {
+                                commitException = e;
+
+                                // Doom the connection, to make sure that the transaction is
+                                // eventually rolled back.
+                                // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
+                                connection.DoomThisConnection();
+                            }
+                            catch (InvalidOperationException e)
+                            {
+                                commitException = e;
+                                connection.DoomThisConnection();
+                            }
+                        }
+                        if (commitException != null)
+                        {
+                            // connection.ExecuteTransaction failed with exception
+                            if (_internalTransaction.IsCommitted)
+                            {
+                                // Even though we got an exception, the transaction
+                                // was committed by the server.
+                                enlistment.Committed();
+                            }
+                            else if (_internalTransaction.IsAborted)
+                            {
+                                // The transaction was aborted, report that to
+                                // SysTx.
+                                enlistment.Aborted(commitException);
+                            }
+                            else
+                            {
+                                // The transaction is still active, we cannot
+                                // know the state of the transaction.
+                                enlistment.InDoubt(commitException);
+                            }
+
+                            // We eat the exception.  This is called on the SysTx
+                            // thread, not the applications thread.  If we don't 
+                            // eat the exception an UnhandledException will occur,
+                            // causing the process to FailFast.
+                        }
+
+                        connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
+                        if (commitException == null)
+                        {
+                            // connection.ExecuteTransaction succeeded
                             enlistment.Committed();
                         }
-                        else if (_internalTransaction.IsAborted)
-                        {
-                            // The transaction was aborted, report that to
-                            // SysTx.
-                            enlistment.Aborted(commitException);
-                        }
-                        else
-                        {
-                            // The transaction is still active, we cannot
-                            // know the state of the transaction.
-                            enlistment.InDoubt(commitException);
-                        }
-
-                        // We eat the exception.  This is called on the SysTx
-                        // thread, not the applications thread.  If we don't 
-                        // eat the exception an UnhandledException will occur,
-                        // causing the process to FailFast.
-                    }
-
-                    connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
-                    if (commitException == null)
-                    {
-                        // connection.ExecuteTransaction succeeded
-                        enlistment.Committed();
                     }
                 }
+                catch (System.OutOfMemoryException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
+                catch (System.StackOverflowException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
+                catch (System.Threading.ThreadAbortException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
             }
-            catch (System.OutOfMemoryException e)
+            else
             {
-                usersConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                usersConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                usersConnection.Abort(e);
-                throw;
+                // The transaction was aborted before we could commit, report that to SysTx and log the same.
+                enlistment.Aborted();
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.SinglePhaseCommit|RES|CPOOL> {0}, Connection {1}, aborted before commit.", ObjectID, connection.ObjectID);
             }
         }
 
@@ -436,7 +454,7 @@ namespace Microsoft.Data.SqlClient
         private SqlInternalConnection GetValidConnection()
         {
             SqlInternalConnection connection = _connection;
-            if (null == connection)
+            if (null == connection && Transaction.TransactionInformation.Status != TransactionStatus.Aborted)
             {
                 throw ADP.ObjectDisposed(this);
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -413,6 +413,8 @@ namespace Microsoft.Data.SqlClient
                         _active = false;
                         _connection = null;
                     }
+                    // Safest approach is to doom this connection, whose transaction has been aborted externally.
+                    connection.DoomThisConnection();
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Data.SqlClient
         private SqlInternalConnection _connection;            // the internal connection that is the root of the transaction
         private IsolationLevel _isolationLevel;        // the IsolationLevel of the transaction we delegated to the server
         private SqlInternalTransaction _internalTransaction;   // the SQL Server transaction we're delegating to
-
         private SysTx.Transaction _atomicTransaction;
 
         private bool _active;                // Is the transaction active?

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -504,6 +504,8 @@ namespace Microsoft.Data.SqlClient
                         _active = false;
                         _connection = null;
                     }
+                    // Safest approach is to doom this connection, whose transaction has been aborted externally.
+                    connection.DoomThisConnection();
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -167,97 +167,110 @@ namespace Microsoft.Data.SqlClient
 
             Exception promoteException;
             byte[] returnValue = null;
-            SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}, Connection {1}, promoting transaction.", ObjectID, connection.ObjectID);
-            RuntimeHelpers.PrepareConstrainedRegions();
-
-            try
+            if (null != connection)
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
+                SqlConnection usersConnection = connection.Connection;
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}, Connection {1}, promoting transaction.", ObjectID, connection.ObjectID);
                 RuntimeHelpers.PrepareConstrainedRegions();
+
                 try
                 {
-                    tdsReliabilitySection.Start();
+#if DEBUG
+                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+
+                    RuntimeHelpers.PrepareConstrainedRegions();
+                    try
+                    {
+                        tdsReliabilitySection.Start();
 #else
                 {
 #endif //DEBUG
-                    lock (connection)
-                    {
-                        try
+                        lock (connection)
                         {
-                            // Now that we've acquired the lock, make sure we still have valid state for this operation.
-                            ValidateActiveOnConnection(connection);
-
-                            connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Promote, null, IsolationLevel.Unspecified, _internalTransaction, true);
-                            returnValue = _connection.PromotedDTCToken;
-
-                            // For Global Transactions, we need to set the Transaction Id since we use a Non-MSDTC Promoter type.
-                            if (_connection.IsGlobalTransaction)
+                            try
                             {
-                                if (SysTxForGlobalTransactions.SetDistributedTransactionIdentifier == null)
+                                // Now that we've acquired the lock, make sure we still have valid state for this operation.
+                                ValidateActiveOnConnection(connection);
+
+                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Promote, null, IsolationLevel.Unspecified, _internalTransaction, true);
+                                returnValue = _connection.PromotedDTCToken;
+
+                                // For Global Transactions, we need to set the Transaction Id since we use a Non-MSDTC Promoter type.
+                                if (_connection.IsGlobalTransaction)
                                 {
-                                    throw SQL.UnsupportedSysTxForGlobalTransactions();
+                                    if (SysTxForGlobalTransactions.SetDistributedTransactionIdentifier == null)
+                                    {
+                                        throw SQL.UnsupportedSysTxForGlobalTransactions();
+                                    }
+
+                                    if (!_connection.IsGlobalTransactionsEnabledForServer)
+                                    {
+                                        throw SQL.GlobalTransactionsNotEnabled();
+                                    }
+
+                                    SysTxForGlobalTransactions.SetDistributedTransactionIdentifier.Invoke(_atomicTransaction, new object[] { this, GetGlobalTxnIdentifierFromToken() });
                                 }
 
-                                if (!_connection.IsGlobalTransactionsEnabledForServer)
-                                {
-                                    throw SQL.GlobalTransactionsNotEnabled();
-                                }
-
-                                SysTxForGlobalTransactions.SetDistributedTransactionIdentifier.Invoke(_atomicTransaction, new object[] { this, GetGlobalTxnIdentifierFromToken() });
+                                promoteException = null;
                             }
+                            catch (SqlException e)
+                            {
+                                promoteException = e;
 
-                            promoteException = null;
-                        }
-                        catch (SqlException e)
-                        {
-                            promoteException = e;
+                                ADP.TraceExceptionWithoutRethrow(e);
 
-                            ADP.TraceExceptionWithoutRethrow(e);
-
-                            // Doom the connection, to make sure that the transaction is
-                            // eventually rolled back.
-                            // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
-                            connection.DoomThisConnection();
-                        }
-                        catch (InvalidOperationException e)
-                        {
-                            promoteException = e;
-                            ADP.TraceExceptionWithoutRethrow(e);
-                            connection.DoomThisConnection();
+                                // Doom the connection, to make sure that the transaction is
+                                // eventually rolled back.
+                                // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
+                                connection.DoomThisConnection();
+                            }
+                            catch (InvalidOperationException e)
+                            {
+                                promoteException = e;
+                                ADP.TraceExceptionWithoutRethrow(e);
+                                connection.DoomThisConnection();
+                            }
                         }
                     }
-                }
 #if DEBUG
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
+                    finally
+                    {
+                        tdsReliabilitySection.Stop();
+                    }
 #endif //DEBUG
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                usersConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                usersConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                usersConnection.Abort(e);
-                throw;
-            }
+                }
+                catch (System.OutOfMemoryException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
+                catch (System.StackOverflowException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
+                catch (System.Threading.ThreadAbortException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
 
-            if (promoteException != null)
-            {
-                throw SQL.PromotionFailed(promoteException);
+                //Throw exception only if Transaction is till active and not yet aborted.
+                if (promoteException != null && Transaction.TransactionInformation.Status != SysTx.TransactionStatus.Aborted)
+                {
+                    throw SQL.PromotionFailed(promoteException);
+                }
+                else
+                {
+                    // The transaction was aborted externally, since it's already doomed above, we only log the same.
+                    SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}, Connection {1}, aborted during promote.", ObjectID, connection.ObjectID);
+                }
             }
-
+            else
+            {
+                // The transaction was aborted externally, doom the connection to make sure it's eventually rolled back and log the same.
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Promote|RES|CPOOL> {0}, Connection {1}, aborted before promote.", ObjectID, connection.ObjectID);
+            }
             return returnValue;
         }
 
@@ -265,19 +278,17 @@ namespace Microsoft.Data.SqlClient
         public void Rollback(SysTx.SinglePhaseEnlistment enlistment)
         {
             Debug.Assert(null != enlistment, "null enlistment?");
-            SqlInternalConnection connection = null;
+            SqlInternalConnection connection = GetValidConnection();
 
-            try
+            if (null != connection)
             {
 #if DEBUG
                 TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
                 tdsReliabilitySection.Start();
 #endif //DEBUG
-                connection = GetValidConnection();
                 SqlConnection usersConnection = connection.Connection;
-                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Rollback|RES|CPOOL> {0}, Connection {1}, aborting transaction.", ObjectID, connection.ObjectID);
+                RuntimeHelpers.PrepareConstrainedRegions();
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Rollback|RES|CPOOL> {0}, Connection {1}, rolling back transaction.", ObjectID, connection.ObjectID);
                 try
                 {
                     lock (connection)
@@ -350,14 +361,11 @@ namespace Microsoft.Data.SqlClient
                 }
 #endif //DEBUG
             }
-            catch (ObjectDisposedException)
+            else
             {
-                if (_atomicTransaction.TransactionInformation.Status == SysTx.TransactionStatus.Active)
-                {
-                    throw;
-                }
-                // Do not throw exception if connection is already aborted/ended from another thread,
-                // replicate as done in TransactionEnded event handler.
+                // The transaction was aborted, report that to SysTx and log the same.
+                enlistment.Aborted();
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.Rollback|RES|CPOOL> {0}, Connection {1}, aborted before rollback.", ObjectID, connection.ObjectID);
             }
         }
 
@@ -365,128 +373,136 @@ namespace Microsoft.Data.SqlClient
         public void SinglePhaseCommit(SysTx.SinglePhaseEnlistment enlistment)
         {
             Debug.Assert(null != enlistment, "null enlistment?");
-
             SqlInternalConnection connection = GetValidConnection();
-            SqlConnection usersConnection = connection.Connection;
-            SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.SinglePhaseCommit|RES|CPOOL> {0}, Connection {1}, committing transaction.", ObjectID, connection.ObjectID);
-            RuntimeHelpers.PrepareConstrainedRegions();
 
-            try
+
+            if (null != connection)
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
+                SqlConnection usersConnection = connection.Connection;
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.SinglePhaseCommit|RES|CPOOL> {0}, Connection {1}, committing transaction.", ObjectID, connection.ObjectID);
                 RuntimeHelpers.PrepareConstrainedRegions();
+
                 try
                 {
-                    tdsReliabilitySection.Start();
+#if DEBUG
+                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                    try
+                    {
+                        tdsReliabilitySection.Start();
 #else
                 {
 #endif //DEBUG
-                    // If the connection is dooomed, we can be certain that the
-                    // transaction will eventually be rolled back, and we shouldn't
-                    // attempt to commit it.
-                    if (connection.IsConnectionDoomed)
-                    {
-                        lock (connection)
+                        // If the connection is dooomed, we can be certain that the
+                        // transaction will eventually be rolled back, and we shouldn't
+                        // attempt to commit it.
+                        if (connection.IsConnectionDoomed)
                         {
-                            _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
-                            _connection = null;
-                        }
-
-                        enlistment.Aborted(SQL.ConnectionDoomed());
-                    }
-                    else
-                    {
-                        Exception commitException;
-                        lock (connection)
-                        {
-                            try
+                            lock (connection)
                             {
-                                // Now that we've acquired the lock, make sure we still have valid state for this operation.
-                                ValidateActiveOnConnection(connection);
-
                                 _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
-                                _connection = null;   // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
-
-                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, IsolationLevel.Unspecified, _internalTransaction, true);
-                                commitException = null;
+                                _connection = null;
                             }
-                            catch (SqlException e)
-                            {
-                                commitException = e;
 
-                                ADP.TraceExceptionWithoutRethrow(e);
-
-                                // Doom the connection, to make sure that the transaction is
-                                // eventually rolled back.
-                                // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
-                                connection.DoomThisConnection();
-                            }
-                            catch (InvalidOperationException e)
-                            {
-                                commitException = e;
-                                ADP.TraceExceptionWithoutRethrow(e);
-                                connection.DoomThisConnection();
-                            }
+                            enlistment.Aborted(SQL.ConnectionDoomed());
                         }
-                        if (commitException != null)
+                        else
                         {
-                            // connection.ExecuteTransaction failed with exception
-                            if (_internalTransaction.IsCommitted)
+                            Exception commitException;
+                            lock (connection)
                             {
-                                // Even though we got an exception, the transaction
-                                // was committed by the server.
+                                try
+                                {
+                                    // Now that we've acquired the lock, make sure we still have valid state for this operation.
+                                    ValidateActiveOnConnection(connection);
+
+                                    _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
+                                    _connection = null;   // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
+
+                                    connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, IsolationLevel.Unspecified, _internalTransaction, true);
+                                    commitException = null;
+                                }
+                                catch (SqlException e)
+                                {
+                                    commitException = e;
+
+                                    ADP.TraceExceptionWithoutRethrow(e);
+
+                                    // Doom the connection, to make sure that the transaction is
+                                    // eventually rolled back.
+                                    // VSTS 144562: doom the connection while having the lock on it to prevent race condition with "Transaction Ended" Event
+                                    connection.DoomThisConnection();
+                                }
+                                catch (InvalidOperationException e)
+                                {
+                                    commitException = e;
+                                    ADP.TraceExceptionWithoutRethrow(e);
+                                    connection.DoomThisConnection();
+                                }
+                            }
+                            if (commitException != null)
+                            {
+                                // connection.ExecuteTransaction failed with exception
+                                if (_internalTransaction.IsCommitted)
+                                {
+                                    // Even though we got an exception, the transaction
+                                    // was committed by the server.
+                                    enlistment.Committed();
+                                }
+                                else if (_internalTransaction.IsAborted)
+                                {
+                                    // The transaction was aborted, report that to
+                                    // SysTx.
+                                    enlistment.Aborted(commitException);
+                                }
+                                else
+                                {
+                                    // The transaction is still active, we cannot
+                                    // know the state of the transaction.
+                                    enlistment.InDoubt(commitException);
+                                }
+
+                                // We eat the exception.  This is called on the SysTx
+                                // thread, not the applications thread.  If we don't 
+                                // eat the exception an UnhandledException will occur,
+                                // causing the process to FailFast.
+                            }
+
+                            connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
+                            if (commitException == null)
+                            {
+                                // connection.ExecuteTransaction succeeded
                                 enlistment.Committed();
                             }
-                            else if (_internalTransaction.IsAborted)
-                            {
-                                // The transaction was aborted, report that to
-                                // SysTx.
-                                enlistment.Aborted(commitException);
-                            }
-                            else
-                            {
-                                // The transaction is still active, we cannot
-                                // know the state of the transaction.
-                                enlistment.InDoubt(commitException);
-                            }
-
-                            // We eat the exception.  This is called on the SysTx
-                            // thread, not the applications thread.  If we don't 
-                            // eat the exception an UnhandledException will occur,
-                            // causing the process to FailFast.
-                        }
-
-                        connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
-                        if (commitException == null)
-                        {
-                            // connection.ExecuteTransaction succeeded
-                            enlistment.Committed();
                         }
                     }
-                }
 #if DEBUG
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
+                    finally
+                    {
+                        tdsReliabilitySection.Stop();
+                    }
 #endif //DEBUG
+                }
+                catch (System.OutOfMemoryException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
+                catch (System.StackOverflowException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
+                catch (System.Threading.ThreadAbortException e)
+                {
+                    usersConnection.Abort(e);
+                    throw;
+                }
             }
-            catch (System.OutOfMemoryException e)
+            else
             {
-                usersConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                usersConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                usersConnection.Abort(e);
-                throw;
+                // The transaction was aborted before we could commit, report that to SysTx and log the same.
+                enlistment.Aborted();
+                SqlClientEventSource.Log.TraceEvent("<sc.SqlDelegatedTransaction.SinglePhaseCommit|RES|CPOOL> {0}, Connection {1}, aborted before commit.", ObjectID, connection.ObjectID);
             }
         }
 
@@ -520,7 +536,7 @@ namespace Microsoft.Data.SqlClient
         private SqlInternalConnection GetValidConnection()
         {
             SqlInternalConnection connection = _connection;
-            if (null == connection)
+            if (null == connection && _atomicTransaction.TransactionInformation.Status != SysTx.TransactionStatus.Aborted)
             {
                 throw ADP.ObjectDisposed(this);
             }


### PR DESCRIPTION
Fixes #237 

After more investigations we found that this issue occurs due to SqlClient's inability to handle "Transaction Aborted" callback in **SqlDelegatedTransaction**. When transaction promotion is triggered by WCF Service after first set of commands, the transaction is also requested to be aborted due to exception scenarios from `SysTx.Transactions`.

The driver receives callback when transaction gets aborted, but it sends this connection back to the pool, without updating its "Current Transaction" state, which gets picked up later by other new connection requests. In the second round of transaction scope, it does not respect new transaction scope created for the new connection request because there was no "currentTransaction" expected.
Hence the [Debug.Assert](https://github.com/dotnet/SqlClient/blob/98834fc04003771cd596b11b8bd1b4c6fb5cf7dd/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs#L9305) failed all the time.

Moving on with this "old" transaction, which is aborted externally, we also notice warning from SQL Server as it sends "TransactionEnded" token followed by "Begin" to initiate new transaction request, Everytime! as explained here: https://github.com/dotnet/SqlClient/issues/237#issuecomment-569965788

Most of the times we get lucky, that the transaction was aborted by SQL Server, before we tried to use it again and it always gave us new transaction to work with. But in 1% scenarios, where the error happened, server got a little late to end this transaction and we end up enlisting our connection for 2nd Transaction Scope in the 1st transaction. But an abort is pending on server side, so as soon as it aborts the transaction, all further requests to server are free of the 1st "TransactionScope", 2nd TransactionScope had no links to this round of queries, and queries get executed with "Implicit" transactions, hence the "Commits".

Everything is linked to the fact that this connection was sent back to "GeneralPool" without cleaning it's transaction state where only connections WITHOUT any "Active" transaction reference must reside.

Since this connection has enlisted transaction that got promoted to DTC but was recently aborted externally, safest approach in my opinion is to Doom this connection as soon as we capture the aborted state of current transaction to block sending back to the pool.

I couldn't find any other clean way to reset this connection properly in order to send it back to General Pool. Would welcome suggestions if that can achieved!

Please give the below package a try, that contains fix:
[Microsoft.Data.SqlClient.2.0.0-dev-437.nupkg.zip](https://github.com/dotnet/SqlClient/files/4396779/Microsoft.Data.SqlClient.2.0.0-dev-437.nupkg.zip)


cc @saurabh500 @David-Engel @scale-tone 