### PR TITLE
Introducing support for DBConnectionPoolCounters in .NET Core

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -245,7 +245,8 @@ namespace Microsoft.Data.ProviderBase
 #endif // DEBUG
 #if NETCORE3
             if (PerformanceCounters != null)
-            { // Pool.Clear will DestroyObject that will clean performanceCounters before going here 
+            {
+                // Pool.Clear will DestroyObject that will clean performanceCounters before going here 
                 PerformanceCounters.NumberOfActiveConnections.Decrement();
             }
 #endif

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -129,6 +129,9 @@ namespace Microsoft.Data.ProviderBase
                     if (pool != null)
                     {
                         DbConnectionFactory connectionFactory = pool.ConnectionFactory;
+#if NETCORE3
+                        connectionFactory.PerformanceCounters.NumberOfActiveConnectionPools.Decrement();
+#endif
                         connectionFactory.QueuePoolForRelease(pool, true);
                     }
                 }
@@ -187,6 +190,9 @@ namespace Microsoft.Data.ProviderBase
                                     newPool.Startup(); // must start pool before usage
                                     bool addResult = _poolCollection.TryAdd(currentIdentity, newPool);
                                     Debug.Assert(addResult, "No other pool with current identity should exist at this point");
+#if NETCORE3
+                                    connectionFactory.PerformanceCounters.NumberOfActiveConnectionPools.Increment();
+#endif
                                     pool = newPool;
                                 }
                                 else
@@ -262,7 +268,9 @@ namespace Microsoft.Data.ProviderBase
                                 // pool into a list of pools to be released when they
                                 // are completely empty.
                                 DbConnectionFactory connectionFactory = pool.ConnectionFactory;
-
+#if NETCORE3
+                                connectionFactory.PerformanceCounters.NumberOfActiveConnectionPools.Decrement();
+#endif
                                 connectionFactory.QueuePoolForRelease(pool, false);
                             }
                             else

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -10,6 +10,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">netcoreapp</TargetGroup>
     <TargetGroup Condition="$(TargetFramework.StartsWith('netstandard'))">netstandard</TargetGroup>
+    <NetCoreVersion></NetCoreVersion>
     <Configurations>Debug;Release;netcoreapp2.1-Debug;netcoreapp2.1-Release;netcoreapp3.1-Debug;netcoreapp3.1-Release</Configurations>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <IntermediateOutputPath>$(ObjFolder)$(Configuration).$(Platform)\$(AssemblyName)\netcore\</IntermediateOutputPath>
@@ -19,9 +20,11 @@
     <Product>Core $(BaseProduct)</Product>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+    <NetCoreVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">3.1</NetCoreVersion>
+    <NetCoreVersion Condition="'$(TargetFramework)' == 'netcoreapp2.1'">2.1</NetCoreVersion>
     <DefineConstants>$(DefineConstants);netcoreapp;</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netcoreapp' AND '$(TargetFramework)' != 'netcoreapp2.1'">
+  <PropertyGroup Condition="'$(NetCoreVersion)' == '3.1'">
     <DefineConstants>$(DefineConstants);NETCORE3</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
@@ -125,6 +128,11 @@
     </Compile>
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\SqlSymmetricKeyCache.cs">
       <Link>Microsoft\Data\SqlClient\SqlSymmetricKeyCache.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(NetCoreVersion)' == '3.1' AND '$(OSGroup)' != 'AnyOS'">
+    <Compile Include="..\..\src\Microsoft\Data\ProviderBase\DbConnectionPoolCounters.cs">
+      <Link>Microsoft\Data\ProviderBase\DbConnectionPoolCounters.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' OR '$(TargetGroup)' == 'netcoreapp' OR '$(IsUAPAssembly)' == 'true'">
@@ -649,6 +657,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Condition="'$(TargetsWindows)' == 'true' and '$(IsUAPAssembly)' != 'true'" Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Condition="'$(NetCoreVersion)' == '3.1'" Include="System.Diagnostics.PerformanceCounter" Version="$(SystemDiagnosticsPerformanceCounterVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -217,7 +217,6 @@ namespace Microsoft.Data.ProviderBase
 #endif // DEBUG
 
             Activate(transaction);
-
 #if NETCORE3
             PerformanceCounters.NumberOfActiveConnections.Increment();
 #endif

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -16,7 +16,13 @@ namespace Microsoft.Data.SqlClient
 
         private const string _metaDataXml = "MetaDataXml";
 
+#if NETCORE3
+        private SqlConnectionFactory() : base(SqlPerformanceCounters.SingletonInstance)
+        {
+        }
+#else
         private SqlConnectionFactory() : base() { }
+#endif
 
         public static readonly SqlConnectionFactory SingletonInstance = new SqlConnectionFactory();
 
@@ -309,5 +315,20 @@ namespace Microsoft.Data.SqlClient
                                           internalConnection.ServerVersion);
         }
     }
-}
 
+#if NETCORE3
+    [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
+    sealed internal class SqlPerformanceCounters : DbConnectionPoolCounters
+    {
+        private const string CategoryName = ".NET Core Data Provider for SqlServer";
+        private const string CategoryHelp = "Counters for Microsoft.Data.SqlClient";
+
+        public static readonly SqlPerformanceCounters SingletonInstance = new SqlPerformanceCounters();
+
+        [System.Diagnostics.PerformanceCounterPermissionAttribute(System.Security.Permissions.SecurityAction.Assert, PermissionAccess = PerformanceCounterPermissionAccess.Write, MachineName = ".", CategoryName = CategoryName)]
+        private SqlPerformanceCounters() : base(CategoryName, CategoryHelp)
+        {
+        }
+    }
+#endif
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Data.SqlClient
     }
 
 #if NETCORE3
-    [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
+    [System.Security.Permissions.PermissionSet(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
     sealed internal class SqlPerformanceCounters : DbConnectionPoolCounters
     {
         private const string CategoryName = ".NET Core Data Provider for SqlServer";

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -7944,7 +7944,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 WriteInt(rec.packetSize, _physicalStateObj);
                 WriteInt(TdsEnums.CLIENT_PROG_VER, _physicalStateObj);
-                WriteInt(TdsParserStaticMethods.GetCurrentProcessIdForTdsLoginOnly(), _physicalStateObj);
+                WriteInt(TdsParserStaticMethods.GetCurrentProcessId(), _physicalStateObj);
                 WriteInt(0, _physicalStateObj); // connectionID is unused
 
                 // Log7Flags (DWORD)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Data.SqlClient
 
         private const int NoProcessId = -1;
         private static int s_currentProcessId = NoProcessId;
-        internal static int GetCurrentProcessIdForTdsLoginOnly()
+        internal static int GetCurrentProcessId()
         {
             if (s_currentProcessId == NoProcessId)
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -105,6 +105,9 @@
     <Compile Include="..\..\src\Microsoft\Data\ProviderBase\DbConnectionPoolAuthenticationContext.cs">
       <Link>Microsoft\Data\ProviderBase\DbConnectionPoolAuthenticationContext.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\Microsoft\Data\ProviderBase\DbConnectionPoolCounters.cs">
+      <Link>Microsoft\Data\ProviderBase\DbConnectionPoolCounters.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\Microsoft\Data\ProviderBase\DbConnectionPoolAuthenticationContextKey.cs">
       <Link>Microsoft\Data\ProviderBase\DbConnectionPoolAuthenticationContextKey.cs</Link>
     </Compile>
@@ -327,7 +330,6 @@
     <Compile Include="Microsoft\Data\ProviderBase\DbConnectionInternal.cs" />
     <Compile Include="Microsoft\Data\ProviderBase\DbConnectionPool.cs" />
     <Compile Include="Microsoft\Data\ProviderBase\DbConnectionPoolGroup.cs" />
-    <Compile Include="Microsoft\Data\ProviderBase\DbConnectionPoolCounters.cs" />
     <Compile Include="Microsoft\Data\ProviderBase\DbConnectionPoolIdentity.cs" />
     <Compile Include="Microsoft\Data\ProviderBase\DbConnectionPoolOptions.cs" />
     <Compile Include="Microsoft\Data\ProviderBase\DbMetaDataFactory.cs" />

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Data.SqlClient
 
     }
 
-    [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
+    [System.Security.Permissions.PermissionSet(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
     sealed internal class SqlPerformanceCounters : DbConnectionPoolCounters
     {
         private const string CategoryName = ".NET Data Provider for SqlServer";

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -8723,7 +8723,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 WriteInt(rec.packetSize, _physicalStateObj);
                 WriteInt(TdsEnums.CLIENT_PROG_VER, _physicalStateObj);
-                WriteInt(TdsParserStaticMethods.GetCurrentProcessIdForTdsLoginOnly(), _physicalStateObj); //MDAC 84718
+                WriteInt(TdsParserStaticMethods.GetCurrentProcessId(), _physicalStateObj); //MDAC 84718
                 WriteInt(0, _physicalStateObj); // connectionID is unused
 
                 // Log7Flags (DWORD)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Data.SqlClient
 
         [ResourceExposure(ResourceScope.None)] // SxS: we use this method for TDS login only
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        static internal int GetCurrentProcessIdForTdsLoginOnly()
+        static internal int GetCurrentProcessId()
         {
             return SafeNativeMethods.GetCurrentProcessId();
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolCounters.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolCounters.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Data.ProviderBase
             {
                 try
                 {
-                    if (categoryName != string.Empty && instanceName != string.Empty)
+                    if (!string.IsNullOrEmpty(categoryName) && !string.IsNullOrEmpty(instanceName))
                     {
                         PerformanceCounter instance = new PerformanceCounter();
                         instance.CategoryName = categoryName;
@@ -179,7 +179,7 @@ namespace Microsoft.Data.ProviderBase
 
             string instanceName = null;
 
-            if (categoryName != string.Empty)
+            if (!string.IsNullOrEmpty(categoryName))
             {
                 instanceName = GetInstanceName();
             }
@@ -199,7 +199,7 @@ namespace Microsoft.Data.ProviderBase
 
             // level 4: expensive stuff
             string verboseCategoryName = null;
-            if (categoryName != string.Empty)
+            if (!string.IsNullOrEmpty(categoryName))
             {
                 // don't load TraceSwitch if no categoryName so that Odbc/OleDb have a chance of not loading TraceSwitch
                 // which are also used by System.Diagnostics.PerformanceCounter.ctor & System.Transactions.get_Current
@@ -244,7 +244,7 @@ namespace Microsoft.Data.ProviderBase
 
             string instanceName = GetAssemblyName(); // instance perfcounter name
 
-            if (instanceName == string.Empty)
+            if (string.IsNullOrEmpty(instanceName))
             {
                 AppDomain appDomain = AppDomain.CurrentDomain;
                 if (null != appDomain)

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -53,6 +53,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netfx'">
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">


### PR DESCRIPTION
Addresses #382 

Sharing implementation of `DBConnectionPoolCounters` between .NET Framework and .NET Core 3.1.