### PR TITLE
remove redundant DbConnectionPoolKey gettype

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionPoolKey.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionPoolKey.cs
@@ -42,14 +42,12 @@ namespace Microsoft.Data.Common
 
         public override bool Equals(object obj)
         {
-            if (obj == null || obj.GetType() != typeof(DbConnectionPoolKey))
+            if (obj == null)
             {
                 return false;
             }
 
-            DbConnectionPoolKey key = obj as DbConnectionPoolKey;
-
-            return (key != null && _connectionString == key._connectionString);
+            return (obj is DbConnectionPoolKey key && _connectionString == key._connectionString);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.Data.SqlClient/netfx/src/Common/src/Microsoft/Data/Common/DbConnectionPoolKey.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Common/src/Microsoft/Data/Common/DbConnectionPoolKey.cs
@@ -43,14 +43,12 @@ namespace Microsoft.Data.Common
 
         public override bool Equals(object obj)
         {
-            if (obj == null || obj.GetType() != typeof(DbConnectionPoolKey))
+            if (obj == null)
             {
                 return false;
             }
 
-            DbConnectionPoolKey key = obj as DbConnectionPoolKey;
-
-            return (key != null && _connectionString == key._connectionString);
+            return (obj is DbConnectionPoolKey key && _connectionString == key._connectionString);
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
i think the GetType is redundant since an as is done below. also converted to a pattern match instead