### PR TITLE
Add "Transaction Id" and "Client Version" in Diagnostic Source traces

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
-                        TransactionId = transaction?.InternalTransaction?.TransactionId,
+                        transaction?.InternalTransaction?.TransactionId,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
 
@@ -74,7 +74,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
-                        TransactionId = transaction?.InternalTransaction?.TransactionId,
+                        transaction?.InternalTransaction?.TransactionId,
                         Statistics = sqlCommand.Statistics?.GetDictionary(),
                         Timestamp = Stopwatch.GetTimestamp()
                     });
@@ -93,7 +93,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
-                        TransactionId = transaction?.InternalTransaction?.TransactionId,
+                        transaction?.InternalTransaction?.TransactionId,
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
@@ -236,7 +236,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transaction?.TransactionId,
+                        transaction?.TransactionId,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
 
@@ -258,7 +258,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transaction?.TransactionId,
+                        transaction?.TransactionId,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
             }
@@ -276,7 +276,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transaction?.TransactionId,
+                        transaction?.TransactionId,
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
@@ -297,7 +297,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transaction?.TransactionId,
+                        transaction?.TransactionId,
                         TransactionName = transactionName,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
@@ -320,7 +320,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transaction?.TransactionId,
+                        transaction?.TransactionId,
                         TransactionName = transactionName,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
@@ -339,7 +339,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transaction?.TransactionId,
+                        transaction?.TransactionId,
                         TransactionName = transactionName,
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.SqlClient
         public const string SqlAfterRollbackTransaction = SqlClientPrefix + nameof(WriteTransactionRollbackAfter);
         public const string SqlErrorRollbackTransaction = SqlClientPrefix + nameof(WriteTransactionRollbackError);
 
-        public static Guid WriteCommandBefore(this DiagnosticListener @this, SqlCommand sqlCommand, long? transactionId, [CallerMemberName] string operation = "")
+        public static Guid WriteCommandBefore(this DiagnosticListener @this, SqlCommand sqlCommand, SqlTransaction transaction, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeExecuteCommand))
             {
@@ -52,7 +52,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
-                        TransactionId = transactionId,
+                        TransactionId = transaction?.InternalTransaction?.TransactionId,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
 
@@ -62,7 +62,7 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
-        public static void WriteCommandAfter(this DiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, long? transactionId, [CallerMemberName] string operation = "")
+        public static void WriteCommandAfter(this DiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, SqlTransaction transaction, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterExecuteCommand))
             {
@@ -74,14 +74,14 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
-                        TransactionId = transactionId,
+                        TransactionId = transaction?.InternalTransaction?.TransactionId,
                         Statistics = sqlCommand.Statistics?.GetDictionary(),
                         Timestamp = Stopwatch.GetTimestamp()
                     });
             }
         }
 
-        public static void WriteCommandError(this DiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, long? transactionId, Exception ex, [CallerMemberName] string operation = "")
+        public static void WriteCommandError(this DiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, SqlTransaction transaction, Exception ex, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorExecuteCommand))
             {
@@ -93,7 +93,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
-                        TransactionId = transactionId,
+                        TransactionId = transaction?.InternalTransaction?.TransactionId,
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
@@ -222,7 +222,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        public static Guid WriteTransactionCommitBefore(this DiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, [CallerMemberName] string operation = "")
+        public static Guid WriteTransactionCommitBefore(this DiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeCommitTransaction))
             {
@@ -236,7 +236,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transactionId,
+                        TransactionId = transaction?.TransactionId,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
 
@@ -246,7 +246,7 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
-        public static void WriteTransactionCommitAfter(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, [CallerMemberName] string operation = "")
+        public static void WriteTransactionCommitAfter(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterCommitTransaction))
             {
@@ -258,13 +258,13 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transactionId,
+                        TransactionId = transaction?.TransactionId,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
             }
         }
 
-        public static void WriteTransactionCommitError(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, Exception ex, [CallerMemberName] string operation = "")
+        public static void WriteTransactionCommitError(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, Exception ex, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorCommitTransaction))
             {
@@ -276,14 +276,14 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transactionId,
+                        TransactionId = transaction?.TransactionId,
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
             }
         }
 
-        public static Guid WriteTransactionRollbackBefore(this DiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, string transactionName = null, [CallerMemberName] string operation = "")
+        public static Guid WriteTransactionRollbackBefore(this DiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName = null, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeRollbackTransaction))
             {
@@ -297,7 +297,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transactionId,
+                        TransactionId = transaction?.TransactionId,
                         TransactionName = transactionName,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
@@ -308,7 +308,7 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
-        public static void WriteTransactionRollbackAfter(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, string transactionName = null, [CallerMemberName] string operation = "")
+        public static void WriteTransactionRollbackAfter(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName = null, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterRollbackTransaction))
             {
@@ -320,14 +320,14 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transactionId,
+                        TransactionId = transaction?.TransactionId,
                         TransactionName = transactionName,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
             }
         }
 
-        public static void WriteTransactionRollbackError(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, Exception ex, string transactionName = null, [CallerMemberName] string operation = "")
+        public static void WriteTransactionRollbackError(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, Exception ex, string transactionName = null, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorRollbackTransaction))
             {
@@ -339,7 +339,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
-                        TransactionId = transactionId,
+                        TransactionId = transaction?.TransactionId,
                         TransactionName = transactionName,
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.SqlClient
         public const string SqlAfterRollbackTransaction = SqlClientPrefix + nameof(WriteTransactionRollbackAfter);
         public const string SqlErrorRollbackTransaction = SqlClientPrefix + nameof(WriteTransactionRollbackError);
 
-        public static Guid WriteCommandBefore(this DiagnosticListener @this, SqlCommand sqlCommand, [CallerMemberName] string operation = "")
+        public static Guid WriteCommandBefore(this DiagnosticListener @this, SqlCommand sqlCommand, long? transactionId, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeExecuteCommand))
             {
@@ -52,6 +52,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
+                        TransactionId = transactionId,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
 
@@ -61,7 +62,7 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
-        public static void WriteCommandAfter(this DiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, [CallerMemberName] string operation = "")
+        public static void WriteCommandAfter(this DiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, long? transactionId, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterExecuteCommand))
             {
@@ -73,13 +74,14 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
+                        TransactionId = transactionId,
                         Statistics = sqlCommand.Statistics?.GetDictionary(),
                         Timestamp = Stopwatch.GetTimestamp()
                     });
             }
         }
 
-        public static void WriteCommandError(this DiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, Exception ex, [CallerMemberName] string operation = "")
+        public static void WriteCommandError(this DiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, long? transactionId, Exception ex, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorExecuteCommand))
             {
@@ -91,6 +93,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlCommand.Connection?.ClientConnectionId,
                         Command = sqlCommand,
+                        TransactionId = transactionId,
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
@@ -216,7 +219,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        public static Guid WriteTransactionCommitBefore(this DiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, [CallerMemberName] string operation = "")
+        public static Guid WriteTransactionCommitBefore(this DiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeCommitTransaction))
             {
@@ -230,6 +233,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
+                        TransactionId = transactionId,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
 
@@ -239,7 +243,7 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
-        public static void WriteTransactionCommitAfter(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, [CallerMemberName] string operation = "")
+        public static void WriteTransactionCommitAfter(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterCommitTransaction))
             {
@@ -251,12 +255,13 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
+                        TransactionId = transactionId,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
             }
         }
 
-        public static void WriteTransactionCommitError(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, Exception ex, [CallerMemberName] string operation = "")
+        public static void WriteTransactionCommitError(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, Exception ex, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorCommitTransaction))
             {
@@ -268,13 +273,14 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
+                        TransactionId = transactionId,
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
             }
         }
 
-        public static Guid WriteTransactionRollbackBefore(this DiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, string transactionName, [CallerMemberName] string operation = "")
+        public static Guid WriteTransactionRollbackBefore(this DiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, string transactionName = null, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeRollbackTransaction))
             {
@@ -288,6 +294,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
+                        TransactionId = transactionId,
                         TransactionName = transactionName,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
@@ -298,7 +305,7 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
-        public static void WriteTransactionRollbackAfter(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, string transactionName, [CallerMemberName] string operation = "")
+        public static void WriteTransactionRollbackAfter(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, string transactionName = null, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterRollbackTransaction))
             {
@@ -310,13 +317,14 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
+                        TransactionId = transactionId,
                         TransactionName = transactionName,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
             }
         }
 
-        public static void WriteTransactionRollbackError(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, string transactionName, Exception ex, [CallerMemberName] string operation = "")
+        public static void WriteTransactionRollbackError(this DiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, Exception ex, string transactionName = null, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorRollbackTransaction))
             {
@@ -328,6 +336,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         IsolationLevel = isolationLevel,
                         Connection = connection,
+                        TransactionId = transactionId,
                         TransactionName = transactionName,
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Data.SqlClient
                         OperationId = operationId,
                         Operation = operation,
                         Connection = sqlConnection,
+                        ClientVersion = ThisAssembly.InformationalVersion,
                         Timestamp = Stopwatch.GetTimestamp()
                     });
 
@@ -134,6 +135,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlConnection.ClientConnectionId,
                         Connection = sqlConnection,
+                        ClientVersion = ThisAssembly.InformationalVersion,
                         Statistics = sqlConnection.Statistics?.GetDictionary(),
                         Timestamp = Stopwatch.GetTimestamp()
                     });
@@ -152,6 +154,7 @@ namespace Microsoft.Data.SqlClient
                         Operation = operation,
                         ConnectionId = sqlConnection.ClientConnectionId,
                         Connection = sqlConnection,
+                        ClientVersion = ThisAssembly.InformationalVersion,
                         Exception = ex,
                         Timestamp = Stopwatch.GetTimestamp()
                     });

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -943,7 +943,7 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
 
             SqlStatistics statistics = null;
 
@@ -981,11 +981,11 @@ namespace Microsoft.Data.SqlClient
                 WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
                 if (e != null)
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, e);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
                 }
                 else
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this);
+                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
                 }
             }
         }
@@ -1027,7 +1027,7 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
 
             SqlStatistics statistics = null;
 
@@ -1051,11 +1051,11 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
                 if (e != null)
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, e);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
                 }
                 else
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this);
+                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
                 }
             }
         }
@@ -1517,7 +1517,7 @@ namespace Microsoft.Data.SqlClient
             _pendingCancel = false;
             bool success = false;
 
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
 
             SqlStatistics statistics = null;
             long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteXmlReader|API> {0}", ObjectID);
@@ -1553,11 +1553,11 @@ namespace Microsoft.Data.SqlClient
                 WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
                 if (e != null)
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, e);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
                 }
                 else
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this);
+                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
                 }
             }
         }
@@ -1844,7 +1844,7 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
 
             SqlStatistics statistics = null;
             bool success = false;
@@ -1873,11 +1873,11 @@ namespace Microsoft.Data.SqlClient
 
                 if (e != null)
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, e);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
                 }
                 else
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this);
+                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
                 }
             }
         }
@@ -2248,7 +2248,7 @@ namespace Microsoft.Data.SqlClient
         public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
         {
             SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQueryAsync|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
 
             TaskCompletionSource<int> source = new TaskCompletionSource<int>();
 
@@ -2274,7 +2274,7 @@ namespace Microsoft.Data.SqlClient
                     if (t.IsFaulted)
                     {
                         Exception e = t.Exception.InnerException;
-                        _diagnosticListener.WriteCommandError(operationId, this, e);
+                        _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
                         source.SetException(e);
                     }
                     else
@@ -2287,13 +2287,13 @@ namespace Microsoft.Data.SqlClient
                         {
                             source.SetResult(t.Result);
                         }
-                        _diagnosticListener.WriteCommandAfter(operationId, this);
+                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
                     }
                 }, TaskScheduler.Default);
             }
             catch (Exception e)
             {
-                _diagnosticListener.WriteCommandError(operationId, this, e);
+                _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
                 source.SetException(e);
             }
 
@@ -2337,7 +2337,7 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReaderAsync|API|Correlation> ObjectID {0}, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
             Guid operationId = default(Guid);
             if (!_parentOperationStarted)
-                operationId = _diagnosticListener.WriteCommandBefore(this);
+                operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
 
             TaskCompletionSource<SqlDataReader> source = new TaskCompletionSource<SqlDataReader>();
 
@@ -2364,7 +2364,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         Exception e = t.Exception.InnerException;
                         if (!_parentOperationStarted)
-                            _diagnosticListener.WriteCommandError(operationId, this, e);
+                            _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
                         source.SetException(e);
                     }
                     else
@@ -2378,14 +2378,14 @@ namespace Microsoft.Data.SqlClient
                             source.SetResult(t.Result);
                         }
                         if (!_parentOperationStarted)
-                            _diagnosticListener.WriteCommandAfter(operationId, this);
+                            _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
                     }
                 }, TaskScheduler.Default);
             }
             catch (Exception e)
             {
                 if (!_parentOperationStarted)
-                    _diagnosticListener.WriteCommandError(operationId, this, e);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
 
                 source.SetException(e);
             }
@@ -2397,7 +2397,7 @@ namespace Microsoft.Data.SqlClient
         public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
         {
             _parentOperationStarted = true;
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
 
             return ExecuteReaderAsync(cancellationToken).ContinueWith((executeTask) =>
             {
@@ -2408,7 +2408,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else if (executeTask.IsFaulted)
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, executeTask.Exception.InnerException);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, executeTask.Exception.InnerException);
                     source.SetException(executeTask.Exception.InnerException);
                 }
                 else
@@ -2426,7 +2426,7 @@ namespace Microsoft.Data.SqlClient
                             else if (readTask.IsFaulted)
                             {
                                 reader.Dispose();
-                                _diagnosticListener.WriteCommandError(operationId, this, readTask.Exception.InnerException);
+                                _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, readTask.Exception.InnerException);
                                 source.SetException(readTask.Exception.InnerException);
                             }
                             else
@@ -2454,12 +2454,12 @@ namespace Microsoft.Data.SqlClient
                                 }
                                 if (exception != null)
                                 {
-                                    _diagnosticListener.WriteCommandError(operationId, this, exception);
+                                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, exception);
                                     source.SetException(exception);
                                 }
                                 else
                                 {
-                                    _diagnosticListener.WriteCommandAfter(operationId, this);
+                                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
                                     source.SetResult(result);
                                 }
                             }
@@ -2486,7 +2486,7 @@ namespace Microsoft.Data.SqlClient
         public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken)
         {
             SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReaderAsync|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
 
             TaskCompletionSource<XmlReader> source = new TaskCompletionSource<XmlReader>();
 
@@ -2512,7 +2512,7 @@ namespace Microsoft.Data.SqlClient
                     if (t.IsFaulted)
                     {
                         Exception e = t.Exception.InnerException;
-                        _diagnosticListener.WriteCommandError(operationId, this, e);
+                        _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
                         source.SetException(e);
                     }
                     else
@@ -2525,13 +2525,13 @@ namespace Microsoft.Data.SqlClient
                         {
                             source.SetResult(t.Result);
                         }
-                        _diagnosticListener.WriteCommandAfter(operationId, this);
+                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
                     }
                 }, TaskScheduler.Default);
             }
             catch (Exception e)
             {
-                _diagnosticListener.WriteCommandError(operationId, this, e);
+                _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
                 source.SetException(e);
             }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -943,7 +943,7 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
             SqlStatistics statistics = null;
 
@@ -981,11 +981,11 @@ namespace Microsoft.Data.SqlClient
                 WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
                 if (e != null)
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                 }
                 else
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
+                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                 }
             }
         }
@@ -1027,7 +1027,7 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
             SqlStatistics statistics = null;
 
@@ -1051,11 +1051,11 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
                 if (e != null)
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                 }
                 else
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
+                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                 }
             }
         }
@@ -1517,7 +1517,7 @@ namespace Microsoft.Data.SqlClient
             _pendingCancel = false;
             bool success = false;
 
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
             SqlStatistics statistics = null;
             long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlCommand.ExecuteXmlReader|API> {0}", ObjectID);
@@ -1553,11 +1553,11 @@ namespace Microsoft.Data.SqlClient
                 WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
                 if (e != null)
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                 }
                 else
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
+                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                 }
             }
         }
@@ -1844,7 +1844,7 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
             SqlStatistics statistics = null;
             bool success = false;
@@ -1873,11 +1873,11 @@ namespace Microsoft.Data.SqlClient
 
                 if (e != null)
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                 }
                 else
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
+                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                 }
             }
         }
@@ -2248,7 +2248,7 @@ namespace Microsoft.Data.SqlClient
         public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
         {
             SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQueryAsync|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
             TaskCompletionSource<int> source = new TaskCompletionSource<int>();
 
@@ -2274,7 +2274,7 @@ namespace Microsoft.Data.SqlClient
                     if (t.IsFaulted)
                     {
                         Exception e = t.Exception.InnerException;
-                        _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
+                        _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                         source.SetException(e);
                     }
                     else
@@ -2287,13 +2287,13 @@ namespace Microsoft.Data.SqlClient
                         {
                             source.SetResult(t.Result);
                         }
-                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
+                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                     }
                 }, TaskScheduler.Default);
             }
             catch (Exception e)
             {
-                _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
+                _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                 source.SetException(e);
             }
 
@@ -2337,7 +2337,7 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteReaderAsync|API|Correlation> ObjectID {0}, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
             Guid operationId = default(Guid);
             if (!_parentOperationStarted)
-                operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
+                operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
             TaskCompletionSource<SqlDataReader> source = new TaskCompletionSource<SqlDataReader>();
 
@@ -2364,7 +2364,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         Exception e = t.Exception.InnerException;
                         if (!_parentOperationStarted)
-                            _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
+                            _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                         source.SetException(e);
                     }
                     else
@@ -2378,14 +2378,14 @@ namespace Microsoft.Data.SqlClient
                             source.SetResult(t.Result);
                         }
                         if (!_parentOperationStarted)
-                            _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
+                            _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                     }
                 }, TaskScheduler.Default);
             }
             catch (Exception e)
             {
                 if (!_parentOperationStarted)
-                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
 
                 source.SetException(e);
             }
@@ -2397,7 +2397,7 @@ namespace Microsoft.Data.SqlClient
         public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken)
         {
             _parentOperationStarted = true;
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
             return ExecuteReaderAsync(cancellationToken).ContinueWith((executeTask) =>
             {
@@ -2408,7 +2408,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else if (executeTask.IsFaulted)
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, executeTask.Exception.InnerException);
+                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, executeTask.Exception.InnerException);
                     source.SetException(executeTask.Exception.InnerException);
                 }
                 else
@@ -2426,7 +2426,7 @@ namespace Microsoft.Data.SqlClient
                             else if (readTask.IsFaulted)
                             {
                                 reader.Dispose();
-                                _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, readTask.Exception.InnerException);
+                                _diagnosticListener.WriteCommandError(operationId, this, _transaction, readTask.Exception.InnerException);
                                 source.SetException(readTask.Exception.InnerException);
                             }
                             else
@@ -2454,12 +2454,12 @@ namespace Microsoft.Data.SqlClient
                                 }
                                 if (exception != null)
                                 {
-                                    _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, exception);
+                                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, exception);
                                     source.SetException(exception);
                                 }
                                 else
                                 {
-                                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
+                                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                                     source.SetResult(result);
                                 }
                             }
@@ -2486,7 +2486,7 @@ namespace Microsoft.Data.SqlClient
         public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken)
         {
             SqlClientEventSource.Log.CorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReaderAsync|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction?.InternalTransaction?.TransactionId);
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
             TaskCompletionSource<XmlReader> source = new TaskCompletionSource<XmlReader>();
 
@@ -2512,7 +2512,7 @@ namespace Microsoft.Data.SqlClient
                     if (t.IsFaulted)
                     {
                         Exception e = t.Exception.InnerException;
-                        _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
+                        _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                         source.SetException(e);
                     }
                     else
@@ -2525,13 +2525,13 @@ namespace Microsoft.Data.SqlClient
                         {
                             source.SetResult(t.Result);
                         }
-                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction?.InternalTransaction?.TransactionId);
+                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                     }
                 }, TaskScheduler.Default);
             }
             catch (Exception e)
             {
-                _diagnosticListener.WriteCommandError(operationId, this, _transaction?.InternalTransaction?.TransactionId, e);
+                _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                 source.SetException(e);
             }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Data.SqlClient
         override public void Commit()
         {
             Exception e = null;
-            Guid operationId = s_diagnosticListener.WriteTransactionCommitBefore(_isolationLevel, _connection);
+            Guid operationId = s_diagnosticListener.WriteTransactionCommitBefore(_isolationLevel, _connection, InternalTransaction?.TransactionId);
 
             ZombieCheck();
 
@@ -176,11 +176,11 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
                 if (e != null)
                 {
-                    s_diagnosticListener.WriteTransactionCommitError(operationId, _isolationLevel, _connection, e);
+                    s_diagnosticListener.WriteTransactionCommitError(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId, e);
                 }
                 else
                 {
-                    s_diagnosticListener.WriteTransactionCommitAfter(operationId, _isolationLevel, _connection);
+                    s_diagnosticListener.WriteTransactionCommitAfter(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId);
                 }
 
                 _isFromAPI = false;
@@ -204,7 +204,7 @@ namespace Microsoft.Data.SqlClient
         override public void Rollback()
         {
             Exception e = null;
-            Guid operationId = s_diagnosticListener.WriteTransactionRollbackBefore(_isolationLevel, _connection, null);
+            Guid operationId = s_diagnosticListener.WriteTransactionRollbackBefore(_isolationLevel, _connection, InternalTransaction?.TransactionId);
 
             if (IsYukonPartialZombie)
             {
@@ -238,11 +238,11 @@ namespace Microsoft.Data.SqlClient
                     SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
                     if (e != null)
                     {
-                        s_diagnosticListener.WriteTransactionRollbackError(operationId, _isolationLevel, _connection, null, e);
+                        s_diagnosticListener.WriteTransactionRollbackError(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId, e);
                     }
                     else
                     {
-                        s_diagnosticListener.WriteTransactionRollbackAfter(operationId, _isolationLevel, _connection, null);
+                        s_diagnosticListener.WriteTransactionRollbackAfter(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId);
                     }
                     _isFromAPI = false;
                 }
@@ -253,7 +253,7 @@ namespace Microsoft.Data.SqlClient
         public void Rollback(string transactionName)
         {
             Exception e = null;
-            Guid operationId = s_diagnosticListener.WriteTransactionRollbackBefore(_isolationLevel, _connection, transactionName);
+            Guid operationId = s_diagnosticListener.WriteTransactionRollbackBefore(_isolationLevel, _connection, InternalTransaction?.TransactionId, transactionName);
 
             ZombieCheck();
             long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Rollback|API> {0} transactionName='{1}'", ObjectID, transactionName);
@@ -277,11 +277,11 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
                 if (e != null)
                 {
-                    s_diagnosticListener.WriteTransactionRollbackError(operationId, _isolationLevel, _connection, transactionName, e);
+                    s_diagnosticListener.WriteTransactionRollbackError(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId, e, transactionName);
                 }
                 else
                 {
-                    s_diagnosticListener.WriteTransactionRollbackAfter(operationId, _isolationLevel, _connection, transactionName);
+                    s_diagnosticListener.WriteTransactionRollbackAfter(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId, transactionName);
                 }
 
                 _isFromAPI = false;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Data.SqlClient
         override public void Commit()
         {
             Exception e = null;
-            Guid operationId = s_diagnosticListener.WriteTransactionCommitBefore(_isolationLevel, _connection, InternalTransaction?.TransactionId);
+            Guid operationId = s_diagnosticListener.WriteTransactionCommitBefore(_isolationLevel, _connection, InternalTransaction);
 
             ZombieCheck();
 
@@ -176,11 +176,11 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
                 if (e != null)
                 {
-                    s_diagnosticListener.WriteTransactionCommitError(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId, e);
+                    s_diagnosticListener.WriteTransactionCommitError(operationId, _isolationLevel, _connection, InternalTransaction, e);
                 }
                 else
                 {
-                    s_diagnosticListener.WriteTransactionCommitAfter(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId);
+                    s_diagnosticListener.WriteTransactionCommitAfter(operationId, _isolationLevel, _connection, InternalTransaction);
                 }
 
                 _isFromAPI = false;
@@ -204,7 +204,7 @@ namespace Microsoft.Data.SqlClient
         override public void Rollback()
         {
             Exception e = null;
-            Guid operationId = s_diagnosticListener.WriteTransactionRollbackBefore(_isolationLevel, _connection, InternalTransaction?.TransactionId);
+            Guid operationId = s_diagnosticListener.WriteTransactionRollbackBefore(_isolationLevel, _connection, InternalTransaction);
 
             if (IsYukonPartialZombie)
             {
@@ -238,11 +238,11 @@ namespace Microsoft.Data.SqlClient
                     SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
                     if (e != null)
                     {
-                        s_diagnosticListener.WriteTransactionRollbackError(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId, e);
+                        s_diagnosticListener.WriteTransactionRollbackError(operationId, _isolationLevel, _connection, InternalTransaction, e);
                     }
                     else
                     {
-                        s_diagnosticListener.WriteTransactionRollbackAfter(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId);
+                        s_diagnosticListener.WriteTransactionRollbackAfter(operationId, _isolationLevel, _connection, InternalTransaction);
                     }
                     _isFromAPI = false;
                 }
@@ -253,7 +253,7 @@ namespace Microsoft.Data.SqlClient
         public void Rollback(string transactionName)
         {
             Exception e = null;
-            Guid operationId = s_diagnosticListener.WriteTransactionRollbackBefore(_isolationLevel, _connection, InternalTransaction?.TransactionId, transactionName);
+            Guid operationId = s_diagnosticListener.WriteTransactionRollbackBefore(_isolationLevel, _connection, InternalTransaction, transactionName);
 
             ZombieCheck();
             long scopeID = SqlClientEventSource.Log.ScopeEnterEvent("<sc.SqlTransaction.Rollback|API> {0} transactionName='{1}'", ObjectID, transactionName);
@@ -277,11 +277,11 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.ScopeLeaveEvent(scopeID);
                 if (e != null)
                 {
-                    s_diagnosticListener.WriteTransactionRollbackError(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId, e, transactionName);
+                    s_diagnosticListener.WriteTransactionRollbackError(operationId, _isolationLevel, _connection, InternalTransaction, e, transactionName);
                 }
                 else
                 {
-                    s_diagnosticListener.WriteTransactionRollbackAfter(operationId, _isolationLevel, _connection, InternalTransaction?.TransactionId, transactionName);
+                    s_diagnosticListener.WriteTransactionRollbackAfter(operationId, _isolationLevel, _connection, InternalTransaction, transactionName);
                 }
 
                 _isFromAPI = false;


### PR DESCRIPTION
Addressing request made by @davidmikh here: https://github.com/dotnet/SqlClient/issues/93#issuecomment-590941699

Hi @davidmikh 

As per our offline discussions, I've made this PR to include "Transaction Id" to `SqlCommand` and `SqlTransaction` events and "Client Version" in `SqlConnection` events.

Regarding other 2 requests:
* Include _Connection Id_ in `SqlTransaction` events
  -- `Connection.ClientConnectionId` contains this info.
* Include _Server Version_ in `SqlConnection` open events
  -- `Connection.ServerVersion` contains this info.

Let me know if you need additional info from here.

P.S. Diagnostic Tests to be enabled in a separate PR (WIP @JRahnama PR #517)