### PR TITLE
Change _SqlMetaData to lazy initialize hidden column map

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AlwaysEncryptedHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AlwaysEncryptedHelperClasses.cs
@@ -234,13 +234,9 @@ namespace Microsoft.Data.SqlClient
         internal readonly SqlTceCipherInfoTable? cekTable; // table of "column encryption keys" used for this metadataset
 
         internal _SqlMetaDataSet(int count, SqlTceCipherInfoTable? cipherTable)
+            : this(count)
         {
             cekTable = cipherTable;
-            _metaDataArray = new _SqlMetaData[count];
-            for (int i = 0; i < _metaDataArray.Length; ++i)
-            {
-                _metaDataArray[i] = new _SqlMetaData(i);
-            }
         }
     }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     return 0;
                 }
-                return (md.VisibleColumnCount);
+                return md.VisibleColumnCount;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -278,8 +278,8 @@ namespace Microsoft.Data.SqlClient
 
             if (null != metaData && 0 < metaData.Length)
             {
-                metaDataReturn = new SmiExtendedMetaData[metaData.visibleColumns];
-
+                metaDataReturn = new SmiExtendedMetaData[metaData.VisibleColumnCount];
+                int returnIndex = 0;
                 for (int index = 0; index < metaData.Length; index++)
                 {
                     _SqlMetaData colMetaData = metaData[index];
@@ -318,7 +318,7 @@ namespace Microsoft.Data.SqlClient
                             length /= ADP.CharSize;
                         }
 
-                        metaDataReturn[index] =
+                        metaDataReturn[returnIndex] =
                             new SmiQueryMetaData(
                                 colMetaData.type,
                                 length,
@@ -346,6 +346,8 @@ namespace Microsoft.Data.SqlClient
                                 colMetaData.IsExpression,
                                 colMetaData.IsDifferentName,
                                 colMetaData.IsHidden);
+
+                        returnIndex += 1;
                     }
                 }
             }
@@ -408,7 +410,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     return 0;
                 }
-                return (md.visibleColumns);
+                return (md.VisibleColumnCount);
             }
         }
 
@@ -1141,31 +1143,6 @@ namespace Microsoft.Data.SqlClient
                     return false;
                 }
                 Debug.Assert(!ignored, "Parser read a row token while trying to read metadata");
-            }
-
-            // we hide hidden columns from the user so build an internal map
-            // that compacts all hidden columns from the array
-            if (null != _metaData)
-            {
-                if (_snapshot != null && object.ReferenceEquals(_snapshot._metadata, _metaData))
-                {
-                    _metaData = (_SqlMetaDataSet)_metaData.Clone();
-                }
-
-                _metaData.visibleColumns = 0;
-
-                Debug.Assert(null == _metaData.indexMap, "non-null metaData indexmap");
-                int[] indexMap = new int[_metaData.Length];
-                for (int i = 0; i < indexMap.Length; ++i)
-                {
-                    indexMap[i] = _metaData.visibleColumns;
-
-                    if (!(_metaData[i].IsHidden))
-                    {
-                        _metaData.visibleColumns++;
-                    }
-                }
-                _metaData.indexMap = indexMap;
             }
 
             return true;
@@ -2623,11 +2600,11 @@ namespace Microsoft.Data.SqlClient
 
                 SetTimeout(_defaultTimeoutMilliseconds);
 
-                int copyLen = (values.Length < _metaData.visibleColumns) ? values.Length : _metaData.visibleColumns;
+                int copyLen = (values.Length < _metaData.VisibleColumnCount) ? values.Length : _metaData.VisibleColumnCount;
 
                 for (int i = 0; i < copyLen; i++)
                 {
-                    values[_metaData.indexMap[i]] = GetSqlValueInternal(i);
+                    values[i] = GetSqlValueInternal(_metaData.GetVisibleColumnIndex(i));
                 }
                 return copyLen;
             }
@@ -2966,7 +2943,7 @@ namespace Microsoft.Data.SqlClient
 
                 CheckMetaDataIsReady();
 
-                int copyLen = (values.Length < _metaData.visibleColumns) ? values.Length : _metaData.visibleColumns;
+                int copyLen = (values.Length < _metaData.VisibleColumnCount) ? values.Length : _metaData.VisibleColumnCount;
                 int maximumColumn = copyLen - 1;
 
                 SetTimeout(_defaultTimeoutMilliseconds);
@@ -2984,12 +2961,19 @@ namespace Microsoft.Data.SqlClient
                 for (int i = 0; i < copyLen; i++)
                 {
                     // Get the usable, TypeSystem-compatible value from the internal buffer
-                    values[_metaData.indexMap[i]] = GetValueFromSqlBufferInternal(_data[i], _metaData[i]);
+                    int fieldIndex = _metaData.GetVisibleColumnIndex(i);
+                    values[i] = GetValueFromSqlBufferInternal(_data[fieldIndex], _metaData[fieldIndex]);
 
                     // If this is sequential access, then we need to wipe the internal buffer
                     if ((sequentialAccess) && (i < maximumColumn))
                     {
-                        _data[i].Clear();
+                        _data[fieldIndex].Clear();
+                        if (fieldIndex > i && fieldIndex>0)
+                        {
+                            // if we jumped an index forward because of a hidden column see if the buffer before the 
+                            // current one was populated by the seek forward and clear it if it was
+                            _data[fieldIndex - 1].Clear();
+                        }
                     }
                 }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -4435,7 +4435,6 @@ namespace Microsoft.Data.SqlClient
             metaData = null;
 
             _SqlMetaDataSet altMetaDataSet = new _SqlMetaDataSet(cColumns, null);
-            int[] indexMap = new int[cColumns];
 
             if (!stateObj.TryReadUInt16(out altMetaDataSet.id))
             {
@@ -4479,12 +4478,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     return false;
                 }
-
-                indexMap[i] = i;
             }
-
-            altMetaDataSet.indexMap = indexMap;
-            altMetaDataSet.visibleColumns = cColumns;
 
             metaData = altMetaDataSet;
             return true;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -562,11 +562,10 @@ namespace Microsoft.Data.SqlClient
 
         private _SqlMetaDataSet(_SqlMetaDataSet original)
         {
-            this.id = original.id;
-            // although indexMap is not immutable, in practice it is initialized once and then passed around
-            this._hiddenColumnCount = original._hiddenColumnCount;
-            this._visibleColumnMap = original._visibleColumnMap;
-            this.dbColumnSchema = original.dbColumnSchema;
+            id = original.id;
+            _hiddenColumnCount = original._hiddenColumnCount;
+            _visibleColumnMap = original._visibleColumnMap;
+            dbColumnSchema = original.dbColumnSchema;
             if (original._metaDataArray == null)
             {
                 _metaDataArray = null;
@@ -648,18 +647,17 @@ namespace Microsoft.Data.SqlClient
 
             if (hiddenColumnCount > 0)
             {
-                int[] hiddenColumnMap = new int[Length - hiddenColumnCount];
-
+                int[] visibleColumnMap = new int[Length - hiddenColumnCount];
                 int mapIndex = 0;
                 for (int metaDataIndex = 0; metaDataIndex < Length; metaDataIndex++)
                 {
                     if (!_metaDataArray[metaDataIndex].IsHidden)
                     {
-                        hiddenColumnMap[mapIndex] = metaDataIndex;
+                        visibleColumnMap[mapIndex] = metaDataIndex;
                         mapIndex += 1;
                     }
                 }
-                _visibleColumnMap = hiddenColumnMap;
+                _visibleColumnMap = visibleColumnMap;
             }
             _hiddenColumnCount = hiddenColumnCount;
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -230,10 +230,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void CheckHiddenColumns()
         {
-            // hidden columns can be found by using CommandBehavious.KeyInfo or at the sql level
+            // hidden columns can be found by using CommandBehavior.KeyInfo or at the sql level
             // by using the FOR BROWSE option. These features return the column information requested and
             // also include any key information required to be able to find the row containing the data
-            // requested. The additional key infomration is provided as hidden columns and can be seen using
+            // requested. The additional key information is provided as hidden columns and can be seen using
             // the difference between VisibleFieldCount and FieldCount on the reader
 
             string tempTableName = DataTestUtility.GenerateObjectName();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Text;
@@ -224,6 +225,82 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 }
             }
             return columnSetPresent;
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void CheckHiddenColumns()
+        {
+            // hidden columns can be found by using CommandBehavious.KeyInfo or at the sql level
+            // by using the FOR BROWSE option. These features return the column information requested and
+            // also include any key information required to be able to find the row containing the data
+            // requested. The additional key infomration is provided as hidden columns and can be seen using
+            // the difference between VisibleFieldCount and FieldCount on the reader
+
+            string tempTableName = DataTestUtility.GenerateObjectName();
+
+            string createQuery = $@"
+create table [{tempTableName}] (
+	user_id int not null identity(1,1),
+	first_name varchar(100) null,
+	last_name varchar(100) null);
+
+alter table [{tempTableName}] add constraint pk_{tempTableName}_user_id primary key (user_id);
+
+insert into [{tempTableName}] (first_name,last_name) values ('Joe','Smith')
+";
+
+            string dataQuery = $@"select first_name, last_name from [{tempTableName}]";
+
+
+            int fieldCount = 0;
+            int visibleFieldCount = 0;
+            Type[] types = null;
+            string[] names = null;
+
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            {
+                connection.Open();
+
+                try
+                {
+                    using (SqlCommand createCommand = new SqlCommand(createQuery, connection))
+                    {
+                        createCommand.ExecuteNonQuery();
+                    }
+
+                    using (SqlCommand queryCommand = new SqlCommand(dataQuery, connection))
+                    {
+                        using (SqlDataReader reader = queryCommand.ExecuteReader(CommandBehavior.KeyInfo))
+                        {
+                            fieldCount = reader.FieldCount;
+                            visibleFieldCount = reader.VisibleFieldCount;
+                            types = new Type[fieldCount];
+                            names = new string[fieldCount];
+                            for (int index = 0; index < fieldCount; index++)
+                            {
+                                types[index] = reader.GetFieldType(index);
+                                names[index] = reader.GetName(index);
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    DataTestUtility.DropTable(connection, tempTableName);
+                }
+            }
+
+            Assert.Equal(3, fieldCount);
+            Assert.Equal(2, visibleFieldCount);
+            Assert.NotNull(types);
+            Assert.NotNull(names);
+
+            // requested fields
+            Assert.Contains("first_name", names, StringComparer.Ordinal);
+            Assert.Contains("last_name", names, StringComparer.Ordinal);
+
+            // hidden field
+            Assert.Contains("user_id", names, StringComparer.Ordinal);
         }
     }
 }


### PR DESCRIPTION
This PR started as a small perf optimization to eliminate the visible column map in the `_SqlMetaDataSet` type but in doing so I found that it wasn't going to work as expected anyway so I've fixed it.

Some background. SQL Server can return additional hidden columns that the user didn't request and if it does this it will mark the metadata entry as hidden. I've never seen one of these and can't find any way to cause them to happen (so no tests) but the behaviour is in the TDS spec. There are only a small number of places that need to care if a column is visible and those places are all acting on entire rows rather than getting a column requested by the user, `GetValues` and `GetSqlValues` are the primary consumers with one additional use in Smi (SQL Metadata Interface?) extended metadata generation. 

Currently every time the metadata is read from the TDS stream an int array is allocated and populated with a map of actual metadata to visible metadata indices. This is almost never used and is thrown away. It can't be cached usefully because it is query dependent. This PR changes the generation of that map to be lazy initialized inside the `_SqlMetaDataSet` type and adds some abstraction so that callers only need to know about whether they want to know about real columns or visible columns.

The way that the visible column map in the current implementation is used causes incorrect output. Consider this gist: https://gist.github.com/Wraith2/06c9391808a43f9bae729a5b52a6bd10
If I have 4 columns (0,1,2,3) and set 1 to be hidden when I call `GetSqlValues` I would expect to get (0,2,3), in the current implementation I do not, I get (0,2,default) and other hidden column locations give similar wrong results. 