### PR TITLE
Fix unsafe cast in `SqlException` for `SerializationEntry.Value`

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.SqlClient
             {
                 if ("ClientConnectionId" == siEntry.Name)
                 {
-                    _clientConnectionId = (Guid)siEntry.Value;
+                    _clientConnectionId = new Guid(siEntry.Value.ToString());
                     break;
                 }
             }
@@ -49,7 +49,7 @@ namespace Microsoft.Data.SqlClient
         {
             base.GetObjectData(si, context);
             si.AddValue("Errors", null); // Not specifying type to enable serialization of null value of non-serializable type
-            si.AddValue("ClientConnectionId", _clientConnectionId, typeof(Guid));
+            si.AddValue("ClientConnectionId", _clientConnectionId, typeof(object));
 
             // Writing sqlerrors to base exception data table
             for (int i = 0; i < Errors.Count; i++)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Data.SqlClient
             HResult = SqlExceptionHResult;
             foreach (SerializationEntry siEntry in si)
             {
-                if ("ClientConnectionId" == siEntry.Name)
+                if (nameof(ClientConnectionId) == siEntry.Name)
                 {
-                    _clientConnectionId = new Guid(siEntry.Value.ToString());
+                    _clientConnectionId = (Guid)si.GetValue(nameof(ClientConnectionId), typeof(Guid));
                     break;
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -40,11 +40,10 @@ namespace Microsoft.Data.SqlClient
             {
                 if ("ClientConnectionId" == siEntry.Name)
                 {
-                    _clientConnectionId = (Guid)siEntry.Value;
+                    _clientConnectionId = new Guid(siEntry.Value.ToString());
                     break;
                 }
             }
-
         }
 
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlException.xml' path='docs/members[@name="SqlException"]/GetObjectData/*' />
@@ -55,7 +54,7 @@ namespace Microsoft.Data.SqlClient
                 throw new ArgumentNullException("si");
             }
             si.AddValue("Errors", _errors, typeof(SqlErrorCollection));
-            si.AddValue("ClientConnectionId", _clientConnectionId, typeof(Guid));
+            si.AddValue("ClientConnectionId", _clientConnectionId, typeof(object));
             base.GetObjectData(si, context);
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Data.SqlClient
             HResult = HResults.SqlException;
             foreach (SerializationEntry siEntry in si)
             {
-                if ("ClientConnectionId" == siEntry.Name)
+                if (nameof(ClientConnectionId) == siEntry.Name)
                 {
-                    _clientConnectionId = new Guid(siEntry.Value.ToString());
+                    _clientConnectionId = (Guid)si.GetValue(nameof(ClientConnectionId), typeof(Guid));
                     break;
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -49,13 +49,20 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlException.xml' path='docs/members[@name="SqlException"]/GetObjectData/*' />
         override public void GetObjectData(SerializationInfo si, StreamingContext context)
         {
-            if (null == si)
-            {
-                throw new ArgumentNullException("si");
-            }
-            si.AddValue("Errors", _errors, typeof(SqlErrorCollection));
-            si.AddValue("ClientConnectionId", _clientConnectionId, typeof(object));
             base.GetObjectData(si, context);
+            si.AddValue("Errors", null); // Not specifying type to enable serialization of null value of non-serializable type
+            si.AddValue("ClientConnectionId", _clientConnectionId, typeof(object));
+
+            // Writing sqlerrors to base exception data table
+            for (int i = 0; i < Errors.Count; i++)
+            {
+                string key = "SqlError " + (i + 1);
+                if (Data.Contains(key))
+                {
+                    Data.Remove(key);
+                }
+                Data.Add(key, Errors[i].ToString());
+            }
         }
 
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlException.xml' path='docs/members[@name="SqlException"]/Errors/*' />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -36,6 +36,7 @@
     <Compile Include="BaseProviderAsyncTest\MockDataReader.cs" />
     <Compile Include="SqlCredentialTest.cs" />
     <Compile Include="SqlDataRecordTest.cs" />
+    <Compile Include="SqlExceptionTest.cs" />
     <Compile Include="SqlParameterTest.cs" />
     <Compile Include="SqlClientFactoryTest.cs" />
     <Compile Include="SqlErrorCollectionTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlExceptionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlExceptionTest.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Data.SqlClient.Tests
         private const string badServer = "92B96911A0BD43E8ADA4451031F7E7CF";
 
         [Fact]
+        [ActiveIssue("12161", TestPlatforms.AnyUnix)]
         public void SerializationTest()
         {
             SqlException e = CreateException();
@@ -21,7 +22,9 @@ namespace Microsoft.Data.SqlClient.Tests
                 TypeNameHandling = TypeNameHandling.All,
             };
 
+            // TODO: Deserialization fails on Unix with "Member 'ClassName' was not found."
             var sqlEx = Newtonsoft.Json.JsonConvert.DeserializeObject<Microsoft.Data.SqlClient.SqlException>(json, settings);
+            
             Assert.Equal(e.ClientConnectionId, sqlEx.ClientConnectionId);
             Assert.Equal(e.StackTrace, sqlEx.StackTrace);
         }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlExceptionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlExceptionTest.cs
@@ -1,6 +1,8 @@
-﻿using System;
-using System.IO;
-using System.Runtime.Serialization;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -15,7 +17,7 @@ namespace Microsoft.Data.SqlClient.Tests
         public void SerializationTest()
         {
             SqlException e = CreateException();
-            string json = Newtonsoft.Json.JsonConvert.SerializeObject(e);
+            string json = JsonConvert.SerializeObject(e);
 
             var settings = new JsonSerializerSettings()
             {
@@ -23,8 +25,8 @@ namespace Microsoft.Data.SqlClient.Tests
             };
 
             // TODO: Deserialization fails on Unix with "Member 'ClassName' was not found."
-            var sqlEx = Newtonsoft.Json.JsonConvert.DeserializeObject<Microsoft.Data.SqlClient.SqlException>(json, settings);
-            
+            var sqlEx = JsonConvert.DeserializeObject<SqlException>(json, settings);
+
             Assert.Equal(e.ClientConnectionId, sqlEx.ClientConnectionId);
             Assert.Equal(e.StackTrace, sqlEx.StackTrace);
         }
@@ -59,8 +61,8 @@ namespace Microsoft.Data.SqlClient.Tests
                 TypeNameHandling = TypeNameHandling.All,
             };
 
-            var sqlEx = Newtonsoft.Json.JsonConvert.DeserializeObject<Microsoft.Data.SqlClient.SqlException>(json, settings);
-            Assert.IsType<Microsoft.Data.SqlClient.SqlException>(sqlEx);
+            var sqlEx = JsonConvert.DeserializeObject<SqlException>(json, settings);
+            Assert.IsType<SqlException>(sqlEx);
             Assert.Equal(clientConnectionId, sqlEx.ClientConnectionId.ToString());
         }
 
@@ -87,7 +89,6 @@ namespace Microsoft.Data.SqlClient.Tests
                     return ex;
                 }
             }
-
             throw new InvalidOperationException("SqlException should have been returned.");
         }
     }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlExceptionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlExceptionTest.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.Tests
+{
+    public class SqlExceptionTest
+    {
+        private const string badServer = "92B96911A0BD43E8ADA4451031F7E7CF";
+
+        [Fact]
+        public void SerializationTest()
+        {
+            SqlException e = CreateException();
+            string json = Newtonsoft.Json.JsonConvert.SerializeObject(e);
+
+            var settings = new JsonSerializerSettings()
+            {
+                TypeNameHandling = TypeNameHandling.All,
+            };
+
+            var sqlEx = Newtonsoft.Json.JsonConvert.DeserializeObject<Microsoft.Data.SqlClient.SqlException>(json, settings);
+            Assert.Equal(e.ClientConnectionId, sqlEx.ClientConnectionId);
+            Assert.Equal(e.StackTrace, sqlEx.StackTrace);
+        }
+
+        [Fact]
+        public void JSONSerializationTest()
+        {
+            string clientConnectionId = "90cdab4d-2145-4c24-a354-c8ccff903542";
+            string json = @"{""ClassName"":""Microsoft.Data.SqlClient.SqlException"","
+                        + @"""Message"":""A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: TCP Provider, error: 40 - Could not open a connection to SQL Server)"","
+                        + @"""Data"":{""HelpLink.ProdName"":""Microsoft SQL Server"","
+                        + @"""HelpLink.EvtSrc"":""MSSQLServer"","
+                        + @"""HelpLink.EvtID"":""0"","
+                        + @"""HelpLink.BaseHelpUrl"":""http://go.microsoft.com/fwlink"","
+                        + @"""HelpLink.LinkId"":""20476"","
+                        + @"""SqlError 1"":""Microsoft.Data.SqlClient.SqlError: A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: TCP Provider, error: 40 - Could not open a connection to SQL Server)"","
+                        + @"""$type"":""System.Collections.ListDictionaryInternal, System.Private.CoreLib""},"
+                        + @"""InnerException"":null,"
+                        + @"""HelpURL"":null,"
+                        + @"""StackTraceString"":""   at Microsoft.Data.SqlClient.SqlInternalConnectionTds..ctor(DbConnectionPoolIdentity identity, SqlConnectionString connectionOptions, SqlCredential credential, Object providerInfo, String newPassword, SecureString newSecurePassword, Boolean redirectedUserInstance, SqlConnectionString userConnectionOptions, SessionData reconnectSessionData, Boolean applyTransientFaultHandling, String accessToken)\\n   at Microsoft.Data.SqlClient.SqlConnectionFactory.CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, Object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)\\n   at System.Data.ProviderBase.DbConnectionFactory.CreatePooledConnection(DbConnectionPool pool, DbConnection owningObject, DbConnectionOptions options, DbConnectionPoolKey poolKey, DbConnectionOptions userOptions)\\n   at System.Data.ProviderBase.DbConnectionPool.CreateObject(DbConnection owningObject, DbConnectionOptions userOptions, DbConnectionInternal oldConnection)\\n   at System.Data.ProviderBase.DbConnectionPool.UserCreateRequest(DbConnection owningObject, DbConnectionOptions userOptions, DbConnectionInternal oldConnection)\\n   at System.Data.ProviderBase.DbConnectionPool.TryGetConnection(DbConnection owningObject, UInt32 waitForMultipleObjectsTimeout, Boolean allowCreate, Boolean onlyOneCheckConnection, DbConnectionOptions userOptions, DbConnectionInternal& connection)\\n   at System.Data.ProviderBase.DbConnectionPool.WaitForPendingOpen()\\n"","
+                        + @"""RemoteStackTraceString"":null,"
+                        + @"""RemoteStackIndex"":0,"
+                        + @"""ExceptionMethod"":null,"
+                        + @"""HResult"":-2146232060,"
+                        + @"""Source"":""Core .Net SqlClient Data Provider"","
+                        + @"""WatsonBuckets"":null,"
+                        + @"""Errors"":null,"
+                        + @"""ClientConnectionId"":""90cdab4d-2145-4c24-a354-c8ccff903542""}";
+
+            var settings = new JsonSerializerSettings()
+            {
+                TypeNameHandling = TypeNameHandling.All,
+            };
+
+            var sqlEx = Newtonsoft.Json.JsonConvert.DeserializeObject<Microsoft.Data.SqlClient.SqlException>(json, settings);
+            Assert.IsType<Microsoft.Data.SqlClient.SqlException>(sqlEx);
+            Assert.Equal(clientConnectionId, sqlEx.ClientConnectionId.ToString());
+        }
+
+        private static SqlException CreateException()
+        {
+            var builder = new SqlConnectionStringBuilder()
+            {
+                DataSource = badServer,
+                ConnectTimeout = 1,
+                Pooling = false
+            };
+
+            using (var connection = new SqlConnection(builder.ConnectionString))
+            {
+                try
+                {
+                    connection.Open();
+                }
+                catch (SqlException ex)
+                {
+                    Assert.NotNull(ex.Errors);
+                    Assert.Single(ex.Errors);
+
+                    return ex;
+                }
+            }
+
+            throw new InvalidOperationException("SqlException should have been returned.");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #524 

It looks like the driver is performing unsafe cast of `value` to `Guid` without considering any other type:
https://github.com/dotnet/SqlClient/blob/8884f6308e119915c15e50619b6c0e45eaa5dc7f/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlException.cs#L41

In normal scenarios this probably works fine, but if one passes a JSON string, the deserializer fails (see reported issue for repro code). Since the type of [Value](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.serializationentry.value?view=netframework-4.8#System_Runtime_Serialization_SerializationEntry_Value) in [SerializationEntry](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.serialization.serializationentry?view=netframework-4.8) is `object`, casting to `Guid` is unsafe.

This PR fixes the issue by generating new `Guid` for `SqlException.ClientConnectionId` property from `object` type.

@saurabh500
I also noticed differences in `SqlException` serialization implementation in .NET Core v/s .NET Framework, e.g. [null value serialization in .NET Core](https://github.com/dotnet/SqlClient/compare/master...cheenamalhotra:fixSqlException?expand=1#diff-4056e6b7197e1feca7991557839c81a8L51) v/s [implementation in .NET Framework](https://github.com/dotnet/SqlClient/compare/master...cheenamalhotra:fixSqlException?expand=1#diff-a751daca4b098272202eb067bfdda8ceR56)
Would like to know more about it and if it should also be updated for .NET Framework.

Edit: Change in NetFx class was needed for serialization to work.