### PR TITLE
perf: Rework ExecuteReaderAsync to minimize allocations

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -706,6 +706,7 @@
     <Reference Include="System.Memory" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Microsoft\Data\SqlClient\AAsyncCallContext.cs" />
     <Compile Include="Resources\SR.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
@@ -15,6 +16,7 @@ namespace Microsoft.Data.ProviderBase
 {
     internal abstract partial class DbConnectionFactory
     {
+        private static readonly Action<Task<DbConnectionInternal>, object> s_tryGetConnectionCompletedContinuation = TryGetConnectionCompletedContinuation;
 
         internal bool TryGetConnection(DbConnection owningConnection, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions, DbConnectionInternal oldConnection, out DbConnectionInternal connection)
         {
@@ -82,25 +84,7 @@ namespace Microsoft.Data.ProviderBase
 
                             // now that we have an antecedent task, schedule our work when it is completed.
                             // If it is a new slot or a completed task, this continuation will start right away.
-                            newTask = s_pendingOpenNonPooled[idx].ContinueWith((_) =>
-                            {
-                                Transaction originalTransaction = ADP.GetCurrentTransaction();
-                                try
-                                {
-                                    ADP.SetCurrentTransaction(retry.Task.AsyncState as Transaction);
-                                    var newConnection = CreateNonPooledConnection(owningConnection, poolGroup, userOptions);
-                                    if ((oldConnection != null) && (oldConnection.State == ConnectionState.Open))
-                                    {
-                                        oldConnection.PrepareForReplaceConnection();
-                                        oldConnection.Dispose();
-                                    }
-                                    return newConnection;
-                                }
-                                finally
-                                {
-                                    ADP.SetCurrentTransaction(originalTransaction);
-                                }
-                            }, cancellationTokenSource.Token, TaskContinuationOptions.LongRunning, TaskScheduler.Default);
+                            newTask = CreateReplaceConnectionContinuation(s_pendingOpenNonPooled[idx], owningConnection, retry, userOptions, oldConnection, poolGroup, cancellationTokenSource);
 
                             // Place this new task in the slot so any future work will be queued behind it
                             s_pendingOpenNonPooled[idx] = newTask;
@@ -114,29 +98,11 @@ namespace Microsoft.Data.ProviderBase
                         }
 
                         // once the task is done, propagate the final results to the original caller
-                        newTask.ContinueWith((task) =>
-                        {
-                            cancellationTokenSource.Dispose();
-                            if (task.IsCanceled)
-                            {
-                                retry.TrySetException(ADP.ExceptionWithStackTrace(ADP.NonPooledOpenTimeout()));
-                            }
-                            else if (task.IsFaulted)
-                            {
-                                retry.TrySetException(task.Exception.InnerException);
-                            }
-                            else
-                            {
-                                if (!retry.TrySetResult(task.Result))
-                                {
-                                    // The outer TaskCompletionSource was already completed
-                                    // Which means that we don't know if someone has messed with the outer connection in the middle of creation
-                                    // So the best thing to do now is to destroy the newly created connection
-                                    task.Result.DoomThisConnection();
-                                    task.Result.Dispose();
-                                }
-                            }
-                        }, TaskScheduler.Default);
+                        newTask.ContinueWith(
+                            continuationAction: s_tryGetConnectionCompletedContinuation, 
+                            state: Tuple.Create(cancellationTokenSource, retry),
+                            scheduler: TaskScheduler.Default
+                        );
 
                         return false;
                     }
@@ -187,6 +153,63 @@ namespace Microsoft.Data.ProviderBase
             }
 
             return true;
+        }
+
+        private Task<DbConnectionInternal> CreateReplaceConnectionContinuation(Task<DbConnectionInternal> task, DbConnection owningConnection, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions, DbConnectionInternal oldConnection, DbConnectionPoolGroup poolGroup, CancellationTokenSource cancellationTokenSource)
+        {
+            return task.ContinueWith(
+                (_) =>
+                {
+                    Transaction originalTransaction = ADP.GetCurrentTransaction();
+                    try
+                    {
+                        ADP.SetCurrentTransaction(retry.Task.AsyncState as Transaction);
+                        var newConnection = CreateNonPooledConnection(owningConnection, poolGroup, userOptions);
+                        if ((oldConnection != null) && (oldConnection.State == ConnectionState.Open))
+                        {
+                            oldConnection.PrepareForReplaceConnection();
+                            oldConnection.Dispose();
+                        }
+                        return newConnection;
+                    }
+                    finally
+                    {
+                        ADP.SetCurrentTransaction(originalTransaction);
+                    }
+                },
+                cancellationTokenSource.Token,
+                TaskContinuationOptions.LongRunning,
+                TaskScheduler.Default
+            );
+        }
+
+        private static void TryGetConnectionCompletedContinuation(Task<DbConnectionInternal> task, object state)
+        {
+            Tuple<CancellationTokenSource, TaskCompletionSource<DbConnectionInternal>> parameters = (Tuple<CancellationTokenSource, TaskCompletionSource<DbConnectionInternal>>)state;
+            CancellationTokenSource source = parameters.Item1;
+            source.Dispose();
+
+            TaskCompletionSource<DbConnectionInternal> retryCompletionSrouce = parameters.Item2;
+
+            if (task.IsCanceled)
+            {
+                retryCompletionSrouce.TrySetException(ADP.ExceptionWithStackTrace(ADP.NonPooledOpenTimeout()));
+            }
+            else if (task.IsFaulted)
+            {
+                retryCompletionSrouce.TrySetException(task.Exception.InnerException);
+            }
+            else
+            {
+                if (!retryCompletionSrouce.TrySetResult(task.Result))
+                {
+                    // The outer TaskCompletionSource was already completed
+                    // Which means that we don't know if someone has messed with the outer connection in the middle of creation
+                    // So the best thing to do now is to destroy the newly created connection
+                    task.Result.DoomThisConnection();
+                    task.Result.Dispose();
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -189,19 +189,19 @@ namespace Microsoft.Data.ProviderBase
             CancellationTokenSource source = parameters.Item1;
             source.Dispose();
 
-            TaskCompletionSource<DbConnectionInternal> retryCompletionSrouce = parameters.Item2;
+            TaskCompletionSource<DbConnectionInternal> retryCompletionSource = parameters.Item2;
 
             if (task.IsCanceled)
             {
-                retryCompletionSrouce.TrySetException(ADP.ExceptionWithStackTrace(ADP.NonPooledOpenTimeout()));
+                retryCompletionSource.TrySetException(ADP.ExceptionWithStackTrace(ADP.NonPooledOpenTimeout()));
             }
             else if (task.IsFaulted)
             {
-                retryCompletionSrouce.TrySetException(task.Exception.InnerException);
+                retryCompletionSource.TrySetException(task.Exception.InnerException);
             }
             else
             {
-                if (!retryCompletionSrouce.TrySetResult(task.Result))
+                if (!retryCompletionSource.TrySetResult(task.Result))
                 {
                     // The outer TaskCompletionSource was already completed
                     // Which means that we don't know if someone has messed with the outer connection in the middle of creation

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AAsyncCallContext.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AAsyncCallContext.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Data.SqlClient
     // avoiding the use of closures and allowing caching/reuse of the instances for frequently used async
     // calls
     //
-    // DO derive from this and seal and your class
+    // DO derive from this and seal your class
     // DO add additional fields or properties needed for the async operation and then override Clear to zero them
     // DO override AfterClear and use the owner parameter to return the object to a cache location if you have one, this is the purpose of the method
     // CONSIDER creating your own Set method that calls the base Set rather than providing a parameterized ctor, it is friendlier to caching
-    // DO NOT use this class after Dispose has been called. It will not throw ObjectDisposedException but it will be a cleared object
+    // DO NOT use this class' state after Dispose has been called. It will not throw ObjectDisposedException but it will be a cleared object
 
     internal abstract class AAsyncCallContext<TOwner, TTask> : IDisposable
         where TOwner : class
@@ -50,7 +50,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <summary>
-        /// overrride this method to cleanup instance data before ClearCore is called which will blank the base data
+        /// override this method to cleanup instance data before ClearCore is called which will blank the base data
         /// </summary>
         protected virtual void Clear()
         {
@@ -61,7 +61,6 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         protected virtual void AfterCleared(TOwner owner)
         {
-
         }
 
         public void Dispose()

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AAsyncCallContext.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AAsyncCallContext.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.SqlClient
+{
+    // this class is a base class for creating derived objects that will store state for async operations
+    // avoiding the use of closures and allowing caching/reuse of the instances for frequently used async
+    // calls
+    //
+    // DO derive from this and seal and your class
+    // DO add additional fields or properties needed for the async operation and then override Clear to zero them
+    // DO override AfterClear and use the owner parameter to return the object to a cache location if you have one, this is the purpose of the method
+    // CONSIDER creating your own Set method that calls the base Set rather than providing a parameterized ctor, it is friendlier to caching
+    // DO NOT use this class after Dispose has been called. It will not throw ObjectDisposedException but it will be a cleared object
+
+    internal abstract class AAsyncCallContext<TOwner, TTask> : IDisposable
+        where TOwner : class
+    {
+        protected TOwner _owner;
+        protected TaskCompletionSource<TTask> _source;
+        protected IDisposable _disposable;
+
+        protected AAsyncCallContext()
+        {
+        }
+
+        protected AAsyncCallContext(TOwner owner, TaskCompletionSource<TTask> source, IDisposable disposable = null)
+        {
+            Set(owner, source, disposable);
+        }
+
+        protected void Set(TOwner owner, TaskCompletionSource<TTask> source, IDisposable disposable = null)
+        {
+            _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+            _disposable = disposable;
+        }
+
+        protected void ClearCore()
+        {
+            _source = null;
+            _owner = default;
+            IDisposable copyDisposable = _disposable;
+            _disposable = null;
+            copyDisposable?.Dispose();
+        }
+
+        /// <summary>
+        /// overrride this method to cleanup instance data before ClearCore is called which will blank the base data
+        /// </summary>
+        protected virtual void Clear()
+        {
+        }
+
+        /// <summary>
+        /// override this method to do work after the instance has been totally blanked, intended for cache return etc
+        /// </summary>
+        protected virtual void AfterCleared(TOwner owner)
+        {
+
+        }
+
+        public void Dispose()
+        {
+            TOwner owner = _owner;
+            try
+            {
+                Clear();
+            }
+            finally
+            {
+                ClearCore();
+            }
+            AfterCleared(owner);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -2265,7 +2265,7 @@ namespace Microsoft.Data.SqlClient
             return writeTask;
         }
 
-        private void RegisterForConnectionCloseNotification<T>(ref Task<T> outerTask)
+        private Task<T> RegisterForConnectionCloseNotification<T>(Task<T> outerTask)
         {
             SqlConnection connection = _connection;
             if (connection == null)
@@ -2274,7 +2274,7 @@ namespace Microsoft.Data.SqlClient
                 throw ADP.ClosedConnectionError();
             }
 
-            connection.RegisterForConnectionCloseNotification<T>(ref outerTask, this, SqlReferenceCollection.BulkCopyTag);
+            return connection.RegisterForConnectionCloseNotification(outerTask, this, SqlReferenceCollection.BulkCopyTag);
         }
 
         // Runs a loop to copy all columns of a single row.
@@ -3057,7 +3057,7 @@ namespace Microsoft.Data.SqlClient
                 source = new TaskCompletionSource<object>(); // Creating the completion source/Task that we pass to application
                 resultTask = source.Task;
 
-                RegisterForConnectionCloseNotification(ref resultTask);
+                resultTask = RegisterForConnectionCloseNotification(resultTask);
             }
 
             if (_destinationTableName == null)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1980,7 +1980,7 @@ namespace Microsoft.Data.SqlClient
         {
             // Connection exists,  schedule removal, will be added to ref collection after calling ValidateAndReconnect
             return outerTask.ContinueWith(
-                continuationFunction: (task,state) =>
+                continuationFunction: (task, state) =>
                 {
                     Tuple<SqlConnection, object> parameters = (Tuple<SqlConnection, object>)state;
                     SqlConnection connection = parameters.Item1;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Data.SqlClient
                 comparer: StringComparer.OrdinalIgnoreCase);
 
         private static readonly Action<object> s_openAsyncCancel = OpenAsyncCancel;
+        private static readonly Action<Task<object>, object> s_openAsyncComplete = OpenAsyncComplete;
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ColumnEncryptionKeyCacheTtl/*' />
         public static TimeSpan ColumnEncryptionKeyCacheTtl { get; set; } = TimeSpan.FromHours(2);
@@ -1380,22 +1381,16 @@ namespace Microsoft.Data.SqlClient
 
                     System.Transactions.Transaction transaction = ADP.GetCurrentTransaction();
                     TaskCompletionSource<DbConnectionInternal> completion = new TaskCompletionSource<DbConnectionInternal>(transaction);
-                    TaskCompletionSource<object> result = new TaskCompletionSource<object>();
+                    TaskCompletionSource<object> result = new TaskCompletionSource<object>(state: this);
 
                     if (s_diagnosticListener.IsEnabled(SqlClientDiagnosticListenerExtensions.SqlAfterOpenConnection) ||
                         s_diagnosticListener.IsEnabled(SqlClientDiagnosticListenerExtensions.SqlErrorOpenConnection))
                     {
-                        result.Task.ContinueWith((t) =>
-                        {
-                            if (t.Exception != null)
-                            {
-                                s_diagnosticListener.WriteConnectionOpenError(operationId, this, t.Exception);
-                            }
-                            else
-                            {
-                                s_diagnosticListener.WriteConnectionOpenAfter(operationId, this);
-                            }
-                        }, TaskScheduler.Default);
+                        result.Task.ContinueWith(
+                            continuationAction: s_openAsyncComplete, 
+                            state: operationId, // connection is passed in TaskCompletionSource async state
+                            scheduler: TaskScheduler.Default
+                        );
                     }
 
                     if (cancellationToken.IsCancellationRequested)
@@ -1450,6 +1445,20 @@ namespace Microsoft.Data.SqlClient
             finally
             {
                 SqlClientEventSource.Log.PoolerScopeLeaveEvent(scopeID);
+            }
+        }
+
+        private static void OpenAsyncComplete(Task<object> task, object state)
+        {
+            Guid operationId = (Guid)state;
+            SqlConnection connection = (SqlConnection)task.AsyncState;
+            if (task.Exception != null)
+            {
+                s_diagnosticListener.WriteConnectionOpenError(operationId, connection, task.Exception);
+            }
+            else
+            {
+                s_diagnosticListener.WriteConnectionOpenAfter(operationId, connection);
             }
         }
 
@@ -1967,14 +1976,22 @@ namespace Microsoft.Data.SqlClient
         // this only happens once per connection
         // SxS: using named file mapping APIs
 
-        internal void RegisterForConnectionCloseNotification<T>(ref Task<T> outerTask, object value, int tag)
+        internal Task<T> RegisterForConnectionCloseNotification<T>(Task<T> outerTask, object value, int tag)
         {
             // Connection exists,  schedule removal, will be added to ref collection after calling ValidateAndReconnect
-            outerTask = outerTask.ContinueWith(task =>
-            {
-                RemoveWeakReference(value);
-                return task;
-            }, TaskScheduler.Default).Unwrap();
+            return outerTask.ContinueWith(
+                continuationFunction: (task,state) =>
+                {
+                    Tuple<SqlConnection, object> parameters = (Tuple<SqlConnection, object>)state;
+                    SqlConnection connection = parameters.Item1;
+                    object obj = parameters.Item2;
+
+                    connection.RemoveWeakReference(obj);
+                    return task;
+                }, 
+                state: Tuple.Create(this, value),
+                scheduler: TaskScheduler.Default
+           ).Unwrap();
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ResetStatistics/*' />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Data.SqlClient
         private bool _isGlobalTransactionEnabledForServer; // Whether Global Transactions are enabled for this Azure SQL DB Server
         private static readonly Guid _globalTransactionTMID = new Guid("1c742caf-6680-40ea-9c26-6b6846079764"); // ID of the Non-MSDTC, Azure SQL DB Transaction Manager
 
+        internal SqlCommand.ExecuteReaderAsyncCallContext CachedCommandExecuteReaderAsyncContext;
         internal SqlDataReader.Snapshot CachedDataReaderSnapshot;
         internal SqlDataReader.IsDBNullAsyncCallContext CachedDataReaderIsDBNullContext;
         internal SqlDataReader.ReadAsyncCallContext CachedDataReaderReadAsyncContext;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Data.SqlClient
         private bool _isGlobalTransactionEnabledForServer = false; // Whether Global Transactions are enabled for this Azure SQL DB Server
         private static readonly Guid _globalTransactionTMID = new Guid("1c742caf-6680-40ea-9c26-6b6846079764"); // ID of the Non-MSDTC, Azure SQL DB Transaction Manager
 
+        internal SqlCommand.ExecuteReaderAsyncCallContext CachedCommandExecuteReaderAsyncContext;
+
         // if connection is not open: null
         // if connection is open: currently active database
         internal string CurrentDatabase { get; set; }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2844,7 +2844,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         if (_executionContext != null)
                         {
-                            ExecutionContext.Run(_executionContext, (state) => ReadAsyncCallbackCaptureException(source), null);
+                            ExecutionContext.Run(_executionContext, state => ReadAsyncCallbackCaptureException((TaskCompletionSource<object>)state), source);
                         }
                         else
                         {


### PR DESCRIPTION
Benchmarking against the usual DataAccessPerformance project I've got all the way down to the once per call allocations now. ExecuteDataReader uses callbacks delegates and closures which can be cached eliminated or minimized in many cases.

The AAsyncCallContext class is very similar to the one already used internally in SqlDataReader because the pattern of allocation and caching is similar. Once this PR is reviewed and merged I intend to go back and rebase the SqlDataReader internal classes on this new base class.

The changes here come in a number of patterns:
1) replace an instance bound delegate which must be allocated on each call with a static cached caller which has a new first parameter of the `this` type and bounces the call through a translation to an instance call again.
2) move continuations into state functions and pass state as parameters wherever possible to allow caching and avoid closures.
3) replace a compiler generated closures (which are always in method scope) with an explicitly and limited scope state object.

I also changed a void returning function which was altering a ref parameter to one which returns the new value because it's easier to understand what it's doing using the more familiar pattern.

some of the allocations eliminated are:
![Capture2](https://user-images.githubusercontent.com/13322696/79485542-4ba11700-800d-11ea-88b9-9894343393dd.png)

there are some more off the bottom of the screenshot. 

The same work can be done for ExecuteScalar eventually.
