### PR TITLE
Fix tests failure on expected exceptions

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -480,7 +480,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             try
             {
                 actionThatFails();
-                Console.WriteLine("ERROR: Did not get expected exception");
+                Assert.False(true, "ERROR: Did not get expected exception");
                 return null;
             }
             catch (Exception ex)
@@ -501,7 +501,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             try
             {
                 actionThatFails();
-                Console.WriteLine("ERROR: Did not get expected exception");
+                Assert.False(true, "ERROR: Did not get expected exception");
                 return null;
             }
             catch (Exception ex)
@@ -522,7 +522,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             try
             {
                 actionThatFails();
-                Console.WriteLine("ERROR: Did not get expected exception");
+                Assert.False(true, "ERROR: Did not get expected exception");
                 return null;
             }
             catch (Exception ex)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             TimeoutCancel(tcp_connStr);
         }
 
+        [ActiveIssue(12167)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public static void TimeoutCancelNP()
@@ -238,6 +239,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private static void TimeoutCancel(string constr)
         {
+            AppContext.SetSwitch("Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", true);
             using (SqlConnection con = new SqlConnection(constr))
             {
                 con.Open();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -239,7 +239,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private static void TimeoutCancel(string constr)
         {
-            AppContext.SetSwitch("Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", true);
             using (SqlConnection con = new SqlConnection(constr))
             {
                 con.Open();


### PR DESCRIPTION
In this PR the expected behavior is rewritten using the `Assert` to raise an exception if it was not on our expectation.