### PR TITLE
[Release 1.1] Fix stored procedure issues introduced in v1.1.2

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2859,7 +2859,7 @@ namespace Microsoft.Data.SqlClient
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //
-            if (!stateObj._attentionSent && !stateObj.HasPendingData && stateObj.HasOpenResult)
+            if (!stateObj.HasReceivedAttention && !stateObj.HasPendingData && stateObj.HasOpenResult)
             {
                 /*
                                 Debug.Assert(!((sqlTransaction != null               && _distributedTransaction != null) ||

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2855,7 +2855,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            // _attentionSent set by 'SendAttention'
+            // HasReceivedAttention set above
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3324,7 +3324,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            // _attentionSent set by 'SendAttention'
+            // _attentionReceived set above
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3328,7 +3328,7 @@ namespace Microsoft.Data.SqlClient
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //
-            if (!stateObj._attentionSent && !stateObj._pendingData && stateObj._hasOpenResult)
+            if (!stateObj._attentionReceived && !stateObj._pendingData && stateObj._hasOpenResult)
             {
                 /*
                                 Debug.Assert(!((sqlTransaction != null               && _distributedTransaction != null) ||

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -120,6 +120,30 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             TimeOutDuringRead(s_connStr);
         }
 
+        [CheckConnStrSetupFact]
+        public static void TCPAttentionPacketTest()
+        {
+            CancelFollowedByTransaction(s_connStr);
+        }
+
+        private static void CancelFollowedByTransaction(string constr)
+        {
+            using (SqlConnection connection = new SqlConnection(constr))
+            {
+                connection.Open();
+                using (SqlCommand cmd = connection.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT @@VERSION";
+                    using (var r = cmd.ExecuteReader())
+                    {
+                        cmd.Cancel();
+                    }
+                }
+                using (var transaction = connection.BeginTransaction())
+                { }
+            }
+        }
+
         private static void MultiThreadedCancel(string constr, bool async)
         {
             using (SqlConnection con = new SqlConnection(constr))


### PR DESCRIPTION
Ports fix from PR #544 to 1.1-servicing

This PR revises fix introduced in #490 to address stored procedure concerns.
The check for `_attentionSent` is applicable for both TDS Tokens DONEPROC and DONE, whereas, we only want to conditionally work when DONE_ATTN bit is received, which is validated when `HasReceivedAttention` is populated in the same flow.

This seems like the right way to fix MARS TDS Header issue.

NuGet Package for testing:
[Microsoft.Data.SqlClient.1.1.3-dev-pr545.nupkg.zip](https://github.com/dotnet/SqlClient/files/4541806/Microsoft.Data.SqlClient.1.1.3-dev-pr545.nupkg.zip)