### PR TITLE
Revert change that made `SqlDataReader.ReadAsync()` non-blocking

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2847,6 +2847,8 @@ namespace Microsoft.Data.SqlClient
             ushort status;
             int count;
 
+            stateObj._syncOverAsync = true;
+
             // status
             // command
             // rowcount (valid only if DONE_COUNT bit is set)
@@ -2946,11 +2948,10 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            // HasReceivedAttention set above
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //
-            if (!stateObj.HasReceivedAttention && !stateObj.HasPendingData && stateObj.HasOpenResult)
+            if (!stateObj.HasPendingData && stateObj.HasOpenResult)
             {
                 /*
                                 Debug.Assert(!((sqlTransaction != null               && _distributedTransaction != null) ||

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2847,6 +2847,10 @@ namespace Microsoft.Data.SqlClient
             ushort status;
             int count;
 
+            // This is added back since removing it from here introduces regressions in Managed SNI.
+            // It forces SqlDataReader.ReadAsync() method to run synchronously, 
+            // and will block the calling thread until data is fed from SQL Server.
+            // TODO Investigate better solution to support non-blocking ReadAsync().
             stateObj._syncOverAsync = true;
 
             // status

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2946,7 +2946,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            // _attentionSent set by 'SendAttention'
+            // HasReceivedAttention set above
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2950,7 +2950,7 @@ namespace Microsoft.Data.SqlClient
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //
-            if (!stateObj._attentionSent && !stateObj.HasPendingData && stateObj.HasOpenResult)
+            if (!stateObj.HasReceivedAttention && !stateObj.HasPendingData && stateObj.HasOpenResult)
             {
                 /*
                                 Debug.Assert(!((sqlTransaction != null               && _distributedTransaction != null) ||

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3341,7 +3341,7 @@ namespace Microsoft.Data.SqlClient
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //
-            if (!stateObj._attentionSent && !stateObj._pendingData && stateObj._hasOpenResult)
+            if (!stateObj._attentionReceived && !stateObj._pendingData && stateObj._hasOpenResult)
             {
                 /*
                                 Debug.Assert(!((sqlTransaction != null               && _distributedTransaction != null) ||

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3337,7 +3337,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            // _attentionSent set by 'SendAttention'
+            // _attentionReceived set above
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3337,11 +3337,10 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            // _attentionReceived set above
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //
-            if (!stateObj._attentionReceived && !stateObj._pendingData && stateObj._hasOpenResult)
+            if (!stateObj._pendingData && stateObj._hasOpenResult)
             {
                 /*
                                 Debug.Assert(!((sqlTransaction != null               && _distributedTransaction != null) ||

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -218,7 +218,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             CancelFollowedByTransaction(tcp_connStr);
         }
 
-        [CheckConnStrSetupFact]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public static void NPAttentionPacketTest()
         {
             CancelFollowedByTransaction(np_connStr);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             CancelFollowedByTransaction(np_connStr);
         }
 
-        [CheckConnStrSetupFact]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
         public static void TCPAttentionPacketTestAlerts()
         {
             CancelFollowedByAlert(tcp_connStr);
@@ -259,6 +259,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private static void CancelFollowedByAlert(string constr)
         {
             var alertName = "myAlert" + Guid.NewGuid().ToString();
+            // Since Alert conditions are randomly generated, 
+            // we will rety on unexpected error messages to avoid collision in pipelines.
             var n = new Random().Next(1, 100);
             bool retry = true;
             int retryAttempt = 0;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -212,6 +212,36 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             AsyncCancelDoesNotWait(np_connStr).Wait();
         }
 
+        [CheckConnStrSetupFact]
+        public static void TCPAttentionPacketTest()
+        {
+            CancelFollowedByTransaction(tcp_connStr);
+        }
+
+        [CheckConnStrSetupFact]
+        public static void NPAttentionPacketTest()
+        {
+            CancelFollowedByTransaction(np_connStr);
+        }
+
+        private static void CancelFollowedByTransaction(string constr)
+        {
+            using (SqlConnection connection = new SqlConnection(constr))
+            {
+                connection.Open();
+                using (SqlCommand cmd = connection.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT @@VERSION";
+                    using (var r = cmd.ExecuteReader())
+                    {
+                        cmd.Cancel();
+                    }
+                }
+                using (var transaction = connection.BeginTransaction())
+                { }
+            }
+        }
+
         private static void MultiThreadedCancel(string constr, bool async)
         {
             using (SqlConnection con = new SqlConnection(constr))

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -303,7 +303,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     {
                         retry = true;
                         retryAttempt++;
-                        Console.WriteLine($"Retry Attempt : {retryAttempt}");
+                        Console.WriteLine($"CancelFollowedByAlert Test retry attempt : {retryAttempt}");
+                        Thread.Sleep(500);
                         continue;
                     }
                 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             var alertName = "myAlert" + Guid.NewGuid().ToString();
             // Since Alert conditions are randomly generated, 
-            // we will rety on unexpected error messages to avoid collision in pipelines.
+            // we will retry on unexpected error messages to avoid collision in pipelines.
             var n = new Random().Next(1, 100);
             bool retry = true;
             int retryAttempt = 0;


### PR DESCRIPTION
This PR reverts https://github.com/dotnet/corefx/pull/26595 and #490 (attempted to fix MARS TDS header issues introduced with https://github.com/dotnet/corefx/pull/26595) with additional tests.

This is an alternate solution to fix #542 but due to #544 and #545 failing intermittently on Unix w. Managed SNI, it doesn't seem an appropriate fix either. 

This revert is likely to hit performance by re-introducing old behavior of SqlDataReader.ReadAsync() method to run synchronously, and will block the calling thread until data is fed from SQL Server. But given the side-effects of the original change, reverting seems most appropriate at this point and a proper investigation would be needed to be done for original performance issue.