### PR TITLE
perf: Reduce tracing related allocations from TVP write

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -9656,7 +9656,7 @@ namespace Microsoft.Data.SqlClient
             if (advancedTraceIsOn)
             {
                 var sendDefaultValue = sendDefault ? 1 : 0;
-                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.WriteSmiParameter|ADV> {0}, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData);
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.WriteSmiParameter|ADV> {0}, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData.TraceString(3));
             }
 
             //

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -8872,6 +8872,8 @@ namespace Microsoft.Data.SqlClient
                         // Stream out parameters
                         int parametersLength = rpcext.userParamCount + rpcext.systemParamCount;
 
+                        bool isAdvancedTraceOn = SqlClientEventSource.Log.IsAdvancedTraceOn();
+
                         for (int i = (ii == startRpc) ? startParam : 0; i < parametersLength; i++)
                         {
                             byte options = 0;
@@ -8904,7 +8906,7 @@ namespace Microsoft.Data.SqlClient
 
                             if (mt.IsNewKatmaiType)
                             {
-                                WriteSmiParameter(param, i, 0 != (options & TdsEnums.RPC_PARAM_DEFAULT), stateObj);
+                                WriteSmiParameter(param, i, 0 != (options & TdsEnums.RPC_PARAM_DEFAULT), stateObj, isAdvancedTraceOn);
                                 continue;
                             }
 
@@ -9601,7 +9603,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private void WriteSmiParameter(SqlParameter param, int paramIndex, bool sendDefault, TdsParserStateObject stateObj)
+        private void WriteSmiParameter(SqlParameter param, int paramIndex, bool sendDefault, TdsParserStateObject stateObj, bool advancedTraceIsOn)
         {
             //
             // Determine Metadata
@@ -9651,8 +9653,11 @@ namespace Microsoft.Data.SqlClient
                 typeCode = MetaDataUtilsSmi.DetermineExtendedTypeCodeForUseWithSqlDbType(metaData.SqlDbType, metaData.IsMultiValued, value, null);
             }
 
-            var sendDefaultValue = sendDefault ? 1 : 0;
-            SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.WriteSmiParameter|ADV> {0}, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData.TraceString(3));
+            if (advancedTraceIsOn)
+            {
+                var sendDefaultValue = sendDefault ? 1 : 0;
+                SqlClientEventSource.Log.AdvancedTraceEvent("<sc.TdsParser.WriteSmiParameter|ADV> {0}, Sending parameter '{1}', default flag={2}, metadata:{3}", ObjectID, param.ParameterName, sendDefaultValue, metaData);
+            }
 
             //
             // Write parameter metadata


### PR DESCRIPTION
There is a case where extended metadata trace information is formatted before being passed into an event tracing method which then may not use the string. 
I chose not to try and make the tracing code more efficient because it will almost never be used. I've added precheck to see if advanced logging is enabled and passed that as a parameter to the function logging the information because it avoids a per-loop invocation of the event trace flag check.

|              Method |     Mean |   Error |  StdDev |     Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|--------:|--------:|----------:|------:|------:|----------:|
| SyncWriteTableParam master | 191.0 ms | 1.69 ms | 1.41 ms | 1000.0000 |     - |     - |  12.05 MB |
| SyncWriteTableParam branch | 185.2 ms | 0.42 ms | 0.33 ms |     - |     - |     - | 313.33 KB |


