### PR TITLE
Do not throw exception for invalid configuration file

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.NetCoreApp.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlClient
         static SqlAuthenticationProviderManager()
         {
             var activeDirectoryAuthNativeProvider = new ActiveDirectoryNativeAuthenticationProvider();
-            SqlAuthenticationProviderConfigurationSection configurationSection;
+            SqlAuthenticationProviderConfigurationSection configurationSection = null;
 
             try
             {
@@ -24,7 +24,7 @@ namespace Microsoft.Data.SqlClient
             }
             catch (ConfigurationErrorsException)
             {
-                configurationSection = null;
+                // Don't throw an error for invalid config files
             }
 
             Instance = new SqlAuthenticationProviderManager(configurationSection);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.NetCoreApp.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Data.SqlClient
             {
                 configurationSection = (SqlAuthenticationProviderConfigurationSection)ConfigurationManager.GetSection(SqlAuthenticationProviderConfigurationSection.Name);
             }
-            catch (ConfigurationErrorsException e)
+            catch (ConfigurationErrorsException)
             {
-                throw SQL.CannotGetAuthProviderConfig(e);
+                configurationSection = null;
             }
 
             Instance = new SqlAuthenticationProviderManager(configurationSection);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Linq;
 
 namespace Microsoft.Data.SqlClient


### PR DESCRIPTION
Fixes #558 

I agree the purpose of driver is to not validate the app.config file, and work with default behavior, as it would in absence of this corrupt file.

NetFx driver already does the same.