### PR TITLE
Fix infinite loop when end of stream is reached

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SslOverTdsStream.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SslOverTdsStream.cs
@@ -104,9 +104,16 @@ namespace Microsoft.Data.SqlClient.SNI
                     // Account for split packets
                     while (readBytes < TdsEnums.HEADER_LEN)
                     {
-                        readBytes += async ?
+                        var readBytesForHeader = async ?
                             await _stream.ReadAsync(packetData, readBytes, TdsEnums.HEADER_LEN - readBytes, token).ConfigureAwait(false) :
                             _stream.Read(packetData, readBytes, TdsEnums.HEADER_LEN - readBytes);
+
+                        if (readBytesForHeader == 0)
+                        {
+                            throw new EndOfStreamException("End of stream reached");
+                        }
+
+                        readBytes += readBytesForHeader;
                     }
 
                     _packetBytes = (packetData[TdsEnums.HEADER_LEN_FIELD_OFFSET] << 8) | packetData[TdsEnums.HEADER_LEN_FIELD_OFFSET + 1];


### PR DESCRIPTION
This is to fix issue #165 

We're seeing this issue in our production and development environments. We're using .NET Core 3.1 on CentOS 7. A reliable way to reproduce it is calling `SqlConnection.Open()` every half a second while Windows Server is restarting. This causes the process to go up to 100% CPU usage, which as you can imagine can cause problems. 😄 

We've tested against our environment and this fixes the problem, as the exception is caught further up and another is thrown out of `SqlConnection.Open()`.

Of course I am open to different approaches if this isn't the preferred way to handle it. 

- I'm not entirely happy with the variable name `readBytesForHeader`, any suggestions are welcome. 
- The exception message seems a bit redundant given the name of the exception. Any preference to having the message or not?
- This is also a problem in System.Data.SqlClient, so it needs backporting. I'm not sure how this is done. Of course I'm happy to submit a PR to fix it there too if that's preferred. 
