### PR TITLE
Fix | Fix SqlClientMetaDataCollectionNames.Parameters mismatching issue

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml
@@ -28,10 +28,6 @@
             <summary>A constant for use with the **GetSchema** method that represents the **ProcedureParameters** collection.</summary>
             <remarks>To be added.</remarks>
         </ProcedureParameters>
-        <ProcedureColumns>
-            <summary>A constant for use with the **GetSchema** method that represents the **ProcedureColumns** collection.</summary>
-            <remarks>To be added.</remarks>
-        </ProcedureColumns>
         <Procedures>
             <summary>A constant for use with the **GetSchema** method that represents the **Procedures** collection.</summary>
             <remarks>To be added.</remarks>
@@ -56,5 +52,13 @@
             <summary>A constant for use with the **GetSchema** method that represents the **Views** collection.</summary>
             <remarks>To be added.</remarks>
         </Views>
+        <AllColumns>
+            <summary>A constant for use with the **GetSchema** method that represents the **AllColumns** collection.</summary>
+            <remarks>To be added.</remarks>
+        </AllColumns>
+        <ColumnSetColumns>
+            <summary>A constant for use with the **GetSchema** method that represents the **ColumnSetColumns** collection.</summary>
+            <remarks>To be added.</remarks>
+        </ColumnSetColumns>
     </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml
@@ -24,10 +24,10 @@
             <summary>A constant for use with the **GetSchema** method that represents the **Indexes** collection.</summary>
             <remarks>To be added.</remarks>
         </Indexes>
-        <Parameters>
-            <summary>A constant for use with the **GetSchema** method that represents the **Parameters** collection.</summary>
+        <ProcedureParameters>
+            <summary>A constant for use with the **GetSchema** method that represents the **ProcedureParameters** collection.</summary>
             <remarks>To be added.</remarks>
-        </Parameters>
+        </ProcedureParameters>
         <ProcedureColumns>
             <summary>A constant for use with the **GetSchema** method that represents the **ProcedureColumns** collection.</summary>
             <remarks>To be added.</remarks>

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -290,8 +290,8 @@ namespace Microsoft.Data.SqlClient
         public static readonly string IndexColumns;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Indexes/*'/>
         public static readonly string Indexes;
-        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Parameters/*'/>
-        public static readonly string Parameters;
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureParameters/*'/>
+        public static readonly string ProcedureParameters;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureColumns/*'/>
         public static readonly string ProcedureColumns;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Procedures/*'/>

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -292,8 +292,6 @@ namespace Microsoft.Data.SqlClient
         public static readonly string Indexes;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureParameters/*'/>
         public static readonly string ProcedureParameters;
-        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureColumns/*'/>
-        public static readonly string ProcedureColumns;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Procedures/*'/>
         public static readonly string Procedures;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Tables/*'/>
@@ -306,6 +304,10 @@ namespace Microsoft.Data.SqlClient
         public static readonly string ViewColumns;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Views/*'/>
         public static readonly string Views;
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/AllColumns/*'/>
+        public static readonly string AllColumns;
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ColumnSetColumns/*'/>
+        public static readonly string ColumnSetColumns;
     }
     /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/SqlCommand/*'/>
     [System.ComponentModel.DefaultEventAttribute("RecordsAffected")]

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientMetaDataCollectionNames.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientMetaDataCollectionNames.cs
@@ -26,9 +26,6 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureParameters/*' />
         public static readonly string ProcedureParameters = "ProcedureParameters";
 
-        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureColumns/*' />
-        public static readonly string ProcedureColumns = "ProcedureColumns";
-
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Procedures/*' />
         public static readonly string Procedures = "Procedures";
 
@@ -46,5 +43,11 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Views/*' />
         public static readonly string Views = "Views";
+
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/AllColumns/*' />
+        public static readonly string AllColumns = "AllColumns";  // supported starting from SQL Server 2008
+
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ColumnSetColumns/*' />
+        public static readonly string ColumnSetColumns = "ColumnSetColumns";  // supported starting from SQL Server 2008
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientMetaDataCollectionNames.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientMetaDataCollectionNames.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Indexes/*' />
         public static readonly string Indexes = "Indexes";
 
-        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Parameters/*' />
-        public static readonly string Parameters = "Parameters";
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureParameters/*' />
+        public static readonly string ProcedureParameters = "ProcedureParameters";
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureColumns/*' />
         public static readonly string ProcedureColumns = "ProcedureColumns";

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -329,8 +329,6 @@ namespace Microsoft.Data.SqlClient
         public static readonly string Indexes;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureParameters/*'/>
         public static readonly string ProcedureParameters;
-        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureColumns/*'/>
-        public static readonly string ProcedureColumns;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Procedures/*'/>
         public static readonly string Procedures;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Tables/*'/>
@@ -343,6 +341,10 @@ namespace Microsoft.Data.SqlClient
         public static readonly string ViewColumns;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Views/*'/>
         public static readonly string Views;
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/AllColumns/*'/>
+        public static readonly string AllColumns;
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ColumnSetColumns/*'/>
+        public static readonly string ColumnSetColumns;
     }
     /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/SqlClientPermission/*'/>
     public sealed partial class SqlClientPermission : System.Data.Common.DBDataPermission

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -327,8 +327,8 @@ namespace Microsoft.Data.SqlClient
         public static readonly string IndexColumns;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Indexes/*'/>
         public static readonly string Indexes;
-        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Parameters/*'/>
-        public static readonly string Parameters;
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureParameters/*'/>
+        public static readonly string ProcedureParameters;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureColumns/*'/>
         public static readonly string ProcedureColumns;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Procedures/*'/>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientMetaDataCollectionNames.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientMetaDataCollectionNames.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Indexes/*' />
         public static readonly string Indexes = "Indexes";
 
-        /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Parameters/*' />
-        public static readonly string Parameters = "Parameters";
+        /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureParameters/*' />
+        public static readonly string ProcedureParameters = "ProcedureParameters";
 
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureColumns/*' />
         public static readonly string ProcedureColumns = "ProcedureColumns";

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientMetaDataCollectionNames.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientMetaDataCollectionNames.cs
@@ -25,9 +25,6 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureParameters/*' />
         public static readonly string ProcedureParameters = "ProcedureParameters";
 
-        /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ProcedureColumns/*' />
-        public static readonly string ProcedureColumns = "ProcedureColumns";
-
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Procedures/*' />
         public static readonly string Procedures = "Procedures";
 
@@ -45,6 +42,12 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/Views/*' />
         public static readonly string Views = "Views";
+
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/AllColumns/*' />
+        public static readonly string AllColumns = "AllColumns";  // supported starting from SQL Server 2008
+
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientMetaDataCollectionNames.xml' path='docs/members[@name="SqlClientMetaDataCollectionNames"]/ColumnSetColumns/*' />
+        public static readonly string ColumnSetColumns = "ColumnSetColumns";  // supported starting from SQL Server 2008
 
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlClientMetaDataCollectionNamesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlClientMetaDataCollectionNamesTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal("ForeignKeys", SqlClientMetaDataCollectionNames.ForeignKeys);
             Assert.Equal("IndexColumns", SqlClientMetaDataCollectionNames.IndexColumns);
             Assert.Equal("Indexes", SqlClientMetaDataCollectionNames.Indexes);
-            Assert.Equal("Parameters", SqlClientMetaDataCollectionNames.Parameters);
+            Assert.Equal("ProcedureParameters", SqlClientMetaDataCollectionNames.ProcedureParameters);
             Assert.Equal("ProcedureColumns", SqlClientMetaDataCollectionNames.ProcedureColumns);
             Assert.Equal("Procedures", SqlClientMetaDataCollectionNames.Procedures);
             Assert.Equal("Tables", SqlClientMetaDataCollectionNames.Tables);

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlClientMetaDataCollectionNamesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlClientMetaDataCollectionNamesTest.cs
@@ -17,13 +17,14 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal("IndexColumns", SqlClientMetaDataCollectionNames.IndexColumns);
             Assert.Equal("Indexes", SqlClientMetaDataCollectionNames.Indexes);
             Assert.Equal("ProcedureParameters", SqlClientMetaDataCollectionNames.ProcedureParameters);
-            Assert.Equal("ProcedureColumns", SqlClientMetaDataCollectionNames.ProcedureColumns);
             Assert.Equal("Procedures", SqlClientMetaDataCollectionNames.Procedures);
             Assert.Equal("Tables", SqlClientMetaDataCollectionNames.Tables);
             Assert.Equal("UserDefinedTypes", SqlClientMetaDataCollectionNames.UserDefinedTypes);
             Assert.Equal("Users", SqlClientMetaDataCollectionNames.Users);
             Assert.Equal("ViewColumns", SqlClientMetaDataCollectionNames.ViewColumns);
             Assert.Equal("Views", SqlClientMetaDataCollectionNames.Views);
+            Assert.Equal("AllColumns", SqlClientMetaDataCollectionNames.AllColumns);
+            Assert.Equal("ColumnSetColumns", SqlClientMetaDataCollectionNames.ColumnSetColumns);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataBaseSchemaTest/ConnectionSchemaTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataBaseSchemaTest/ConnectionSchemaTest.cs
@@ -12,22 +12,88 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     {
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        public static void GetAllTablesFromSchema()
+        public static void GetTablesFromSchema()
         {
             VerifySchemaTable(SqlClientMetaDataCollectionNames.Tables, new string[] { "TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE" });
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        public static void GetAllProceduresFromSchema()
+        public static void GetProceduresFromSchema()
         {
             VerifySchemaTable(SqlClientMetaDataCollectionNames.Procedures, new string[] { "ROUTINE_SCHEMA", "ROUTINE_NAME", "ROUTINE_TYPE" });
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        public static void GetAllProcedureParametersFromSchema()
+        public static void GetProcedureParametersFromSchema()
         {
             VerifySchemaTable(SqlClientMetaDataCollectionNames.ProcedureParameters, new string[] { "PARAMETER_MODE", "PARAMETER_NAME" });
         }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetDatabasesFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.Databases, new string[] { "database_name", "dbid", "create_date" });
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetForeignKeysFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.ForeignKeys, new string[] { "CONSTRAINT_TYPE", "IS_DEFERRABLE", "INITIALLY_DEFERRED" });
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetIndexesFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.Indexes, new string[] { "index_name", "constraint_name" });
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetIndexColumnsFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.IndexColumns, new string[] { "index_name", "KeyType", "column_name" });
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetColumnsFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.Columns, new string[] { "IS_NULLABLE", "COLUMN_DEFAULT" });
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetAllColumnsFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.AllColumns, new string[] { "IS_NULLABLE", "COLUMN_DEFAULT", "IS_FILESTREAM", "IS_SPARSE", "IS_COLUMN_SET" });
+        }
+        
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetColumnSetColumnsFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.ColumnSetColumns, new string[] { "IS_NULLABLE", "COLUMN_DEFAULT", "IS_FILESTREAM", "IS_SPARSE", "IS_COLUMN_SET" });
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetUsersFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.Users, new string[] { "uid", "user_name" });
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetViewsFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.Views, new string[] { "TABLE_NAME", "CHECK_OPTION", "IS_UPDATABLE" });
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetViewColumnsFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.ViewColumns, new string[] { "VIEW_CATALOG", "VIEW_SCHEMA", "VIEW_NAME" });
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetUserDefinedTypesFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.UserDefinedTypes, new string[] { "assembly_name", "version_revision", "culture_info" });
+        }        
 
         private static void VerifySchemaTable(string schemaItemName, string[] testColumnNames)
         {
@@ -41,13 +107,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 // Connect to the database then retrieve the schema information.  
                 connection.Open();
                 DataTable table = connection.GetSchema(schemaItemName);
-
-                // Display the contents of the table.
-                // For ProcedureParameters, we may get table.Rows.Count = 0 according to database setup
-                if (SqlClientMetaDataCollectionNames.ProcedureParameters != schemaItemName)
-                {
-                    Assert.InRange<int>(table.Rows.Count, 1, int.MaxValue);
-                }
 
                 // Get all table columns 
                 HashSet<string> columnNames = new HashSet<string>();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataBaseSchemaTest/ConnectionSchemaTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataBaseSchemaTest/ConnectionSchemaTest.cs
@@ -23,6 +23,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             VerifySchemaTable(SqlClientMetaDataCollectionNames.Procedures, new string[] { "ROUTINE_SCHEMA", "ROUTINE_NAME", "ROUTINE_TYPE" });
         }
 
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static void GetAllProcedureParametersFromSchema()
+        {
+            VerifySchemaTable(SqlClientMetaDataCollectionNames.ProcedureParameters, new string[] { "PARAMETER_MODE", "PARAMETER_NAME" });
+        }
+
         private static void VerifySchemaTable(string schemaItemName, string[] testColumnNames)
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString)
@@ -36,8 +42,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 connection.Open();
                 DataTable table = connection.GetSchema(schemaItemName);
 
-                // Display the contents of the table.  
-                Assert.InRange<int>(table.Rows.Count, 1, int.MaxValue);
+                // Display the contents of the table.
+                // For ProcedureParameters, we may get table.Rows.Count = 0 according to database setup
+                if (SqlClientMetaDataCollectionNames.ProcedureParameters != schemaItemName)
+                {
+                    Assert.InRange<int>(table.Rows.Count, 1, int.MaxValue);
+                }
 
                 // Get all table columns 
                 HashSet<string> columnNames = new HashSet<string>();


### PR DESCRIPTION
This is a fix for [GH#575](https://github.com/dotnet/SqlClient/issues/575).

- Change initial `SqlClientMetaDataCollectionNames.Parameters` to `SqlClientMetaDataCollectionNames.ProcedureParameters`.
- Add test cases for this.