### PR TITLE
Fix Collated database reader issue

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2606,8 +2606,8 @@ namespace Microsoft.Data.SqlClient
                                 if (newCodePage != _defaultCodePage)
                                 {
                                     _defaultCodePage = newCodePage;
-                                    _defaultEncoding = System.Text.Encoding.GetEncoding(_defaultCodePage);
                                 }
+                                _defaultEncoding = System.Text.Encoding.GetEncoding(_defaultCodePage);
                             }
                             _defaultLCID = env.newCollation.LCID;
                         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2056,7 +2056,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     tdsReliabilitySection.Start();
 #endif //DEBUG
-                return Run(runBehavior, cmdHandler, dataStream, bulkCopyHandler, stateObj);
+                    return Run(runBehavior, cmdHandler, dataStream, bulkCopyHandler, stateObj);
 #if DEBUG
                 }
                 finally
@@ -2949,12 +2949,11 @@ namespace Microsoft.Data.SqlClient
                             }
                             else
                             {
-
                                 if (newCodePage != _defaultCodePage)
                                 {
                                     _defaultCodePage = newCodePage;
-                                    _defaultEncoding = System.Text.Encoding.GetEncoding(_defaultCodePage);
                                 }
+                                _defaultEncoding = System.Text.Encoding.GetEncoding(_defaultCodePage);
                             }
                         }
 
@@ -9689,7 +9688,7 @@ namespace Microsoft.Data.SqlClient
 
                         // Stream out parameters
                         SqlParameter[] parameters = rpcext.parameters;
-                        
+
                         bool isAdvancedTraceOn = SqlClientEventSource.Log.IsAdvancedTraceOn();
 
                         for (int i = (ii == startRpc) ? startParam : 0; i < parameters.Length; i++)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Text;
+using System.Threading;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
@@ -82,7 +83,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 }
             }
         }
-        
+
         // Checks for the IsColumnSet bit in the GetSchemaTable for Sparse columns
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void CheckSparseColumnBit()
@@ -141,6 +142,61 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     // drop the temp table to release its resources
                     cmd.CommandText = "DROP TABLE " + tempTableName;
                     cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
+        public static void CollatedDataReaderTest()
+        {
+            var databaseName = DataTestUtility.GetUniqueName("DB");
+            // Remove square brackets
+            var dbName = databaseName.Substring(1, databaseName.Length - 2);
+            try
+            {
+                using (SqlConnection con = new SqlConnection(DataTestUtility.TCPConnectionString))
+                using (SqlCommand cmd = con.CreateCommand())
+                {
+                    con.Open();
+
+                    // Create collated database
+                    cmd.CommandText = $"CREATE DATABASE {databaseName} COLLATE KAZAKH_90_CI_AI";
+                    cmd.ExecuteNonQuery();
+
+                    //Create connection without pooling in order to delete database later.
+                    using (SqlConnection dbCon = new SqlConnection(DataTestUtility.TCPConnectionString + $";Initial Catalog = {dbName};Pooling=no;"))
+                    using (SqlCommand dbCmd = dbCon.CreateCommand())
+                    {
+                        var data = "TestData";
+
+                        dbCon.Open();
+                        dbCmd.CommandText = $"SELECT '{data}'";
+                        using (SqlDataReader reader = dbCmd.ExecuteReader())
+                        {
+                            reader.Read();
+                            Assert.Equal(data, reader.GetString(0));
+                        }
+                        dbCon.Close();
+                    }
+
+                    // Let connection close safely before dropping database for slow servers.
+                    Thread.Sleep(500);
+                }
+            }
+            catch (SqlException e)
+            {
+                Assert.True(false, $"Unexpected Exception occurred: {e.Message}");
+            }
+            finally
+            {
+                using (SqlConnection con = new SqlConnection(DataTestUtility.TCPConnectionString))
+                using (SqlCommand cmd = con.CreateCommand())
+                {
+                    con.Open();
+
+                    cmd.CommandText = $"DROP DATABASE {databaseName}";
+                    cmd.ExecuteNonQuery();
+
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -152,10 +152,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             var databaseName = DataTestUtility.GetUniqueName("DB");
             // Remove square brackets
             var dbName = databaseName.Substring(1, databaseName.Length - 2);
-            try
+
+            using (SqlConnection con = new SqlConnection(DataTestUtility.TCPConnectionString))
+            using (SqlCommand cmd = con.CreateCommand())
             {
-                using (SqlConnection con = new SqlConnection(DataTestUtility.TCPConnectionString))
-                using (SqlCommand cmd = con.CreateCommand())
+                try
                 {
                     con.Open();
 
@@ -176,27 +177,19 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             reader.Read();
                             Assert.Equal(data, reader.GetString(0));
                         }
-                        dbCon.Close();
                     }
 
                     // Let connection close safely before dropping database for slow servers.
                     Thread.Sleep(500);
                 }
-            }
-            catch (SqlException e)
-            {
-                Assert.True(false, $"Unexpected Exception occurred: {e.Message}");
-            }
-            finally
-            {
-                using (SqlConnection con = new SqlConnection(DataTestUtility.TCPConnectionString))
-                using (SqlCommand cmd = con.CreateCommand())
+                catch (SqlException e)
                 {
-                    con.Open();
-
+                    Assert.True(false, $"Unexpected Exception occurred: {e.Message}");
+                }
+                finally
+                {
                     cmd.CommandText = $"DROP DATABASE {databaseName}";
                     cmd.ExecuteNonQuery();
-
                 }
             }
         }


### PR DESCRIPTION
Fixes #576 

This is a proposal to fix default behavior of driver to generate default collation from .NET process.
Although it does depend on client's operating system and may not provide accurate encoding to match collation of user's database/columns.

Other Sql Server drivers maintain their list of collations/encoding mappings as supported for SQL Server, unlike SqlClient, that depends on "System.Globalization" hence we encountered this issue.

The "Kazakh" collation is mapped to 0 AnsiCodePage in System.Globalization which maps to CP_ACP (system default codepage), whereas on SQL Server it's mapped to CodePage 1251.

**Edit:** After discussions below, it seems like we can only accept database code page here, for which we'll have to come up with our own list of collation/encoding mapping as supported by SQL Server just like other drivers.