### PR TITLE
Fix | Add correct code page for Kazakh collation

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -4258,6 +4258,9 @@ namespace Microsoft.Data.SqlClient
                             {
                             }
                             break;
+                        case 0x43f:
+                            codePage = 1251;  // Kazakh code page based on SQL Server
+                            break;
                         default:
                             break;
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -4725,6 +4725,9 @@ namespace Microsoft.Data.SqlClient
                                 ADP.TraceExceptionWithoutRethrow(e);
                             }
                             break;
+                        case 0x43f:
+                            codePage = 1251;  // Kazakh code page based on SQL Server
+                            break;
                         default:
                             break;
                     }


### PR DESCRIPTION
Fix for [GH#576](https://github.com/dotnet/SqlClient/issues/576).

The System.Globalization returns 0 code page for Kazakh collation while the SQL Server maps it to 1251. Change the code page to 1251 for Kazakh to keep the consistency. 

In the future, we will let the driver maintain all valid mapping between the collation and code page. 