### PR TITLE
WIP | Suggested fix for Multiple Active Result sets in Managed SNI

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     continuationAction: _readCallback,
                     state: callback,
                     CancellationToken.None,
-                    TaskContinuationOptions.DenyChildAttach,
+                    TaskContinuationOptions.ExecuteSynchronously,
                     TaskScheduler.Default
                 );
         }


### PR DESCRIPTION
This might be the solution for Multiple Active Result Sets (MARS)  [Issue 422](https://github.com/dotnet/SqlClient/issues/422).

According to [Microsoft Documentation](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcontinuationoptions?view=netcore-3.1) The `DenyChildAttach` will make each child task (that is, any nested inner task created by this continuation) to not be attached to parent task and to execute as a detach child task. Changing this to ExecuteSynchronously, Specifies that the continuation task should be executed synchronously. With this option specified, the continuation runs on the same thread that causes the antecedent task to transition into its final state. If the antecedent is already complete when the continuation is created, the continuation will run on the thread that creates the continuation.
@Wraith2 