### PR TITLE
WIP | Managed SNI, Add single threaded task scheduler 

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -355,6 +355,7 @@
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIPhysicalHandle.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIProxy.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNITcpHandle.cs" />
+    <Compile Include="Microsoft\Data\SqlClient\SNI\SNITaskScheduler.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SslOverTdsStream.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNICommon.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SspiClientContextStatus.cs" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     state: callback,
                     CancellationToken.None,
                     TaskContinuationOptions.DenyChildAttach,
-                    TaskScheduler.Default
+                    SNITaskScheduler.Instance
                 );
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITaskScheduler.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITaskScheduler.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.SqlClient.SNI
+{
+    internal sealed class SNITaskScheduler : TaskScheduler
+    {
+        private static SNITaskScheduler s_scheduler;
+
+        public static SNITaskScheduler Instance
+        {
+            get
+            {
+                LazyInitializer.EnsureInitialized(ref s_scheduler);
+                ;
+                return s_scheduler;
+            }
+        }
+
+        private BlockingCollection<Task> _tasks;
+        private readonly Thread _thread;
+
+        public SNITaskScheduler()
+        {
+            _tasks = new BlockingCollection<Task>();
+            _thread = new Thread(new ThreadStart(ExecuteThreadStart));
+            _thread.IsBackground = true;
+            _thread.Name = typeof(SNITaskScheduler).FullName;
+            _thread.Start();
+        }
+
+        private void ExecuteThreadStart()
+        {
+            foreach (Task task in _tasks.GetConsumingEnumerable())
+            {
+                TryExecuteTask(task);
+            }
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            if (task != null)
+            {
+                _tasks.Add(task);
+            }
+        }
+
+        protected override IEnumerable<Task> GetScheduledTasks() => _tasks.ToArray();
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+    }
+}


### PR DESCRIPTION
To avoid thread pool starvation handle receipts very specifically on a dedicated thread by using a custome task scheduler. No waits must be performed on this thread and execution must be pushed back to the standard thread pool for user callbacks and data handling.