### PR TITLE
Feature | Add support for Data Classification v2

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/ColumnSensitivity.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/ColumnSensitivity.xml
@@ -3,15 +3,14 @@
     <members name="ColumnSensitivity">
         <ColumnSensitivity>
             <summary>Represents the Data Classification Sensitivity Information for columns as configured in Database.</summary>
-            <remarks>To be added.</remarks>
         </ColumnSensitivity>
         <ctor>
             <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity" /> class.</summary>
+            <param name="sensitivityProperties">List of sensitivity properties.</param>
         </ctor>
         <GetSensitivityProperties>
             <summary>Returns the list of sensitivity properties as received from Server for this 'ColumnSensitivity' information</summary>
             <value>List of sensitivity properties.</value>
-            <remarks>To be added.</remarks>
         </GetSensitivityProperties>
     </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/InformationType.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/InformationType.xml
@@ -3,20 +3,19 @@
     <members name="InformationType">
         <InformationType>
             <summary>Represents the Data Classification Information Types as received from SQL Server for the active 'SqlDataReader'</summary>
-            <remarks>To be added.</remarks>
         </InformationType>
         <ctor>
             <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.InformationType" /> class.</summary>
+          <param name="name">Name of Information Type.</param>
+          <param name="id">ID of Information Type.</param>
         </ctor>
         <Id>
             <summary>Gets the ID for this 'InformationType' object</summary>
-            <value>ID of InformationType.</value>
-            <remarks>To be added.</remarks>
+            <value>ID of Information Type.</value>
         </Id>
         <Name>
             <summary>Gets the name for this 'InformationType' object</summary>
-            <value>Name of InformationType.</value>
-            <remarks>To be added.</remarks>
+            <value>Name of Information Type.</value>
         </Name>
     </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml
@@ -3,20 +3,19 @@
     <members name="Label">
         <Label>
             <summary>Represents the Data Classification Labels as received from SQL Server for the active 'SqlDataReader'</summary>
-            <remarks>To be added.</remarks>
         </Label>
         <ctor>
             <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.Label" /> class.</summary>
+            <param name="name">Name of label.</param>
+            <param name="id">ID of label.</param>
         </ctor>
         <Id>
             <summary>Gets the ID for this 'Label' object</summary>
             <value>ID of label.</value>
-            <remarks>To be added.</remarks>
         </Id>
         <Name>
             <summary>Gets the name for this 'Label' object</summary>
             <value>Name of label.</value>
-            <remarks>To be added.</remarks>
         </Name>
     </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml
@@ -3,26 +3,47 @@
     <members name="SensitivityClassification">
         <SensitivityClassification>
             <summary>Provides the functionlity to retrieve Sensitivity Classification data as received from SQL Server for the active 'SqlDataReader'</summary>
-            <remarks>To be added.</remarks>
         </SensitivityClassification>
         <ColumnSensitivities>
             <summary>Returns the column sensitivity for this 'SensitivityClassification' Object</summary>
             <value>List of column sensitivities.</value>
-            <remarks>To be added.</remarks>
         </ColumnSensitivities>
         <InformationTypes>
             <summary>Returns the information types collection for this 'SensitivityClassification' Object</summary>
             <value>List of information types.</value>
-            <remarks>To be added.</remarks>
         </InformationTypes>
         <Labels>
             <summary>Returns the labels collection for this 'SensitivityClassification' Object</summary>
             <value>List of labels.</value>
-            <remarks>To be added.</remarks>
         </Labels>
+        <SensitivityRank>
+          <summary>Returns the relative sensitivity rank for the query associated with the active 'SqlDataReader'.</summary>
+          <value>Relative sensitivity ranking for this query.</value>
+          <remarks>
+            <format type="text/markdown">
+              <![CDATA[
+
+## Remarks
+A relative ranking of the sensitivity of a query or of a column that is part of percolumn data. Available values are as below:
+
+| Sensitivity Rank | Description |
+| --- | --- |
+| -1 | Not Defined (default) |
+| 0 | None |
+| 10 | Low |
+| 20 | Medium |
+| 30 | High |
+| 40 | Critical |
+]]>
+            </format>
+          </remarks>
+        </SensitivityRank>
         <ctor>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityClassification" />
- class.</summary>
+            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityClassification" /> class.</summary>
+            <param name="labels">List of labels.</param>
+            <param name="informationTypes">List of information types.</param>
+            <param name="columnSensitivity">List of column sensitivities.</param>
+            <param name="sensitivityRank">Relative sensitivity rank for the query associated with the active 'SqlDataReader'.</param>
         </ctor>
     </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml
@@ -24,7 +24,7 @@
               <![CDATA[
 
 ## Remarks
-A relative ranking of the sensitivity of a query or of a column that is part of percolumn data. Available values are as below:
+A relative sensitivity ranking of the query. Available values are as below:
 
 | Sensitivity Rank | Description |
 | --- | --- |

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml
@@ -26,7 +26,7 @@
               <![CDATA[
 
 ## Remarks
-A relative ranking of the sensitivity of a query or of a column that is part of percolumn data. Available values are as below:
+A relative sensitivity ranking of a column that is part of percolumn data. Available values are as below:
 
 | Sensitivity Rank | Description |
 | --- | --- |

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml
@@ -3,20 +3,42 @@
     <members name="SensitivityProperty">
         <SensitivityProperty>
             <summary>Represents the Data Classification Sensitivity Information for columns as configured in Database.</summary>
-            <remarks>To be added.</remarks>
         </SensitivityProperty>
         <ctor>
             <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" /> class.</summary>
+          <param name="label">Label for this SensitivityProperty.</param>
+          <param name="informationType">Information type for this SensitivityProperty.</param>
+          <param name="sensitivityRank">Sensitivity rank for this SensitivityProperty.</param>
         </ctor>
         <InformationType>
             <summary>Returns the information type for this 'SensitivityProperty' Object</summary>
             <value>Information type for this SensitivityProperty.</value>
-            <remarks>To be added.</remarks>
         </InformationType>
         <Label>
             <summary>Returns the label for this 'SensitivityProperty' Object</summary>
             <value>Label for this SensitivityProperty.</value>
-            <remarks>To be added.</remarks>
         </Label>
+        <SensitivityRank>
+          <summary>Returns the sensitivity rank for this 'SensitivityProperty' Object</summary>
+          <value>Sensitivity rank for this SensitivityProperty.</value>
+          <remarks>
+            <format type="text/markdown">
+              <![CDATA[
+
+## Remarks
+A relative ranking of the sensitivity of a query or of a column that is part of percolumn data. Available values are as below:
+
+| Sensitivity Rank | Description |
+| --- | --- |
+| -1 | Not Defined (default) |
+| 0 | None |
+| 10 | Low |
+| 20 | Medium |
+| 30 | High |
+| 40 | Critical |
+]]>
+            </format>
+          </remarks>
+        </SensitivityRank>
     </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0"?>
+<docs>
+  <members name="SensitivityRank">
+    <SensitivityRank>
+      <summary>
+        A relative ranking of the sensitivity of a query or of a column that is part of percolumn data.
+        It is an identifier based on a predefined set of values which define sensitivity rank. Used by other services like Advanced Threat Protection to detect anomalies based on their rank.
+      </summary>
+    </SensitivityRank>
+    <NotDefined>No sensitivity rank defined.</NotDefined>
+    <None>Corresponds to rank value of 0.</None>
+    <Low>Corresponds to rank value of 10.</Low>
+    <Medium>Corresponds to rank value 20.</Medium>
+    <High>Corresponds to rank value 30.</High>
+    <Critical>Corresponds to rank value 40.</Critical>
+  </members>
+</docs>

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -1895,26 +1895,46 @@ namespace Microsoft.Data.SqlClient.DataClassification
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml' path='docs/members[@name="Label"]/Name/*' />
         public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
+    /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/SensitivityRank/*' />
+    public enum SensitivityRank
+    {
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/NotDefined/*' />
+        NOT_DEFINED = -1,
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/None/*' />
+        NONE = 0,
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/Low/*' />
+        LOW = 10,
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/Medium/*' />
+        MEDIUM = 20,
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/High/*' />
+        HIGH = 30,
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/Critical/*' />
+        CRITICAL = 40
+    }
     /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/SensitivityClassification/*' />
     public partial class SensitivityClassification
     {
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/ctor/*' />
-        public SensitivityClassification(System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.Label> labels, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.InformationType> informationTypes, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> columnSensitivity) { }
+        public SensitivityClassification(System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.Label> labels, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.InformationType> informationTypes, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> columnSensitivity, SensitivityRank sensitivityRank) { }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/ColumnSensitivities/*' />
         public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> ColumnSensitivities { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/InformationTypes/*' />
         public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.InformationType> InformationTypes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/Labels/*' />
         public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.Label> Labels { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/SensitivityRank/*' />
+        public SensitivityRank SensitivityRank { get { throw null; } }
     }
     /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/SensitivityProperty/*' />
     public partial class SensitivityProperty
     {
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/ctor/*' />
-        public SensitivityProperty(Microsoft.Data.SqlClient.DataClassification.Label label, Microsoft.Data.SqlClient.DataClassification.InformationType informationType) { }
+        public SensitivityProperty(Microsoft.Data.SqlClient.DataClassification.Label label, Microsoft.Data.SqlClient.DataClassification.InformationType informationType, SensitivityRank sensitivityRank) { }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/InformationType/*' />
         public Microsoft.Data.SqlClient.DataClassification.InformationType InformationType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/Label/*' />
         public Microsoft.Data.SqlClient.DataClassification.Label Label { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/SensitivityRank/*' />
+        public SensitivityRank SensitivityRank { get { throw null; } }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -129,8 +129,9 @@ namespace Microsoft.Data.SqlClient
         private readonly SqlAuthenticationProviderManager _sqlAuthenticationProviderManager;
 
         internal bool _cleanSQLDNSCaching = false;
-
         private bool _serverSupportsDNSCaching = false;
+
+        internal byte _supportedDataClassificationVersion = TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED;
 
         /// <summary>
         /// Get or set if SQLDNSCaching is supported by the server.
@@ -2609,11 +2610,11 @@ namespace Microsoft.Data.SqlClient
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown token for DATACLASSIFICATION", ObjectID);
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
-                        byte supportedDataClassificationVersion = data[0];
-                        if ((0 == supportedDataClassificationVersion) || (supportedDataClassificationVersion > TdsEnums.MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION))
+                        _supportedDataClassificationVersion = data[0];
+                        if ((0 == _supportedDataClassificationVersion) || (_supportedDataClassificationVersion > TdsEnums.MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION))
                         {
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for DATACLASSIFICATION", ObjectID);
-                            throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, supportedDataClassificationVersion);
+                            throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, _supportedDataClassificationVersion);
                         }
 
                         if (data.Length != 2)
@@ -2622,7 +2623,7 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         byte enabled = data[1];
-                        _parser.DataClassificationVersion = (enabled == 0) ? TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED : supportedDataClassificationVersion;
+                        _parser.DataClassificationVersion = (enabled == 0) ? TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED : _supportedDataClassificationVersion;
                         break;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -131,8 +131,6 @@ namespace Microsoft.Data.SqlClient
         internal bool _cleanSQLDNSCaching = false;
         private bool _serverSupportsDNSCaching = false;
 
-        internal byte _supportedDataClassificationVersion = TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED;
-
         /// <summary>
         /// Get or set if SQLDNSCaching is supported by the server.
         /// </summary>
@@ -2610,11 +2608,11 @@ namespace Microsoft.Data.SqlClient
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown token for DATACLASSIFICATION", ObjectID);
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
-                        _supportedDataClassificationVersion = data[0];
-                        if ((0 == _supportedDataClassificationVersion) || (_supportedDataClassificationVersion > TdsEnums.MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION))
+                        byte supportedDataClassificationVersion = data[0];
+                        if ((0 == supportedDataClassificationVersion) || (supportedDataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_MAX_SUPPORTED))
                         {
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for DATACLASSIFICATION", ObjectID);
-                            throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, _supportedDataClassificationVersion);
+                            throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, supportedDataClassificationVersion);
                         }
 
                         if (data.Length != 2)
@@ -2623,7 +2621,7 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         byte enabled = data[1];
-                        _parser.DataClassificationVersion = (enabled == 0) ? TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED : _supportedDataClassificationVersion;
+                        _parser.DataClassificationVersion = (enabled == 0) ? TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED : supportedDataClassificationVersion;
                         break;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -933,7 +933,8 @@ namespace Microsoft.Data.SqlClient
 
         // Data Classification constants
         internal const byte DATA_CLASSIFICATION_NOT_ENABLED = 0x00;
-        internal const byte MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION = 0x01;
+        internal const byte DATA_CLASSIFICATION_VERSION_WITHOUT_RANK_SUPPORT = 0x01;
+        internal const byte MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION = 0x02;
 
         // Needed for UapAot, since we cannot use Enum.GetName() on SniContext.
         // Enum.GetName() uses reflection, which is blocked on UapAot for internal types

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -934,7 +934,7 @@ namespace Microsoft.Data.SqlClient
         // Data Classification constants
         internal const byte DATA_CLASSIFICATION_NOT_ENABLED = 0x00;
         internal const byte DATA_CLASSIFICATION_VERSION_WITHOUT_RANK_SUPPORT = 0x01;
-        internal const byte MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION = 0x02;
+        internal const byte DATA_CLASSIFICATION_VERSION_MAX_SUPPORTED = 0x02;
 
         // Needed for UapAot, since we cannot use Enum.GetName() on SniContext.
         // Enum.GetName() uses reflection, which is blocked on UapAot for internal types

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3364,7 +3364,6 @@ namespace Microsoft.Data.SqlClient
                 {
                     return false;
                 }
-                Console.WriteLine(sensitivityRank);
                 if (!Enum.IsDefined(typeof(SensitivityRank), sensitivityRank))
                 {
                     return false;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3416,7 +3416,7 @@ namespace Microsoft.Data.SqlClient
                         }
                     }
 
-                    // add sentivity properties for the source
+                    // add sensitivity properties for the source
                     sensitivityProperties.Add(new SensitivityProperty(label, informationType, (SensitivityRank)sensitivityRankProperty));
                 }
                 columnSensitivities.Add(new ColumnSensitivity(sensitivityProperties));

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3313,7 +3313,7 @@ namespace Microsoft.Data.SqlClient
 
         private bool TryProcessDataClassification(TdsParserStateObject stateObj, out SensitivityClassification sensitivityClassification)
         {
-            if (this.DataClassificationVersion == 0)
+            if (DataClassificationVersion == 0)
             {
                 throw SQL.ParsingError(ParsingErrorState.DataClassificationNotExpected);
             }
@@ -3321,17 +3321,14 @@ namespace Microsoft.Data.SqlClient
             sensitivityClassification = null;
 
             // get the labels
-            UInt16 numLabels;
-            if (!stateObj.TryReadUInt16(out numLabels))
+            if (!stateObj.TryReadUInt16(out ushort numLabels))
             {
                 return false;
             }
             var labels = new List<Label>(numLabels);
-            for (UInt16 i = 0; i < numLabels; i++)
+            for (ushort i = 0; i < numLabels; i++)
             {
-                string label;
-                string id;
-                if (!TryReadSensitivityLabel(stateObj, out label, out id))
+                if (!TryReadSensitivityLabel(stateObj, out string label, out string id))
                 {
                     return false;
                 }
@@ -3339,17 +3336,14 @@ namespace Microsoft.Data.SqlClient
             }
 
             // get the information types
-            UInt16 numInformationTypes;
-            if (!stateObj.TryReadUInt16(out numInformationTypes))
+            if (!stateObj.TryReadUInt16(out ushort numInformationTypes))
             {
                 return false;
             }
             var informationTypes = new List<InformationType>(numInformationTypes);
-            for (UInt16 i = 0; i < numInformationTypes; i++)
+            for (ushort i = 0; i < numInformationTypes; i++)
             {
-                string informationType;
-                string id;
-                if (!TryReadSensitivityInformationType(stateObj, out informationType, out id))
+                if (!TryReadSensitivityInformationType(stateObj, out string informationType, out string id))
                 {
                     return false;
                 }
@@ -3357,45 +3351,38 @@ namespace Microsoft.Data.SqlClient
             }
 
             // get sensitivity rank
-            Int32 sensitivityRank = (int)SensitivityRank.NOT_DEFINED;
-            if (_connHandler._supportedDataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_WITHOUT_RANK_SUPPORT)
+            int sensitivityRank = (int)SensitivityRank.NOT_DEFINED;
+            if (DataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_WITHOUT_RANK_SUPPORT)
             {
-                if (!stateObj.TryReadInt32(out sensitivityRank))
-                {
-                    return false;
-                }
-                if (!Enum.IsDefined(typeof(SensitivityRank), sensitivityRank))
+                if (!stateObj.TryReadInt32(out sensitivityRank) || !Enum.IsDefined(typeof(SensitivityRank), sensitivityRank))
                 {
                     return false;
                 }
             }
 
             // get the per column classification data (corresponds to order of output columns for query)
-            UInt16 numResultColumns;
-            if (!stateObj.TryReadUInt16(out numResultColumns))
+            if (!stateObj.TryReadUInt16(out ushort numResultColumns))
             {
                 return false;
             }
             var columnSensitivities = new List<ColumnSensitivity>(numResultColumns);
-            for (UInt16 columnNum = 0; columnNum < numResultColumns; columnNum++)
+            for (ushort columnNum = 0; columnNum < numResultColumns; columnNum++)
             {
                 // get sensitivity properties for all the different sources which were used in generating the column output
-                UInt16 numSources;
-                if (!stateObj.TryReadUInt16(out numSources))
+                if (!stateObj.TryReadUInt16(out ushort numSources))
                 {
                     return false;
                 }
                 var sensitivityProperties = new List<SensitivityProperty>(numSources);
-                for (UInt16 sourceNum = 0; sourceNum < numSources; sourceNum++)
+                for (ushort sourceNum = 0; sourceNum < numSources; sourceNum++)
                 {
                     // get the label index and then lookup label to use for source
-                    UInt16 labelIndex;
-                    if (!stateObj.TryReadUInt16(out labelIndex))
+                    if (!stateObj.TryReadUInt16(out ushort labelIndex))
                     {
                         return false;
                     }
                     Label label = null;
-                    if (labelIndex != UInt16.MaxValue)
+                    if (labelIndex != ushort.MaxValue)
                     {
                         if (labelIndex >= labels.Count)
                         {
@@ -3405,13 +3392,12 @@ namespace Microsoft.Data.SqlClient
                     }
 
                     // get the information type index and then lookup information type to use for source
-                    UInt16 informationTypeIndex;
-                    if (!stateObj.TryReadUInt16(out informationTypeIndex))
+                    if (!stateObj.TryReadUInt16(out ushort informationTypeIndex))
                     {
                         return false;
                     }
                     InformationType informationType = null;
-                    if (informationTypeIndex != UInt16.MaxValue)
+                    if (informationTypeIndex != ushort.MaxValue)
                     {
                         if (informationTypeIndex >= informationTypes.Count)
                         {
@@ -3421,14 +3407,10 @@ namespace Microsoft.Data.SqlClient
                     }
 
                     // get sensitivity rank
-                    Int32 sensitivityRankProperty = (int)SensitivityRank.NOT_DEFINED;
-                    if (_connHandler._supportedDataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_WITHOUT_RANK_SUPPORT)
+                    int sensitivityRankProperty = (int)SensitivityRank.NOT_DEFINED;
+                    if (DataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_WITHOUT_RANK_SUPPORT)
                     {
-                        if (!stateObj.TryReadInt32(out sensitivityRankProperty))
-                        {
-                            return false;
-                        }
-                        if (!Enum.IsDefined(typeof(SensitivityRank), sensitivityRankProperty))
+                        if (!stateObj.TryReadInt32(out sensitivityRankProperty) || !Enum.IsDefined(typeof(SensitivityRank), sensitivityRankProperty))
                         {
                             return false;
                         }
@@ -7856,7 +7838,7 @@ namespace Microsoft.Data.SqlClient
                 // Write Feature ID, length of the version# field and Sensitivity Classification Version#
                 _physicalStateObj.WriteByte(TdsEnums.FEATUREEXT_DATACLASSIFICATION);
                 WriteInt(1, _physicalStateObj);
-                _physicalStateObj.WriteByte(TdsEnums.MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION);
+                _physicalStateObj.WriteByte(TdsEnums.DATA_CLASSIFICATION_VERSION_MAX_SUPPORTED);
             }
 
             return len; // size of data written

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -2194,7 +2194,7 @@ namespace Microsoft.Data.SqlClient.DataClassification
     public partial class SensitivityClassification
     {
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/ctor/*' />
-        public SensitivityClassification(System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.Label> labels, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.InformationType> informationTypes, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> columnSensitivity, int sensitivityRank) { }
+        public SensitivityClassification(System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.Label> labels, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.InformationType> informationTypes, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> columnSensitivity, SensitivityRank sensitivityRank) { }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/ColumnSensitivities/*' />
         public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> ColumnSensitivities { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/InformationTypes/*' />
@@ -2202,19 +2202,19 @@ namespace Microsoft.Data.SqlClient.DataClassification
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/Labels/*' />
         public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.Label> Labels { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/SensitivityRank/*' />
-        public int SensitivityRank { get { throw null; } }
+        public SensitivityRank SensitivityRank { get { throw null; } }
     }
     /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/SensitivityProperty/*' />
     public partial class SensitivityProperty
     {
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/ctor/*' />
-        public SensitivityProperty(Microsoft.Data.SqlClient.DataClassification.Label label, Microsoft.Data.SqlClient.DataClassification.InformationType informationType, int sensitivityRank) { }
+        public SensitivityProperty(Microsoft.Data.SqlClient.DataClassification.Label label, Microsoft.Data.SqlClient.DataClassification.InformationType informationType, SensitivityRank sensitivityRank) { }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/InformationType/*' />
         public Microsoft.Data.SqlClient.DataClassification.InformationType InformationType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/Label/*' />
         public Microsoft.Data.SqlClient.DataClassification.Label Label { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/SensitivityRank/*' />
-        public int SensitivityRank { get { throw null; } }
+        public SensitivityRank SensitivityRank { get { throw null; } }
     }
 }
 namespace Microsoft.Data.SqlTypes

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -5,7 +5,7 @@
 [assembly: System.Resources.NeutralResourcesLanguageAttribute("en-US")]
 namespace Microsoft.Data
 {
-    /// <include file='..\..\..\..\doc\snippets\Microsoft.Data\OperationAbortedException.xml' path='docs/members[@name="OperationAbortedException"]/OperationAbortedException/*' />
+    /// <include file='../../../../doc/snippets/Microsoft.Data/OperationAbortedException.xml' path='docs/members[@name="OperationAbortedException"]/OperationAbortedException/*' />
     [System.Serializable]
     public sealed partial class OperationAbortedException : System.SystemException
     {
@@ -17,18 +17,18 @@ namespace Microsoft.Data
 }
 namespace Microsoft.Data.Sql
 {
-    /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.Sql\SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/SqlNotificationRequest/*' />
+    /// <include file='../../../../doc/snippets/Microsoft.Data.Sql/SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/SqlNotificationRequest/*' />
     public sealed partial class SqlNotificationRequest
     {
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.Sql\SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/ctor1/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.Sql/SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/ctor1/*' />
         public SqlNotificationRequest() { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.Sql\SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/ctor2/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.Sql/SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/ctor2/*' />
         public SqlNotificationRequest(string userData, string options, int timeout) { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.Sql\SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/Options/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.Sql/SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/Options/*' />
         public string Options { get { throw null; } set { } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.Sql\SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/Timeout/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.Sql/SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/Timeout/*' />
         public int Timeout { get { throw null; } set { } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.Sql\SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/UserData/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.Sql/SqlNotificationRequest.xml' path='docs/members[@name="SqlNotificationRequest"]/UserData/*' />
         public string UserData { get { throw null; } set { } }
     }
 }
@@ -826,21 +826,21 @@ namespace Microsoft.Data.SqlClient
         Enabled = 1,
     }
 
-    /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/SqlConnectionAttestationProtocol/*' />
+    /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/SqlConnectionAttestationProtocol/*' />
     public enum SqlConnectionAttestationProtocol
     {
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/NotSpecified/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/NotSpecified/*' />
         NotSpecified = 0,
 
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/AAS/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/AAS/*' />
         AAS = 1,
 
 #if ENCLAVE_SIMULATOR
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/SIM/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/SIM/*' />
         SIM = 2,
 #endif
 
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/HGS/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionAttestationProtocol.xml' path='docs/members[@name="SqlConnectionAttestationProtocol"]/HGS/*' />
         HGS = 3
     }
 
@@ -923,7 +923,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/AttestationProtocol/*'/>
         [System.ComponentModel.DisplayNameAttribute("Attestation Protocol")]
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
-        public Microsoft.Data.SqlClient.SqlConnectionAttestationProtocol AttestationProtocol {get { throw null; } set { } }
+        public Microsoft.Data.SqlClient.SqlConnectionAttestationProtocol AttestationProtocol { get { throw null; } set { } }
 
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/Encrypt/*'/>
         [System.ComponentModel.DisplayNameAttribute("Encrypt")]
@@ -1921,332 +1921,352 @@ namespace Microsoft.Data.SqlClient.Server
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetValues/*'/>
         public virtual int SetValues(params object[] values) { throw null; }
     }
-    /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/SqlFunctionAttribute/*' />
+    /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/SqlFunctionAttribute/*' />
     [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = false, Inherited = false), System.SerializableAttribute]
     public partial class SqlFunctionAttribute : System.Attribute
     {
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/ctor/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/ctor/*' />
         public SqlFunctionAttribute() { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/IsDeterministic/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/IsDeterministic/*' />
         public bool IsDeterministic { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/DataAccess/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/DataAccess/*' />
         public DataAccessKind DataAccess { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/SystemDataAccess/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/SystemDataAccess/*' />
         public SystemDataAccessKind SystemDataAccess { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/IsPrecise/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/IsPrecise/*' />
         public bool IsPrecise { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/Name/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/Name/*' />
         public string Name { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/TableDefinition/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/TableDefinition/*' />
         public string TableDefinition { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/FillRowMethodName/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFunctionAttribute.xml' path='docs/members[@name="SqlFunctionAttribute"]/FillRowMethodName/*' />
         public string FillRowMethodName { get { throw null; } set { } }
     }
-    /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/SqlMetaData/*' />
+    /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/SqlMetaData/*' />
     public sealed partial class SqlMetaData
     {
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbType/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbType/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypePrecisionScale/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypePrecisionScale/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, byte precision, byte scale) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypePrecisionScaleUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypePrecisionScaleUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, byte precision, byte scale, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLength/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLength/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLengthUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLengthUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedType/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedType/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, byte precision, byte scale, long locale, System.Data.SqlTypes.SqlCompareOptions compareOptions, System.Type userDefinedType) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, byte precision, byte scale, long localeId, System.Data.SqlTypes.SqlCompareOptions compareOptions, System.Type userDefinedType, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLengthLocaleCompareOptions/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLengthLocaleCompareOptions/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, long locale, System.Data.SqlTypes.SqlCompareOptions compareOptions) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLengthLocaleCompareOptionsUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeMaxLengthLocaleCompareOptionsUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, long maxLength, long locale, System.Data.SqlTypes.SqlCompareOptions compareOptions, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeDatabaseOwningSchemaObjectName/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeDatabaseOwningSchemaObjectName/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, string database, string owningSchema, string objectName) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeDatabaseOwningSchemaObjectNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeDatabaseOwningSchemaObjectNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, string database, string owningSchema, string objectName, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeUserDefinedType/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeUserDefinedType/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, System.Type userDefinedType) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeUserDefinedTypeServerTypeName/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeUserDefinedTypeServerTypeName/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, System.Type userDefinedType, string serverTypeName) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeUserDefinedTypeServerTypeNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/ctorNameDbTypeUserDefinedTypeServerTypeNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal/*' />
         public SqlMetaData(string name, System.Data.SqlDbType dbType, System.Type userDefinedType, string serverTypeName, bool useServerDefault, bool isUniqueKey, Microsoft.Data.SqlClient.SortOrder columnSortOrder, int sortOrdinal) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/CompareOptions/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/CompareOptions/*' />
         public System.Data.SqlTypes.SqlCompareOptions CompareOptions { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/DbType/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/DbType/*' />
         public System.Data.DbType DbType { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/IsUniqueKey/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/IsUniqueKey/*' />
         public bool IsUniqueKey { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/LocaleId/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/LocaleId/*' />
         public long LocaleId { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/Max/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/Max/*' />
         public static long Max { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/MaxLength/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/MaxLength/*' />
         public long MaxLength { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/Name/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/Name/*' />
         public string Name { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/Precision/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/Precision/*' />
         public byte Precision { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/Scale/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/Scale/*' />
         public byte Scale { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/SortOrder/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/SortOrder/*' />
         public Microsoft.Data.SqlClient.SortOrder SortOrder { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/SortOrdinal/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/SortOrdinal/*' />
         public int SortOrdinal { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/SqlDbType/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/SqlDbType/*' />
         public System.Data.SqlDbType SqlDbType { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/Type/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/Type/*' />
         public System.Type Type { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/TypeName/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/TypeName/*' />
         public string TypeName { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/UseServerDefault/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/UseServerDefault/*' />
         public bool UseServerDefault { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/XmlSchemaCollectionDatabase/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/XmlSchemaCollectionDatabase/*' />
         public string XmlSchemaCollectionDatabase { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/XmlSchemaCollectionName/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/XmlSchemaCollectionName/*' />
         public string XmlSchemaCollectionName { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/XmlSchemaCollectionOwningSchema/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/XmlSchemaCollectionOwningSchema/*' />
         public string XmlSchemaCollectionOwningSchema { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue1/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue1/*' />
         public bool Adjust(bool value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue2/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue2/*' />
         public byte Adjust(byte value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue3/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue3/*' />
         public byte[] Adjust(byte[] value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue4/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue4/*' />
         public char Adjust(char value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue5/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue5/*' />
         public char[] Adjust(char[] value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue6/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue6/*' />
         public System.Data.SqlTypes.SqlBinary Adjust(System.Data.SqlTypes.SqlBinary value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue7/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue7/*' />
         public System.Data.SqlTypes.SqlBoolean Adjust(System.Data.SqlTypes.SqlBoolean value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue8/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue8/*' />
         public System.Data.SqlTypes.SqlByte Adjust(System.Data.SqlTypes.SqlByte value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue9/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue9/*' />
         public System.Data.SqlTypes.SqlBytes Adjust(System.Data.SqlTypes.SqlBytes value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue10/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue10/*' />
         public System.Data.SqlTypes.SqlChars Adjust(System.Data.SqlTypes.SqlChars value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue11/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue11/*' />
         public System.Data.SqlTypes.SqlDateTime Adjust(System.Data.SqlTypes.SqlDateTime value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue12/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue12/*' />
         public System.Data.SqlTypes.SqlDecimal Adjust(System.Data.SqlTypes.SqlDecimal value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue13/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue13/*' />
         public System.Data.SqlTypes.SqlDouble Adjust(System.Data.SqlTypes.SqlDouble value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue14/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue14/*' />
         public System.Data.SqlTypes.SqlGuid Adjust(System.Data.SqlTypes.SqlGuid value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue15/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue15/*' />
         public System.Data.SqlTypes.SqlInt16 Adjust(System.Data.SqlTypes.SqlInt16 value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue16/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue16/*' />
         public System.Data.SqlTypes.SqlInt32 Adjust(System.Data.SqlTypes.SqlInt32 value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue17/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue17/*' />
         public System.Data.SqlTypes.SqlInt64 Adjust(System.Data.SqlTypes.SqlInt64 value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue18/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue18/*' />
         public System.Data.SqlTypes.SqlMoney Adjust(System.Data.SqlTypes.SqlMoney value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue19/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue19/*' />
         public System.Data.SqlTypes.SqlSingle Adjust(System.Data.SqlTypes.SqlSingle value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue20/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue20/*' />
         public System.Data.SqlTypes.SqlString Adjust(System.Data.SqlTypes.SqlString value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue21/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue21/*' />
         public System.Data.SqlTypes.SqlXml Adjust(System.Data.SqlTypes.SqlXml value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue22/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue22/*' />
         public System.DateTime Adjust(System.DateTime value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue23/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue23/*' />
         public System.DateTimeOffset Adjust(System.DateTimeOffset value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue24/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue24/*' />
         public decimal Adjust(decimal value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue25/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue25/*' />
         public double Adjust(double value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue26/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue26/*' />
         public System.Guid Adjust(System.Guid value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue27/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue27/*' />
         public short Adjust(short value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue28/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue28/*' />
         public int Adjust(int value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue29/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue29/*' />
         public long Adjust(long value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue30/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue30/*' />
         public object Adjust(object value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue31/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue31/*' />
         public float Adjust(float value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue32/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue32/*' />
         public string Adjust(string value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue33/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/AdjustValue33/*' />
         public System.TimeSpan Adjust(System.TimeSpan value) { throw null; }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/InferFromValue/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml' path='docs/members[@name="SqlMetaData"]/InferFromValue/*' />
         public static Microsoft.Data.SqlClient.Server.SqlMetaData InferFromValue(object value, string name) { throw null; }
     }
-    /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMethodAttribute.xml' path='docs/members[@name="SqlMethodAttribute"]/SqlMethodAttribute/*' />
+    /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMethodAttribute.xml' path='docs/members[@name="SqlMethodAttribute"]/SqlMethodAttribute/*' />
     [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = false, Inherited = false), System.SerializableAttribute]
     public sealed partial class SqlMethodAttribute : SqlFunctionAttribute
     {
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMethodAttribute.xml' path='docs/members[@name="SqlMethodAttribute"]/ctor/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMethodAttribute.xml' path='docs/members[@name="SqlMethodAttribute"]/ctor/*' />
         public SqlMethodAttribute() { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMethodAttribute.xml' path='docs/members[@name="SqlMethodAttribute"]/OnNullCall/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMethodAttribute.xml' path='docs/members[@name="SqlMethodAttribute"]/OnNullCall/*' />
         public bool OnNullCall { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMethodAttribute.xml' path='docs/members[@name="SqlMethodAttribute"]/IsMutator/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMethodAttribute.xml' path='docs/members[@name="SqlMethodAttribute"]/IsMutator/*' />
         public bool IsMutator { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlMethodAttribute.xml' path='docs/members[@name="SqlMethodAttribute"]/InvokeIfReceiverIsNull/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlMethodAttribute.xml' path='docs/members[@name="SqlMethodAttribute"]/InvokeIfReceiverIsNull/*' />
         public bool InvokeIfReceiverIsNull { get { throw null; } set { } }
     }
-    /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/SqlUserDefinedAggregateAttribute/*' />
+    /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/SqlUserDefinedAggregateAttribute/*' />
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
     public sealed partial class SqlUserDefinedAggregateAttribute : System.Attribute
     {
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/MaxByteSizeValue/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/MaxByteSizeValue/*' />
         public const int MaxByteSizeValue = 8000;
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/ctor/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/ctor/*' />
         public SqlUserDefinedAggregateAttribute(Format format) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/MaxByteSize/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/MaxByteSize/*' />
         public int MaxByteSize { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/IsInvariantToDuplicates/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/IsInvariantToDuplicates/*' />
         public bool IsInvariantToDuplicates { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/IsInvariantToNulls/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/IsInvariantToNulls/*' />
         public bool IsInvariantToNulls { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/IsInvariantToOrder/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/IsInvariantToOrder/*' />
         public bool IsInvariantToOrder { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/IsNullIfEmpty/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/IsNullIfEmpty/*' />
         public bool IsNullIfEmpty { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/Format/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/Format/*' />
         public Format Format { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/Name/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedAggregateAttribute.xml' path='docs/members[@name="SqlUserDefinedAggregateAttribute"]/Name/*' />
         public string Name { get { throw null; } set { } }
     }
-    /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/SqlUserDefinedTypeAttribute/*' />
+    /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/SqlUserDefinedTypeAttribute/*' />
     [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, AllowMultiple = false, Inherited = true)]
     public sealed partial class SqlUserDefinedTypeAttribute : System.Attribute
     {
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/ctor/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/ctor/*' />
         public SqlUserDefinedTypeAttribute(Format format) { }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/MaxByteSize/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/MaxByteSize/*' />
         public int MaxByteSize { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/IsFixedLength/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/IsFixedLength/*' />
         public bool IsFixedLength { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/IsByteOrdered/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/IsByteOrdered/*' />
         public bool IsByteOrdered { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/Format/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/Format/*' />
         public Format Format { get { throw null; } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/ValidationMethodName/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/ValidationMethodName/*' />
         public string ValidationMethodName { get { throw null; } set { } }
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/Name/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/Name/*' />
         public string Name { get { throw null; } set { } }
     }
-    /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SystemDataAccessKind.xml' path='docs/members[@name="SystemDataAccessKind"]/SystemDataAccessKind/*' />
+    /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SystemDataAccessKind.xml' path='docs/members[@name="SystemDataAccessKind"]/SystemDataAccessKind/*' />
     public enum SystemDataAccessKind
     {
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SystemDataAccessKind.xml' path='docs/members[@name="SystemDataAccessKind"]/None/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SystemDataAccessKind.xml' path='docs/members[@name="SystemDataAccessKind"]/None/*' />
         None = 0,
-        /// <include file='.\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SystemDataAccessKind.xml' path='docs/members[@name="SystemDataAccessKind"]/Read/*' />
+        /// <include file='./../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SystemDataAccessKind.xml' path='docs/members[@name="SystemDataAccessKind"]/Read/*' />
         Read = 1
     }
 }
 namespace Microsoft.Data.SqlClient.DataClassification
 {
-    /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\ColumnSensitivity.xml' path='docs/members[@name="ColumnSensitivity"]/ColumnSensitivity/*' />
+    /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/ColumnSensitivity.xml' path='docs/members[@name="ColumnSensitivity"]/ColumnSensitivity/*' />
     public partial class ColumnSensitivity
     {
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\ColumnSensitivity.xml' path='docs/members[@name="ColumnSensitivity"]/ctor/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/ColumnSensitivity.xml' path='docs/members[@name="ColumnSensitivity"]/ctor/*' />
         public ColumnSensitivity(System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.SensitivityProperty> sensitivityProperties) { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\ColumnSensitivity.xml' path='docs/members[@name="ColumnSensitivity"]/GetSensitivityProperties/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/ColumnSensitivity.xml' path='docs/members[@name="ColumnSensitivity"]/GetSensitivityProperties/*' />
         public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.SensitivityProperty> SensitivityProperties { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
-    /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\InformationType.xml' path='docs/members[@name="InformationType"]/InformationType/*' />
+    /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/InformationType.xml' path='docs/members[@name="InformationType"]/InformationType/*' />
     public partial class InformationType
     {
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\InformationType.xml' path='docs/members[@name="InformationType"]/ctor/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/InformationType.xml' path='docs/members[@name="InformationType"]/ctor/*' />
         public InformationType(string name, string id) { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\InformationType.xml' path='docs/members[@name="InformationType"]/Id/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/InformationType.xml' path='docs/members[@name="InformationType"]/Id/*' />
         public string Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\InformationType.xml' path='docs/members[@name="InformationType"]/Name/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/InformationType.xml' path='docs/members[@name="InformationType"]/Name/*' />
         public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
-    /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\Label.xml' path='docs/members[@name="Label"]/Label/*' />
+    /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml' path='docs/members[@name="Label"]/Label/*' />
     public partial class Label
     {
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\Label.xml' path='docs/members[@name="Label"]/ctor/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml' path='docs/members[@name="Label"]/ctor/*' />
         public Label(string name, string id) { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\Label.xml' path='docs/members[@name="Label"]/Id/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml' path='docs/members[@name="Label"]/Id/*' />
         public string Id { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\Label.xml' path='docs/members[@name="Label"]/Name/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml' path='docs/members[@name="Label"]/Name/*' />
         public string Name { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
     }
-    /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/SensitivityClassification/*' />
+    /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/SensitivityRank/*' />
+    public enum SensitivityRank
+    {
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/NotDefined/*' />
+        NOT_DEFINED = -1,
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/None/*' />
+        NONE = 0,
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/Low/*' />
+        LOW = 10,
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/Medium/*' />
+        MEDIUM = 20,
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/High/*' />
+        HIGH = 30,
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/Critical/*' />
+        CRITICAL = 40
+    }
+    /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/SensitivityClassification/*' />
     public partial class SensitivityClassification
     {
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/ctor/*' />
-        public SensitivityClassification(System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.Label> labels, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.InformationType> informationTypes, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> columnSensitivity) { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/ColumnSensitivities/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/ctor/*' />
+        public SensitivityClassification(System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.Label> labels, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.InformationType> informationTypes, System.Collections.Generic.IList<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> columnSensitivity, int sensitivityRank) { }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/ColumnSensitivities/*' />
         public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity> ColumnSensitivities { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/InformationTypes/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/InformationTypes/*' />
         public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.InformationType> InformationTypes { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/Labels/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/Labels/*' />
         public System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.Data.SqlClient.DataClassification.Label> Labels { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/SensitivityRank/*' />
+        public int SensitivityRank { get { throw null; } }
     }
-    /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/SensitivityProperty/*' />
+    /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/SensitivityProperty/*' />
     public partial class SensitivityProperty
     {
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/ctor/*' />
-        public SensitivityProperty(Microsoft.Data.SqlClient.DataClassification.Label label, Microsoft.Data.SqlClient.DataClassification.InformationType informationType) { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/InformationType/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/ctor/*' />
+        public SensitivityProperty(Microsoft.Data.SqlClient.DataClassification.Label label, Microsoft.Data.SqlClient.DataClassification.InformationType informationType, int sensitivityRank) { }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/InformationType/*' />
         public Microsoft.Data.SqlClient.DataClassification.InformationType InformationType { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.DataClassification\SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/Label/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/Label/*' />
         public Microsoft.Data.SqlClient.DataClassification.Label Label { [System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/SensitivityRank/*' />
+        public int SensitivityRank { get { throw null; } }
     }
 }
 namespace Microsoft.Data.SqlTypes
 {
-    /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/SqlFileStream/*' />
+    /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/SqlFileStream/*' />
     public sealed partial class SqlFileStream : System.IO.Stream
     {
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/ctor1/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/ctor1/*' />
         public SqlFileStream(string path, byte[] transactionContext, System.IO.FileAccess access) { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/ctor2/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/ctor2/*' />
         public SqlFileStream(string path, byte[] transactionContext, System.IO.FileAccess access, System.IO.FileOptions options, System.Int64 allocationSize) { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Name/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Name/*' />
         public string Name { get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/TransactionContext/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/TransactionContext/*' />
         public byte[] TransactionContext { get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/CanRead/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/CanRead/*' />
         public override bool CanRead { get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/CanSeek/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/CanSeek/*' />
         public override bool CanSeek { get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/CanTimeout/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/CanTimeout/*' />
         public override bool CanTimeout { get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/CanWrite/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/CanWrite/*' />
         public override bool CanWrite { get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Length/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Length/*' />
         public override long Length { get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Position/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Position/*' />
         public override long Position { get { throw null; } set { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/ReadTimeout/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/ReadTimeout/*' />
         public override int ReadTimeout { get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/WriteTimeout/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/WriteTimeout/*' />
         public override int WriteTimeout { get { throw null; } }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Flush/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Flush/*' />
         public override void Flush() { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/BeginRead/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/BeginRead/*' />
         public override System.IAsyncResult BeginRead(byte[] buffer, int offset, int count, System.AsyncCallback callback, object state) { throw null; }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/EndRead/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/EndRead/*' />
         public override int EndRead(System.IAsyncResult asyncResult) { throw null; }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/BeginWrite/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/BeginWrite/*' />
         public override System.IAsyncResult BeginWrite(byte[] buffer, int offset, int count, System.AsyncCallback callback, System.Object state) { throw null; }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/EndWrite/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/EndWrite/*' />
         public override void EndWrite(System.IAsyncResult asyncResult) { }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Seek/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Seek/*' />
         public override long Seek(long offset, System.IO.SeekOrigin origin) { throw null; }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/SetLength/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/SetLength/*' />
         public override void SetLength(long value) { throw null; }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Read/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Read/*' />
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/ReadByte/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/ReadByte/*' />
         public override int ReadByte() { throw null; }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Write/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/Write/*' />
         public override void Write(byte[] buffer, int offset, int count) { throw null; }
-        /// <include file='..\..\..\..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/WriteByte/*' />
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/WriteByte/*' />
         public override void WriteByte(byte value) { }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -145,8 +145,6 @@ namespace Microsoft.Data.SqlClient
         internal bool _cleanSQLDNSCaching = false;
         private bool _serverSupportsDNSCaching = false;
 
-        internal byte _supportedDataClassificationVersion = TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED;
-
         /// <summary>
         /// Get or set if SQLDNSCaching FeatureExtAck is supported by the server.
         /// </summary>
@@ -3063,11 +3061,11 @@ namespace Microsoft.Data.SqlClient
 
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
-                        _supportedDataClassificationVersion = data[0];
-                        if ((0 == _supportedDataClassificationVersion) || (_supportedDataClassificationVersion > TdsEnums.MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION))
+                        byte supportedDataClassificationVersion = data[0];
+                        if ((0 == supportedDataClassificationVersion) || (supportedDataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_MAX_SUPPORTED))
                         {
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for DATACLASSIFICATION", ObjectID);
-                            throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, _supportedDataClassificationVersion);
+                            throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, supportedDataClassificationVersion);
                         }
 
                         if (data.Length != 2)
@@ -3076,7 +3074,7 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         byte enabled = data[1];
-                        _parser.DataClassificationVersion = (enabled == 0) ? TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED : _supportedDataClassificationVersion;
+                        _parser.DataClassificationVersion = (enabled == 0) ? TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED : supportedDataClassificationVersion;
                         break;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -143,8 +143,9 @@ namespace Microsoft.Data.SqlClient
         SqlClientOriginalNetworkAddressInfo _originalNetworkAddressInfo;
 
         internal bool _cleanSQLDNSCaching = false;
-
         private bool _serverSupportsDNSCaching = false;
+
+        internal byte _supportedDataClassificationVersion = TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED;
 
         /// <summary>
         /// Get or set if SQLDNSCaching FeatureExtAck is supported by the server.
@@ -3062,11 +3063,11 @@ namespace Microsoft.Data.SqlClient
 
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
-                        byte supportedDataClassificationVersion = data[0];
-                        if ((0 == supportedDataClassificationVersion) || (supportedDataClassificationVersion > TdsEnums.MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION))
+                        _supportedDataClassificationVersion = data[0];
+                        if ((0 == _supportedDataClassificationVersion) || (_supportedDataClassificationVersion > TdsEnums.MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION))
                         {
                             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for DATACLASSIFICATION", ObjectID);
-                            throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, supportedDataClassificationVersion);
+                            throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, _supportedDataClassificationVersion);
                         }
 
                         if (data.Length != 2)
@@ -3075,7 +3076,7 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         byte enabled = data[1];
-                        _parser.DataClassificationVersion = (enabled == 0) ? TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED : supportedDataClassificationVersion;
+                        _parser.DataClassificationVersion = (enabled == 0) ? TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED : _supportedDataClassificationVersion;
                         break;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -939,7 +939,7 @@ namespace Microsoft.Data.SqlClient
         // Data Classification constants
         internal const byte DATA_CLASSIFICATION_NOT_ENABLED = 0x00;
         internal const byte DATA_CLASSIFICATION_VERSION_WITHOUT_RANK_SUPPORT = 0x01;
-        internal const byte MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION = 0x02;
+        internal const byte DATA_CLASSIFICATION_VERSION_MAX_SUPPORTED = 0x02;
 
         // TCE Related constants
         internal const byte MAX_SUPPORTED_TCE_VERSION = 0x02; // max version

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -938,7 +938,8 @@ namespace Microsoft.Data.SqlClient
 
         // Data Classification constants
         internal const byte DATA_CLASSIFICATION_NOT_ENABLED = 0x00;
-        internal const byte MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION = 0x01;
+        internal const byte DATA_CLASSIFICATION_VERSION_WITHOUT_RANK_SUPPORT = 0x01;
+        internal const byte MAX_SUPPORTED_DATA_CLASSIFICATION_VERSION = 0x02;
 
         // TCE Related constants
         internal const byte MAX_SUPPORTED_TCE_VERSION = 0x02; // max version

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3785,7 +3785,6 @@ namespace Microsoft.Data.SqlClient
                 {
                     return false;
                 }
-                Console.WriteLine(sensitivityRank);
                 if (!Enum.IsDefined(typeof(SensitivityRank), sensitivityRank))
                 {
                     return false;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3837,7 +3837,7 @@ namespace Microsoft.Data.SqlClient
                         }
                     }
 
-                    // add sentivity properties for the source
+                    // add sensitivity properties for the source
                     sensitivityProperties.Add(new SensitivityProperty(label, informationType, (SensitivityRank)sensitivityRankProperty));
                 }
                 columnSensitivities.Add(new ColumnSensitivity(sensitivityProperties));

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -623,7 +623,7 @@ namespace Microsoft.Data.SqlClient
 
             UInt32 result = SNINativeMethodWrapper.SniGetConnectionId(_physicalStateObj.Handle, ref _connHandler._clientConnectionId);
             Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionId");
-  
+
             // for DNS Caching phase 1
             AssignPendingDNSInfo(serverInfo.UserProtocol, FQDNforDNSCahce);
 
@@ -705,12 +705,12 @@ namespace Microsoft.Data.SqlClient
 
             if (string.IsNullOrEmpty(userProtocol))
             {
-                
+
                 result = SNINativeMethodWrapper.SniGetProviderNumber(_physicalStateObj.Handle, ref providerNumber);
                 Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetProviderNumber");
                 isTcpProtocol = (providerNumber == SNINativeMethodWrapper.ProviderEnum.TCP_PROV);
             }
-            else if (userProtocol == TdsEnums.TCP) 
+            else if (userProtocol == TdsEnums.TCP)
             {
                 isTcpProtocol = true;
             }
@@ -3558,7 +3558,7 @@ namespace Microsoft.Data.SqlClient
                 ret = SQLFallbackDNSCache.Instance.DeleteDNSInfo(FQDNforDNSCahce);
             }
 
-            if ( _connHandler.IsSQLDNSCachingSupported && _connHandler.pendingSQLDNSObject != null 
+            if (_connHandler.IsSQLDNSCachingSupported && _connHandler.pendingSQLDNSObject != null
                     && !SQLFallbackDNSCache.Instance.IsDuplicate(_connHandler.pendingSQLDNSObject))
             {
                 ret = SQLFallbackDNSCache.Instance.AddDNSInfo(_connHandler.pendingSQLDNSObject);
@@ -3777,6 +3777,21 @@ namespace Microsoft.Data.SqlClient
                 informationTypes.Add(new InformationType(informationType, id));
             }
 
+            // get sensitivity rank
+            Int32 sensitivityRank = (int)SensitivityRank.NOT_DEFINED;
+            if (_connHandler._supportedDataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_WITHOUT_RANK_SUPPORT)
+            {
+                if (!stateObj.TryReadInt32(out sensitivityRank))
+                {
+                    return false;
+                }
+                Console.WriteLine(sensitivityRank);
+                if (!Enum.IsDefined(typeof(SensitivityRank), sensitivityRank))
+                {
+                    return false;
+                }
+            }
+
             // get the per column classification data (corresponds to order of output columns for query)
             UInt16 numResultColumns;
             if (!stateObj.TryReadUInt16(out numResultColumns))
@@ -3827,14 +3842,27 @@ namespace Microsoft.Data.SqlClient
                         informationType = informationTypes[informationTypeIndex];
                     }
 
+                    // get sensitivity rank
+                    Int32 sensitivityRankProperty = (int)SensitivityRank.NOT_DEFINED;
+                    if (_connHandler._supportedDataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_WITHOUT_RANK_SUPPORT)
+                    {
+                        if (!stateObj.TryReadInt32(out sensitivityRankProperty))
+                        {
+                            return false;
+                        }
+                        if (!Enum.IsDefined(typeof(SensitivityRank), sensitivityRankProperty))
+                        {
+                            return false;
+                        }
+                    }
+
                     // add sentivity properties for the source
-                    sensitivityProperties.Add(new SensitivityProperty(label, informationType));
+                    sensitivityProperties.Add(new SensitivityProperty(label, informationType, (SensitivityRank)sensitivityRankProperty));
                 }
                 columnSensitivities.Add(new ColumnSensitivity(sensitivityProperties));
             }
 
-            sensitivityClassification = new SensitivityClassification(labels, informationTypes, columnSensitivities);
-
+            sensitivityClassification = new SensitivityClassification(labels, informationTypes, columnSensitivities, (SensitivityRank)sensitivityRank);
             return true;
         }
 
@@ -9828,7 +9856,7 @@ namespace Microsoft.Data.SqlClient
 
                         // Stream out parameters
                         SqlParameter[] parameters = rpcext.parameters;
-                        
+
                         bool isAdvancedTraceOn = SqlClientEventSource.Log.IsAdvancedTraceOn();
 
                         for (int i = (ii == startRpc) ? startParam : 0; i < parameters.Length; i++)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/DataClassification/SensitivityClassification.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/DataClassification/SensitivityClassification.cs
@@ -41,6 +41,23 @@ namespace Microsoft.Data.SqlClient.DataClassification
         }
     }
 
+    /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/SensitivityRank/*' />
+    public enum SensitivityRank
+    {
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/NotDefined/*' />
+        NOT_DEFINED = -1,
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/None/*' />
+        NONE = 0,
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/Low/*' />
+        LOW = 10,
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/Medium/*' />
+        MEDIUM = 20,
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/High/*' />
+        HIGH = 30,
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml' path='docs/members[@name="SensitivityRank"]/Critical/*' />
+        CRITICAL = 40
+    }
+
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/SensitivityProperty/*' />
     public class SensitivityProperty
     {
@@ -50,11 +67,15 @@ namespace Microsoft.Data.SqlClient.DataClassification
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/InformationType/*' />
         public InformationType InformationType { get; private set; }
 
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/SensitivityRank/*' />
+        public SensitivityRank SensitivityRank { get; private set; }
+        
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/ctor/*' />
-        public SensitivityProperty(Label label, InformationType informationType)
+        public SensitivityProperty(Label label, InformationType informationType, SensitivityRank sensitivityRank = SensitivityRank.NOT_DEFINED) // Default to NOT_DEFINED for backwards compatibility
         {
             Label = label;
             InformationType = informationType;
+            SensitivityRank = sensitivityRank;
         }
     }
 
@@ -80,15 +101,19 @@ namespace Microsoft.Data.SqlClient.DataClassification
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/InformationTypes/*' />
         public ReadOnlyCollection<InformationType> InformationTypes { get; private set; }
 
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/SensitivityRank/*' />
+        public SensitivityRank SensitivityRank { get; private set; }
+
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/ColumnSensitivities/*' />
         public ReadOnlyCollection<ColumnSensitivity> ColumnSensitivities { get; private set; }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/ctor/*' />
-        public SensitivityClassification(IList<Label> labels, IList<InformationType> informationTypes, IList<ColumnSensitivity> columnSensitivity)
+        public SensitivityClassification(IList<Label> labels, IList<InformationType> informationTypes, IList<ColumnSensitivity> columnSensitivity, SensitivityRank sensitivityRank = SensitivityRank.NOT_DEFINED) // Default to NOT_DEFINED for backwards compatibility
         {
             Labels = new ReadOnlyCollection<Label>(labels);
             InformationTypes = new ReadOnlyCollection<InformationType>(informationTypes);
             ColumnSensitivities = new ReadOnlyCollection<ColumnSensitivity>(columnSensitivity);
+            SensitivityRank = sensitivityRank;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/DataClassification/SensitivityClassification.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/DataClassification/SensitivityClassification.cs
@@ -8,7 +8,7 @@ using System.Collections.ObjectModel;
 namespace Microsoft.Data.SqlClient.DataClassification
 {
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml' path='docs/members[@name="Label"]/Label/*' />
-    public class Label
+    public sealed class Label
     {
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml' path='docs/members[@name="Label"]/Name/*' />
         public string Name { get; private set; }
@@ -25,7 +25,7 @@ namespace Microsoft.Data.SqlClient.DataClassification
     }
 
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/InformationType.xml' path='docs/members[@name="InformationType"]/InformationType/*' />
-    public class InformationType
+    public sealed class InformationType
     {
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/InformationType.xml' path='docs/members[@name="InformationType"]/Name/*' />
         public string Name { get; private set; }
@@ -59,7 +59,7 @@ namespace Microsoft.Data.SqlClient.DataClassification
     }
 
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/SensitivityProperty/*' />
-    public class SensitivityProperty
+    public sealed class SensitivityProperty
     {
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml' path='docs/members[@name="SensitivityProperty"]/Label/*' />
         public Label Label { get; private set; }
@@ -80,7 +80,7 @@ namespace Microsoft.Data.SqlClient.DataClassification
     }
 
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/ColumnSensitivity.xml' path='docs/members[@name="ColumnSensitivity"]/ColumnSensitivity/*' />
-    public class ColumnSensitivity
+    public sealed class ColumnSensitivity
     {
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/ColumnSensitivity.xml' path='docs/members[@name="ColumnSensitivity"]/GetSensitivityProperties/*' />
         public ReadOnlyCollection<SensitivityProperty> SensitivityProperties { get; private set; }
@@ -93,7 +93,7 @@ namespace Microsoft.Data.SqlClient.DataClassification
     }
 
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/SensitivityClassification/*' />
-    public class SensitivityClassification
+    public sealed class SensitivityClassification
     {
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml' path='docs/members[@name="SensitivityClassification"]/Labels/*' />
         public ReadOnlyCollection<Label> Labels { get; private set; }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataClassificationTest/DataClassificationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataClassificationTest/DataClassificationTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     {
         private static string s_tableName;
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsSupportedDataClassification))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsSupportedDataClassification))]
         public static void TestDataClassificationResultSetRank()
         {
             s_tableName = DataTestUtility.GetUniqueNameForSqlServer("DC");
@@ -37,7 +37,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsSupportedDataClassification))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsSupportedDataClassification))]
         public static void TestDataClassificationResultSet()
         {
             s_tableName = DataTestUtility.GetUniqueNameForSqlServer("DC");
@@ -218,7 +218,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             sqlCommand.ExecuteNonQuery();
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsSupportedDataClassification))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsSupportedDataClassification))]
         public static void TestDataClassificationBulkCopy()
         {
             var data = new DataTable("Company");

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataClassificationTest/DataClassificationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataClassificationTest/DataClassificationTest.cs
@@ -245,11 +245,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             $" [CompanyId] [uniqueidentifier] NOT NULL," +
                             $" [CompanyName][nvarchar](255) NOT NULL," +
                             $" [Email] [nvarchar](50) NULL," +
-                            $" [CompanyType] [int] not null," +
-                            $" CONSTRAINT[PK_Company] PRIMARY KEY CLUSTERED (" +
-                            $"      [CompanyId] ASC" +
-                            $"      ) WITH(STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON[PRIMARY]" +
-                            $"  ) ON[PRIMARY]";
+                            $" [CompanyType] [int] not null)";
                         sqlCommand.ExecuteNonQuery();
                         sqlCommand.CommandText = $"ADD SENSITIVITY CLASSIFICATION TO {tableName}.CompanyName WITH (label = 'Confidential', label_id = 'c185460f-4e20-4b89-9876-ae95f07ba087', information_type = 'Contact Info', information_type_id = '5c503e21-22c6-81fa-620b-f369b8ec38d1');";
                         sqlCommand.CommandText = $"ADD SENSITIVITY CLASSIFICATION TO {tableName}.Email WITH (label = 'Confidential', label_id = 'c185460f-4e20-4b89-9876-ae95f07ba087', information_type = 'Contact Info', information_type_id = '5c503e21-22c6-81fa-620b-f369b8ec38d1', rank = HIGH);";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataClassificationTest/DataClassificationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataClassificationTest/DataClassificationTest.cs
@@ -15,6 +15,29 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private static string s_tableName;
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsSupportedDataClassification))]
+        public static void TestDataClassificationResultSetRank()
+        {
+            s_tableName = DataTestUtility.GetUniqueNameForSqlServer("DC");
+            using (SqlConnection sqlConnection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            using (SqlCommand sqlCommand = sqlConnection.CreateCommand())
+            {
+                try
+                {
+                    sqlConnection.Open();
+                    Assert.True(DataTestUtility.IsSupportedDataClassification());
+                    CreateTable(sqlCommand);
+                    AddSensitivity(sqlCommand, rankEnabled: true);
+                    InsertData(sqlCommand);
+                    RunTestsForServer(sqlCommand, rankEnabled: true);
+                }
+                finally
+                {
+                    DataTestUtility.DropTable(sqlConnection, s_tableName);
+                }
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsSupportedDataClassification))]
         public static void TestDataClassificationResultSet()
         {
             s_tableName = DataTestUtility.GetUniqueNameForSqlServer("DC");
@@ -26,6 +49,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     sqlConnection.Open();
                     Assert.True(DataTestUtility.IsSupportedDataClassification());
                     CreateTable(sqlCommand);
+                    AddSensitivity(sqlCommand);
+                    InsertData(sqlCommand);
                     RunTestsForServer(sqlCommand);
                 }
                 finally
@@ -35,16 +60,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        private static void RunTestsForServer(SqlCommand sqlCommand)
+        private static void RunTestsForServer(SqlCommand sqlCommand, bool rankEnabled = false)
         {
             sqlCommand.CommandText = "SELECT * FROM " + s_tableName;
             using (SqlDataReader reader = sqlCommand.ExecuteReader())
             {
-                VerifySensitivityClassification(reader);
+                VerifySensitivityClassification(reader, rankEnabled);
             }
         }
 
-        private static void VerifySensitivityClassification(SqlDataReader reader)
+        private static void VerifySensitivityClassification(SqlDataReader reader, bool rankEnabled = false)
         {
             if (null != reader.SensitivityClassification)
             {
@@ -69,8 +94,24 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             VerifyLabel(sp.Label);
                             VerifyInfoType(sp.InformationType, columnPos);
                         }
+                        if (rankEnabled)
+                        {
+                            if (columnPos == 1 || columnPos == 2)
+                            {
+                                Assert.True(sp.SensitivityRank == SensitivityRank.LOW);
+                            }
+                            else if (columnPos == 6 || columnPos == 7)
+                            {
+                                Assert.True(sp.SensitivityRank == SensitivityRank.MEDIUM);
+                            }
+                        }
+                        else
+                        {
+                            Assert.True(reader.SensitivityClassification.SensitivityRank == SensitivityRank.NOT_DEFINED);
+                        }
                     }
                 }
+                Assert.Equal(reader.SensitivityClassification.SensitivityRank, rankEnabled ? SensitivityRank.MEDIUM : SensitivityRank.NOT_DEFINED);
             }
         }
 
@@ -100,23 +141,50 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 + "[Phone] [nvarchar](30) MASKED WITH (FUNCTION = 'default()') NULL,"
                 + "[Fax] [nvarchar](30) MASKED WITH (FUNCTION = 'default()') NULL)";
             sqlCommand.ExecuteNonQuery();
+        }
 
-            sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
-                    + ".CompanyName WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Company Name', INFORMATION_TYPE_ID='COMPANY')";
-            sqlCommand.ExecuteNonQuery();
+        private static void AddSensitivity(SqlCommand sqlCommand, bool rankEnabled = false)
+        {
+            if (rankEnabled)
+            {
+                sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
+                        + ".CompanyName WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Company Name', INFORMATION_TYPE_ID='COMPANY', RANK=LOW)";
+                sqlCommand.ExecuteNonQuery();
 
-            sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
-                    + ".ContactName WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Person Name', INFORMATION_TYPE_ID='NAME')";
-            sqlCommand.ExecuteNonQuery();
+                sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
+                        + ".ContactName WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Person Name', INFORMATION_TYPE_ID='NAME', RANK=LOW)";
+                sqlCommand.ExecuteNonQuery();
 
-            sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
-                    + ".Phone WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Contact Information', INFORMATION_TYPE_ID='CONTACT')";
-            sqlCommand.ExecuteNonQuery();
+                sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
+                        + ".Phone WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Contact Information', INFORMATION_TYPE_ID='CONTACT', RANK=MEDIUM)";
+                sqlCommand.ExecuteNonQuery();
 
-            sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
-                    + ".Fax WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Contact Information', INFORMATION_TYPE_ID='CONTACT')";
-            sqlCommand.ExecuteNonQuery();
+                sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
+                        + ".Fax WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Contact Information', INFORMATION_TYPE_ID='CONTACT', RANK=MEDIUM)";
+                sqlCommand.ExecuteNonQuery();
+            }
+            else
+            {
+                sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
+                        + ".CompanyName WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Company Name', INFORMATION_TYPE_ID='COMPANY')";
+                sqlCommand.ExecuteNonQuery();
 
+                sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
+                        + ".ContactName WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Person Name', INFORMATION_TYPE_ID='NAME')";
+                sqlCommand.ExecuteNonQuery();
+
+                sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
+                        + ".Phone WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Contact Information', INFORMATION_TYPE_ID='CONTACT')";
+                sqlCommand.ExecuteNonQuery();
+
+                sqlCommand.CommandText = "ADD SENSITIVITY CLASSIFICATION TO " + s_tableName
+                        + ".Fax WITH (LABEL='PII', LABEL_ID='L1', INFORMATION_TYPE='Contact Information', INFORMATION_TYPE_ID='CONTACT')";
+                sqlCommand.ExecuteNonQuery();
+            }
+        }
+
+        private static void InsertData(SqlCommand sqlCommand)
+        {
             // INSERT ROWS OF DATA
             sqlCommand.CommandText = "INSERT INTO " + s_tableName + " VALUES (@companyName, @contactName, @contactTitle, @city, @country, @phone, @fax)";
 
@@ -126,7 +194,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             sqlCommand.Parameters.AddWithValue("city", "London");
             sqlCommand.Parameters.AddWithValue("@country", "UK");
             sqlCommand.Parameters.AddWithValue("@phone", "(171) 555-2222");
-            sqlCommand.Parameters.AddWithValue("@fax", "");
+            sqlCommand.Parameters.AddWithValue("@fax", "(171) 554-2222");
             sqlCommand.ExecuteNonQuery();
 
             sqlCommand.Parameters.Clear();
@@ -136,7 +204,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             sqlCommand.Parameters.AddWithValue("city", "New Orleans");
             sqlCommand.Parameters.AddWithValue("@country", "USA");
             sqlCommand.Parameters.AddWithValue("@phone", "(100) 555-4822");
-            sqlCommand.Parameters.AddWithValue("@fax", "");
+            sqlCommand.Parameters.AddWithValue("@fax", "(100) 223-3243");
             sqlCommand.ExecuteNonQuery();
 
             sqlCommand.Parameters.Clear();
@@ -183,8 +251,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             $"      ) WITH(STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON[PRIMARY]" +
                             $"  ) ON[PRIMARY]";
                         sqlCommand.ExecuteNonQuery();
-
-                        sqlCommand.CommandText = $"ADD SENSITIVITY CLASSIFICATION TO {tableName}.Email WITH (label = 'Confidential', label_id = 'c185460f-4e20-4b89-9876-ae95f07ba087', information_type = 'Contact Info', information_type_id = '5c503e21-22c6-81fa-620b-f369b8ec38d1');";
+                        sqlCommand.CommandText = $"ADD SENSITIVITY CLASSIFICATION TO {tableName}.CompanyName WITH (label = 'Confidential', label_id = 'c185460f-4e20-4b89-9876-ae95f07ba087', information_type = 'Contact Info', information_type_id = '5c503e21-22c6-81fa-620b-f369b8ec38d1');";
+                        sqlCommand.CommandText = $"ADD SENSITIVITY CLASSIFICATION TO {tableName}.Email WITH (label = 'Confidential', label_id = 'c185460f-4e20-4b89-9876-ae95f07ba087', information_type = 'Contact Info', information_type_id = '5c503e21-22c6-81fa-620b-f369b8ec38d1', rank = HIGH);";
                         sqlCommand.ExecuteNonQuery();
                     }
 


### PR DESCRIPTION
Introduces Sensitivity Rank with Sensitivity Classification information.

_Additional Notes:_
The driver supports Max version of v2. So if server only supports v1 , based on received version in FEATUREEXTACK packages, we do not read Sensitivity Rank. Only if server supports v2, we read this new Rank info. The Rank value for queries made on v1 server is "NOT DEFINED". This way the driver supports both v1 and v2 of Data Classification support from Server.

Testing has been done with both v1 and v2 servers.