### PR TITLE
[Release/2.0] Fix | Fix Enclave Session Cache Issue with Azure Database

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml
@@ -21,7 +21,7 @@ the enclave attestation protocol as well as the logic for creating and caching e
             <param name="clientDiffieHellmanKey">A Diffie-Hellman algorithm object that encapsulates a client-side key pair.</param>
             <param name="attestationUrl">The endpoint of an attestation service for attesting the enclave.</param>
             <param name="servername">The name of the SQL Server instance containing the enclave.</param>
-            <param name="database">The database that SqlClient contacts to.</param>
+            <param name="database">The database that SqlClient contacts to request an enclave session.</param>
             <param name="customData">The set of extra data needed for attestating the enclave.</param>
             <param name="customDataLength">The length of the extra data needed for attestating the enclave.</param>
             <param name="sqlEnclaveSession">The requested enclave session or <see langword="null" /> if the provider doesn't implement session caching.</param>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml
@@ -40,7 +40,7 @@ the enclave attestation protocol as well as the logic for creating and caching e
         <GetEnclaveSession>
             <param name="serverName">The name of the SQL Server instance containing the enclave.</param>
             <param name="attestationUrl">The endpoint of an attestation service, SqlClient contacts to attest the enclave.</param>
-            <param name="database">The database that SqlClient contacts to.</param>
+            <param name="database">The database that SqlClient contacts to request an enclave session.</param>
             <param name="generateCustomData"><see langword="true" /> to indicate that a set of extra data needs to be generated for attestation; otherwise, <see langword="false" />.</param>
             <param name="sqlEnclaveSession">When this method returns, the requested enclave session or <see langword="null" /> if the provider doesn't implement session caching. This parameter is treated as uninitialized.</param>
             <param name="counter">A counter that the enclave provider is expected to increment each time SqlClient retrieves the session from the cache. The purpose of this field is to prevent replay attacks.</param>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml
@@ -53,7 +53,7 @@ the enclave attestation protocol as well as the logic for creating and caching e
         <InvalidateEnclaveSession>
             <param name="serverName">The name of the SQL Server instance containing the enclave.</param>
             <param name="enclaveAttestationUrl">The endpoint of an attestation service, SqlClient contacts to attest the enclave.</param>
-            <param name="database">The database that SqlClient contacts to.</param>
+            <param name="database">The database that SqlClient contacts to request an enclave session.</param>
             <param name="enclaveSession">The session to be invalidated.</param>
             <summary>When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.</summary>
             <remarks>To be added.</remarks>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml
@@ -21,6 +21,7 @@ the enclave attestation protocol as well as the logic for creating and caching e
             <param name="clientDiffieHellmanKey">A Diffie-Hellman algorithm object that encapsulates a client-side key pair.</param>
             <param name="attestationUrl">The endpoint of an attestation service for attesting the enclave.</param>
             <param name="servername">The name of the SQL Server instance containing the enclave.</param>
+            <param name="database">The database that SqlClient contacts to.</param>
             <param name="customData">The set of extra data needed for attestating the enclave.</param>
             <param name="customDataLength">The length of the extra data needed for attestating the enclave.</param>
             <param name="sqlEnclaveSession">The requested enclave session or <see langword="null" /> if the provider doesn't implement session caching.</param>
@@ -39,6 +40,7 @@ the enclave attestation protocol as well as the logic for creating and caching e
         <GetEnclaveSession>
             <param name="serverName">The name of the SQL Server instance containing the enclave.</param>
             <param name="attestationUrl">The endpoint of an attestation service, SqlClient contacts to attest the enclave.</param>
+            <param name="database">The database that SqlClient contacts to.</param>
             <param name="generateCustomData"><see langword="true" /> to indicate that a set of extra data needs to be generated for attestation; otherwise, <see langword="false" />.</param>
             <param name="sqlEnclaveSession">When this method returns, the requested enclave session or <see langword="null" /> if the provider doesn't implement session caching. This parameter is treated as uninitialized.</param>
             <param name="counter">A counter that the enclave provider is expected to increment each time SqlClient retrieves the session from the cache. The purpose of this field is to prevent replay attacks.</param>
@@ -51,6 +53,7 @@ the enclave attestation protocol as well as the logic for creating and caching e
         <InvalidateEnclaveSession>
             <param name="serverName">The name of the SQL Server instance containing the enclave.</param>
             <param name="enclaveAttestationUrl">The endpoint of an attestation service, SqlClient contacts to attest the enclave.</param>
+            <param name="database">The database that SqlClient contacts to.</param>
             <param name="enclaveSession">The session to be invalidated.</param>
             <summary>When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.</summary>
             <remarks>To be added.</remarks>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.NetCoreApp.cs
@@ -65,9 +65,9 @@ namespace Microsoft.Data.SqlClient
         #region Internal methods
         // When overridden in a derived class, looks up an existing enclave session information in the enclave session cache.
         // If the enclave provider doesn't implement enclave session caching, this method is expected to return null in the sqlEnclaveSession parameter.
-        internal override void GetEnclaveSession(string servername, string attestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
+        internal override void GetEnclaveSession(string servername, string attestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
         {
-            GetEnclaveSessionHelper(servername, attestationUrl, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength);
+            GetEnclaveSessionHelper(servername, attestationUrl, database, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength);
         }
 
         // Gets the information that SqlClient subsequently uses to initiate the process of attesting the enclave and to establish a secure session with the enclave.
@@ -81,14 +81,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, string database, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             sqlEnclaveSession = null;
             counter = 0;
             try
             {
                 ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
-                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, out counter);
+                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, database, out counter);
                 if (sqlEnclaveSession == null)
                 {
                     if (!string.IsNullOrEmpty(attestationUrl) && customData != null && customDataLength > 0)
@@ -107,7 +107,7 @@ namespace Microsoft.Data.SqlClient
                         byte[] sharedSecret = GetSharedSecret(attestInfo.Identity, nonce, attestInfo.EnclaveType, attestInfo.EnclaveDHInfo, clientDHKey);
 
                         // add session to cache
-                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, sharedSecret, attestInfo.SessionId, out counter);
+                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, database, sharedSecret, attestInfo.SessionId, out counter);
                     }
                     else
                     {
@@ -126,9 +126,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
-        internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {
-            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, enclaveSessionToInvalidate);
+            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, database, enclaveSessionToInvalidate);
         }
         #endregion
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetCoreApp.cs
@@ -64,11 +64,12 @@ namespace Microsoft.Data.SqlClient
         /// <param name="enclaveType">enclave type</param>
         /// <param name="serverName">servername</param>
         /// <param name="attestationUrl">attestation url for attestation service endpoint</param>
+        /// <param name="database">The database that SqlClient contacts to.</param>
         /// <param name="attestationInfo">attestation info from SQL Server</param>
         /// <param name="attestationParameters">attestation parameters</param>
         /// <param name="customData">A set of extra data needed for attestating the enclave.</param>
         /// <param name="customDataLength">The length of the extra data needed for attestating the enclave.</param>
-        internal void CreateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string attestationUrl,
+        internal void CreateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string attestationUrl, string database,
             byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, byte[] customData, int customDataLength)
         {
 
@@ -79,15 +80,14 @@ namespace Microsoft.Data.SqlClient
                 SqlEnclaveSession sqlEnclaveSession = null;
                 byte[] dummyCustomData = null;
                 int dummyCustomDataLength;
-
-                sqlColumnEncryptionEnclaveProvider.GetEnclaveSession(serverName, attestationUrl, false, out sqlEnclaveSession, out counter, out dummyCustomData, out dummyCustomDataLength);
+                sqlColumnEncryptionEnclaveProvider.GetEnclaveSession(serverName, attestationUrl, database, false, out sqlEnclaveSession, out counter, out dummyCustomData, out dummyCustomDataLength);
 
                 if (sqlEnclaveSession != null)
                 {
                     return;
                 }
 
-                sqlColumnEncryptionEnclaveProvider.CreateEnclaveSession(attestationInfo, attestationParameters.ClientDiffieHellmanKey, attestationUrl, serverName, customData, customDataLength, out sqlEnclaveSession, out counter);
+                sqlColumnEncryptionEnclaveProvider.CreateEnclaveSession(attestationInfo, attestationParameters.ClientDiffieHellmanKey, attestationUrl, serverName, database, customData, customDataLength, out sqlEnclaveSession, out counter);
 
                 if (sqlEnclaveSession == null) 
                 {
@@ -105,8 +105,9 @@ namespace Microsoft.Data.SqlClient
         /// <param name="enclaveType">enclave type</param>
         /// <param name="serverName">server name</param>
         /// <param name="enclaveAttestationUrl">url for attestation endpoint</param>
+        /// <param name="database">The database that SqlClient contacts to.</param>
         /// <returns></returns>
-        internal EnclavePackage GenerateEnclavePackage(SqlConnectionAttestationProtocol attestationProtocol, Dictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave, string queryText, string enclaveType, string serverName, string enclaveAttestationUrl)
+        internal EnclavePackage GenerateEnclavePackage(SqlConnectionAttestationProtocol attestationProtocol, Dictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave, string queryText, string enclaveType, string serverName, string enclaveAttestationUrl, string database)
         {
 
             SqlEnclaveSession sqlEnclaveSession = null;
@@ -116,7 +117,7 @@ namespace Microsoft.Data.SqlClient
 
             try
             {
-                GetEnclaveSession(attestationProtocol, enclaveType, serverName, enclaveAttestationUrl, false, out sqlEnclaveSession, out counter, out dummyCustomData, out dummyCustomDataLength, throwIfNull: true);
+                GetEnclaveSession(attestationProtocol, enclaveType, serverName, enclaveAttestationUrl, database, false, out sqlEnclaveSession, out counter, out dummyCustomData, out dummyCustomDataLength, throwIfNull: true);
             }
             catch (Exception e)
             {
@@ -133,10 +134,10 @@ namespace Microsoft.Data.SqlClient
             return new EnclavePackage(byteArrayToBeSentToEnclave, sqlEnclaveSession);
         }
 
-        internal void InvalidateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string EnclaveAttestationUrl, SqlEnclaveSession enclaveSession)
+        internal void InvalidateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string EnclaveAttestationUrl, string database, SqlEnclaveSession enclaveSession)
         {
             SqlColumnEncryptionEnclaveProvider sqlColumnEncryptionEnclaveProvider = GetEnclaveProvider(attestationProtocol, enclaveType);
-            sqlColumnEncryptionEnclaveProvider.InvalidateEnclaveSession(serverName, EnclaveAttestationUrl, enclaveSession);
+            sqlColumnEncryptionEnclaveProvider.InvalidateEnclaveSession(serverName, EnclaveAttestationUrl, database, enclaveSession);
         }
 
         
@@ -207,16 +208,16 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal void GetEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string enclaveAttestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out byte[] customData, out int customDataLength)
+        internal void GetEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string enclaveAttestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out byte[] customData, out int customDataLength)
         {
             long counter;
-            GetEnclaveSession(attestationProtocol, enclaveType, serverName, enclaveAttestationUrl, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength, throwIfNull: false);
+            GetEnclaveSession(attestationProtocol, enclaveType, serverName, enclaveAttestationUrl, database, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength, throwIfNull: false);
         }
 
-        private void GetEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string enclaveAttestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength, bool throwIfNull)
+        private void GetEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string enclaveAttestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength, bool throwIfNull)
         {
             SqlColumnEncryptionEnclaveProvider sqlColumnEncryptionEnclaveProvider = GetEnclaveProvider(attestationProtocol, enclaveType);
-            sqlColumnEncryptionEnclaveProvider.GetEnclaveSession(serverName, enclaveAttestationUrl, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength);
+            sqlColumnEncryptionEnclaveProvider.GetEnclaveSession(serverName, enclaveAttestationUrl, database, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength);
 
             if (throwIfNull && sqlEnclaveSession == null)
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetCoreApp.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="enclaveType">enclave type</param>
         /// <param name="serverName">servername</param>
         /// <param name="attestationUrl">attestation url for attestation service endpoint</param>
-        /// <param name="database">The database that SqlClient contacts to.</param>
+        /// <param name="database">The database that SqlClient contacts to request an enclave session.</param>
         /// <param name="attestationInfo">attestation info from SQL Server</param>
         /// <param name="attestationParameters">attestation parameters</param>
         /// <param name="customData">A set of extra data needed for attestating the enclave.</param>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetCoreApp.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="enclaveType">enclave type</param>
         /// <param name="serverName">server name</param>
         /// <param name="enclaveAttestationUrl">url for attestation endpoint</param>
-        /// <param name="database">The database that SqlClient contacts to.</param>
+        /// <param name="database">The database that SqlClient contacts to request an enclave session.</param>
         /// <returns></returns>
         internal EnclavePackage GenerateEnclavePackage(SqlConnectionAttestationProtocol attestationProtocol, Dictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave, string queryText, string enclaveType, string serverName, string enclaveAttestationUrl, string database)
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetStandard.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetStandard.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="enclaveType">enclave type</param>
         /// <param name="serverName">servername</param>
         /// <param name="attestationUrl">attestation url for attestation service endpoint</param>
-        /// <param name="database">The database that SqlClient contacts to.</param>
+        /// <param name="database">The database that SqlClient contacts to request an enclave session.</param>
         /// <param name="attestationInfo">attestation info from SQL Server</param>
         /// <param name="attestationParameters">attestation parameters</param>
         /// <param name="customData">A set of extra data needed for attestating the enclave.</param>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetStandard.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveDelegate.NetStandard.cs
@@ -25,27 +25,28 @@ namespace Microsoft.Data.SqlClient
         /// <param name="enclaveType">enclave type</param>
         /// <param name="serverName">servername</param>
         /// <param name="attestationUrl">attestation url for attestation service endpoint</param>
+        /// <param name="database">The database that SqlClient contacts to.</param>
         /// <param name="attestationInfo">attestation info from SQL Server</param>
         /// <param name="attestationParameters">attestation parameters</param>
         /// <param name="customData">A set of extra data needed for attestating the enclave.</param>
         /// <param name="customDataLength">The length of the extra data needed for attestating the enclave.</param>
-        internal void CreateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string attestationUrl,
+        internal void CreateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string attestationUrl, string database,
             byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, byte[] customData, int customDataLength)
         {
             throw new PlatformNotSupportedException();
         }
 
-        internal void GetEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string enclaveAttestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out byte[] customData, out int customDataLength)
+        internal void GetEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string enclaveAttestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out byte[] customData, out int customDataLength)
         {
             throw new PlatformNotSupportedException();
         }
 
-        internal EnclavePackage GenerateEnclavePackage(SqlConnectionAttestationProtocol attestationProtocol, Dictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave, string queryText, string enclaveType, string serverName, string enclaveAttestationUrl)
+        internal EnclavePackage GenerateEnclavePackage(SqlConnectionAttestationProtocol attestationProtocol, Dictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave, string queryText, string enclaveType, string serverName, string enclaveAttestationUrl, string database)
         {
             throw new PlatformNotSupportedException();
         }
 
-        internal void InvalidateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string EnclaveAttestationUrl, SqlEnclaveSession enclaveSession)
+        internal void InvalidateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string EnclaveAttestationUrl, string database, SqlEnclaveSession enclaveSession)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveProviderBase.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveProviderBase.NetCoreApp.cs
@@ -87,13 +87,13 @@ namespace Microsoft.Data.SqlClient
         protected static readonly MemoryCache ThreadRetryCache = new MemoryCache("ThreadRetryCache");
         #endregion
 
-        #region Public methods
+        #region Protected methods
         // Helper method to get the enclave session from the cache if present
-        protected void GetEnclaveSessionHelper(string servername, string attestationUrl, bool shouldGenerateNonce, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
+        protected void GetEnclaveSessionHelper(string servername, string attestationUrl, string database, bool shouldGenerateNonce, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
         {
             customData = null;
             customDataLength = 0;
-            sqlEnclaveSession = SessionCache.GetEnclaveSession(servername, attestationUrl, out counter);
+            sqlEnclaveSession = SessionCache.GetEnclaveSession(servername, attestationUrl, database, out counter);
 
             if (sqlEnclaveSession == null)
             {
@@ -128,7 +128,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // While the current thread is waiting for event to be signaled and in the meanwhile we already completed the attestation on different thread
                     // then we need to signal the event here
-                    sqlEnclaveSession = SessionCache.GetEnclaveSession(servername, attestationUrl, out counter);
+                    sqlEnclaveSession = SessionCache.GetEnclaveSession(servername, attestationUrl, database, out counter);
                     if (sqlEnclaveSession != null && !sameThreadRetry)
                     {
                         lock (lockUpdateSessionLock)
@@ -194,21 +194,21 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Helper method to remove the enclave session from the cache
-        protected void InvalidateEnclaveSessionHelper(string servername, string attestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        protected void InvalidateEnclaveSessionHelper(string servername, string attestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {
-            SessionCache.InvalidateSession(servername, attestationUrl, enclaveSessionToInvalidate);
+            SessionCache.InvalidateSession(servername, attestationUrl, database, enclaveSessionToInvalidate);
         }
 
         // Helper method for getting the enclave session from the session cache
-        protected SqlEnclaveSession GetEnclaveSessionFromCache(string attestationUrl, string servername, out long counter)
+        protected SqlEnclaveSession GetEnclaveSessionFromCache(string attestationUrl, string servername, string database, out long counter)
         {
-            return SessionCache.GetEnclaveSession(servername, attestationUrl, out counter);
+            return SessionCache.GetEnclaveSession(servername, attestationUrl, database, out counter);
         }
 
         // Helper method for adding the enclave session to the session cache
-        protected SqlEnclaveSession AddEnclaveSessionToCache(string attestationUrl, string servername, byte[] sharedSecret, long sessionId, out long counter)
+        protected SqlEnclaveSession AddEnclaveSessionToCache(string attestationUrl, string servername, string database, byte[] sharedSecret, long sessionId, out long counter)
         {
-            return SessionCache.CreateSession(attestationUrl, servername, sharedSecret, sessionId, out counter);
+            return SessionCache.CreateSession(attestationUrl, servername, database, sharedSecret, sessionId, out counter);
         }
     }
     #endregion

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveSessionCache.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveSessionCache.NetCoreApp.cs
@@ -22,23 +22,23 @@ namespace Microsoft.Data.SqlClient
         private static int enclaveCacheTimeOutInHours = 8;
 
         // Retrieves a SqlEnclaveSession from the cache
-        internal SqlEnclaveSession GetEnclaveSession(string servername, string attestationUrl, out long counter)
+        internal SqlEnclaveSession GetEnclaveSession(string servername, string attestationUrl, string database, out long counter)
         {
-            string cacheKey = GenerateCacheKey(servername, attestationUrl);
+            string cacheKey = GenerateCacheKey(servername, attestationUrl, database);
             SqlEnclaveSession enclaveSession = enclaveMemoryCache[cacheKey] as SqlEnclaveSession;
             counter = Interlocked.Increment(ref _counter);
             return enclaveSession;
         }
 
         // Invalidates a SqlEnclaveSession entry in the cache
-        internal void InvalidateSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        internal void InvalidateSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {
-            string cacheKey = GenerateCacheKey(serverName, enclaveAttestationUrl);
+            string cacheKey = GenerateCacheKey(serverName, enclaveAttestationUrl, database);
 
             lock (enclaveCacheLock)
             {
                 long counter;
-                SqlEnclaveSession enclaveSession = GetEnclaveSession(serverName, enclaveAttestationUrl, out counter);
+                SqlEnclaveSession enclaveSession = GetEnclaveSession(serverName, enclaveAttestationUrl, database, out counter);
 
                 if (enclaveSession != null && enclaveSession.SessionId == enclaveSessionToInvalidate.SessionId)
                 {
@@ -52,9 +52,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Creates a new SqlEnclaveSession and adds it to the cache
-        internal SqlEnclaveSession CreateSession(string attestationUrl, string serverName, byte[] sharedSecret, long sessionId, out long counter)
+        internal SqlEnclaveSession CreateSession(string attestationUrl, string serverName, string database, byte[] sharedSecret, long sessionId, out long counter)
         {
-            string cacheKey = GenerateCacheKey(serverName, attestationUrl);
+            string cacheKey = GenerateCacheKey(serverName, attestationUrl, database);
             SqlEnclaveSession enclaveSession = null;
             lock (enclaveCacheLock)
             {
@@ -67,9 +67,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Generates the cache key for the enclave session cache
-        private string GenerateCacheKey(string serverName, string attestationUrl)
+        private string GenerateCacheKey(string serverName, string attestationUrl, string database)
         {
-            return (serverName + attestationUrl).ToLowerInvariant();
+            return (serverName + database + attestationUrl).ToLowerInvariant();
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveSessionCache.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/EnclaveSessionCache.NetCoreApp.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Data.SqlClient
         // Generates the cache key for the enclave session cache
         private string GenerateCacheKey(string serverName, string attestationUrl, string database)
         {
-            return (serverName + database + attestationUrl).ToLowerInvariant();
+            return (serverName + '+' + database + attestationUrl).ToLowerInvariant();
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.NetCoreApp.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         /// <param name="serverName">The name of the SQL Server instance containing the enclave.</param>
         /// <param name="enclaveAttestationUrl">The endpoint of an attestation service, SqlClient contacts to attest the enclave.</param>
-        /// <param name="database">The database that SqlClient contacts to.</param>
+        /// <param name="database">The database that SqlClient contacts to request an enclave session.</param>
         /// <param name="enclaveSessionToInvalidate">The session to be invalidated.</param>
         public override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.NetCoreApp.cs
@@ -16,11 +16,12 @@ namespace Microsoft.Data.SqlClient
         /// <param name="clientDiffieHellmanKey">A Diffie-Hellman algorithm object encapsulating a client-side key pair.</param>
         /// <param name="attestationUrl">The endpoint of an attestation service for attesting the enclave.</param>
         /// <param name="servername">The name of the SQL Server instance containing the enclave.</param>
+        /// <param name="database">The database that SqlClient contacts to.</param>
         /// <param name="customData">The set of extra data needed for attestating the enclave.</param>
         /// <param name="customDataLength">The length of the extra data needed for attestating the enclave.</param>
         /// <param name="sqlEnclaveSession">The requested enclave session or null if the provider does not implement session caching.</param>
         /// <param name="counter">A counter that the enclave provider is expected to increment each time SqlClient retrieves the session from the cache. The purpose of this field is to prevent replay attacks.</param>
-        internal abstract void CreateEnclaveSession(byte[] enclaveAttestationInfo, ECDiffieHellmanCng clientDiffieHellmanKey, string attestationUrl, string servername, byte[] customData, int customDataLength,
+        internal abstract void CreateEnclaveSession(byte[] enclaveAttestationInfo, ECDiffieHellmanCng clientDiffieHellmanKey, string attestationUrl, string servername, string database, byte[] customData, int customDataLength,
             out SqlEnclaveSession sqlEnclaveSession, out long counter);
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.NetCoreApp.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="clientDiffieHellmanKey">A Diffie-Hellman algorithm object encapsulating a client-side key pair.</param>
         /// <param name="attestationUrl">The endpoint of an attestation service for attesting the enclave.</param>
         /// <param name="servername">The name of the SQL Server instance containing the enclave.</param>
-        /// <param name="database">The database that SqlClient contacts to.</param>
+        /// <param name="database">The database that SqlClient contacts to request an enclave session.</param>
         /// <param name="customData">The set of extra data needed for attestating the enclave.</param>
         /// <param name="customDataLength">The length of the extra data needed for attestating the enclave.</param>
         /// <param name="sqlEnclaveSession">The requested enclave session or null if the provider does not implement session caching.</param>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Data.SqlClient
     internal abstract partial class SqlColumnEncryptionEnclaveProvider
     {
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml' path='docs/members[@name="SqlColumnEncryptionEnclaveProvider"]/GetEnclaveSession/*'/>
-        internal abstract void GetEnclaveSession(string serverName, string attestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength);
+        internal abstract void GetEnclaveSession(string serverName, string attestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml' path='docs/members[@name="SqlColumnEncryptionEnclaveProvider"]/GetAttestationParameters/*'/>
         internal abstract SqlEnclaveAttestationParameters GetAttestationParameters(string attestationUrl, byte[] customData, int customDataLength);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml' path='docs/members[@name="SqlColumnEncryptionEnclaveProvider"]/InvalidateEnclaveSession/*'/>
-        internal abstract void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSession);
+        internal abstract void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSession);
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2164,7 +2164,7 @@ namespace Microsoft.Data.SqlClient
                             if (ShouldUseEnclaveBasedWorkflow && this.enclavePackage != null)
                             {
                                 EnclaveDelegate.Instance.InvalidateEnclaveSession(this._activeConnection.AttestationProtocol, this._activeConnection.Parser.EnclaveType,
-                                    this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl,
+                                    this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this._activeConnection.Database,
                                     this.enclavePackage.EnclaveSession);
                             }
 
@@ -3483,8 +3483,9 @@ namespace Microsoft.Data.SqlClient
                 string enclaveType = this._activeConnection.Parser.EnclaveType;
                 string dataSource = this._activeConnection.DataSource;
                 string enclaveAttestationUrl = this._activeConnection.EnclaveAttestationUrl;
+                string database = this._activeConnection.Database;
                 SqlEnclaveSession sqlEnclaveSession = null;
-                EnclaveDelegate.Instance.GetEnclaveSession(attestationProtocol, enclaveType, dataSource, enclaveAttestationUrl, true, out sqlEnclaveSession, out customData, out customDataLength);
+                EnclaveDelegate.Instance.GetEnclaveSession(attestationProtocol, enclaveType, dataSource, enclaveAttestationUrl, database, true, out sqlEnclaveSession, out customData, out customDataLength);
                 if (sqlEnclaveSession == null)
                 {
                     enclaveAttestationParameters = EnclaveDelegate.Instance.GetAttestationParameters(attestationProtocol, enclaveType, enclaveAttestationUrl, customData, customDataLength);
@@ -4010,8 +4011,9 @@ namespace Microsoft.Data.SqlClient
                         string enclaveType = this._activeConnection.Parser.EnclaveType;
                         string dataSource = this._activeConnection.DataSource;
                         string enclaveAttestationUrl = this._activeConnection.EnclaveAttestationUrl;
+                        string database = this._activeConnection.Database;
 
-                        EnclaveDelegate.Instance.CreateEnclaveSession(attestationProtocol, enclaveType, dataSource, enclaveAttestationUrl, attestationInfo, enclaveAttestationParameters, customData, customDataLength);
+                        EnclaveDelegate.Instance.CreateEnclaveSession(attestationProtocol, enclaveType, dataSource, enclaveAttestationUrl, database, attestationInfo, enclaveAttestationParameters, customData, customDataLength);
                         enclaveAttestationParameters = null;
                         attestationInfoRead = true;
                     }
@@ -4125,7 +4127,7 @@ namespace Microsoft.Data.SqlClient
                     if (ShouldUseEnclaveBasedWorkflow && this.enclavePackage != null)
                     {
                         EnclaveDelegate.Instance.InvalidateEnclaveSession(this._activeConnection.AttestationProtocol, this._activeConnection.Parser.EnclaveType,
-                            this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this.enclavePackage.EnclaveSession);
+                            this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this._activeConnection.Database, this.enclavePackage.EnclaveSession);
                     }
 
                     return RunExecuteReader(cmdBehavior, runBehavior, returnStream, null, TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart), out task, out usedCache, isAsync, inRetry: true, method: method);
@@ -4168,7 +4170,7 @@ namespace Microsoft.Data.SqlClient
                         if (ShouldUseEnclaveBasedWorkflow && this.enclavePackage != null)
                         {
                             EnclaveDelegate.Instance.InvalidateEnclaveSession(this._activeConnection.AttestationProtocol, this._activeConnection.Parser.EnclaveType,
-                              this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this.enclavePackage.EnclaveSession);
+                              this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this._activeConnection.Database, this.enclavePackage.EnclaveSession);
                         }
 
                         return RunExecuteReader(cmdBehavior, runBehavior, returnStream, null, TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart), out task, out usedCache, isAsync, inRetry: true, method: method);
@@ -4275,7 +4277,7 @@ namespace Microsoft.Data.SqlClient
             {
                 this.enclavePackage = EnclaveDelegate.Instance.GenerateEnclavePackage(attestationProtocol, keysToBeSentToEnclave,
                     this.CommandText, enclaveType, this._activeConnection.DataSource,
-                    this._activeConnection.EnclaveAttestationUrl);
+                    this._activeConnection.EnclaveAttestationUrl, this._activeConnection.Database);
             }
             catch (EnclaveDelegate.RetryableEnclaveQueryExecutionException)
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.NetCoreApp.cs
@@ -86,9 +86,9 @@ namespace Microsoft.Data.SqlClient
 
         // When overridden in a derived class, looks up an existing enclave session information in the enclave session cache.
         // If the enclave provider doesn't implement enclave session caching, this method is expected to return null in the sqlEnclaveSession parameter.
-        internal override void GetEnclaveSession(string servername, string attestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
+        internal override void GetEnclaveSession(string servername, string attestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
         {
-            GetEnclaveSessionHelper(servername, attestationUrl, false, out sqlEnclaveSession, out counter, out customData, out customDataLength);
+            GetEnclaveSessionHelper(servername, attestationUrl, database, false, out sqlEnclaveSession, out counter, out customData, out customDataLength);
         }
 
         // Gets the information that SqlClient subsequently uses to initiate the process of attesting the enclave and to establish a secure session with the enclave.
@@ -101,14 +101,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, string database, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             sqlEnclaveSession = null;
             counter = 0;
             try
             {
                 ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
-                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, out counter);
+                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, database, out counter);
                 if (sqlEnclaveSession == null)
                 {
                     if (!string.IsNullOrEmpty(attestationUrl))
@@ -126,7 +126,7 @@ namespace Microsoft.Data.SqlClient
                         byte[] sharedSecret = GetSharedSecret(info.Identity, info.EnclaveDHInfo, clientDHKey);
 
                         // add session to cache
-                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, sharedSecret, info.SessionId, out counter);
+                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, database, sharedSecret, info.SessionId, out counter);
                     }
                     else
                     {
@@ -141,9 +141,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
-        internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {
-            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, enclaveSessionToInvalidate);
+            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, database, enclaveSessionToInvalidate);
         }
 
         #endregion

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -65,9 +65,9 @@ namespace Microsoft.Data.SqlClient
         #region Internal methods
         // When overridden in a derived class, looks up an existing enclave session information in the enclave session cache.
         // If the enclave provider doesn't implement enclave session caching, this method is expected to return null in the sqlEnclaveSession parameter.
-        internal override void GetEnclaveSession(string servername, string attestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
+        internal override void GetEnclaveSession(string servername, string attestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
         {
-            GetEnclaveSessionHelper(servername, attestationUrl, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength);
+            GetEnclaveSessionHelper(servername, attestationUrl, database, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength);
         }
 
         // Gets the information that SqlClient subsequently uses to initiate the process of attesting the enclave and to establish a secure session with the enclave.
@@ -81,14 +81,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, string database, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             sqlEnclaveSession = null;
             counter = 0;
             try
             {
                 ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
-                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, out counter);
+                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, database, out counter);
                 if (sqlEnclaveSession == null)
                 {
                     if (!string.IsNullOrEmpty(attestationUrl) && customData != null && customDataLength > 0)
@@ -107,7 +107,7 @@ namespace Microsoft.Data.SqlClient
                         byte[] sharedSecret = GetSharedSecret(attestInfo.Identity, nonce, attestInfo.EnclaveType, attestInfo.EnclaveDHInfo, clientDHKey);
 
                         // add session to cache
-                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, sharedSecret, attestInfo.SessionId, out counter);
+                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, database, sharedSecret, attestInfo.SessionId, out counter);
                     }
                     else
                     {
@@ -126,9 +126,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
-        internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {
-            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, enclaveSessionToInvalidate);
+            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, database, enclaveSessionToInvalidate);
         }
         #endregion
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
@@ -42,8 +42,9 @@ namespace Microsoft.Data.SqlClient
         /// <param name="enclaveType">enclave type</param>
         /// <param name="serverName">server name</param>
         /// <param name="enclaveAttestationUrl">url for attestation endpoint</param>
+        /// <param name="database">The database that SqlClient contacts to.</param>
         /// <returns></returns>
-        internal EnclavePackage GenerateEnclavePackage(SqlConnectionAttestationProtocol attestationProtocol, Dictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave, string queryText, string enclaveType, string serverName, string enclaveAttestationUrl)
+        internal EnclavePackage GenerateEnclavePackage(SqlConnectionAttestationProtocol attestationProtocol, Dictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave, string queryText, string enclaveType, string serverName, string enclaveAttestationUrl, string database)
         {
 
             SqlEnclaveSession sqlEnclaveSession = null;
@@ -52,7 +53,7 @@ namespace Microsoft.Data.SqlClient
             int dummyCustomDataLength;
             try
             {
-                GetEnclaveSession(attestationProtocol, enclaveType, serverName, enclaveAttestationUrl, false, out sqlEnclaveSession, out counter, out dummyCustomData, out dummyCustomDataLength, throwIfNull: true);
+                GetEnclaveSession(attestationProtocol, enclaveType, serverName, enclaveAttestationUrl, database, false, out sqlEnclaveSession, out counter, out dummyCustomData, out dummyCustomDataLength, throwIfNull: true);
             }
             catch (Exception e)
             {
@@ -69,22 +70,22 @@ namespace Microsoft.Data.SqlClient
             return new EnclavePackage(byteArrayToBeSentToEnclave, sqlEnclaveSession);
         }
 
-        internal void InvalidateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string EnclaveAttestationUrl, SqlEnclaveSession enclaveSession)
+        internal void InvalidateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string EnclaveAttestationUrl, string database, SqlEnclaveSession enclaveSession)
         {
             SqlColumnEncryptionEnclaveProvider sqlColumnEncryptionEnclaveProvider = GetEnclaveProvider(attestationProtocol, enclaveType);
-            sqlColumnEncryptionEnclaveProvider.InvalidateEnclaveSession(serverName, EnclaveAttestationUrl, enclaveSession);
+            sqlColumnEncryptionEnclaveProvider.InvalidateEnclaveSession(serverName, EnclaveAttestationUrl, database, enclaveSession);
         }
 
-        internal void GetEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string enclaveAttestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out byte[] customData, out int customDataLength)
+        internal void GetEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string enclaveAttestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out byte[] customData, out int customDataLength)
         {
             long counter;
-            GetEnclaveSession(attestationProtocol, enclaveType, serverName, enclaveAttestationUrl, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength, throwIfNull: false);
+            GetEnclaveSession(attestationProtocol, enclaveType, serverName, enclaveAttestationUrl, database, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength, throwIfNull: false);
         }
 
-        private void GetEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string enclaveAttestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength, bool throwIfNull)
+        private void GetEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string enclaveAttestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength, bool throwIfNull)
         {
             SqlColumnEncryptionEnclaveProvider sqlColumnEncryptionEnclaveProvider = GetEnclaveProvider(attestationProtocol, enclaveType);
-            sqlColumnEncryptionEnclaveProvider.GetEnclaveSession(serverName, enclaveAttestationUrl, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength);
+            sqlColumnEncryptionEnclaveProvider.GetEnclaveSession(serverName, enclaveAttestationUrl, database, generateCustomData, out sqlEnclaveSession, out counter, out customData, out customDataLength);
 
             if (throwIfNull && sqlEnclaveSession == null)
             {
@@ -159,11 +160,12 @@ namespace Microsoft.Data.SqlClient
         /// <param name="enclaveType">enclave type</param>
         /// <param name="serverName">servername</param>
         /// <param name="attestationUrl">attestation url for attestation service endpoint</param>
+        /// <param name="database">The database that SqlClient contacts to.</param>
         /// <param name="attestationInfo">attestation info from SQL Server</param>
         /// <param name="attestationParameters">attestation parameters</param>
         /// <param name="customData">A set of extra data needed for attestating the enclave.</param>
         /// <param name="customDataLength">The length of the extra data needed for attestating the enclave.</param>
-        internal void CreateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string attestationUrl,
+        internal void CreateEnclaveSession(SqlConnectionAttestationProtocol attestationProtocol, string enclaveType, string serverName, string attestationUrl, string database,
             byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, byte[] customData, int customDataLength)
         {
 
@@ -174,14 +176,14 @@ namespace Microsoft.Data.SqlClient
                 SqlEnclaveSession sqlEnclaveSession = null;
                 byte[] dummyCustomData = null;
                 int dummyCustomDataLength;
-                sqlColumnEncryptionEnclaveProvider.GetEnclaveSession(serverName, attestationUrl, false, out sqlEnclaveSession, out counter, out dummyCustomData, out dummyCustomDataLength);
+                sqlColumnEncryptionEnclaveProvider.GetEnclaveSession(serverName, attestationUrl, database, false, out sqlEnclaveSession, out counter, out dummyCustomData, out dummyCustomDataLength);
 
                 if (sqlEnclaveSession != null)
                 {
                     return;
                 }
 
-                sqlColumnEncryptionEnclaveProvider.CreateEnclaveSession(attestationInfo, attestationParameters.ClientDiffieHellmanKey, attestationUrl, serverName, customData, customDataLength, out sqlEnclaveSession, out counter);
+                sqlColumnEncryptionEnclaveProvider.CreateEnclaveSession(attestationInfo, attestationParameters.ClientDiffieHellmanKey, attestationUrl, serverName, database, customData, customDataLength, out sqlEnclaveSession, out counter);
 
                 if (sqlEnclaveSession == null)
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveDelegate.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="enclaveType">enclave type</param>
         /// <param name="serverName">server name</param>
         /// <param name="enclaveAttestationUrl">url for attestation endpoint</param>
-        /// <param name="database">The database that SqlClient contacts to.</param>
+        /// <param name="database">The database that SqlClient contacts to request an enclave session.</param>
         /// <returns></returns>
         internal EnclavePackage GenerateEnclavePackage(SqlConnectionAttestationProtocol attestationProtocol, Dictionary<int, SqlTceCipherInfoEntry> keysTobeSentToEnclave, string queryText, string enclaveType, string serverName, string enclaveAttestationUrl, string database)
         {
@@ -160,7 +160,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="enclaveType">enclave type</param>
         /// <param name="serverName">servername</param>
         /// <param name="attestationUrl">attestation url for attestation service endpoint</param>
-        /// <param name="database">The database that SqlClient contacts to.</param>
+        /// <param name="database">The database that SqlClient contacts to request an enclave session.</param>
         /// <param name="attestationInfo">attestation info from SQL Server</param>
         /// <param name="attestationParameters">attestation parameters</param>
         /// <param name="customData">A set of extra data needed for attestating the enclave.</param>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
@@ -89,11 +89,11 @@ namespace Microsoft.Data.SqlClient
 
         #region Public methods
         // Helper method to get the enclave session from the cache if present
-        protected void GetEnclaveSessionHelper(string servername, string attestationUrl, bool shouldGenerateNonce, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
+        protected void GetEnclaveSessionHelper(string servername, string attestationUrl, string database, bool shouldGenerateNonce, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
         {
             customData = null;
             customDataLength = 0;
-            sqlEnclaveSession = SessionCache.GetEnclaveSession(servername, attestationUrl, out counter);
+            sqlEnclaveSession = SessionCache.GetEnclaveSession(servername, attestationUrl, database, out counter);
 
             if (sqlEnclaveSession == null)
             {
@@ -128,7 +128,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // While the current thread is waiting for event to be signaled and in the meanwhile we already completed the attestation on different thread
                     // then we need to signal the event here
-                    sqlEnclaveSession = SessionCache.GetEnclaveSession(servername, attestationUrl, out counter);
+                    sqlEnclaveSession = SessionCache.GetEnclaveSession(servername, attestationUrl, database, out counter);
                     if (sqlEnclaveSession != null && !sameThreadRetry)
                     {
                         lock (lockUpdateSessionLock)
@@ -194,21 +194,21 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Helper method to remove the enclave session from the cache
-        protected void InvalidateEnclaveSessionHelper(string servername, string attestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        protected void InvalidateEnclaveSessionHelper(string servername, string attestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {
-            SessionCache.InvalidateSession(servername, attestationUrl, enclaveSessionToInvalidate);
+            SessionCache.InvalidateSession(servername, attestationUrl, database, enclaveSessionToInvalidate);
         }
 
         // Helper method for getting the enclave session from the session cache
-        protected SqlEnclaveSession GetEnclaveSessionFromCache(string attestationUrl, string servername, out long counter)
+        protected SqlEnclaveSession GetEnclaveSessionFromCache(string attestationUrl, string servername, string database, out long counter)
         {
-            return SessionCache.GetEnclaveSession(servername, attestationUrl, out counter);
+            return SessionCache.GetEnclaveSession(servername, attestationUrl, database, out counter);
         }
 
         // Helper method for adding the enclave session to the session cache
-        protected SqlEnclaveSession AddEnclaveSessionToCache(string attestationUrl, string servername, byte[] sharedSecret, long sessionId, out long counter)
+        protected SqlEnclaveSession AddEnclaveSessionToCache(string attestationUrl, string servername, string database, byte[] sharedSecret, long sessionId, out long counter)
         {
-            return SessionCache.CreateSession(attestationUrl, servername, sharedSecret, sessionId, out counter);
+            return SessionCache.CreateSession(attestationUrl, servername, database, sharedSecret, sessionId, out counter);
         }
     }
     #endregion

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveSessionCache.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveSessionCache.cs
@@ -22,23 +22,23 @@ namespace Microsoft.Data.SqlClient
         private static int enclaveCacheTimeOutInHours = 8;
 
         // Retrieves a SqlEnclaveSession from the cache
-        internal SqlEnclaveSession GetEnclaveSession(string servername, string attestationUrl, out long counter)
+        internal SqlEnclaveSession GetEnclaveSession(string servername, string attestationUrl, string database, out long counter)
         {
-            string cacheKey = GenerateCacheKey(servername, attestationUrl);
+            string cacheKey = GenerateCacheKey(servername, attestationUrl, database);
             SqlEnclaveSession enclaveSession = enclaveMemoryCache[cacheKey] as SqlEnclaveSession;
             counter = Interlocked.Increment(ref _counter);
             return enclaveSession;
         }
 
         // Invalidates a SqlEnclaveSession entry in the cache
-        internal void InvalidateSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        internal void InvalidateSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {
-            string cacheKey = GenerateCacheKey(serverName, enclaveAttestationUrl);
+            string cacheKey = GenerateCacheKey(serverName, enclaveAttestationUrl, database);
 
             lock (enclaveCacheLock)
             {
                 long counter;
-                SqlEnclaveSession enclaveSession = GetEnclaveSession(serverName, enclaveAttestationUrl, out counter);
+                SqlEnclaveSession enclaveSession = GetEnclaveSession(serverName, enclaveAttestationUrl, database, out counter);
 
                 if (enclaveSession != null && enclaveSession.SessionId == enclaveSessionToInvalidate.SessionId)
                 {
@@ -52,9 +52,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Creates a new SqlEnclaveSession and adds it to the cache
-        internal SqlEnclaveSession CreateSession(string attestationUrl, string serverName, byte[] sharedSecret, long sessionId, out long counter)
+        internal SqlEnclaveSession CreateSession(string attestationUrl, string serverName, string database, byte[] sharedSecret, long sessionId, out long counter)
         {
-            string cacheKey = GenerateCacheKey(serverName, attestationUrl);
+            string cacheKey = GenerateCacheKey(serverName, attestationUrl, database);
             SqlEnclaveSession enclaveSession = null;
             lock (enclaveCacheLock)
             {
@@ -67,9 +67,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Generates the cache key for the enclave session cache
-        private string GenerateCacheKey(string serverName, string attestationUrl)
+        private string GenerateCacheKey(string serverName, string attestationUrl, string database)
         {
-            return (serverName + attestationUrl).ToLowerInvariant();
+            return (serverName + database + attestationUrl).ToLowerInvariant();
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveSessionCache.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/EnclaveSessionCache.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Data.SqlClient
         // Generates the cache key for the enclave session cache
         private string GenerateCacheKey(string serverName, string attestationUrl, string database)
         {
-            return (serverName + database + attestationUrl).ToLowerInvariant();
+            return (serverName + '+' + database + attestationUrl).ToLowerInvariant();
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         /// <param name="serverName">The name of the SQL Server instance containing the enclave.</param>
         /// <param name="enclaveAttestationUrl">The endpoint of an attestation service, SqlClient contacts to attest the enclave.</param>
-        /// <param name="database">The database that SqlClient contacts to.</param>
+        /// <param name="database">The database that SqlClient contacts to request an enclave session.</param>
         /// <param name="enclaveSessionToInvalidate">The session to be invalidated.</param>
         internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Data.SqlClient
 
         // When overridden in a derived class, looks up an existing enclave session information in the enclave session cache.
         // If the enclave provider doesn't implement enclave session caching, this method is expected to return null in the sqlEnclaveSession parameter.
-        internal override void GetEnclaveSession(string servername, string attestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
+        internal override void GetEnclaveSession(string servername, string attestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
         {
-            GetEnclaveSessionHelper(servername, attestationUrl, false, out sqlEnclaveSession, out counter, out customData, out customDataLength);
+            GetEnclaveSessionHelper(servername, attestationUrl, database, false, out sqlEnclaveSession, out counter, out customData, out customDataLength);
         }
 
         // Gets the information that SqlClient subsequently uses to initiate the process of attesting the enclave and to establish a secure session with the enclave.
@@ -39,7 +39,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, string database, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             ////for simulator: enclave does not send public key, and sends an empty attestation info
             //// The only non-trivial content it sends is the session setup info (DH pubkey of enclave)
@@ -49,7 +49,7 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
-                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, out counter);
+                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, database, out counter);
 
                 if (sqlEnclaveSession == null)
                 {
@@ -88,7 +88,7 @@ namespace Microsoft.Data.SqlClient
                         CngKey k = CngKey.Import(trustedModuleDHPublicKey, CngKeyBlobFormat.EccPublicBlob);
                         byte[] sharedSecret = clientDHKey.DeriveKeyMaterial(k);
                         long sessionId = BitConverter.ToInt64(enclaveSessionHandle, 0);
-                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, sharedSecret, sessionId, out counter);
+                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, database, sharedSecret, sessionId, out counter);
                     }
                     else
                     {
@@ -107,10 +107,11 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         /// <param name="serverName">The name of the SQL Server instance containing the enclave.</param>
         /// <param name="enclaveAttestationUrl">The endpoint of an attestation service, SqlClient contacts to attest the enclave.</param>
+        /// <param name="database">The database that SqlClient contacts to.</param>
         /// <param name="enclaveSessionToInvalidate">The session to be invalidated.</param>
-        internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {
-            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, enclaveSessionToInvalidate);
+            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, database, enclaveSessionToInvalidate);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.cs
@@ -11,15 +11,15 @@ namespace Microsoft.Data.SqlClient
     {
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml' path='docs/members[@name="SqlColumnEncryptionEnclaveProvider"]/GetEnclaveSession/*'/>
-        internal abstract void GetEnclaveSession(string serverName, string attestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength);
+        internal abstract void GetEnclaveSession(string serverName, string attestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml' path='docs/members[@name="SqlColumnEncryptionEnclaveProvider"]/GetAttestationParameters/*'/>
         internal abstract SqlEnclaveAttestationParameters GetAttestationParameters(string attestationUrl, byte[] customData, int customDataLength);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml' path='docs/members[@name="SqlColumnEncryptionEnclaveProvider"]/CreateEnclaveSession/*'/>
-        internal abstract void CreateEnclaveSession(byte[] enclaveAttestationInfo, ECDiffieHellmanCng clientDiffieHellmanKey, string attestationUrl, string servername, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter);
+        internal abstract void CreateEnclaveSession(byte[] enclaveAttestationInfo, ECDiffieHellmanCng clientDiffieHellmanKey, string attestationUrl, string servername, string database, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml' path='docs/members[@name="SqlColumnEncryptionEnclaveProvider"]/InvalidateEnclaveSession/*'/>
-        internal abstract void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSession);
+        internal abstract void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSession);
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2714,7 +2714,8 @@ namespace Microsoft.Data.SqlClient
 
                                 if (ShouldUseEnclaveBasedWorkflow && this.enclavePackage != null)
                                 {
-                                    EnclaveDelegate.Instance.InvalidateEnclaveSession(this._activeConnection.AttestationProtocol, this._activeConnection.Parser.EnclaveType, this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this.enclavePackage.EnclaveSession);
+                                    EnclaveDelegate.Instance.InvalidateEnclaveSession(this._activeConnection.AttestationProtocol, this._activeConnection.Parser.EnclaveType, 
+                                        this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this._activeConnection.Database, this.enclavePackage.EnclaveSession);
                                 }
 
                                 try
@@ -4257,8 +4258,9 @@ namespace Microsoft.Data.SqlClient
                 string enclaveType = this._activeConnection.Parser.EnclaveType;
                 string dataSource = this._activeConnection.DataSource;
                 string enclaveAttestationUrl = this._activeConnection.EnclaveAttestationUrl;
+                string database = this._activeConnection.Database;
                 SqlEnclaveSession sqlEnclaveSession = null;
-                EnclaveDelegate.Instance.GetEnclaveSession(attestationProtocol, enclaveType, dataSource, enclaveAttestationUrl, true, out sqlEnclaveSession, out customData, out customDataLength);
+                EnclaveDelegate.Instance.GetEnclaveSession(attestationProtocol, enclaveType, dataSource, enclaveAttestationUrl, database, true, out sqlEnclaveSession, out customData, out customDataLength);
                 if (sqlEnclaveSession == null)
                 {
                     this.enclaveAttestationParameters = EnclaveDelegate.Instance.GetAttestationParameters(attestationProtocol, enclaveType, enclaveAttestationUrl, customData, customDataLength);
@@ -4794,8 +4796,9 @@ namespace Microsoft.Data.SqlClient
                         string enclaveType = this._activeConnection.Parser.EnclaveType;
                         string dataSource = this._activeConnection.DataSource;
                         string enclaveAttestationUrl = this._activeConnection.EnclaveAttestationUrl;
+                        string database = this._activeConnection.Database;
 
-                        EnclaveDelegate.Instance.CreateEnclaveSession(attestationProtocol, enclaveType, dataSource, enclaveAttestationUrl, attestationInfo, enclaveAttestationParameters, customData, customDataLength);
+                        EnclaveDelegate.Instance.CreateEnclaveSession(attestationProtocol, enclaveType, dataSource, enclaveAttestationUrl, database, attestationInfo, enclaveAttestationParameters, customData, customDataLength);
                         enclaveAttestationParameters = null;
                         attestationInfoRead = true;
                     }
@@ -4930,7 +4933,7 @@ namespace Microsoft.Data.SqlClient
                             if (ShouldUseEnclaveBasedWorkflow && this.enclavePackage != null)
                             {
                                 EnclaveDelegate.Instance.InvalidateEnclaveSession(this._activeConnection.AttestationProtocol, this._activeConnection.Parser.EnclaveType,
-                                    this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this.enclavePackage.EnclaveSession);
+                                    this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this._activeConnection.Database, this.enclavePackage.EnclaveSession);
                             }
 
                             return RunExecuteReader(cmdBehavior, runBehavior, returnStream, method, null, TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart), out task, out usedCache, async, inRetry: true);
@@ -4973,7 +4976,7 @@ namespace Microsoft.Data.SqlClient
                                 if (ShouldUseEnclaveBasedWorkflow && this.enclavePackage != null)
                                 {
                                     EnclaveDelegate.Instance.InvalidateEnclaveSession(this._activeConnection.AttestationProtocol, this._activeConnection.Parser.EnclaveType,
-                                        this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this.enclavePackage.EnclaveSession);
+                                        this._activeConnection.DataSource, this._activeConnection.EnclaveAttestationUrl, this._activeConnection.Database, this.enclavePackage.EnclaveSession);
                                 }
 
                                 return RunExecuteReader(cmdBehavior, runBehavior, returnStream, method, null, TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart), out task, out usedCache, async, inRetry: true);
@@ -5118,7 +5121,7 @@ namespace Microsoft.Data.SqlClient
             {
                 this.enclavePackage = EnclaveDelegate.Instance.GenerateEnclavePackage(attestationProtocol, keysToBeSentToEnclave,
                     this.CommandText, enclaveType, this._activeConnection.DataSource,
-                    this._activeConnection.EnclaveAttestationUrl);
+                    this._activeConnection.EnclaveAttestationUrl, this._activeConnection.Database);
             }
             catch (EnclaveDelegate.RetryableEnclaveQueryExecutionException)
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -86,9 +86,9 @@ namespace Microsoft.Data.SqlClient
 
         // When overridden in a derived class, looks up an existing enclave session information in the enclave session cache.
         // If the enclave provider doesn't implement enclave session caching, this method is expected to return null in the sqlEnclaveSession parameter.
-        internal override void GetEnclaveSession(string servername, string attestationUrl, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
+        internal override void GetEnclaveSession(string servername, string attestationUrl, string database, bool generateCustomData, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
         {
-            GetEnclaveSessionHelper(servername, attestationUrl, false, out sqlEnclaveSession, out counter, out customData, out customDataLength);
+            GetEnclaveSessionHelper(servername, attestationUrl, database, false, out sqlEnclaveSession, out counter, out customData, out customDataLength);
         }
 
         // Gets the information that SqlClient subsequently uses to initiate the process of attesting the enclave and to establish a secure session with the enclave.
@@ -102,14 +102,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, string attestationUrl, string servername, string database, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             sqlEnclaveSession = null;
             counter = 0;
             try
             {
                 ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
-                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, out counter);
+                sqlEnclaveSession = GetEnclaveSessionFromCache(servername, attestationUrl, database, out counter);
                 if (sqlEnclaveSession == null)
                 {
                     if (!string.IsNullOrEmpty(attestationUrl))
@@ -127,7 +127,7 @@ namespace Microsoft.Data.SqlClient
                         byte[] sharedSecret = GetSharedSecret(info.Identity, info.EnclaveDHInfo, clientDHKey);
 
                         // add session to cache
-                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, sharedSecret, info.SessionId, out counter);
+                        sqlEnclaveSession = AddEnclaveSessionToCache(attestationUrl, servername, database, sharedSecret, info.SessionId, out counter);
                     }
                     else
                     {
@@ -142,9 +142,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
-        internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, SqlEnclaveSession enclaveSessionToInvalidate)
+        internal override void InvalidateEnclaveSession(string serverName, string enclaveAttestationUrl, string database, SqlEnclaveSession enclaveSessionToInvalidate)
         {
-            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, enclaveSessionToInvalidate);
+            InvalidateEnclaveSessionHelper(serverName, enclaveAttestationUrl, database, enclaveSessionToInvalidate);
         }
 
         #endregion

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/EnclaveAzureDatabaseTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/EnclaveAzureDatabaseTests.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.using System;
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider;
+using Microsoft.Data.SqlClient.ManualTesting.Tests;
+using Xunit;
+using Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
+{
+    public class EnclaveAzureDatabaseTests : IDisposable
+    {
+        private ColumnMasterKey akvColumnMasterKey;
+        private ColumnEncryptionKey akvColumnEncryptionKey;
+        private SqlColumnEncryptionAzureKeyVaultProvider sqlColumnEncryptionAzureKeyVaultProvider; 
+        private List<DbObject> databaseObjects = new List<DbObject>();
+        private List<string> connStrings = new List<string>();
+             
+        public EnclaveAzureDatabaseTests()
+        {
+            if (DataTestUtility.IsEnclaveAzureDatabaseSetup() && DataTestUtility.EnclaveEnabled)
+            {
+                // Initialize AKV provider
+                sqlColumnEncryptionAzureKeyVaultProvider = new SqlColumnEncryptionAzureKeyVaultProvider(AADUtility.AzureActiveDirectoryAuthenticationCallback);
+
+                // Register AKV provider
+                SqlConnection.RegisterColumnEncryptionKeyStoreProviders(customProviders: new Dictionary<string, SqlColumnEncryptionKeyStoreProvider>(capacity: 1, comparer: StringComparer.OrdinalIgnoreCase)
+                {
+                    { SqlColumnEncryptionAzureKeyVaultProvider.ProviderName, sqlColumnEncryptionAzureKeyVaultProvider}
+                });
+
+                akvColumnMasterKey = new AkvColumnMasterKey(DatabaseHelper.GenerateUniqueName("AKVCMK"), akvUrl: DataTestUtility.AKVUrl, sqlColumnEncryptionAzureKeyVaultProvider, DataTestUtility.EnclaveEnabled);
+                databaseObjects.Add(akvColumnMasterKey);
+
+                akvColumnEncryptionKey= new ColumnEncryptionKey(DatabaseHelper.GenerateUniqueName("AKVCEK"),
+                                                              akvColumnMasterKey,
+                                                              sqlColumnEncryptionAzureKeyVaultProvider);
+                databaseObjects.Add(akvColumnEncryptionKey);
+
+                SqlConnectionStringBuilder connString1 = new SqlConnectionStringBuilder(DataTestUtility.EnclaveAzureDatabaseConnString);
+                connString1.InitialCatalog = "testdb001";
+
+                SqlConnectionStringBuilder connString2 = new SqlConnectionStringBuilder(DataTestUtility.EnclaveAzureDatabaseConnString);
+                connString2.InitialCatalog = "testdb002";
+
+                connStrings.Add(connString1.ToString());
+                connStrings.Add(connString2.ToString());
+
+                foreach (string connString in connStrings)
+                {
+                    using (SqlConnection connection = new SqlConnection(connString))
+                    {
+                        connection.Open();
+                        databaseObjects.ForEach(o => o.Create(connection));
+                    }
+                }
+            }            
+        }
+
+        [PlatformSpecific(TestPlatforms.Windows)]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsEnclaveAzureDatabaseSetup))]
+        public void ConnectToAzureDatabaseWithEnclave()
+        {
+            if (DataTestUtility.EnclaveEnabled)
+            {
+                string tableName = DatabaseHelper.GenerateUniqueName("AzureTable");
+
+                foreach (string connString in connStrings)
+                {
+                    using (SqlConnection sqlConnection = new SqlConnection(connString))
+                    {
+                        sqlConnection.Open();
+
+                        Customer customer = new Customer(1, @"Microsoft", @"Corporation");
+
+                        try
+                        {
+                            CreateTable(sqlConnection, akvColumnEncryptionKey.Name, tableName);
+                            InsertData(sqlConnection, tableName, customer);
+                            VerifyData(sqlConnection, tableName, customer);
+                        }
+                        finally
+                        {
+                            DropTableIfExists(sqlConnection, tableName);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void CreateTable(SqlConnection sqlConnection, string cekName, string tableName)
+        {
+            string ColumnEncryptionAlgorithmName = @"AEAD_AES_256_CBC_HMAC_SHA_256";
+            string sql =
+                    $@"CREATE TABLE [dbo].[{tableName}]
+                (
+                    [CustomerId] [int] ENCRYPTED WITH (COLUMN_ENCRYPTION_KEY = [{cekName}], ENCRYPTION_TYPE = RANDOMIZED, ALGORITHM = '{ColumnEncryptionAlgorithmName}'),
+                    [FirstName] [nvarchar](50) COLLATE Latin1_General_BIN2 ENCRYPTED WITH (COLUMN_ENCRYPTION_KEY = [{cekName}], ENCRYPTION_TYPE = RANDOMIZED, ALGORITHM = '{ColumnEncryptionAlgorithmName}'),
+                    [LastName] [nvarchar](50) COLLATE Latin1_General_BIN2 ENCRYPTED WITH (COLUMN_ENCRYPTION_KEY = [{cekName}], ENCRYPTION_TYPE = RANDOMIZED, ALGORITHM = '{ColumnEncryptionAlgorithmName}')
+                )";
+            using (SqlCommand command = sqlConnection.CreateCommand())
+            {
+                command.CommandText = sql;
+                command.ExecuteNonQuery();
+            }
+        }
+
+        private void InsertData(SqlConnection sqlConnection, string tableName, Customer newCustomer)
+        {
+            string insertSql = $"INSERT INTO [{tableName}] (CustomerId, FirstName, LastName) VALUES (@CustomerId, @FirstName, @LastName);";
+            using (SqlTransaction sqlTransaction = sqlConnection.BeginTransaction())
+            using (SqlCommand sqlCommand = new SqlCommand(insertSql,
+            connection: sqlConnection, transaction: sqlTransaction,
+            columnEncryptionSetting: SqlCommandColumnEncryptionSetting.Enabled))
+            {
+                sqlCommand.Parameters.AddWithValue(@"CustomerId", newCustomer.Id);
+                sqlCommand.Parameters.AddWithValue(@"FirstName", newCustomer.FirstName);
+                sqlCommand.Parameters.AddWithValue(@"LastName", newCustomer.LastName);
+                sqlCommand.ExecuteNonQuery();
+                sqlTransaction.Commit();
+            }
+        }
+
+        private void VerifyData(SqlConnection sqlConnection, string tableName, Customer customer)
+        {
+            // Test INPUT parameter on an encrypted parameter
+            using (SqlCommand sqlCommand = new SqlCommand($"SELECT CustomerId, FirstName, LastName FROM [{tableName}] WHERE FirstName = @firstName",
+                                                            sqlConnection))
+            {
+                SqlParameter customerFirstParam = sqlCommand.Parameters.AddWithValue(@"firstName", @"Microsoft");
+                customerFirstParam.Direction = System.Data.ParameterDirection.Input;
+                customerFirstParam.ForceColumnEncryption = true;
+                using (SqlDataReader sqlDataReader = sqlCommand.ExecuteReader())
+                {
+                    ValidateResultSet(sqlDataReader);
+                }
+            }
+        }
+
+        private void ValidateResultSet(SqlDataReader sqlDataReader)
+        {
+            Assert.True(sqlDataReader.HasRows, "We didn't find any rows.");
+            while (sqlDataReader.Read())
+            {
+                Assert.True(sqlDataReader.GetInt32(0) == 1, "Employee Id didn't match");
+                Assert.True(sqlDataReader.GetString(1) == @"Microsoft", "Employee FirstName didn't match.");
+                Assert.True(sqlDataReader.GetString(2) == @"Corporation", "Employee LastName didn't match.");
+            }
+        }
+
+        private void DropTableIfExists(SqlConnection sqlConnection, string tableName)
+        {
+            string cmdText = $@"IF EXISTS (select * from sys.objects where name = '{tableName}') BEGIN DROP TABLE [{tableName}] END";
+            using (SqlCommand command = sqlConnection.CreateCommand())
+            {
+                command.CommandText = cmdText;
+                command.ExecuteNonQuery();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (DataTestUtility.IsEnclaveAzureDatabaseSetup() && DataTestUtility.EnclaveEnabled)
+            {
+                databaseObjects.Reverse();
+                foreach (string connStr in connStrings)
+                {
+                    using (SqlConnection sqlConnection = new SqlConnection(connStr))
+                    {
+                        sqlConnection.Open();
+                        databaseObjects.ForEach(o => o.Drop(sqlConnection));
+                    }
+                }
+            }
+        }
+    }    
+}

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/SQLSetupStrategyAzureKeyVault.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/SQLSetupStrategyAzureKeyVault.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 {
     public class SQLSetupStrategyAzureKeyVault : SQLSetupStrategy
     {
-        private static bool isAKVProviderRegistered = false;
+        internal static bool isAKVProviderRegistered = false;
 
         public Table AKVTestTable { get; private set; }
         public SqlColumnEncryptionAzureKeyVaultProvider AkvStoreProvider;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/SQLSetupStrategyAzureKeyVault.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/SQLSetupStrategyAzureKeyVault.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
         internal override void SetupDatabase()
         {
-            ColumnMasterKey akvColumnMasterKey = new AkvColumnMasterKey(GenerateUniqueName("AKVCMK"), akvUrl: DataTestUtility.AKVUrl);
+            ColumnMasterKey akvColumnMasterKey = new AkvColumnMasterKey(GenerateUniqueName("AKVCMK"), akvUrl: DataTestUtility.AKVUrl, AkvStoreProvider, DataTestUtility.EnclaveEnabled);
             databaseObjects.Add(akvColumnMasterKey);
 
             List<ColumnEncryptionKey> akvColumnEncryptionKeys = CreateColumnEncryptionKeys(akvColumnMasterKey, 2, AkvStoreProvider);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/AkvColumnMasterKey.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/AkvColumnMasterKey.cs
@@ -2,16 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup
 {
     public class AkvColumnMasterKey : ColumnMasterKey
     {
         public override string KeyPath { get; }
 
-        public AkvColumnMasterKey(string name, string akvUrl) : base(name)
+        public AkvColumnMasterKey(string name, string akvUrl, SqlColumnEncryptionKeyStoreProvider akvProvider, bool allowEnclaveComputations) : base(name)
         {
             KeyStoreProviderName = @"AZURE_KEY_VAULT";
             KeyPath = akvUrl;
+
+            // For keys which allow enclave computation
+            byte[] cmkSign = akvProvider.SignColumnMasterKeyMetadata(akvUrl, allowEnclaveComputations);
+            cmkSignStr = string.Concat("0x", BitConverter.ToString(cmkSign).Replace("-", string.Empty));
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CspColumnMasterKey.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CspColumnMasterKey.cs
@@ -14,21 +14,21 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup
         public string Thumbprint { get; }
         public override string KeyPath { get; }
 
-        public CspColumnMasterKey(string name, string certificateThumbprint, SqlColumnEncryptionKeyStoreProvider certStoreProvider, bool allEnclaveComputations) : base(name)
+        public CspColumnMasterKey(string name, string certificateThumbprint, SqlColumnEncryptionKeyStoreProvider certStoreProvider, bool allowEnclaveComputations) : base(name)
         {
             KeyStoreProviderName = @"MSSQL_CERTIFICATE_STORE";
             Thumbprint = certificateThumbprint;
             KeyPath = string.Concat(CertificateStoreLocation.ToString(), "/", CertificateStoreName.ToString(), "/", Thumbprint);
 
-            byte[] cmkSign = certStoreProvider.SignColumnMasterKeyMetadata(KeyPath, allEnclaveComputations);
+            byte[] cmkSign = certStoreProvider.SignColumnMasterKeyMetadata(KeyPath, allowEnclaveComputations);
             cmkSignStr = string.Concat("0x", BitConverter.ToString(cmkSign).Replace("-", string.Empty));
         }
 
-        public CspColumnMasterKey(string name, string providerName, string cspKeyPath, SqlColumnEncryptionKeyStoreProvider certStoreProvider, bool allEnclaveComputations) : base(name)
+        public CspColumnMasterKey(string name, string providerName, string cspKeyPath, SqlColumnEncryptionKeyStoreProvider certStoreProvider, bool allowEnclaveComputations) : base(name)
         {
             KeyStoreProviderName = providerName;
             KeyPath = cspKeyPath;
-            byte[] cmkSign = certStoreProvider.SignColumnMasterKeyMetadata(KeyPath, allEnclaveComputations);
+            byte[] cmkSign = certStoreProvider.SignColumnMasterKeyMetadata(KeyPath, allowEnclaveComputations);
             cmkSignStr = string.Concat("0x", BitConverter.ToString(cmkSign).Replace("-", string.Empty));
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static readonly bool IsDNSCachingSupportedCR = false;  // this is for the control ring
         public static readonly bool IsDNSCachingSupportedTR = false;  // this is for the tenant ring
 
+        public static readonly string EnclaveAzureDatabaseConnString = null;
+
         public const string UdtTestDbName = "UdtTestDb";
         public const string AKVKeyName = "TestSqlClientAzureKeyVaultProvider";
         private const string ManagedNetworkingAppContextSwitch = "Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows";
@@ -86,6 +88,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             public string DNSCachingServerTR = null;  // this is for the tenant ring
             public bool IsDNSCachingSupportedCR = false;  // this is for the control ring
             public bool IsDNSCachingSupportedTR = false;  // this is for the tenant ring
+            public string EnclaveAzureDatabaseConnString = null;
         }
 
         static DataTestUtility()
@@ -116,6 +119,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 DNSCachingServerTR = c.DNSCachingServerTR;
                 IsDNSCachingSupportedCR = c.IsDNSCachingSupportedCR;
                 IsDNSCachingSupportedTR = c.IsDNSCachingSupportedTR;
+
+                EnclaveAzureDatabaseConnString = c.EnclaveAzureDatabaseConnString;
 
                 if (TracingEnabled)
                 {
@@ -283,6 +288,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         public static bool IsDNSCachingSetup() => !string.IsNullOrEmpty(DNSCachingConnString);
+
+        public static bool IsEnclaveAzureDatabaseSetup() => !string.IsNullOrEmpty(EnclaveAzureDatabaseConnString);
 
         public static bool IsUdtTestDatabasePresent() => IsDatabasePresent(UdtTestDbName);
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -289,7 +289,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static bool IsDNSCachingSetup() => !string.IsNullOrEmpty(DNSCachingConnString);
 
-        public static bool IsEnclaveAzureDatabaseSetup() => !string.IsNullOrEmpty(EnclaveAzureDatabaseConnString);
+        public static bool IsEnclaveAzureDatabaseSetup()
+        {
+            return EnclaveEnabled && !string.IsNullOrEmpty(EnclaveAzureDatabaseConnString);
+        }  
 
         public static bool IsUdtTestDatabasePresent() => IsDatabasePresent(UdtTestDbName);
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="AlwaysEncrypted\End2EndSmokeTests.cs" />
     <Compile Include="AlwaysEncrypted\CspProviderExt.cs" />
     <Compile Include="AlwaysEncrypted\ConversionTests.cs" />
+    <Compile Include="AlwaysEncrypted\EnclaveAzureDatabaseTests.cs" />
     <Compile Include="AlwaysEncrypted\SqlBulkCopyTruncation.cs" />
     <Compile Include="AlwaysEncrypted\SqlNullValues.cs" />
     <Compile Include="AlwaysEncrypted\ExceptionsGenericError.cs" />


### PR DESCRIPTION
This PR is to fix the issue when connecting to Azure SQL databases with secure enclaves. 

The initial enclave session cache key only contains the enclave attestation URL and the server name. It works well with on-prem SQL Servers if we switch between various databases under the same server. However, this will fail for Azure SQL. Sharing the same enclave session among different databases under the same logic Azure server will cause the Azure attestation to fail.  

To fix this issue, the database name is also added to the enclave session cache key. 