### PR TITLE
Fix pooled connection re-use on access token expiry

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -29,7 +29,10 @@ namespace Microsoft.Data.Common
         internal static Task<bool> FalseTask => _falseTask ?? (_falseTask = Task.FromResult(false));
 
         internal const CompareOptions DefaultCompareOptions = CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase;
+        
         internal const int DefaultConnectionTimeout = DbConnectionStringDefaults.ConnectTimeout;
+        internal const int InfiniteConnectionTimeout = 0; // infinite connection timeout identifier in seconds
+        internal const int MaxBufferAccessTokenExpiry = 600; // max duration for buffer in seconds
 
         static private void TraceException(string trace, Exception e)
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -203,7 +203,8 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        virtual internal bool IsAccessTokenExpired => false;
+        internal virtual bool IsAccessTokenExpired => false;
+
         abstract protected void Activate(Transaction transaction);
 
         internal void ActivateConnection(Transaction transaction)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -203,14 +203,7 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        virtual internal bool IsAccessTokenExpired
-        {
-            get
-            {
-                return false;
-            }
-        }
-
+        virtual internal bool IsAccessTokenExpired => false;
         abstract protected void Activate(Transaction transaction);
 
         internal void ActivateConnection(Transaction transaction)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -203,6 +203,14 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
+        virtual internal bool IsAccessTokenExpired
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         abstract protected void Activate(Transaction transaction);
 
         internal void ActivateConnection(Transaction transaction)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -1285,6 +1285,13 @@ namespace Microsoft.Data.ProviderBase
                             _waitHandles.CreationSemaphore.Release(1);
                         }
                     }
+
+                    // Do not use this pooled connection if access token is about to expire soon before we can connect.
+                    if(null != obj && obj.IsAccessTokenExpired)
+                    {
+                        DestroyObject(obj);
+                        obj = null;
+                    }
                 } while (null == obj);
             }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Data.SqlClient
         {
             SqlConnectionString opt = (SqlConnectionString)options;
             SqlConnectionPoolKey key = (SqlConnectionPoolKey)poolKey;
-            SqlInternalConnection result = null;
             SessionData recoverySessionData = null;
 
             SqlConnection sqlOwningConnection = (SqlConnection)owningConnection;
@@ -131,8 +130,7 @@ namespace Microsoft.Data.SqlClient
                 opt = new SqlConnectionString(opt, instanceName, userInstance: false, setEnlistValue: null);
                 poolGroupProviderInfo = null; // null so we do not pass to constructor below...
             }
-            result = new SqlInternalConnectionTds(identity, opt, key.Credential, poolGroupProviderInfo, "", null, redirectedUserInstance, userOpt, recoverySessionData, applyTransientFaultHandling: applyTransientFaultHandling, key.AccessToken, pool);
-            return result;
+            return new SqlInternalConnectionTds(identity, opt, key.Credential, poolGroupProviderInfo, "", null, redirectedUserInstance, userOpt, recoverySessionData, applyTransientFaultHandling: applyTransientFaultHandling, key.AccessToken, pool);
         }
 
         protected override DbConnectionOptions CreateConnectionOptions(string connectionString, DbConnectionOptions previous)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -702,13 +702,7 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// Validates if federated authentication is used, Access Token used by this connection is active for the value of 'accessTokenExpirationBufferTime'.
         /// </summary>
-        internal override bool IsAccessTokenExpired
-        {
-            get
-            {
-                return _federatedAuthenticationInfoRequested && DateTime.FromFileTimeUtc(_fedAuthToken.expirationFileTime) < DateTime.UtcNow.AddSeconds(accessTokenExpirationBufferTime);
-            }
-        }
+        internal override bool IsAccessTokenExpired => _federatedAuthenticationInfoRequested && DateTime.FromFileTimeUtc(_fedAuthToken.expirationFileTime) < DateTime.UtcNow.AddSeconds(accessTokenExpirationBufferTime);
 
         ////////////////////////////////////////////////////////////////////////////////////////
         // GENERAL METHODS

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2193,6 +2193,7 @@ namespace Microsoft.Data.SqlClient
                 // If the code flow is here, then we are re-using the context from the cache for this connection attempt and not
                 // generating a new access token on this thread.
                 _fedAuthToken.accessToken = dbConnectionPoolAuthenticationContext.AccessToken;
+                _fedAuthToken.expirationFileTime = dbConnectionPoolAuthenticationContext.ExpirationTime.ToFileTime();
             }
 
             Debug.Assert(_fedAuthToken != null && _fedAuthToken.accessToken != null, "fedAuthToken and fedAuthToken.accessToken cannot be null.");

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -123,6 +123,9 @@ namespace Microsoft.Data.SqlClient
         internal bool _federatedAuthenticationAcknowledged;
         internal bool _federatedAuthenticationInfoRequested; // Keep this distinct from _federatedAuthenticationRequested, since some fedauth library types may not need more info
         internal bool _federatedAuthenticationInfoReceived;
+
+        // The Federated Authentication returned by TryGetFedAuthTokenLocked or GetFedAuthToken.
+        SqlFedAuthToken _fedAuthToken = null;
         internal byte[] _accessTokenInBytes;
 
         private readonly ActiveDirectoryAuthenticationTimeoutRetryHelper _activeDirectoryAuthTimeoutRetryHelper;
@@ -181,7 +184,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-       internal SQLDNSInfo pendingSQLDNSObject = null;   
+        internal SQLDNSInfo pendingSQLDNSObject = null;
 
         // TCE flags
         internal byte _tceVersionSupported;
@@ -684,6 +687,16 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <summary>
+        /// Validates if federated authentication is used, Access Token used by this connection is active for the next 10 minutes.
+        /// </summary>
+        internal override bool IsAccessTokenExpired
+        {
+            get
+            {
+                return _federatedAuthenticationInfoRequested && DateTime.FromFileTimeUtc(_fedAuthToken.expirationFileTime) < DateTime.UtcNow.AddMinutes(10d);
+            }
+        }
 
         ////////////////////////////////////////////////////////////////////////////////////////
         // GENERAL METHODS
@@ -2091,8 +2104,6 @@ namespace Microsoft.Data.SqlClient
             // We want to refresh the token, if taking the lock on the authentication context is successful.
             bool attemptRefreshTokenLocked = false;
 
-            // The Federated Authentication returned by TryGetFedAuthTokenLocked or GetFedAuthToken.
-            SqlFedAuthToken fedAuthToken = null;
 
             if (_dbConnectionPool != null)
             {
@@ -2127,7 +2138,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else if (_forceExpiryLocked)
                     {
-                        attemptRefreshTokenLocked = TryGetFedAuthTokenLocked(fedAuthInfo, dbConnectionPoolAuthenticationContext, out fedAuthToken);
+                        attemptRefreshTokenLocked = TryGetFedAuthTokenLocked(fedAuthInfo, dbConnectionPoolAuthenticationContext, out _fedAuthToken);
                     }
 #endif
 
@@ -2141,11 +2152,11 @@ namespace Microsoft.Data.SqlClient
 
                         // Call the function which tries to acquire a lock over the authentication context before trying to update.
                         // If the lock could not be obtained, it will return false, without attempting to fetch a new token.
-                        attemptRefreshTokenLocked = TryGetFedAuthTokenLocked(fedAuthInfo, dbConnectionPoolAuthenticationContext, out fedAuthToken);
+                        attemptRefreshTokenLocked = TryGetFedAuthTokenLocked(fedAuthInfo, dbConnectionPoolAuthenticationContext, out _fedAuthToken);
 
                         // If TryGetFedAuthTokenLocked returns true, it means lock was obtained and fedAuthToken should not be null.
                         // If there was an exception in retrieving the new token, TryGetFedAuthTokenLocked should have thrown, so we won't be here.
-                        Debug.Assert(!attemptRefreshTokenLocked || fedAuthToken != null, "Either Lock should not have been obtained or fedAuthToken should not be null.");
+                        Debug.Assert(!attemptRefreshTokenLocked || _fedAuthToken != null, "Either Lock should not have been obtained or fedAuthToken should not be null.");
                         Debug.Assert(!attemptRefreshTokenLocked || _newDbConnectionPoolAuthenticationContext != null, "Either Lock should not have been obtained or _newDbConnectionPoolAuthenticationContext should not be null.");
 
                         // Indicate in EventSource Trace that we are successful with the update.
@@ -2162,8 +2173,8 @@ namespace Microsoft.Data.SqlClient
             if (dbConnectionPoolAuthenticationContext == null || attemptRefreshTokenUnLocked)
             {
                 // Get the Federated Authentication Token.
-                fedAuthToken = GetFedAuthToken(fedAuthInfo);
-                Debug.Assert(fedAuthToken != null, "fedAuthToken should not be null.");
+                _fedAuthToken = GetFedAuthToken(fedAuthInfo);
+                Debug.Assert(_fedAuthToken != null, "fedAuthToken should not be null.");
 
                 if (_dbConnectionPool != null)
                 {
@@ -2174,18 +2185,18 @@ namespace Microsoft.Data.SqlClient
             else if (!attemptRefreshTokenLocked)
             {
                 Debug.Assert(dbConnectionPoolAuthenticationContext != null, "dbConnectionPoolAuthenticationContext should not be null.");
-                Debug.Assert(fedAuthToken == null, "fedAuthToken should be null in this case.");
+                Debug.Assert(_fedAuthToken == null, "fedAuthToken should be null in this case.");
                 Debug.Assert(_newDbConnectionPoolAuthenticationContext == null, "_newDbConnectionPoolAuthenticationContext should be null.");
 
-                fedAuthToken = new SqlFedAuthToken();
+                _fedAuthToken = new SqlFedAuthToken();
 
                 // If the code flow is here, then we are re-using the context from the cache for this connection attempt and not
                 // generating a new access token on this thread.
-                fedAuthToken.accessToken = dbConnectionPoolAuthenticationContext.AccessToken;
+                _fedAuthToken.accessToken = dbConnectionPoolAuthenticationContext.AccessToken;
             }
 
-            Debug.Assert(fedAuthToken != null && fedAuthToken.accessToken != null, "fedAuthToken and fedAuthToken.accessToken cannot be null.");
-            _parser.SendFedAuthToken(fedAuthToken);
+            Debug.Assert(_fedAuthToken != null && _fedAuthToken.accessToken != null, "fedAuthToken and fedAuthToken.accessToken cannot be null.");
+            _parser.SendFedAuthToken(_fedAuthToken);
         }
 
         /// <summary>
@@ -2260,7 +2271,7 @@ namespace Microsoft.Data.SqlClient
             int numberOfAttempts = 0;
 
             // Object that will be returned to the caller, containing all required data about the token.
-            SqlFedAuthToken fedAuthToken = new SqlFedAuthToken();
+            _fedAuthToken = new SqlFedAuthToken();
 
             // Username to use in error messages.
             string username = null;
@@ -2300,31 +2311,31 @@ namespace Microsoft.Data.SqlClient
 
                             if (_activeDirectoryAuthTimeoutRetryHelper.State == ActiveDirectoryAuthenticationTimeoutRetryState.Retrying)
                             {
-                                fedAuthToken = _activeDirectoryAuthTimeoutRetryHelper.CachedToken;
+                                _fedAuthToken = _activeDirectoryAuthTimeoutRetryHelper.CachedToken;
                             }
                             else
                             {
-                                Task.Run(() => fedAuthToken = authProvider.AcquireTokenAsync(authParamsBuilder).Result.ToSqlFedAuthToken()).Wait();
-                                _activeDirectoryAuthTimeoutRetryHelper.CachedToken = fedAuthToken;
+                                Task.Run(() => _fedAuthToken = authProvider.AcquireTokenAsync(authParamsBuilder).Result.ToSqlFedAuthToken()).Wait();
+                                _activeDirectoryAuthTimeoutRetryHelper.CachedToken = _fedAuthToken;
                             }
                             break;
                         case SqlAuthenticationMethod.ActiveDirectoryInteractive:
                             if (_activeDirectoryAuthTimeoutRetryHelper.State == ActiveDirectoryAuthenticationTimeoutRetryState.Retrying)
                             {
-                                fedAuthToken = _activeDirectoryAuthTimeoutRetryHelper.CachedToken;
+                                _fedAuthToken = _activeDirectoryAuthTimeoutRetryHelper.CachedToken;
                             }
                             else
                             {
                                 authParamsBuilder.WithUserId(ConnectionOptions.UserID);
-                                Task.Run(() => fedAuthToken = authProvider.AcquireTokenAsync(authParamsBuilder).Result.ToSqlFedAuthToken()).Wait();
-                                _activeDirectoryAuthTimeoutRetryHelper.CachedToken = fedAuthToken;
+                                Task.Run(() => _fedAuthToken = authProvider.AcquireTokenAsync(authParamsBuilder).Result.ToSqlFedAuthToken()).Wait();
+                                _activeDirectoryAuthTimeoutRetryHelper.CachedToken = _fedAuthToken;
                             }
                             break;
                         case SqlAuthenticationMethod.ActiveDirectoryPassword:
                         case SqlAuthenticationMethod.ActiveDirectoryServicePrincipal:
                             if (_activeDirectoryAuthTimeoutRetryHelper.State == ActiveDirectoryAuthenticationTimeoutRetryState.Retrying)
                             {
-                                fedAuthToken = _activeDirectoryAuthTimeoutRetryHelper.CachedToken;
+                                _fedAuthToken = _activeDirectoryAuthTimeoutRetryHelper.CachedToken;
                             }
                             else
                             {
@@ -2332,22 +2343,22 @@ namespace Microsoft.Data.SqlClient
                                 {
                                     username = _credential.UserId;
                                     authParamsBuilder.WithUserId(username).WithPassword(_credential.Password);
-                                    Task.Run(() => fedAuthToken = authProvider.AcquireTokenAsync(authParamsBuilder).Result.ToSqlFedAuthToken()).Wait();
+                                    Task.Run(() => _fedAuthToken = authProvider.AcquireTokenAsync(authParamsBuilder).Result.ToSqlFedAuthToken()).Wait();
                                 }
                                 else
                                 {
                                     username = ConnectionOptions.UserID;
                                     authParamsBuilder.WithUserId(username).WithPassword(ConnectionOptions.Password);
-                                    Task.Run(() => fedAuthToken = authProvider.AcquireTokenAsync(authParamsBuilder).Result.ToSqlFedAuthToken()).Wait();
+                                    Task.Run(() => _fedAuthToken = authProvider.AcquireTokenAsync(authParamsBuilder).Result.ToSqlFedAuthToken()).Wait();
                                 }
-                                _activeDirectoryAuthTimeoutRetryHelper.CachedToken = fedAuthToken;
+                                _activeDirectoryAuthTimeoutRetryHelper.CachedToken = _fedAuthToken;
                             }
                             break;
                         default:
                             throw SQL.UnsupportedAuthenticationSpecified(ConnectionOptions.Authentication);
                     }
 
-                    Debug.Assert(fedAuthToken.accessToken != null, "AccessToken should not be null.");
+                    Debug.Assert(_fedAuthToken.accessToken != null, "AccessToken should not be null.");
 #if DEBUG
                     if (_forceMsalRetry)
                     {
@@ -2417,28 +2428,29 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            Debug.Assert(fedAuthToken != null, "fedAuthToken should not be null.");
-            Debug.Assert(fedAuthToken.accessToken != null && fedAuthToken.accessToken.Length > 0, "fedAuthToken.accessToken should not be null or empty.");
+            Debug.Assert(_fedAuthToken != null, "fedAuthToken should not be null.");
+            Debug.Assert(_fedAuthToken.accessToken != null && _fedAuthToken.accessToken.Length > 0, "fedAuthToken.accessToken should not be null or empty.");
 
             // Store the newly generated token in _newDbConnectionPoolAuthenticationContext, only if using pooling.
             if (_dbConnectionPool != null)
             {
-                DateTime expirationTime = DateTime.FromFileTimeUtc(fedAuthToken.expirationFileTime);
-                _newDbConnectionPoolAuthenticationContext = new DbConnectionPoolAuthenticationContext(fedAuthToken.accessToken, expirationTime);
+                DateTime expirationTime = DateTime.FromFileTimeUtc(_fedAuthToken.expirationFileTime);
+                _newDbConnectionPoolAuthenticationContext = new DbConnectionPoolAuthenticationContext(_fedAuthToken.accessToken, expirationTime);
             }
             SqlClientEventSource.Log.TraceEvent("<sc.SqlInternalConnectionTds.GetFedAuthToken> {0}, Finished generating federated authentication token.", ObjectID);
-            return fedAuthToken;
+            return _fedAuthToken;
         }
 
         internal void OnFeatureExtAck(int featureId, byte[] data)
         {
             if (RoutingInfo != null)
             {
-                if (TdsEnums.FEATUREEXT_SQLDNSCACHING != featureId) {
+                if (TdsEnums.FEATUREEXT_SQLDNSCACHING != featureId)
+                {
                     return;
                 }
             }
-            
+
             switch (featureId)
             {
                 case TdsEnums.FEATUREEXT_SRECOVERY:
@@ -2636,16 +2648,18 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
 
-                        if (1 == data[0]) {
+                        if (1 == data[0])
+                        {
                             IsSQLDNSCachingSupported = true;
                             _cleanSQLDNSCaching = false;
-                            
+
                             if (RoutingInfo != null)
                             {
                                 IsDNSCachingBeforeRedirectSupported = true;
                             }
                         }
-                        else {
+                        else
+                        {
                             // we receive the IsSupported whose value is 0
                             IsSQLDNSCachingSupported = false;
                             _cleanSQLDNSCaching = true;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -2180,6 +2180,8 @@ namespace Microsoft.Data.Common
         internal const int DecimalMaxPrecision28 = 28;  // there are some cases in Odbc where we need that ...
         internal const int DefaultCommandTimeout = 30;
         internal const int DefaultConnectionTimeout = DbConnectionStringDefaults.ConnectTimeout;
+        internal const int InfiniteConnectionTimeout = 0; // infinite connection timeout identifier in seconds
+        internal const int MaxBufferAccessTokenExpiry = 600; // max duration for buffer in seconds
         internal const float FailoverTimeoutStep = 0.08F;    // fraction of timeout to use for fast failover connections
         internal const float FailoverTimeoutStepForTnir = 0.125F; // Fraction of timeout to use in case of Transparent Network IP resolution.
         internal const int MinimumTimeoutForTnirMs = 500; // The first login attempt in  Transparent network IP Resolution 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -381,6 +381,13 @@ namespace Microsoft.Data.ProviderBase
                 return _state;
             }
         }
+        virtual internal bool IsAccessTokenExpired
+        {
+            get
+            {
+                return false;
+            }
+        }
 
         abstract protected void Activate(SysTx.Transaction transaction);
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -381,7 +381,8 @@ namespace Microsoft.Data.ProviderBase
                 return _state;
             }
         }
-        virtual internal bool IsAccessTokenExpired => false;
+
+        internal virtual bool IsAccessTokenExpired => false;
 
         abstract protected void Activate(SysTx.Transaction transaction);
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -381,13 +381,7 @@ namespace Microsoft.Data.ProviderBase
                 return _state;
             }
         }
-        virtual internal bool IsAccessTokenExpired
-        {
-            get
-            {
-                return false;
-            }
-        }
+        virtual internal bool IsAccessTokenExpired => false;
 
         abstract protected void Activate(SysTx.Transaction transaction);
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -1528,6 +1528,13 @@ namespace Microsoft.Data.ProviderBase
                     {
                         Marshal.ThrowExceptionForHR(releaseSemaphoreResult); // will only throw if (hresult < 0)
                     }
+
+                    // Do not use this pooled connection if access token is about to expire soon before we can connect.
+                    if (null != obj && obj.IsAccessTokenExpired)
+                    {
+                        DestroyObject(obj);
+                        obj = null;
+                    }
                 } while (null == obj);
             }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2638,6 +2638,7 @@ namespace Microsoft.Data.SqlClient
                 // If the code flow is here, then we are re-using the context from the cache for this connection attempt and not
                 // generating a new access token on this thread.
                 _fedAuthToken.accessToken = dbConnectionPoolAuthenticationContext.AccessToken;
+                _fedAuthToken.expirationFileTime = dbConnectionPoolAuthenticationContext.ExpirationTime.ToFileTime();
             }
 
             Debug.Assert(_fedAuthToken != null && _fedAuthToken.accessToken != null, "_fedAuthToken and _fedAuthToken.accessToken cannot be null.");

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -824,13 +824,7 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// Validates if federated authentication is used, Access Token used by this connection is active for the value of 'accessTokenExpirationBufferTime'.
         /// </summary>
-        internal override bool IsAccessTokenExpired
-        {
-            get
-            {
-                return _federatedAuthenticationInfoRequested && DateTime.FromFileTimeUtc(_fedAuthToken.expirationFileTime) < DateTime.UtcNow.AddSeconds(accessTokenExpirationBufferTime);
-            }
-        }
+        internal override bool IsAccessTokenExpired => _federatedAuthenticationInfoRequested && DateTime.FromFileTimeUtc(_fedAuthToken.expirationFileTime) < DateTime.UtcNow.AddSeconds(accessTokenExpirationBufferTime);
 
         ////////////////////////////////////////////////////////////////////////////////////////
         // GENERAL METHODS

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -131,13 +131,14 @@ namespace Microsoft.Data.SqlClient
         internal bool _federatedAuthenticationInfoRequested; // Keep this distinct from _federatedAuthenticationRequested, since some fedauth library types may not need more info
         internal bool _federatedAuthenticationInfoReceived;
 
+        // The Federated Authentication returned by TryGetFedAuthTokenLocked or GetFedAuthToken.
+        SqlFedAuthToken _fedAuthToken = null;
         internal byte[] _accessTokenInBytes;
 
         private readonly ActiveDirectoryAuthenticationTimeoutRetryHelper _activeDirectoryAuthTimeoutRetryHelper;
         private readonly SqlAuthenticationProviderManager _sqlAuthenticationProviderManager;
 
         // Certificate auth calbacks.
-        //
         ServerCertificateValidationCallback _serverCallback;
         ClientCertificateRetrievalCallback _clientCallback;
         SqlClientOriginalNetworkAddressInfo _originalNetworkAddressInfo;
@@ -808,6 +809,16 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <summary>
+        /// Validates if federated authentication is used, Access Token used by this connection is active for the next 10 minutes.
+        /// </summary>
+        internal override bool IsAccessTokenExpired
+        {
+            get
+            {
+                return _federatedAuthenticationInfoRequested && DateTime.FromFileTimeUtc(_fedAuthToken.expirationFileTime) < DateTime.UtcNow.AddMinutes(10d);
+            }
+        }
 
         ////////////////////////////////////////////////////////////////////////////////////////
         // GENERAL METHODS
@@ -2538,9 +2549,6 @@ namespace Microsoft.Data.SqlClient
             // We want to refresh the token, if taking the lock on the authentication context is successful.
             bool attemptRefreshTokenLocked = false;
 
-            // The Federated Authentication returned by TryGetFedAuthTokenLocked or GetFedAuthToken.
-            SqlFedAuthToken fedAuthToken = null;
-
             if (_dbConnectionPool != null)
             {
                 Debug.Assert(_dbConnectionPool.AuthenticationContexts != null);
@@ -2575,7 +2583,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else if (_forceExpiryLocked)
                     {
-                        attemptRefreshTokenLocked = TryGetFedAuthTokenLocked(fedAuthInfo, dbConnectionPoolAuthenticationContext, out fedAuthToken);
+                        attemptRefreshTokenLocked = TryGetFedAuthTokenLocked(fedAuthInfo, dbConnectionPoolAuthenticationContext, out _fedAuthToken);
                     }
 #endif
 
@@ -2589,11 +2597,11 @@ namespace Microsoft.Data.SqlClient
 
                         // Call the function which tries to acquire a lock over the authentication context before trying to update.
                         // If the lock could not be obtained, it will return false, without attempting to fetch a new token.
-                        attemptRefreshTokenLocked = TryGetFedAuthTokenLocked(fedAuthInfo, dbConnectionPoolAuthenticationContext, out fedAuthToken);
+                        attemptRefreshTokenLocked = TryGetFedAuthTokenLocked(fedAuthInfo, dbConnectionPoolAuthenticationContext, out _fedAuthToken);
 
-                        // If TryGetFedAuthTokenLocked returns true, it means lock was obtained and fedAuthToken should not be null.
+                        // If TryGetFedAuthTokenLocked returns true, it means lock was obtained and _fedAuthToken should not be null.
                         // If there was an exception in retrieving the new token, TryGetFedAuthTokenLocked should have thrown, so we won't be here.
-                        Debug.Assert(!attemptRefreshTokenLocked || fedAuthToken != null, "Either Lock should not have been obtained or fedAuthToken should not be null.");
+                        Debug.Assert(!attemptRefreshTokenLocked || _fedAuthToken != null, "Either Lock should not have been obtained or _fedAuthToken should not be null.");
                         Debug.Assert(!attemptRefreshTokenLocked || _newDbConnectionPoolAuthenticationContext != null, "Either Lock should not have been obtained or _newDbConnectionPoolAuthenticationContext should not be null.");
 
                         // Indicate in Bid Trace that we are successful with the update.
@@ -2610,8 +2618,8 @@ namespace Microsoft.Data.SqlClient
             if (dbConnectionPoolAuthenticationContext == null || attemptRefreshTokenUnLocked)
             {
                 // Get the Federated Authentication Token.
-                fedAuthToken = GetFedAuthToken(fedAuthInfo);
-                Debug.Assert(fedAuthToken != null, "fedAuthToken should not be null.");
+                _fedAuthToken = GetFedAuthToken(fedAuthInfo);
+                Debug.Assert(_fedAuthToken != null, "_fedAuthToken should not be null.");
 
                 if (_dbConnectionPool != null)
                 {
@@ -2622,18 +2630,18 @@ namespace Microsoft.Data.SqlClient
             else if (!attemptRefreshTokenLocked)
             {
                 Debug.Assert(dbConnectionPoolAuthenticationContext != null, "dbConnectionPoolAuthenticationContext should not be null.");
-                Debug.Assert(fedAuthToken == null, "fedAuthToken should be null in this case.");
+                Debug.Assert(_fedAuthToken == null, "_fedAuthToken should be null in this case.");
                 Debug.Assert(_newDbConnectionPoolAuthenticationContext == null, "_newDbConnectionPoolAuthenticationContext should be null.");
 
-                fedAuthToken = new SqlFedAuthToken();
+                _fedAuthToken = new SqlFedAuthToken();
 
                 // If the code flow is here, then we are re-using the context from the cache for this connection attempt and not
                 // generating a new access token on this thread.
-                fedAuthToken.accessToken = dbConnectionPoolAuthenticationContext.AccessToken;
+                _fedAuthToken.accessToken = dbConnectionPoolAuthenticationContext.AccessToken;
             }
 
-            Debug.Assert(fedAuthToken != null && fedAuthToken.accessToken != null, "fedAuthToken and fedAuthToken.accessToken cannot be null.");
-            _parser.SendFedAuthToken(fedAuthToken);
+            Debug.Assert(_fedAuthToken != null && _fedAuthToken.accessToken != null, "_fedAuthToken and _fedAuthToken.accessToken cannot be null.");
+            _parser.SendFedAuthToken(_fedAuthToken);
         }
 
         /// <summary>
@@ -2873,7 +2881,8 @@ namespace Microsoft.Data.SqlClient
         {
             if (_routingInfo != null)
             {
-                if (TdsEnums.FEATUREEXT_SQLDNSCACHING != featureId) {
+                if (TdsEnums.FEATUREEXT_SQLDNSCACHING != featureId)
+                {
                     return;
                 }
             }
@@ -3101,16 +3110,18 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
 
-                        if (1 == data[0]) {
+                        if (1 == data[0])
+                        {
                             IsSQLDNSCachingSupported = true;
                             _cleanSQLDNSCaching = false;
-                            
+
                             if (_routingInfo != null)
                             {
                                 IsDNSCachingBeforeRedirectSupported = true;
                             }
                         }
-                        else {
+                        else
+                        {
                             // we receive the IsSupported whose value is 0
                             IsSQLDNSCachingSupported = false;
                             _cleanSQLDNSCaching = true;


### PR DESCRIPTION
Fixes #617 

When federated authentication mode is used, the driver continues to re-use pooled connection even if associated access token is expired. This leads to failures on client environments when Azure DB re-validates credentials after 10 hours (as of now), and physical connection ends up no longer usable.

This PR fixes the behavior and does not let the pooled connection be re-used again if associated access token is due expire soon.

NuGet package for testing is available here:
https://dev.azure.com/sqlclientdrivers-ci/sqlclient/_build/results?buildId=13352&view=artifacts&type=publishedArtifacts