### PR TITLE
Fix transient fault handling for Pooled connections

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -530,6 +530,8 @@ namespace Microsoft.Data.SqlClient
             {
                 if (s_transientErrors.Contains(error.Number))
                 {
+                    // When server timeouts, connection is doomed. Reset here to allow reconnect.
+                    UnDoomThisConnection();
                     return true;
                 }
             }
@@ -1610,7 +1612,7 @@ namespace Microsoft.Data.SqlClient
             timeout.Reset();
             // When server timeout, the auth context key was already created. Clean it up here.
             _dbConnectionPoolAuthenticationContextKey = null;
-            // When server timeout, connection is doomed. Reset here to allow reconnect.
+            // When server timeouts, connection is doomed. Reset here to allow reconnect.
             UnDoomThisConnection();
             // Change retry state so it only retries once for timeout error.
             _activeDirectoryAuthTimeoutRetryHelper.State = ActiveDirectoryAuthenticationTimeoutRetryState.Retrying;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -620,6 +620,8 @@ namespace Microsoft.Data.SqlClient
             {
                 if (transientErrors.Contains(error.Number))
                 {
+                    // When server timeouts, connection is doomed. Reset here to allow reconnect.
+                    UnDoomThisConnection();
                     return true;
                 }
             }
@@ -1960,7 +1962,7 @@ namespace Microsoft.Data.SqlClient
             timeout.Reset();
             // When server timeout, the auth context key was already created. Clean it up here.
             _dbConnectionPoolAuthenticationContextKey = null;
-            // When server timeout, connection is doomed. Reset here to allow reconnect.
+            // When server timeouts, connection is doomed. Reset here to allow reconnect.
             UnDoomThisConnection();
             // Change retry state so it only retries once for timeout error.
             _activeDirectoryAuthTimeoutRetryHelper.State = ActiveDirectoryAuthenticationTimeoutRetryState.Retrying;


### PR DESCRIPTION
All versions of SqlClient (including System.Data.SqlClient) that support Transient Fault Handling do not reset the connection before retrying for transient fault handling cases and if Azure connections fail to connect first time **due to server timeout**, the next round of connect fails with below error:

```bash
Type=System.InvalidOperationException.Message=Internal .Net Framework Data Provider error 6.
```

When pooling is disabled, apps are able to connect with Transient Fault Handling.
The PR fixes this issue for pooled connections.

NuGet package for testing: [Published Artifacts](https://dev.azure.com/sqlclientdrivers-ci/sqlclient/_build/results?buildId=13583&view=artifacts&type=publishedArtifacts)