### PR TITLE
Fix typo in build guide

### DIFF
--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -179,10 +179,10 @@ For .NET Core, all 4 reference types are supported:
 For .NET Framework, below reference types are supported:
 
 ```bash
-> msbuild /t:BuildTestsNetCore /p:ReferenceType=Project
+> msbuild /t:BuildTestsNetFx /p:ReferenceType=Project
 # Default setting uses Project Reference.
 
-> msbuild /t:BuildTestsNetCore /p:ReferenceType=Package
+> msbuild /t:BuildTestsNetFx /p:ReferenceType=Package
 ```
 
 ### Running Tests:


### PR DESCRIPTION
`BuildTestsNetCore` to `BuildTestsNetFx`