### PR TITLE
Small spanifications

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1616,45 +1616,47 @@ namespace Microsoft.Data.SqlClient
         {
             if (null == stateObj._bIntBytes)
             {
-                stateObj._bIntBytes = new byte[4];
+                stateObj._bIntBytes = new byte[sizeof(int)];
             }
             else
             {
-                Debug.Assert(4 == stateObj._bIntBytes.Length);
+                Debug.Assert(sizeof(int) == stateObj._bIntBytes.Length);
             }
 
-            int current = 0;
-            byte[] bytes = stateObj._bIntBytes;
-            bytes[current++] = (byte)(v & 0xff);
-            bytes[current++] = (byte)((v >> 8) & 0xff);
-            bytes[current++] = (byte)((v >> 16) & 0xff);
-            bytes[current++] = (byte)((v >> 24) & 0xff);
-            return bytes;
+            WriteInt(stateObj._bIntBytes.AsSpan(), v);
+            return stateObj._bIntBytes;
         }
 
-        //
-        // Takes an int and writes it as an int.
-        //
         internal void WriteInt(int v, TdsParserStateObject stateObj)
         {
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            WriteInt(buffer, v);
             if ((stateObj._outBytesUsed + 4) > stateObj._outBuff.Length)
             {
                 // if all of the int doesn't fit into the buffer
-                for (int shiftValue = 0; shiftValue < sizeof(int) * 8; shiftValue += 8)
+                for (int index = 0; index < sizeof(int); index++)
                 {
-                    stateObj.WriteByte((byte)((v >> shiftValue) & 0xff));
+                    stateObj.WriteByte(buffer[index]);
                 }
             }
             else
             {
                 // all of the int fits into the buffer
-                // NOTE: We don't use a loop here for performance
-                stateObj._outBuff[stateObj._outBytesUsed] = (byte)(v & 0xff);
-                stateObj._outBuff[stateObj._outBytesUsed + 1] = (byte)((v >> 8) & 0xff);
-                stateObj._outBuff[stateObj._outBytesUsed + 2] = (byte)((v >> 16) & 0xff);
-                stateObj._outBuff[stateObj._outBytesUsed + 3] = (byte)((v >> 24) & 0xff);
+                buffer.CopyTo(stateObj._outBuff.AsSpan(stateObj._outBytesUsed, sizeof(int)));
                 stateObj._outBytesUsed += 4;
             }
+        }
+
+        internal static void WriteInt(Span<byte> buffer, int value)
+        {
+#if netcoreapp
+            BitConverter.TryWriteBytes(buffer, value);
+#else
+            buffer[0] = (byte)(value & 0xff);
+            buffer[1] = (byte)((value >> 8) & 0xff);
+            buffer[2] = (byte)((value >> 16) & 0xff);
+            buffer[3] = (byte)((value >> 24) & 0xff);
+#endif
         }
 
         //

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -1397,36 +1397,28 @@ namespace Microsoft.Data.SqlClient
         {
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
 
-            byte[] buffer;
-            int offset;
+            Span<byte> buffer = stackalloc byte[2];
             if (((_inBytesUsed + 2) > _inBytesRead) || (_inBytesPacket < 2))
             {
                 // If the char isn't fully in the buffer, or if it isn't fully in the packet,
                 // then use ReadByteArray since the logic is there to take care of that.
-
-                if (!TryReadByteArray(_bTmp, 2))
+                if (!TryReadByteArray(buffer, 2))
                 {
                     value = '\0';
                     return false;
                 }
-
-                buffer = _bTmp;
-                offset = 0;
             }
             else
             {
                 // The entire char is in the packet and in the buffer, so just return it
                 // and take care of the counters.
-
-                buffer = _inBuff;
-                offset = _inBytesUsed;
-
+                buffer = _inBuff.AsSpan(_inBytesUsed, 2);
                 _inBytesUsed += 2;
                 _inBytesPacket -= 2;
             }
 
             AssertValidState();
-            value = (char)((buffer[offset + 1] << 8) + buffer[offset]);
+            value = (char)((buffer[1] << 8) + buffer[0]);
             return true;
         }
 
@@ -1434,70 +1426,58 @@ namespace Microsoft.Data.SqlClient
         {
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
 
-            byte[] buffer;
-            int offset;
+            Span<byte> buffer = stackalloc byte[2];
             if (((_inBytesUsed + 2) > _inBytesRead) || (_inBytesPacket < 2))
             {
                 // If the int16 isn't fully in the buffer, or if it isn't fully in the packet,
                 // then use ReadByteArray since the logic is there to take care of that.
-
-                if (!TryReadByteArray(_bTmp, 2))
+                if (!TryReadByteArray(buffer, 2))
                 {
                     value = default;
                     return false;
                 }
-
-                buffer = _bTmp;
-                offset = 0;
             }
             else
             {
                 // The entire int16 is in the packet and in the buffer, so just return it
                 // and take care of the counters.
-
-                buffer = _inBuff;
-                offset = _inBytesUsed;
-
+                buffer = _inBuff.AsSpan(_inBytesUsed,2);
                 _inBytesUsed += 2;
                 _inBytesPacket -= 2;
             }
 
             AssertValidState();
-            value = (short)((buffer[offset + 1] << 8) + buffer[offset]);
+            value = (short)((buffer[1] << 8) + buffer[0]);
             return true;
         }
 
         internal bool TryReadInt32(out int value)
         {
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
+            Span<byte> buffer = stackalloc byte[4];
             if (((_inBytesUsed + 4) > _inBytesRead) || (_inBytesPacket < 4))
             {
                 // If the int isn't fully in the buffer, or if it isn't fully in the packet,
                 // then use ReadByteArray since the logic is there to take care of that.
-
-                if (!TryReadByteArray(_bTmp, 4))
+                if (!TryReadByteArray(buffer, 4))
                 {
                     value = 0;
                     return false;
                 }
-
-                AssertValidState();
-                value = BitConverter.ToInt32(_bTmp, 0);
-                return true;
             }
             else
             {
                 // The entire int is in the packet and in the buffer, so just return it
                 // and take care of the counters.
-
-                value = BitConverter.ToInt32(_inBuff, _inBytesUsed);
-
+                buffer = _inBuff.AsSpan(_inBytesUsed, 4);
                 _inBytesUsed += 4;
                 _inBytesPacket -= 4;
-
-                AssertValidState();
-                return true;
             }
+
+            AssertValidState();
+            value = (buffer[3] << 24) + (buffer[2] <<16) + (buffer[1] << 8) + buffer[0];
+            return true;
+
         }
 
         // This method is safe to call when doing async without snapshot
@@ -1553,36 +1533,28 @@ namespace Microsoft.Data.SqlClient
         {
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
 
-            byte[] buffer;
-            int offset;
+            Span<byte> buffer = stackalloc byte[2];
             if (((_inBytesUsed + 2) > _inBytesRead) || (_inBytesPacket < 2))
             {
                 // If the uint16 isn't fully in the buffer, or if it isn't fully in the packet,
                 // then use ReadByteArray since the logic is there to take care of that.
-
-                if (!TryReadByteArray(_bTmp, 2))
+                if (!TryReadByteArray(buffer, 2))
                 {
                     value = default;
                     return false;
                 }
-
-                buffer = _bTmp;
-                offset = 0;
             }
             else
             {
                 // The entire uint16 is in the packet and in the buffer, so just return it
                 // and take care of the counters.
-
-                buffer = _inBuff;
-                offset = _inBytesUsed;
-
+                buffer = _inBuff.AsSpan(_inBytesUsed, 2);
                 _inBytesUsed += 2;
                 _inBytesPacket -= 2;
             }
 
             AssertValidState();
-            value = (ushort)((buffer[offset + 1] << 8) + buffer[offset]);
+            value = (ushort)((buffer[1] << 8) + buffer[0]);
             return true;
         }
 
@@ -3621,8 +3593,8 @@ namespace Microsoft.Data.SqlClient
                 statistics.RequestNetworkServerTimer();
             }
         }
-        [Conditional("DEBUG")]
 
+        [Conditional("DEBUG")]
         private void AssertValidState()
         {
             if (_inBytesUsed < 0 || _inBytesRead < 0)


### PR DESCRIPTION
Two pretty small changes.

The use of a shared temp array in some places was bothering me so I've replaced it with a const sized stack allocated span that the jit will simply allocate as part of the stack frame and then work entirely on locals. This should allow better codegen and referential locality.

The presence of multiple ways of writing an int to an array was wasteful. The most efficient way to do this is to use the netcore BitConverter.TryWriteByte method which uses MemoryMarshal to do safe il level tricks to write all 4 bytes in one. If that isn't present (netstandard, netfx) then do it using const offsets so the codegen can reorder or pipeline them efficiently.

Measuring a real-world impact of either of these in the context of the entire library is impossible. These are opinionated changes based on good performance practice picked up from work in corefx and I believe they improve the code quality overall.
