### PR TITLE
Only check inexact match when no exact match is found.

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Data.ProviderBase
                             exactCollectionName = candidateCollectionName;
                             haveExactMatch = true;
                         }
-                        else
+                        else if (haveExactMatch == false)
                         {
                             // have an inexact match - ok only if it is the only one
                             if (exactCollectionName != null)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Data.ProviderBase
                             exactCollectionName = candidateCollectionName;
                             haveExactMatch = true;
                         }
-                        else
+                        else if (haveExactMatch == false)
                         {
                             // have an inexact match - ok only if it is the only one
                             if (exactCollectionName != null)


### PR DESCRIPTION
Fix dotnet/runtime#39620

The same as dotnet/runtime#39961

Avoid the exact match result be overwrite by later inexact ones.
This may not happen due to limited callsites, just make the code more clear.