### PR TITLE
Remove _parsetable from DbConnectionOptions.

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
@@ -12,7 +12,7 @@ using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Data.Common
 {
-    partial class DbConnectionOptions
+    abstract partial class DbConnectionOptions
     {
 #if DEBUG
         /*private const string ConnectionStringPatternV1 =
@@ -98,8 +98,17 @@ namespace Microsoft.Data.Common
 
         protected readonly string _usersConnectionString;
 
+        public abstract string UsersConnectionString(bool hidePassword);
 
+        internal abstract string UsersConnectionStringForTrace();
+        public abstract bool IsEmpty { get;}
 
+        protected static bool ConvertValueToBoolean(Dictionary<string, string> parsetable, string keyName, bool defaultValue)
+        {
+	        return parsetable.TryGetValue(keyName, out string value) ?
+		        ConvertValueToBooleanInternal(keyName, value) :
+		        defaultValue;
+        }
 
         internal static bool ConvertValueToBooleanInternal(string keyName, string stringValue)
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
@@ -96,44 +96,10 @@ namespace Microsoft.Data.Common
             internal const string UID = "uid";
         }
 
-        internal readonly bool HasPasswordKeyword;
-        internal readonly bool HasUserIdKeyword;
+        protected readonly string _usersConnectionString;
 
-        private readonly string _usersConnectionString;
-        private readonly Dictionary<string, string> _parsetable;
-        internal readonly NameValuePair _keyChain;
 
-        internal Dictionary<string, string> Parsetable
-        {
-            get { return _parsetable; }
-        }
 
-        public string UsersConnectionString(bool hidePassword) =>
-            UsersConnectionString(hidePassword, false);
-
-        internal string UsersConnectionStringForTrace() => UsersConnectionString(true, true);
-
-        private string UsersConnectionString(bool hidePassword, bool forceHidePassword)
-        {
-            string connectionString = _usersConnectionString;
-            if (HasPasswordKeyword && (forceHidePassword || (hidePassword && !HasPersistablePassword)))
-            {
-                ReplacePasswordPwd(out connectionString, false);
-            }
-            return connectionString ?? string.Empty;
-        }
-
-        internal bool HasPersistablePassword => HasPasswordKeyword ?
-            ConvertValueToBoolean(KEY.Persist_Security_Info, false) :
-            true; // no password means persistable password so we don't have to munge
-
-        public bool ConvertValueToBoolean(string keyName, bool defaultValue)
-        {
-            string value;
-            return _parsetable.TryGetValue(keyName, out value) ?
-                ConvertValueToBooleanInternal(keyName, value) :
-                defaultValue;
-        }
 
         internal static bool ConvertValueToBooleanInternal(string keyName, string stringValue)
         {
@@ -571,7 +537,7 @@ namespace Microsoft.Data.Common
         }
 #endif
 
-        private static NameValuePair ParseInternal(Dictionary<string, string> parsetable, string connectionString, bool buildChain, Dictionary<string, string> synonyms, bool firstKey)
+        protected static NameValuePair ParseInternal(Dictionary<string, string> parsetable, string connectionString, bool buildChain, Dictionary<string, string> synonyms, bool firstKey)
         {
             Debug.Assert(null != connectionString, "null connectionstring");
             StringBuilder buffer = new StringBuilder();
@@ -633,13 +599,13 @@ namespace Microsoft.Data.Common
             return keychain;
         }
 
-        internal NameValuePair ReplacePasswordPwd(out string constr, bool fakePassword)
+        internal NameValuePair ReplacePasswordPwd(NameValuePair keyChain, out string constr, bool fakePassword)
         {
             bool expanded = false;
             int copyPosition = 0;
             NameValuePair head = null, tail = null, next = null;
             StringBuilder builder = new StringBuilder(_usersConnectionString.Length);
-            for (NameValuePair current = _keyChain; null != current; current = current.Next)
+            for (NameValuePair current = keyChain; null != current; current = current.Next)
             {
                 if ((KEY.Password != current.Name) && (SYNONYM.Pwd != current.Name))
                 {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionOptions.cs
@@ -27,6 +27,16 @@ namespace Microsoft.Data.Common
             _usersConnectionString = connectionOptions._usersConnectionString;            
         }
 
+        protected static bool TryGetParsetableValue(Dictionary<string, string> parsetable, string key, out string value) => parsetable.TryGetValue(key, out value);
+
+        // same as Boolean, but with SSPI thrown in as valid yes
+        protected bool ConvertValueToIntegratedSecurity(Dictionary<string, string> parsetable)
+        {
+	        return parsetable.TryGetValue(KEY.Integrated_Security, out string value) && value != null ?
+		        ConvertValueToIntegratedSecurityInternal(value) :
+		        false;
+        }
+
         internal bool ConvertValueToIntegratedSecurityInternal(string stringValue)
         {
             if (CompareInsensitiveInvariant(stringValue, "sspi") || CompareInsensitiveInvariant(stringValue, "true") || CompareInsensitiveInvariant(stringValue, "yes"))
@@ -45,6 +55,35 @@ namespace Microsoft.Data.Common
                     throw ADP.InvalidConnectionOptionValue(KEY.Integrated_Security);
                 }
             }
+        }
+
+        public int ConvertValueToInt32(Dictionary<string, string> parsetable, string keyName, int defaultValue)
+        {
+	        string value;
+	        return parsetable.TryGetValue(keyName, out value) && value != null ?
+		        ConvertToInt32Internal(keyName, value) :
+		        defaultValue;
+        }
+
+        internal static int ConvertToInt32Internal(string keyname, string stringValue)
+        {
+	        try
+	        {
+		        return int.Parse(stringValue, System.Globalization.NumberStyles.Integer, CultureInfo.InvariantCulture);
+	        }
+	        catch (FormatException e)
+	        {
+		        throw ADP.InvalidConnectionOptionValue(keyname, e);
+	        }
+	        catch (OverflowException e)
+	        {
+		        throw ADP.InvalidConnectionOptionValue(keyname, e);
+	        }
+        }
+
+        public string ConvertValueToString(Dictionary<string, string> parsetable, string keyName, string defaultValue)
+        {
+            return parsetable.TryGetValue(keyName, out string value) && value != null ? value : defaultValue;
         }
 
         protected internal virtual string Expand()

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -63,7 +63,11 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Get|API> {0}", ObjectID);
             bool hidePassword = InnerConnection.ShouldHidePassword;
             DbConnectionOptions connectionOptions = UserConnectionOptions;
-            return ((null != connectionOptions) ? connectionOptions.UsersConnectionString(hidePassword) : "");
+            if (connectionOptions is SqlConnectionString sqlOptions)
+            {
+                return sqlOptions.UsersConnectionString(hidePassword);
+            }
+            return "";
         }
 
         private void ConnectionString_Set(DbConnectionPoolKey key)
@@ -229,7 +233,7 @@ namespace Microsoft.Data.SqlClient
         {
             Debug.Assert(DbConnectionClosedConnecting.SingletonInstance == _innerConnection, "not connecting");
             DbConnectionPoolGroup poolGroup = PoolGroup;
-            DbConnectionOptions connectionOptions = ((null != poolGroup) ? poolGroup.ConnectionOptions : null);
+            SqlConnectionString connectionOptions = ((null != poolGroup) ? poolGroup.ConnectionOptions : null) as SqlConnectionString;
             if ((null == connectionOptions) || connectionOptions.IsEmpty)
             {
                 throw ADP.NoConnectionString();

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw ADP.OpenConnectionPropertySet(nameof(ConnectionString), connectionInternal.State);
             }
-            string cstr = ((null != connectionOptions) ? connectionOptions.UsersConnectionStringForTrace() : "");
+            string cstr = ((null != connectionOptions && connectionOptions is SqlConnectionString sqlConnectionOptions) ? sqlConnectionOptions.UsersConnectionStringForTrace() : "");
             SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Set|API> {0}, '{1}'", ObjectID, cstr);
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -63,11 +63,7 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Get|API> {0}", ObjectID);
             bool hidePassword = InnerConnection.ShouldHidePassword;
             DbConnectionOptions connectionOptions = UserConnectionOptions;
-            if (connectionOptions is SqlConnectionString sqlOptions)
-            {
-                return sqlOptions.UsersConnectionString(hidePassword);
-            }
-            return "";
+            return ((null != connectionOptions) ? connectionOptions.UsersConnectionString(hidePassword) : "");
         }
 
         private void ConnectionString_Set(DbConnectionPoolKey key)
@@ -90,7 +86,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw ADP.OpenConnectionPropertySet(nameof(ConnectionString), connectionInternal.State);
             }
-            string cstr = ((null != connectionOptions && connectionOptions is SqlConnectionString sqlConnectionOptions) ? sqlConnectionOptions.UsersConnectionStringForTrace() : "");
+            string cstr = ((null != connectionOptions) ? connectionOptions.UsersConnectionStringForTrace() : "");
             SqlClientEventSource.Log.TraceEvent("<prov.DbConnectionHelper.ConnectionString_Set|API> {0}, '{1}'", ObjectID, cstr);
         }
 
@@ -233,7 +229,7 @@ namespace Microsoft.Data.SqlClient
         {
             Debug.Assert(DbConnectionClosedConnecting.SingletonInstance == _innerConnection, "not connecting");
             DbConnectionPoolGroup poolGroup = PoolGroup;
-            SqlConnectionString connectionOptions = ((null != poolGroup) ? poolGroup.ConnectionOptions : null) as SqlConnectionString;
+            DbConnectionOptions connectionOptions = ((null != poolGroup) ? poolGroup.ConnectionOptions : null);
             if ((null == connectionOptions) || connectionOptions.IsEmpty)
             {
                 throw ADP.NoConnectionString();

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionString.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionString.NetCoreApp.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient
@@ -18,10 +19,10 @@ namespace Microsoft.Data.SqlClient
 
         internal PoolBlockingPeriod PoolBlockingPeriod { get { return _poolBlockingPeriod; } }
 
-        internal Microsoft.Data.SqlClient.PoolBlockingPeriod ConvertValueToPoolBlockingPeriod()
+        private static PoolBlockingPeriod ConvertValueToPoolBlockingPeriod(Dictionary<string, string> parsetable)
         {
             string value;
-            if (!TryGetParsetableValue(KEY.PoolBlockingPeriod, out value))
+            if (!TryGetParsetableValue(parsetable, KEY.PoolBlockingPeriod, out value))
             {
                 return DEFAULT.PoolBlockingPeriod;
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -538,6 +538,10 @@ namespace Microsoft.Data.SqlClient
             _enclaveAttestationUrl = connectionOptions._enclaveAttestationUrl;
             _attestationProtocol = connectionOptions._attestationProtocol;
 
+            HasPasswordKeyword = connectionOptions.HasPasswordKeyword;
+            HasUserIdKeyword = connectionOptions.HasUserIdKeyword;
+            _keyChain = connectionOptions._keyChain;
+
             ValidateValueLength(_dataSource, TdsEnums.MAXLEN_SERVERNAME, KEY.Data_Source);
         }
 


### PR DESCRIPTION
This refactoring should allow us to remove _parsetable Dictionary as it is needed only during initalization.
All methods that was using this property receive it as parameter.

Question issue: [682](https://github.com/dotnet/SqlClient/issues/682)