### PR TITLE
Update config Section name for Microsoft.Data.SqlClient

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.NetCoreApp.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.SqlClient
             catch (ConfigurationErrorsException e)
             {
                 // Don't throw an error for invalid config files
-                SqlClientEventSource.Log.TraceEvent("Unable to load custom SqlAuthenticationProviders. ConfigurationManager failed to load due to configuration errors: {0}", e);
+                SqlClientEventSource.Log.TraceEvent("Unable to load custom SqlClientAuthenticationProviders. ConfigurationManager failed to load due to configuration errors: {0}", e);
             }
 
             Instance = new SqlAuthenticationProviderManager(configurationSection);
@@ -129,7 +129,7 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         internal class SqlAuthenticationProviderConfigurationSection : ConfigurationSection
         {
-            public const string Name = "SqlAuthenticationProviders";
+            public const string Name = "SqlClientAuthenticationProviders";
 
             /// <summary>
             /// User-defined auth providers.

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.SqlClient
             catch (ConfigurationErrorsException e)
             {
                 // Don't throw an error for invalid config files
-                SqlClientEventSource.Log.TraceEvent("Unable to load custom SqlAuthenticationProviders. ConfigurationManager failed to load due to configuration errors: {0}", e);
+                SqlClientEventSource.Log.TraceEvent("Unable to load custom SqlClientAuthenticationProviders. ConfigurationManager failed to load due to configuration errors: {0}", e);
             }
             Instance = new SqlAuthenticationProviderManager(configurationSection);
             Instance.SetProvider(SqlAuthenticationMethod.ActiveDirectoryIntegrated, activeDirectoryAuthProvider);
@@ -196,7 +196,7 @@ namespace Microsoft.Data.SqlClient
     /// </summary>
     internal class SqlAuthenticationProviderConfigurationSection : ConfigurationSection
     {
-        public const string Name = "SqlAuthenticationProviders";
+        public const string Name = "SqlClientAuthenticationProviders";
 
         /// <summary>
         /// User-defined auth providers.


### PR DESCRIPTION
This PR renames config section for Microsoft.Data.SqlClient for future versions, since currently it doesn't allow co-existence of config sections for both S.D.S and M.D.S. The fix in PR #701 is to only handle driver failures for current release version and not introduce a breaking change.

While, this is a breaking change in the driver, hence next version of M.D.S is promoted to **v3.0**