### PR TITLE
Tests | Fix Test lab failures related to access token acquiry

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -83,6 +83,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             IsDNSCachingSupportedTR = c.IsDNSCachingSupportedTR;
             EnclaveAzureDatabaseConnString = c.EnclaveAzureDatabaseConnString;
 
+            System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
+
             if (TracingEnabled)
             {
                 TraceListener = new TraceEventListener();
@@ -123,8 +125,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     AEConnStrings.Add(TCPConnectionStringAASSGX);
                     AEConnStringsSetup.Add(TCPConnectionStringAASSGX);
                 }
-
-                System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
             }
             else
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static readonly string AADPasswordConnectionString = null;
         public static readonly string AADServicePrincipalId = null;
         public static readonly string AADServicePrincipalSecret = null;
-        public static readonly string AADAccessToken = null;
         public static readonly string AKVBaseUrl = null;
         public static readonly string AKVUrl = null;
         public static readonly string AKVClientId = null;
@@ -51,6 +50,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static readonly string EnclaveAzureDatabaseConnString = null;
 
+        public static string AADAccessToken = null;
         public const string UdtTestDbName = "UdtTestDb";
         public const string AKVKeyName = "TestSqlClientAzureKeyVaultProvider";
         private const string ManagedNetworkingAppContextSwitch = "Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows";
@@ -85,20 +85,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             if (TracingEnabled)
             {
-                TraceListener = new DataTestUtility.TraceEventListener();
+                TraceListener = new TraceEventListener();
             }
 
             if (UseManagedSNIOnWindows)
             {
                 AppContext.SetSwitch(ManagedNetworkingAppContextSwitch, true);
                 Console.WriteLine($"App Context switch {ManagedNetworkingAppContextSwitch} enabled on {Environment.OSVersion}");
-            }
-
-            if (IsAADPasswordConnStrSetup() && IsAADAuthorityURLSetup())
-            {
-                string username = RetrieveValueFromConnStr(AADPasswordConnectionString, new string[] { "User ID", "UID" });
-                string password = RetrieveValueFromConnStr(AADPasswordConnectionString, new string[] { "Password", "PWD" });
-                AADAccessToken = GenerateAccessToken(AADAuthorityURL, username, password);
             }
 
             string url = c.AzureKeyVaultURL;
@@ -177,13 +170,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             string scope = "https://database.windows.net//.default";
             string applicationName = "Microsoft Data SqlClient Manual Tests";
             string clientVersion = "1.0.0.0";
-            string adoClientId = "4d079b4c-cab7-4b7c-a115-8fd51b6f8239";
+            string adoClientId = "2fd908ad-0664-4344-b9be-cd3e8b574c38";
 
             IPublicClientApplication app = PublicClientApplicationBuilder.Create(adoClientId)
                 .WithAuthority(authorityURL)
                 .WithClientName(applicationName)
                 .WithClientVersion(clientVersion)
                 .Build();
+
             AuthenticationResult result;
             string[] scopes = new string[] { scope };
 
@@ -283,7 +277,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static bool IsNotAzureServer()
         {
-            return !AreConnStringsSetup() || !Utils.IsAzureSqlServer(new SqlConnectionStringBuilder((DataTestUtility.TCPConnectionString)).DataSource);
+            return !AreConnStringsSetup() || !Utils.IsAzureSqlServer(new SqlConnectionStringBuilder((TCPConnectionString)).DataSource);
         }
 
         public static bool IsAKVSetupAvailable()
@@ -300,7 +294,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             bool retval = false;
             if (AreConnStringsSetup())
             {
-                using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+                using (SqlConnection connection = new SqlConnection(TCPConnectionString))
                 using (SqlCommand command = new SqlCommand())
                 {
                     command.Connection = connection;
@@ -387,6 +381,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static string GetAccessToken()
         {
+            if (null == AADAccessToken && IsAADPasswordConnStrSetup() && IsAADAuthorityURLSetup())
+            {
+                string username = RetrieveValueFromConnStr(AADPasswordConnectionString, new string[] { "User ID", "UID" });
+                string password = RetrieveValueFromConnStr(AADPasswordConnectionString, new string[] { "Password", "PWD" });
+                AADAccessToken = GenerateAccessToken(AADAuthorityURL, username, password);
+            }
             // Creates a new Object Reference of Access Token - See GitHub Issue 438
             return (null != AADAccessToken) ? new string(AADAccessToken.ToCharArray()) : null;
         }


### PR DESCRIPTION
Fixes Test Lab hitting errors: "An Existing Connection was Forcibly Closed by the Remote Host" when acquiring Access Token for AAD authentication.