### PR TITLE
Implement public client application global cache

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
@@ -312,13 +312,7 @@ namespace Microsoft.Data.SqlClient
 
         private IPublicClientApplication GetPublicClientAppInstance(PublicClientAppKey publicClientAppKey)
         {
-            IPublicClientApplication clientApplicationInstance;
-
-            if (s_pcaMap.ContainsKey(publicClientAppKey))
-            {
-                s_pcaMap.TryGetValue(publicClientAppKey, out clientApplicationInstance);
-            }
-            else
+            if (!s_pcaMap.TryGetValue(publicClientAppKey, out IPublicClientApplication clientApplicationInstance))
             {
                 clientApplicationInstance = CreateClientAppInstance(publicClientAppKey);
                 s_pcaMap.TryAdd(publicClientAppKey, clientApplicationInstance);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
@@ -374,7 +374,6 @@ namespace Microsoft.Data.SqlClient
 #if NETSTANDARD
             public readonly Func<object> _parentActivityOrWindowFunc;
 #endif
-            private int _hashValue;
 
             public PublicClientAppKey(string authority, string redirectUri, string applicationClientId
 #if NETFRAMEWORK
@@ -394,7 +393,6 @@ namespace Microsoft.Data.SqlClient
 #if NETSTANDARD
                 _parentActivityOrWindowFunc = parentActivityOrWindowFunc;
 #endif
-                CalculateHashCode();
             }
 
             public override bool Equals(object obj)
@@ -415,56 +413,14 @@ namespace Microsoft.Data.SqlClient
                 return false;
             }
 
-            public override int GetHashCode()
-            {
-                return _hashValue;
-            }
-
-            private void CalculateHashCode()
-            {
-                // use const value here to be able to compare by value and not by reference.
-                _hashValue = 1430287;
-
-                if (_authority != null)
-                {
-                    unchecked
-                    {
-                        _hashValue = _hashValue * 17 + _authority.GetHashCode();
-                    }
-                }
-                if (_redirectUri != null)
-                {
-                    unchecked
-                    {
-                        _hashValue = _hashValue * 17 + _redirectUri.GetHashCode();
-                    }
-                }
-                if (_applicationClientId != null)
-                {
-                    unchecked
-                    {
-                        _hashValue = _hashValue * 17 + _applicationClientId.GetHashCode();
-                    }
-                }
+            public override int GetHashCode() => Tuple.Create(_authority, _redirectUri, _applicationClientId
 #if NETFRAMEWORK
-                if (_iWin32WindowFunc != null)
-                {
-                    unchecked
-                    {
-                        _hashValue = _hashValue * 17 + _iWin32WindowFunc.GetHashCode();
-                    }
-                }
+                , _iWin32WindowFunc
 #endif
 #if NETSTANDARD
-                if (_parentActivityOrWindowFunc != null)
-                {
-                    unchecked
-                    {
-                        _hashValue = _hashValue * 17 + _parentActivityOrWindowFunc.GetHashCode();
-                    }
-                }
+                , _parentActivityOrWindowFunc
 #endif
-            }
+                ).GetHashCode();
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
@@ -394,6 +394,7 @@ namespace Microsoft.Data.SqlClient
 #if NETSTANDARD
                 _parentActivityOrWindowFunc = parentActivityOrWindowFunc;
 #endif
+                CalculateHashCode();
             }
 
             public override bool Equals(object obj)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
@@ -422,7 +422,8 @@ namespace Microsoft.Data.SqlClient
 
             private void CalculateHashCode()
             {
-                _hashValue = base.GetHashCode();
+                // use const value here to be able to compare by value and not by reference.
+                _hashValue = 1430287;
 
                 if (_authority != null)
                 {


### PR DESCRIPTION
Fixes an issue where driver continues to prompt for credentials when requesting access token for AAD authentication, mainly visible when using Interactive authentication.