### PR TITLE
Fix | Fix Assembly signing issue due to InternalsVisibleTo attribute

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -17,8 +17,6 @@ using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.Data.Common;
 
-[assembly: InternalsVisibleTo("FunctionalTests")]
-
 namespace Microsoft.Data.SqlClient
 {
     internal static class AsyncHelper

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -17,8 +17,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using SysTx = System.Transactions;
 
-[assembly: InternalsVisibleTo("FunctionalTests")]
-
 namespace Microsoft.Data.SqlClient
 {
     using Microsoft.Data.Common;

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -53,8 +53,7 @@
     <Compile Include="SqlConnectionStringBuilderTest.cs" />
     <Compile Include="SerializeSqlTypesTest.cs" />
     <Compile Include="TestTdsServer.cs" />
-    <!--Test disabled till we find a better solution-->
-    <!--Compile Include="SqlHelperTest.cs" /-->
+    <Compile Include="SqlHelperTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -42,7 +42,6 @@
     <Compile Include="SqlCredentialTest.cs" />
     <Compile Include="SqlDataRecordTest.cs" />
     <Compile Include="SqlExceptionTest.cs" />
-    <Compile Include="SqlHelperTest.cs" />
     <Compile Include="SqlParameterTest.cs" />
     <Compile Include="SqlClientFactoryTest.cs" />
     <Compile Include="SqlErrorCollectionTest.cs" />
@@ -54,6 +53,8 @@
     <Compile Include="SqlConnectionStringBuilderTest.cs" />
     <Compile Include="SerializeSqlTypesTest.cs" />
     <Compile Include="TestTdsServer.cs" />
+    <!--Test disabled till we find a better solution-->
+    <!--Compile Include="SqlHelperTest.cs" /-->
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlHelperTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlHelperTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -11,11 +12,16 @@ namespace Microsoft.Data.SqlClient.Tests
 {
     public class SqlHelperTest
     {
-        // This test is skipped on .NET Framework as AsyncHelper cannot be accessed from a Strong name assembly.
         private void TimeOutATask()
         {
+            var sqlClientAssembly = Assembly.GetAssembly(typeof(SqlCommand));
+            //We're using reflection to avoid exposing the internals
+            MethodInfo waitForCompletion = sqlClientAssembly.GetType("Microsoft.Data.SqlClient.AsyncHelper")
+                ?.GetMethod("WaitForCompletion", BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.False(waitForCompletion == null, "Running a test on SqlUtil.WaitForCompletion but could not find this method");
             TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
-            AsyncHelper.WaitForCompletion(tcs.Task, 1); //Will time out as task uncompleted
+            waitForCompletion.Invoke(null, new object[] { tcs.Task, 1, null, true }); //Will time out as task uncompleted
             tcs.SetException(new TimeoutException("Dummy timeout exception")); //Our task now completes with an error
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlHelperTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlHelperTest.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Data.SqlClient.Tests
 {
     public class SqlHelperTest
     {
+        // This test is skipped on .NET Framework as AsyncHelper cannot be accessed from a Strong name assembly.
         private void TimeOutATask()
         {
             TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();


### PR DESCRIPTION
We need to remove assembly attribute added in #692 , as the FunctionalTests assembly is not signed, neither it will be signed during build process. The test has been updated to use reflection instead.