### PR TITLE
Fix | Fix serialization issue with SqlException (.NET Core)

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Data.SqlClient
 {
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/SqlException/*' />
     [Serializable]
-    [System.Runtime.CompilerServices.TypeForwardedFrom("System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public sealed partial class SqlException : System.Data.Common.DbException
     {
         private const string OriginalClientConnectionIdKey = "OriginalClientConnectionId";
@@ -214,7 +213,7 @@ namespace Microsoft.Data.SqlClient
             }
             exception.Data.Add("HelpLink.EvtSrc", "MSSQLServer");
             exception.Data.Add("HelpLink.EvtID", errorCollection[0].Number.ToString(CultureInfo.InvariantCulture));
-            exception.Data.Add("HelpLink.BaseHelpUrl", "http://go.microsoft.com/fwlink");
+            exception.Data.Add("HelpLink.BaseHelpUrl", "https://go.microsoft.com/fwlink");
             exception.Data.Add("HelpLink.LinkId", "20476");
 
             return exception;

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlExceptionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlExceptionTest.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -29,6 +31,28 @@ namespace Microsoft.Data.SqlClient.Tests
 
             Assert.Equal(e.ClientConnectionId, sqlEx.ClientConnectionId);
             Assert.Equal(e.StackTrace, sqlEx.StackTrace);
+        }
+
+
+        [Fact]
+        [ActiveIssue("12161", TestPlatforms.AnyUnix)]
+        public static void SqlExcpetionSerializationTest()
+        {
+            var formatter = new BinaryFormatter();
+            SqlException e = CreateException();
+            using (var stream = new MemoryStream())
+            {
+                try
+                {
+                    formatter.Serialize(stream, e);
+                    stream.Position = 0;
+                    var e2 = (SqlException)formatter.Deserialize(stream);
+                }
+                catch (Exception ex)
+                {
+                    Assert.False(true, $"Unexpected Exception occurred: {ex.Message}");
+                }
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #778

Reported issue #778 is not reproducible with any other SqlClient driver except Microsoft.Data.SqlClient (.NET Core - all versions).
Apparently the `System.Runtime.CompilerServices.TypeForwardedFrom` tag is the cause of this issue.

Removing this tag fixes the issue.
Test added.