### PR TITLE
Update dependency versions of Microsoft.IdentityModel NuGets

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -21,7 +21,6 @@ using Microsoft.Data.Sql;
 using Microsoft.Data.SqlClient.DataClassification;
 using Microsoft.Data.SqlClient.Server;
 using Microsoft.Data.SqlTypes;
-using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Data.SqlClient
 {

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -19,8 +19,8 @@
   <!-- NetFx and NetCore project dependencies -->
   <PropertyGroup>
     <MicrosoftIdentityClientVersion>4.21.1</MicrosoftIdentityClientVersion>
-    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>5.6.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
-    <MicrosoftIdentityModelJsonWebTokensVersion>5.6.0</MicrosoftIdentityModelJsonWebTokensVersion>
+    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.8.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
+    <MicrosoftIdentityModelJsonWebTokensVersion>6.8.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemIOVersion>4.3.0</SystemIOVersion>
   </PropertyGroup>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -29,8 +29,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       <group targetFramework="net46">
         <dependency id="Microsoft.Data.SqlClient.SNI" version="2.1.1" />
         <dependency id="Microsoft.Identity.Client" version="4.21.1" />
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.6.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="5.6.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
       <group targetFramework="netcoreapp2.1">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="2.1.1" exclude="Compile" />
@@ -41,8 +41,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="4.7.0" exclude="Compile" />
         <dependency id="Microsoft.Identity.Client" version="4.21.1" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.6.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="5.6.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="2.1.1" exclude="Compile" />
@@ -53,8 +53,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="4.7.0" exclude="Compile" />
         <dependency id="Microsoft.Identity.Client" version="4.21.1" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.6.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="5.6.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="2.1.1" exclude="Compile" />
@@ -64,8 +64,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Security.Principal.Windows" version="4.7.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="4.7.0" exclude="Compile" />
         <dependency id="Microsoft.Identity.Client" version="4.21.1" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.6.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="5.6.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
       <group targetFramework="netstandard2.1">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="2.1.1" exclude="Compile" />
@@ -75,8 +75,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Security.Principal.Windows" version="4.7.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="4.7.0" exclude="Compile" />
         <dependency id="Microsoft.Identity.Client" version="4.21.1" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.6.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="5.6.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
     </dependencies>
     <frameworkAssemblies>


### PR DESCRIPTION
Fixes #788 

_Since Microsoft.Identity.Client 4.21.1 has been tested, and contains all bug fixes as of current, we'll continue to use that._