### PR TITLE
Implementation of DateTime2 + accompanying GetSqlDateTime2 method (#846)

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml
@@ -634,6 +634,25 @@
  ]]></format>
             </remarks>
         </GetSqlDateTime>
+      <GetSqlDateTime2>
+        <param name="i">The zero-based column ordinal.</param>
+        <summary>
+          Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlDateTime2" />.
+        </summary>
+        <returns>
+          The value of the column expressed as a  <see cref="T:System.Data.SqlTypes.SqlDateTime2" />.
+        </returns>
+        <remarks>
+          <format type="text/markdown">
+            <![CDATA[  
+  
+## Remarks  
+ No conversions are performed; therefore, the data retrieved must already be a date/time value or Null, otherwise an exception is thrown.  
+  
+ ]]>
+          </format>
+        </remarks>
+      </GetSqlDateTime2>
         <GetSqlDecimal>
             <param name="i">The zero-based column ordinal.</param>
             <summary>Gets the value of the specified column as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</summary>

--- a/doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml
+++ b/doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml
@@ -1,0 +1,72 @@
+﻿<docs>
+  <members name="SqlDateTime2">
+    <SqlFileStream>
+      <summary>Exposes SQL Server data that is stored as a DATETIME2.</summary>
+      <remarks>
+        <format type="text/markdown">
+          <![CDATA[  
+
+## Remarks  
+The <xref:Microsoft.Data.SqlTypes.SqlDateTime2> class is used to work with `DATETIME2` data.  
+`DATETIME2`has a wider range than DATETIME and thus needs its own type.
+
+]]>
+        </format>
+      </remarks>
+    </SqlFileStream>
+    <ctor1>
+      <param name="isNull">Whether or not this instance should be considered null - true means null, false not null</param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlTypes.SqlDateTime2" /> struct.
+        Will initialize the datetime value to 0.
+      </summary>
+    </ctor1>
+    <ctor2>
+      <param name="ticks">Number of ticks to initialize this instance with - in the range of <see cref="T:Microsoft.DateTime.MinValue.Ticks"/> &amp;  <see cref="T:Microsoft.DateTime.MaxValue.Ticks"/></param>
+     
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlTypes.SqlDateTime2" /> class.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <paramref name="ticks" /> is not in the range of <see cref="T:Microsoft.DateTime.MinValue.Ticks"/> &amp;  <see cref="T:Microsoft.DateTime.MaxValue.Ticks"/>
+      </exception>
+    </ctor2>
+    <Value>
+      <summary>
+        Gets the <see cref="T:System.DateTime"/> representation of this instance.
+      </summary>
+      <exception cref="T:Microsoft.Data.SqlTypes.SqlNullValueException">
+       If this instance is null
+      </exception>
+    </Value>
+    <Null>
+      <summary>
+        Gets an instance representing the value NULL from the database.
+      </summary>
+    </Null>
+    <OperatorDateTime>
+      <summary>
+        Converts a DateTime into a SqlDateTime2
+      </summary>
+    </OperatorDateTime>
+    <OperatorDBNull>
+      <summary>
+        Converts a DBNull instance into a Null SqlDateTime2
+      </summary>
+    </OperatorDBNull>
+    <OperatorSqlDateTime>
+    <summary>
+      Converts a SqlDateTime2 into DateTime
+    </summary>
+      <exception cref="T:Microsoft.Data.SqlTypes.SqlNullValueException">
+        If the SqlDateTime2 instance has a null value
+      </exception>
+    </OperatorSqlDateTime>
+    <GetXsdType>
+      <summary>
+        returns a <see cref="T:System.Xml.XmlQualifiedName"/> for serialization purposes
+      </summary>
+      <param name="schemaSet">unused parameter</param>
+    </GetXsdType>
+  </members>
+</docs>

--- a/src/Microsoft.Data.SqlClient.sln
+++ b/src/Microsoft.Data.SqlClient.sln
@@ -159,6 +159,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.Data.SqlClient.Se
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft.Data.SqlTypes", "Microsoft.Data.SqlTypes", "{5A7600BD-AED8-44AB-8F2A-7CB33A8D9C02}"
 	ProjectSection(SolutionItems) = preProject
+		..\doc\snippets\Microsoft.Data.SqlTypes\SqlDateTime2.xml = ..\doc\snippets\Microsoft.Data.SqlTypes\SqlDateTime2.xml
 		..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml = ..\doc\snippets\Microsoft.Data.SqlTypes\SqlFileStream.xml
 	EndProjectSection
 EndProject

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -527,5 +527,10 @@ namespace Microsoft.Data.Common
         {
             Transaction.Current = transaction;
         }
+
+        static internal Exception WrongType(Type got, Type expected)
+        {
+            return Argument(StringsHelper.GetString(Strings.SQL_WrongType, got.ToString(), expected.ToString()));
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -464,6 +464,7 @@
     <Compile Include="Microsoft\Data\SqlClient\SqlColumnEncryptionEnclaveProvider.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlEnclaveAttestationParameters.cs" />
     <Compile Include="Microsoft\Data\SqlClient\EnclaveDelegate.cs" />
+    <Compile Include="..\..\src\Microsoft\Data\SqlTypes\SqlDateTime2.cs" Link="Microsoft\Data\SQLTypes\SqlDateTime2.cs" />
   </ItemGroup>
   <!-- Windows only -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -615,6 +615,40 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        internal SqlDateTime2 SqlDateTime2
+        {
+            get
+            {
+                if (IsNull)
+                {
+                    return SqlDateTime2.Null;
+                }
+
+                if (StorageType.DateTime2 == _type)
+                {
+                    return new SqlDateTime2(GetTicksFromDateTime2Info(_value._dateTime2Info));
+                }
+
+                if (StorageType.DateTime == _type)
+                {
+                    // also handle DATETIME without boxing to object first
+                    var dateTime = SqlTypeWorkarounds.SqlDateTimeToDateTime(_value._dateTimeInfo._daypart, _value._dateTimeInfo._timepart);
+
+                    return new SqlDateTime2(dateTime.Ticks);
+                }
+
+                if (StorageType.Date == _type)
+                {
+                    return (SqlDateTime2)DateTime.MinValue.AddDays(_value._int32);
+                }
+
+                // cannot use SqlValue, since that causes invalid cast exception since object cannot be dynamic cast to SqlDateTime2 - only explicit cast
+                // (SqlDateTime2)(object)dateTimeValue;
+                // So assume its called on some kind of DATE type, so DateTime property can handle it
+                return (SqlDateTime2)DateTime; 
+            }
+        }
+
         internal SqlDecimal SqlDecimal
         {
             get

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -2397,6 +2397,13 @@ namespace Microsoft.Data.SqlClient
             return _data[i].SqlDateTime;
         }
 
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDateTime2/*' />
+        virtual public SqlDateTime2 GetSqlDateTime2(int i)
+        {
+            ReadColumn(i);
+            return _data[i].SqlDateTime2;
+        }
+
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDecimal/*' />
         virtual public SqlDecimal GetSqlDecimal(int i)
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -103,6 +103,9 @@
     <Compile Include="..\..\src\Microsoft\Data\Common\ActivityCorrelator.cs">
       <Link>Microsoft\Data\Common\ActivityCorrelator.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\Microsoft\Data\SqlTypes\SqlDateTime2.cs">
+      <Link>Microsoft\Data\SqlTypes\SqlDateTime2.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\Microsoft\Data\Common\DbConnectionPoolKey.cs">
       <Link>Microsoft\Data\Common\DbConnectionPoolKey.cs</Link>
     </Compile>
@@ -368,10 +371,16 @@
     <Compile Include="Microsoft\Data\SqlClient\SqlColumnEncryptionCngProvider.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlColumnEncryptionCspProvider.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlColumnEncryptionEnclaveProvider.cs" />
-    <Compile Include="Microsoft\Data\SqlClient\SqlCommand.cs" />
-    <Compile Include="Microsoft\Data\SqlClient\SqlCommandBuilder.cs" />
+    <Compile Include="Microsoft\Data\SqlClient\SqlCommand.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Microsoft\Data\SqlClient\SqlCommandBuilder.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Microsoft\Data\SqlClient\SqlCommandSet.cs" />
-    <Compile Include="Microsoft\Data\SqlClient\SqlConnection.cs" />
+    <Compile Include="Microsoft\Data\SqlClient\SqlConnection.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Microsoft\Data\SqlClient\SqlConnectionFactory.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlConnectionPoolGroupProviderInfo.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlConnectionPoolKey.cs" />
@@ -379,7 +388,9 @@
     <Compile Include="Microsoft\Data\SqlClient\SqlConnectionStringBuilder.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlConnectionTimeoutErrorInternal.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlCredential.cs" />
-    <Compile Include="Microsoft\Data\SqlClient\SqlDataAdapter.cs" />
+    <Compile Include="Microsoft\Data\SqlClient\SqlDataAdapter.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Microsoft\Data\SqlClient\SqlDataReader.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlDataReaderSmi.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlDelegatedTransaction.cs" />
@@ -443,7 +454,9 @@
     <Compile Include="Microsoft\Data\ProviderBase\DbBuffer.cs" />
     <Compile Include="Microsoft\Data\ProviderBase\DbConnectionClosed.cs" />
     <Compile Include="Microsoft\Data\ProviderBase\DbConnectionFactory.cs" />
-    <Compile Include="Microsoft\Data\ProviderBase\SqlConnectionHelper.cs" />
+    <Compile Include="Microsoft\Data\ProviderBase\SqlConnectionHelper.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Microsoft\Data\ProviderBase\DbConnectionInternal.cs" />
     <Compile Include="Microsoft\Data\ProviderBase\DbConnectionPool.cs" />
     <Compile Include="Microsoft\Data\ProviderBase\DbConnectionPoolGroup.cs" />

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -597,6 +597,40 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        internal SqlDateTime2 SqlDateTime2
+        {
+            get
+            {
+                if (IsNull)
+                {
+                    return SqlDateTime2.Null;
+                }
+
+                if (StorageType.DateTime2 == _type)
+                {
+                    return new SqlDateTime2(GetTicksFromDateTime2Info(_value._dateTime2Info));
+                }
+
+                if (StorageType.DateTime == _type)
+                {
+                    // also handle DATETIME without boxing to object first
+                    var dateTime = SqlTypeWorkarounds.SqlDateTimeToDateTime(_value._dateTimeInfo._daypart, _value._dateTimeInfo._timepart);
+
+                    return new SqlDateTime2(dateTime.Ticks);
+                }
+
+                if (StorageType.Date == _type)
+                {
+                    return (SqlDateTime2)DateTime.MinValue.AddDays(_value._int32);
+                }
+
+                // cannot use SqlValue, since that causes invalid cast exception since object cannot be dynamic cast to SqlDateTime2 - only explicit cast
+                // (SqlDateTime2)(object)dateTimeValue;
+                // So assume its called on some kind of DATE type, so DateTime property can handle it
+                return (SqlDateTime2)DateTime;
+            }
+        }
+
         internal SqlDecimal SqlDecimal
         {
             get

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -2777,6 +2777,13 @@ namespace Microsoft.Data.SqlClient
             return _data[i].SqlDateTime;
         }
 
+        /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDateTime2/*' />
+        virtual public SqlDateTime2 GetSqlDateTime2(int i)
+        {
+            ReadColumn(i);
+            return _data[i].SqlDateTime2;
+        }
+
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDecimal/*' />
         virtual public SqlDecimal GetSqlDecimal(int i)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlDateTime2.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlDateTime2.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Data.SqlTypes;
+using System.Runtime.InteropServices;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+using Microsoft.Data.Common;
+
+namespace Microsoft.Data.SqlTypes
+{
+    /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml' path='docs/members[@name="SqlDateTime2"]/SqlDateTime2/*' />
+    [XmlSchemaProvider("GetXsdType")]
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SqlDateTime2 : INullable, IComparable<SqlDateTime2>, IEquatable<SqlDateTime2>, IComparable, IXmlSerializable
+    {
+        private const long _minTicks = 0; // DateTime.MinValue.Ticks
+        private const long _maxTicks = 3155378975999999999; // DateTime.MaxValue.Ticks
+
+        private bool _notNull;    // false if null - has to be _notNull and not _isNull - otherwise default(SqlDateTime2) will return a SqlDateTime2 with _isNull=false and that would make XmlSerialization fail
+        private long _ticks; // Ticks representation similar to DateTime.Tics
+        
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml' path='docs/members[@name="SqlDateTime2"]/ctor1/*' />
+        private SqlDateTime2(bool isNull)
+        {
+            _notNull = !isNull;
+            _ticks = 0;
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml' path='docs/members[@name="SqlDateTime2"]/ctor2/*' />
+        public SqlDateTime2(long ticks)
+        {
+            if (ticks < _minTicks || ticks > _maxTicks)
+            {
+                throw ADP.ArgumentOutOfRange(nameof(ticks));
+            }
+            _notNull = true;
+            _ticks = ticks;
+        }
+
+        /// <inheritdoc />
+        public bool IsNull => !_notNull;
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml' path='docs/members[@name="SqlDateTime2"]/Value/*' />
+        public DateTime Value => _notNull ? new DateTime(_ticks) : throw new SqlNullValueException();
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml' path='docs/members[@name="SqlDateTime2"]/Null/*' />
+        public static readonly SqlDateTime2 Null = new SqlDateTime2(true);
+
+        /// <inheritdoc />
+        public bool Equals(SqlDateTime2 other)
+        {
+            return _notNull == other._notNull && _ticks == other._ticks;
+        }
+
+        /// <inheritdoc />
+        public int CompareTo(SqlDateTime2 other)
+        {
+            var result = _notNull.CompareTo(other._notNull);
+            
+            if (result != 0) 
+            {
+                return result;
+            }
+
+            return _ticks.CompareTo(other._ticks);
+        }
+
+        /// <inheritdoc />
+        public int CompareTo(object obj)
+        {
+            if (obj is SqlDateTime2 sqlDateTime2)
+            {
+                return CompareTo(sqlDateTime2);
+            }
+
+            throw ADP.WrongType(obj.GetType(), typeof(SqlDateTime2));
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml' path='docs/members[@name="SqlDateTime2"]/OperatorDateTime/*' />
+        public static explicit operator SqlDateTime2(DateTime dateTime)
+        {
+            return new SqlDateTime2(dateTime.Ticks);
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml' path='docs/members[@name="SqlDateTime2"]/OperatorDBNull/*' />
+        public static explicit operator SqlDateTime2(DBNull _)
+        {
+            return Null;
+        }
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml' path='docs/members[@name="SqlDateTime2"]/OperatorSqlDateTime/*' />
+        public static explicit operator DateTime(SqlDateTime2 sqlDateTime2)
+        {
+            return sqlDateTime2.Value;
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml' path='docs/members[@name="SqlDateTime2"]/GetXsdType/*' />
+        public static XmlQualifiedName GetXsdType(XmlSchemaSet schemaSet)
+        {
+            return new XmlQualifiedName("dateTime2", "http://www.w3.org/2001/XMLSchema");
+        }
+
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            return null;
+        }
+
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            string attribute = reader.GetAttribute("nil", "http://www.w3.org/2001/XMLSchema-instance");
+            if (attribute != null && XmlConvert.ToBoolean(attribute))
+            {
+                reader.ReadElementString();
+                _notNull = false;
+            }
+            else
+            {
+                DateTime dateTime = XmlConvert.ToDateTime(reader.ReadElementString(), XmlDateTimeSerializationMode.RoundtripKind);
+                if (dateTime.Kind != DateTimeKind.Unspecified)
+                    throw new SqlTypeException(SQLResource.TimeZoneSpecifiedMessage);
+                _ticks = dateTime.Ticks;
+                _notNull = true;
+            }
+        }
+
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            if (IsNull)
+                writer.WriteAttributeString("xsi", "nil", "http://www.w3.org/2001/XMLSchema-instance", "true");
+            else
+                writer.WriteString(XmlConvert.ToString(Value, "yyyy-MM-ddTHH:mm:ss.fffffff"));
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlDateTime2.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlDateTime2.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.SqlTypes
         private const long _maxTicks = 3155378975999999999; // DateTime.MaxValue.Ticks
 
         private bool _notNull;    // false if null - has to be _notNull and not _isNull - otherwise default(SqlDateTime2) will return a SqlDateTime2 with _isNull=false and that would make XmlSerialization fail
-        private long _ticks; // Ticks representation similar to DateTime.Tics
+        private long _ticks; // Ticks representation similar to DateTime.Ticks
         
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlDateTime2.xml' path='docs/members[@name="SqlDateTime2"]/ctor1/*' />
         private SqlDateTime2(bool isNull)

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="BaseProviderAsyncTest\MockDataReader.cs" />
     <Compile Include="SqlCredentialTest.cs" />
     <Compile Include="SqlDataRecordTest.cs" />
+    <Compile Include="SqlDateTime2Test.cs" />
     <Compile Include="SqlExceptionTest.cs" />
     <Compile Include="SqlFacetAttributeTest.cs" />
     <Compile Include="SqlParameterTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlDateTime2Test.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlDateTime2Test.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Data.SqlTypes;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.Tests
+{
+    public class SqlDateTime2Test
+    {
+        [Fact]
+        public void ConvertFromDBNull()
+        {
+            var value = DBNull.Value;
+
+            SqlDateTime2 sqlDateTime2 = (SqlDateTime2)value;
+            Assert.Equal(SqlDateTime2.Null, sqlDateTime2);
+        }
+
+        [Fact]
+        public void ConvertFromDateTime()
+        {
+            var value = new DateTime(2020, 12, 17, 14, 06, 10, 123, DateTimeKind.Utc);
+
+            SqlDateTime2 expected = new SqlDateTime2(value.Ticks);
+            SqlDateTime2 sqlDateTime2 = (SqlDateTime2)value;
+
+            Assert.Equal(expected, sqlDateTime2);
+        }
+
+        [Fact]
+        public void ConvertToDateTime()
+        {
+            var value = new DateTime(2020, 12, 17, 14, 06, 10, 123, DateTimeKind.Utc);
+
+            SqlDateTime2 expected = new SqlDateTime2(value.Ticks);
+            DateTime converted = (DateTime)expected;
+
+            Assert.Equal(value, converted);
+        }
+
+        [Fact]
+        public void TwoSameShouldBeEquals()
+        {
+            Assert.Equal(SqlDateTime2.Null, SqlDateTime2.Null);
+        }
+
+        [Fact]
+        public void NullShouldBeLessThanSomething()
+        {
+            var result = SqlDateTime2.Null.CompareTo(new SqlDateTime2(1));
+            Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public void ZeroShouldBeLessThanOne()
+        {
+            var result = new SqlDateTime2(0).CompareTo(new SqlDateTime2(1));
+            Assert.Equal(-1, result);
+        }
+
+        [Fact]
+        public void OutOfLowRangeTicksTest()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new SqlDateTime2(-1));
+        }
+
+        [Fact]
+        public void OutOfHighRangeTicksTest()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new SqlDateTime2(long.MaxValue));
+        }
+        [Fact]
+        public void OutOfHighRangeTicksTest2()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new SqlDateTime2(DateTime.MaxValue.Ticks+1));
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -57,6 +57,7 @@
       <Link>Common\System\Collections\DictionaryExtensions.cs</Link>
     </Compile>
     <Compile Include="DataCommon\AADUtility.cs" />
+    <Compile Include="SQL\DateTime2Test\DateTime2Test.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\OrderHint.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\OrderHintAsync.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\OrderHintDuplicateColumn.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DateTime2Test/DateTime2Test.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DateTime2Test/DateTime2Test.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.DateTime2Test
+{
+    public class DateTime2Test
+    {
+        private static readonly DateTime TestDate = new DateTime(2020, 12, 17, 18, 33, 12, 123).AddTicks(4567);
+
+        private const string SqlDateTimeFormat = "yyyy'-'MM'-'dd HH':'mm':'ss'.'fff";
+        private const string SqlDateTime2Format = "yyyy'-'MM'-'dd HH':'mm':'ss'.'fffffff";
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public void NullDefinedAsDateTime2()
+        {
+            var value = GetValueFromReader(@"SELECT CAST(NULL AS DATETIME2)", reader => reader.GetSqlDateTime2(0));
+            Assert.True(value.IsNull);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public void DateTimeAsNullDateTime2()
+        {
+            var value = GetValueFromReader(@"SELECT CAST(NULL AS DATETIME)", reader => reader.GetSqlDateTime2(0));
+            Assert.True(value.IsNull);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public void DateAsNullDateTime2()
+        {
+            var value = GetValueFromReader(@"SELECT CAST(NULL AS DATE)", reader => reader.GetSqlDateTime2(0));
+            Assert.True(value.IsNull);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public void DateTimeAsDateTime2()
+        {
+            var value = GetValueFromReader($"SELECT CAST(CAST('{TestDate.ToString(SqlDateTime2Format)}' AS DATETIME2) as DATETIME)", reader => reader.GetSqlDateTime2(0));
+            Assert.False(value.IsNull);
+            //DATETIME has reduced precision, so we only get the first 3 digits of time
+            var expected = new DateTime(TestDate.Year, TestDate.Month, TestDate.Day, TestDate.Hour, TestDate.Minute, TestDate.Second, 123);
+            Assert.Equal(expected, value.Value);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public void DateAsDateTime2()
+        {
+            var value = GetValueFromReader($"SELECT CAST(CAST('{TestDate.ToString(SqlDateTimeFormat)}' AS DATETIME) as DATE)", reader => reader.GetSqlDateTime2(0));
+            Assert.False(value.IsNull);
+            Assert.Equal(TestDate.Date, value.Value.Date);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public void DateTime2AsDateTime2DecreasedPrecision()
+        {
+            var value = GetValueFromReader($"SELECT CAST('{TestDate.ToString(SqlDateTime2Format)}' AS DATETIME2(3))", reader => reader.GetSqlDateTime2(0));
+            Assert.False(value.IsNull);
+            var expected = new DateTime(TestDate.Year, TestDate.Month, TestDate.Day, TestDate.Hour, TestDate.Minute, TestDate.Second, 123);
+            Assert.Equal(expected, value.Value);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public void DateTime2AsDateTime2FullPrecision()
+        {
+            var value = GetValueFromReader($"SELECT CAST('{TestDate.ToString(SqlDateTime2Format)}' AS DATETIME2(7))", reader => reader.GetSqlDateTime2(0));
+            Assert.False(value.IsNull);
+            
+            Assert.Equal(TestDate, value.Value);
+        }
+
+        private static T GetValueFromReader<T>(string sql, Func<SqlDataReader, T> extractor)
+        {
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            {
+                connection.Open();
+
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    command.CommandText = sql;
+                    command.CommandType = System.Data.CommandType.Text;
+
+                    using (var reader = command.ExecuteReader())
+                    {
+                        reader.Read();
+                        return extractor(reader);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Initial implementation - let me know what you think so far.
I have tried to do everything I could think of and have tried to follow the "style"
I don't know why VS insists on changing the .csproj for SqlCommand etc - I have done nothing, but will try to revert the changes out side of VS

And I need some help understanding why VS can build my stuff when I use the ADP class, but I cannot build it outside of VS - possibly some "tweaks" needed - which is why I am throwing exceptions directly and not going through the ADP class like the other classes do.