### PR TITLE
Fix | TrimStart in LocalDBAPI with default constructor is not in netstandard2.0

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/LocalDBAPI.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/LocalDBAPI.cs
@@ -21,7 +21,10 @@ namespace Microsoft.Data
         {
             if (serverName == null)
                 return null;
-            serverName = serverName.TrimStart(); // it can start with spaces if specified in quotes
+            serverName = serverName.TrimStart(null); // it can start with spaces if specified in quotes
+                                                     // Default constructor for TrimStart is not in netstandard2.0
+                                                     // when the TrimStart(chars[]) passes null or empty array it will remove leading whitespaces
+                                                     // By passing null we enforce that behavior
             if (!serverName.StartsWith(const_localDbPrefix, StringComparison.OrdinalIgnoreCase))
                 return null;
             string instanceName = serverName.Substring(const_localDbPrefix.Length).Trim();

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/LocalDBAPI.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/LocalDBAPI.cs
@@ -32,7 +32,10 @@ namespace Microsoft.Data
         {
             if (serverName == null)
                 return null;
-            serverName = serverName.TrimStart(); // it can start with spaces if specified in quotes
+            serverName = serverName.TrimStart(null); // it can start with spaces if specified in quotes
+                                                     // Default constructor for TrimStart is not in netstandard2.0
+                                                     // when the TrimStart(chars[]) passes null or empty array it will remove leading whitespaces
+                                                     // By passing null we enforce that behavior
             if (!serverName.StartsWith(const_localDbPrefix, StringComparison.OrdinalIgnoreCase))
                 return null;
             string instanceName = serverName.Substring(const_localDbPrefix.Length).Trim();


### PR DESCRIPTION
Class `LocalDBAPI` is calling [TrimStart()](https://docs.microsoft.com/en-us/dotnet/api/system.string.trimstart?view=net-5.0#System_String_TrimStart) with default constructor. As the description explains, the default constructor was added to `netstandard2.1` and is not supported in netstandard2.0. 

According to the [documentation for TrimStart(params char[]? trimChars)](https://docs.microsoft.com/en-us/dotnet/api/system.string.trimstart?view=net-5.0#System_String_TrimStart_System_Char___) :

`If trimChars is null or an empty array, white-space characters are removed instead.`

However in some cases such as [Issue#850](https://github.com/dotnet/SqlClient/issues/850) that functionality does not work properly and user gets `System.MissingMethodException: Method not found: 'System.String System.String.TrimStart()'`.

Looking at [Source code of TrimStart(params char[]? trimChars)](https://source.dot.net/#System.Private.CoreLib/String.Manipulation.cs,5137a6065a1c1234) we can enforce that behavior by passing a null value to the constructor to distinguish the default constructor and mentioned constructor. Same pattern happens in netfx. 

By doing so, we confirm that TrimStart is taking care of any kind of whitespaces instead of defining limited values in an array.

For testing, as the `LocalDBFormatMessageDelegate` is private and I could not check the value (it happens internally and is not visible to connection properties by the user), I have added some tests to check for some of the common whitespaces.