### PR TITLE
Tests | Addressing string.Format parametes issue in test lab

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static string GetUniqueNameForSqlServer(string prefix)
         {
             string extendedPrefix = string.Format(
-                "{0}_{1}@{2}",
+                "{0}_{1}_{2}@{3}",
                 prefix,
                 Environment.UserName,
                 Environment.MachineName,

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static string GetUniqueNameForSqlServer(string prefix)
         {
             string extendedPrefix = string.Format(
-                "{0}_{1}_{2}@{3}",
+                "{0}_{1}-{2}@{3}",
                 prefix,
                 Environment.UserName,
                 Environment.MachineName,

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static string GetUniqueNameForSqlServer(string prefix)
         {
             string extendedPrefix = string.Format(
-                "{0}_{1}-{2}@{3}",
+                "{0}_{1}_{2}@{3}",
                 prefix,
                 Environment.UserName,
                 Environment.MachineName,

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomizer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomizer.cs
@@ -661,7 +661,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             Process currentProcess = Process.GetCurrentProcess();
             string extendedPrefix = string.Format(
-                "{0}_{1}@{2}",
+                "{0}_{1}_{2}@{3}",
                 prefix,
                 currentProcess.ProcessName,
                 currentProcess.MachineName,

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomizer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomizer.cs
@@ -661,7 +661,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             Process currentProcess = Process.GetCurrentProcess();
             string extendedPrefix = string.Format(
-                "{0}_{1}_{2}@{3}",
+                "{0}_{1}-{2}@{3}",
                 prefix,
                 currentProcess.ProcessName,
                 currentProcess.MachineName,

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomizer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/SqlRandomizer.cs
@@ -661,7 +661,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             Process currentProcess = Process.GetCurrentProcess();
             string extendedPrefix = string.Format(
-                "{0}_{1}-{2}@{3}",
+                "{0}_{1}_{2}@{3}",
                 prefix,
                 currentProcess.ProcessName,
                 currentProcess.MachineName,


### PR DESCRIPTION
While working in .net5 test lab, I noticed .net5 runtime has captured some unobserved issues in our test labs. 

`DataTestUtility` class at line 357 uses string.Format with 3 variables placeholder, but we are passing 4 items to it.
Also in SqlRandmizer at line 663 same issue happens. This PR is to address that urgently other fixes come after in separate PR.