### PR TITLE
Security Fix | Prohibit DtdProcessing on XmlTextReader instance in .NET Core

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -1155,8 +1155,8 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                         return null;
                     }
 
-                    // Create a new XmlTextReader on the Message node value.
-                    using (XmlTextReader xmlMessageReader = new XmlTextReader(xmlReader.Value, XmlNodeType.Element, null))
+                    // Create a new XmlTextReader on the Message node value. Prohibit DTD processing when dealing with untrusted sources.
+                    using (XmlTextReader xmlMessageReader = new XmlTextReader(xmlReader.Value, XmlNodeType.Element, null) { DtdProcessing = DtdProcessing.Prohibit })
                     {
                         // Proceed to the Text Node.
                         if (!xmlMessageReader.Read())


### PR DESCRIPTION
The setting is already set in NetFx.
Fixes vulnerability.