### PR TITLE
Managed SNI prevent orphaned active packets being GC'ed without clear

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// #define TRACE_HISTORY // this is used for advanced debugging when you need to trace the entire lifetime of a single packet, be very careful with it
+ // #define TRACE_HISTORY // this is used for advanced debugging when you need to trace the entire lifetime of a single packet, be very careful with it
 
 using System;
 using System.Buffers;
@@ -41,15 +41,15 @@ namespace Microsoft.Data.SqlClient.SNI
         {
             public enum Direction
             {
-                Rent=0,
-                Return=1,
+                Rent = 0,
+                Return = 1,
             }
 
             public Direction Action;
             public int RefCount;
             public string Stack;
         }
-
+      
         internal List<History> _history = null;
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Microsoft.Data.SqlClient.SNI
             : this()
         {
 #if TRACE_HISTORY
-            _history = new List<Activity>();
+            _history = new List<History>();
 #endif
             _id = id;
             _owner = owner;
@@ -284,6 +284,12 @@ namespace Microsoft.Data.SqlClient.SNI
             }
 
             callback(this, error ? TdsEnums.SNI_ERROR : TdsEnums.SNI_SUCCESS);
+#if DEBUG
+            if (!IsInvalid)
+            {
+                Debug.Fail("unreleased packet will be dropped to GC");
+            }
+#endif
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
@@ -284,12 +284,6 @@ namespace Microsoft.Data.SqlClient.SNI
             }
 
             callback(this, error ? TdsEnums.SNI_ERROR : TdsEnums.SNI_SUCCESS);
-#if DEBUG
-            if (!IsInvalid)
-            {
-                Debug.Fail("unreleased packet will be dropped to GC");
-            }
-#endif
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -71,14 +71,46 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal void ReadAsyncCallback(SNIPacket packet, uint error)
         {
-            ReadAsyncCallback(IntPtr.Zero, PacketHandle.FromManagedPacket(packet), error);
-            _sessionHandle?.ReturnPacket(packet);
+            SNIHandle sessionHandle = _sessionHandle;
+            if (sessionHandle != null)
+            {
+                ReadAsyncCallback(IntPtr.Zero, PacketHandle.FromManagedPacket(packet), error);
+                sessionHandle?.ReturnPacket(packet);
+            }
+            else
+            {
+                // clear the packet and drop it to GC because we no longer know how to return it to the correct owner
+                // this can only happen if a packet is in-flight when the _sessionHandle is cleared
+                try
+                {
+                    packet.Release();
+                }
+                catch
+                {
+                }
+            }
         }
 
         internal void WriteAsyncCallback(SNIPacket packet, uint sniError)
         {
-            WriteAsyncCallback(IntPtr.Zero, PacketHandle.FromManagedPacket(packet), sniError);
-            _sessionHandle?.ReturnPacket(packet);
+            SNIHandle sessionHandle = _sessionHandle;
+            if (sessionHandle != null)
+            {
+                WriteAsyncCallback(IntPtr.Zero, PacketHandle.FromManagedPacket(packet), sniError);
+                sessionHandle?.ReturnPacket(packet);
+            }
+            else
+            {
+                // clear the packet and drop it to GC because we no longer know how to return it to the correct owner
+                // this can only happen if a packet is in-flight when the _sessionHandle is cleared
+                try
+                {
+                    packet.Release();
+                }
+                catch
+                {
+                }
+            }
         }
 
         protected override void RemovePacketFromPendingList(PacketHandle packet)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -81,13 +81,7 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 // clear the packet and drop it to GC because we no longer know how to return it to the correct owner
                 // this can only happen if a packet is in-flight when the _sessionHandle is cleared
-                try
-                {
-                    packet.Release();
-                }
-                catch
-                {
-                }
+                packet.Release();
             }
         }
 
@@ -103,13 +97,7 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 // clear the packet and drop it to GC because we no longer know how to return it to the correct owner
                 // this can only happen if a packet is in-flight when the _sessionHandle is cleared
-                try
-                {
-                    packet.Release();
-                }
-                catch
-                {
-                }
+                packet.Release();
             }
         }
 


### PR DESCRIPTION
In carefully timed situations a packet received asynchronously can be received after the session handle that owns the packet has been cleared. 

This change takes a safety copy of the session handle (as other methods in this class already did) and checks to see if the handle is non-null before calling the read/write callback to pass the data on to the caller. 

If the session handle is not valid the packet is directly cleared and dropped to the GC, this is safe to do as packets can easily be created if a pool has none available, it's just more efficient to re-use them

This was found using the reproduction in https://github.com/dotnet/SqlClient/issues/659 but it does not fix that issue.

/cc @cheenamalhotra