### PR TITLE
small perf changes

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -722,8 +722,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                ConnectionState state = State;
-                if (state == ConnectionState.Open || state == ConnectionState.Executing || state == ConnectionState.Fetching)
+                if ((State & (ConnectionState.Open | ConnectionState.Executing | ConnectionState.Fetching)) > 0)
                 {
                     return GetOpenTdsConnection().ServerProcessId;
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -720,8 +720,15 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ServerProcessId/*' />
         public int ServerProcessId
         {
-            get => State.Equals(ConnectionState.Open) | State.Equals(ConnectionState.Executing) | State.Equals(ConnectionState.Fetching) ?
-                GetOpenTdsConnection().ServerProcessId : 0;
+            get
+            {
+                ConnectionState state = State;
+                if (state == ConnectionState.Open || state == ConnectionState.Executing || state == ConnectionState.Fetching)
+                {
+                    return GetOpenTdsConnection().ServerProcessId;
+                }
+                return 0;
+            }
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/State/*' />


### PR DESCRIPTION
I did a memory profile of the test case in https://github.com/dotnet/SqlClient/issues/659 and noted some easy to fix issues:

![Untitled](https://user-images.githubusercontent.com/13322696/105781079-beaac700-5f69-11eb-9e72-c17b5195c107.png)

The ConnectionState change was using `.Equals(object)` which caused boxing, it's just changed to state value capture and a direct comparison. The `ConcurrentQueueSemaphore` simply changes a delegate instantiation and context capture to a static delegate and state object parameter invocation as we've used elsewhere to reduce allocations.