### PR TITLE
Fix | Fixes wrong data errors due to exceptions not handled in time

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1779,6 +1779,7 @@ namespace Microsoft.Data.SqlClient
             int? sqlExceptionNumber = null;
             try
             {
+                CheckThrowSNIException();
                 success = true;
                 return CompleteXmlReader(InternalEndExecuteReader(asyncResult, false, nameof(EndExecuteXmlReader)), true);
             }
@@ -1973,6 +1974,7 @@ namespace Microsoft.Data.SqlClient
             int? sqlExceptionNumber = null;
             try
             {
+                CheckThrowSNIException();
                 success = true;
                 statistics = SqlStatistics.StartTimer(Statistics);
                 return InternalEndExecuteReader(asyncResult, false, nameof(EndExecuteReader));

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1368,6 +1368,7 @@ namespace Microsoft.Data.SqlClient
 
             try
             {
+                CheckThrowSNIException();
                 statistics = SqlStatistics.StartTimer(Statistics);
                 int result = (int)InternalEndExecuteNonQuery(asyncResult, isInternal: false, endMethod: nameof(EndExecuteNonQuery));
                 success = true;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2230,6 +2230,7 @@ namespace Microsoft.Data.SqlClient
             int? sqlExceptionNumber = null;
             try
             {
+                CheckThrowSNIException();
                 XmlReader result = CompleteXmlReader(InternalEndExecuteReader(asyncResult, ADP.EndExecuteXmlReader, isInternal: false), true);
                 success = true;
                 return result;
@@ -2486,6 +2487,7 @@ namespace Microsoft.Data.SqlClient
             int? sqlExceptionNumber = null;
             try
             {
+                CheckThrowSNIException();
                 statistics = SqlStatistics.StartTimer(Statistics);
                 SqlDataReader result = InternalEndExecuteReader(asyncResult, ADP.EndExecuteReader, isInternal: false);
                 success = true;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1720,6 +1720,7 @@ namespace Microsoft.Data.SqlClient
             int? sqlExceptionNumber = null;
             try
             {
+                CheckThrowSNIException();
                 statistics = SqlStatistics.StartTimer(Statistics);
                 int result = (int)InternalEndExecuteNonQuery(asyncResult, ADP.EndExecuteNonQuery, isInternal: false);
                 success = true;


### PR DESCRIPTION
This change fixes the wrong data issue in #659

## Root Cause

Ref: [Case_Study.zip](https://github.com/dotnet/SqlClient/files/5898735/Case_Study.zip) (RCA explained - https://github.com/dotnet/SqlClient/issues/659#issuecomment-765221632)

**Attempt 3 [The Fix - Updated 04-02-2021]**
Those missing checks in SqlCommand methods added here caused wrong data flow, adding them respectively fixes it by capturing exception on time and throwing it immediately. 

These checks were always done in Old Async APIs, e.g. [InternalEndExecuteReader](https://github.com/dotnet/SqlClient/blob/master/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs#L2373) , [InternalEndExecuteNonQuery](https://github.com/dotnet/SqlClient/blob/master/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs#L1433)

Fix applies to all platforms on all supported .NET SDKs. APIs fixed:
- SqlCommand.ExecuteNonQueryAsync
- SqlCommand.ExecuteReaderAsync
- SqlCommand.ExecuteXmlReaderAsync

-------
_Old Attempts_

_Attempt 2 [Updated 02-02-2021]_
[Discarded - Breaks Timeout Flows]
The first attempted solution was discarded after further investigations as the counter adjustment only made the connection cleaned out from connection pool, but the original issue existed.

After more investigations into the trigger point of Attention packets, I looked more into `_networkPacketTimeout` being used in https://github.com/dotnet/SqlClient/blob/cde615e83612635d397c290ce033a617c7c67280/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs#L2388-L2393
This timer when times out (when duration is updated again) triggers an Attention signal, and is likely causing some issues here. The update to duration when there is time left, kicks off this timer to timeout on another thread independently while the read could still be going on. If we only timeout when we hit 0 (next few lines) we aren't allowing timeout and read to be in a position to occur simultaneously. 

_Attempt 1 [Discarded]_

The repro apps created by community in #659 were very helpful to reproduce this issue, thanks to everyone for helping us with that! We really appreciate your support and patience!

### Repro Test Results

Below is the screenshot for the repro from https://github.com/dotnet/SqlClient/issues/659#issuecomment-740065821 in multiple parallel sessions all at once with the fix, which has never been possible! Yes there are network errors, but that is due to thread-pool starvation issue #422 which we'll continue to investigate!

![image](https://user-images.githubusercontent.com/13396919/106718369-d6133100-65b5-11eb-8f56-f4ee14d2085e.png)

**[Updated 04-02-2021]**
[Attempt 3 - no wrong data observed in multiple sessions, results similar to screenshot]

### Without this fix, invalid data is easily captured in a single process

![image](https://user-images.githubusercontent.com/13396919/106349116-13a74f80-6280-11eb-88dd-0bf126aa3a25.png)


