### PR TITLE
tiny perf change

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Data.SqlClient
             _language = null;
             if (_deltaDirty)
             {
-                _delta = new SessionStateRecord[_maxNumberOfSessionStates];
+                Array.Clear(_delta, 0, _delta.Length);
                 _deltaDirty = false;
             }
             _unrecoverableStatesCount = 0;


### PR DESCRIPTION
in https://github.com/dotnet/SqlClient/pull/889 there was one item which generated a huge number of arrays and discarded them causing GC pressure. I tracked and identified all uses of the code that generates it. There is only one `SessionStateRecord` used and no other location keeps a reference to it so it is safe to clear the array for re-use instead of creating and entirely new one each time.