### PR TITLE
Fix | Fixes incorrect data errors due to timeout running very late

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -609,6 +609,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 session = _physicalStateObj;
+                _physicalStateObj.Owner = owner;
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0} getting physical session {1}", ObjectID, session.ObjectID);
             }
             Debug.Assert(session._outputPacketNumber == 1, "The packet number is expected to be 1");

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -851,6 +851,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 session = _physicalStateObj;
+                _physicalStateObj.Owner = owner;
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.GetSession|ADV> {0} getting physical session {1}", ObjectID, session.ObjectID);
             }
             Debug.Assert(session._outputPacketNumber == 1, "The packet number is expected to be 1");

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -392,11 +392,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 _owner.Target = value;
 
-                _networkPacketTimeout = value == null ? null : ADP.UnsafeCreateTimer(
-                    new TimerCallback(OnTimeout),
-                    new WeakReference(value),
-                    Timeout.Infinite,
-                    Timeout.Infinite);
+                _networkPacketTimeout = value == null ? null : new Timer(OnTimeout, null, Timeout.Infinite, Timeout.Infinite);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Data.SqlClient
         internal int _inBytesUsed = 0;                   // number of bytes used in internal read buffer
         internal int _inBytesRead = 0;                   // number of bytes read into internal read buffer
         internal int _inBytesPacket = 0;                   // number of bytes left in packet
-        
+
         internal int _spid;                                 // SPID of the current connection
 
         // Packet state variables
@@ -108,6 +108,12 @@ namespace Microsoft.Data.SqlClient
         internal volatile bool _attentionSending = false;
         internal bool _internalTimeout = false;               // an internal timeout occurred
         private readonly LastIOTimer _lastSuccessfulIOTimer;
+
+        // Below 2 properties are used to enforce timeout delays in code to 
+        // reproduce issues related to theadpool starvation and timeout delay.
+        // It should always be set to false by default, and only be enabled during testing.
+        internal bool _enforceTimeoutDelay = false;
+        internal int _enforcedTimeoutDelayInMilliSeconds = 5000;
 
         // secure password information to be stored
         //  At maximum number of secure string that need to be stored is two; one for login password and the other for new change password
@@ -296,7 +302,7 @@ namespace Microsoft.Data.SqlClient
             SetPacketSize(_parser._physicalStateObj._outBuff.Length);
 
             SNINativeMethodWrapper.ConsumerInfo myInfo = CreateConsumerInfo(async);
-            
+
             SQLDNSInfo cachedDNSInfo;
             bool ret = SQLFallbackDNSCache.Instance.GetDNSInfo(_parser.FQDNforDNSCahce, out cachedDNSInfo);
 
@@ -797,7 +803,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         tdsReliabilitySection.Start();
 #endif //DEBUG
-                        Parser.ProcessPendingAck(this);
+                    Parser.ProcessPendingAck(this);
 #if DEBUG
                     }
                     finally
@@ -2332,6 +2338,10 @@ namespace Microsoft.Data.SqlClient
 
         private void OnTimeout(object state)
         {
+            if (_enforceTimeoutDelay)
+            {
+                Thread.Sleep(_enforcedTimeoutDelayInMilliSeconds);
+            }
             WeakReference timerOwner = (WeakReference)state;
             if (_owner.Target == null ||
                 timerOwner.Target == null ||
@@ -3523,35 +3533,35 @@ namespace Microsoft.Data.SqlClient
                     if (!_skipSendAttention)
                     {
 #endif
-                        // Take lock and send attention
-                        bool releaseLock = false;
-                        if ((mustTakeWriteLock) && (!_parser.Connection.ThreadHasParserLockForClose))
+                    // Take lock and send attention
+                    bool releaseLock = false;
+                    if ((mustTakeWriteLock) && (!_parser.Connection.ThreadHasParserLockForClose))
+                    {
+                        releaseLock = true;
+                        _parser.Connection._parserLock.Wait(canReleaseFromAnyThread: false);
+                        _parser.Connection.ThreadHasParserLockForClose = true;
+                    }
+                    try
+                    {
+                        // Check again (just in case the connection was closed while we were waiting)
+                        if (_parser.State == TdsParserState.Closed || _parser.State == TdsParserState.Broken)
                         {
-                            releaseLock = true;
-                            _parser.Connection._parserLock.Wait(canReleaseFromAnyThread: false);
-                            _parser.Connection.ThreadHasParserLockForClose = true;
+                            return;
                         }
-                        try
-                        {
-                            // Check again (just in case the connection was closed while we were waiting)
-                            if (_parser.State == TdsParserState.Closed || _parser.State == TdsParserState.Broken)
-                            {
-                                return;
-                            }
 
-                            UInt32 sniError;
-                            _parser._asyncWrite = false; // stop async write 
-                            SNIWritePacket(Handle, attnPacket, out sniError, canAccumulate: false, callerHasConnectionLock: false);
-                            SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.SendAttention|{0}> Send Attention ASync.", "Info");
-                        }
-                        finally
+                        UInt32 sniError;
+                        _parser._asyncWrite = false; // stop async write 
+                        SNIWritePacket(Handle, attnPacket, out sniError, canAccumulate: false, callerHasConnectionLock: false);
+                        SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.SendAttention|{0}> Send Attention ASync.", "Info");
+                    }
+                    finally
+                    {
+                        if (releaseLock)
                         {
-                            if (releaseLock)
-                            {
-                                _parser.Connection.ThreadHasParserLockForClose = false;
-                                _parser.Connection._parserLock.Release();
-                            }
+                            _parser.Connection.ThreadHasParserLockForClose = false;
+                            _parser.Connection._parserLock.Release();
                         }
+                    }
 
 #if DEBUG
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -391,6 +391,12 @@ namespace Microsoft.Data.SqlClient
                     _readerState = reader._sharedState;
                 }
                 _owner.Target = value;
+
+                _networkPacketTimeout = value == null ? null : ADP.UnsafeCreateTimer(
+                    new TimerCallback(OnTimeout),
+                    new WeakReference(value),
+                    Timeout.Infinite,
+                    Timeout.Infinite);
             }
         }
 
@@ -2330,6 +2336,16 @@ namespace Microsoft.Data.SqlClient
 
         private void OnTimeout(object state)
         {
+            WeakReference timerOwner = (WeakReference)state;
+            if (_owner.Target == null ||
+                timerOwner.Target == null ||
+                !object.ReferenceEquals(_owner.Target, timerOwner.Target))
+            {
+                // The timer is firing so late that other things have moved on and the timeout is no longer relevant (high load / thread starvation)
+                SqlClientEventSource.Log.TryTraceEvent("TdsParser.OnTimeout | Info | OnTimeout fired without an owner or with a different owner than originally created with.");
+                return;
+            }
+
             if (!_internalTimeout)
             {
                 _internalTimeout = true;
@@ -2463,11 +2479,7 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 Debug.Assert(completion != null, "Async on but null asyncResult passed");
-
-                if (_networkPacketTimeout == null)
-                {
-                    _networkPacketTimeout = new Timer(OnTimeout, null, Timeout.Infinite, Timeout.Infinite);
-                }
+                Debug.Assert(_networkPacketTimeout != null, "_networkPacketTimeout should not be null");
 
                 // -1 == Infinite
                 //  0 == Already timed out (NOTE: To simulate the same behavior as sync we will only timeout on 0 if we receive an IO Pending from SNI)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="SQL\DataClassificationTest\DataClassificationTest.cs" />
     <Compile Include="TracingTests\EventSourceTest.cs" />
     <Compile Include="SQL\AdapterTest\AdapterTest.cs" />
+    <Compile Include="SQL\AsyncTest\AsyncTimeoutTest.cs" />
     <Compile Include="SQL\AsyncTest\BeginExecAsyncTest.cs" />
     <Compile Include="SQL\AsyncTest\BeginExecReaderAsyncTest.cs" />
     <Compile Include="SQL\AsyncTest\XmlReaderAsyncTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncTimeoutTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncTimeoutTest.cs
@@ -1,0 +1,210 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.Data.SqlClient.ManualTesting.Tests.SystemDataInternals;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests
+{
+    public static class AsyncTimeoutTest
+    {
+        static string delayQuery2s = "WAITFOR DELAY '00:00:02'";
+        static string delayQuery10s = "WAITFOR DELAY '00:00:10'";
+
+        public enum AsyncAPI
+        {
+            ExecuteReaderAsync,
+            ExecuteScalarAsync,
+            ExecuteXmlReaderAsync
+        }
+
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ClassData(typeof(AsyncTimeoutTestVariations))]
+        public static void TestDelayedAsyncTimeout(AsyncAPI api, string commonObj, int delayPeriod, bool marsEnabled) =>
+            RunTest(api, commonObj, delayPeriod, marsEnabled);
+
+        public class AsyncTimeoutTestVariations : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Connection", 8000, true };
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Connection", 5000, true };
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Connection", 0, true };
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Connection", 8000, false };
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Connection", 5000, false };
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Connection", 0, false };
+
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Connection", 8000, true };
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Connection", 5000, true };
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Connection", 0, true };
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Connection", 8000, false };
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Connection", 5000, false };
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Connection", 0, false };
+
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Connection", 8000, true };
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Connection", 5000, true };
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Connection", 0, true };
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Connection", 8000, false };
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Connection", 5000, false };
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Connection", 0, false };
+
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Command", 8000, true };
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Command", 5000, true };
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Command", 0, true };
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Command", 8000, false };
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Command", 5000, false };
+                yield return new object[] { AsyncAPI.ExecuteReaderAsync, "Command", 0, false };
+
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Command", 8000, true };
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Command", 5000, true };
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Command", 0, true };
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Command", 8000, false };
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Command", 5000, false };
+                yield return new object[] { AsyncAPI.ExecuteScalarAsync, "Command", 0, false };
+                
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Command", 8000, true };
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Command", 5000, true };
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Command", 0, true };
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Command", 8000, false };
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Command", 5000, false };
+                yield return new object[] { AsyncAPI.ExecuteXmlReaderAsync, "Command", 0, false };
+            }
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        private static void RunTest(AsyncAPI api, string commonObj, int timeoutDelay, bool marsEnabled)
+        {
+            string connString = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString)
+            {
+                MultipleActiveResultSets = marsEnabled
+            }.ConnectionString;
+
+            using (SqlConnection sqlConnection = new SqlConnection(connString))
+            {
+                sqlConnection.Open();
+                if (timeoutDelay != 0)
+                {
+                    ConnectionHelper.SetEnforcedTimeout(sqlConnection, true, timeoutDelay);
+                }
+                switch (commonObj)
+                {
+                    case "Connection":
+                        QueryAndValidate(api, 1, delayQuery2s, 1, false, true, sqlConnection).Wait(); // Special case handled here - Does not throw exception
+                        QueryAndValidate(api, 2, delayQuery2s, 5, false, true, sqlConnection).Wait();
+                        QueryAndValidate(api, 3, delayQuery10s, 1, true, true, sqlConnection).Wait();
+                        QueryAndValidate(api, 4, delayQuery2s, 10, false, true, sqlConnection).Wait();
+                        break;
+                    case "Command":
+                        using (SqlCommand cmd = sqlConnection.CreateCommand())
+                        {
+                            QueryAndValidate(api, 1, delayQuery2s, 1, false, false, sqlConnection, cmd).Wait(); // Special case handled here - Does not throw exception
+                            QueryAndValidate(api, 2, delayQuery2s, 5, false, false, sqlConnection, cmd).Wait();
+                            QueryAndValidate(api, 3, delayQuery10s, 1, true, false, sqlConnection, cmd).Wait();
+                            QueryAndValidate(api, 4, delayQuery2s, 10, false, false, sqlConnection, cmd).Wait();
+                        }
+                        break;
+                }
+            }
+        }
+
+        private static async Task QueryAndValidate(AsyncAPI api, int index, string delayQuery, int timeout,
+            bool timeoutExExpected = false, bool useTransaction = false, SqlConnection cn = null, SqlCommand cmd = null)
+        {
+            SqlTransaction tx = null;
+            try
+            {
+                if (cn != null)
+                {
+                    if (cn.State != ConnectionState.Open)
+                    {
+                        await cn.OpenAsync();
+                    }
+                    cmd = cn.CreateCommand();
+                    if (useTransaction)
+                    {
+                        tx = cn.BeginTransaction(IsolationLevel.ReadCommitted);
+                        cmd.Transaction = tx;
+                    }
+                }
+
+                cmd.CommandTimeout = timeout;
+                if (api != AsyncAPI.ExecuteXmlReaderAsync)
+                {
+                    cmd.CommandText = delayQuery + $";select {index} as Id;";
+                }
+                else
+                {
+                    cmd.CommandText = delayQuery + $";select {index} as Id FOR XML PATH;";
+                }
+
+                var result = -1;
+                switch (api)
+                {
+                    case AsyncAPI.ExecuteReaderAsync:
+                        using (SqlDataReader reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
+                        {
+                            while (await reader.ReadAsync().ConfigureAwait(false))
+                            {
+                                var columnIndex = reader.GetOrdinal("Id");
+                                result = reader.GetInt32(columnIndex);
+                                break;
+                            }
+                        }
+                        break;
+                    case AsyncAPI.ExecuteScalarAsync:
+                        result = (int)await cmd.ExecuteScalarAsync().ConfigureAwait(false);
+                        break;
+                    case AsyncAPI.ExecuteXmlReaderAsync:
+                        using (XmlReader reader = await cmd.ExecuteXmlReaderAsync().ConfigureAwait(false))
+                        {
+                            try
+                            {
+                                Assert.True(reader.Settings.Async);
+                                reader.ReadToDescendant("Id");
+                                result = reader.ReadElementContentAsInt();
+                            }
+                            catch (Exception ex)
+                            {
+                                Assert.False(true, "Exception occurred: " + ex.Message);
+                            }
+                        }
+                        break;
+                }
+
+                if (result != index)
+                {
+                    throw new Exception("High Alert! Wrong data received for index: " + index);
+                }
+                else
+                {
+                    if (timeoutExExpected)
+                        throw new Exception("Index " + index + " did not throw exception");
+                    Assert.True(!timeoutExExpected && result == index);
+                }
+            }
+            catch (SqlException e)
+            {
+                if (!timeoutExExpected)
+                    throw new Exception("Index " + index + " failed with: " + e.Message);
+                else
+                    Assert.True(timeoutExExpected && e.Class == 11 && e.Number == -2);
+            }
+            finally
+            {
+                if (cn != null)
+                {
+                    if (useTransaction)
+                        tx.Commit();
+                    cn.Close();
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/ConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/ConnectionHelper.cs
@@ -10,15 +10,22 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
 {
     internal static class ConnectionHelper
     {
-        private static Assembly s_systemDotData = Assembly.Load(new AssemblyName(typeof(SqlConnection).GetTypeInfo().Assembly.FullName));
-        private static Type s_sqlConnection = s_systemDotData.GetType("Microsoft.Data.SqlClient.SqlConnection");
-        private static Type s_sqlInternalConnection = s_systemDotData.GetType("Microsoft.Data.SqlClient.SqlInternalConnection");
-        private static Type s_sqlInternalConnectionTds = s_systemDotData.GetType("Microsoft.Data.SqlClient.SqlInternalConnectionTds");
-        private static Type s_dbConnectionInternal = s_systemDotData.GetType("Microsoft.Data.ProviderBase.DbConnectionInternal");
+        private static Assembly s_MicrosoftDotData = Assembly.Load(new AssemblyName(typeof(SqlConnection).GetTypeInfo().Assembly.FullName));
+        private static Type s_sqlConnection = s_MicrosoftDotData.GetType("Microsoft.Data.SqlClient.SqlConnection");
+        private static Type s_sqlInternalConnection = s_MicrosoftDotData.GetType("Microsoft.Data.SqlClient.SqlInternalConnection");
+        private static Type s_sqlInternalConnectionTds = s_MicrosoftDotData.GetType("Microsoft.Data.SqlClient.SqlInternalConnectionTds");
+        private static Type s_dbConnectionInternal = s_MicrosoftDotData.GetType("Microsoft.Data.ProviderBase.DbConnectionInternal");
+        private static Type s_tdsParser = s_MicrosoftDotData.GetType("Microsoft.Data.SqlClient.TdsParser");
+        private static Type s_tdsParserStateObject = s_MicrosoftDotData.GetType("Microsoft.Data.SqlClient.TdsParserStateObject");
         private static PropertyInfo s_sqlConnectionInternalConnection = s_sqlConnection.GetProperty("InnerConnection", BindingFlags.Instance | BindingFlags.NonPublic);
         private static PropertyInfo s_dbConnectionInternalPool = s_dbConnectionInternal.GetProperty("Pool", BindingFlags.Instance | BindingFlags.NonPublic);
         private static MethodInfo s_dbConnectionInternalIsConnectionAlive = s_dbConnectionInternal.GetMethod("IsConnectionAlive", BindingFlags.Instance | BindingFlags.NonPublic);
         private static FieldInfo s_sqlInternalConnectionTdsParser = s_sqlInternalConnectionTds.GetField("_parser", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static PropertyInfo s_innerConnectionProperty = s_sqlConnection.GetProperty("InnerConnection", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static PropertyInfo s_tdsParserProperty = s_sqlInternalConnectionTds.GetProperty("Parser", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static FieldInfo s_tdsParserStateObjectProperty = s_tdsParser.GetField("_physicalStateObj", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static FieldInfo s_enforceTimeoutDelayProperty = s_tdsParserStateObject.GetField("_enforceTimeoutDelay", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static FieldInfo s_enforcedTimeoutDelayInMilliSeconds = s_tdsParserStateObject.GetField("_enforcedTimeoutDelayInMilliSeconds", BindingFlags.Instance | BindingFlags.NonPublic);
 
         public static object GetConnectionPool(object internalConnection)
         {
@@ -28,11 +35,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
 
         public static object GetInternalConnection(this SqlConnection connection)
         {
+            VerifyObjectIsConnection(connection);
             object internalConnection = s_sqlConnectionInternalConnection.GetValue(connection, null);
             Debug.Assert(((internalConnection != null) && (s_dbConnectionInternal.IsInstanceOfType(internalConnection))), "Connection provided has an invalid internal connection");
             return internalConnection;
         }
-
 
         public static bool IsConnectionAlive(object internalConnection)
         {
@@ -45,13 +52,32 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
             if (internalConnection == null)
                 throw new ArgumentNullException(nameof(internalConnection));
             if (!s_dbConnectionInternal.IsInstanceOfType(internalConnection))
-                throw new ArgumentException("Object provided was not a DbConnectionInternal", "internalConnection");
+                throw new ArgumentException("Object provided was not a DbConnectionInternal", nameof(internalConnection));
+        }
+
+        private static void VerifyObjectIsConnection(object connection)
+        {
+            if (connection == null)
+                throw new ArgumentNullException(nameof(connection));
+            if (!s_sqlConnection.IsInstanceOfType(connection))
+                throw new ArgumentException("Object provided was not a SqlConnection", nameof(connection));
         }
 
         public static object GetParser(object internalConnection)
         {
             VerifyObjectIsInternalConnection(internalConnection);
             return s_sqlInternalConnectionTdsParser.GetValue(internalConnection);
+        }
+
+        public static void SetEnforcedTimeout(this SqlConnection connection, bool enforce, int timeout)
+        {
+            VerifyObjectIsConnection(connection);
+            var stateObj = s_tdsParserStateObjectProperty.GetValue(
+                            s_tdsParserProperty.GetValue(
+                                s_innerConnectionProperty.GetValue(
+                                    connection, null), null));
+            s_enforceTimeoutDelayProperty.SetValue(stateObj, enforce);
+            s_enforcedTimeoutDelayInMilliSeconds.SetValue(stateObj, timeout);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/ConnectionPoolHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/ConnectionPoolHelper.cs
@@ -13,13 +13,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
 {
     internal static class ConnectionPoolHelper
     {
-        private static Assembly s_systemDotData = Assembly.Load(new AssemblyName(typeof(SqlConnection).GetTypeInfo().Assembly.FullName));
-        private static Type s_dbConnectionPool = s_systemDotData.GetType("Microsoft.Data.ProviderBase.DbConnectionPool");
-        private static Type s_dbConnectionPoolGroup = s_systemDotData.GetType("Microsoft.Data.ProviderBase.DbConnectionPoolGroup");
-        private static Type s_dbConnectionPoolIdentity = s_systemDotData.GetType("Microsoft.Data.ProviderBase.DbConnectionPoolIdentity");
-        private static Type s_dbConnectionFactory = s_systemDotData.GetType("Microsoft.Data.ProviderBase.DbConnectionFactory");
-        private static Type s_sqlConnectionFactory = s_systemDotData.GetType("Microsoft.Data.SqlClient.SqlConnectionFactory");
-        private static Type s_dbConnectionPoolKey = s_systemDotData.GetType("Microsoft.Data.Common.DbConnectionPoolKey");
+        private static Assembly s_MicrosoftDotData = Assembly.Load(new AssemblyName(typeof(SqlConnection).GetTypeInfo().Assembly.FullName));
+        private static Type s_dbConnectionPool = s_MicrosoftDotData.GetType("Microsoft.Data.ProviderBase.DbConnectionPool");
+        private static Type s_dbConnectionPoolGroup = s_MicrosoftDotData.GetType("Microsoft.Data.ProviderBase.DbConnectionPoolGroup");
+        private static Type s_dbConnectionPoolIdentity = s_MicrosoftDotData.GetType("Microsoft.Data.ProviderBase.DbConnectionPoolIdentity");
+        private static Type s_dbConnectionFactory = s_MicrosoftDotData.GetType("Microsoft.Data.ProviderBase.DbConnectionFactory");
+        private static Type s_sqlConnectionFactory = s_MicrosoftDotData.GetType("Microsoft.Data.SqlClient.SqlConnectionFactory");
+        private static Type s_dbConnectionPoolKey = s_MicrosoftDotData.GetType("Microsoft.Data.Common.DbConnectionPoolKey");
         private static Type s_dictStringPoolGroup = typeof(Dictionary<,>).MakeGenericType(s_dbConnectionPoolKey, s_dbConnectionPoolGroup);
         private static Type s_dictPoolIdentityPool = typeof(ConcurrentDictionary<,>).MakeGenericType(s_dbConnectionPoolIdentity, s_dbConnectionPool);
         private static PropertyInfo s_dbConnectionPoolCount = s_dbConnectionPool.GetProperty("Count", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -122,7 +122,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SystemDataInternals
             VerifyObjectIsPool(pool);
             return (int)s_dbConnectionPoolCount.GetValue(pool, null);
         }
-
 
         private static void VerifyObjectIsPool(object pool)
         {


### PR DESCRIPTION
Attempted fix for #659.

Many thanks to Cheena for the legwork in locating the troublesome area.

The underlying problem is that the timer that fires OnTimeout can fire very late when there are no free threads in the pool, even after the state object has been recycled and is put back into use on another query. My solution is to track the owning object that the timeout is supposed to be associated with and if it is has changed when the timer runs, OnTimeout should simply return rather than send attention for the now incorrect query.

Cheena also observed timeouts not working on subsequent re-uses of the state object. I think this also fixes those. We should add tests specific to these scenarios to this PR before merging.

This seems to fix the incorrect data repros for 659 that I've run. Hopefully others can validate it, too, so that we can get a solution finalized.

CC: @cheenamalhotra @Wraith2 