### PR TITLE
Perf: Improve perf of SqlDateTimeToDateTime

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -742,7 +742,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception DateTimeOverflow()
         {
-            throw new OverflowException(SqlTypes.SQLResource.DateTimeOverflowMessage);
+            return new OverflowException(SqlTypes.SQLResource.DateTimeOverflowMessage);
         }
 
         //

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -740,6 +740,11 @@ namespace Microsoft.Data.SqlClient
             return ADP.TypeLoad(System.StringsHelper.GetString(Strings.SQLUDT_Unexpected, exceptionText));
         }
 
+        internal static Exception DateTimeOverflow()
+        {
+            throw new OverflowException(SqlTypes.SQLResource.DateTimeOverflowMessage);
+        }
+
         //
         // SQL.SqlDependency
         //

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -799,6 +799,11 @@ namespace Microsoft.Data.SqlClient
             return e;
         }
 
+        internal static Exception DateTimeOverflow()
+        {
+            throw new OverflowException(SqlTypes.SQLResource.DateTimeOverflowMessage);
+        }
+
         //
         // SQL.SqlDependency
         //

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -801,7 +801,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception DateTimeOverflow()
         {
-            throw new OverflowException(SqlTypes.SQLResource.DateTimeOverflowMessage);
+            return new OverflowException(SqlTypes.SQLResource.DateTimeOverflowMessage);
         }
 
         //

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Xml;
+using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Data.SqlTypes
 {
@@ -82,10 +83,8 @@ namespace Microsoft.Data.SqlTypes
             return new DateTime(totalTicks);
         }
 
-        private static void ThrowOverflowException()
-        {
-            throw new OverflowException(SQLResource.DateTimeOverflowMessage);
-        }
+        private static Exception ThrowOverflowException() => throw SQL.DateTimeOverflow();
+
         #endregion
 
         #region Work around inability to access SqlMoney.ctor(long, int) and SqlMoney.ToSqlInternalRepresentation

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.cs
@@ -62,20 +62,27 @@ namespace Microsoft.Data.SqlTypes
             const int SQLTicksPerHour = SQLTicksPerMinute * 60;
             const int SQLTicksPerDay = SQLTicksPerHour * 24;
             const int MinDay = -53690;                // Jan 1 1753
-            const int MaxDay = 2958463;               // Dec 31 9999 is this many days from Jan 1 1900
+            const uint MaxDay = 2958463;               // Dec 31 9999 is this many days from Jan 1 1900
+            const uint MaxTime = SQLTicksPerDay - 1; // = 25919999,  11:59:59:997PM
             const int MinTime = 0;                    // 00:00:0:000PM
-            const int MaxTime = SQLTicksPerDay - 1; // = 25919999,  11:59:59:997PM
+            const long BaseDateTicks = 599266080000000000L;//new DateTime(1900, 1, 1).Ticks;
 
-            if (daypart < MinDay || daypart > MaxDay || timepart < MinTime || timepart > MaxTime)
+            if ((uint)daypart > MaxDay || (uint)timepart > MaxTime || daypart < MinDay || timepart < MinTime)
             {
-                throw new OverflowException(SQLResource.DateTimeOverflowMessage);
+                ThrowOverflowException();
             }
 
-            long baseDateTicks = new DateTime(1900, 1, 1).Ticks;
             long dayticks = daypart * TimeSpan.TicksPerDay;
-            long timeticks = ((long)(timepart / SQLTicksPerMillisecond + 0.5)) * TimeSpan.TicksPerMillisecond;
+            double timePartPerMs = timepart / SQLTicksPerMillisecond;
+            double int1 = timePartPerMs + 0.5;
+            long timeticks1 = ((long)int1) * TimeSpan.TicksPerMillisecond;
+            long ticks1 = BaseDateTicks + dayticks + timeticks1;
+            return new DateTime(ticks1);
+        }
 
-            return new DateTime(baseDateTicks + dayticks + timeticks);
+        private static void ThrowOverflowException()
+        {
+            throw new OverflowException(SQLResource.DateTimeOverflowMessage);
         }
         #endregion
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.cs
@@ -6,6 +6,7 @@ using System;
 using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Xml;
 using Microsoft.Data.SqlClient;
@@ -83,6 +84,10 @@ namespace Microsoft.Data.SqlTypes
             return new DateTime(totalTicks);
         }
 
+        // this method is split out of SqlDateTimeToDateTime for performance reasons
+        // it is faster to make a method call than it is to incorporate the asm for this
+        // method in the calling method.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private static Exception ThrowOverflowException() => throw SQL.DateTimeOverflow();
 
         #endregion


### PR DESCRIPTION
While reviewing https://github.com/dotnet/SqlClient/pull/853 I did some digging into the related code and profiling. The function used to convert sql date times to .net datetimes came up as hot so I tinkered with it a bit. The most important part is to avoid creating a datetime just to get a constant value from it, hardcode it instead.

Gist of the benchmark code is here: https://gist.github.com/Wraith2/d0d220f07e640c17daeb9db2d446aaa4

results: 
```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.200-preview.21079.7
  [Host]     : .NET Core 3.1.12 (CoreCLR 4.700.21.6504, CoreFX 4.700.21.6905), X64 RyuJIT
  DefaultJob : .NET Core 3.1.12 (CoreCLR 4.700.21.6504, CoreFX 4.700.21.6905), X64 RyuJIT
```

|   Method |      Mean |    Error |   StdDev | Ratio |
|--------- |----------:|---------:|---------:|------:|
| Original | 271.50 ms | 4.619 ms | 4.321 ms |  1.00 |
|      New |  82.45 ms | 0.232 ms | 0.206 ms |  0.30 |

/cc @bjornbouetsmith who this may interest