### PR TITLE
[.NET Core] Support Assembly Context Unloading

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -474,5 +474,10 @@ namespace Microsoft.Data.ProviderBase
         abstract internal bool SetInnerConnectionFrom(DbConnection owningObject, DbConnectionInternal to, DbConnectionInternal from);
 
         abstract internal void SetInnerConnectionTo(DbConnection owningObject, DbConnectionInternal to);
+
+        virtual internal void Unload()
+        {
+            _pruningTimer.Dispose();
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -309,6 +309,8 @@
     <Compile Include="Microsoft\Data\SqlClient\SqlDelegatedTransaction.NetCoreApp.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParser.NetCoreApp.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SslOverTdsStream.NetCoreApp.cs" />
+    <Compile Include="Microsoft\Data\SqlClient\SqlConnectionFactory.AssemblyLoadContext.cs" />    
+    <Compile Include="Microsoft\Data\SqlClient\SqlDependencyUtils.AssemblyLoadContext.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetGroup)' == 'netcoreapp' AND '$(BuildSimulator)' == 'true'">
     <Compile Include="Microsoft\Data\SqlClient\SimulatorEnclaveProvider.NetCoreApp.cs" />
@@ -778,7 +780,7 @@
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Runtime.Caching" Version="$(SystemRuntimeCachingVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources\Strings.resx">

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.AssemblyLoadContext.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.AssemblyLoadContext.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Reflection;
 using System.Runtime.Loader;
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.AssemblyLoadContext.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.AssemblyLoadContext.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Microsoft.Data.SqlClient
+{
+    sealed internal partial class SqlConnectionFactory
+    { 
+        partial void SubscribeToAssemblyLoadContextUnload()
+        {
+            AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()).Unloading += SqlConnectionFactoryAssemblyLoadContext_Unloading;
+        }
+
+        private void SqlConnectionFactoryAssemblyLoadContext_Unloading(AssemblyLoadContext obj)
+        {
+            Unload(obj, EventArgs.Empty);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -11,12 +11,15 @@ using Microsoft.Data.ProviderBase;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlConnectionFactory : DbConnectionFactory
+    sealed internal partial class SqlConnectionFactory : DbConnectionFactory
     {
 
         private const string _metaDataXml = "MetaDataXml";
 
-        private SqlConnectionFactory() : base() { }
+        private SqlConnectionFactory() : base()
+        {
+            SubscribeToAssemblyLoadContextUnload();
+        }
 
         public static readonly SqlConnectionFactory SingletonInstance = new SqlConnectionFactory();
 
@@ -306,6 +309,20 @@ namespace Microsoft.Data.SqlClient
                                           internalConnection.ServerVersion,
                                           internalConnection.ServerVersion);
         }
+
+        private void Unload(object sender, EventArgs e)
+        {
+            try
+            {
+                Unload();
+            }
+            finally
+            {
+                ClearAllPools();
+            }
+        }
+
+        partial void SubscribeToAssemblyLoadContextUnload();
     }
 }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.AppDomain.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.AppDomain.cs
@@ -11,28 +11,10 @@ namespace Microsoft.Data.SqlClient
     // for example, some mobile profiles on mono
     partial class SqlDependencyPerAppDomainDispatcher
     {
-        private void SubscribeToAppDomainUnload()
+        partial void SubscribeToAppDomainUnload()
         {
             // If rude abort - we'll leak.  This is acceptable for now.
             AppDomain.CurrentDomain.DomainUnload += new EventHandler(UnloadEventHandler);
-        }
-
-        private void UnloadEventHandler(object sender, EventArgs e)
-        {
-            long scopeID = SqlClientEventSource.Log.TryNotificationScopeEnterEvent("SqlDependencyPerAppDomainDispatcher.UnloadEventHandler | DEP | Object Id {0}", ObjectID);
-            try
-            {
-                // Make non-blocking call to ProcessDispatcher to ThreadPool.QueueUserWorkItem to complete
-                // stopping of all start calls in this AppDomain.  For containers shared among various AppDomains,
-                // this will just be a ref-count subtract.  For non-shared containers, we will close the container
-                // and clean-up.
-                var dispatcher = SqlDependency.ProcessDispatcher;
-                dispatcher?.QueueAppDomainUnloading(SqlDependency.AppDomainKey);
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryNotificationScopeLeaveEvent(scopeID);
-            }
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.AssemblyLoadContext.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDependencyUtils.AssemblyLoadContext.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Microsoft.Data.SqlClient
+{
+    // these members were moved to a separate file in order
+    // to be able to skip them on platforms where AssemblyLoadContext members are not supported
+    // for example, netstandard
+    partial class SqlDependencyPerAppDomainDispatcher
+    {
+        partial void SubscribeToAssemblyLoadContextUnload()
+        {
+            AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()).Unloading += SqlDependencyPerAppDomainDispatcher_Unloading;
+        }
+
+        private void SqlDependencyPerAppDomainDispatcher_Unloading(AssemblyLoadContext obj)
+        {
+            UnloadEventHandler(null, EventArgs.Empty);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDiagnosticListener.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDiagnosticListener.NetCoreApp.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Loader;
 
 namespace Microsoft.Data.SqlClient
 {
@@ -10,6 +12,12 @@ namespace Microsoft.Data.SqlClient
     {
         public SqlDiagnosticListener(string name) : base(name)
         {
+            AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()).Unloading += SqlDiagnosticListener_Unloading;
+        }
+
+        private void SqlDiagnosticListener_Unloading(AssemblyLoadContext obj)
+        {
+            Dispose();
         }
     }
 }


### PR DESCRIPTION
Initial changes required to get same app from https://github.com/dotnet/SqlClient/issues/414 unloading successfully.
Then the .net 5 build is ready it will need to take account of the ALC files to make sure they are included in 5 and later builds which use ALC.