### PR TITLE
FIX | Throwing exception from Dispose should not happen

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -844,7 +844,7 @@ namespace Microsoft.Data.SqlClient
             }
             catch(SqlException ex)
             {
-                SqlClientEventSource.Log.TryTraceEvent("SqlDataReader.Dispose | ERR | Error: {0}", ex);
+                SqlClientEventSource.Log.TryTraceEvent("SqlDataReader.Dispose | ERR | Error Message: {0}, Stack Trace: {1}", ex.Message, ex.StackTrace);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -924,6 +924,10 @@ namespace Microsoft.Data.SqlClient
                     }
                 }
             }
+            catch (SqlException ex)
+            {
+                SqlClientEventSource.Log.TryTraceEvent("SqlDataReader.Close | ERR | Error Stack: {0}, Error Message: {1}", ex, ex.Message);
+            }
             finally
             {
                 SqlStatistics.StopTimer(statistics);
@@ -2966,7 +2970,7 @@ namespace Microsoft.Data.SqlClient
                     if ((sequentialAccess) && (i < maximumColumn))
                     {
                         _data[fieldIndex].Clear();
-                        if (fieldIndex > i && fieldIndex>0)
+                        if (fieldIndex > i && fieldIndex > 0)
                         {
                             // if we jumped an index forward because of a hidden column see if the buffer before the
                             // current one was populated by the seek forward and clear it if it was
@@ -4515,7 +4519,7 @@ namespace Microsoft.Data.SqlClient
                 if (!isContinuation)
                 {
                     // This is the first async operation which is happening - setup the _currentTask and timeout
-                    Debug.Assert(context._source==null, "context._source should not be non-null when trying to change to async");
+                    Debug.Assert(context._source == null, "context._source should not be non-null when trying to change to async");
                     source = new TaskCompletionSource<int>();
                     Task original = Interlocked.CompareExchange(ref _currentTask, source.Task, null);
                     if (original != null)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -834,11 +834,18 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Dispose/*' />
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
+            try
             {
-                Close();
+                if (disposing)
+                {
+                    Close();
+                }
+                base.Dispose(disposing);
             }
-            base.Dispose(disposing);
+            catch(SqlException ex)
+            {
+                SqlClientEventSource.Log.TryTraceEvent("SqlDataReader.Dispose | ERR | Error: {0}", ex);
+            }
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Close/*' />
@@ -923,10 +930,6 @@ namespace Microsoft.Data.SqlClient
                         }
                     }
                 }
-            }
-            catch (SqlException ex)
-            {
-                SqlClientEventSource.Log.TryTraceEvent("SqlDataReader.Close | ERR | Error Stack: {0}, Error Message: {1}", ex, ex.Message);
             }
             finally
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -935,6 +935,23 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Dispose/*' />
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (disposing)
+                {
+                    Close();
+                }
+                base.Dispose(disposing);
+            }
+            catch (SqlException ex)
+            {
+                SqlClientEventSource.Log.TryTraceEvent("SqlDataReader.Dispose | ERR | Error Message: {0}, Stack Trace: {1}", ex.Message, ex.StackTrace);
+            }
+        }
+
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Close/*' />
         override public void Close()
         {


### PR DESCRIPTION
Addressing Issue #672, throwing exception from Dispose should not happen. 
`TryCloseInternal` passes an unhandled exception to `Close` function and the exception comes up from `Dispose` method. Adding the `try/catch` block  will fix the issue.