### PR TITLE
Rework MARSConnection state machine

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -530,6 +530,7 @@
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIMarsQueuedPacket.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNINpHandle.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIPacket.cs" />
+    <Compile Include="Microsoft\Data\SqlClient\SNI\SNIPacket.Debug.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIPacketPool.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIPhysicalHandle.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIProxy.cs" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
@@ -90,8 +90,7 @@ namespace Microsoft.Data.SqlClient.SNI
     /// <summary>
     /// SMUX packet flags
     /// </summary>
-    [Flags]
-    internal enum SNISMUXFlags
+    internal enum SNISMUXFlags : uint
     {
         SMUX_SYN = 1,       // Begin SMUX connection
         SMUX_ACK = 2,       // Acknowledge SMUX packets

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
@@ -35,30 +35,40 @@ namespace Microsoft.Data.SqlClient.SNI
     /// <summary>
     /// SMUX packet header
     /// </summary>
-    internal sealed class SNISMUXHeader
+    internal struct SNISMUXHeader
     {
         public const int HEADER_LENGTH = 16;
 
-        public byte SMID;
-        public byte flags;
-        public ushort sessionId;
-        public uint length;
-        public uint sequenceNumber;
-        public uint highwater;
+        public byte SMID { get; private set; }
+        public byte Flags { get; private set; }
+        public ushort SessionId { get; private set; }
+        public uint Length { get; private set; }
+        public uint SequenceNumber { get; private set; }
+        public uint Highwater { get; private set; }
+
+        public void Set(byte smid, byte flags, ushort sessionID, uint length, uint sequenceNumber, uint highwater)
+        {
+            SMID = smid;
+            Flags = flags;
+            SessionId = sessionID;
+            Length = length;
+            SequenceNumber = sequenceNumber;
+            Highwater = highwater;
+        }
 
         public void Read(byte[] bytes)
         {
             SMID = bytes[0];
-            flags = bytes[1];
-            sessionId = BitConverter.ToUInt16(bytes, 2);
-            length = BitConverter.ToUInt32(bytes, 4) - SNISMUXHeader.HEADER_LENGTH;
-            sequenceNumber = BitConverter.ToUInt32(bytes, 8);
-            highwater = BitConverter.ToUInt32(bytes, 12);
+            Flags = bytes[1];
+            SessionId = BitConverter.ToUInt16(bytes, 2);
+            Length = BitConverter.ToUInt32(bytes, 4) - SNISMUXHeader.HEADER_LENGTH;
+            SequenceNumber = BitConverter.ToUInt32(bytes, 8);
+            Highwater = BitConverter.ToUInt32(bytes, 12);
         }
 
         public void Write(Span<byte> bytes)
         {
-            uint value = highwater;
+            uint value = Highwater;
             // access the highest element first to cause the largest range check in the jit, then fill in the rest of the value and carry on as normal
             bytes[15] = (byte)((value >> 24) & 0xff);
             bytes[12] = (byte)(value & 0xff); // BitConverter.GetBytes(_currentHeader.highwater).CopyTo(headerBytes, 12);
@@ -66,24 +76,46 @@ namespace Microsoft.Data.SqlClient.SNI
             bytes[14] = (byte)((value >> 16) & 0xff);
 
             bytes[0] = SMID; // BitConverter.GetBytes(_currentHeader.SMID).CopyTo(headerBytes, 0);
-            bytes[1] = flags; // BitConverter.GetBytes(_currentHeader.flags).CopyTo(headerBytes, 1);
+            bytes[1] = Flags; // BitConverter.GetBytes(_currentHeader.flags).CopyTo(headerBytes, 1);
 
-            value = sessionId;
+            value = SessionId;
             bytes[2] = (byte)(value & 0xff); // BitConverter.GetBytes(_currentHeader.sessionId).CopyTo(headerBytes, 2);
             bytes[3] = (byte)((value >> 8) & 0xff);
 
-            value = length;
+            value = Length;
             bytes[4] = (byte)(value & 0xff); // BitConverter.GetBytes(_currentHeader.length).CopyTo(headerBytes, 4);
             bytes[5] = (byte)((value >> 8) & 0xff);
             bytes[6] = (byte)((value >> 16) & 0xff);
             bytes[7] = (byte)((value >> 24) & 0xff);
 
-            value = sequenceNumber;
+            value = SequenceNumber;
             bytes[8] = (byte)(value & 0xff); // BitConverter.GetBytes(_currentHeader.sequenceNumber).CopyTo(headerBytes, 8);
             bytes[9] = (byte)((value >> 8) & 0xff);
             bytes[10] = (byte)((value >> 16) & 0xff);
             bytes[11] = (byte)((value >> 24) & 0xff);
 
+        }
+
+        public SNISMUXHeader Clone()
+        {
+            SNISMUXHeader copy = new SNISMUXHeader();
+            copy.SMID = SMID;
+            copy.Flags = Flags;
+            copy.SessionId = SessionId;
+            copy.Length = Length;
+            copy.SequenceNumber = SequenceNumber;
+            copy.Highwater = Highwater;
+            return copy;
+        }
+
+        public void Clear()
+        {
+            SMID = 0;
+            Flags = 0;
+            SessionId = 0;
+            Length = 0;
+            SequenceNumber = 0;
+            Highwater = 0;
         }
     }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Data.SqlClient.SNI
             Demux,
             HandleAck,
             HandleData,
-            Recieve,
+            Receive,
             Finish,
             Error
         }
@@ -312,7 +312,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                         }
                                         else
                                         {
-                                            state = State.Recieve;
+                                            state = State.Receive;
                                         }
                                         break;
 
@@ -346,14 +346,14 @@ namespace Microsoft.Data.SqlClient.SNI
                                             {
                                                 // payload is complete so dispatch the current packet
                                                 _demuxState = DemuxState.Dispatch;
-                                                state = State.Recieve;
+                                                state = State.Receive;
                                                 goto case DemuxState.Dispatch;
                                             }
                                             else if (packet.DataLeft == 0)
                                             {
                                                 // no more data in the delivered packet so wait for a new one
                                                 _demuxState = DemuxState.Payload;
-                                                state = State.Recieve;
+                                                state = State.Receive;
                                             }
                                             else
                                             {
@@ -388,7 +388,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                                     }
                                                     else
                                                     {
-                                                        nextState = State.Recieve;
+                                                        nextState = State.Receive;
                                                     }
                                                     break;
 
@@ -407,7 +407,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                                     }
                                                     else
                                                     {
-                                                        nextState = State.Recieve;
+                                                        nextState = State.Receive;
                                                     }
                                                     break;
 
@@ -438,7 +438,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                                 {
                                                     SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "MARS Session Id {0}, run out of data , queuing receive", args0: _lowerHandle?.ConnectionId, args1: _header.SessionId);
                                                 }
-                                                state = State.Recieve;
+                                                state = State.Receive;
                                             }
 
                                         }
@@ -500,7 +500,7 @@ namespace Microsoft.Data.SqlClient.SNI
                             nextState = State.Finish;
                             break;
 
-                        case State.Recieve:
+                        case State.Receive:
                             if (packet != null)
                             {
                                 Debug.Assert(packet.DataLeft == 0, "loop exit with data remaining");

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Data.SqlClient.SNI
     /// </summary>
     internal class SNIMarsConnection
     {
+        private readonly object _sync;
         private readonly Guid _connectionId;
         private readonly Dictionary<int, SNIMarsHandle> _sessions;
         private SNIHandle _lowerHandle;
@@ -26,7 +27,7 @@ namespace Microsoft.Data.SqlClient.SNI
 
         public int ProtocolVersion => _lowerHandle.ProtocolVersion;
 
-        public object DemuxerSync => this;
+        public object DemuxerSync => _sync;
 
         /// <summary>
         /// Constructor
@@ -34,6 +35,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="lowerHandle">Lower handle</param>
         public SNIMarsConnection(SNIHandle lowerHandle)
         {
+            _sync = new object();
             _connectionId = Guid.NewGuid();
             _sessions = new Dictionary<int, SNIMarsHandle>();
             _demuxState = DemuxState.Header;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                 {
                                     // if the data in the packet being processed is exactly and only the data that is going to sent
                                     // on to the parser then don't copy it to a new packet just forward the current packet once we've
-                                    // fiddled the data pointer so that it skips the header data when
+                                    // fiddled the data pointer so that it skips the header data
                                     _partial = packet;
                                     packet = null;
                                     _partial.SetDataToRemainingContents();
@@ -388,7 +388,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                     _headerCount = 0;
                                     _state = State.Header;
 
-                                    if (packet==null || packet.DataLeft == 0)
+                                    if (packet == null || packet.DataLeft == 0)
                                     {
                                         if (packet != null)
                                         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.SqlClient.SNI
         private readonly ushort _sessionId;
         private readonly ManualResetEventSlim _packetEvent = new ManualResetEventSlim(false);
         private readonly ManualResetEventSlim _ackEvent = new ManualResetEventSlim(false);
-        private readonly SNISMUXHeader _currentHeader = new SNISMUXHeader();
+        //private readonly SNISMUXHeader _currentHeader = new SNISMUXHeader();
         private readonly SNIAsyncCallback _handleSendCompleteCallback;
 
         private uint _sendHighwater = 4;
@@ -55,6 +55,11 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public override void Dispose()
         {
+            // SendControlPacket will lock so make sure that it cannot deadlock by failing to enter the DemuxerLock
+            if (_connection != null && Monitor.IsEntered(_connection.DemuxerSync))
+            {
+                throw new InvalidOperationException("SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
+            }
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {
@@ -106,8 +111,8 @@ namespace Microsoft.Data.SqlClient.SNI
 #endif
                 lock (this)
                 {
-                    SetupSMUXHeader(0, flags);
-                    _currentHeader.Write(packet.GetHeaderBuffer(SNISMUXHeader.HEADER_LENGTH));
+                    SNISMUXHeader header = SetupSMUXHeader(0, flags);
+                    header.Write(packet.GetHeaderBuffer(SNISMUXHeader.HEADER_LENGTH));
                     packet.SetHeaderActive();
                 }
 
@@ -124,17 +129,22 @@ namespace Microsoft.Data.SqlClient.SNI
             }
         }
 
-        private void SetupSMUXHeader(int length, SNISMUXFlags flags)
+        private SNISMUXHeader SetupSMUXHeader(int length, SNISMUXFlags flags)
         {
             Debug.Assert(Monitor.IsEntered(this), "must take lock on self before updating smux header");
 
-            _currentHeader.SMID = 83;
-            _currentHeader.flags = (byte)flags;
-            _currentHeader.sessionId = _sessionId;
-            _currentHeader.length = (uint)SNISMUXHeader.HEADER_LENGTH + (uint)length;
-            _currentHeader.sequenceNumber = ((flags == SNISMUXFlags.SMUX_FIN) || (flags == SNISMUXFlags.SMUX_ACK)) ? _sequenceNumber - 1 : _sequenceNumber++;
-            _currentHeader.highwater = _receiveHighwater;
-            _receiveHighwaterLastAck = _currentHeader.highwater;
+            SNISMUXHeader header = new SNISMUXHeader();
+            header.Set(
+                smid: 83,
+                flags: (byte)flags,
+                sessionID: _sessionId,
+                length: (uint)SNISMUXHeader.HEADER_LENGTH + (uint)length,
+                sequenceNumber: ((flags == SNISMUXFlags.SMUX_FIN) || (flags == SNISMUXFlags.SMUX_ACK)) ? _sequenceNumber - 1 : _sequenceNumber++,
+                highwater: _receiveHighwater
+            );
+            _receiveHighwaterLastAck = header.Highwater;
+
+            return header;
         }
 
         /// <summary>
@@ -145,9 +155,10 @@ namespace Microsoft.Data.SqlClient.SNI
         private SNIPacket SetPacketSMUXHeader(SNIPacket packet)
         {
             Debug.Assert(packet.ReservedHeaderSize == SNISMUXHeader.HEADER_LENGTH, "mars handle attempting to smux packet without smux reservation");
+            Debug.Assert(Monitor.IsEntered(this), "cannot create mux header outside lock");
 
-            SetupSMUXHeader(packet.DataLength, SNISMUXFlags.SMUX_DATA);
-            _currentHeader.Write(packet.GetHeaderBuffer(SNISMUXHeader.HEADER_LENGTH));
+            SNISMUXHeader header = SetupSMUXHeader(packet.DataLength, SNISMUXFlags.SMUX_DATA);
+            header.Write(packet.GetHeaderBuffer(SNISMUXHeader.HEADER_LENGTH));
             packet.SetHeaderActive();
 #if DEBUG
             SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, Setting SMUX_DATA header in current header for packet {1}", args0: ConnectionId, args1: packet?._id);
@@ -290,6 +301,10 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
         {
+            if (Monitor.IsEntered(_connection.DemuxerSync))
+            {
+                throw new InvalidOperationException("SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
+            }
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {
@@ -423,6 +438,10 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="highwater">Send highwater mark</param>
         public void HandleAck(uint highwater)
         {
+            if (Monitor.IsEntered(_connection.DemuxerSync))
+            {
+                throw new InvalidOperationException("SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
+            }
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {
@@ -449,15 +468,19 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="header">SMUX header</param>
         public void HandleReceiveComplete(SNIPacket packet, SNISMUXHeader header)
         {
+            if (Monitor.IsEntered(_connection.DemuxerSync))
+            {
+                throw new InvalidOperationException("SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
+            }
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {
                 lock (this)
                 {
-                    if (_sendHighwater != header.highwater)
+                    if (_sendHighwater != header.Highwater)
                     {
-                        SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, header.highwater {1}, _sendHighwater {2}, Handle Ack with header.highwater", args0: ConnectionId, args1: header?.highwater, args2: _sendHighwater);
-                        HandleAck(header.highwater);
+                        SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, header.highwater {1}, _sendHighwater {2}, Handle Ack with header.highwater", args0: ConnectionId, args1: header.Highwater, args2: _sendHighwater);
+                        HandleAck(header.Highwater);
                     }
 
                     lock (_receivedPacketQueue)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -56,10 +56,7 @@ namespace Microsoft.Data.SqlClient.SNI
         public override void Dispose()
         {
             // SendControlPacket will lock so make sure that it cannot deadlock by failing to enter the DemuxerLock
-            if (_connection != null && Monitor.IsEntered(_connection.DemuxerSync))
-            {
-                throw new InvalidOperationException("SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
-            }
+            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {
@@ -301,10 +298,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
         {
-            if (Monitor.IsEntered(_connection.DemuxerSync))
-            {
-                throw new InvalidOperationException("SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
-            }
+            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {
@@ -438,10 +432,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="highwater">Send highwater mark</param>
         public void HandleAck(uint highwater)
         {
-            if (Monitor.IsEntered(_connection.DemuxerSync))
-            {
-                throw new InvalidOperationException("SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
-            }
+            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {
@@ -468,10 +459,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="header">SMUX header</param>
         public void HandleReceiveComplete(SNIPacket packet, SNISMUXHeader header)
         {
-            if (Monitor.IsEntered(_connection.DemuxerSync))
-            {
-                throw new InvalidOperationException("SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
-            }
+            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Data.SqlClient.SNI
         public override void Dispose()
         {
             // SendControlPacket will lock so make sure that it cannot deadlock by failing to enter the DemuxerLock
-            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
+            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {
@@ -298,7 +298,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public override uint SendAsync(SNIPacket packet, SNIAsyncCallback callback = null)
         {
-            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
+            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {
@@ -432,7 +432,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="highwater">Send highwater mark</param>
         public void HandleAck(uint highwater)
         {
-            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
+            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {
@@ -459,7 +459,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="header">SMUX header</param>
         public void HandleReceiveComplete(SNIPacket packet, SNISMUXHeader header)
         {
-            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
+            Debug.Assert(_connection != null && Monitor.IsEntered(_connection.DemuxerSync), "SNIMarsHandle.HandleRecieveComplete should be called while holding the SNIMarsConnection.DemuxerSync because it can cause deadlocks");
             long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
             try
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Data.SqlClient.SNI
         {
             Debug.Assert(packet.ReservedHeaderSize == SNISMUXHeader.HEADER_LENGTH, "mars handle attempting to smux packet without smux reservation");
 
-            SetupSMUXHeader(packet.Length, SNISMUXFlags.SMUX_DATA);
+            SetupSMUXHeader(packet.DataLength, SNISMUXFlags.SMUX_DATA);
             _currentHeader.Write(packet.GetHeaderBuffer(SNISMUXHeader.HEADER_LENGTH));
             packet.SetHeaderActive();
 #if DEBUG

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNINpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNINpHandle.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Data.SqlClient.SNI
                         packet.ReadFromStream(_stream);
                         SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "Connection Id {0}, Rented and read packet, dataLeft {1}", args0: _connectionId, args1: packet?.DataLeft);
 
-                        if (packet.Length == 0)
+                        if (packet.DataLength == 0)
                         {
                             errorPacket = packet;
                             packet = null;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.Debug.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.Debug.cs
@@ -1,0 +1,188 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//#define TRACE_HISTORY // this is used for advanced debugging when you need to trace where a packet is rented and returned, mostly used to identify double
+                      // return problems
+
+//#define TRACE_PATH  // this is used for advanced debugging when you need to see what functions the packet passes through. In each location you want to trace
+                    // add a call to PushPath or PushPathStack and then when you hit a breakpoint or assertion failure inspect the _path variable
+                    // to see the pushed entries since the packet was rented. 
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.Data.SqlClient.SNI
+{
+#if DEBUG
+    internal sealed partial class SNIPacket
+    {
+#if TRACE_HISTORY
+        [DebuggerDisplay("{Action.ToString(),nq}")]
+        internal struct History
+        {
+            public enum Direction
+            {
+                Rent = 0,
+                Return = 1,
+            }
+
+            public Direction Action;
+            public int RefCount;
+            public string Stack;
+        }
+#endif
+
+#if TRACE_PATH
+        [DebuggerTypeProxy(typeof(PathEntryDebugView))]
+        [DebuggerDisplay("{Name,nq}")]
+        internal sealed class PathEntry
+        {
+            public PathEntry Previous = null;
+            public string Name = null;
+        }
+
+        internal sealed class PathEntryDebugView
+        {
+            private readonly PathEntry _data;
+
+            public PathEntryDebugView(PathEntry data)
+            {
+                if (data == null)
+                {
+                    throw new ArgumentNullException(nameof(data));
+                }
+
+                _data = data;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public string[] Items
+            {
+                get
+                {
+                    string[] items = Array.Empty<string>();
+                    if (_data != null)
+                    {
+                        int count = 0;
+                        for (PathEntry current = _data; current != null; current = current?.Previous)
+                        {
+                            count++;
+                        }
+                        items = new string[count];
+                        int index = 0;
+                        for (PathEntry current = _data; current != null; current = current?.Previous, index++)
+                        {
+                            items[index] = current.Name;
+                        }
+                    }
+                    return items;
+                }
+            }
+        }
+#endif
+
+        internal readonly int _id;  // in debug mode every packet is assigned a unique id so that the entire lifetime can be tracked when debugging
+        /// refcount = 0 means that a packet should only exist in the pool
+        /// refcount = 1 means that a packet is active
+        /// refcount > 1 means that a packet has been reused in some way and is a serious error
+        internal int _refCount;
+        internal readonly SNIHandle _owner; // used in debug builds to check that packets are being returned to the correct pool
+        internal string _traceTag; // used to assist tracing what steps the packet has been through
+#if TRACE_PATH
+        internal PathEntry _path;
+#endif
+#if TRACE_HISTORY
+        internal List<History> _history;
+#endif
+
+        public void PushPath(string name)
+        {
+#if TRACE_PATH
+            var entry = new PathEntry { Previous = _path, Name = name };
+            _path = entry;
+#endif
+        }
+
+        public void PushPathStack()
+        {
+#if TRACE_PATH
+            PushPath(new StackTrace().ToString());
+#endif
+        }
+
+        public void PopPath()
+        {
+#if TRACE_PATH
+            _path = _path?.Previous;
+#endif
+        }
+
+        public void ClearPath()
+        {
+#if TRACE_PATH
+            _path = null;
+#endif
+        }
+
+        public void AddHistory(bool renting)
+        {
+#if TRACE_HISTORY
+            _history.Add(
+                new History 
+                {
+                    Action = renting ? History.Direction.Rent : History.Direction.Return,
+                    Stack = GetStackParts(), 
+                    RefCount = _refCount 
+                }
+            );
+#endif
+        }
+
+        /// <summary>
+        /// uses the packet refcount in debug mode to identify if the packet is considered active
+        /// it is an error to use a packet which is not active in any function outside the pool implementation
+        /// </summary>
+        public bool IsActive => _refCount == 1;
+
+        public SNIPacket(SNIHandle owner, int id)
+            : this()
+        {
+            _id = id;
+            _owner = owner;
+#if TRACE_PATH
+            _path = null;
+#endif
+#if TRACE_HISTORY
+            _history = new List<History>();
+#endif
+        }
+
+        // the finalizer is only included in debug builds and is used to ensure that all packets are correctly recycled
+        // it is not an error if a packet is dropped but it is undesirable so all efforts should be made to make sure we
+        // do not drop them for the GC to pick up
+        ~SNIPacket()
+        {
+            if (_data != null)
+            {
+                Debug.Fail($@"finalizer called for unreleased SNIPacket, tag: {_traceTag}");
+            }
+        }
+
+#if TRACE_HISTORY
+        private string GetStackParts()
+        {
+            return string.Join(Environment.NewLine,
+                Environment.StackTrace
+                .Split(new string[] { Environment.NewLine }, StringSplitOptions.None)
+                .Skip(3) // trims off the common parts at the top of the stack so you can see what the actual caller was
+                .Take(9) // trims off most of the bottom of the stack because when running under xunit there's a lot of spam
+            );
+        }
+#endif
+
+    }
+#endif
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.Debug.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.Debug.cs
@@ -6,8 +6,8 @@
                       // return problems
 
 //#define TRACE_PATH  // this is used for advanced debugging when you need to see what functions the packet passes through. In each location you want to trace
-                    // add a call to PushPath or PushPathStack and then when you hit a breakpoint or assertion failure inspect the _path variable
-                    // to see the pushed entries since the packet was rented. 
+                    // add a call to PushPath or PushPathStack e.g. packet.PushPath(new StackTrace().ToString()); and then when you hit a breakpoint or
+                    // assertion failure inspect the _path variable to see the pushed entries since the packet was rented. 
 
 using System;
 using System.Collections.Generic;
@@ -182,7 +182,6 @@ namespace Microsoft.Data.SqlClient.SNI
             );
         }
 #endif
-
     }
 #endif
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
- // #define TRACE_HISTORY // this is used for advanced debugging when you need to trace the entire lifetime of a single packet, be very careful with it
-
 using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -17,7 +14,7 @@ namespace Microsoft.Data.SqlClient.SNI
     /// <summary>
     /// SNI Packet
     /// </summary>
-    internal sealed class SNIPacket
+    internal sealed partial class SNIPacket
     {
         private const string s_className = nameof(SNIPacket);
         private int _dataLength; // the length of the data in the data segment, advanced by Append-ing data, does not include smux header length
@@ -28,62 +25,7 @@ namespace Microsoft.Data.SqlClient.SNI
         private byte[] _data;
         private SNIAsyncCallback _completionCallback;
         private readonly Action<Task<int>, object> _readCallback;
-#if DEBUG
-        internal readonly int _id;  // in debug mode every packet is assigned a unique id so that the entire lifetime can be tracked when debugging
-        /// refcount = 0 means that a packet should only exist in the pool
-        /// refcount = 1 means that a packet is active
-        /// refcount > 1 means that a packet has been reused in some way and is a serious error
-        internal int _refCount;
-        internal readonly SNIHandle _owner; // used in debug builds to check that packets are being returned to the correct pool
-        internal string _traceTag; // used in debug builds to assist tracing what steps the packet has been through
 
-#if TRACE_HISTORY
-        [DebuggerDisplay("{Action.ToString(),nq}")]
-        internal struct History
-        {
-            public enum Direction
-            {
-                Rent = 0,
-                Return = 1,
-            }
-
-            public Direction Action;
-            public int RefCount;
-            public string Stack;
-        }
-      
-        internal List<History> _history = null;
-#endif
-
-        /// <summary>
-        /// uses the packet refcount in debug mode to identify if the packet is considered active
-        /// it is an error to use a packet which is not active in any function outside the pool implementation
-        /// </summary>
-        public bool IsActive => _refCount == 1;
-
-        public SNIPacket(SNIHandle owner, int id)
-            : this()
-        {
-#if TRACE_HISTORY
-            _history = new List<History>();
-#endif
-            _id = id;
-            _owner = owner;
-            SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "Connection Id {0}, Packet Id {1} instantiated,", args0: _owner?.ConnectionId, args1: _id);
-        }
-
-        // the finalizer is only included in debug builds and is used to ensure that all packets are correctly recycled
-        // it is not an error if a packet is dropped but it is undesirable so all efforts should be made to make sure we
-        // do not drop them for the GC to pick up
-        ~SNIPacket()
-        {
-            if (_data != null)
-            {
-                SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.ERR, "Finalizer called for unreleased SNIPacket, Connection Id {0}, Packet Id {1}, _refCount {2}, DataLeft {3}, tag {4}", args0: _owner?.ConnectionId, args1: _id, args2: _refCount, args3: DataLeft, args4: _traceTag);
-            }
-        }
-
-#endif
         public SNIPacket()
         {
             _readCallback = ReadFromStreamAsyncContinuation;
@@ -92,7 +34,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <summary>
         /// Length of data left to process
         /// </summary>
-        public int DataLeft => (_dataLength - _dataOffset);
+        public int DataLeft => _dataLength - _dataOffset;
 
         /// <summary>
         /// Indicates that the packet should be sent out of band bypassing the normal send-recieve lock
@@ -102,7 +44,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <summary>
         /// Length of data
         /// </summary>
-        public int Length => _dataLength;
+        public int DataLength => _dataLength;
 
         /// <summary>
         /// Packet validity
@@ -144,7 +86,7 @@ namespace Microsoft.Data.SqlClient.SNI
             _dataOffset = 0;
             _headerLength = headerLength;
 #if DEBUG
-            SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "Connection Id {0}, Packet Id {1} allocated with _headerLength {2}, _dataCapacity {3}", args0: _owner?.ConnectionId, args1: _id, args2: _headerLength, args3: _dataCapacity);
+            SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIPacket), EventType.INFO, "Connection Id {0}, Packet Id {1} allocated with _headerLength {2}, _dataCapacity {3}", args0: _owner?.ConnectionId, args1: _id, args2: _headerLength, args3: _dataCapacity);
 #endif
         }
 
@@ -155,7 +97,8 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="dataSize">Number of bytes read from the packet into the buffer</param>
         public void GetData(byte[] buffer, ref int dataSize)
         {
-            Buffer.BlockCopy(_data, _headerLength, buffer, 0, _dataLength);
+            Debug.Assert(_data != null, "GetData on empty or returned packet");
+            Buffer.BlockCopy(_data, _headerLength + _dataOffset, buffer, 0, _dataLength);
             dataSize = _dataLength;
         }
 
@@ -167,7 +110,9 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>Amount of data taken</returns>
         public int TakeData(SNIPacket packet, int size)
         {
-            int dataSize = TakeData(packet._data, packet._headerLength + packet._dataLength, size);
+            Debug.Assert(_data != null, "TakeData on empty or returned packet");
+            int dataSize = TakeData(packet._data, packet._headerLength + packet._dataOffset, size);
+            Debug.Assert(packet._dataLength + dataSize <= packet._dataCapacity, "added too much data to a packet");
             packet._dataLength += dataSize;
 #if DEBUG
             SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "Connection Id {0}, Packet Id {1} took data from Packet Id {2} dataSize {3}, _dataLength {4}", args0: _owner?.ConnectionId, args1: _id, args2: packet?._id, args3: dataSize, args4: packet._dataLength);
@@ -182,6 +127,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="size">Size</param>
         public void AppendData(byte[] data, int size)
         {
+            Debug.Assert(_data != null, "AppendData on empty or returned packet");
             Buffer.BlockCopy(data, 0, _data, _headerLength + _dataLength, size);
             _dataLength += size;
 #if DEBUG
@@ -207,7 +153,7 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 size = _dataLength - _dataOffset;
             }
-
+            Debug.Assert(_data != null, "TakeData on empty or returned packet");
             Buffer.BlockCopy(_data, _headerLength + _dataOffset, buffer, dataOffset, size);
             _dataOffset += size;
 #if DEBUG
@@ -233,6 +179,12 @@ namespace Microsoft.Data.SqlClient.SNI
 #if DEBUG
             SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "Connection Id {0}, Packet Id {1} _dataLength {2} header set to active.", args0: _owner?.ConnectionId, args1: _id, args2: _dataLength);
 #endif
+        }
+
+        public void SetDataToRemainingContents()
+        {
+            Debug.Assert(_headerLength == 0, "cannot set data to remaining contents when _headerLength is already reserved");
+            _dataLength -= _dataOffset;
         }
 
         /// <summary>
@@ -357,5 +309,33 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             callback(this, status);
         }
+
+        public ArraySegment<byte> GetDataBuffer()
+        {
+            return new ArraySegment<byte>(_data, _headerLength + _dataOffset, DataLeft);
+        }
+
+        public ArraySegment<byte> GetFreeBuffer()
+        {
+            int start = _headerLength + _dataOffset + DataLeft;
+            int length = _dataCapacity - start;
+            return new ArraySegment<byte>(_data, start, length);
+        }
+
+        public static int TransferData(SNIPacket source, SNIPacket target, int maximumLength)
+        {
+            ArraySegment<byte> sourceBuffer = source.GetDataBuffer();
+            ArraySegment<byte> targetBuffer = target.GetFreeBuffer();
+
+            int copyLength = Math.Min(Math.Min(sourceBuffer.Count, targetBuffer.Count), maximumLength);
+
+            Buffer.BlockCopy(sourceBuffer.Array, sourceBuffer.Offset, targetBuffer.Array, targetBuffer.Offset, copyLength);
+
+            source._dataOffset += copyLength;
+            target._dataLength += copyLength;
+
+            return copyLength;
+        }
+
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
@@ -336,6 +336,5 @@ namespace Microsoft.Data.SqlClient.SNI
 
             return copyLength;
         }
-
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPhysicalHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPhysicalHandle.cs
@@ -42,14 +42,10 @@ namespace Microsoft.Data.SqlClient.SNI
                 Debug.Assert(packet.IsInvalid, "dequeue returned valid packet");
                 GC.ReRegisterForFinalize(packet);
             }
-#if TRACE_HISTORY
-            if (packet._history != null)
-            {
-                packet._history.Add(new SNIPacket.History { Action = SNIPacket.History.Direction.Rent, Stack = GetStackParts(), RefCount = packet._refCount });
-            }
-#endif
+            packet.AddHistory(true);
             Interlocked.Add(ref packet._refCount, 1);
-            Debug.Assert(packet.IsActive, "SNIPacket _refcount must be 1 or a lifetime issue has occurred, trace with the #TRACE_HISTORY define");
+            Debug.Assert(packet.IsActive, "SNIPacket _refcount must be 1 or a lifetime issue has occured, trace with the #TRACE_HISTORY define");
+            packet.ClearPath();
 #endif
             packet.Allocate(headerSize, dataSize);
             return packet;
@@ -57,38 +53,22 @@ namespace Microsoft.Data.SqlClient.SNI
 
         public override void ReturnPacket(SNIPacket packet)
         {
-#if DEBUG
             Debug.Assert(packet != null, "releasing null SNIPacket");
-            Debug.Assert(packet.IsActive, "SNIPacket _refcount must be 1 or a lifetime issue has occurred, trace with the #TRACE_HISTORY define");
+#if DEBUG
+            Debug.Assert(packet.IsActive, "SNIPacket _refcount must be 1 or a lifetime issue has occured, trace with the #TRACE_HISTORY define");
             Debug.Assert(ReferenceEquals(packet._owner, this), "releasing SNIPacket that belongs to another physical handle");
-            Debug.Assert(!packet.IsInvalid, "releasing already released SNIPacket");
 #endif
+            Debug.Assert(!packet.IsInvalid, "releasing already released SNIPacket");
 
             packet.Release();
 #if DEBUG
             Interlocked.Add(ref packet._refCount, -1);
             packet._traceTag = null;
-#if TRACE_HISTORY
-            if (packet._history != null)
-            {
-                packet._history.Add(new SNIPacket.History { Action = SNIPacket.History.Direction.Return, Stack = GetStackParts(), RefCount = packet._refCount });
-            }
-#endif
+            packet.AddHistory(false);
+            //packet.PushPath(new StackTrace().ToString());
             GC.SuppressFinalize(packet);
 #endif
             _pool.Return(packet);
         }
-
-#if DEBUG
-        private string GetStackParts()
-        {
-            return string.Join(Environment.NewLine,
-                Environment.StackTrace
-                .Split(new string[] { Environment.NewLine },StringSplitOptions.None)
-                .Skip(3) // trims off the common parts at the top of the stack so you can see what the actual caller was
-                .Take(7) // trims off most of the bottom of the stack because when running under xunit there's a lot of spam
-            );
-        }
-#endif
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPhysicalHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPhysicalHandle.cs
@@ -65,7 +65,6 @@ namespace Microsoft.Data.SqlClient.SNI
             Interlocked.Add(ref packet._refCount, -1);
             packet._traceTag = null;
             packet.AddHistory(false);
-            //packet.PushPath(new StackTrace().ToString());
             GC.SuppressFinalize(packet);
 #endif
             _pool.Return(packet);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -740,7 +740,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     packet = RentPacket(headerSize: 0, dataSize: _bufferSize);
                     packet.ReadFromStream(_stream);
 
-                    if (packet.Length == 0)
+                    if (packet.DataLength == 0)
                     {
                         errorPacket = packet;
                         packet = null;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2532,6 +2532,11 @@ namespace Microsoft.Data.SqlClient
                     Debug.Assert(IsValidPacket(readPacket), "ReadNetworkPacket should not have been null on this async operation!");
                     // Evaluate this condition for MANAGED_SNI. This may not be needed because the network call is happening Async and only the callback can receive a success.
                     ReadAsyncCallback(IntPtr.Zero, readPacket, 0);
+
+                    if (!IsPacketEmpty(readPacket))
+                    {
+                        ReleasePacket(readPacket);
+                    }
                 }
                 else if (TdsEnums.SNI_SUCCESS_IO_PENDING != error)
                 { // FAILURE!

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -1105,14 +1105,26 @@ namespace Microsoft.Data.SqlClient
         public const string ERR = " | ERR | ";
     }
     
-    internal readonly struct SNIEventScope : IDisposable
+    internal readonly struct TrySNIEventScope : IDisposable
     {
         private readonly long _scopeId;
 
-        public SNIEventScope(long scopeID) => _scopeId = scopeID;
-        public void Dispose() =>
-            SqlClientEventSource.Log.SNIScopeLeave(string.Format("Exit SNI Scope {0}", _scopeId));
+        public TrySNIEventScope(long scopeID)
+        {
+            _scopeId = scopeID;
+        }
 
-        public static SNIEventScope Create(string message) => new SNIEventScope(SqlClientEventSource.Log.SNIScopeEnter(message));
+        public void Dispose()
+        {
+            if (_scopeId != 0)
+            {
+                SqlClientEventSource.Log.TrySNIScopeLeaveEvent(_scopeId);
+            }
+        }
+
+        public static TrySNIEventScope Create(string message, [System.Runtime.CompilerServices.CallerMemberName] string memberName = "")
+        {
+            return new TrySNIEventScope(SqlClientEventSource.Log.TrySNIScopeEnterEvent(message, memberName));
+        }
     }
 }


### PR DESCRIPTION
The MARSConnection class uses a confusing implicit state machine in HandleRecieveComplete to demux incoming packets and dispatch them to the correct MARSHandle instances. This PR reworks that state machine to be explicit allowing easier visualization of exactly what is happening as packets travel through it. It also allows a small optimization to be added which is where a packet header is decoded and the rest of the packet contents is exactly the payload it will be forwarded rather than reconstructed, this cuts down on copies allowing faster running.