### PR TITLE
Simplify SNIProxy

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
@@ -33,38 +33,6 @@ namespace Microsoft.Data.SqlClient.SNI
         internal static SNIProxy GetInstance() => s_singleton;
 
         /// <summary>
-        /// Enable SSL on a connection
-        /// </summary>
-        /// <param name="handle">Connection handle</param>
-        /// <param name="options"></param>
-        /// <returns>SNI error code</returns>
-        internal uint EnableSsl(SNIHandle handle, uint options)
-        {
-            try
-            {
-                SqlClientEventSource.Log.TryTraceEvent("SNIProxy.EnableSsl | Info | Session Id {0}", handle?.ConnectionId);
-                return handle.EnableSsl(options);
-            }
-            catch (Exception e)
-            {
-                SqlClientEventSource.Log.TryTraceEvent("SNIProxy.EnableSsl | Err | Session Id {0}, SNI Handshake failed with exception: {1}", handle?.ConnectionId, e?.Message);
-                return SNICommon.ReportSNIError(SNIProviders.SSL_PROV, SNICommon.HandshakeFailureError, e);
-            }
-        }
-
-        /// <summary>
-        /// Disable SSL on a connection
-        /// </summary>
-        /// <param name="handle">Connection handle</param>
-        /// <returns>SNI error code</returns>
-        internal uint DisableSsl(SNIHandle handle)
-        {
-            SqlClientEventSource.Log.TryTraceEvent("SNIProxy.DisableSsl | Info | Session Id {0}", handle?.ConnectionId);
-            handle.DisableSsl();
-            return TdsEnums.SNI_SUCCESS;
-        }
-
-        /// <summary>
         /// Generate SSPI context
         /// </summary>
         /// <param name="sspiClientContextStatus">SSPI client context status</param>
@@ -72,7 +40,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="sendBuff">Send buffer</param>
         /// <param name="serverName">Service Principal Name buffer</param>
         /// <returns>SNI error code</returns>
-        internal void GenSspiClientContext(SspiClientContextStatus sspiClientContextStatus, byte[] receivedBuff, ref byte[] sendBuff, byte[][] serverName)
+        internal static void GenSspiClientContext(SspiClientContextStatus sspiClientContextStatus, byte[] receivedBuff, ref byte[] sendBuff, byte[][] serverName)
         {
             SafeDeleteContext securityContext = sspiClientContextStatus.SecurityContext;
             ContextFlagsPal contextFlags = sspiClientContextStatus.ContextFlags;
@@ -166,83 +134,6 @@ namespace Microsoft.Data.SqlClient.SNI
         }
 
         /// <summary>
-        /// Set connection buffer size
-        /// </summary>
-        /// <param name="handle">SNI handle</param>
-        /// <param name="bufferSize">Buffer size</param>
-        /// <returns>SNI error code</returns>
-        internal uint SetConnectionBufferSize(SNIHandle handle, uint bufferSize)
-        {
-            handle.SetBufferSize((int)bufferSize);
-            return TdsEnums.SNI_SUCCESS;
-        }
-
-        /// <summary>
-        /// Copies data in SNIPacket to given byte array parameter
-        /// </summary>
-        /// <param name="packet">SNIPacket object containing data packets</param>
-        /// <param name="inBuff">Destination byte array where data packets are copied to</param>
-        /// <param name="dataSize">Length of data packets</param>
-        /// <returns>SNI error status</returns>
-        internal uint PacketGetData(SNIPacket packet, byte[] inBuff, ref uint dataSize)
-        {
-            int dataSizeInt = 0;
-            packet.GetData(inBuff, ref dataSizeInt);
-            dataSize = (uint)dataSizeInt;
-
-            return TdsEnums.SNI_SUCCESS;
-        }
-
-        /// <summary>
-        /// Read synchronously
-        /// </summary>
-        /// <param name="handle">SNI handle</param>
-        /// <param name="packet">SNI packet</param>
-        /// <param name="timeout">Timeout</param>
-        /// <returns>SNI error status</returns>
-        internal uint ReadSyncOverAsync(SNIHandle handle, out SNIPacket packet, int timeout)
-        {
-            return handle.Receive(out packet, timeout);
-        }
-
-        /// <summary>
-        /// Get SNI connection ID
-        /// </summary>
-        /// <param name="handle">SNI handle</param>
-        /// <param name="clientConnectionId">Client connection ID</param>
-        /// <returns>SNI error status</returns>
-        internal uint GetConnectionId(SNIHandle handle, ref Guid clientConnectionId)
-        {
-            clientConnectionId = handle.ConnectionId;
-            SqlClientEventSource.Log.TryTraceEvent("SNIProxy.GetConnectionId | Info | Session Id {0}", clientConnectionId);
-            return TdsEnums.SNI_SUCCESS;
-        }
-
-        /// <summary>
-        /// Send a packet
-        /// </summary>
-        /// <param name="handle">SNI handle</param>
-        /// <param name="packet">SNI packet</param>
-        /// <param name="sync">true if synchronous, false if asynchronous</param>
-        /// <returns>SNI error status</returns>
-        internal uint WritePacket(SNIHandle handle, SNIPacket packet, bool sync)
-        {
-            uint result;
-            if (sync)
-            {
-                result = handle.Send(packet);
-                handle.ReturnPacket(packet);
-            }
-            else
-            {
-                result = handle.SendAsync(packet);
-            }
-
-            SqlClientEventSource.Log.TryTraceEvent("SNIProxy.WritePacket | Info | Session Id {0}, SendAsync Result {1}", handle?.ConnectionId, result);
-            return result;
-        }
-
-        /// <summary>
         /// Create a SNI connection handle
         /// </summary>
         /// <param name="fullServerName">Full server name from connection string</param>
@@ -258,7 +149,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="cachedFQDN">Used for DNS Cache</param>
         /// <param name="pendingDNSInfo">Used for DNS Cache</param>       
         /// <returns>SNI handle</returns>
-        internal SNIHandle CreateConnectionHandle(string fullServerName, bool ignoreSniOpenTimeout, long timerExpire, out byte[] instanceName, ref byte[][] spnBuffer, 
+        internal static SNIHandle CreateConnectionHandle(string fullServerName, bool ignoreSniOpenTimeout, long timerExpire, out byte[] instanceName, ref byte[][] spnBuffer, 
                                         bool flushCache, bool async, bool parallel, bool isIntegratedSecurity, SqlConnectionIPAddressPreference ipPreference, string cachedFQDN, ref SQLDNSInfo pendingDNSInfo)
         {
             instanceName = new byte[1];
@@ -380,7 +271,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="cachedFQDN">Key for DNS Cache</param>
         /// <param name="pendingDNSInfo">Used for DNS Cache</param>        
         /// <returns>SNITCPHandle</returns>
-        private SNITCPHandle CreateTcpHandle(DataSource details, long timerExpire, bool parallel, SqlConnectionIPAddressPreference ipPreference, string cachedFQDN, ref SQLDNSInfo pendingDNSInfo)
+        private static SNITCPHandle CreateTcpHandle(DataSource details, long timerExpire, bool parallel, SqlConnectionIPAddressPreference ipPreference, string cachedFQDN, ref SQLDNSInfo pendingDNSInfo)
         {
             // TCP Format:
             // tcp:<host name>\<instance name>
@@ -421,8 +312,6 @@ namespace Microsoft.Data.SqlClient.SNI
             return new SNITCPHandle(hostName, port, timerExpire, parallel, ipPreference, cachedFQDN, ref pendingDNSInfo);
         }
 
-
-
         /// <summary>
         /// Creates an SNINpHandle object
         /// </summary>
@@ -430,7 +319,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="timerExpire">Timer expiration</param>
         /// <param name="parallel">Should MultiSubnetFailover be used. Only returns an error for named pipes.</param>
         /// <returns>SNINpHandle</returns>
-        private SNINpHandle CreateNpHandle(DataSource details, long timerExpire, bool parallel)
+        private static SNINpHandle CreateNpHandle(DataSource details, long timerExpire, bool parallel)
         {
             if (parallel)
             {
@@ -439,39 +328,6 @@ namespace Microsoft.Data.SqlClient.SNI
                 return null;
             }
             return new SNINpHandle(details.PipeHostName, details.PipeName, timerExpire);
-        }
-
-        /// <summary>
-        /// Read packet asynchronously
-        /// </summary>
-        /// <param name="handle">SNI handle</param>
-        /// <param name="packet">Packet</param>
-        /// <returns>SNI error status</returns>
-        internal uint ReadAsync(SNIHandle handle, out SNIPacket packet)
-        {
-            packet = null;
-            return handle.ReceiveAsync(ref packet);
-        }
-
-        /// <summary>
-        /// Set packet data
-        /// </summary>
-        /// <param name="packet">SNI packet</param>
-        /// <param name="data">Data</param>
-        /// <param name="length">Length</param>
-        internal void PacketSetData(SNIPacket packet, byte[] data, int length)
-        {
-            packet.AppendData(data, length);
-        }
-
-        /// <summary>
-        /// Check SNI handle connection
-        /// </summary>
-        /// <param name="handle"></param>
-        /// <returns>SNI error status</returns>
-        internal uint CheckConnection(SNIHandle handle)
-        {
-            return handle.CheckConnection();
         }
 
         /// <summary>
@@ -489,7 +345,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="fullServerName">The data source</param>
         /// <param name="error">Set true when an error occurred while getting LocalDB up</param>
         /// <returns></returns>
-        private string GetLocalDBDataSource(string fullServerName, out bool error)
+        private static string GetLocalDBDataSource(string fullServerName, out bool error)
         {
             string localDBConnectionString = null;
             bool isBadLocalDBDataSource;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
@@ -21,16 +21,9 @@ namespace Microsoft.Data.SqlClient.SNI
         private const int DefaultSqlServerDacPort = 1434;
         private const string SqlServerSpnHeader = "MSSQLSvc";
 
-        internal class SspiClientContextResult
-        {
-            internal const uint OK = 0;
-            internal const uint Failed = 1;
-            internal const uint KerberosTicketMissing = 2;
-        }
+        private static readonly SNIProxy s_singleton = new SNIProxy();
 
-        internal static readonly SNIProxy s_singleton = new SNIProxy();
-
-        internal static SNIProxy GetInstance() => s_singleton;
+        internal static SNIProxy Instance => s_singleton;
 
         /// <summary>
         /// Generate SSPI context

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Unix.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Unix.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.SqlClient
         private SNIErrorDetails GetSniErrorDetails()
         {
             SNIErrorDetails details;
-            SNIError sniError = SNIProxy.GetInstance().GetLastError();
+            SNIError sniError = SNIProxy.Instance.GetLastError();
             details.sniErrorNumber = sniError.sniError;
             details.errorMessage = sniError.errorMessage;
             details.nativeError = sniError.nativeError;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Windows.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Data.SqlClient
 
             if (TdsParserStateObjectFactory.UseManagedSNI)
             {
-                SNIError sniError = SNIProxy.GetInstance().GetLastError();
+                SNIError sniError = SNIProxy.Instance.GetLastError();
                 details.sniErrorNumber = sniError.sniError;
                 details.errorMessage = sniError.errorMessage;
                 details.nativeError = sniError.nativeError;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -47,6 +47,13 @@ namespace Microsoft.Data.SqlClient.SNI
             return _marsConnection.CreateMarsSession(callbackObject, async);
         }
 
+        /// <summary>
+        /// Copies data in SNIPacket to given byte array parameter
+        /// </summary>
+        /// <param name="packet">SNIPacket object containing data packets</param>
+        /// <param name="inBuff">Destination byte array where data packets are copied to</param>
+        /// <param name="dataSize">Length of data packets</param>
+        /// <returns>SNI error status</returns>
         protected override uint SNIPacketGetData(PacketHandle packet, byte[] inBuff, ref uint dataSize)
         {
             int dataSizeInt = 0;
@@ -279,7 +286,7 @@ namespace Microsoft.Data.SqlClient.SNI
         internal override uint SniGetConnectionId(ref Guid clientConnectionId)
         {
             clientConnectionId = Handle.ConnectionId;
-            SqlClientEventSource.Log.TryTraceEvent("SNIProxy.GetConnectionId | Info | Session Id {0}", clientConnectionId);
+            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.GetConnectionId | Info | Session Id {0}", clientConnectionId);
             return TdsEnums.SNI_SUCCESS;
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -47,13 +47,18 @@ namespace Microsoft.Data.SqlClient.SNI
             return _marsConnection.CreateMarsSession(callbackObject, async);
         }
 
-        protected override uint SNIPacketGetData(PacketHandle packet, byte[] _inBuff, ref uint dataSize)
-            => SNIProxy.GetInstance().PacketGetData(packet.ManagedPacket, _inBuff, ref dataSize);
+        protected override uint SNIPacketGetData(PacketHandle packet, byte[] inBuff, ref uint dataSize)
+        {
+            int dataSizeInt = 0;
+            packet.ManagedPacket.GetData(inBuff, ref dataSizeInt);
+            dataSize = (uint)dataSizeInt;
+            return TdsEnums.SNI_SUCCESS;
+        }
 
         internal override void CreatePhysicalSNIHandle(string serverName, bool ignoreSniOpenTimeout, long timerExpire, out byte[] instanceName, ref byte[][] spnBuffer, bool flushCache, bool async, bool parallel, 
                                            SqlConnectionIPAddressPreference iPAddressPreference, string cachedFQDN, ref SQLDNSInfo pendingDNSInfo, bool isIntegratedSecurity)
         {
-            _sessionHandle = SNIProxy.GetInstance().CreateConnectionHandle(serverName, ignoreSniOpenTimeout, timerExpire, out instanceName, ref spnBuffer, flushCache, async, parallel, isIntegratedSecurity, 
+            _sessionHandle = SNIProxy.CreateConnectionHandle(serverName, ignoreSniOpenTimeout, timerExpire, out instanceName, ref spnBuffer, flushCache, async, parallel, isIntegratedSecurity, 
                                                         iPAddressPreference, cachedFQDN, ref pendingDNSInfo);
             if (_sessionHandle == null)
             {
@@ -162,7 +167,9 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 throw ADP.ClosedConnectionError();
             }
-            error = SNIProxy.GetInstance().ReadSyncOverAsync(handle, out SNIPacket packet, timeoutRemaining);
+
+            error = handle.Receive(out SNIPacket packet, timeoutRemaining);
+            
             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.ReadSyncOverAsync | Info | State Object Id {0}, Session Id {1}", _objectID, _sessionHandle?.ConnectionId);
 #if DEBUG
             SqlClientEventSource.Log.TryAdvancedTraceEvent("TdsParserStateObjectManaged.ReadSyncOverAsync | TRC | State Object Id {0}, Session Id {1}, Packet {2} received, Packet owner Id {3}, Packet dataLeft {4}", _objectID, _sessionHandle?.ConnectionId, packet?._id, packet?._owner.ConnectionId, packet?.DataLeft);
@@ -191,12 +198,14 @@ namespace Microsoft.Data.SqlClient.SNI
         internal override uint CheckConnection()
         {
             SNIHandle handle = Handle;
-            return handle == null ? TdsEnums.SNI_SUCCESS : SNIProxy.GetInstance().CheckConnection(handle);
+            return handle == null ? TdsEnums.SNI_SUCCESS : handle.CheckConnection();
         }
 
         internal override PacketHandle ReadAsync(SessionHandle handle, out uint error)
         {
-            error = SNIProxy.GetInstance().ReadAsync(handle.ManagedHandle, out SNIPacket packet);
+            SNIPacket packet = null;
+            error = handle.ManagedHandle.ReceiveAsync(ref packet);
+
             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.ReadAsync | Info | State Object Id {0}, Session Id {1}, Packet DataLeft {2}", _objectID, _sessionHandle?.ConnectionId, packet?.DataLeft);
             return PacketHandle.FromManagedPacket(packet);
         }
@@ -214,8 +223,24 @@ namespace Microsoft.Data.SqlClient.SNI
             return packetHandle;
         }
 
-        internal override uint WritePacket(PacketHandle packet, bool sync) =>
-            SNIProxy.GetInstance().WritePacket(Handle, packet.ManagedPacket, sync);
+        internal override uint WritePacket(PacketHandle packetHandle, bool sync)
+        {
+            uint result;
+            SNIHandle handle = Handle;
+            SNIPacket packet = packetHandle.ManagedPacket;
+            if (sync)
+            {
+                result = handle.Send(packet);
+                handle.ReturnPacket(packet);
+            }
+            else
+            {
+                result = handle.SendAsync(packet);
+            }
+
+            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.WritePacket | Info | Session Id {0}, SendAsync Result {1}", handle?.ConnectionId, result);
+            return result;
+        }
 
         // No- Op in managed SNI
         internal override PacketHandle AddPacketToPendingList(PacketHandle packet) => packet;
@@ -246,11 +271,25 @@ namespace Microsoft.Data.SqlClient.SNI
             Debug.Assert(_asyncWriteCount == 0, "Should not clear all write packets if there are packets pending");
         }
 
-        internal override void SetPacketData(PacketHandle packet, byte[] buffer, int bytesUsed) => SNIProxy.GetInstance().PacketSetData(packet.ManagedPacket, buffer, bytesUsed);
+        internal override void SetPacketData(PacketHandle packet, byte[] buffer, int bytesUsed)
+        {
+            packet.ManagedPacket.AppendData(buffer, bytesUsed);
+        }
 
-        internal override uint SniGetConnectionId(ref Guid clientConnectionId) => SNIProxy.GetInstance().GetConnectionId(Handle, ref clientConnectionId);
+        internal override uint SniGetConnectionId(ref Guid clientConnectionId)
+        {
+            clientConnectionId = Handle.ConnectionId;
+            SqlClientEventSource.Log.TryTraceEvent("SNIProxy.GetConnectionId | Info | Session Id {0}", clientConnectionId);
+            return TdsEnums.SNI_SUCCESS;
+        }
 
-        internal override uint DisableSsl() => SNIProxy.GetInstance().DisableSsl(Handle);
+        internal override uint DisableSsl()
+        {
+            SNIHandle handle = Handle;
+            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.DisableSsl | Info | Session Id {0}", handle?.ConnectionId);
+            handle.DisableSsl();
+            return TdsEnums.SNI_SUCCESS;
+        }
 
         internal override uint EnableMars(ref uint info)
         {
@@ -265,9 +304,26 @@ namespace Microsoft.Data.SqlClient.SNI
             return TdsEnums.SNI_ERROR;
         }
 
-        internal override uint EnableSsl(ref uint info) => SNIProxy.GetInstance().EnableSsl(Handle, info);
+        internal override uint EnableSsl(ref uint info)
+        {
+            SNIHandle handle = Handle;
+            try
+            {
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.EnableSsl | Info | Session Id {0}", handle?.ConnectionId);
+                return handle.EnableSsl(info);
+            }
+            catch (Exception e)
+            {
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.EnableSsl | Err | Session Id {0}, SNI Handshake failed with exception: {1}", handle?.ConnectionId, e?.Message);
+                return SNICommon.ReportSNIError(SNIProviders.SSL_PROV, SNICommon.HandshakeFailureError, e);
+            }
+        }
 
-        internal override uint SetConnectionBufferSize(ref uint unsignedPacketSize) => SNIProxy.GetInstance().SetConnectionBufferSize(Handle, unsignedPacketSize);
+        internal override uint SetConnectionBufferSize(ref uint unsignedPacketSize)
+        {
+            Handle.SetBufferSize((int)unsignedPacketSize);
+            return TdsEnums.SNI_SUCCESS;
+        }
 
         internal override uint GenerateSspiClientContext(byte[] receivedBuff, uint receivedLength, ref byte[] sendBuff, ref uint sendLength, byte[][] _sniSpnBuffer)
         {
@@ -276,8 +332,8 @@ namespace Microsoft.Data.SqlClient.SNI
                 _sspiClientContextStatus = new SspiClientContextStatus();
             }
 
-            SNIProxy.GetInstance().GenSspiClientContext(_sspiClientContextStatus, receivedBuff, ref sendBuff, _sniSpnBuffer);
-            SqlClientEventSource.Log.TryTraceEvent("SNIProxy.GenerateSspiClientContext | Info | Session Id {0}", _sessionHandle?.ConnectionId);
+            SNIProxy.GenSspiClientContext(_sspiClientContextStatus, receivedBuff, ref sendBuff, _sniSpnBuffer);
+            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.GenerateSspiClientContext | Info | Session Id {0}", _sessionHandle?.ConnectionId);
             sendLength = (uint)(sendBuff != null ? sendBuff.Length : 0);
             return 0;
         }


### PR DESCRIPTION
SniProxy is used as a single instance and called like this:
```csharp
internal override uint SniGetConnectionId(ref Guid clientConnectionId) => SNIProxy.GetInstance().GetConnectionId(Handle, ref clientConnectionId);
```
This involves calling the GetInstance() method to get the single instance and then calling a function on that instance which only uses the parameters that are passed in. In these cases the functions could be static or merged into the callsite if there is only one use of the function.

The only thing that can't be removed from this single instance pattern is the GetLastError functions. I've investigated what it would take to remove it and it's very very complicated and involves significant changes to the StateObject interface between shared and platform implementations. I choose not to do that now.