### PR TITLE
Change MakeReadAsyncBlocking default to false

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlClient
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                return AppContext.TryGetSwitch(MakeReadAsyncBlockingString, out _makeReadAsyncBlocking) ? _makeReadAsyncBlocking : true;
+                return AppContext.TryGetSwitch(MakeReadAsyncBlockingString, out _makeReadAsyncBlocking) ? _makeReadAsyncBlocking : false;
             }
         }
     }


### PR DESCRIPTION
Now that the underlying open result set counter issue is fixed, it should be safe to change this to false and regain the performance we lost when we had to change it to true.