### PR TITLE
Do not truncate given value in exception message for BulkLoadCannotConvertValue

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -884,11 +884,7 @@ namespace Microsoft.Data.SqlClient
         }
         internal static Exception BulkLoadCannotConvertValue(Type sourcetype, MetaType metatype, int ordinal, int rowNumber, bool isEncrypted, string columnName, string value, Exception e)
         {
-            string quotedValue = string.Empty;
-            if (!isEncrypted)
-            {
-                quotedValue = string.Format(" '{0}'", (value.Length > 100 ? value.Substring(0, 100) : value));
-            }
+            string quotedValue = isEncrypted ? string.Empty : $" '{value}'";
             if (rowNumber == -1)
             {
                 return ADP.InvalidOperation(System.StringsHelper.GetString(Strings.SQL_BulkLoadCannotConvertValueWithoutRowNo, quotedValue, sourcetype.Name, metatype.TypeName, ordinal, columnName), e);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -1025,11 +1025,7 @@ namespace Microsoft.Data.SqlClient
         }
         static internal Exception BulkLoadCannotConvertValue(Type sourcetype, MetaType metatype, int ordinal, int rowNumber, bool isEncrypted, string columnName, string value, Exception e)
         {
-            string quotedValue = string.Empty;
-            if (!isEncrypted)
-            {
-                quotedValue = string.Format(" '{0}'", (value.Length > 100 ? value.Substring(0, 100) : value));
-            }
+            string quotedValue = isEncrypted ? string.Empty : $" '{value}'";
             if (rowNumber == -1)
             {
                 return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_BulkLoadCannotConvertValueWithoutRowNo, quotedValue, sourcetype.Name, metatype.TypeName, ordinal, columnName), e);


### PR DESCRIPTION
It was introduced in #437 - for some reason the given value is getting truncated when it is longer than 100 chars - I looked trough PR comments and didn't see anything why it is like this. The exception message together with inner exception is really missleading when column is bigger than 100 chars and given value is bigger than column size. It looks like this:

Exception message:
```
The given value 'https://something.com/5e6109fb8ca1de00010b2446/documents/3d47b19d-c469-4c36-a3f4-edda' of type String from the data source cannot be converted to type nvarchar for Column 8 [Url] Row 1.
```

Inner exception message:
```
String or binary data would be truncated in table '[Something].[File]', column 'Url'. Truncated value: 'https://something.com/5e6109fb8ca1de00010b2446/documents/3d47b19d-c469-4c36-a3f4-edda
```