### PR TITLE
Docs | Correct disables > enables for MARS doc

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -535,7 +535,7 @@ False
    
   
 ## Examples  
- The following example explicitly disables the Multiple Active Result Sets feature.  
+ The following example explicitly enables the Multiple Active Result Sets feature.  
   
  [!code-csharp[SqlConnectionStringBuilder_MultipleActiveResultSets.MARS#1](~/../sqlclient/doc/samples/SqlConnectionStringBuilder_MultipleActiveResultSets.cs#1)]
   


### PR DESCRIPTION
Originally captured here: https://github.com/dotnet/dotnet-api-docs/pull/5336
Should be fixed in MDS docs too.