### PR TITLE
Fix | Fix blocked `Cancel()` method when executing Async APIs

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1364,19 +1364,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                // If we have already initiate the End call internally, we have already done that, so no point doing it again.
-                if (!_internalEndExecuteInitiated)
-                {
-                    lock (_stateObj)
-                    {
-                        return EndExecuteNonQueryInternal(asyncResult);
-                    }
-                }
-                else
-                {
-                    return EndExecuteNonQueryInternal(asyncResult);
-                }
+                return EndExecuteNonQueryInternal(asyncResult);
             }
         }
 
@@ -1778,19 +1766,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                // If we have already initiate the End call internally, we have already done that, so no point doing it again.
-                if (!_internalEndExecuteInitiated)
-                {
-                    lock (_stateObj)
-                    {
-                        return EndExecuteXmlReaderInternal(asyncResult);
-                    }
-                }
-                else
-                {
-                    return EndExecuteXmlReaderInternal(asyncResult);
-                }
+                return EndExecuteXmlReaderInternal(asyncResult);
             }
         }
 
@@ -1973,18 +1949,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                if (!_internalEndExecuteInitiated)
-                {
-                    lock (_stateObj)
-                    {
-                        return EndExecuteReaderInternal(asyncResult);
-                    }
-                }
-                else
-                {
-                    return EndExecuteReaderInternal(asyncResult);
-                }
+                return EndExecuteReaderInternal(asyncResult);
             }
         }
 
@@ -2263,11 +2228,7 @@ namespace Microsoft.Data.SqlClient
                         Debug.Assert(!_internalEndExecuteInitiated);
                         _internalEndExecuteInitiated = true;
 
-                        // lock on _stateObj prevents races with close/cancel.
-                        lock (_stateObj)
-                        {
-                            endFunc(this, tsk, true, endMethod /*inInternal*/);
-                        }
+                        endFunc(this, tsk, true, endMethod /*inInternal*/);
 
                         globalCompletion.TrySetResult(tsk.Result);
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1718,19 +1718,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                // If we have already initiate the End call internally, we have already done that, so no point doing it again.
-                if (!_internalEndExecuteInitiated)
-                {
-                    lock (_stateObj)
-                    {
-                        return EndExecuteNonQueryInternal(asyncResult);
-                    }
-                }
-                else
-                {
-                    return EndExecuteNonQueryInternal(asyncResult);
-                }
+                return EndExecuteNonQueryInternal(asyncResult);
             }
         }
 
@@ -2229,19 +2217,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                // If we have already initiate the End call internally, we have already done that, so no point doing it again.
-                if (!_internalEndExecuteInitiated)
-                {
-                    lock (_stateObj)
-                    {
-                        return EndExecuteXmlReaderInternal(asyncResult);
-                    }
-                }
-                else
-                {
-                    return EndExecuteXmlReaderInternal(asyncResult);
-                }
+                return EndExecuteXmlReaderInternal(asyncResult);
             }
         }
 
@@ -2484,19 +2460,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                // If we have already initiate the End call internally, we have already done that, so no point doing it again.
-                if (!_internalEndExecuteInitiated)
-                {
-                    lock (_stateObj)
-                    {
-                        return EndExecuteReaderInternal(asyncResult);
-                    }
-                }
-                else
-                {
-                    return EndExecuteReaderInternal(asyncResult);
-                }
+                return EndExecuteReaderInternal(asyncResult);
             }
         }
 
@@ -2655,11 +2619,8 @@ namespace Microsoft.Data.SqlClient
                             Debug.Assert(!_internalEndExecuteInitiated);
                             _internalEndExecuteInitiated = true;
 
-                            // lock on _stateObj prevents races with close/cancel.
-                            lock (_stateObj)
-                            {
-                                endFunc(tsk, endMethod, true/*inInternal*/);
-                            }
+                            endFunc(tsk, endMethod, true/*inInternal*/);
+                            
                             globalCompletion.TrySetResult(tsk.Result);
                         }
                         catch (Exception e)


### PR DESCRIPTION
 Locks should not be needed in SqlCommand Async APIs - as they simply block Cancel method from execution.
More details in issue #44 discussions.

The test "[SqlCommandCancelTest.AsyncCancelDoesNotWait](https://github.com/dotnet/SqlClient/blob/d150725aa1d6a296ebc5153e509b77ea19fe7904/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs#L534)" did not reproduce this error as it used WAITFOR DELAY. Modifying query to a continuous while loop reproduces error.

_WIP - Validate fix._