### PR TITLE
Fix | documentation path is not addressing the right location.

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlFacetAttribute.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlFacetAttribute.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Data.SqlClient.Server
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
     public class SqlFacetAttribute : Attribute
     {
-        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFacetAttribute.xml' path='docs/members[@name="SqlFacetAttribute"]/ctor/*'/>
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFacetAttribute.xml' path='docs/members[@name="SqlFacetAttribute"]/ctor/*'/>
         public SqlFacetAttribute() { }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlFacetAttribute.xml' path='docs/members[@name="SqlFacetAttribute"]/IsFixedLength/*' />


### PR DESCRIPTION
While working on some other issue noticed this mistake. The error is caught by VSCode and not VS 2019. Comparing with the other paths in the same file I believe this should be the correct path. 