### PR TITLE
Do not instantiate multiple Random instances within SqlFixedIntervalEnumerator

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlRetryIntervalEnumerators.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlRetryIntervalEnumerators.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Data.SqlClient
     {
         private readonly int maxRandom;
         private readonly int minRandom;
+        private readonly Random random = new Random();
 
         public SqlFixedIntervalEnumerator(TimeSpan gapTimeInterval, TimeSpan maxTimeInterval, TimeSpan minTimeInterval)
             : base(gapTimeInterval, maxTimeInterval, minTimeInterval)
@@ -94,7 +95,6 @@ namespace Microsoft.Data.SqlClient
 
         protected override TimeSpan GetNextInterval()
         {
-            var random = new Random();
             Current = TimeSpan.FromMilliseconds(random.Next(minRandom, maxRandom));
             return Current;
         }


### PR DESCRIPTION
Do not continually recreate Random instances inside SqlFixedIntervalEnumerator.GetNextInterval.

https://docs.microsoft.com/en-us/dotnet/api/system.random?view=net-5.0#Multiple