### PR TITLE
Test | Improving Exceptions to get better messages on test lab in ExtUtilities

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.ExtUtilities/Runner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.ExtUtilities/Runner.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 
 namespace Microsoft.Data.SqlClient.ExtUtilities
 {
@@ -16,9 +17,9 @@ namespace Microsoft.Data.SqlClient.ExtUtilities
         ///      [0] = CreateDatabase, DropDatabase
         ///      [1] = Name of Database
         /// </param>
-        public static void Main(string [] args)
+        public static void Main(string[] args)
         {
-            if (args == null || args.Length < 1)
+            if (!args.Any() || args.Length < 1)
             {
                 throw new ArgumentException("Utility name not provided.");
             }


### PR DESCRIPTION
While working on our test lab noticed some of the exceptions are not caught and a meaningful message is not shown. I have addressed the code to catch  [ExecutionFailureException](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.management.common.executionfailureexception?view=sql-smo-160).
Also while testing noticed when args is passing as null `if(args==null)  ` does not work and the message in the catch block does not show on the console, while using Any() will do a better job.