### PR TITLE
Perf: Add non-waited semaphore check

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -2152,14 +2152,22 @@ namespace Microsoft.Data.SqlClient
 
         public Task WaitAsync(CancellationToken cancellationToken)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            _queue.Enqueue(tcs);
-            _semaphore.WaitAsync().ContinueWith(
-                continuationAction: s_continuePop,
-                state: _queue,
-                cancellationToken: cancellationToken
-            );
-            return tcs.Task;
+            // try sync wait with 0 which will not block to see if we need to do an async wait
+            if (_semaphore.Wait(0, cancellationToken))
+            {
+                return Task.CompletedTask;
+            }
+            else
+            {
+                var tcs = new TaskCompletionSource<bool>();
+                _queue.Enqueue(tcs);
+                _semaphore.WaitAsync().ContinueWith(
+                    continuationAction: s_continuePop,
+                    state: _queue,
+                    cancellationToken: cancellationToken
+                );
+                return tcs.Task;
+            }
         }
 
         public void Release()


### PR DESCRIPTION
This is a small change broken out from https://github.com/dotnet/SqlClient/pull/902 after discussion with @cheenamalhotra . This change avoids allocation of a task and completion source on the common path where the semaphore can immediately be taken and then falls back to the previous task version if required. This avoids two allocations per packet wait.