### PR TITLE
Docs | Add code comment to highlight an important step in the example

### DIFF
--- a/doc/samples/CustomDeviceCodeFlowAzureAuthenticationProvider.cs
+++ b/doc/samples/CustomDeviceCodeFlowAzureAuthenticationProvider.cs
@@ -44,6 +44,7 @@ namespace CustomAuthenticationProviderExamples
     {
         public static void Main()
         {
+            // Register our custom authentication provider class to override Active Directory Device Code Flow
             SqlAuthenticationProvider.SetProvider(SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow, new CustomDeviceCodeFlowAzureAuthenticationProvider());
             using (SqlConnection sqlConnection = new SqlConnection("Server=<myserver>.database.windows.net;Authentication=Active Directory Device Code Flow;Database=<db>;"))
             {


### PR DESCRIPTION
I also made a corresponding change in the [public docs](https://docs.microsoft.com/en-us/sql/connect/ado-net/sql/azure-active-directory-authentication?view=sql-server-ver15#support-for-a-custom-sql-authentication-provider) noting that any of the Active Directory authentication methods can be overridden with a custom provider, to make it more apparent that more than just Device Code Flow could be overridden.