### PR TITLE
Fix TvpTest intermittent failure with Azure SQL Server

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/StreamInputParam.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/StreamInputParam.cs
@@ -625,7 +625,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         byte[] binarydata = new byte[dataSize];
                         rand.NextBytes(binarydata);
                         MemoryStream ms = new MemoryStream(binarydata, false);
-                        // Included a daly to make a room for cancellation command
+                        // Include a delay to allow time for cancellation
                         cmd.CommandText = "WAITFOR DELAY '00:00:05'; insert into #blobs (Id, blob) values (1, @blob)";
 
                         cmd.Parameters.Add("@blob", SqlDbType.VarBinary, dataSize);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/StreamInputParam.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/StreamInputParam.cs
@@ -625,22 +625,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         byte[] binarydata = new byte[dataSize];
                         rand.NextBytes(binarydata);
                         MemoryStream ms = new MemoryStream(binarydata, false);
-                        cmd.CommandText = "insert into #blobs (Id, blob) values (1, @blob)";
+                        // Included a daly to make a room for cancellation command
+                        cmd.CommandText = "WAITFOR DELAY '00:00:05'; insert into #blobs (Id, blob) values (1, @blob)";
 
                         cmd.Parameters.Add("@blob", SqlDbType.VarBinary, dataSize);
                         cmd.Parameters["@blob"].Direction = ParameterDirection.Input;
                         cmd.Parameters["@blob"].Value = ms;
 
-                        Task t = func(cmd, cts.Token);
-                        if (!t.IsCompleted)
-                        {
-                            cts.Cancel();
-                        }
-
                         try
                         {
-                            t.Wait();
-                            Console.WriteLine("FAIL: Expected AggregateException on Task wait for Cancelled Task! Task Status: " + t.Status);
+                            Task.WaitAll(func(cmd, cts.Token), Task.Run(() => cts.Cancel()));
+                            Console.WriteLine("FAIL: Expected AggregateException on Task wait for Cancelled Task!");
                         }
                         catch (AggregateException ae)
                         {


### PR DESCRIPTION
**Unexpected exception message**: `Invalid command sent to ExecuteXmlReader. The command must return an Xml result.`