### PR TITLE
Test | Addressing Net5 failure for CA2100 and CA1063 on Test lab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -163,3 +163,6 @@ end_of_line = crlf
 
 # Analyzers
 dotnet_code_quality.ca1802.api_surface = private, internal
+
+[*.cs]
+dotnet_code_quality.CA2100.excluded_type_names_with_derived_types = Microsoft.Data.SqlClient.ManualTesting.Tests.*

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
     /// <summary>
     /// Always Encrypted public API Manual tests.
     /// </summary>
-    public class ApiShould : IClassFixture<PlatformSpecificTestContext>, IDisposable
+    public sealed class ApiShould : IClassFixture<PlatformSpecificTestContext>, IDisposable
     {
         private SQLSetupStrategy _fixture;
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/BulkCopyAE.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/BulkCopyAE.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
     /// <summary>
     /// Always Encrypted public API Manual tests.
     /// </summary>
-    public class BulkCopyAE : IClassFixture<PlatformSpecificTestContext>, IDisposable
+    public sealed class BulkCopyAE : IClassFixture<PlatformSpecificTestContext>, IDisposable
     {
         private SQLSetupStrategy fixture;
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ConversionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ConversionTests.cs
@@ -18,7 +18,7 @@ using Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup;
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 {
     [PlatformSpecific(TestPlatforms.Windows)]
-    public class ConversionTests : IDisposable
+    public sealed class ConversionTests : IDisposable
     {
 
         private const string IdentityColumnName = "IdentityColumn";
@@ -33,7 +33,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         private ColumnMasterKey columnMasterKey;
         private ColumnEncryptionKey columnEncryptionKey;
         private SqlColumnEncryptionCertificateStoreProvider certStoreProvider = new SqlColumnEncryptionCertificateStoreProvider();
-        protected List<DbObject> databaseObjects = new List<DbObject>();
+        private List<DbObject> _databaseObjects = new List<DbObject>();
 
         private class ColumnMetaData
         {
@@ -60,19 +60,19 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                 certificate = CertificateUtility.CreateCertificate();
             }
             columnMasterKey = new CspColumnMasterKey(DatabaseHelper.GenerateUniqueName("CMK"), certificate.Thumbprint, certStoreProvider, DataTestUtility.EnclaveEnabled);
-            databaseObjects.Add(columnMasterKey);
+            _databaseObjects.Add(columnMasterKey);
 
             columnEncryptionKey = new ColumnEncryptionKey(DatabaseHelper.GenerateUniqueName("CEK"),
                                                           columnMasterKey,
                                                           certStoreProvider);
-            databaseObjects.Add(columnEncryptionKey);
+            _databaseObjects.Add(columnEncryptionKey);
 
             foreach (string connectionStr in DataTestUtility.AEConnStringsSetup)
             {
                 using (SqlConnection sqlConnection = new SqlConnection(connectionStr))
                 {
                     sqlConnection.Open();
-                    databaseObjects.ForEach(o => o.Create(sqlConnection));
+                    _databaseObjects.ForEach(o => o.Create(sqlConnection));
                 }
             }
         }
@@ -1345,13 +1345,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
         public void Dispose()
         {
-            databaseObjects.Reverse();
+            _databaseObjects.Reverse();
             foreach (string connectionStr in DataTestUtility.AEConnStringsSetup)
             {
                 using (SqlConnection sqlConnection = new SqlConnection(connectionStr))
                 {
                     sqlConnection.Open();
-                    databaseObjects.ForEach(o => o.Drop(sqlConnection));
+                    _databaseObjects.ForEach(o => o.Drop(sqlConnection));
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/EnclaveAzureDatabaseTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/EnclaveAzureDatabaseTests.cs
@@ -14,7 +14,7 @@ using Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup;
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 {
     // This test class is for internal use only
-    public class EnclaveAzureDatabaseTests : IDisposable
+    public sealed class EnclaveAzureDatabaseTests : IDisposable
     {
         private ColumnMasterKey akvColumnMasterKey;
         private ColumnEncryptionKey akvColumnEncryptionKey;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/End2EndSmokeTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/End2EndSmokeTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 {
-    public class End2EndSmokeTests : IClassFixture<PlatformSpecificTestContext>, IDisposable
+    public sealed class End2EndSmokeTests : IClassFixture<PlatformSpecificTestContext>, IDisposable
     {
         private SQLSetupStrategy fixture;
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ExceptionsGenericError.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ExceptionsGenericError.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         }
     }
 
-    public class ExceptionGenericErrorFixture : IDisposable
+    public sealed class ExceptionGenericErrorFixture : IDisposable
     {
         static public string encryptedTableName;
         static public string encryptedProcedureName;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/SqlNullValues.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/SqlNullValues.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 {
-    public class SqlNullValuesTests : IClassFixture<PlatformSpecificTestContext>, IDisposable
+    public sealed class SqlNullValuesTests : IClassFixture<PlatformSpecificTestContext>, IDisposable
     {
         private SQLSetupStrategy fixture;
         private readonly string tableName;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/SQLSetupStrategy.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/SQLSetupStrategy.cs
@@ -251,6 +251,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
             databaseObjects.Reverse();
             foreach (string value in DataTestUtility.AEConnStringsSetup)
             {
@@ -285,9 +291,19 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+
             try
             {
-                akvFixture?.Dispose();
+                if (disposing)
+                {
+                    akvFixture?.Dispose();
+                }
             }
             finally
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ProxyServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ProxyServer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     /// This is a simple network listener that redirects traffic
     /// It is used to simulate network delay
     /// </summary>
-    public class ProxyServer : IDisposable
+    public sealed class ProxyServer : IDisposable
     {
         private volatile bool _stopRequested;
         private StringBuilder _eventLog;
@@ -65,12 +65,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// <summary>
         /// Gets/Sets the listener
         /// </summary>
-        protected TcpListener ListenerSocket { get; set; }
+        private TcpListener ListenerSocket { get; set; }
 
         /// <summary>
         /// Gets/Sets the listener thread
         /// </summary>
-        protected Thread ListenerThread { get; set; }
+        private Thread ListenerThread { get; set; }
 
         /// <summary>
         /// Delay incoming 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/AsyncDebugScope.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/AsyncDebugScope.cs
@@ -47,12 +47,21 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public void Dispose()
         {
-            TdsParserStateObjectHelper.FailAsyncPends = false;
-            TdsParserStateObjectHelper.ForceAllPends = false;
-            TdsParserStateObjectHelper.ForcePendingReadsToWaitForUser = false;
-            TdsParserStateObjectHelper.ForceSyncOverAsyncAfterFirstPend = false;
-            TdsParserStateObjectHelper.SkipSendAttention = false;
-            CommandHelper.ForceAsyncWriteDelay = 0;
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                TdsParserStateObjectHelper.FailAsyncPends = false;
+                TdsParserStateObjectHelper.ForceAllPends = false;
+                TdsParserStateObjectHelper.ForcePendingReadsToWaitForUser = false;
+                TdsParserStateObjectHelper.ForceSyncOverAsyncAfterFirstPend = false;
+                TdsParserStateObjectHelper.SkipSendAttention = false;
+                CommandHelper.ForceAsyncWriteDelay = 0;
+            }
         }
     }
 
@@ -77,6 +86,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
         {
             if (_reader != null)
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -185,7 +185,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             public void Dispose()
             {
-                _doneEvent.Dispose();
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _doneEvent.Dispose();
+                }
             }
 
             public void SqlConnectionOpen()

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
@@ -366,7 +366,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public void Dispose()
         {
-            _endEvent?.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _endEvent?.Dispose();
+            }
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomizerPool.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomizerPool.cs
@@ -272,12 +272,19 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             Randomizer IScope.Current { get { return Current; } }
 
+
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
             /// <summary>
             /// Disposes the scope and reverts the current thread scope to previous one. 
             /// Note that the "last created scope" is not changed on Dispose, thus the scope instance
             /// itself can still be used to collect repro states.
             /// </summary>
-            public void Dispose()
+            protected virtual void Dispose(bool disposing)
             {
                 if (_current != null)
                 {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/DataConversionErrorMessageTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/DataConversionErrorMessageTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         _varChar3 = 1
     }
 
-    public class InitialDatabase : IDisposable
+    public sealed class InitialDatabase : IDisposable
     {
         private string srcConstr { get; }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlNotificationTest/SqlNotificationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlNotificationTest/SqlNotificationTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
-    public class SqlNotificationTest : IDisposable
+    public sealed class SqlNotificationTest : IDisposable
     {
         // Misc constants
         private const int CALLBACK_TIMEOUT = 5000; // milliseconds


### PR DESCRIPTION
After updating VS2019 NET5 test runs started to fail on Manual tests. There were around 508 error messages. 
[CA1063: Implement IDisposable correctly](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1063): around 40 error messages regarding this topic and had to be addressed. Warnings from this rule should not be suppressed.

[CA2100: Review SQL queries for security vulnerabilities](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2100) the rest of the error messages were about this violation. This type of warnings could be suppressed through editorconfig file.