### PR TITLE
Sync SqlDataRecord

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
@@ -2,7 +2,7 @@
 <docs>
     <members name="SqlDataRecord">
         <SqlDataRecord>
-            <summary>Represents a single row of data and its metadata. This class cannot be inherited.</summary>
+            <summary>Represents a single row of data and its metadata.</summary>
             <remarks>
                 <format type="text/markdown"><![CDATA[  
   

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
@@ -796,6 +796,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/System.Data.IDataRecord.GetData/*' />
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         IDataReader System.Data.IDataRecord.GetData(int ordinal)
         {
             throw ADP.NotSupported();

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
@@ -21,12 +21,15 @@ namespace Microsoft.Data.SqlClient.Server
         private FieldNameLookup _fieldNameLookup;
         private bool _usesStringStorageForXml;
 
-        private static readonly SmiMetaData s_maxNVarCharForXml = new SmiMetaData(SqlDbType.NVarChar, SmiMetaData.UnlimitedMaxLengthIndicator,
-                                        SmiMetaData.DefaultNVarChar_NoCollation.Precision,
-                                        SmiMetaData.DefaultNVarChar_NoCollation.Scale,
-                                        SmiMetaData.DefaultNVarChar.LocaleId,
-                                        SmiMetaData.DefaultNVarChar.CompareOptions,
-                                        null);
+        private static readonly SmiMetaData s_maxNVarCharForXml = new SmiMetaData(
+            SqlDbType.NVarChar, 
+            SmiMetaData.UnlimitedMaxLengthIndicator,
+            SmiMetaData.DefaultNVarChar_NoCollation.Precision,
+            SmiMetaData.DefaultNVarChar_NoCollation.Scale,
+            SmiMetaData.DefaultNVarChar.LocaleId,
+            SmiMetaData.DefaultNVarChar.CompareOptions,
+            userDefinedType: null
+        );
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/FieldCount/*' />
         public virtual int FieldCount
@@ -50,7 +53,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             EnsureSubclassOverride();
             SqlMetaData metaData = GetSqlMetaData(ordinal);
-            if (SqlDbType.Udt == metaData.SqlDbType)
+            if (metaData.SqlDbType == SqlDbType.Udt)
             {
                 return metaData.UdtTypeName;
             }
@@ -64,10 +67,8 @@ namespace Microsoft.Data.SqlClient.Server
         public virtual Type GetFieldType(int ordinal)
         {
             EnsureSubclassOverride();
-            {
-                SqlMetaData md = GetSqlMetaData(ordinal);
-                return MetaType.GetMetaTypeFromSqlDbType(md.SqlDbType, false).ClassType;
-            }
+            SqlMetaData md = GetSqlMetaData(ordinal);
+            return MetaType.GetMetaTypeFromSqlDbType(md.SqlDbType, false).ClassType;
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetValue/*' />
@@ -75,20 +76,14 @@ namespace Microsoft.Data.SqlClient.Server
         {
             EnsureSubclassOverride();
             SmiMetaData metaData = GetSmiMetaData(ordinal);
-
-            return ValueUtilsSmi.GetValue200(
-                            _eventSink,
-                            _recordBuffer,
-                            ordinal,
-                            metaData
-                                );
+            return ValueUtilsSmi.GetValue200(_eventSink, _recordBuffer, ordinal, metaData);
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetValues/*' />
         public virtual int GetValues(object[] values)
         {
             EnsureSubclassOverride();
-            if (null == values)
+            if (values == null)
             {
                 throw ADP.ArgumentNull(nameof(values));
             }
@@ -158,7 +153,7 @@ namespace Microsoft.Data.SqlClient.Server
         public virtual long GetBytes(int ordinal, long fieldOffset, byte[] buffer, int bufferOffset, int length)
         {
             EnsureSubclassOverride();
-            return ValueUtilsSmi.GetBytes(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), fieldOffset, buffer, bufferOffset, length, true);
+            return ValueUtilsSmi.GetBytes(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), fieldOffset, buffer, bufferOffset, length, throwOnNull: true);
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetChar/*' />
@@ -222,7 +217,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             EnsureSubclassOverride();
             SmiMetaData colMeta = GetSmiMetaData(ordinal);
-            if (_usesStringStorageForXml && SqlDbType.Xml == colMeta.SqlDbType)
+            if (_usesStringStorageForXml && colMeta.SqlDbType == SqlDbType.Xml)
             {
                 return ValueUtilsSmi.GetString(_eventSink, _recordBuffer, ordinal, s_maxNVarCharForXml);
             }
@@ -296,11 +291,10 @@ namespace Microsoft.Data.SqlClient.Server
         public virtual int GetSqlValues(object[] values)
         {
             EnsureSubclassOverride();
-            if (null == values)
+            if (values == null)
             {
                 throw ADP.ArgumentNull(nameof(values));
             }
-
 
             int copyLength = (values.Length < FieldCount) ? values.Length : FieldCount;
             for (int i = 0; i < copyLength; i++)
@@ -428,7 +422,7 @@ namespace Microsoft.Data.SqlClient.Server
         public virtual int SetValues(params object[] values)
         {
             EnsureSubclassOverride();
-            if (null == values)
+            if (values == null)
             {
                 throw ADP.ArgumentNull(nameof(values));
             }
@@ -443,8 +437,12 @@ namespace Microsoft.Data.SqlClient.Server
             {
                 SqlMetaData metaData = GetSqlMetaData(i);
                 typeCodes[i] = MetaDataUtilsSmi.DetermineExtendedTypeCodeForUseWithSqlDbType(
-                    metaData.SqlDbType, false /* isMultiValued */, values[i], metaData.Type);
-                if (ExtendedClrTypeCode.Invalid == typeCodes[i])
+                    metaData.SqlDbType,
+                    isMultiValued: false,
+                    values[i],
+                    metaData.Type
+                );
+                if (typeCodes[i] == ExtendedClrTypeCode.Invalid)
                 {
                     throw ADP.InvalidCast();
                 }
@@ -454,7 +452,7 @@ namespace Microsoft.Data.SqlClient.Server
             //      the validation loop and here, or if an invalid UDT was sent).
             for (int i = 0; i < copyLength; i++)
             {
-                ValueUtilsSmi.SetCompatibleValueV200(_eventSink, _recordBuffer, i, GetSmiMetaData(i), values[i], typeCodes[i], 0, 0, null);
+                ValueUtilsSmi.SetCompatibleValueV200(_eventSink, _recordBuffer, i, GetSmiMetaData(i), values[i], typeCodes[i], offset: 0, length: 0, peekAhead: null);
             }
 
             return copyLength;
@@ -466,13 +464,17 @@ namespace Microsoft.Data.SqlClient.Server
             EnsureSubclassOverride();
             SqlMetaData metaData = GetSqlMetaData(ordinal);
             ExtendedClrTypeCode typeCode = MetaDataUtilsSmi.DetermineExtendedTypeCodeForUseWithSqlDbType(
-                        metaData.SqlDbType, false /* isMultiValued */, value, metaData.Type);
-            if (ExtendedClrTypeCode.Invalid == typeCode)
+                metaData.SqlDbType, 
+                isMultiValued: false,
+                value,
+                metaData.Type
+            );
+            if (typeCode == ExtendedClrTypeCode.Invalid)
             {
                 throw ADP.InvalidCast();
             }
 
-            ValueUtilsSmi.SetCompatibleValueV200(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value, typeCode, 0, 0, null);
+            ValueUtilsSmi.SetCompatibleValueV200(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value, typeCode, offset: 0, length: 0, peekAhead: null);
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetBoolean/*' />
@@ -710,7 +712,7 @@ namespace Microsoft.Data.SqlClient.Server
         public SqlDataRecord(params SqlMetaData[] metaData)
         {
             // Initial consistency check
-            if (null == metaData)
+            if (metaData == null)
             {
                 throw ADP.ArgumentNull(nameof(metaData));
             }
@@ -719,7 +721,7 @@ namespace Microsoft.Data.SqlClient.Server
             _columnSmiMetaData = new SmiExtendedMetaData[metaData.Length];
             for (int i = 0; i < _columnSmiMetaData.Length; i++)
             {
-                if (null == metaData[i])
+                if (metaData[i] == null)
                 {
                     throw ADP.ArgumentNull($"{nameof(metaData)}[{i}]");
                 }
@@ -728,7 +730,6 @@ namespace Microsoft.Data.SqlClient.Server
             }
 
             _eventSink = new SmiEventSink_Default();
-
             _recordBuffer = new MemoryRecordBuffer(_columnSmiMetaData);
             _usesStringStorageForXml = true;
             _eventSink.ProcessMessagesAndThrow();
@@ -736,8 +737,8 @@ namespace Microsoft.Data.SqlClient.Server
 
         internal SqlDataRecord(SmiRecordBuffer recordBuffer, params SmiExtendedMetaData[] metaData)
         {
-            Debug.Assert(null != recordBuffer, "invalid attempt to instantiate SqlDataRecord with null SmiRecordBuffer");
-            Debug.Assert(null != metaData, "invalid attempt to instantiate SqlDataRecord with null SmiExtendedMetaData[]");
+            Debug.Assert(recordBuffer != null, "invalid attempt to instantiate SqlDataRecord with null SmiRecordBuffer");
+            Debug.Assert(metaData != null, "invalid attempt to instantiate SqlDataRecord with null SmiExtendedMetaData[]");
 
             _columnMetaData = new SqlMetaData[metaData.Length];
             _columnSmiMetaData = new SmiExtendedMetaData[metaData.Length];
@@ -748,7 +749,6 @@ namespace Microsoft.Data.SqlClient.Server
             }
 
             _eventSink = new SmiEventSink_Default();
-
             _recordBuffer = recordBuffer;
             _eventSink.ProcessMessagesAndThrow();
         }
@@ -763,7 +763,6 @@ namespace Microsoft.Data.SqlClient.Server
                 return _recordBuffer;
             }
         }
-
 
         internal SqlMetaData[] InternalGetMetaData()
         {
@@ -787,9 +786,10 @@ namespace Microsoft.Data.SqlClient.Server
                 throw ADP.IndexOutOfRange(ordinal);
             }
         }
+
         private void EnsureSubclassOverride()
         {
-            if (null == _recordBuffer)
+            if (_recordBuffer == null)
             {
                 throw SQL.SubclassMustOverride();
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
@@ -550,6 +550,7 @@ namespace Microsoft.Data.SqlClient.Server
             EnsureSubclassOverride();
             ValueUtilsSmi.SetString(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
+
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDecimal/*' />
         public virtual void SetDecimal(int ordinal, decimal value)
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
@@ -40,14 +40,14 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetName/*' />
-        public virtual String GetName(int ordinal)
+        public virtual string GetName(int ordinal)
         {
             EnsureSubclassOverride();
             return GetSqlMetaData(ordinal).Name;
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDataTypeName/*' />
-        public virtual String GetDataTypeName(int ordinal)
+        public virtual string GetDataTypeName(int ordinal)
         {
             EnsureSubclassOverride();
             SqlMetaData metaData = GetSqlMetaData(ordinal);
@@ -77,7 +77,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetValue/*' />
-        public virtual Object GetValue(int ordinal)
+        public virtual object GetValue(int ordinal)
         {
             EnsureSubclassOverride();
             SmiMetaData metaData = GetSmiMetaData(ordinal);
@@ -110,7 +110,7 @@ namespace Microsoft.Data.SqlClient.Server
             EnsureSubclassOverride();
             if (null == values)
             {
-                throw ADP.ArgumentNull("values");
+                throw ADP.ArgumentNull(nameof(values));
             }
 
             int copyLength = (values.Length < FieldCount) ? values.Length : FieldCount;
@@ -134,7 +134,7 @@ namespace Microsoft.Data.SqlClient.Server
                     names[i] = GetSqlMetaData(i).Name;
                 }
 
-                _fieldNameLookup = new FieldNameLookup(names, -1);  // UNDONE: is this correct LCID?
+                _fieldNameLookup = new FieldNameLookup(names, -1);
             }
 
             return _fieldNameLookup.GetOrdinal(name);
@@ -151,7 +151,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/ItemName/*' />
-        public virtual object this[String name]
+        public virtual object this[string name]
         {
             get
             {
@@ -203,21 +203,21 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetInt16/*' />
-        public virtual Int16 GetInt16(int ordinal)
+        public virtual short GetInt16(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetInt16(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetInt32/*' />
-        public virtual Int32 GetInt32(int ordinal)
+        public virtual int GetInt32(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetInt32(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetInt64/*' />
-        public virtual Int64 GetInt64(int ordinal)
+        public virtual long GetInt64(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetInt64(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
@@ -253,7 +253,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDecimal/*' />
-        public virtual Decimal GetDecimal(int ordinal)
+        public virtual decimal GetDecimal(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetDecimal(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
@@ -278,13 +278,6 @@ namespace Microsoft.Data.SqlClient.Server
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetTimeSpan(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
-        }
-
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/System.Data.IDataRecord.GetData/*' />
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)] // MDAC 69508
-        IDataReader IDataRecord.GetData(int ordinal)
-        {
-            throw ADP.NotSupported();
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/IsDBNull/*' />
@@ -329,7 +322,7 @@ namespace Microsoft.Data.SqlClient.Server
             EnsureSubclassOverride();
             if (null == values)
             {
-                throw ADP.ArgumentNull("values");
+                throw ADP.ArgumentNull(nameof(values));
             }
 
 
@@ -461,10 +454,10 @@ namespace Microsoft.Data.SqlClient.Server
             EnsureSubclassOverride();
             if (null == values)
             {
-                throw ADP.ArgumentNull("values");
+                throw ADP.ArgumentNull(nameof(values));
             }
 
-            // SQLBUDT #346883 Allow values array longer than FieldCount, just ignore the extra cells.
+            // Allow values array longer than FieldCount, just ignore the extra cells.
             int copyLength = (values.Length > FieldCount) ? FieldCount : values.Length;
 
             ExtendedClrTypeCode[] typeCodes = new ExtendedClrTypeCode[copyLength];
@@ -556,21 +549,21 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetInt16/*' />
-        public virtual void SetInt16(int ordinal, System.Int16 value)
+        public virtual void SetInt16(int ordinal, short value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetInt16(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetInt32/*' />
-        public virtual void SetInt32(int ordinal, System.Int32 value)
+        public virtual void SetInt32(int ordinal, int value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetInt32(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetInt64/*' />
-        public virtual void SetInt64(int ordinal, System.Int64 value)
+        public virtual void SetInt64(int ordinal, long value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetInt64(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
@@ -597,7 +590,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDecimal/*' />
-        public virtual void SetDecimal(int ordinal, Decimal value)
+        public virtual void SetDecimal(int ordinal, decimal value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetDecimal(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
@@ -757,7 +750,7 @@ namespace Microsoft.Data.SqlClient.Server
             // Initial consistency check
             if (null == metaData)
             {
-                throw ADP.ArgumentNull("metadata");
+                throw ADP.ArgumentNull(nameof(metaData));
             }
 
             _columnMetaData = new SqlMetaData[metaData.Length];
@@ -767,7 +760,7 @@ namespace Microsoft.Data.SqlClient.Server
             {
                 if (null == metaData[i])
                 {
-                    throw ADP.ArgumentNull("metadata[" + i + "]");
+                    throw ADP.ArgumentNull($"{nameof(metaData)}[{i}]");
                 }
                 _columnMetaData[i] = metaData[i];
                 _columnSmiMetaData[i] = MetaDataUtilsSmi.SqlMetaDataToSmiExtendedMetaData(_columnMetaData[i]);
@@ -876,6 +869,12 @@ namespace Microsoft.Data.SqlClient.Server
             {
                 throw SQL.SubclassMustOverride();
             }
+        }
+
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/System.Data.IDataRecord.GetData/*' />
+        IDataReader System.Data.IDataRecord.GetData(int ordinal)
+        {
+            throw ADP.NotSupported();
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
@@ -11,7 +11,7 @@ using Microsoft.Data.ProviderBase;
 
 namespace Microsoft.Data.SqlClient.Server
 {
-    /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SqlDataRecord/*' />
+    /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SqlDataRecord/*' />
     public class SqlDataRecord : IDataRecord
     {
         SmiRecordBuffer _recordBuffer;
@@ -29,7 +29,7 @@ namespace Microsoft.Data.SqlClient.Server
                                         SmiMetaData.DefaultNVarChar.CompareOptions,
                                         null);
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/FieldCount/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/FieldCount/*' />
         public virtual int FieldCount
         {
             get
@@ -39,14 +39,14 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetName/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetName/*' />
         public virtual String GetName(int ordinal)
         {
             EnsureSubclassOverride();
             return GetSqlMetaData(ordinal).Name;
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDataTypeName/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDataTypeName/*' />
         public virtual String GetDataTypeName(int ordinal)
         {
             EnsureSubclassOverride();
@@ -61,7 +61,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetFieldType/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetFieldType/*' />
         public virtual Type GetFieldType(int ordinal)
         {
             EnsureSubclassOverride();
@@ -76,7 +76,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetValue/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetValue/*' />
         public virtual Object GetValue(int ordinal)
         {
             EnsureSubclassOverride();
@@ -104,7 +104,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetValues/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetValues/*' />
         public virtual int GetValues(object[] values)
         {
             EnsureSubclassOverride();
@@ -122,7 +122,7 @@ namespace Microsoft.Data.SqlClient.Server
             return copyLength;
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetOrdinal/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetOrdinal/*' />
         public virtual int GetOrdinal(string name)
         {
             EnsureSubclassOverride();
@@ -140,7 +140,7 @@ namespace Microsoft.Data.SqlClient.Server
             return _fieldNameLookup.GetOrdinal(name);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/ItemOrdinal/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/ItemOrdinal/*' />
         public virtual object this[int ordinal]
         {
             get
@@ -150,7 +150,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/ItemName/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/ItemName/*' />
         public virtual object this[String name]
         {
             get
@@ -160,84 +160,84 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetBoolean/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetBoolean/*' />
         public virtual bool GetBoolean(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetBoolean(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetByte/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetByte/*' />
         public virtual byte GetByte(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetByte(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetBytes/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetBytes/*' />
         public virtual long GetBytes(int ordinal, long fieldOffset, byte[] buffer, int bufferOffset, int length)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetBytes(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), fieldOffset, buffer, bufferOffset, length, true);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetChar/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetChar/*' />
         public virtual char GetChar(int ordinal)
         {
             EnsureSubclassOverride();
             throw ADP.NotSupported();
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetChars/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetChars/*' />
         public virtual long GetChars(int ordinal, long fieldOffset, char[] buffer, int bufferOffset, int length)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetChars(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), fieldOffset, buffer, bufferOffset, length);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetGuid/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetGuid/*' />
         public virtual Guid GetGuid(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetGuid(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetInt16/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetInt16/*' />
         public virtual Int16 GetInt16(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetInt16(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetInt32/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetInt32/*' />
         public virtual Int32 GetInt32(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetInt32(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetInt64/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetInt64/*' />
         public virtual Int64 GetInt64(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetInt64(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetFloat/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetFloat/*' />
         public virtual float GetFloat(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSingle(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDouble/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDouble/*' />
         public virtual double GetDouble(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetDouble(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetString/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetString/*' />
         public virtual string GetString(int ordinal)
         {
             EnsureSubclassOverride();
@@ -252,28 +252,28 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDecimal/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDecimal/*' />
         public virtual Decimal GetDecimal(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetDecimal(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDateTime/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDateTime/*' />
         public virtual DateTime GetDateTime(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetDateTime(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDateTimeOffset/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetDateTimeOffset/*' />
         public virtual DateTimeOffset GetDateTimeOffset(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetDateTimeOffset(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetTimeSpan/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetTimeSpan/*' />
         public virtual TimeSpan GetTimeSpan(int ordinal)
         {
             EnsureSubclassOverride();
@@ -287,7 +287,7 @@ namespace Microsoft.Data.SqlClient.Server
             throw ADP.NotSupported();
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/IsDBNull/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/IsDBNull/*' />
         public virtual bool IsDBNull(int ordinal)
         {
             EnsureSubclassOverride();
@@ -295,7 +295,7 @@ namespace Microsoft.Data.SqlClient.Server
             return ValueUtilsSmi.IsDBNull(_eventSink, _recordBuffer, ordinal);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlMetaData/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlMetaData/*' />
         //  ISqlRecord implementation
         public virtual SqlMetaData GetSqlMetaData(int ordinal)
         {
@@ -303,7 +303,7 @@ namespace Microsoft.Data.SqlClient.Server
             return _columnMetaData[ordinal];
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlFieldType/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlFieldType/*' />
         public virtual Type GetSqlFieldType(int ordinal)
         {
             EnsureSubclassOverride();
@@ -311,7 +311,7 @@ namespace Microsoft.Data.SqlClient.Server
             return MetaType.GetMetaTypeFromSqlDbType(md.SqlDbType, false).SqlType;
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlValue/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlValue/*' />
         public virtual object GetSqlValue(int ordinal)
         {
             EnsureSubclassOverride();
@@ -323,7 +323,7 @@ namespace Microsoft.Data.SqlClient.Server
             return ValueUtilsSmi.GetSqlValue(_eventSink, _recordBuffer, ordinal, metaData, _recordContext);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlValues/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlValues/*' />
         public virtual int GetSqlValues(object[] values)
         {
             EnsureSubclassOverride();
@@ -342,119 +342,119 @@ namespace Microsoft.Data.SqlClient.Server
             return copyLength;
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlBinary/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlBinary/*' />
         public virtual SqlBinary GetSqlBinary(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlBinary(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlBytes/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlBytes/*' />
         public virtual SqlBytes GetSqlBytes(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlBytes(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), _recordContext);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlXml/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlXml/*' />
         public virtual SqlXml GetSqlXml(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlXml(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), _recordContext);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlBoolean/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlBoolean/*' />
         public virtual SqlBoolean GetSqlBoolean(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlBoolean(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlByte/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlByte/*' />
         public virtual SqlByte GetSqlByte(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlByte(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlChars/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlChars/*' />
         public virtual SqlChars GetSqlChars(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlChars(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), _recordContext);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlInt16/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlInt16/*' />
         public virtual SqlInt16 GetSqlInt16(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlInt16(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlInt32/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlInt32/*' />
         public virtual SqlInt32 GetSqlInt32(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlInt32(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlInt64/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlInt64/*' />
         public virtual SqlInt64 GetSqlInt64(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlInt64(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlSingle/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlSingle/*' />
         public virtual SqlSingle GetSqlSingle(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlSingle(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlDouble/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlDouble/*' />
         public virtual SqlDouble GetSqlDouble(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlDouble(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlMoney/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlMoney/*' />
         public virtual SqlMoney GetSqlMoney(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlMoney(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlDateTime/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlDateTime/*' />
         public virtual SqlDateTime GetSqlDateTime(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlDateTime(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlDecimal/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlDecimal/*' />
         public virtual SqlDecimal GetSqlDecimal(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlDecimal(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlString/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlString/*' />
         public virtual SqlString GetSqlString(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlString(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlGuid/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlGuid/*' />
         public virtual SqlGuid GetSqlGuid(int ordinal)
         {
             EnsureSubclassOverride();
             return ValueUtilsSmi.GetSqlGuid(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal));
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetValues/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetValues/*' />
         // ISqlUpdateableRecord Implementation
         public virtual int SetValues(params object[] values)
         {
@@ -498,7 +498,7 @@ namespace Microsoft.Data.SqlClient.Server
             return copyLength;
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetValue/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetValue/*' />
         public virtual void SetValue(int ordinal, object value)
         {
             EnsureSubclassOverride();
@@ -520,231 +520,230 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetBoolean/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetBoolean/*' />
         public virtual void SetBoolean(int ordinal, bool value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetBoolean(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetByte/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetByte/*' />
         public virtual void SetByte(int ordinal, byte value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetByte(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetBytes/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetBytes/*' />
         public virtual void SetBytes(int ordinal, long fieldOffset, byte[] buffer, int bufferOffset, int length)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetBytes(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), fieldOffset, buffer, bufferOffset, length);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetChar/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetChar/*' />
         public virtual void SetChar(int ordinal, char value)
         {
             EnsureSubclassOverride();
             throw ADP.NotSupported();
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetChars/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetChars/*' />
         public virtual void SetChars(int ordinal, long fieldOffset, char[] buffer, int bufferOffset, int length)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetChars(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), fieldOffset, buffer, bufferOffset, length);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetInt16/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetInt16/*' />
         public virtual void SetInt16(int ordinal, System.Int16 value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetInt16(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetInt32/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetInt32/*' />
         public virtual void SetInt32(int ordinal, System.Int32 value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetInt32(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetInt64/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetInt64/*' />
         public virtual void SetInt64(int ordinal, System.Int64 value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetInt64(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetFloat/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetFloat/*' />
         public virtual void SetFloat(int ordinal, float value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSingle(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
-
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDouble/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDouble/*' />
         public virtual void SetDouble(int ordinal, double value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetDouble(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetString/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetString/*' />
         public virtual void SetString(int ordinal, string value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetString(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDecimal/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDecimal/*' />
         public virtual void SetDecimal(int ordinal, Decimal value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetDecimal(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDateTime/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDateTime/*' />
         public virtual void SetDateTime(int ordinal, DateTime value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetDateTime(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetTimeSpan/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetTimeSpan/*' />
         public virtual void SetTimeSpan(int ordinal, TimeSpan value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetTimeSpan(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value, SmiVersion >= SmiContextFactory.KatmaiVersion);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDateTimeOffset/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDateTimeOffset/*' />
         public virtual void SetDateTimeOffset(int ordinal, DateTimeOffset value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetDateTimeOffset(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value, SmiVersion >= SmiContextFactory.KatmaiVersion);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDBNull/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetDBNull/*' />
         public virtual void SetDBNull(int ordinal)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetDBNull(_eventSink, _recordBuffer, ordinal, true);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetGuid/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetGuid/*' />
         public virtual void SetGuid(int ordinal, Guid value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetGuid(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlBoolean/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlBoolean/*' />
         public virtual void SetSqlBoolean(int ordinal, SqlBoolean value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlBoolean(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlByte/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlByte/*' />
         public virtual void SetSqlByte(int ordinal, SqlByte value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlByte(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlInt16/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlInt16/*' />
         public virtual void SetSqlInt16(int ordinal, SqlInt16 value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlInt16(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlInt32/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlInt32/*' />
         public virtual void SetSqlInt32(int ordinal, SqlInt32 value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlInt32(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlInt64/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlInt64/*' />
         public virtual void SetSqlInt64(int ordinal, SqlInt64 value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlInt64(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlSingle/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlSingle/*' />
         public virtual void SetSqlSingle(int ordinal, SqlSingle value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlSingle(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlDouble/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlDouble/*' />
         public virtual void SetSqlDouble(int ordinal, SqlDouble value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlDouble(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlMoney/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlMoney/*' />
         public virtual void SetSqlMoney(int ordinal, SqlMoney value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlMoney(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlDateTime/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlDateTime/*' />
         public virtual void SetSqlDateTime(int ordinal, SqlDateTime value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlDateTime(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlXml/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlXml/*' />
         public virtual void SetSqlXml(int ordinal, SqlXml value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlXml(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlDecimal/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlDecimal/*' />
         public virtual void SetSqlDecimal(int ordinal, SqlDecimal value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlDecimal(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlString/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlString/*' />
         public virtual void SetSqlString(int ordinal, SqlString value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlString(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlBinary/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlBinary/*' />
         public virtual void SetSqlBinary(int ordinal, SqlBinary value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlBinary(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlGuid/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlGuid/*' />
         public virtual void SetSqlGuid(int ordinal, SqlGuid value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlGuid(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlChars/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlChars/*' />
         public virtual void SetSqlChars(int ordinal, SqlChars value)
         {
             EnsureSubclassOverride();
             ValueUtilsSmi.SetSqlChars(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value);
         }
 
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlBytes/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/SetSqlBytes/*' />
         public virtual void SetSqlBytes(int ordinal, SqlBytes value)
         {
             EnsureSubclassOverride();
@@ -752,7 +751,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         //  SqlDataRecord public API
-        /// <include file='..\..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient.Server\SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/ctor/*' />
+        /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/ctor/*' />
         public SqlDataRecord(params SqlMetaData[] metaData)
         {
             // Initial consistency check

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
@@ -872,6 +872,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         /// <include file='../../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/System.Data.IDataRecord.GetData/*' />
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         IDataReader System.Data.IDataRecord.GetData(int ordinal)
         {
             throw ADP.NotSupported();


### PR DESCRIPTION
This is a small one. Identify similar parts of the two SqlDataRecord classes from netcore and netfx and sync those differences so the functional differences can be seen.

Observations:
1) There are only two constructors for SqlDataRecord and both of them set the _recordBuffer to a non-null value. This means that the frequent calls to `EnsureSubclassOverride` which checks _recordBuffer is non-null or throws are pointless and I have seen them in profile traces in the past when looking at UDT performance. I propose to remove `EnsureSubclassOverride` entirely.
2) All the private fields can be made readonly
3) `ThrowIfInvalidOrdinal(ordinal)` is used only once in `IsDBNull`, either it should be used in all functions that take an ordinal parameter or none of them. If it is not used ordinal will often be used without further checks in called methods which could result in out of range or key not found exceptions.
4) The functional differences between these two implementations seem to fall into two categories, in-proc hosting and old sql versions. The in-proc code could be kept in case it is needed in future and the old sql version checks could be dropped after checking version compatibility for this library.

Any of those changes would be a separate PR.

Oh. and the [docs](https://docs.microsoft.com/en-us/dotnet/api/microsoft.sqlserver.server.sqldatarecord?view=netframework-4.8) state that "Represents a single row of data and its metadata. This class cannot be inherited." when the class is not sealed and can be inherited from. Either the docs are wrong or the class should be sealed.