### PR TITLE
Sync SmiTypedGetterSetter

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiTypedGetterSetter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiTypedGetterSetter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Data.SqlTypes;
+using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient.Server
 {
@@ -34,11 +35,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -48,11 +49,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -61,11 +62,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -74,11 +75,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -88,22 +89,22 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
         public virtual int GetBytes(SmiEventSink sink, int ordinal, long fieldOffset, byte[] buffer, int bufferOffset, int length)
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -112,33 +113,33 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
         public virtual int GetChars(SmiEventSink sink, int ordinal, long fieldOffset, char[] buffer, int bufferOffset, int length)
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
         public virtual String GetString(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -147,11 +148,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -160,11 +161,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -173,11 +174,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -186,11 +187,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -199,11 +200,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -212,11 +213,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -225,11 +226,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -238,11 +239,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -251,11 +252,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -264,11 +265,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -276,7 +277,7 @@ namespace Microsoft.Data.SqlClient.Server
         //  This method called for both get and set.
         internal virtual SmiTypedGetterSetter GetTypedGetterSetter(SmiEventSink sink, int ordinal)
         {
-            throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+            throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
         }
 
         // valid for multi-valued types only
@@ -284,11 +285,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanGet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
         #endregion
@@ -301,11 +302,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -314,11 +315,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -327,11 +328,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -343,22 +344,22 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
         public virtual void SetBytesLength(SmiEventSink sink, int ordinal, long length)
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -370,22 +371,22 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
         public virtual void SetCharsLength(SmiEventSink sink, int ordinal, long length)
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -394,11 +395,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -407,11 +408,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -420,11 +421,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -433,11 +434,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -446,11 +447,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -459,11 +460,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -472,11 +473,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -485,11 +486,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -498,11 +499,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -511,11 +512,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -524,11 +525,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -540,7 +541,7 @@ namespace Microsoft.Data.SqlClient.Server
             // Implement body with throw because there are only a couple of ways to get to this code:
             //  1) Client is calling this method even though the server negotiated for V3+ and dropped support for V2-.
             //  2) Server didn't implement V2- on some interface and negotiated V2-.
-            throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+            throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
         }
 
         // valid for multi-valued types only
@@ -548,11 +549,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
 
@@ -560,11 +561,11 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (!CanSet)
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.InvalidSmiCall);
+                throw ADP.InternalError(ADP.InternalErrorCode.InvalidSmiCall);
             }
             else
             {
-                throw Microsoft.Data.Common.ADP.InternalError(Microsoft.Data.Common.ADP.InternalErrorCode.UnimplementedSMIMethod);
+                throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
         #endregion

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiTypedGetterSetter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiTypedGetterSetter.cs
@@ -8,7 +8,6 @@ using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient.Server
 {
-
     // Central interface for getting/setting data values from/to a set of values indexed by ordinal 
     //  (record, row, array, etc)
     //  Which methods are allowed to be called depends on SmiMetaData type of data offset.
@@ -58,7 +57,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         //  valid for SqlDbType.Bit
-        public virtual Boolean GetBoolean(SmiEventSink sink, int ordinal)
+        public virtual bool GetBoolean(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
@@ -71,7 +70,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         //  valid for SqlDbType.TinyInt
-        public virtual Byte GetByte(SmiEventSink sink, int ordinal)
+        public virtual byte GetByte(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
@@ -85,7 +84,7 @@ namespace Microsoft.Data.SqlClient.Server
 
         // valid for SqlDbTypes: Binary, VarBinary, Image, Udt, Xml, Char, VarChar, Text, NChar, NVarChar, NText
         //  (Character type support needed for ExecuteXmlReader handling)
-        public virtual Int64 GetBytesLength(SmiEventSink sink, int ordinal)
+        public virtual long GetBytesLength(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
@@ -109,7 +108,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for character types: Char, VarChar, Text, NChar, NVarChar, NText
-        public virtual Int64 GetCharsLength(SmiEventSink sink, int ordinal)
+        public virtual long GetCharsLength(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
@@ -131,7 +130,7 @@ namespace Microsoft.Data.SqlClient.Server
                 throw ADP.InternalError(ADP.InternalErrorCode.UnimplementedSMIMethod);
             }
         }
-        public virtual String GetString(SmiEventSink sink, int ordinal)
+        public virtual string GetString(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
@@ -144,7 +143,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for SqlDbType.SmallInt
-        public virtual Int16 GetInt16(SmiEventSink sink, int ordinal)
+        public virtual short GetInt16(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
@@ -157,7 +156,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for SqlDbType.Int
-        public virtual Int32 GetInt32(SmiEventSink sink, int ordinal)
+        public virtual int GetInt32(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
@@ -170,7 +169,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for SqlDbType.BigInt, SqlDbType.Money, SqlDbType.SmallMoney
-        public virtual Int64 GetInt64(SmiEventSink sink, int ordinal)
+        public virtual long GetInt64(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
@@ -183,7 +182,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for SqlDbType.Real
-        public virtual Single GetSingle(SmiEventSink sink, int ordinal)
+        public virtual float GetSingle(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
@@ -196,7 +195,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for SqlDbType.Float
-        public virtual Double GetDouble(SmiEventSink sink, int ordinal)
+        public virtual double GetDouble(SmiEventSink sink, int ordinal)
         {
             if (!CanGet)
             {
@@ -311,7 +310,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         //  valid for SqlDbType.Bit
-        public virtual void SetBoolean(SmiEventSink sink, int ordinal, Boolean value)
+        public virtual void SetBoolean(SmiEventSink sink, int ordinal, bool value)
         {
             if (!CanSet)
             {
@@ -324,7 +323,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         //  valid for SqlDbType.TinyInt
-        public virtual void SetByte(SmiEventSink sink, int ordinal, Byte value)
+        public virtual void SetByte(SmiEventSink sink, int ordinal, byte value)
         {
             if (!CanSet)
             {
@@ -404,7 +403,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for SqlDbType.SmallInt
-        public virtual void SetInt16(SmiEventSink sink, int ordinal, Int16 value)
+        public virtual void SetInt16(SmiEventSink sink, int ordinal, short value)
         {
             if (!CanSet)
             {
@@ -417,7 +416,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for SqlDbType.Int
-        public virtual void SetInt32(SmiEventSink sink, int ordinal, Int32 value)
+        public virtual void SetInt32(SmiEventSink sink, int ordinal, int value)
         {
             if (!CanSet)
             {
@@ -430,7 +429,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for SqlDbType.BigInt, SqlDbType.Money, SqlDbType.SmallMoney
-        public virtual void SetInt64(SmiEventSink sink, int ordinal, Int64 value)
+        public virtual void SetInt64(SmiEventSink sink, int ordinal, long value)
         {
             if (!CanSet)
             {
@@ -443,7 +442,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for SqlDbType.Real
-        public virtual void SetSingle(SmiEventSink sink, int ordinal, Single value)
+        public virtual void SetSingle(SmiEventSink sink, int ordinal, float value)
         {
             if (!CanSet)
             {
@@ -456,7 +455,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // valid for SqlDbType.Float
-        public virtual void SetDouble(SmiEventSink sink, int ordinal, Double value)
+        public virtual void SetDouble(SmiEventSink sink, int ordinal, double value)
         {
             if (!CanSet)
             {


### PR DESCRIPTION
Trivial clean up of a single file. The only remaining difference is an extra method in netfx `bool NextElement(SmiEventSink sink)`