### PR TITLE
Shrink SqlParameter XmlSchema

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Data.SqlClient
             Value = value;
             if (!string.IsNullOrEmpty(xmlSchemaCollectionDatabase) || !string.IsNullOrEmpty(xmlSchemaCollectionOwningSchema) || !string.IsNullOrEmpty(xmlSchemaCollectionName))
             {
-                EnsureXmlSchemaCollectionExists();
+                EnsureXmlSchemaCollection();
                 _xmlSchemaCollection.Database = xmlSchemaCollectionDatabase;
                 _xmlSchemaCollection.OwningSchema = xmlSchemaCollectionOwningSchema;
                 _xmlSchemaCollection.Name = xmlSchemaCollectionName;
@@ -408,11 +408,7 @@ namespace Microsoft.Data.SqlClient
         public string XmlSchemaCollectionDatabase
         {
             get => _xmlSchemaCollection?.Database ?? string.Empty;
-            set
-            {
-                EnsureXmlSchemaCollectionExists();
-                _xmlSchemaCollection.Database = value;
-            }
+            set => EnsureXmlSchemaCollection().Database = value;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/XmlSchemaCollectionOwningSchema/*' />
@@ -420,11 +416,7 @@ namespace Microsoft.Data.SqlClient
         public string XmlSchemaCollectionOwningSchema
         {
             get => _xmlSchemaCollection?.OwningSchema ?? string.Empty;
-            set
-            {
-                EnsureXmlSchemaCollectionExists();
-                _xmlSchemaCollection.OwningSchema = value;
-            }
+            set => EnsureXmlSchemaCollection().OwningSchema = value;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/XmlSchemaCollectionName/*' />
@@ -432,11 +424,7 @@ namespace Microsoft.Data.SqlClient
         public string XmlSchemaCollectionName
         {
             get => _xmlSchemaCollection?.Name ?? string.Empty;
-            set
-            {
-                EnsureXmlSchemaCollectionExists();
-                _xmlSchemaCollection.Name = value;
-            }
+            set => EnsureXmlSchemaCollection().Name = value;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ForceColumnEncryption/*' />
@@ -997,8 +985,7 @@ namespace Microsoft.Data.SqlClient
             destination._collation = _collation;
             if (_xmlSchemaCollection != null)
             {
-                destination.EnsureXmlSchemaCollectionExists();
-                destination._xmlSchemaCollection.CopyFrom(_xmlSchemaCollection);
+                destination.EnsureXmlSchemaCollection().CopyFrom(_xmlSchemaCollection);
             }
             destination._udtTypeName = _udtTypeName;
             destination._typeName = _typeName;
@@ -1035,12 +1022,13 @@ namespace Microsoft.Data.SqlClient
             return parent;
         }
 
-        private void EnsureXmlSchemaCollectionExists()
+        private SqlMetaDataXmlSchemaCollection EnsureXmlSchemaCollection()
         {
             if (_xmlSchemaCollection is null)
             {
                 _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
             }
+            return _xmlSchemaCollection;
         }
 
         internal void FixStreamDataForNonPLP()

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -244,6 +244,7 @@ namespace Microsoft.Data.SqlClient
         {
             _isNull = true;
             _actualSize = -1;
+            _direction = ParameterDirection.Input;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ctorParameterNameDbType/*' />
@@ -725,11 +726,7 @@ namespace Microsoft.Data.SqlClient
         ]
         public override ParameterDirection Direction
         {
-            get
-            {
-                ParameterDirection direction = _direction;
-                return (direction != 0) ? direction : ParameterDirection.Input;
-            }
+            get => _direction;
             set
             {
                 if (_direction != value)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -467,7 +467,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ParameterName/*' />
         public override string ParameterName
         {
-            get => _parameterName ?? ADP.StrEmpty;
+            get => _parameterName ?? string.Empty;
             set
             {
                 if (
@@ -672,7 +672,7 @@ namespace Microsoft.Data.SqlClient
         ]
         public string UdtTypeName
         {
-            get => _udtTypeName ?? ADP.StrEmpty;
+            get => _udtTypeName ?? string.Empty;
             set => _udtTypeName = value;
         }
 
@@ -683,7 +683,7 @@ namespace Microsoft.Data.SqlClient
         ]
         public string TypeName
         {
-            get => _typeName ?? ADP.StrEmpty;
+            get => _typeName ?? string.Empty;
             set 
             { 
                 _typeName = value;
@@ -824,7 +824,7 @@ namespace Microsoft.Data.SqlClient
         [ResCategory("Update")]
         public override string SourceColumn
         {
-            get => _sourceColumn ?? ADP.StrEmpty;
+            get => _sourceColumn ?? string.Empty;
             set => _sourceColumn = value;
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Data.SqlClient
             Value = value;
             if (!string.IsNullOrEmpty(xmlSchemaCollectionDatabase) || !string.IsNullOrEmpty(xmlSchemaCollectionOwningSchema) || !string.IsNullOrEmpty(xmlSchemaCollectionName))
             {
-                EnsureXmlSchemaCollectionExists();
+                EnsureXmlSchemaCollection();
                 _xmlSchemaCollection.Database = xmlSchemaCollectionDatabase;
                 _xmlSchemaCollection.OwningSchema = xmlSchemaCollectionOwningSchema;
                 _xmlSchemaCollection.Name = xmlSchemaCollectionName;
@@ -391,11 +391,7 @@ namespace Microsoft.Data.SqlClient
         public string XmlSchemaCollectionDatabase
         {
             get => _xmlSchemaCollection?.Database ?? string.Empty;
-            set
-            {
-                EnsureXmlSchemaCollectionExists();
-                _xmlSchemaCollection.Database = value;
-            }
+            set => EnsureXmlSchemaCollection().Database = value;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/XmlSchemaCollectionOwningSchema/*' />
@@ -403,11 +399,7 @@ namespace Microsoft.Data.SqlClient
         public string XmlSchemaCollectionOwningSchema
         {
             get => _xmlSchemaCollection?.OwningSchema ?? string.Empty;
-            set
-            {
-                EnsureXmlSchemaCollectionExists();
-                _xmlSchemaCollection.OwningSchema = value;
-            }
+            set => EnsureXmlSchemaCollection().OwningSchema = value;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/XmlSchemaCollectionName/*' />
@@ -415,11 +407,7 @@ namespace Microsoft.Data.SqlClient
         public string XmlSchemaCollectionName
         {
             get => _xmlSchemaCollection?.Name ?? string.Empty;
-            set
-            {
-                EnsureXmlSchemaCollectionExists();
-                _xmlSchemaCollection.Name = value;
-            }
+            set => EnsureXmlSchemaCollection().Name = value;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ForceColumnEncryption/*' />
@@ -984,8 +972,7 @@ namespace Microsoft.Data.SqlClient
             destination._collation = _collation;
             if (_xmlSchemaCollection != null)
             {
-                destination.EnsureXmlSchemaCollectionExists();
-                destination._xmlSchemaCollection.CopyFrom(_xmlSchemaCollection);
+                destination.EnsureXmlSchemaCollection().CopyFrom(_xmlSchemaCollection);
             }
             destination._udtTypeName = _udtTypeName;
             destination._typeName = _typeName;
@@ -1026,12 +1013,13 @@ namespace Microsoft.Data.SqlClient
             return parent;
         }
 
-        private void EnsureXmlSchemaCollectionExists()
+        private SqlMetaDataXmlSchemaCollection EnsureXmlSchemaCollection()
         {
             if (_xmlSchemaCollection is null)
             {
                 _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
             }
+            return _xmlSchemaCollection;
         }
 
         internal void FixStreamDataForNonPLP()

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -193,9 +193,7 @@ namespace Microsoft.Data.SqlClient
 
         private MetaType _metaType;
         private SqlCollation _collation;
-        private string _xmlSchemaCollectionDatabase;
-        private string _xmlSchemaCollectionOwningSchema;
-        private string _xmlSchemaCollectionName;
+        private SqlMetaDataXmlSchemaCollection _xmlSchemaCollection;
         private string _udtTypeName;
         private string _typeName;
         private Exception _udtLoadError;
@@ -315,9 +313,13 @@ namespace Microsoft.Data.SqlClient
             SourceVersion = sourceVersion;
             SourceColumnNullMapping = sourceColumnNullMapping;
             Value = value;
-            _xmlSchemaCollectionDatabase = xmlSchemaCollectionDatabase;
-            _xmlSchemaCollectionOwningSchema = xmlSchemaCollectionOwningSchema;
-            _xmlSchemaCollectionName = xmlSchemaCollectionName;
+            if (!string.IsNullOrEmpty(xmlSchemaCollectionDatabase) || !string.IsNullOrEmpty(xmlSchemaCollectionOwningSchema) || !string.IsNullOrEmpty(xmlSchemaCollectionName))
+            {
+                EnsureXmlSchemaCollectionExists();
+                _xmlSchemaCollection.Database = xmlSchemaCollectionDatabase;
+                _xmlSchemaCollection.OwningSchema = xmlSchemaCollectionOwningSchema;
+                _xmlSchemaCollection.Name = xmlSchemaCollectionName;
+            }
         }
 
         private SqlParameter(SqlParameter source) : this()
@@ -388,24 +390,36 @@ namespace Microsoft.Data.SqlClient
         [ResCategory("XML")]
         public string XmlSchemaCollectionDatabase
         {
-            get => _xmlSchemaCollectionDatabase ?? ADP.StrEmpty;
-            set => _xmlSchemaCollectionDatabase = value;
+            get => _xmlSchemaCollection?.Database ?? string.Empty;
+            set
+            {
+                EnsureXmlSchemaCollectionExists();
+                _xmlSchemaCollection.Database = value;
+            }
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/XmlSchemaCollectionOwningSchema/*' />
         [ResCategory("XML")]
         public string XmlSchemaCollectionOwningSchema
         {
-            get => _xmlSchemaCollectionOwningSchema ?? ADP.StrEmpty;
-            set => _xmlSchemaCollectionOwningSchema = value;
+            get => _xmlSchemaCollection?.OwningSchema ?? string.Empty;
+            set
+            {
+                EnsureXmlSchemaCollectionExists();
+                _xmlSchemaCollection.OwningSchema = value;
+            }
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/XmlSchemaCollectionName/*' />
         [ResCategory("XML")]
         public string XmlSchemaCollectionName
         {
-            get => _xmlSchemaCollectionName ?? ADP.StrEmpty;
-            set => _xmlSchemaCollectionName = value;
+            get => _xmlSchemaCollection?.Name ?? string.Empty;
+            set
+            {
+                EnsureXmlSchemaCollectionExists();
+                _xmlSchemaCollection.Name = value;
+            }
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ForceColumnEncryption/*' />
@@ -968,9 +982,11 @@ namespace Microsoft.Data.SqlClient
 
             destination._metaType = _metaType;
             destination._collation = _collation;
-            destination._xmlSchemaCollectionDatabase = _xmlSchemaCollectionDatabase;
-            destination._xmlSchemaCollectionOwningSchema = _xmlSchemaCollectionOwningSchema;
-            destination._xmlSchemaCollectionName = _xmlSchemaCollectionName;
+            if (_xmlSchemaCollection != null)
+            {
+                destination.EnsureXmlSchemaCollectionExists();
+                destination._xmlSchemaCollection.CopyFrom(_xmlSchemaCollection);
+            }
             destination._udtTypeName = _udtTypeName;
             destination._typeName = _typeName;
             destination._udtLoadError = _udtLoadError;
@@ -1008,6 +1024,14 @@ namespace Microsoft.Data.SqlClient
                 _parent = value;
             }
             return parent;
+        }
+
+        private void EnsureXmlSchemaCollectionExists()
+        {
+            if (_xmlSchemaCollection is null)
+            {
+                _xmlSchemaCollection = new SqlMetaDataXmlSchemaCollection();
+            }
         }
 
         internal void FixStreamDataForNonPLP()

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -450,7 +450,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ParameterName/*' />
         public override string ParameterName
         {
-            get => _parameterName ?? ADP.StrEmpty;
+            get => _parameterName ?? string.Empty;
             set
             {
                 if (
@@ -655,7 +655,7 @@ namespace Microsoft.Data.SqlClient
         ]
         public string UdtTypeName
         {
-            get => _udtTypeName ?? ADP.StrEmpty;
+            get => _udtTypeName ?? string.Empty;
             set => _udtTypeName = value;
         }
 
@@ -666,7 +666,7 @@ namespace Microsoft.Data.SqlClient
         ]
         public string TypeName
         {
-            get => _typeName ?? ADP.StrEmpty;
+            get => _typeName ?? string.Empty;
             set
             {
                 _typeName = value;
@@ -807,7 +807,7 @@ namespace Microsoft.Data.SqlClient
         [ResCategory("Update")]
         public override string SourceColumn
         {
-            get => _sourceColumn ?? ADP.StrEmpty;
+            get => _sourceColumn ?? string.Empty;
             set => _sourceColumn = value;
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -227,6 +227,7 @@ namespace Microsoft.Data.SqlClient
         {
             _isNull = true;
             _actualSize = -1;
+            _direction = ParameterDirection.Input;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ctorParameterNameDbType/*' />
@@ -276,16 +277,12 @@ namespace Microsoft.Data.SqlClient
             DataRowVersion sourceVersion,
             object value
         ) 
-            : this()
+            : this(parameterName, dbType, size, sourceColumn)
         {
-            ParameterName = parameterName;
-            SqlDbType = dbType;
-            Size = size;
             Direction = direction;
             IsNullable = isNullable;
             PrecisionInternal = precision;
             ScaleInternal = scale;
-            SourceColumn = sourceColumn;
             SourceVersion = sourceVersion;
             Value = value;
         }
@@ -712,11 +709,7 @@ namespace Microsoft.Data.SqlClient
         ]
         public override ParameterDirection Direction
         {
-            get
-            {
-                ParameterDirection direction = _direction;
-                return (direction != 0) ? direction : ParameterDirection.Input;
-            }
+            get => _direction;
             set
             {
                 if (_direction != value)

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
@@ -1612,6 +1612,70 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal("  a  ", p1.XmlSchemaCollectionOwningSchema);
         }
 
+        [Fact]
+        public void CreateParameterWithValidXmlSchema()
+        {
+            string xmlDatabase = "database";
+            string xmlSchema = "schema";
+            string xmlName = "name";
+
+            SqlParameter parameter = new SqlParameter("@name", SqlDbType.Int, 4, ParameterDirection.Input, 0, 0, "name", DataRowVersion.Original, false, 1, xmlDatabase, xmlSchema, xmlName);
+
+            Assert.Equal(xmlDatabase, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(xmlSchema, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(xmlName, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void CreateParameterWithEmptyXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter("@name", SqlDbType.Int, 4, ParameterDirection.Input, 0, 0, "name", DataRowVersion.Original, false, 1, string.Empty, string.Empty, string.Empty);
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void CreateParameterWithNullXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter("@name", SqlDbType.Int, 4, ParameterDirection.Input, 0, 0, "name", DataRowVersion.Original, false, 1, null, null, null);
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void CreateParameterWithoutXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter();
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionDatabase);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionOwningSchema);
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
+
+        [Fact]
+        public void SetParameterXmlSchema()
+        {
+            SqlParameter parameter = new SqlParameter();
+
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+
+            // verify that if we set it to null we still get an empty string back
+            parameter.XmlSchemaCollectionName = null;
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+
+            // verify that if we set a value we get it back
+            parameter.XmlSchemaCollectionName = "name";
+            Assert.Equal("name", parameter.XmlSchemaCollectionName);
+
+            // verify that if we set it explicitly to null it reverts to empty string
+            parameter.XmlSchemaCollectionName = null;
+            Assert.Equal(string.Empty, parameter.XmlSchemaCollectionName);
+        }
+
         private enum ByteEnum : byte
         {
             A = 0x0a,


### PR DESCRIPTION
In https://github.com/dotnet/corefx/pull/35549 I changed `SqlParameter` to use `SqlMetaDataXmlSchemaCollection` to hold xml schema information if it is present. This reduces the memory size because rather than keeping 3 string references which will mostly be null a single reference is kept for the sub object and it is created before use. This ports that change to netcore and netfx and adds the covering tests, it includes the fixes from dotnet/corefx#41008 which covered a problem in the original.

While working on `SqlParameter` i made a couple of other minor changes:

The direction field was not initialized but had a getter which checked for the 0 value and then returned ParameterDirection.Input. Recent profiling work on parameter passing showed that getting the parameter direction is an unexpectedly hot call. Because it is not possible for users to observe the 0 value it is safe to simply initialize the value in the ctors and then use a simple getter. The only observable change in this is if a user changes the value and is using INotifyPropertyChanged (usually designers use this) they will now not see a change from 0 to 1 if they assign to the Direction property, given that they could never observe the 0 value this seems like it is unlikely to break anyone.

The ctor call chain in netfx and netcore was slightly different so I synchronized them. This should have no practical effect but it will make merging the files later easier.

I removed some uses of `ADP.StrEmpty` and replaced them with `string.Empty`, these two expressions point to the same string instance because of runtime interning of constant strings. Using our own alias for it is no more secure than referring to it as `string.Empty` or `""`, as such just use the runtime supported constant and remove our copy from the library at some future date when all other references have been removed.