### PR TITLE
Fix version downgrade

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -18,7 +18,7 @@
   <!-- NetFx and NetCore project dependencies -->
   <PropertyGroup>
     <AzureIdentityVersion>1.3.0</AzureIdentityVersion>
-    <MicrosoftIdentityClientVersion>4.21.1</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityClientVersion>4.22.0</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.8.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
     <MicrosoftIdentityModelJsonWebTokensVersion>6.8.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -30,7 +30,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       <group targetFramework="net461">
         <dependency id="Microsoft.Data.SqlClient.SNI" version="3.0.0-preview1.21104.2" />
         <dependency id="Azure.Identity" version="1.3.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.21.1" />
+        <dependency id="Microsoft.Identity.Client" version="4.22.0" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
@@ -43,7 +43,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="4.7.0" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.3.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.21.1" exclude="Compile"/>
+        <dependency id="Microsoft.Identity.Client" version="4.22.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
@@ -56,7 +56,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="4.7.0" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.3.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.21.1" exclude="Compile"/>
+        <dependency id="Microsoft.Identity.Client" version="4.22.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
@@ -69,7 +69,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Text.Encoding.CodePages" version="4.7.0" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="4.7.0" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.3.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.21.1" exclude="Compile"/>
+        <dependency id="Microsoft.Identity.Client" version="4.22.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
@@ -82,7 +82,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Text.Encoding.CodePages" version="4.7.0" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="4.7.0" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.3.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.21.1" exclude="Compile"/>
+        <dependency id="Microsoft.Identity.Client" version="4.22.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>


### PR DESCRIPTION
Azure Identity references the newer version of the MSAL library which causes version downgrade issue.