### PR TITLE
Add SqlCommand.DisableOutputParameters Feature

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
@@ -286,8 +286,13 @@ The following console application creates updates data within the **AdventureWor
 			<exception cref="T:System.InvalidOperationException">
 				The
 				<see cref="T:Microsoft.Data.SqlClient.SqlConnection" />
-				closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
-			</exception>
+        closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
+
+        - or -
+
+        <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+      </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
 				<see cref="T:System.IO.Stream" />
@@ -399,8 +404,13 @@ To set up this example, create a new Windows application. Put a <xref:System.Win
 			<exception cref="T:System.InvalidOperationException">
 				The
 				<see cref="T:Microsoft.Data.SqlClient.SqlConnection" />
-				closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
-			</exception>
+        closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
+
+        - or -
+
+        <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+      </exception>
 		</BeginExecuteNonQuery>
 		<BeginExecuteReader name="default">
 			<summary>
@@ -477,8 +487,13 @@ The following console application starts the process of retrieving a data reader
 			<exception cref="T:System.InvalidOperationException">
 				The
 				<see cref="T:Microsoft.Data.SqlClient.SqlConnection" />
-				closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
-			</exception>
+        closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
+
+        - or -
+
+        <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+      </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
 				<see cref="T:System.IO.Stream" />
@@ -584,8 +599,13 @@ This example also passes the `CommandBehavior.CloseConnection` and `CommandBehav
 			<exception cref="T:System.InvalidOperationException">
 				The
 				<see cref="T:Microsoft.Data.SqlClient.SqlConnection" />
-				closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
-			</exception>
+        closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
+
+        - or -
+
+        <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+      </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
 				<see cref="T:System.IO.Stream" />
@@ -702,8 +722,13 @@ To set up this example, create a new Windows application. Put a <xref:System.Win
 			<exception cref="T:System.InvalidOperationException">
 				The
 				<see cref="T:Microsoft.Data.SqlClient.SqlConnection" />
-				closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
-			</exception>
+        closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
+
+        - or -
+
+        <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+      </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
 				<see cref="T:System.IO.Stream" />
@@ -831,8 +856,13 @@ This example passes the `CommandBehavior.CloseConnection` value in the `behavior
 			<exception cref="T:System.InvalidOperationException">
 				The
 				<see cref="T:Microsoft.Data.SqlClient.SqlConnection" />
-				closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
-			</exception>
+        closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
+
+        - or -
+
+        <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+      </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
 				<see cref="T:System.IO.Stream" />
@@ -940,6 +970,11 @@ The following console application starts the process of retrieving XML data asyn
 				The
 				<see cref="T:Microsoft.Data.SqlClient.SqlConnection" />
 				closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
+        
+        - or -
+
+        <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
 			</exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
@@ -1067,8 +1102,13 @@ To set up this example, create a new Windows application. Put a <xref:System.Win
 			<exception cref="T:System.InvalidOperationException">
 				The
 				<see cref="T:Microsoft.Data.SqlClient.SqlConnection" />
-				closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
-			</exception>
+        closed or dropped during a streaming operation. For more information about streaming, see [SqlClient Streaming Support](/sql/connect/ado-net/sqlclient-streaming-support).
+
+        - or -
+
+        <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+      </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
 				<see cref="T:System.IO.Stream" />

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
@@ -291,7 +291,7 @@ The following console application creates updates data within the **AdventureWor
         - or -
 
         <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
-        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" /> collection.
       </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
@@ -409,7 +409,7 @@ To set up this example, create a new Windows application. Put a <xref:System.Win
         - or -
 
         <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
-        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" /> collection.
       </exception>
 		</BeginExecuteNonQuery>
 		<BeginExecuteReader name="default">
@@ -492,7 +492,7 @@ The following console application starts the process of retrieving a data reader
         - or -
 
         <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
-        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" /> collection.
       </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
@@ -604,7 +604,7 @@ This example also passes the `CommandBehavior.CloseConnection` and `CommandBehav
         - or -
 
         <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
-        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" /> collection.
       </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
@@ -727,7 +727,7 @@ To set up this example, create a new Windows application. Put a <xref:System.Win
         - or -
 
         <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
-        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" /> collection.
       </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
@@ -861,7 +861,7 @@ This example passes the `CommandBehavior.CloseConnection` value in the `behavior
         - or -
 
         <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
-        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" /> collection.
       </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
@@ -974,7 +974,7 @@ The following console application starts the process of retrieving XML data asyn
         - or -
 
         <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
-        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" /> collection.
 			</exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a
@@ -1107,7 +1107,7 @@ To set up this example, create a new Windows application. Put a <xref:System.Win
         - or -
 
         <see cref="P:Microssoft.Data.SqlClient.SqlCommand.EnableOptimizedParameterBinding" />
-        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" />Parameters collection.
+        is set to true and a parameter with direction Output or InputOutput has been added to the <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Parameters" /> collection.
       </exception>
 			<exception cref="T:System.IO.IOException">
 				An error occurred in a

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
@@ -1343,6 +1343,33 @@ The <xref:Microsoft.Data.SqlClient.SqlCommand.CreateParameter%2A> method is a st
 				To be added.
 			</remarks>
 		</Dispose>
+    <EnableOptimizedParameterBinding>
+      <summary>
+        Gets or sets a value indicating whether the command object should optimize parameter performance by disabling Output and InputOutput directions when submitting the command to the SQL Server.
+      </summary>
+      <value>
+        A value indicating whether the command object should optimize parameter performance by disabling Output and InputOuput parameter directions when submitting the command to the SQL Server. 
+        The default is <see langword="false" />.
+      </value>
+      <remarks>
+        <format type="text/markdown">
+          <![CDATA[
+## Remarks
+You must set the value for this property before the command is executed for it to take effect.
+
+When a command is submitted to the server with parameters a list of the parameter names is sent as part of the submission. The list is used on the server to match Output and InputOutput parameters to the results of the query execution so that the values can be returned to the caller. This option disables the construction and submission of the parameter name list and as a consequence disables the use of Output and InputOutput parameters. The return parameter is not affected by this option.
+
+A command sent with this option changes the way parameters are handled on the server, because there is no need to maintain an output parameter map. The result of this change is that queries with large numbers of input parameters may execute much faster. 
+
+The fewest number of parameters where this will take effect depends on the individual situation and should be detected by measuring query duration with and without the option enabled. Any query with more than 24 parameters may show lower overall query duration. Queries with parameter counts lower than 24 are unlikely to show a difference.
+
+> [!NOTE]
+If the option is enabled and a parameter with Direction Output or InputOutput is present in the Parameters collection an InvalidOperationException will be thrown when the command is executed.
+
+]]>
+</format>
+      </remarks>
+    </EnableOptimizedParameterBinding>
 		<EndExecuteNonQuery name="IAsyncResult">
 			<param name="asyncResult">
 				The

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -535,8 +535,8 @@ namespace Microsoft.Data.SqlClient
         [System.ComponentModel.DesignOnlyAttribute(true)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool DesignTimeVisible { get { throw null; } set { } }
-        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
-        public bool DisableOutputParameters { get { throw null; } set { } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/EnableOptimizedParameterBinding/*'/>
+        public bool EnableOptimizedParameterBinding { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Parameters/*'/>
         public new Microsoft.Data.SqlClient.SqlParameterCollection Parameters { get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Transaction/*'/>

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -535,6 +535,8 @@ namespace Microsoft.Data.SqlClient
         [System.ComponentModel.DesignOnlyAttribute(true)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool DesignTimeVisible { get { throw null; } set { } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
+        public bool DisableOutputParameters { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Parameters/*'/>
         public new Microsoft.Data.SqlClient.SqlParameterCollection Parameters { get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Transaction/*'/>
@@ -544,8 +546,6 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UpdatedRowSource/*'/>
         [System.ComponentModel.DefaultValueAttribute(3)]
         public override System.Data.UpdateRowSource UpdatedRowSource { get { throw null; } set { } }
-        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
-        public bool UsePositionalParameters { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/StatementCompleted/*'/>
         public event System.Data.StatementCompletedEventHandler StatementCompleted { add { } remove { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteNonQuery[@name="default"]/*'/>

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -544,6 +544,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UpdatedRowSource/*'/>
         [System.ComponentModel.DefaultValueAttribute(3)]
         public override System.Data.UpdateRowSource UpdatedRowSource { get { throw null; } set { } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
+        public bool UsePositionalParameters { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/StatementCompleted/*'/>
         public event System.Data.StatementCompletedEventHandler StatementCompleted { add { } remove { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteNonQuery[@name="default"]/*'/>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -692,8 +692,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/DisableOutputParameters/*'/>
-        public bool DisableOutputParameters { get; set; }
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/EnableOptimizedParameterBinding/*'/>
+        public bool EnableOptimizedParameterBinding { get; set; }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Parameters/*'/>
         new public SqlParameterCollection Parameters

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -692,6 +692,9 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/DisableOutputParameters/*'/>
+        public bool DisableOutputParameters { get; set; }
+
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Parameters/*'/>
         new public SqlParameterCollection Parameters
         {
@@ -739,9 +742,6 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.TryTraceEvent("SqlCommand.UpdatedRowSource | API | ObjectId {0}, Updated row source value {1}, Client Connection Id {2}", ObjectID, (int)value, Connection?.ClientConnectionId);
             }
         }
-
-        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
-        public bool UsePositionalParameters { get; set; }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/StatementCompleted/*'/>
         public event StatementCompletedEventHandler StatementCompleted

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -740,6 +740,9 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
+        public bool UsePositionalParameters { get; set; }
+
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/StatementCompleted/*'/>
         public event StatementCompletedEventHandler StatementCompleted
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -495,6 +495,11 @@ namespace Microsoft.Data.SqlClient
             return ADP.ArgumentNull(System.StringsHelper.GetString(Strings.SQL_ParameterCannotBeEmpty, paramName));
         }
 
+        internal static Exception ParameterDirectionInvalidForOptimizedBinding(string paramName)
+        {
+            return ADP.InvalidOperation(System.StringsHelper.GetString(Strings.SQL_ParameterDirectionInvalidForOptimizedBinding, paramName));
+        }
+
         internal static Exception ActiveDirectoryInteractiveTimeout()
         {
             return ADP.TimeoutException(Strings.SQL_Timeout_Active_Directory_Interactive_Authentication);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -9021,7 +9021,7 @@ namespace Microsoft.Data.SqlClient
 
                             if (mt.IsNewKatmaiType)
                             {
-                                WriteSmiParameter(param, i, 0 != (options & TdsEnums.RPC_PARAM_DEFAULT), stateObj, cmd.UsePositionalParameters, isAdvancedTraceOn);
+                                WriteSmiParameter(param, i, 0 != (options & TdsEnums.RPC_PARAM_DEFAULT), stateObj, cmd.DisableOutputParameters, isAdvancedTraceOn);
                                 continue;
                             }
 
@@ -9031,7 +9031,7 @@ namespace Microsoft.Data.SqlClient
                                 throw ADP.VersionDoesNotSupportDataType(mt.TypeName);
                             }
 
-                            Task writeParamTask = TDSExecuteRPCAddParameter(stateObj, param, mt, options, cmd.UsePositionalParameters);
+                            Task writeParamTask = TDSExecuteRPCAddParameter(stateObj, param, mt, options, cmd.DisableOutputParameters);
 
                             if (!sync)
                             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -9041,7 +9041,7 @@ namespace Microsoft.Data.SqlClient
                                 throw ADP.VersionDoesNotSupportDataType(mt.TypeName);
                             }
 
-                            Task writeParamTask = TDSExecuteRPCAddParameter(stateObj, param, mt, options, enableOptimizedParameterBinding);
+                            Task writeParamTask = TDSExecuteRPCAddParameter(stateObj, param, mt, options, cmd, enableOptimizedParameterBinding);
 
                             if (!sync)
                             {
@@ -9158,7 +9158,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private Task TDSExecuteRPCAddParameter(TdsParserStateObject stateObj, SqlParameter param, MetaType mt, byte options, bool isAnonymous)
+        private Task TDSExecuteRPCAddParameter(TdsParserStateObject stateObj, SqlParameter param, MetaType mt, byte options, SqlCommand command, bool isAnonymous)
         {
             int tempLen;
             object value = null;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.Designer.cs
@@ -2932,6 +2932,15 @@ namespace System {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Parameter &apos;{0}&apos; cannot have Direction Output or InputOutput when EnableOptimizedParameterBinding is enabled on the parent command..
+        /// </summary>
+        internal static string SQL_ParameterDirectionInvalidForOptimizedBinding {
+            get {
+                return ResourceManager.GetString("SQL_ParameterDirectionInvalidForOptimizedBinding", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Parameter &apos;{0}&apos; exceeds the size limit for the sql_variant datatype..
         /// </summary>
         internal static string SQL_ParameterInvalidVariant {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.resx
@@ -1932,4 +1932,7 @@
   <data name="SqlRetryLogic_InvalidMinMaxPair" xml:space="preserve">
     <value>'{0}' is not less than '{1}'; '{2}' cannot be greater than '{3}'.</value>
   </data>
+  <data name="SQL_ParameterDirectionInvalidForOptimizedBinding" xml:space="preserve">
+    <value>Parameter '{0}' cannot have Direction Output or InputOutput when EnableOptimizedParameterBinding is enabled on the parent command.</value>
+  </data>
 </root>

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -556,6 +556,8 @@ namespace Microsoft.Data.SqlClient
         [System.ComponentModel.DesignOnlyAttribute(true)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool DesignTimeVisible { get { throw null; } set { } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
+        public bool DisableOutputParameters { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Parameters/*'/>
         public new Microsoft.Data.SqlClient.SqlParameterCollection Parameters { get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Transaction/*'/>
@@ -565,8 +567,6 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UpdatedRowSource/*'/>
         [System.ComponentModel.DefaultValueAttribute(3)]
         public override System.Data.UpdateRowSource UpdatedRowSource { get { throw null; } set { } }
-        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
-        public bool UsePositionalParameters { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/StatementCompleted/*'/>
         public event System.Data.StatementCompletedEventHandler StatementCompleted { add { } remove { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteNonQuery[@name="default"]/*'/>

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -556,8 +556,8 @@ namespace Microsoft.Data.SqlClient
         [System.ComponentModel.DesignOnlyAttribute(true)]
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         public override bool DesignTimeVisible { get { throw null; } set { } }
-        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
-        public bool DisableOutputParameters { get { throw null; } set { } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/EnableOptimizedParameterBinding/*'/>
+        public bool EnableOptimizedParameterBinding { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Parameters/*'/>
         public new Microsoft.Data.SqlClient.SqlParameterCollection Parameters { get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Transaction/*'/>

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -565,6 +565,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UpdatedRowSource/*'/>
         [System.ComponentModel.DefaultValueAttribute(3)]
         public override System.Data.UpdateRowSource UpdatedRowSource { get { throw null; } set { } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
+        public bool UsePositionalParameters { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/StatementCompleted/*'/>
         public event System.Data.StatementCompletedEventHandler StatementCompleted { add { } remove { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteNonQuery[@name="default"]/*'/>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -954,6 +954,9 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
+        public bool UsePositionalParameters { get; set; }
+
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/StatementCompleted/*'/>
         [
         ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_StatementCompleted),

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -880,6 +880,9 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/DisableOutputParameters/*'/>
+        public bool DisableOutputParameters { get; set; }
+
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Parameters/*'/>
         [
         DesignerSerializationVisibility(DesignerSerializationVisibility.Content),
@@ -953,9 +956,6 @@ namespace Microsoft.Data.SqlClient
                 }
             }
         }
-
-        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UsePositionalParameters/*'/>
-        public bool UsePositionalParameters { get; set; }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/StatementCompleted/*'/>
         [

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -880,8 +880,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/DisableOutputParameters/*'/>
-        public bool DisableOutputParameters { get; set; }
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/EnableOptimizedParameterBinding/*'/>
+        public bool EnableOptimizedParameterBinding { get; set; }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Parameters/*'/>
         [

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -636,6 +636,11 @@ namespace Microsoft.Data.SqlClient
             return ADP.ArgumentNull(StringsHelper.GetString(Strings.SQL_ParameterCannotBeEmpty, paramName));
         }
 
+        internal static Exception ParameterDirectionInvalidForOptimizedBinding(string paramName)
+        {
+            return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ParameterDirectionInvalidForOptimizedBinding, paramName));
+        }
+
         static internal Exception ActiveDirectoryInteractiveTimeout()
         {
             return ADP.TimeoutException(Strings.SQL_Timeout_Active_Directory_Interactive_Authentication);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -9914,7 +9914,7 @@ namespace Microsoft.Data.SqlClient
 
                             if (mt.IsNewKatmaiType)
                             {
-                                WriteSmiParameter(param, i, 0 != (rpcext.paramoptions[i] & TdsEnums.RPC_PARAM_DEFAULT), stateObj, isAdvancedTraceOn);
+                                WriteSmiParameter(param, i, 0 != (rpcext.paramoptions[i] & TdsEnums.RPC_PARAM_DEFAULT), stateObj, cmd.UsePositionalParameters, isAdvancedTraceOn);
                                 continue;
                             }
 
@@ -9946,7 +9946,7 @@ namespace Microsoft.Data.SqlClient
                                 }
                             }
 
-                            WriteParameterName(param.ParameterNameFixed, stateObj);
+                            WriteParameterName(param.ParameterNameFixed, stateObj, cmd.UsePositionalParameters);
 
                             // Write parameter status
                             stateObj.WriteByte(rpcext.paramoptions[i]);
@@ -10628,11 +10628,11 @@ namespace Microsoft.Data.SqlClient
         }
 
 
-        private void WriteParameterName(string parameterName, TdsParserStateObject stateObj)
+        private void WriteParameterName(string parameterName, TdsParserStateObject stateObj, bool isAnonymous)
         {
             // paramLen
             // paramName
-            if (!ADP.IsEmpty(parameterName))
+            if (!isAnonymous && !string.IsNullOrEmpty(parameterName))
             {
                 Debug.Assert(parameterName.Length <= 0xff, "parameter name can only be 255 bytes, shouldn't get to TdsParser!");
                 int tempLen = parameterName.Length & 0xff;
@@ -10646,7 +10646,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         private static readonly IEnumerable<SqlDataRecord> __tvpEmptyValue = new List<SqlDataRecord>().AsReadOnly();
-        private void WriteSmiParameter(SqlParameter param, int paramIndex, bool sendDefault, TdsParserStateObject stateObj, bool advancedTraceIsOn)
+        private void WriteSmiParameter(SqlParameter param, int paramIndex, bool sendDefault, TdsParserStateObject stateObj, bool isAnonymous, bool advancedTraceIsOn)
         {
             //
             // Determine Metadata
@@ -10706,7 +10706,7 @@ namespace Microsoft.Data.SqlClient
             //
             // Write parameter metadata
             //
-            WriteSmiParameterMetaData(metaData, sendDefault, stateObj);
+            WriteSmiParameterMetaData(metaData, sendDefault, isAnonymous, stateObj);
 
             //
             // Now write the value
@@ -10725,7 +10725,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Writes metadata portion of parameter stream from an SmiParameterMetaData object.
-        private void WriteSmiParameterMetaData(SmiParameterMetaData metaData, bool sendDefault, TdsParserStateObject stateObj)
+        private void WriteSmiParameterMetaData(SmiParameterMetaData metaData, bool sendDefault, bool isAnonymous, TdsParserStateObject stateObj)
         {
             // Determine status
             byte status = 0;
@@ -10740,7 +10740,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             // Write everything out
-            WriteParameterName(metaData.Name, stateObj);
+            WriteParameterName(metaData.Name, stateObj, isAnonymous);
             stateObj.WriteByte(status);
             WriteSmiTypeInfo(metaData, stateObj);
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -9914,7 +9914,7 @@ namespace Microsoft.Data.SqlClient
 
                             if (mt.IsNewKatmaiType)
                             {
-                                WriteSmiParameter(param, i, 0 != (rpcext.paramoptions[i] & TdsEnums.RPC_PARAM_DEFAULT), stateObj, cmd.DisableOutputParameters, isAdvancedTraceOn);
+                                WriteSmiParameter(param, i, 0 != (rpcext.paramoptions[i] & TdsEnums.RPC_PARAM_DEFAULT), stateObj, cmd.EnableOptimizedParameterBinding, isAdvancedTraceOn);
                                 continue;
                             }
 
@@ -9946,7 +9946,7 @@ namespace Microsoft.Data.SqlClient
                                 }
                             }
 
-                            WriteParameterName(param.ParameterNameFixed, stateObj, cmd.DisableOutputParameters);
+                            WriteParameterName(param.ParameterNameFixed, stateObj, cmd.EnableOptimizedParameterBinding);
 
                             // Write parameter status
                             stateObj.WriteByte(rpcext.paramoptions[i]);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -9914,7 +9914,7 @@ namespace Microsoft.Data.SqlClient
 
                             if (mt.IsNewKatmaiType)
                             {
-                                WriteSmiParameter(param, i, 0 != (rpcext.paramoptions[i] & TdsEnums.RPC_PARAM_DEFAULT), stateObj, cmd.UsePositionalParameters, isAdvancedTraceOn);
+                                WriteSmiParameter(param, i, 0 != (rpcext.paramoptions[i] & TdsEnums.RPC_PARAM_DEFAULT), stateObj, cmd.DisableOutputParameters, isAdvancedTraceOn);
                                 continue;
                             }
 
@@ -9946,7 +9946,7 @@ namespace Microsoft.Data.SqlClient
                                 }
                             }
 
-                            WriteParameterName(param.ParameterNameFixed, stateObj, cmd.UsePositionalParameters);
+                            WriteParameterName(param.ParameterNameFixed, stateObj, cmd.DisableOutputParameters);
 
                             // Write parameter status
                             stateObj.WriteByte(rpcext.paramoptions[i]);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
@@ -9127,6 +9127,15 @@ namespace System {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot create normalizer for &apos;{0}&apos;..
+        /// </summary>
+        internal static string SQL_CannotCreateNormalizer {
+            get {
+                return ResourceManager.GetString("SQL_CannotCreateNormalizer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot find an authentication provider for &apos;{0}&apos;..
         /// </summary>
         internal static string SQL_CannotFindAuthProvider {
@@ -9168,15 +9177,6 @@ namespace System {
         internal static string SQL_CannotModifyPropertyAsyncOperationInProgress {
             get {
                 return ResourceManager.GetString("SQL_CannotModifyPropertyAsyncOperationInProgress", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Cannot create normalizer for &apos;{0}&apos;..
-        /// </summary>
-        internal static string Sql_CanotCreateNormalizer {
-            get {
-                return ResourceManager.GetString("Sql_CanotCreateNormalizer", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
@@ -1825,15 +1825,6 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The validation of an attestation token failed. The token signature does not match the signature omputed using a public key retrieved from the attestation public key endpoint at &apos;{0}&apos;. Verify the DNS apping for the endpoint - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If correct, contact Customer Support Services..
-        /// </summary>
-        internal static string AttestationTokenSignatureValidationFailed {
-            get {
-                return ResourceManager.GetString("AttestationTokenSignatureValidationFailed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Destination array is not long enough to copy all the items in the collection. Check array index and length..
         /// </summary>
         internal static string Arg_ArrayPlusOffTooSmall {
@@ -1866,6 +1857,15 @@ namespace System {
         internal static string ArgumentOutOfRange_NeedNonNegNum {
             get {
                 return ResourceManager.GetString("ArgumentOutOfRange_NeedNonNegNum", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The validation of an attestation token failed. The token signature does not match the signature omputed using a public key retrieved from the attestation public key endpoint at &apos;{0}&apos;. Verify the DNS apping for the endpoint - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If correct, contact Customer Support Services..
+        /// </summary>
+        internal static string AttestationTokenSignatureValidationFailed {
+            get {
+                return ResourceManager.GetString("AttestationTokenSignatureValidationFailed", resourceCulture);
             }
         }
         
@@ -9127,15 +9127,6 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot create normalizer for &apos;{0}&apos;..
-        /// </summary>
-        internal static string SQL_CannotCreateNormalizer {
-            get {
-                return ResourceManager.GetString("SQL_CannotCreateNormalizer", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cannot find an authentication provider for &apos;{0}&apos;..
         /// </summary>
         internal static string SQL_CannotFindAuthProvider {
@@ -9177,6 +9168,15 @@ namespace System {
         internal static string SQL_CannotModifyPropertyAsyncOperationInProgress {
             get {
                 return ResourceManager.GetString("SQL_CannotModifyPropertyAsyncOperationInProgress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot create normalizer for &apos;{0}&apos;..
+        /// </summary>
+        internal static string Sql_CanotCreateNormalizer {
+            get {
+                return ResourceManager.GetString("Sql_CanotCreateNormalizer", resourceCulture);
             }
         }
         
@@ -9640,15 +9640,6 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot use &apos;Authentication={0}&apos; with &apos;Password&apos; or &apos;PWD&apos; connection string keywords..
-        /// </summary>
-        internal static string SQL_NonInteractiveWithPassword {
-            get {
-                return ResourceManager.GetString("SQL_NonInteractiveWithPassword", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The connection does not support MultipleActiveResultSets..
         /// </summary>
         internal static string SQL_MarsUnsupportedOnConnection {
@@ -9717,6 +9708,15 @@ namespace System {
         internal static string SQL_NonCharColumn {
             get {
                 return ResourceManager.GetString("SQL_NonCharColumn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot use &apos;Authentication={0}&apos; with &apos;Password&apos; or &apos;PWD&apos; connection string keywords..
+        /// </summary>
+        internal static string SQL_NonInteractiveWithPassword {
+            get {
+                return ResourceManager.GetString("SQL_NonInteractiveWithPassword", resourceCulture);
             }
         }
         
@@ -9816,6 +9816,15 @@ namespace System {
         internal static string SQL_ParameterCannotBeEmpty {
             get {
                 return ResourceManager.GetString("SQL_ParameterCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter &apos;{0}&apos; cannot have Direction Output or InputOutput when EnableOptimizedParameterBinding is enabled on the parent command..
+        /// </summary>
+        internal static string SQL_ParameterDirectionInvalidForOptimizedBinding {
+            get {
+                return ResourceManager.GetString("SQL_ParameterDirectionInvalidForOptimizedBinding", resourceCulture);
             }
         }
         
@@ -12077,12 +12086,6 @@ namespace System {
                 return ResourceManager.GetString("TCE_DbConnectionString_AttestationProtocol", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Specifies an IP address preference when connecting to SQL instances.
-        /// </summary>
-        internal static string TCE_DbConnectionString_IPAddressPreference
-            => ResourceManager.GetString("TCE_DbConnectionString_IPAddressPreference", resourceCulture);
         
         /// <summary>
         ///   Looks up a localized string similar to Default column encryption setting for all the commands on the connection..
@@ -12099,6 +12102,15 @@ namespace System {
         internal static string TCE_DbConnectionString_EnclaveAttestationUrl {
             get {
                 return ResourceManager.GetString("TCE_DbConnectionString_EnclaveAttestationUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specifies an IP address preference when connecting to SQL instances..
+        /// </summary>
+        internal static string TCE_DbConnectionString_IPAddressPreference {
+            get {
+                return ResourceManager.GetString("TCE_DbConnectionString_IPAddressPreference", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>Subclass did not override a required method.</value>
   </data>
-  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
+  <data name="SQL_CannotCreateNormalizer" xml:space="preserve">
     <value>Cannot create normalizer for '{0}'.</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
@@ -4614,4 +4614,7 @@
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non-negative number required.</value>
   </data>
+  <data name="SQL_ParameterDirectionInvalidForOptimizedBinding" xml:space="preserve">
+    <value>Parameter '{0}' cannot have Direction Output or InputOutput when EnableOptimizedParameterBinding is enabled on the parent command.</value>
+  </data>
 </root>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         private static void EnableOptimizedParameterBinding_ParametersAreUsedByName()
         {
             int firstInput = 1;
@@ -562,7 +562,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         private static void EnableOptimizedParameterBinding_NamesMustMatch()
         {
             using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
@@ -592,7 +592,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         private static void EnableOptimizedParameterBinding_AllNamesMustBeDeclared()
         {
             using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
@@ -621,7 +621,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         private static void EnableOptimizedParameterBinding_NamesCanBeReUsed()
         {
             int firstInput = 1;
@@ -655,7 +655,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         private static void EnableOptimizedParameterBinding_InputOutputFails()
         {
             int firstInput = 1;
@@ -681,7 +681,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         private static void EnableOptimizedParameterBinding_OutputFails()
         {
             int firstInput = 1;
@@ -707,7 +707,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         private static void EnableOptimizedParameterBinding_ReturnSucceeds()
         {
             int firstInput = 12;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -557,7 +557,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         Assert.Equal(firstInput, secondOutput);
                         Assert.Equal(secondInput, firstOutput);
                     }
-
                 }
             }
         }
@@ -587,7 +586,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     Assert.NotNull(sqlException);
                     Assert.Contains("Must declare the scalar variable",sqlException.Message);
                     Assert.Contains("@DoesNotExist", sqlException.Message);
-
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -533,7 +533,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void DisableOutputParameters_ParametersAreUsedByName()
+        private static void EnableOptimizedParameterBinding_ParametersAreUsedByName()
         {
             int firstInput = 1;
             int secondInput = 2;
@@ -543,7 +543,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @Second, @First", connection))
                 {
-                    command.DisableOutputParameters = true;
+                    command.EnableOptimizedParameterBinding = true;
                     command.Parameters.AddWithValue("@First", firstInput);
                     command.Parameters.AddWithValue("@Second", secondInput);
 
@@ -563,7 +563,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void DisableOutputParameters_NamesMustMatch()
+        private static void EnableOptimizedParameterBinding_NamesMustMatch()
         {
             using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
@@ -571,7 +571,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @DoesNotExist", connection))
                 {
-                    command.DisableOutputParameters = true;
+                    command.EnableOptimizedParameterBinding = true;
                     command.Parameters.AddWithValue("@Exists", 1);
 
                     SqlException sqlException = null;
@@ -593,7 +593,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void DisableOutputParameters_AllNamesMustBeDeclared()
+        private static void EnableOptimizedParameterBinding_AllNamesMustBeDeclared()
         {
             using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
@@ -601,7 +601,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @Exists, @DoesNotExist", connection))
                 {
-                    command.DisableOutputParameters = true;
+                    command.EnableOptimizedParameterBinding = true;
                     command.Parameters.AddWithValue("@Exists", 1);
 
                     SqlException sqlException = null;
@@ -622,7 +622,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void DisableOutputParameters_NamesCanBeReUsed()
+        private static void EnableOptimizedParameterBinding_NamesCanBeReUsed()
         {
             int firstInput = 1;
             int secondInput = 2;
@@ -634,7 +634,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @First, @Second, @First", connection))
                 {
-                    command.DisableOutputParameters = true;
+                    command.EnableOptimizedParameterBinding = true;
                     command.Parameters.AddWithValue("@First", firstInput);
                     command.Parameters.AddWithValue("@Second", secondInput);
                     command.Parameters.AddWithValue("@Third", thirdInput);
@@ -656,7 +656,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void DisableOutputParameters_InputOutputFails()
+        private static void EnableOptimizedParameterBinding_InputOutputFails()
         {
             int firstInput = 1;
             int secondInput = 2;
@@ -668,21 +668,21 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @Third = (@Third + @First + @Second)", connection))
                 {
-                    command.DisableOutputParameters = true;
+                    command.EnableOptimizedParameterBinding = true;
                     command.Parameters.AddWithValue("@First", firstInput);
                     command.Parameters.AddWithValue("@Second", secondInput);
                     SqlParameter thirdParameter = command.Parameters.AddWithValue("@Third", thirdInput);
                     thirdParameter.Direction = ParameterDirection.InputOutput;
 
-                    command.ExecuteNonQuery();
+                    InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => command.ExecuteNonQuery());
 
-                    Assert.Equal(thirdInput, Convert.ToInt32(thirdParameter.Value));
+                    Assert.Contains("OptimizedParameterBinding", exception.Message);
                 }
             }
         }
 
         [Fact]
-        private static void DisableOutputParameters_OutputFails()
+        private static void EnableOptimizedParameterBinding_OutputFails()
         {
             int firstInput = 1;
             int secondInput = 2;
@@ -694,21 +694,21 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @Third = (@Third + @First + @Second)", connection))
                 {
-                    command.DisableOutputParameters = true;
+                    command.EnableOptimizedParameterBinding = true;
                     command.Parameters.AddWithValue("@First", firstInput);
                     command.Parameters.AddWithValue("@Second", secondInput);
                     SqlParameter thirdParameter = command.Parameters.AddWithValue("@Third", thirdInput);
                     thirdParameter.Direction = ParameterDirection.Output;
 
-                    command.ExecuteNonQuery();
+                    InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => command.ExecuteNonQuery());
 
-                    Assert.Equal(0, Convert.ToInt32(thirdParameter.Value));
+                    Assert.Contains("OptimizedParameterBinding", exception.Message);
                 }
             }
         }
 
         [Fact]
-        private static void DisableOutputParameters_ReturnSucceeds()
+        private static void EnableOptimizedParameterBinding_ReturnSucceeds()
         {
             int firstInput = 12;
 
@@ -731,7 +731,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                     using (var command = new SqlCommand(sprocName, connection) { CommandType = CommandType.StoredProcedure })
                     {
-                        command.DisableOutputParameters = true;
+                        command.EnableOptimizedParameterBinding = true;
                         command.Parameters.AddWithValue("@in", firstInput);
                         SqlParameter returnParameter = command.Parameters.AddWithValue("@retval", 0);
                         returnParameter.Direction = ParameterDirection.ReturnValue;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -533,7 +533,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void PositionalParameters_ParametersAreUsedByPosition()
+        private static void DisableOutputParameters_ParametersAreUsedByName()
         {
             int firstInput = 1;
             int secondInput = 2;
@@ -543,7 +543,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @Second, @First", connection))
                 {
-                    command.UsePositionalParameters = true;
+                    command.DisableOutputParameters = true;
                     command.Parameters.AddWithValue("@First", firstInput);
                     command.Parameters.AddWithValue("@Second", secondInput);
 
@@ -563,7 +563,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void PositionalParameters_NamesMustMatch()
+        private static void DisableOutputParameters_NamesMustMatch()
         {
             using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
@@ -571,7 +571,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @DoesNotExist", connection))
                 {
-                    command.UsePositionalParameters = true;
+                    command.DisableOutputParameters = true;
                     command.Parameters.AddWithValue("@Exists", 1);
 
                     SqlException sqlException = null;
@@ -593,7 +593,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void PositionalParameters_AllNamesMustBeDeclared()
+        private static void DisableOutputParameters_AllNamesMustBeDeclared()
         {
             using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
@@ -601,7 +601,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @Exists, @DoesNotExist", connection))
                 {
-                    command.UsePositionalParameters = true;
+                    command.DisableOutputParameters = true;
                     command.Parameters.AddWithValue("@Exists", 1);
 
                     SqlException sqlException = null;
@@ -622,7 +622,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void PositionalParameters_NamesCanBeReUsed()
+        private static void DisableOutputParameters_NamesCanBeReUsed()
         {
             int firstInput = 1;
             int secondInput = 2;
@@ -634,7 +634,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @First, @Second, @First", connection))
                 {
-                    command.UsePositionalParameters = true;
+                    command.DisableOutputParameters = true;
                     command.Parameters.AddWithValue("@First", firstInput);
                     command.Parameters.AddWithValue("@Second", secondInput);
                     command.Parameters.AddWithValue("@Third", thirdInput);
@@ -656,7 +656,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void PositionalParameters_InputOutputFails()
+        private static void DisableOutputParameters_InputOutputFails()
         {
             int firstInput = 1;
             int secondInput = 2;
@@ -668,7 +668,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @Third = (@Third + @First + @Second)", connection))
                 {
-                    command.UsePositionalParameters = true;
+                    command.DisableOutputParameters = true;
                     command.Parameters.AddWithValue("@First", firstInput);
                     command.Parameters.AddWithValue("@Second", secondInput);
                     SqlParameter thirdParameter = command.Parameters.AddWithValue("@Third", thirdInput);
@@ -682,7 +682,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void PositionalParameters_OutputFails()
+        private static void DisableOutputParameters_OutputFails()
         {
             int firstInput = 1;
             int secondInput = 2;
@@ -694,7 +694,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (var command = new SqlCommand("SELECT @Third = (@Third + @First + @Second)", connection))
                 {
-                    command.UsePositionalParameters = true;
+                    command.DisableOutputParameters = true;
                     command.Parameters.AddWithValue("@First", firstInput);
                     command.Parameters.AddWithValue("@Second", secondInput);
                     SqlParameter thirdParameter = command.Parameters.AddWithValue("@Third", thirdInput);
@@ -708,7 +708,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Fact]
-        private static void PositionalParameters_ReturnSucceeds()
+        private static void DisableOutputParameters_ReturnSucceeds()
         {
             int firstInput = 12;
 
@@ -731,7 +731,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                     using (var command = new SqlCommand(sprocName, connection) { CommandType = CommandType.StoredProcedure })
                     {
-                        command.UsePositionalParameters = true;
+                        command.DisableOutputParameters = true;
                         command.Parameters.AddWithValue("@in", firstInput);
                         SqlParameter returnParameter = command.Parameters.AddWithValue("@retval", 0);
                         returnParameter.Direction = ParameterDirection.ReturnValue;


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/974

This PR adds a new property to SqlCommand called DisableOutputParameters. When set to true parameters names will not be sent to the sql server when the command is executed. This behaviour has been show to increase performance for commands with very large numbers of parameters which are used in bulk operations.

This is a draft because:
1) This adds public surface area. The external name is open to debate.
2) This needs documenting.
3) This needs tests adding.

@KristianWedberg would you mind running your perf tests with the artifacts from this PR to ensure that this small change still has the performance changes observed in the investigation we did in your original issue?