### PR TITLE
Fix | Fix race condition issues between SinglePhaseCommit and TransactionEnded events

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -324,24 +324,21 @@ namespace Microsoft.Data.SqlClient
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-                    // If the connection is doomed, we can be certain that the
-                    // transaction will eventually be rolled back, and we shouldn't
-                    // attempt to commit it.
-                    if (connection.IsConnectionDoomed)
+                    lock (connection)
                     {
-                        lock (connection)
+                        // If the connection is doomed, we can be certain that the
+                        // transaction will eventually be rolled back or has already been aborted externally, and we shouldn't
+                        // attempt to commit it.
+                        if (connection.IsConnectionDoomed)
                         {
                             _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
                             _connection = null;
-                        }
 
-                        enlistment.Aborted(SQL.ConnectionDoomed());
-                    }
-                    else
-                    {
-                        Exception commitException;
-                        lock (connection)
+                            enlistment.Aborted(SQL.ConnectionDoomed());
+                        }
+                        else
                         {
+                            Exception commitException;
                             try
                             {
                                 // Now that we've acquired the lock, make sure we still have valid state for this operation.
@@ -367,40 +364,40 @@ namespace Microsoft.Data.SqlClient
                                 commitException = e;
                                 connection.DoomThisConnection();
                             }
-                        }
-                        if (commitException != null)
-                        {
-                            // connection.ExecuteTransaction failed with exception
-                            if (_internalTransaction.IsCommitted)
+                            if (commitException != null)
                             {
-                                // Even though we got an exception, the transaction
-                                // was committed by the server.
+                                // connection.ExecuteTransaction failed with exception
+                                if (_internalTransaction.IsCommitted)
+                                {
+                                    // Even though we got an exception, the transaction
+                                    // was committed by the server.
+                                    enlistment.Committed();
+                                }
+                                else if (_internalTransaction.IsAborted)
+                                {
+                                    // The transaction was aborted, report that to
+                                    // SysTx.
+                                    enlistment.Aborted(commitException);
+                                }
+                                else
+                                {
+                                    // The transaction is still active, we cannot
+                                    // know the state of the transaction.
+                                    enlistment.InDoubt(commitException);
+                                }
+
+                                // We eat the exception.  This is called on the SysTx
+                                // thread, not the applications thread.  If we don't
+                                // eat the exception an UnhandledException will occur,
+                                // causing the process to FailFast.
+                            }
+
+                            connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
+                            if (commitException == null)
+                            {
+                                // connection.ExecuteTransaction succeeded
                                 enlistment.Committed();
                             }
-                            else if (_internalTransaction.IsAborted)
-                            {
-                                // The transaction was aborted, report that to
-                                // SysTx.
-                                enlistment.Aborted(commitException);
-                            }
-                            else
-                            {
-                                // The transaction is still active, we cannot
-                                // know the state of the transaction.
-                                enlistment.InDoubt(commitException);
-                            }
-
-                            // We eat the exception.  This is called on the SysTx
-                            // thread, not the applications thread.  If we don't
-                            // eat the exception an UnhandledException will occur,
-                            // causing the process to FailFast.
-                        }
-
-                        connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
-                        if (commitException == null)
-                        {
-                            // connection.ExecuteTransaction succeeded
-                            enlistment.Committed();
                         }
                     }
                 }


### PR DESCRIPTION
A race condition exists between "Single Phase Commit" and "Transaction Ended" as both are triggered externally by delegated SqlTransaction. With recent changes to doom connection in "Transaction Ended" Event (https://github.com/dotnet/SqlClient/pull/543), "Commit" started failing intermittently leading to this issue. Dooming connection is essential to prevent connection re-use that leads to security issues, so that fix is intact. 

But as a consequence, "Commit"'s inconsistent locking leads to this problem. Locking is essential in this design, but in "Single Phase Commit" implementation, late and split locking causes issues between Commit and Abort event handling, leading to intermittent "Transaction Aborted Exception".

This change in lock scope fixes the issue. It wasn't easily reproducible in Microsoft.Data.SqlClient but happens very often with System.Data.SqlClient 4.8.2. Making test-case more rigorous and forcing latency while debugging aided in reproducing this issue.

[Link to Repro](https://gist.github.com/cheenamalhotra/0ae1d2114e32a38731568213156fbabf).
Possibly also related to issue #729 ([repro](https://github.com/dotnet/SqlClient/issues/729#issuecomment-814978239))

P.S. Fix tested with System.Data.SqlClient in debug session.
cc @saurabh500 