### PR TITLE
update enclave sim to use new crypto apis

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.NetCoreApp.cs
@@ -84,9 +84,11 @@ namespace Microsoft.Data.SqlClient
                         Buffer.BlockCopy(attestationInfo, attestationInfoOffset, trustedModuleDHPublicKeySignature, 0,
                             checked((int)sizeOfTrustedModuleDHPublicKeySignatureBuffer));
 
-                        ECParameters ecParams = KeyConverter.ECCPublicKeyBlobToParams(trustedModuleDHPublicKey);
-                        ECDiffieHellman enclaveDHKey = ECDiffieHellman.Create(ecParams);
-                        byte[] sharedSecret = clientDHKey.DeriveKeyFromHash(enclaveDHKey.PublicKey, HashAlgorithmName.SHA256);
+                        byte[] sharedSecret;
+                        using (ECDiffieHellman ecdh = KeyConverter.CreateECDiffieHellmanFromPublicKeyBlob(trustedModuleDHPublicKey))
+                        {
+                            sharedSecret = KeyConverter.DeriveKey(clientDHKey, ecdh.PublicKey);
+                        }
                         long sessionId = BitConverter.ToInt64(enclaveSessionHandle, 0);
                         sqlEnclaveSession = AddEnclaveSessionToCache(enclaveSessionParameters, sharedSecret, sessionId, out counter);
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SimulatorEnclaveProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellmanCng clientDHKey, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellman clientDHKey, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             ////for simulator: enclave does not send public key, and sends an empty attestation info
             //// The only non-trivial content it sends is the session setup info (DH pubkey of enclave)
@@ -84,8 +84,11 @@ namespace Microsoft.Data.SqlClient
                         Buffer.BlockCopy(attestationInfo, attestationInfoOffset, trustedModuleDHPublicKeySignature, 0,
                             checked((int)sizeOfTrustedModuleDHPublicKeySignatureBuffer));
 
-                        CngKey k = CngKey.Import(trustedModuleDHPublicKey, CngKeyBlobFormat.EccPublicBlob);
-                        byte[] sharedSecret = clientDHKey.DeriveKeyMaterial(k);
+                        byte[] sharedSecret;
+                        using (ECDiffieHellman ecdh = KeyConverter.CreateECDiffieHellmanFromPublicKeyBlob(trustedModuleDHPublicKey))
+                        {
+                            sharedSecret = KeyConverter.DeriveKey(clientDHKey, ecdh.PublicKey);
+                        }
                         long sessionId = BitConverter.ToInt64(enclaveSessionHandle, 0);
                         sqlEnclaveSession = AddEnclaveSessionToCache(enclaveSessionParameters, sharedSecret, sessionId, out counter);
                     }


### PR DESCRIPTION
Changes in [#1022](https://github.com/dotnet/SqlClient/pull/1022) requires some small changes in the enclave simulator.