### PR TITLE
Perf: Change SqlParameter bool fields to flags

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -733,7 +733,7 @@ namespace Microsoft.Data.SqlClient
                 _coercedValue = null;
                 _valueAsINullable = _value as INullable;
                 SetFlag(SqlParameterFlags.IsSqlParameterSqlType, _valueAsINullable != null);
-                SetFlag(SqlParameterFlags.IsNull, (null == _value) || (_value == DBNull.Value) || HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && _valueAsINullable.IsNull);
+                SetFlag(SqlParameterFlags.IsNull, (null == _value) || (_value == DBNull.Value) || (HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && _valueAsINullable.IsNull));
                 _udtLoadError = null;
                 _actualSize = -1;
             }
@@ -1012,7 +1012,9 @@ namespace Microsoft.Data.SqlClient
                 SqlParameterFlags.IsSqlParameterSqlType |
                 SqlParameterFlags.CoercedValueIsDataFeed |
                 SqlParameterFlags.CoercedValueIsSqlType |
-                SqlParameterFlags.ForceColumnEncryption
+                SqlParameterFlags.ForceColumnEncryption |
+                SqlParameterFlags.IsDerivedParameterTypeName
+                // HasScale and HasReceivedMetadata deliberately omitted
             );
             destination._metaType = _metaType;
             destination._collation = _collation;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -208,6 +208,22 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [Flags]
+        private enum SqlParameterFlags : ushort
+        {
+            None = 0,
+            IsNull = 1,
+            IsNullable = 2,
+            IsSqlParameterSqlType = 4,
+            SourceColumnNullMapping = 8,
+            CoercedValueIsSqlType = 16,
+            CoercedValueIsDataFeed = 32,
+            HasReceivedMetadata = 64,
+            ForceColumnEncryption = 128,
+            IsDerivedParameterTypeName = 256,
+            HasScale = 512,
+        }
+
         private MetaType _metaType;
         private SqlCollation _collation;
         private SqlMetaDataXmlSchemaCollection _xmlSchemaCollection;
@@ -217,14 +233,9 @@ namespace Microsoft.Data.SqlClient
         private string _parameterName;
         private byte _precision;
         private byte _scale;
-        private bool _hasScale; // V1.0 compat, ignore _hasScale
         private MetaType _internalMetaType;
         private SqlBuffer _sqlBufferReturnValue;
         private INullable _valueAsINullable;
-        private bool _isSqlParameterSqlType;
-        private bool _isNull;
-        private bool _coercedValueIsSqlType;
-        private bool _coercedValueIsDataFeed;
         private int _actualSize;
         private object _value;
         private object _coercedValue;
@@ -234,13 +245,12 @@ namespace Microsoft.Data.SqlClient
         private int _offset;
         private string _sourceColumn;
         private DataRowVersion _sourceVersion;
-        private bool _sourceColumnNullMapping;
-        private bool _isNullable;
+        private SqlParameterFlags _flags;
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ctor2/*' />
         public SqlParameter() : base()
         {
-            _isNull = true;
+            _flags = SqlParameterFlags.IsNull;
             _actualSize = -1;
             _direction = ParameterDirection.Input;
         }
@@ -360,7 +370,11 @@ namespace Microsoft.Data.SqlClient
         /// For unencrypted parameters, the encryption metadata should still be sent (and will indicate 
         /// that no encryption is needed).
         /// </summary>
-        internal bool HasReceivedMetadata { get; set; }
+        internal bool HasReceivedMetadata 
+        { 
+            get => HasFlag(SqlParameterFlags.HasReceivedMetadata); 
+            set => SetFlag(SqlParameterFlags.HasReceivedMetadata, value); 
+        }
 
         /// <summary>
         /// Returns the normalization rule version number as a byte
@@ -432,7 +446,11 @@ namespace Microsoft.Data.SqlClient
         DefaultValue(false),
         ResCategory("Data")
         ]
-        public bool ForceColumnEncryption { get; set; }
+        public bool ForceColumnEncryption
+        {
+            get => HasFlag(SqlParameterFlags.ForceColumnEncryption);
+            set => SetFlag(SqlParameterFlags.ForceColumnEncryption, value);
+        }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/DbType/*' />
         public override DbType DbType
@@ -547,11 +565,11 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                if (_scale != value || !_hasScale)
+                if (_scale != value || !HasFlag(SqlParameterFlags.HasScale))
                 {
                     PropertyChanging();
                     _scale = value;
-                    _hasScale = true;
+                    SetFlag(SqlParameterFlags.HasScale, true);
                     _actualSize = -1;   // Invalidate actual size such that it is re-calculated
                 }
             }
@@ -714,8 +732,8 @@ namespace Microsoft.Data.SqlClient
                 _sqlBufferReturnValue = null;
                 _coercedValue = null;
                 _valueAsINullable = _value as INullable;
-                _isSqlParameterSqlType = _valueAsINullable != null;
-                _isNull = (null == _value) || (_value == DBNull.Value) || (_isSqlParameterSqlType && _valueAsINullable.IsNull);
+                SetFlag(SqlParameterFlags.IsSqlParameterSqlType, _valueAsINullable != null);
+                SetFlag(SqlParameterFlags.IsNull, (null == _value) || (_value == DBNull.Value) || HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && _valueAsINullable.IsNull);
                 _udtLoadError = null;
                 _actualSize = -1;
             }
@@ -752,8 +770,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/IsNullable/*' />
         public override bool IsNullable
         {
-            get => _isNullable;
-            set => _isNullable = value;
+            get => HasFlag(SqlParameterFlags.IsNullable);
+            set => SetFlag(SqlParameterFlags.IsNullable, value);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/Offset/*' />
@@ -819,8 +837,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/SourceColumnNullMapping/*' />
         public override bool SourceColumnNullMapping
         {
-            get => _sourceColumnNullMapping;
-            set => _sourceColumnNullMapping = value;
+            get => HasFlag(SqlParameterFlags.SourceColumnNullMapping);
+            set => SetFlag(SqlParameterFlags.SourceColumnNullMapping, value);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ToString/*' />
@@ -869,7 +887,7 @@ namespace Microsoft.Data.SqlClient
                     GetCoercedValue();
                 }
                 AssertCachedPropertiesAreValid();
-                return _coercedValueIsDataFeed;
+                return HasFlag(SqlParameterFlags.CoercedValueIsDataFeed);
             }
         }
 
@@ -882,7 +900,7 @@ namespace Microsoft.Data.SqlClient
                     GetCoercedValue();
                 }
                 AssertCachedPropertiesAreValid();
-                return _coercedValueIsSqlType;
+                return HasFlag(SqlParameterFlags.CoercedValueIsSqlType);
             }
         }
 
@@ -895,6 +913,11 @@ namespace Microsoft.Data.SqlClient
             set => _collation = value;
         }
 
+        private bool HasFlag(SqlParameterFlags flag)
+        {
+            return (_flags & flag) != 0;
+        }
+
         internal bool IsNull
         {
             get
@@ -902,9 +925,9 @@ namespace Microsoft.Data.SqlClient
                 // NOTE: Udts can change their value any time
                 if (_internalMetaType.SqlDbType == SqlDbType.Udt)
                 {
-                    _isNull = (_value == null) || (_value == DBNull.Value) || (_isSqlParameterSqlType && _valueAsINullable.IsNull);
+                    SetFlag(SqlParameterFlags.IsNull, (_value == null) || (_value == DBNull.Value) || (HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && _valueAsINullable.IsNull));
                 }
-                return _isNull;
+                return HasFlag(SqlParameterFlags.IsNull);
             }
         }
 
@@ -947,8 +970,8 @@ namespace Microsoft.Data.SqlClient
 
         internal bool ParameterIsSqlType
         {
-            get => _isSqlParameterSqlType;
-            set => _isSqlParameterSqlType = value;
+            get => HasFlag(SqlParameterFlags.IsSqlParameterSqlType);
+            set => SetFlag(SqlParameterFlags.IsSqlParameterSqlType, value);
         }
 
         internal string ParameterNameFixed
@@ -967,7 +990,11 @@ namespace Microsoft.Data.SqlClient
 
         internal INullable ValueAsINullable => _valueAsINullable;
 
-        internal bool IsDerivedParameterTypeName { get; set; }
+        internal bool IsDerivedParameterTypeName
+        {
+            get => HasFlag(SqlParameterFlags.IsDerivedParameterTypeName);
+            set => SetFlag(SqlParameterFlags.IsDerivedParameterTypeName, value);
+        }
 
         private void CloneHelper(SqlParameter destination)
         {
@@ -978,9 +1005,15 @@ namespace Microsoft.Data.SqlClient
             destination._offset = _offset;
             destination._sourceColumn = _sourceColumn;
             destination._sourceVersion = _sourceVersion;
-            destination._sourceColumnNullMapping = _sourceColumnNullMapping;
-            destination._isNullable = _isNullable;
-
+            destination._flags = _flags & (
+                SqlParameterFlags.SourceColumnNullMapping |
+                SqlParameterFlags.IsNull |
+                SqlParameterFlags.IsNullable |
+                SqlParameterFlags.IsSqlParameterSqlType |
+                SqlParameterFlags.CoercedValueIsDataFeed |
+                SqlParameterFlags.CoercedValueIsSqlType |
+                SqlParameterFlags.ForceColumnEncryption
+            );
             destination._metaType = _metaType;
             destination._collation = _collation;
             if (_xmlSchemaCollection != null)
@@ -990,20 +1023,14 @@ namespace Microsoft.Data.SqlClient
             destination._udtTypeName = _udtTypeName;
             destination._typeName = _typeName;
             destination._udtLoadError = _udtLoadError;
-
             destination._parameterName = _parameterName;
             destination._precision = _precision;
             destination._scale = _scale;
             destination._sqlBufferReturnValue = _sqlBufferReturnValue;
-            destination._isSqlParameterSqlType = _isSqlParameterSqlType;
             destination._internalMetaType = _internalMetaType;
             destination.CoercedValue = CoercedValue; // copy cached value reference because of XmlReader problem
             destination._valueAsINullable = _valueAsINullable;
-            destination._isNull = _isNull;
-            destination._coercedValueIsDataFeed = _coercedValueIsDataFeed;
-            destination._coercedValueIsSqlType = _coercedValueIsSqlType;
             destination._actualSize = _actualSize;
-            destination.ForceColumnEncryption = ForceColumnEncryption;
         }
 
         internal void CopyTo(SqlParameter destination)
@@ -1035,12 +1062,12 @@ namespace Microsoft.Data.SqlClient
         {
             object value = GetCoercedValue();
             AssertCachedPropertiesAreValid();
-            if (!_coercedValueIsDataFeed)
+            if (!HasFlag(SqlParameterFlags.CoercedValueIsDataFeed))
             {
                 return;
             }
 
-            _coercedValueIsDataFeed = false;
+            SetFlag(SqlParameterFlags.CoercedValueIsDataFeed, false);
 
             if (value is TextDataFeed textFeed)
             {
@@ -1466,7 +1493,7 @@ namespace Microsoft.Data.SqlClient
                         case SqlDbType.NText:
                         case SqlDbType.Xml:
                             {
-                                coercedSize = ((!_isNull) && (!_coercedValueIsDataFeed)) ? (StringSize(val, _coercedValueIsSqlType)) : 0;
+                                coercedSize = ((!HasFlag(SqlParameterFlags.IsNull)) && (!HasFlag(SqlParameterFlags.CoercedValueIsDataFeed))) ? (StringSize(val, HasFlag(SqlParameterFlags.CoercedValueIsSqlType))) : 0;
                                 _actualSize = (ShouldSerializeSize() ? Size : 0);
                                 _actualSize = (ShouldSerializeSize() && (_actualSize <= coercedSize)) ? _actualSize : coercedSize;
                                 if (_actualSize == -1)
@@ -1481,7 +1508,7 @@ namespace Microsoft.Data.SqlClient
                         case SqlDbType.Text:
                             {
                                 // for these types, ActualSize is the num of chars, not actual bytes - since non-unicode chars are not always uniform size
-                                coercedSize = ((!_isNull) && (!_coercedValueIsDataFeed)) ? (StringSize(val, _coercedValueIsSqlType)) : 0;
+                                coercedSize = ((!HasFlag(SqlParameterFlags.IsNull)) && (!HasFlag(SqlParameterFlags.CoercedValueIsDataFeed))) ? (StringSize(val, HasFlag(SqlParameterFlags.CoercedValueIsSqlType))) : 0;
                                 _actualSize = (ShouldSerializeSize() ? Size : 0);
                                 _actualSize = (ShouldSerializeSize() && (_actualSize <= coercedSize)) ? _actualSize : coercedSize;
                                 if (_actualSize == -1)
@@ -1494,7 +1521,7 @@ namespace Microsoft.Data.SqlClient
                         case SqlDbType.VarBinary:
                         case SqlDbType.Image:
                         case SqlDbType.Timestamp:
-                            coercedSize = ((!_isNull) && (!_coercedValueIsDataFeed)) ? (BinarySize(val, _coercedValueIsSqlType)) : 0;
+                            coercedSize = ((!HasFlag(SqlParameterFlags.IsNull)) && (!HasFlag(SqlParameterFlags.CoercedValueIsDataFeed))) ? (BinarySize(val, HasFlag(SqlParameterFlags.CoercedValueIsSqlType))) : 0;
                             _actualSize = (ShouldSerializeSize() ? Size : 0);
                             _actualSize = ((ShouldSerializeSize() && (_actualSize <= coercedSize)) ? _actualSize : coercedSize);
                             if (_actualSize == -1)
@@ -1553,14 +1580,15 @@ namespace Microsoft.Data.SqlClient
                 {
                     // No coercion is done for DataFeeds and Nulls
                     _coercedValue = Value;
-                    _coercedValueIsSqlType = _coercedValue != null && _isSqlParameterSqlType; // set to null for output parameters that keeps _isSqlParameterSqlType
-                    _coercedValueIsDataFeed = isDataFeed;
+                    SetFlag(SqlParameterFlags.CoercedValueIsSqlType, _coercedValue != null && HasFlag(SqlParameterFlags.IsSqlParameterSqlType)); // set to null for output parameters that keeps _isSqlParameterSqlType
+                    SetFlag(SqlParameterFlags.CoercedValueIsDataFeed, isDataFeed);
                     _actualSize = IsNull ? 0 : -1;
                 }
                 else
                 {
-                    _coercedValue = CoerceValue(Value, _internalMetaType, out _coercedValueIsDataFeed, out bool typeChanged);
-                    _coercedValueIsSqlType = _isSqlParameterSqlType && (!typeChanged);  // Type changed always results in a CLR type
+                    _coercedValue = CoerceValue(Value, _internalMetaType, out bool coercedValueIsDataFeed, out bool typeChanged);
+                    SetFlag(SqlParameterFlags.CoercedValueIsDataFeed, coercedValueIsDataFeed);
+                    SetFlag(SqlParameterFlags.CoercedValueIsSqlType, HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && (!typeChanged));  // Type changed always results in a CLR type
                     _actualSize = -1;
                 }
             }
@@ -1758,7 +1786,7 @@ namespace Microsoft.Data.SqlClient
         [Conditional("DEBUG")]
         internal void AssertCachedPropertiesAreValid()
         {
-            AssertPropertiesAreValid(_coercedValue, _coercedValueIsSqlType, _coercedValueIsDataFeed, IsNull);
+            AssertPropertiesAreValid(_coercedValue, HasFlag(SqlParameterFlags.CoercedValueIsSqlType), HasFlag(SqlParameterFlags.CoercedValueIsDataFeed), IsNull);
         }
 
         [Conditional("DEBUG")]
@@ -1806,7 +1834,7 @@ namespace Microsoft.Data.SqlClient
             }
             else if (_sqlBufferReturnValue != null)
             {  // value came back from the server
-                Type valueType = _sqlBufferReturnValue.GetTypeFromStorageType(_isSqlParameterSqlType);
+                Type valueType = _sqlBufferReturnValue.GetTypeFromStorageType(HasFlag(SqlParameterFlags.IsSqlParameterSqlType));
                 if (valueType != null)
                 {
                     return MetaType.GetMetaTypeFromType(valueType);
@@ -1849,11 +1877,16 @@ namespace Microsoft.Data.SqlClient
             _sqlBufferReturnValue = buff;
             _value = null;
             _coercedValue = null;
-            _isNull = _sqlBufferReturnValue.IsNull;
-            _coercedValueIsDataFeed = false;
-            _coercedValueIsSqlType = false;
+            SetFlag(SqlParameterFlags.IsNull, _sqlBufferReturnValue.IsNull);
+            SetFlag(SqlParameterFlags.CoercedValueIsDataFeed, false);
+            SetFlag(SqlParameterFlags.CoercedValueIsSqlType, false);
             _udtLoadError = null;
             _actualSize = -1;
+        }
+
+        private void SetFlag(SqlParameterFlags flag, bool value)
+        {
+            _flags = value ? _flags | flag : _flags & ~flag;
         }
 
         internal void SetUdtLoadError(Exception e)
@@ -1955,7 +1988,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (
                     (maxSizeInBytes > TdsEnums.TYPE_SIZE_LIMIT) ||
-                    _coercedValueIsDataFeed ||
+                    HasFlag(SqlParameterFlags.CoercedValueIsDataFeed) ||
                     (sizeInCharacters == -1) || 
                     (actualSizeInBytes == -1)
                 )

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -191,6 +191,22 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [Flags]
+        private enum SqlParameterFlags : ushort
+        {
+            None = 0,
+            IsNull = 1,
+            IsNullable = 2,
+            IsSqlParameterSqlType = 4,
+            SourceColumnNullMapping = 8,
+            CoercedValueIsSqlType = 16,
+            CoercedValueIsDataFeed = 32,
+            HasReceivedMetadata = 64,
+            ForceColumnEncryption = 128,
+            IsDerivedParameterTypeName = 256,
+            HasScale = 512,
+        }
+
         private MetaType _metaType;
         private SqlCollation _collation;
         private SqlMetaDataXmlSchemaCollection _xmlSchemaCollection;
@@ -200,14 +216,9 @@ namespace Microsoft.Data.SqlClient
         private string _parameterName;
         private byte _precision;
         private byte _scale;
-        private bool _hasScale; // V1.0 compat, ignore _hasScale
         private MetaType _internalMetaType;
         private SqlBuffer _sqlBufferReturnValue;
         private INullable _valueAsINullable;
-        private bool _isSqlParameterSqlType;
-        private bool _isNull;
-        private bool _coercedValueIsSqlType;
-        private bool _coercedValueIsDataFeed;
         private int _actualSize;
         private object _value;
         private object _coercedValue;
@@ -217,13 +228,12 @@ namespace Microsoft.Data.SqlClient
         private int _offset;
         private string _sourceColumn;
         private DataRowVersion _sourceVersion;
-        private bool _sourceColumnNullMapping;
-        private bool _isNullable;
+        private SqlParameterFlags _flags;
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ctor2/*' />
         public SqlParameter() : base()
         {
-            _isNull = true;
+            _flags = SqlParameterFlags.IsNull;
             _actualSize = -1;
             _direction = ParameterDirection.Input;
         }
@@ -343,7 +353,11 @@ namespace Microsoft.Data.SqlClient
         /// For unencrypted parameters, the encryption metadata should still be sent (and will indicate 
         /// that no encryption is needed).
         /// </summary>
-        internal bool HasReceivedMetadata { get; set; }
+        internal bool HasReceivedMetadata
+        {
+            get => HasFlag(SqlParameterFlags.HasReceivedMetadata);
+            set => SetFlag(SqlParameterFlags.HasReceivedMetadata, value);
+        }
 
         /// <summary>
         /// Returns the normalization rule version number as a byte
@@ -415,7 +429,11 @@ namespace Microsoft.Data.SqlClient
         DefaultValue(false),
         ResCategory("Data")
         ]
-        public bool ForceColumnEncryption { get; set; }
+        public bool ForceColumnEncryption
+        {
+            get => HasFlag(SqlParameterFlags.ForceColumnEncryption);
+            set => SetFlag(SqlParameterFlags.ForceColumnEncryption, value);
+        }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/DbType/*' />
         public override DbType DbType
@@ -530,11 +548,11 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                if (_scale != value || !_hasScale)
+                if (_scale != value || !HasFlag(SqlParameterFlags.HasScale))
                 {
                     PropertyChanging();
                     _scale = value;
-                    _hasScale = true;
+                    SetFlag(SqlParameterFlags.HasScale, true);
                     _actualSize = -1;   // Invalidate actual size such that it is re-calculated
                 }
             }
@@ -697,8 +715,8 @@ namespace Microsoft.Data.SqlClient
                 _sqlBufferReturnValue = null;
                 _coercedValue = null;
                 _valueAsINullable = _value as INullable;
-                _isSqlParameterSqlType = _valueAsINullable != null;
-                _isNull = (null == _value) || (_value == DBNull.Value) || (_isSqlParameterSqlType && _valueAsINullable.IsNull);
+                SetFlag(SqlParameterFlags.IsSqlParameterSqlType, _valueAsINullable != null);
+                SetFlag(SqlParameterFlags.IsNull, (null == _value) || (_value == DBNull.Value) || HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && _valueAsINullable.IsNull);
                 _udtLoadError = null;
                 _actualSize = -1;
             }
@@ -735,8 +753,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/IsNullable/*' />
         public override bool IsNullable
         {
-            get => _isNullable;
-            set => _isNullable = value;
+            get => HasFlag(SqlParameterFlags.IsNullable);
+            set => SetFlag(SqlParameterFlags.IsNullable, value);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/Offset/*' />
@@ -802,8 +820,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/SourceColumnNullMapping/*' />
         public override bool SourceColumnNullMapping
         {
-            get => _sourceColumnNullMapping;
-            set => _sourceColumnNullMapping = value;
+            get => HasFlag(SqlParameterFlags.SourceColumnNullMapping);
+            set => SetFlag(SqlParameterFlags.SourceColumnNullMapping, value);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/ToString/*' />
@@ -854,7 +872,7 @@ namespace Microsoft.Data.SqlClient
                     GetCoercedValue();
                 }
                 AssertCachedPropertiesAreValid();
-                return _coercedValueIsDataFeed;
+                return HasFlag(SqlParameterFlags.CoercedValueIsDataFeed);
             }
         }
 
@@ -867,7 +885,7 @@ namespace Microsoft.Data.SqlClient
                     GetCoercedValue();
                 }
                 AssertCachedPropertiesAreValid();
-                return _coercedValueIsSqlType;
+                return HasFlag(SqlParameterFlags.CoercedValueIsSqlType);
             }
         }
 
@@ -880,6 +898,11 @@ namespace Microsoft.Data.SqlClient
             set => _collation = value;
         }
 
+        private bool HasFlag(SqlParameterFlags flag)
+        {
+            return (_flags & flag) != 0;
+        }
+
         internal bool IsNull
         {
             get
@@ -887,9 +910,9 @@ namespace Microsoft.Data.SqlClient
                 // NOTE: Udts can change their value any time
                 if (_internalMetaType.SqlDbType == SqlDbType.Udt)
                 {
-                    _isNull = (_value == null) || (_value == DBNull.Value) || (_isSqlParameterSqlType && _valueAsINullable.IsNull);
+                    SetFlag(SqlParameterFlags.IsNull, (_value == null) || (_value == DBNull.Value) || (HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && _valueAsINullable.IsNull));
                 }
-                return _isNull;
+                return HasFlag(SqlParameterFlags.IsNull);
             }
         }
 
@@ -932,8 +955,8 @@ namespace Microsoft.Data.SqlClient
 
         internal bool ParameterIsSqlType
         {
-            get => _isSqlParameterSqlType;
-            set => _isSqlParameterSqlType = value;
+            get => HasFlag(SqlParameterFlags.IsSqlParameterSqlType);
+            set => SetFlag(SqlParameterFlags.IsSqlParameterSqlType, value);
         }
 
         internal string ParameterNameFixed
@@ -954,7 +977,11 @@ namespace Microsoft.Data.SqlClient
 
         internal INullable ValueAsINullable => _valueAsINullable;
 
-        internal bool IsDerivedParameterTypeName { get; set; }
+        internal bool IsDerivedParameterTypeName
+        {
+            get => HasFlag(SqlParameterFlags.IsDerivedParameterTypeName);
+            set => SetFlag(SqlParameterFlags.IsDerivedParameterTypeName, value);
+        }
 
         private void CloneHelper(SqlParameter destination)
         {
@@ -965,9 +992,15 @@ namespace Microsoft.Data.SqlClient
             destination._offset = _offset;
             destination._sourceColumn = _sourceColumn;
             destination._sourceVersion = _sourceVersion;
-            destination._sourceColumnNullMapping = _sourceColumnNullMapping;
-            destination._isNullable = _isNullable;
-
+            destination._flags = _flags & (
+                SqlParameterFlags.SourceColumnNullMapping |
+                SqlParameterFlags.IsNull |
+                SqlParameterFlags.IsNullable |
+                SqlParameterFlags.IsSqlParameterSqlType |
+                SqlParameterFlags.CoercedValueIsDataFeed |
+                SqlParameterFlags.CoercedValueIsSqlType |
+                SqlParameterFlags.ForceColumnEncryption
+            );
             destination._metaType = _metaType;
             destination._collation = _collation;
             if (_xmlSchemaCollection != null)
@@ -977,20 +1010,14 @@ namespace Microsoft.Data.SqlClient
             destination._udtTypeName = _udtTypeName;
             destination._typeName = _typeName;
             destination._udtLoadError = _udtLoadError;
-
             destination._parameterName = _parameterName;
             destination._precision = _precision;
             destination._scale = _scale;
             destination._sqlBufferReturnValue = _sqlBufferReturnValue;
-            destination._isSqlParameterSqlType = _isSqlParameterSqlType;
             destination._internalMetaType = _internalMetaType;
             destination.CoercedValue = CoercedValue; // copy cached value reference because of XmlReader problem
             destination._valueAsINullable = _valueAsINullable;
-            destination._isNull = _isNull;
-            destination._coercedValueIsDataFeed = _coercedValueIsDataFeed;
-            destination._coercedValueIsSqlType = _coercedValueIsSqlType;
             destination._actualSize = _actualSize;
-            destination.ForceColumnEncryption = ForceColumnEncryption;
         }
 
         internal void CopyTo(SqlParameter destination)
@@ -1026,12 +1053,12 @@ namespace Microsoft.Data.SqlClient
         {
             object value = GetCoercedValue();
             AssertCachedPropertiesAreValid();
-            if (!_coercedValueIsDataFeed)
+            if (!HasFlag(SqlParameterFlags.CoercedValueIsDataFeed))
             {
                 return;
             }
 
-            _coercedValueIsDataFeed = false;
+            SetFlag(SqlParameterFlags.CoercedValueIsDataFeed, false);
 
             if (value is TextDataFeed textFeed)
             {
@@ -1461,7 +1488,7 @@ namespace Microsoft.Data.SqlClient
                         case SqlDbType.NText:
                         case SqlDbType.Xml:
                             {
-                                coercedSize = ((!_isNull) && (!_coercedValueIsDataFeed)) ? (StringSize(val, _coercedValueIsSqlType)) : 0;
+                                coercedSize = ((!HasFlag(SqlParameterFlags.IsNull)) && (!HasFlag(SqlParameterFlags.CoercedValueIsDataFeed))) ? (StringSize(val, HasFlag(SqlParameterFlags.CoercedValueIsSqlType))) : 0;
                                 _actualSize = (ShouldSerializeSize() ? Size : 0);
                                 _actualSize = (ShouldSerializeSize() && (_actualSize <= coercedSize)) ? _actualSize : coercedSize;
                                 if (_actualSize == -1)
@@ -1476,7 +1503,7 @@ namespace Microsoft.Data.SqlClient
                         case SqlDbType.Text:
                             {
                                 // for these types, ActualSize is the num of chars, not actual bytes - since non-unicode chars are not always uniform size
-                                coercedSize = ((!_isNull) && (!_coercedValueIsDataFeed)) ? (StringSize(val, _coercedValueIsSqlType)) : 0;
+                                coercedSize = (!HasFlag(SqlParameterFlags.IsNull) && (!HasFlag(SqlParameterFlags.CoercedValueIsDataFeed))) ? (StringSize(val, HasFlag(SqlParameterFlags.CoercedValueIsSqlType))) : 0;
                                 _actualSize = (ShouldSerializeSize() ? Size : 0);
                                 _actualSize = (ShouldSerializeSize() && (_actualSize <= coercedSize)) ? _actualSize : coercedSize;
                                 if (_actualSize == -1)
@@ -1489,7 +1516,7 @@ namespace Microsoft.Data.SqlClient
                         case SqlDbType.VarBinary:
                         case SqlDbType.Image:
                         case SqlDbType.Timestamp:
-                            coercedSize = ((!_isNull) && (!_coercedValueIsDataFeed)) ? (BinarySize(val, _coercedValueIsSqlType)) : 0;
+                            coercedSize = (!HasFlag(SqlParameterFlags.IsNull) && (!HasFlag(SqlParameterFlags.CoercedValueIsDataFeed))) ? (BinarySize(val, HasFlag(SqlParameterFlags.CoercedValueIsSqlType))) : 0;
                             _actualSize = (ShouldSerializeSize() ? Size : 0);
                             _actualSize = ((ShouldSerializeSize() && (_actualSize <= coercedSize)) ? _actualSize : coercedSize);
                             if (_actualSize == -1)
@@ -1549,14 +1576,15 @@ namespace Microsoft.Data.SqlClient
                 {
                     // No coercion is done for DataFeeds and Nulls
                     _coercedValue = Value;
-                    _coercedValueIsSqlType = _coercedValue != null && _isSqlParameterSqlType; // set to null for output parameters that keeps _isSqlParameterSqlType
-                    _coercedValueIsDataFeed = isDataFeed;
+                    SetFlag(SqlParameterFlags.CoercedValueIsSqlType, _coercedValue != null && HasFlag(SqlParameterFlags.IsSqlParameterSqlType)); // set to null for output parameters that keeps _isSqlParameterSqlType
+                    SetFlag(SqlParameterFlags.CoercedValueIsDataFeed, isDataFeed);
                     _actualSize = IsNull ? 0 : -1;
                 }
                 else
                 {
-                    _coercedValue = CoerceValue(Value, _internalMetaType, out _coercedValueIsDataFeed, out bool typeChanged);
-                    _coercedValueIsSqlType = _isSqlParameterSqlType && (!typeChanged);  // Type changed always results in a CLR type
+                    _coercedValue = CoerceValue(Value, _internalMetaType, out bool coercedValueIsDataFeed, out bool typeChanged);
+                    SetFlag(SqlParameterFlags.CoercedValueIsDataFeed, coercedValueIsDataFeed);
+                    SetFlag(SqlParameterFlags.CoercedValueIsSqlType, HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && (!typeChanged));  // Type changed always results in a CLR type
                     _actualSize = -1;
                 }
             }
@@ -1755,7 +1783,7 @@ namespace Microsoft.Data.SqlClient
         [Conditional("DEBUG")]
         internal void AssertCachedPropertiesAreValid()
         {
-            AssertPropertiesAreValid(_coercedValue, _coercedValueIsSqlType, _coercedValueIsDataFeed, IsNull);
+            AssertPropertiesAreValid(_coercedValue, HasFlag(SqlParameterFlags.CoercedValueIsSqlType), HasFlag(SqlParameterFlags.CoercedValueIsDataFeed), IsNull);
         }
 
         [Conditional("DEBUG")]
@@ -1803,7 +1831,7 @@ namespace Microsoft.Data.SqlClient
             }
             else if (_sqlBufferReturnValue != null)
             {  // value came back from the server
-                Type valueType = _sqlBufferReturnValue.GetTypeFromStorageType(_isSqlParameterSqlType);
+                Type valueType = _sqlBufferReturnValue.GetTypeFromStorageType(HasFlag(SqlParameterFlags.IsSqlParameterSqlType));
                 if (valueType != null)
                 {
                     return MetaType.GetMetaTypeFromType(valueType);
@@ -1841,14 +1869,19 @@ namespace Microsoft.Data.SqlClient
 
         internal void ResetParent() => _parent = null;
 
+        private void SetFlag(SqlParameterFlags flag, bool value)
+        {
+            _flags = value ? _flags | flag : _flags & ~flag;
+        }
+
         internal void SetSqlBuffer(SqlBuffer buff)
         {
             _sqlBufferReturnValue = buff;
             _value = null;
             _coercedValue = null;
-            _isNull = _sqlBufferReturnValue.IsNull;
-            _coercedValueIsDataFeed = false;
-            _coercedValueIsSqlType = false;
+            SetFlag(SqlParameterFlags.IsNull, _sqlBufferReturnValue.IsNull);
+            SetFlag(SqlParameterFlags.CoercedValueIsDataFeed, false);
+            SetFlag(SqlParameterFlags.CoercedValueIsSqlType, false);
             _udtLoadError = null;
             _actualSize = -1;
         }
@@ -1972,7 +2005,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (
                     (maxSizeInBytes > TdsEnums.TYPE_SIZE_LIMIT) ||
-                    _coercedValueIsDataFeed ||
+                    HasFlag(SqlParameterFlags.CoercedValueIsDataFeed) ||
                     (sizeInCharacters == -1) || 
                     (actualSizeInBytes == -1)
                 )

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -716,7 +716,7 @@ namespace Microsoft.Data.SqlClient
                 _coercedValue = null;
                 _valueAsINullable = _value as INullable;
                 SetFlag(SqlParameterFlags.IsSqlParameterSqlType, _valueAsINullable != null);
-                SetFlag(SqlParameterFlags.IsNull, (null == _value) || (_value == DBNull.Value) || HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && _valueAsINullable.IsNull);
+                SetFlag(SqlParameterFlags.IsNull, (null == _value) || (_value == DBNull.Value) || (HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && _valueAsINullable.IsNull));
                 _udtLoadError = null;
                 _actualSize = -1;
             }
@@ -999,7 +999,9 @@ namespace Microsoft.Data.SqlClient
                 SqlParameterFlags.IsSqlParameterSqlType |
                 SqlParameterFlags.CoercedValueIsDataFeed |
                 SqlParameterFlags.CoercedValueIsSqlType |
-                SqlParameterFlags.ForceColumnEncryption
+                SqlParameterFlags.ForceColumnEncryption |
+                SqlParameterFlags.IsDerivedParameterTypeName
+                // HasScale and HasReceivedMetadata deliberately omitted
             );
             destination._metaType = _metaType;
             destination._collation = _collation;


### PR DESCRIPTION
This ports the second part of the changes from In https://github.com/dotnet/corefx/pull/35549 , it replaces many individual boolean fields with bitflags to reduce the size of each instance. I've used masking not Enum.HasFlag because it is portable over netcore and netfx as pointed out by @cmeyertons in https://github.com/dotnet/SqlClient/pull/1054

Using ObjectInspector mockups (replaced real ref types with object which are same size), gives a reduction from 152 to 136, a 10% size reduction.

```
Type layout for 'OldSqlParameter'
Size: 152 bytes. Paddings: 7 bytes (%4 of empty space)
|=====================================================================|
| Object Header (8 bytes)                                             |
|---------------------------------------------------------------------|
| Method Table Ptr (8 bytes)                                          |
|=====================================================================|
|   0-7: Object _metaType (8 bytes)                                   |
|---------------------------------------------------------------------|
|  8-15: Object _collation (8 bytes)                                  |
|---------------------------------------------------------------------|
| 16-23: Object _xmlSchemaCollection (8 bytes)                        |
|---------------------------------------------------------------------|
| 24-31: String _udtTypeName (8 bytes)                                |
|---------------------------------------------------------------------|
| 32-39: String _typeName (8 bytes)                                   |
|---------------------------------------------------------------------|
| 40-47: Exception _udtLoadError (8 bytes)                            |
|---------------------------------------------------------------------|
| 48-55: String _parameterName (8 bytes)                              |
|---------------------------------------------------------------------|
| 56-63: Object _internalMetaType (8 bytes)                           |
|---------------------------------------------------------------------|
| 64-71: Object _sqlBufferReturnValue (8 bytes)                       |
|---------------------------------------------------------------------|
| 72-79: Object _valueAsINullable (8 bytes)                           |
|---------------------------------------------------------------------|
| 80-87: Object _value (8 bytes)                                      |
|---------------------------------------------------------------------|
| 88-95: Object _coercedValue (8 bytes)                               |
|---------------------------------------------------------------------|
| 96-103: Object _parent (8 bytes)                                    |
|---------------------------------------------------------------------|
| 104-111: String _sourceColumn (8 bytes)                             |
|---------------------------------------------------------------------|
| 112-115: Int32 _actualSize (4 bytes)                                |
|---------------------------------------------------------------------|
| 116-119: Int32 _direction (4 bytes)                                 |
|---------------------------------------------------------------------|
| 120-123: Int32 _size (4 bytes)                                      |
|---------------------------------------------------------------------|
| 124-127: Int32 _offset (4 bytes)                                    |
|---------------------------------------------------------------------|
| 128-131: Int32 _sourceVersion (4 bytes)                             |
|---------------------------------------------------------------------|
|   132: Byte _precision (1 byte)                                     |
|---------------------------------------------------------------------|
|   133: Byte _scale (1 byte)                                         |
|---------------------------------------------------------------------|
|   134: Boolean _hasScale (1 byte)                                   |
|---------------------------------------------------------------------|
|   135: Boolean _isSqlParameterSqlType (1 byte)                      |
|---------------------------------------------------------------------|
|   136: Boolean _isNull (1 byte)                                     |
|---------------------------------------------------------------------|
|   137: Boolean _coercedValueIsSqlType (1 byte)                      |
|---------------------------------------------------------------------|
|   138: Boolean _coercedValueIsDataFeed (1 byte)                     |
|---------------------------------------------------------------------|
|   139: Boolean _sourceColumnNullMapping (1 byte)                    |
|---------------------------------------------------------------------|
|   140: Boolean _isNullable (1 byte)                                 |
|---------------------------------------------------------------------|
|   141: Boolean <HasRecievedMetadata>k__BackingField (1 byte)        |
|---------------------------------------------------------------------|
|   142: Boolean <ForceColumnEncryption>k__BackingField (1 byte)      |
|---------------------------------------------------------------------|
|   143: Boolean <SourceColumnNullMapping>k__BackingField (1 byte)    |
|---------------------------------------------------------------------|
|   144: Boolean <IsDerivedParameterTypeName>k__BackingField (1 byte) |
|---------------------------------------------------------------------|
| 145-151: padding (7 bytes)                                          |
|=====================================================================|


Type layout for 'NewSqlParameter'
Size: 136 bytes. Paddings: 0 bytes (%0 of empty space)
|===============================================|
| Object Header (8 bytes)                       |
|-----------------------------------------------|
| Method Table Ptr (8 bytes)                    |
|===============================================|
|   0-7: Object _metaType (8 bytes)             |
|-----------------------------------------------|
|  8-15: Object _collation (8 bytes)            |
|-----------------------------------------------|
| 16-23: Object _xmlSchemaCollection (8 bytes)  |
|-----------------------------------------------|
| 24-31: String _udtTypeName (8 bytes)          |
|-----------------------------------------------|
| 32-39: String _typeName (8 bytes)             |
|-----------------------------------------------|
| 40-47: Exception _udtLoadError (8 bytes)      |
|-----------------------------------------------|
| 48-55: String _parameterName (8 bytes)        |
|-----------------------------------------------|
| 56-63: Object _internalMetaType (8 bytes)     |
|-----------------------------------------------|
| 64-71: Object _sqlBufferReturnValue (8 bytes) |
|-----------------------------------------------|
| 72-79: Object _valueAsINullable (8 bytes)     |
|-----------------------------------------------|
| 80-87: Object _value (8 bytes)                |
|-----------------------------------------------|
| 88-95: Object _coercedValue (8 bytes)         |
|-----------------------------------------------|
| 96-103: Object _parent (8 bytes)              |
|-----------------------------------------------|
| 104-111: String _sourceColumn (8 bytes)       |
|-----------------------------------------------|
| 112-115: Int32 _actualSize (4 bytes)          |
|-----------------------------------------------|
| 116-119: Int32 _direction (4 bytes)           |
|-----------------------------------------------|
| 120-123: Int32 _size (4 bytes)                |
|-----------------------------------------------|
| 124-127: Int32 _offset (4 bytes)              |
|-----------------------------------------------|
| 128-131: Int32 _sourceVersion (4 bytes)       |
|-----------------------------------------------|
| 132-133: UInt16 _flags (2 bytes)              |
|-----------------------------------------------|
|   134: Byte _precision (1 byte)               |
|-----------------------------------------------|
|   135: Byte _scale (1 byte)                   |
|===============================================|
```