### PR TITLE
Update doc for SqlCommand.ColumnEncryptionSetting

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
@@ -1129,7 +1129,7 @@ The following example demonstrates the use of the <xref:Microsoft.Data.SqlClient
 		</Clone>
 		<ColumnEncryptionSetting>
 			<summary>
-				Gets or sets the column encryption setting for this command.
+				Gets the column encryption setting for this command.
 			</summary>
 			<value>
 				The column encryption setting for this command.

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
@@ -1134,9 +1134,6 @@ The following example demonstrates the use of the <xref:Microsoft.Data.SqlClient
 			<value>
 				The column encryption setting for this command.
 			</value>
-			<remarks>
-				To be added.
-			</remarks>
 		</ColumnEncryptionSetting>
 		<CommandText>
 			<summary>


### PR DESCRIPTION
The [SqlCommand.ColumnEncryptionSetting](https://docs.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlcommand.columnencryptionsetting) property has no set accessor.