### PR TITLE
Fixes corrupted connection issue when an exception occurs during RPC execution with TVP types

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -38,7 +38,7 @@
     <FunctionalTests Include="**/tools/Microsoft.DotNet.XUnitExtensions/Microsoft.DotNet.XUnitExtensions.csproj" />
     <FunctionalTests Include="**/tools/CoreFx.Private.TestUtilities/CoreFx.Private.TestUtilities.csproj" />
     <FunctionalTests Include="**/ManualTests/SQL/UdtTest/UDTs/Address/Address.csproj" />
-    <FunctionalTests Include="**/Microsoft.Data.SqlClient.Tests.csproj" />
+    <FunctionalTests Include="**/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj" />
 
     <ManualTests Condition="$(ReferenceType.Contains('NetStandard'))" Include="**/NSLibrary/Microsoft.Data.SqlClient.NSLibrary.csproj" />
     <ManualTests Include="**/ManualTests/SQL/UdtTest/UDTs/Address/Address.csproj" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -9106,13 +9106,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 catch (Exception e)
                 {
-                    if (!ADP.IsCatchableExceptionType(e))
-                    {
-                        throw;
-                    }
-
                     FailureCleanup(stateObj, e);
-
                     throw;
                 }
                 FinalizeExecuteRPC(stateObj);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -10441,14 +10441,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 catch (Exception e)
                 {
-                    // UNDONE - should not be catching all exceptions!!!
-                    if (!ADP.IsCatchableExceptionType(e))
-                    {
-                        throw;
-                    }
-
                     FailureCleanup(stateObj, e);
-
                     throw;
                 }
                 FinalizeExecuteRPC(stateObj);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.Data.SqlClient.Server;
 using Xunit;
+using System.Linq;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
@@ -80,6 +81,99 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 Console.WriteLine($"enumerator.Count={enumerator.Count}, enumerator.MaxCount={enumerator.MaxCount}, elapsed={stopwatch.Elapsed.TotalSeconds}");
             }
             Assert.True(enumerator.MaxCount == enumerator.Count);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
+        public void TestConnectionIsSafeToReuse()
+        {
+            // Force enable pooling for this test case to reproduce issue with Bad Types.
+            using (SqlConnection connection = new(DataTestUtility.TCPConnectionString + ";pooling=true;"))
+            {
+                // Bad Scenario - exception expected.
+                try
+                {
+                    List<A> list = new()
+                    {
+                        new A(0),
+                        null,
+                        new A(2),
+                        new A(3),
+                        new A(4),
+                        new A(5)
+                    };
+
+                    IEnumerable<int> Ids = list.Select(x => x.id.Value).Distinct();
+
+                    var sqlParam = new SqlParameter("ids", SqlDbType.Structured)
+                    {
+                        TypeName = "dbo.TableOfIntId",
+                        SqlValue = Ids.Select(x =>
+                        {
+                            SqlDataRecord rec = new(new[] { new SqlMetaData("Id", SqlDbType.Int) });
+                            rec.SetInt32(0, x);
+                            return rec;
+                        })
+                    };
+
+                    var parameters = new List<SqlParameter>() { sqlParam };
+                    const string SQL = @"SELECT * FROM information_schema.COLUMNS cols INNER JOIN  @ids Ids on Ids.id = cols.ORDINAL_POSITION";
+                    using SqlCommand cmd = new(SQL, connection);
+                    cmd.CommandTimeout = 100;
+                    AddCommandParameters(cmd, parameters);
+                    new SqlDataAdapter(cmd).Fill(new("BadFunc"));
+                }
+                catch
+                {
+                    // Ignore this exception as it's deliberately introduced.
+                }
+
+                // Good Scenario - No failure expected.
+                try
+                {
+                    const string SQL = @"SELECT * FROM information_schema.tables WHERE TABLE_NAME = @TableName";
+                    var parameters = new List<SqlParameter>() { new SqlParameter("@TableName", "Temp") };
+                    using SqlCommand cmd = new(SQL, connection);
+                    cmd.CommandTimeout = 100;
+                    AddCommandParameters(cmd, parameters);
+                    new SqlDataAdapter(cmd).Fill(new("GoodFunc"));
+                }
+                catch (Exception e)
+                {
+                    Assert.False(true, $"Unexpected error occurred: {e.Message}");
+                }
+            }
+        }
+
+        private class A
+        {
+            public A(int? v)
+            {
+                id = v;
+            }
+            public int? id { get; set; }
+        }
+
+        static internal void AddCommandParameters(SqlCommand command, IEnumerable parameters)
+        {
+            if (parameters == null)
+                return;
+
+            foreach (SqlParameter p in parameters)
+            {
+                if (p == null)
+                    continue;
+
+                if (p.Value == null)
+                {
+                    var clone = (SqlParameter)((ICloneable)p).Clone();
+                    clone.Value = DBNull.Value;
+                    command.Parameters.Add(clone);
+                }
+                else
+                {
+                    command.Parameters.Add(p);
+                }
+            }
         }
 
         public TvpTest()
@@ -693,7 +787,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     // allowable max-length adjustments
                     if (maxLength == resultBytes.Length)
                     {  // a bit optimistic, but what the heck.
-                        // truncation
+                       // truncation
                         if (maxLength <= source.Length)
                         {
                             returnValue = true;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
@@ -91,14 +91,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             // Bad Scenario - exception expected.
             try
             {
-                List<A> list = new()
+                List<Item> list = new()
                 {
-                    new A(0),
+                    new Item(0),
                     null,
-                    new A(2),
-                    new A(3),
-                    new A(4),
-                    new A(5)
+                    new Item(2),
+                    new Item(3),
+                    new Item(4),
+                    new Item(5)
                 };
 
                 IEnumerable<int> Ids = list.Select(x => x.id.Value).Distinct();
@@ -120,10 +120,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 cmd.CommandTimeout = 100;
                 AddCommandParameters(cmd, parameters);
                 new SqlDataAdapter(cmd).Fill(new("BadFunc"));
+                Assert.False(true, "Expected exception did not occur");
             }
-            catch
+            catch (Exception e)
             {
                 // Ignore this exception as it's deliberately introduced.
+                Assert.True(e.Message.Contains("Object reference not set to an instance of an object"), "Expected exception did not occur");
             }
 
             // Good Scenario - No failure expected.
@@ -142,9 +144,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        private class A
+        private class Item
         {
-            public A(int? v)
+            public Item(int? v)
             {
                 id = v;
             }


### PR DESCRIPTION
**Repro**
The test case added here reproduces the issue with current driver.

**Root Cause:**
Looks like call to `FailureCleanup(stateObj, e);` has been missed when exception is handled which contributes to connection corruption for future queries.

This issue also exists in all System.Data.SqlClient drivers.
cc @saurabh500 @corivera 