### PR TITLE
Control building tools separately

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -166,7 +166,3 @@ dotnet_code_quality.ca1802.api_surface = private, internal
 
 [*.cs]
 dotnet_code_quality.CA2100.excluded_type_names_with_derived_types = Microsoft.Data.SqlClient.ManualTesting.Tests.*
-[*.cs]
-dotnet_code_quality.CA2000.excluded_type_names_with_derived_types = Microsoft.Cci.* | Microsoft.Cci.Extensions.* | Microsoft.Cci.Writers.Syntax.*
-[*.cs]
-dotnet_code_quality.excluded_type_names_with_derived_types = Microsoft.Cci.* | Microsoft.Cci.Extensions.* | Microsoft.Cci.Writers.Syntax.*

--- a/.editorconfig
+++ b/.editorconfig
@@ -166,3 +166,7 @@ dotnet_code_quality.ca1802.api_surface = private, internal
 
 [*.cs]
 dotnet_code_quality.CA2100.excluded_type_names_with_derived_types = Microsoft.Data.SqlClient.ManualTesting.Tests.*
+[*.cs]
+dotnet_code_quality.CA2000.excluded_type_names_with_derived_types = Microsoft.Cci.* | Microsoft.Cci.Extensions.* | Microsoft.Cci.Writers.Syntax.*
+[*.cs]
+dotnet_code_quality.excluded_type_names_with_derived_types = Microsoft.Cci.* | Microsoft.Cci.Extensions.* | Microsoft.Cci.Writers.Syntax.*

--- a/build.proj
+++ b/build.proj
@@ -9,6 +9,8 @@
     <RestoreConfigFile>src\NuGet.config</RestoreConfigFile>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
+    <!-- Flag to control whether or not to build Microsoft.DotNet.GenAPI project in tools -->
+    <BuildTools Condition="'$(BuildTools)' == ''">true</BuildTools>
     <!-- Flag to control if Windows drivers should be built or not -->
     <IsEnabledWindows Condition="'$(IsEnabledWindows)' == '' AND '$(TargetsWindows)' == 'true'">true</IsEnabledWindows>
     <IsEnabledWindows Condition="'$(TargetsUnix)' == 'true'">false</IsEnabledWindows>
@@ -54,8 +56,8 @@
 
   <!-- Top Level Build targets -->
   <Target Name="Restore" DependsOnTargets="RestoreNetCore;RestoreNetFx" />
-  <Target Name="BuildAll" DependsOnTargets="BuildNetFx;BuildNetCore" />
-  <Target Name="BuildAllConfigurations" DependsOnTargets="Restore;BuildNetFx;BuildNetCoreAllOS;GenerateNugetPackage" />
+  <Target Name="BuildAll" DependsOnTargets="BuildTools;BuildNetFx;BuildNetCore" />
+  <Target Name="BuildAllConfigurations" DependsOnTargets="Restore;BuildTools;BuildNetFx;BuildNetCoreAllOS;GenerateNugetPackage" />
   <Target Name="BuildTestsNetCore" DependsOnTargets="RestoreTestsNetCore;BuildAKVNetCore;BuildFunctionalTestsNetCore;BuildManualTestsNetCore" />
   <Target Name="BuildTestsNetFx" DependsOnTargets="RestoreTestsNetFx;BuildAKVNetFx;BuildFunctionalTestsNetFx;BuildManualTestsNetFx;" />
 
@@ -75,6 +77,13 @@
   <Target Name="RestoreTestsNetFx">
     <MSBuild Projects="@(ManualTests)" Targets="restore" Properties="TestTargetOS=$(TestOS)netfx" />
     <MSBuild Projects="@(FunctionalTests)" Targets="restore" Properties="TestTargetOS=$(TestOS)netfx" />
+  </Target>
+
+  <Target Name="BuildTools" Condition="'$(BuildTools)' == 'true'">
+    <PropertyGroup>
+      <DotnetBuildCmd>$(DotNetCmd) dotnet build -c Release"</DotnetBuildCmd>
+    </PropertyGroup>
+    <Exec Command="$(DotnetBuildCmd)" WorkingDirectory="$(GenAPISrcDir)Microsoft.DotNet.GenAPI\" />
   </Target>
 
   <Target Name="BuildNetFx" DependsOnTargets="RestoreNetFx" Condition="'$(IsEnabledWindows)' == 'true'">

--- a/build.proj
+++ b/build.proj
@@ -79,7 +79,7 @@
     <MSBuild Projects="@(FunctionalTests)" Targets="restore" Properties="TestTargetOS=$(TestOS)netfx" />
   </Target>
 
-  <Target Name="BuildTools" Condition="'$(BuildTools)' == 'true'">
+  <Target Name="BuildTools" Condition="'$(BuildTools)' == 'true' AND '$(OSGroup)' == 'AnyOS'">
     <PropertyGroup>
       <DotnetBuildCmd>$(DotNetCmd) dotnet build -c Release"</DotnetBuildCmd>
     </PropertyGroup>

--- a/build.proj
+++ b/build.proj
@@ -56,7 +56,7 @@
 
   <!-- Top Level Build targets -->
   <Target Name="Restore" DependsOnTargets="RestoreNetCore;RestoreNetFx" />
-  <Target Name="BuildAll" DependsOnTargets="BuildTools;BuildNetFx;BuildNetCore" />
+  <Target Name="BuildAll" DependsOnTargets="BuildNetFx;BuildNetCore" />
   <Target Name="BuildAllConfigurations" DependsOnTargets="Restore;BuildTools;BuildNetFx;BuildNetCoreAllOS;GenerateNugetPackage" />
   <Target Name="BuildTestsNetCore" DependsOnTargets="RestoreTestsNetCore;BuildAKVNetCore;BuildFunctionalTestsNetCore;BuildManualTestsNetCore" />
   <Target Name="BuildTestsNetFx" DependsOnTargets="RestoreTestsNetFx;BuildAKVNetFx;BuildFunctionalTestsNetFx;BuildManualTestsNetFx;" />
@@ -79,7 +79,7 @@
     <MSBuild Projects="@(FunctionalTests)" Targets="restore" Properties="TestTargetOS=$(TestOS)netfx" />
   </Target>
 
-  <Target Name="BuildTools" Condition="'$(BuildTools)' == 'true' AND '$(OSGroup)' == 'AnyOS'">
+  <Target Name="BuildTools" Condition="'$(BuildTools)' == 'true'">
     <PropertyGroup>
       <DotnetBuildCmd>$(DotNetCmd) dotnet build -c Release"</DotnetBuildCmd>
     </PropertyGroup>

--- a/tools/targets/NotSupported.targets
+++ b/tools/targets/NotSupported.targets
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <PropertyGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
@@ -9,7 +8,6 @@
     <!-- Not supported sources are created from the ref assembly, we currently don't produce finalizers in dummmy assemblies, so we disable ApiCompat to not fail. -->
     <RunApiCompat>false</RunApiCompat>
     <GenerateDocumentationFile Condition="'$(OSGroup)' != 'Windows_NT'">false</GenerateDocumentationFile>
-    <BuildTools Condition="'$(BuildTools)' == ''">true</BuildTools>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
@@ -22,7 +20,6 @@
        Inputs:
          * A contract assembly
          * Reference assemblies
-
        Generates source for the contract that throws PlatformNotSupportedException
   -->
   <Target Name="GenerateNotSupportedSource"
@@ -43,17 +40,12 @@
       <GenAPIArgs>"%(ResolvedMatchingContract.Identity)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -l:"@(_referencePathDirectories)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -o:"$(NotSupportedSourceFile)"</GenAPIArgs>
-      <DotnetBuildCmd>$(DotNetCmd) dotnet build -c Release"</DotnetBuildCmd>
       <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(GenAPIArgs) -t:"$(GeneratePlatformNotSupportedAssemblyMessage)"</GenAPIArgs>
       <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssemblyWithGlobalPrefix)' == 'true'">$(GenAPIArgs) -global</GenAPIArgs>
       <GenAPIPath Condition="'$(MSBuildRuntimeType)' == 'core'"> "$(DotNetCmd) $(ToolsArtifactsDir)netcoreapp2.1\Microsoft.DotNet.GenAPI.dll"</GenAPIPath>
       <GenAPIPath Condition="'$(MSBuildRuntimeType)' != 'core'"> "$(ToolsArtifactsDir)net472\Microsoft.DotNet.GenAPI.exe"</GenAPIPath>
     </PropertyGroup>
-    <Message Condition="'$(BuildTools)' != 'true'" Text="Skip building tools." />
-
-    <Exec Command="$(DotnetBuildCmd)" WorkingDirectory="$(GenAPISrcDir)Microsoft.DotNet.GenAPI\" Condition="'$(BuildTools)' == 'true'" />
-    <Exec Command="$(GenAPIPath) $(GenAPIArgs)" WorkingDirectory="$(ToolRuntimePath)" Condition="'$(BuildTools)' == 'true'" />
-
+    <Exec Command="$(GenAPIPath) $(GenAPIArgs)" WorkingDirectory="$(ToolRuntimePath)"/>
     <ItemGroup>
       <FileWrites Include="$(NotSupportedSourceFile)" />
       <Compile Include="$(NotSupportedSourceFile)" />

--- a/tools/targets/NotSupported.targets
+++ b/tools/targets/NotSupported.targets
@@ -9,6 +9,7 @@
     <!-- Not supported sources are created from the ref assembly, we currently don't produce finalizers in dummmy assemblies, so we disable ApiCompat to not fail. -->
     <RunApiCompat>false</RunApiCompat>
     <GenerateDocumentationFile Condition="'$(OSGroup)' != 'Windows_NT'">false</GenerateDocumentationFile>
+    <BuildTools Condition="'$(BuildTools)' == ''">true</BuildTools>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
@@ -48,11 +49,12 @@
       <GenAPIPath Condition="'$(MSBuildRuntimeType)' == 'core'"> "$(DotNetCmd) $(ToolsArtifactsDir)netcoreapp2.1\Microsoft.DotNet.GenAPI.dll"</GenAPIPath>
       <GenAPIPath Condition="'$(MSBuildRuntimeType)' != 'core'"> "$(ToolsArtifactsDir)net472\Microsoft.DotNet.GenAPI.exe"</GenAPIPath>
     </PropertyGroup>
+    <message Condition="'$(BuildTools)' != 'true'" Text="Skip building tools." />
 
-    <Exec Command="$(DotnetBuildCmd)" WorkingDirectory="$(GenAPISrcDir)Microsoft.DotNet.GenAPI\" />
-    <Exec Command="$(GenAPIPath) $(GenAPIArgs)" WorkingDirectory="$(ToolRuntimePath)" />
+    <Exec Command="$(DotnetBuildCmd)" WorkingDirectory="$(GenAPISrcDir)Microsoft.DotNet.GenAPI\" Condition="'$(BuildTools)' == 'true'" />
+    <Exec Command="$(GenAPIPath) $(GenAPIArgs)" WorkingDirectory="$(ToolRuntimePath)" Condition="'$(BuildTools)' == 'true'" />
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(BuildTools)' == 'true'">
       <FileWrites Include="$(NotSupportedSourceFile)" />
       <Compile Include="$(NotSupportedSourceFile)" />
     </ItemGroup>

--- a/tools/targets/NotSupported.targets
+++ b/tools/targets/NotSupported.targets
@@ -49,12 +49,12 @@
       <GenAPIPath Condition="'$(MSBuildRuntimeType)' == 'core'"> "$(DotNetCmd) $(ToolsArtifactsDir)netcoreapp2.1\Microsoft.DotNet.GenAPI.dll"</GenAPIPath>
       <GenAPIPath Condition="'$(MSBuildRuntimeType)' != 'core'"> "$(ToolsArtifactsDir)net472\Microsoft.DotNet.GenAPI.exe"</GenAPIPath>
     </PropertyGroup>
-    <message Condition="'$(BuildTools)' != 'true'" Text="Skip building tools." />
+    <Message Condition="'$(BuildTools)' != 'true'" Text="Skip building tools." />
 
     <Exec Command="$(DotnetBuildCmd)" WorkingDirectory="$(GenAPISrcDir)Microsoft.DotNet.GenAPI\" Condition="'$(BuildTools)' == 'true'" />
     <Exec Command="$(GenAPIPath) $(GenAPIArgs)" WorkingDirectory="$(ToolRuntimePath)" Condition="'$(BuildTools)' == 'true'" />
 
-    <ItemGroup Condition="'$(BuildTools)' == 'true'">
+    <ItemGroup>
       <FileWrites Include="$(NotSupportedSourceFile)" />
       <Compile Include="$(NotSupportedSourceFile)" />
     </ItemGroup>


### PR DESCRIPTION
- Introducing `BuildTools`=`true`/`false` property with default value `true`.
- The build process builds tools if `BuildTools`=`true`, otherwise will skip it.

Steps to build Only tools separately:
```cmd
msbuild /t:BuildTools
msbuild /p:BuildTools=false
```

Or build normally:
```cmd
msbuild
```

> NOTE: 
> Running build with **/p:BuildTools=false** on a clean source code or right after running by **/t:clean** is not acceptable and will face a `file could not found` exception. You can use this property just in case when build's happened with **BuildTools=true** before or it's run with `/t:BuildTools` target.