### PR TITLE
Set ColumnEncryptionKeyCacheTtl to zero when key store provider is registered and used globally

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -98,8 +98,6 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         private static IReadOnlyDictionary<string, SqlColumnEncryptionKeyStoreProvider> s_globalCustomColumnEncryptionKeyStoreProviders;
 
-        private static string s_akvProviderName = "AZURE_KEY_VAULT";
-
         /// <summary>
         /// Dictionary object holding trusted key paths for various SQL Servers.
         /// Key to the dictionary is a SQL Server Name

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -314,9 +314,10 @@ namespace Microsoft.Data.SqlClient
                     throw SQL.CanOnlyCallOnce();
                 }
 
-                if (customProviders.ContainsKey(s_akvProviderName))
+                // to prevent conflicts between CEK caches, global providers should not use their own CEK caches
+                foreach (SqlColumnEncryptionKeyStoreProvider provider in customProviders.Values)
                 {
-                    customProviders[s_akvProviderName].ColumnEncryptionKeyCacheTtl = new TimeSpan(0);
+                    provider.ColumnEncryptionKeyCacheTtl = new TimeSpan(0);
                 }
 
                 // Create a temporary dictionary and then add items from the provided dictionary.

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -149,9 +149,10 @@ namespace Microsoft.Data.SqlClient
                     throw SQL.CanOnlyCallOnce();
                 }
 
-                if (customProviders.ContainsKey(s_akvProviderName))
+                // to prevent conflicts between CEK caches, global providers should not use their own CEK caches
+                foreach (SqlColumnEncryptionKeyStoreProvider provider in customProviders.Values)
                 {
-                    customProviders[s_akvProviderName].ColumnEncryptionKeyCacheTtl = new TimeSpan(0);
+                    provider.ColumnEncryptionKeyCacheTtl = new TimeSpan(0);
                 }
 
                 // Create a temporary dictionary and then add items from the provided dictionary.

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -67,8 +67,6 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         private static IReadOnlyDictionary<string, SqlColumnEncryptionKeyStoreProvider> s_globalCustomColumnEncryptionKeyStoreProviders;
 
-        private static string s_akvProviderName = "AZURE_KEY_VAULT";
-
         /// Instance-level list of custom key store providers. It can be set more than once by the user.
         private IReadOnlyDictionary<string, SqlColumnEncryptionKeyStoreProvider> _customColumnEncryptionKeyStoreProviders;
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs
@@ -74,6 +74,8 @@ namespace Microsoft.Data.SqlClient
                 byte[] plaintextKey;
                 try
                 {
+                    // to prevent conflicts between CEK caches, global providers should not use their own CEK caches
+                    provider.ColumnEncryptionKeyCacheTtl = new TimeSpan(0);
                     plaintextKey = provider.DecryptColumnEncryptionKey(keyInfo.keyPath, keyInfo.algorithmName, keyInfo.encryptedKey);
                 }
                 catch (Exception e)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVUnitTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVUnitTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAKVSetupAvailable))]
-        public static void CekCacheShouldBeDisabledWhenAkvProviderIsRegisteredGlobally()
+        public static void CekCacheShouldBeDisabledWhenCustomProviderIsRegisteredGlobally()
         {
             if (SQLSetupStrategyAzureKeyVault.IsAKVProviderRegistered)
             {


### PR DESCRIPTION
When a provider is registered globally, its `ColumnEncryptionKeyCacheTtl` property should be set to zero. Before decrypting with a global provider, the property will again be set to zero. Any CEK caching implementation should check this value before caching CEKs and not cache if the value is zero. A globally registered provider should only use the global CEK cache in the driver.