### PR TITLE
Avoid executing sp_describe_parameter_encryption when an enclave query does not have any parameters

### DIFF
--- a/doc/samples/AzureKeyVaultProviderExample_2_0.cs
+++ b/doc/samples/AzureKeyVaultProviderExample_2_0.cs
@@ -242,7 +242,5 @@ namespace Microsoft.Data.SqlClient.Samples
             }
         }
     }
-
-    //</Snippet1>
-
 }
+//</Snippet1>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -3854,7 +3854,7 @@ namespace Microsoft.Data.SqlClient
                                 "The number of decribe parameter encryption RPC requests is more than the number of original RPC requests.");
             }
             //Always Encrypted generally operates only on parameterized queries. However enclave based Always encrypted also supports unparameterized queries
-            else if (ShouldUseEnclaveBasedWorkflow && (0 != GetParameterCount(_parameters)))
+            else if ((ShouldUseEnclaveBasedWorkflow && 0 != GetParameterCount(_parameters)) || (0 != GetParameterCount(_parameters)))
             {
                 // Fetch params for a single batch
                 inputParameterEncryptionNeeded = true;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -3854,7 +3854,7 @@ namespace Microsoft.Data.SqlClient
                                 "The number of decribe parameter encryption RPC requests is more than the number of original RPC requests.");
             }
             //Always Encrypted generally operates only on parameterized queries. However enclave based Always encrypted also supports unparameterized queries
-            else if (ShouldUseEnclaveBasedWorkflow || (0 != GetParameterCount(_parameters)))
+            else if (ShouldUseEnclaveBasedWorkflow && (0 != GetParameterCount(_parameters)))
             {
                 // Fetch params for a single batch
                 inputParameterEncryptionNeeded = true;


### PR DESCRIPTION
Fixes [#1105 ](https://github.com/dotnet/SqlClient/issues/1105)

The exception occurs because even when no input parameters are provided, the driver tries to execute `sp_describe_parameter_encryption`.

Current behaviour:

When executing a stored procedure that does not require an input parameter:

- Always encrypted: 
succeeds without executing 'sp_describe_parameter_encryption'
- Always encrypted with secure enclaves: 
**unexpected: fails with NRE. Driver attempts to add parameters to execute `sp_describe_parameter_encryption` but parameters are null and not required. Should succeed like above without attempting to execute `sp_describe_parameter_encryption`**


When executing a stored procedure that requires an input parameter but none are provided by the user:

- Always encrypted: 
fails with error `Microsoft.Data.SqlClient.SqlException (0x80131904): Procedure or function '[name of sp]' expects parameter '@[name of param]', which was not supplied.`
- Always encrypted with secure enclaves: 
**unexpected: fails with NRE. Driver attempts to add parameters to execute `sp_describe_parameter_encryption` but parameters are null. Should fail with same exception above**


This change fixes both unexpected behaviours above.