### PR TITLE
Fix EntryPointNotFoundException in InOutOfProcHelper constructor

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading;
@@ -358,6 +359,12 @@ namespace Microsoft.Data.SqlClient
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
         private InOutOfProcHelper()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // SafeNativeMethods.GetModuleHandle calls into kernel32.dll, so return early to avoid
+                // a System.EntryPointNotFoundException on non-Windows platforms, e.g. Mono.
+                return;
+            }
             // Don't need to close this handle...
             // SxS: we use this method to check if we are running inside the SQL Server process. This call should be safe in SxS environment.
             IntPtr handle = SafeNativeMethods.GetModuleHandle(null);

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -35,6 +35,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
         <dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Compile" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
       </group>
       <group targetFramework="netcoreapp2.1">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="3.0.0" exclude="Compile" />


### PR DESCRIPTION
The constructor of InOutOfProcHelper would throw a `System.EntryPointNotFoundException` when running on a non-Windows platform such as Mono on Linux or macOS:

```
GetModuleHandle assembly:<unknown assembly> type:<unknown type> member:(null)
  at (wrapper managed-to-native) Microsoft.Data.Common.SafeNativeMethods.GetModuleHandle(string)
  at Microsoft.Data.SqlClient.InOutOfProcHelper..ctor () [0x00006] in <de6019a43b5544ecb987a2a77d294ad3>:0
  at Microsoft.Data.SqlClient.InOutOfProcHelper..cctor () [0x00000] in <de6019a43b5544ecb987a2a77d294ad3>:0
```

We avoid the EntryPointNotFoundException by returning early on non-Windows platforms where the module can't be inside the SQL Server process anyway.