### PR TITLE
Change WeakReference to WeakReference<T>

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Data.ProviderBase
                             // this is safe since we're about to dispose the
                             // object and it won't have an owner after that for
                             // certain.
-                            _owningObject.Target = null;
+                            _owningObject.SetTarget(null);
 
                             if (IsTransactionRoot)
                             {
@@ -359,7 +359,7 @@ namespace Microsoft.Data.ProviderBase
                 }
                 pool.PutObjectFromTransactedPool(this);
             }
-            else if (-1 == _pooledCount && !_owningObject.IsAlive)
+            else if (-1 == _pooledCount && !_owningObject.TryGetTarget(out DbConnection _))
             {
                 // When _pooledCount is -1 and the owning object no longer exists,
                 // it indicates a closed (or leaked), non-pooled connection so 


### PR DESCRIPTION
Reading https://github.com/dotnet/SqlClient/issues/1121 I remembered that we're using `WeakReference` and not `WeakReference<T>`, the generic version has a different api shape using `bool isAlive = TryGetTarget(out T target)`  to prevent the possibility of a GC between `IsAlive` and `Target` property accesses. Note that `TryGetTarget` returns false for null which is why some null checks are no longer needed.