### PR TITLE
WIP | Fixing issue with ignoreSniOpenTimeout in NetCore

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1521,7 +1521,7 @@ namespace Microsoft.Data.SqlClient
                     AttemptOneLogin(serverInfo,
                                     newPassword,
                                     newSecurePassword,
-                                    !connectionOptions.MultiSubnetFailover,    // ignore timeout for SniOpen call unless MSF
+                                    connectionOptions.MultiSubnetFailover,
                                     connectionOptions.MultiSubnetFailover ? intervalTimer : timeout);
 
                     if (connectionOptions.MultiSubnetFailover && null != ServerProvidedFailOverPartner)
@@ -2632,7 +2632,7 @@ namespace Microsoft.Data.SqlClient
                         Debug.Assert(_tceVersionSupported <= TdsEnums.MAX_SUPPORTED_TCE_VERSION, "Client support TCE version 2");
                         _parser.IsColumnEncryptionSupported = true;
                         _parser.TceVersionSupported = _tceVersionSupported;
-                        _parser.AreEnclaveRetriesSupported = _tceVersionSupported == 3; 
+                        _parser.AreEnclaveRetriesSupported = _tceVersionSupported == 3;
 
                         if (data.Length > 1)
                         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1967,7 +1967,7 @@ namespace Microsoft.Data.SqlClient
 
         private bool ShouldDisableTnir(SqlConnectionString connectionOptions)
         {
-            var isAzureEndPoint = ADP.IsAzureSqlServerEndpoint(connectionOptions.DataSource);
+            bool isAzureEndPoint = ADP.IsAzureSqlServerEndpoint(connectionOptions.DataSource);
 
             bool isFedAuthEnabled = this._accessTokenInBytes != null ||
                                        connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryPassword ||

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -983,7 +983,7 @@ namespace Microsoft.Data.SqlClient
                 tdsReliabilitySection.Start();
 #endif //DEBUG
 
-            isAlive = _parser._physicalStateObj.IsConnectionAlive(throwOnException);
+                isAlive = _parser._physicalStateObj.IsConnectionAlive(throwOnException);
 
 #if DEBUG
             }
@@ -1759,11 +1759,11 @@ namespace Microsoft.Data.SqlClient
 
             ResolveExtendedServerName(serverInfo, !redirectedUserInstance, connectionOptions);
 
-            Boolean disableTnir = ShouldDisableTnir(connectionOptions);
+            bool disableTnir = ShouldDisableTnir(connectionOptions);
 
             long timeoutUnitInterval = 0;
 
-            Boolean isParallel = connectionOptions.MultiSubnetFailover || (connectionOptions.TransparentNetworkIPResolution && !disableTnir);
+            bool isParallel = connectionOptions.MultiSubnetFailover || (connectionOptions.TransparentNetworkIPResolution && !disableTnir);
 
 
             if (isParallel)
@@ -1795,7 +1795,7 @@ namespace Microsoft.Data.SqlClient
             while (true)
             {
 
-                Boolean isFirstTransparentAttempt = connectionOptions.TransparentNetworkIPResolution && !disableTnir && attemptNumber == 1;
+                var isFirstTransparentAttempt = connectionOptions.TransparentNetworkIPResolution && !disableTnir && attemptNumber == 1;
 
                 if (isParallel)
                 {
@@ -1967,9 +1967,9 @@ namespace Microsoft.Data.SqlClient
 
         private bool ShouldDisableTnir(SqlConnectionString connectionOptions)
         {
-            Boolean isAzureEndPoint = ADP.IsAzureSqlServerEndpoint(connectionOptions.DataSource);
+            var isAzureEndPoint = ADP.IsAzureSqlServerEndpoint(connectionOptions.DataSource);
 
-            Boolean isFedAuthEnabled = this._accessTokenInBytes != null ||
+            bool isFedAuthEnabled = this._accessTokenInBytes != null ||
                                        connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryPassword ||
                                        connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryIntegrated ||
                                        connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryInteractive ||
@@ -2378,18 +2378,18 @@ namespace Microsoft.Data.SqlClient
                     {
                         tdsReliabilitySection.Start();
 #endif //DEBUG
-                    Task reconnectTask = parent.ValidateAndReconnect(() =>
-                    {
-                        ThreadHasParserLockForClose = false;
-                        _parserLock.Release();
-                        releaseConnectionLock = false;
-                    }, timeout);
-                    if (reconnectTask != null)
-                    {
-                        AsyncHelper.WaitForCompletion(reconnectTask, timeout);
-                        return true;
-                    }
-                    return false;
+                        Task reconnectTask = parent.ValidateAndReconnect(() =>
+                        {
+                            ThreadHasParserLockForClose = false;
+                            _parserLock.Release();
+                            releaseConnectionLock = false;
+                        }, timeout);
+                        if (reconnectTask != null)
+                        {
+                            AsyncHelper.WaitForCompletion(reconnectTask, timeout);
+                            return true;
+                        }
+                        return false;
 #if DEBUG
                     }
                     finally

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1795,7 +1795,7 @@ namespace Microsoft.Data.SqlClient
             while (true)
             {
 
-                var isFirstTransparentAttempt = connectionOptions.TransparentNetworkIPResolution && !disableTnir && attemptNumber == 1;
+                bool isFirstTransparentAttempt = connectionOptions.TransparentNetworkIPResolution && !disableTnir && attemptNumber == 1;
 
                 if (isParallel)
                 {


### PR DESCRIPTION
While working on #1126  I noticed in NetFx:

SqlInternalConnectionTds at line 1762 and 1766
```
Boolean disableTnir = ShouldDisableTnir(connectionOptions); 
Boolean isParallel = connectionOptions.MultiSubnetFailover || (connectionOptions.TransparentNetworkIPResolution && !disableTnir);
```

Basically, `isParallel` is mostly coming true if we do not disable `TransparentNetworkIPResolution` default value.
further in the code, we attemp  `AttemptOneLogin` we pass the value for bool` ignoreSniOpenTimeout` as `!isParallel` comes to false and in result when we get to `TdsParserSafeHandles` we ignore the part for `timeout = Timeout.Infinite;`

However, in Net Core since there is no `TransparentNetworkIPResolution` we only check for `connectionOptions.MultiSubnetFailover  `and by sending `!connectionOptions.MultiSubnetFailover ` we set the timeout to `Timeout.Infinite`. This will cause the expected exception  not to happen even if the connection timeout is set to some values lower than 15 seconds.



I am looking for tests to add as this needs to stop SqlServices as the repro suggests.


Changes in NetFx are only some simplifications as I was looking into them.