### PR TITLE
Update CannotCreateNormalize resource name in resource files

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.de.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.de.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>Die Unterklasse hat keine erforderliche Methode überschrieben.</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>Die Normalisierungsfunktion für '{0}' kann nicht erstellt werden.</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.es.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.es.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>La subclase no invalidó un método requerido.</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>No se puede crear un normalizador para '{0}'.</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.fr.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.fr.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>La sous-classe n'a pas substituée une méthode requise.</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>Impossible de créer un normaliseur pour '{0}'.</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.it.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.it.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>La sottoclasse non ha eseguito l'override di un metodo di richiesta.</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>Impossibile creare un normalizzatore per '{0}'.</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.ja.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.ja.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>サブクラスが、必要なメソッドをオーバーライドしませんでした。</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>'{0}' のノーマライザーを作成できません。</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.ko.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.ko.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>서브클래스에서 필요한 메서드를 재정의하지 않았습니다.</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>'{0}'에 대한 노멀라이저를 만들 수 없습니다.</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.pt-BR.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.pt-BR.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>A subclasse não substituiu um método necessário.</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>Não é possível criar o normalizador para '{0}'.</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>Subclass did not override a required method.</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>Cannot create normalizer for '{0}'.</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.ru.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.ru.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>Подклассы не переопределяют необходимый метод.</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>Не удается создать нормализатор для "{0}".</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.zh-Hans.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.zh-Hans.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>子类未覆盖所需方法。</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>无法为“{0}”创建标准化程序。</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.zh-Hant.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.zh-Hant.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>子類別並未覆寫所需的方法。</value>
   </data>
-  <data name="Sql_CanotCreateNormalizer" xml:space="preserve">
+  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
     <value>無法建立 '{0}' 的正規器。</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">


### PR DESCRIPTION
In https://github.com/dotnet/SqlClient/pull/1041 I noticed a CI error https://github.com/dotnet/SqlClient/pull/1041/checks?check_run_id=2889045989 which indicates that a string resource can't be found. This is an update from https://github.com/dotnet/SqlClient/pull/1057 which changed the name from `Sql_CanotCreateNormalizer` to `SQL_CannotCreateNormalizer` but these seem to have been reverted at some point since. This PR just makes sure the incorrect version no longer exists in the project.

Can we get this reviewed and merged asap to prevent CI problems affecting other PRs? @cheenamalhotra 