### PR TITLE
FIX | Strings.resx in netfx

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.resx
@@ -3048,7 +3048,7 @@
   <data name="SqlMisc_SubclassMustOverride" xml:space="preserve">
     <value>Subclass did not override a required method.</value>
   </data>
-  <data name="Sql_CannotCreateNormalizer" xml:space="preserve">
+  <data name="SQL_CannotCreateNormalizer" xml:space="preserve">
     <value>Cannot create normalizer for '{0}'.</value>
   </data>
   <data name="Sql_InternalError" xml:space="preserve">


### PR DESCRIPTION
While working on a different matter had some complication to build the driver after adding new values to `strings.resx` in `netcore`. It took me a while to find out the source of issue was coming  from the difference between `SQL_CannotCreateNormalizer` in netcore and `Sql_CannotCreateNormalizer` in netfx. 