### PR TITLE
Update keyword count and synonym count after removing Asynchronous Processing property

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Data.SqlClient
 #else
         internal const int SynonymCount = 25;
 #endif
-        internal const int DeprecatedSynonymCount = 3;
+        internal const int DeprecatedSynonymCount = 2;
 
         internal enum TypeSystem
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         internal const int KeywordsCount = (int)Keywords.KeywordsCount;
-        internal const int DeprecatedKeywordsCount = 4;
+        internal const int DeprecatedKeywordsCount = 3;
 
         private static readonly string[] s_validKeywords = CreateValidKeywords();
         private static readonly Dictionary<string, Keywords> s_keywords = CreateKeywordsDictionary();

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -125,7 +125,6 @@ namespace Microsoft.Data.SqlClient
             internal const string APPLICATIONINTENT = "applicationintent";
             // application name
             internal const string APP = "app";
-            internal const string Async = "async";
             // attachDBFilename
             internal const string EXTENDED_PROPERTIES = "extended properties";
             internal const string INITIAL_FILE_NAME = "initial file name";
@@ -175,7 +174,7 @@ namespace Microsoft.Data.SqlClient
             // make sure to update SynonymCount value below when adding or removing synonyms
         }
 
-        internal const int SynonymCount = 30;
+        internal const int SynonymCount = 29;
 
         // the following are all inserted as keys into the _netlibMapping hash
         internal static class NETLIB


### PR DESCRIPTION
`Debug.Assert()` failing in [netcore](https://github.com/dotnet/SqlClient/blob/ac43fa454813bae45d4caea6b4091b65cd3a7c06/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionString.cs#L731) and [netfx](https://github.com/dotnet/SqlClient/blob/ac43fa454813bae45d4caea6b4091b65cd3a7c06/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionString.cs#L866).


