### PR TITLE
FIX | DbType when it is set to Time in SqlEnums

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlEnums.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Data.SqlClient
                 case DbType.StringFixedLength:
                     return s_metaNChar;
                 case DbType.Time:
-                    return MetaTime;
+                    return s_metaDateTime;
                 case DbType.Xml:
                     return MetaXml;
                 case DbType.DateTime2:

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlEnums.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Data.SqlClient
                 case DbType.StringFixedLength:
                     return MetaNChar;
                 case DbType.Time:
-                    return MetaTime;
+                    return MetaDateTime;
                 case DbType.Xml:
                     return MetaXml;
                 case DbType.DateTime2:


### PR DESCRIPTION
Fixes #1164

Looks like an oversight porting from SDS. When DBType is set to Time SDS is behaving differently than MDS. MDS acts same as `SqlDbType` whereas in `SqlEnums` There are two different methods `GetMetaTypeFromDbType` and `GetMetaTypeFromSqlDbType` changing the Switch statement in `GetMetaTypeFromDbType` to same as SDS solved the issue.