### PR TITLE
Document difference in DateTime vs TimeSpan value for DbType.Time parameter

### DIFF
--- a/porting-cheat-sheet.md
+++ b/porting-cheat-sheet.md
@@ -36,6 +36,7 @@ For .NET Framework projects it may be necessary to include the following in your
 | System.Data.SqlClient | Microsoft.Data.SqlClient |
 |--|--|
 | Can use DateTime object as value for SqlParameter with type `DbType.Time`. | Must use TimeSpan object as value for SqlParameter with type `DbType.Time`. |
+| Using DateTime object as value for SqlParameter with type `DbType.Date` would send date and time to SQL Server. | DateTime object's time components will be truncated when sent to SQL Server using `DbType.Date`. |
 
 ## Contribute to this Cheat Sheet
 

--- a/porting-cheat-sheet.md
+++ b/porting-cheat-sheet.md
@@ -31,6 +31,12 @@ For .NET Framework projects it may be necessary to include the following in your
 </configuration>
 ```
 
+## Functionality Changes
+
+| System.Data.SqlClient | Microsoft.Data.SqlClient |
+|--|--|
+| Can use DateTime object as value for SqlParameter with type `DbType.Time`. | Must use TimeSpan object as value for SqlParameter with type `DbType.Time`. |
+
 ## Contribute to this Cheat Sheet
 
 We would love the SqlClient community to help enhance this cheat sheet by contributing experiences and challenges faced when porting their applications.


### PR DESCRIPTION
Added the only difference in functionality I've found so far, from #1164.