### PR TITLE
Simplify event tracing

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -49,8 +49,7 @@ namespace Microsoft.Data.ProviderBase
 
         public void ClearAllPools()
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<prov.DbConnectionFactory.ClearAllPools|API");
-            try
+            using (TryEventScope.Create("<prov.DbConnectionFactory.ClearAllPools|API"))
             {
                 Dictionary<DbConnectionPoolKey, DbConnectionPoolGroup> connectionPoolGroups = _connectionPoolGroups;
                 foreach (KeyValuePair<DbConnectionPoolKey, DbConnectionPoolGroup> entry in connectionPoolGroups)
@@ -62,17 +61,12 @@ namespace Microsoft.Data.ProviderBase
                     }
                 }
             }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-            }
         }
 
         public void ClearPool(DbConnection connection)
         {
             ADP.CheckArgumentNull(connection, nameof(connection));
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<prov.DbConnectionFactory.ClearPool|API> {0}", GetObjectId(connection));
-            try
+            using (TryEventScope.Create("<prov.DbConnectionFactory.ClearPool|API> {0}", GetObjectId(connection)))
             {
                 DbConnectionPoolGroup poolGroup = GetConnectionPoolGroup(connection);
                 if (null != poolGroup)
@@ -80,29 +74,19 @@ namespace Microsoft.Data.ProviderBase
                     poolGroup.Clear();
                 }
             }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-            }
         }
 
         public void ClearPool(DbConnectionPoolKey key)
         {
             Debug.Assert(key != null, "key cannot be null");
             ADP.CheckArgumentNull(key.ConnectionString, nameof(key) + "." + nameof(key.ConnectionString));
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<prov.DbConnectionFactory.ClearPool|API> connectionString");
-            try
+            using (TryEventScope.Create("<prov.DbConnectionFactory.ClearPool|API> connectionString"))
             {
-                DbConnectionPoolGroup poolGroup;
                 Dictionary<DbConnectionPoolKey, DbConnectionPoolGroup> connectionPoolGroups = _connectionPoolGroups;
-                if (connectionPoolGroups.TryGetValue(key, out poolGroup))
+                if (connectionPoolGroups.TryGetValue(key, out DbConnectionPoolGroup poolGroup))
                 {
                     poolGroup.Clear();
                 }
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -792,67 +792,68 @@ namespace Microsoft.Data.SqlClient
             _pendingCancel = false;
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlCommand.Prepare | API | Object Id {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.Prepare | API | Correlation | Object Id {0}, ActivityID {1}, Client Connection Id {2}", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId);
-            try
+            using (TryEventScope.Create("SqlCommand.Prepare | API | Object Id {0}", ObjectID))
             {
-                statistics = SqlStatistics.StartTimer(Statistics);
-
-                // only prepare if batch with parameters
-                if (this.IsPrepared && !this.IsDirty
-                    || (this.CommandType == CommandType.StoredProcedure)
-                    || ((System.Data.CommandType.Text == this.CommandType)
-                            && (0 == GetParameterCount(_parameters))))
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.Prepare | API | Correlation | Object Id {0}, ActivityID {1}, Client Connection Id {2}", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId);
+                try
                 {
-                    if (null != Statistics)
-                    {
-                        Statistics.SafeIncrement(ref Statistics._prepares);
-                    }
-                    _hiddenPrepare = false;
-                }
-                else
-                {
-                    // Validate the command outside of the try/catch to avoid putting the _stateObj on error
-                    ValidateCommand(isAsync: false);
+                    statistics = SqlStatistics.StartTimer(Statistics);
 
-                    bool processFinallyBlock = true;
-                    try
+                    // only prepare if batch with parameters
+                    if (this.IsPrepared && !this.IsDirty
+                        || (this.CommandType == CommandType.StoredProcedure)
+                        || ((System.Data.CommandType.Text == this.CommandType)
+                                && (0 == GetParameterCount(_parameters))))
                     {
-                        // NOTE: The state object isn't actually needed for this, but it is still here for back-compat (since it does a bunch of checks)
-                        GetStateObject();
-
-                        // Loop through parameters ensuring that we do not have unspecified types, sizes, scales, or precisions
-                        if (null != _parameters)
+                        if (null != Statistics)
                         {
-                            int count = _parameters.Count;
-                            for (int i = 0; i < count; ++i)
+                            Statistics.SafeIncrement(ref Statistics._prepares);
+                        }
+                        _hiddenPrepare = false;
+                    }
+                    else
+                    {
+                        // Validate the command outside of the try/catch to avoid putting the _stateObj on error
+                        ValidateCommand(isAsync: false);
+
+                        bool processFinallyBlock = true;
+                        try
+                        {
+                            // NOTE: The state object isn't actually needed for this, but it is still here for back-compat (since it does a bunch of checks)
+                            GetStateObject();
+
+                            // Loop through parameters ensuring that we do not have unspecified types, sizes, scales, or precisions
+                            if (null != _parameters)
                             {
-                                _parameters[i].Prepare(this);
+                                int count = _parameters.Count;
+                                for (int i = 0; i < count; ++i)
+                                {
+                                    _parameters[i].Prepare(this);
+                                }
+                            }
+
+                            InternalPrepare();
+                        }
+                        catch (Exception e)
+                        {
+                            processFinallyBlock = ADP.IsCatchableExceptionType(e);
+                            throw;
+                        }
+                        finally
+                        {
+                            if (processFinallyBlock)
+                            {
+                                _hiddenPrepare = false; // The command is now officially prepared
+
+                                ReliablePutStateObject();
                             }
                         }
-
-                        InternalPrepare();
-                    }
-                    catch (Exception e)
-                    {
-                        processFinallyBlock = ADP.IsCatchableExceptionType(e);
-                        throw;
-                    }
-                    finally
-                    {
-                        if (processFinallyBlock)
-                        {
-                            _hiddenPrepare = false; // The command is now officially prepared
-
-                            ReliablePutStateObject();
-                        }
                     }
                 }
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                }
             }
         }
 
@@ -915,86 +916,87 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Cancel/*'/>
         public override void Cancel()
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlCommand.Cancel | API | Object Id {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.Cancel | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
-
-            SqlStatistics statistics = null;
-            try
+            using (TryEventScope.Create("SqlCommand.Cancel | API | Object Id {0}", ObjectID))
             {
-                statistics = SqlStatistics.StartTimer(Statistics);
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.Cancel | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
 
-                // If we are in reconnect phase simply cancel the waiting task
-                var reconnectCompletionSource = _reconnectionCompletionSource;
-                if (reconnectCompletionSource != null)
+                SqlStatistics statistics = null;
+                try
                 {
-                    if (reconnectCompletionSource.TrySetCanceled())
+                    statistics = SqlStatistics.StartTimer(Statistics);
+
+                    // If we are in reconnect phase simply cancel the waiting task
+                    var reconnectCompletionSource = _reconnectionCompletionSource;
+                    if (reconnectCompletionSource != null)
                     {
-                        return;
-                    }
-                }
-
-                // the pending data flag means that we are awaiting a response or are in the middle of processing a response
-                // if we have no pending data, then there is nothing to cancel
-                // if we have pending data, but it is not a result of this command, then we don't cancel either.  Note that
-                // this model is implementable because we only allow one active command at any one time.  This code
-                // will have to change we allow multiple outstanding batches
-                if (null == _activeConnection)
-                {
-                    return;
-                }
-                SqlInternalConnectionTds connection = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
-                if (null == connection)
-                {  // Fail with out locking
-                    return;
-                }
-
-                // The lock here is to protect against the command.cancel / connection.close race condition
-                // The SqlInternalConnectionTds is set to OpenBusy during close, once this happens the cast below will fail and
-                // the command will no longer be cancelable.  It might be desirable to be able to cancel the close operation, but this is
-                // outside of the scope of Whidbey RTM.  See (SqlConnection::Close) for other lock.
-                lock (connection)
-                {
-                    if (connection != (_activeConnection.InnerConnection as SqlInternalConnectionTds))
-                    { // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
-                        return;
-                    }
-
-                    TdsParser parser = connection.Parser;
-                    if (null == parser)
-                    {
-                        return;
-                    }
-
-
-                    if (!_pendingCancel)
-                    { // Do nothing if already pending.
-                      // Before attempting actual cancel, set the _pendingCancel flag to false.
-                      // This denotes to other thread before obtaining stateObject from the
-                      // session pool that there is another thread wishing to cancel.
-                      // The period in question is between entering the ExecuteAPI and obtaining
-                      // a stateObject.
-                        _pendingCancel = true;
-
-                        TdsParserStateObject stateObj = _stateObj;
-                        if (null != stateObj)
+                        if (reconnectCompletionSource.TrySetCanceled())
                         {
-                            stateObj.Cancel(this);
+                            return;
                         }
-                        else
+                    }
+
+                    // the pending data flag means that we are awaiting a response or are in the middle of processing a response
+                    // if we have no pending data, then there is nothing to cancel
+                    // if we have pending data, but it is not a result of this command, then we don't cancel either.  Note that
+                    // this model is implementable because we only allow one active command at any one time.  This code
+                    // will have to change we allow multiple outstanding batches
+                    if (null == _activeConnection)
+                    {
+                        return;
+                    }
+                    SqlInternalConnectionTds connection = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
+                    if (null == connection)
+                    {  // Fail with out locking
+                        return;
+                    }
+
+                    // The lock here is to protect against the command.cancel / connection.close race condition
+                    // The SqlInternalConnectionTds is set to OpenBusy during close, once this happens the cast below will fail and
+                    // the command will no longer be cancelable.  It might be desirable to be able to cancel the close operation, but this is
+                    // outside of the scope of Whidbey RTM.  See (SqlConnection::Close) for other lock.
+                    lock (connection)
+                    {
+                        if (connection != (_activeConnection.InnerConnection as SqlInternalConnectionTds))
+                        { // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
+                            return;
+                        }
+
+                        TdsParser parser = connection.Parser;
+                        if (null == parser)
                         {
-                            SqlDataReader reader = connection.FindLiveReader(this);
-                            if (reader != null)
+                            return;
+                        }
+
+
+                        if (!_pendingCancel)
+                        { // Do nothing if already pending.
+                          // Before attempting actual cancel, set the _pendingCancel flag to false.
+                          // This denotes to other thread before obtaining stateObject from the
+                          // session pool that there is another thread wishing to cancel.
+                          // The period in question is between entering the ExecuteAPI and obtaining
+                          // a stateObject.
+                            _pendingCancel = true;
+
+                            TdsParserStateObject stateObj = _stateObj;
+                            if (null != stateObj)
                             {
-                                reader.Cancel(this);
+                                stateObj.Cancel(this);
+                            }
+                            else
+                            {
+                                SqlDataReader reader = connection.FindLiveReader(this);
+                                if (reader != null)
+                                {
+                                    reader.Cancel(this);
+                                }
                             }
                         }
                     }
                 }
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                }
             }
         }
 
@@ -1031,52 +1033,51 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
-
             SqlStatistics statistics = null;
-
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlCommand.ExecuteScalar | API | ObjectId {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.ExecuteScalar | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
-
             Exception e = null;
             bool success = false;
             int? sqlExceptionNumber = null;
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
-            try
+            using (TryEventScope.Create("SqlCommand.ExecuteScalar | API | ObjectId {0}", ObjectID))
             {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                WriteBeginExecuteEvent();
-                SqlDataReader ds;
-                ds = IsRetryEnabled ?
-                    RunExecuteReaderWithRetry(0, RunBehavior.ReturnImmediately, returnStream: true) :
-                    RunExecuteReader(0, RunBehavior.ReturnImmediately, returnStream: true, method: nameof(ExecuteScalar));
-                success = true;
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.ExecuteScalar | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
 
-                return CompleteExecuteScalar(ds, false);
-            }
-            catch (Exception ex)
-            {
-                if (ex is SqlException)
+                try
                 {
-                    SqlException exception = (SqlException)ex;
-                    sqlExceptionNumber = exception.Number;
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    WriteBeginExecuteEvent();
+                    SqlDataReader ds;
+                    ds = IsRetryEnabled ?
+                        RunExecuteReaderWithRetry(0, RunBehavior.ReturnImmediately, returnStream: true) :
+                        RunExecuteReader(0, RunBehavior.ReturnImmediately, returnStream: true, method: nameof(ExecuteScalar));
+                    success = true;
+
+                    return CompleteExecuteScalar(ds, false);
                 }
+                catch (Exception ex)
+                {
+                    if (ex is SqlException)
+                    {
+                        SqlException exception = (SqlException)ex;
+                        sqlExceptionNumber = exception.Number;
+                    }
 
-                e = ex;
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-                WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
-                if (e != null)
-                {
-                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
+                    e = ex;
+                    throw;
                 }
-                else
+                finally
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
+                    SqlStatistics.StopTimer(statistics);
+                    WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
+                    if (e != null)
+                    {
+                        _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
+                    }
+                    else
+                    {
+                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
+                    }
                 }
             }
         }
@@ -1126,43 +1127,44 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
+            SqlStatistics statistics = null;
+            Exception e = null;
             Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
-            SqlStatistics statistics = null;
+            using (TryEventScope.Create("SqlCommand.ExecuteNonQuery | API | Object Id {0}", ObjectID))
+            {
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.ExecuteNonQuery | API | Correlation | Object Id {0}, ActivityID {1}, Client Connection Id {2}, Command Text {3}", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
 
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlCommand.ExecuteNonQuery | API | Object Id {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.ExecuteNonQuery | API | Correlation | Object Id {0}, ActivityID {1}, Client Connection Id {2}, Command Text {3}", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
-            Exception e = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                WriteBeginExecuteEvent();
-                if (IsRetryEnabled)
+                try
                 {
-                    InternalExecuteNonQueryWithRetry(sendToPipe: false, timeout: CommandTimeout, out _, asyncWrite: false, inRetry: false);
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    WriteBeginExecuteEvent();
+                    if (IsRetryEnabled)
+                    {
+                        InternalExecuteNonQueryWithRetry(sendToPipe: false, timeout: CommandTimeout, out _, asyncWrite: false, inRetry: false);
+                    }
+                    else
+                    {
+                        InternalExecuteNonQuery(completion: null, sendToPipe: false, timeout: CommandTimeout, out _);
+                    }
+                    return _rowsAffected;
                 }
-                else
+                catch (Exception ex)
                 {
-                    InternalExecuteNonQuery(completion: null, sendToPipe: false, timeout: CommandTimeout, out _);
+                    e = ex;
+                    throw;
                 }
-                return _rowsAffected;
-            }
-            catch (Exception ex)
-            {
-                e = ex;
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-                if (e != null)
+                finally
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
-                }
-                else
-                {
-                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
+                    SqlStatistics.StopTimer(statistics);
+                    if (e != null)
+                    {
+                        _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
+                    }
+                    else
+                    {
+                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
+                    }
                 }
             }
         }
@@ -1621,51 +1623,52 @@ namespace Microsoft.Data.SqlClient
             // Reset _pendingCancel upon entry into any Execute - used to synchronize state
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
-            bool success = false;
-
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlCommand.ExecuteXmlReader | API | Object Id {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.ExecuteXmlReader | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
+            bool success = false;
             int? sqlExceptionNumber = null;
-
             Exception e = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                WriteBeginExecuteEvent();
-                // use the reader to consume metadata
-                SqlDataReader ds;
-                ds = IsRetryEnabled ?
-                    RunExecuteReaderWithRetry(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true) :
-                    RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true);
-                success = true;
-                return CompleteXmlReader(ds);
-            }
-            catch (Exception ex)
-            {
-                e = ex;
-                if (ex is SqlException)
-                {
-                    SqlException exception = (SqlException)ex;
-                    sqlExceptionNumber = exception.Number;
-                }
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
-                throw;
-            }
-            finally
+            using (TryEventScope.Create("SqlCommand.ExecuteXmlReader | API | Object Id {0}", ObjectID))
             {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-                WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
-                if (e != null)
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.ExecuteXmlReader | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
+
+                try
                 {
-                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    WriteBeginExecuteEvent();
+                    // use the reader to consume metadata
+                    SqlDataReader ds;
+                    ds = IsRetryEnabled ?
+                        RunExecuteReaderWithRetry(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true) :
+                        RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true);
+                    success = true;
+                    return CompleteXmlReader(ds);
                 }
-                else
+                catch (Exception ex)
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
+                    e = ex;
+                    if (ex is SqlException)
+                    {
+                        SqlException exception = (SqlException)ex;
+                        sqlExceptionNumber = exception.Number;
+                    }
+
+                    throw;
+                }
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                    WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
+                    if (e != null)
+                    {
+                        _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
+                    }
+                    else
+                    {
+                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
+                    }
                 }
             }
         }
@@ -1946,50 +1949,50 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReader[@name="CommandBehavior"]/*'/>
         new public SqlDataReader ExecuteReader(CommandBehavior behavior)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlCommand.ExecuteReader | API | Object Id {0}", ObjectID);
             // Reset _pendingCancel upon entry into any Execute - used to synchronize state
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
-
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
             SqlStatistics statistics = null;
             bool success = false;
             int? sqlExceptionNumber = null;
             Exception e = null;
-            try
-            {
-                WriteBeginExecuteEvent();
-                statistics = SqlStatistics.StartTimer(Statistics);
-                return IsRetryEnabled ?
-                    RunExecuteReaderWithRetry(behavior, RunBehavior.ReturnImmediately, returnStream: true) :
-                    RunExecuteReader(behavior, RunBehavior.ReturnImmediately, returnStream: true);
-            }
-            catch (Exception ex)
-            {
-                if (ex is SqlException)
-                {
-                    SqlException exception = (SqlException)ex;
-                    sqlExceptionNumber = exception.Number;
-                }
+            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
 
-                e = ex;
-                throw;
-            }
-            finally
+            using (TryEventScope.Create("SqlCommand.ExecuteReader | API | Object Id {0}", ObjectID))
             {
-                SqlStatistics.StopTimer(statistics);
-                WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
+                try
+                {
+                    WriteBeginExecuteEvent();
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    return IsRetryEnabled ?
+                        RunExecuteReaderWithRetry(behavior, RunBehavior.ReturnImmediately, returnStream: true) :
+                        RunExecuteReader(behavior, RunBehavior.ReturnImmediately, returnStream: true);
+                }
+                catch (Exception ex)
+                {
+                    if (ex is SqlException)
+                    {
+                        SqlException exception = (SqlException)ex;
+                        sqlExceptionNumber = exception.Number;
+                    }
 
-                if (e != null)
-                {
-                    _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
+                    e = ex;
+                    throw;
                 }
-                else
+                finally
                 {
-                    _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
+                    SqlStatistics.StopTimer(statistics);
+                    WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
+                    if (e != null)
+                    {
+                        _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
+                    }
+                    else
+                    {
+                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
+                    }
                 }
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
@@ -278,9 +278,7 @@ namespace Microsoft.Data.SqlClient
         internal int ExecuteNonQuery()
         {
             ValidateCommandBehavior(nameof(ExecuteNonQuery), CommandBehavior.Default);
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlCommandSet.ExecuteNonQuery | API | Object Id {0}, Commands executed in Batch RPC mode", ObjectID);
-
-            try
+            using (TryEventScope.Create("SqlCommandSet.ExecuteNonQuery | API | Object Id {0}, Commands executed in Batch RPC mode", ObjectID))
             {
                 BatchCommand.BatchRPCMode = true;
                 BatchCommand.ClearBatchCommand();
@@ -292,10 +290,6 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 return BatchCommand.ExecuteBatchRPCCommand();
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1034,8 +1034,7 @@ namespace Microsoft.Data.SqlClient
         [SuppressMessage("Microsoft.Reliability", "CA2004:RemoveCallsToGCKeepAlive")]
         override protected DbTransaction BeginDbTransaction(System.Data.IsolationLevel isolationLevel)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlConnection.BeginDbTransaction | API | Object Id {0}, Isolation Level {1}", ObjectID, (int)isolationLevel);
-            try
+            using (TryEventScope.Create("SqlConnection.BeginDbTransaction | API | Object Id {0}, Isolation Level {1}", ObjectID, (int)isolationLevel))
             {
                 DbTransaction transaction = BeginTransaction(isolationLevel);
 
@@ -1047,10 +1046,6 @@ namespace Microsoft.Data.SqlClient
 
                 return transaction;
             }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-            }
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/BeginTransactionIsoTransactionName/*' />
@@ -1058,32 +1053,33 @@ namespace Microsoft.Data.SqlClient
         {
             WaitForPendingReconnection();
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlConnection.BeginTransaction | API | Object Id {0}, Iso {1}, Transaction Name '{2}'", ObjectID, (int)iso, transactionName);
-            try
+            using (TryEventScope.Create(SqlClientEventSource.Log.TryScopeEnterEvent("SqlConnection.BeginTransaction | API | Object Id {0}, Iso {1}, Transaction Name '{2}'", ObjectID, (int)iso, transactionName)))
             {
-                statistics = SqlStatistics.StartTimer(Statistics);
-
-                SqlTransaction transaction;
-                bool isFirstAttempt = true;
-                do
+                try
                 {
-                    transaction = GetOpenTdsConnection().BeginSqlTransaction(iso, transactionName, isFirstAttempt); // do not reconnect twice
-                    Debug.Assert(isFirstAttempt || !transaction.InternalTransaction.ConnectionHasBeenRestored, "Restored connection on non-first attempt");
-                    isFirstAttempt = false;
-                } while (transaction.InternalTransaction.ConnectionHasBeenRestored);
+                    statistics = SqlStatistics.StartTimer(Statistics);
+
+                    SqlTransaction transaction;
+                    bool isFirstAttempt = true;
+                    do
+                    {
+                        transaction = GetOpenTdsConnection().BeginSqlTransaction(iso, transactionName, isFirstAttempt); // do not reconnect twice
+                        Debug.Assert(isFirstAttempt || !transaction.InternalTransaction.ConnectionHasBeenRestored, "Restored connection on non-first attempt");
+                        isFirstAttempt = false;
+                    } while (transaction.InternalTransaction.ConnectionHasBeenRestored);
 
 
-                //  The GetOpenConnection line above doesn't keep a ref on the outer connection (this),
-                //  and it could be collected before the inner connection can hook it to the transaction, resulting in
-                //  a transaction with a null connection property.  Use GC.KeepAlive to ensure this doesn't happen.
-                GC.KeepAlive(this);
+                    //  The GetOpenConnection line above doesn't keep a ref on the outer connection (this),
+                    //  and it could be collected before the inner connection can hook it to the transaction, resulting in
+                    //  a transaction with a null connection property.  Use GC.KeepAlive to ensure this doesn't happen.
+                    GC.KeepAlive(this);
 
-                return transaction;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
+                    return transaction;
+                }
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                }
             }
         }
 
@@ -1137,10 +1133,10 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/Close/*' />
         public override void Close()
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlConnection.Close | API | Object Id {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.Close | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}", ObjectID, ActivityCorrelator.Current, ClientConnectionId);
-            try
+            using (TryEventScope.Create("SqlConnection.Close | API | Object Id {0}", ObjectID))
             {
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.Close | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}", ObjectID, ActivityCorrelator.Current, ClientConnectionId);
+
                 ConnectionState previousState = State;
                 Guid operationId = default(Guid);
                 Guid clientConnectionId = default(Guid);
@@ -1214,10 +1210,6 @@ namespace Microsoft.Data.SqlClient
                     }
                 }
             }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-            }
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/CreateCommand/*' />
@@ -1260,10 +1252,10 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OpenWithOverrides/*' />
         public void Open(SqlConnectionOverrides overrides)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlConnection.Open | API | Correlation | Object Id {0}, Activity Id {1}", ObjectID, ActivityCorrelator.Current);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.Open | API | Correlation | Object Id {0}, Activity Id {1}", ObjectID, ActivityCorrelator.Current);
-            try
+            using (TryEventScope.Create("SqlConnection.Open | API | Correlation | Object Id {0}, Activity Id {1}", ObjectID, ActivityCorrelator.Current))
             {
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.Open | API | Correlation | Object Id {0}, Activity Id {1}", ObjectID, ActivityCorrelator.Current);
+
                 Guid operationId = s_diagnosticListener.WriteConnectionOpenBefore(this);
 
                 PrepareStatisticsForNewConnection();
@@ -1297,10 +1289,6 @@ namespace Microsoft.Data.SqlClient
                         s_diagnosticListener.WriteConnectionOpenAfter(operationId, this);
                     }
                 }
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 
@@ -2023,10 +2011,10 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ChangePasswordConnectionStringNewPassword/*' />
         public static void ChangePassword(string connectionString, string newPassword)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlConnection.ChangePassword | API | Password change requested.");
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.ChangePassword | API | Correlation | ActivityID {0}", ActivityCorrelator.Current);
-            try
+            using (TryEventScope.Create("SqlConnection.ChangePassword | API | Password change requested."))
             {
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.ChangePassword | API | Correlation | ActivityID {0}", ActivityCorrelator.Current);
+
                 if (string.IsNullOrEmpty(connectionString))
                 {
                     throw SQL.ChangePasswordArgumentMissing(nameof(newPassword));
@@ -2054,19 +2042,15 @@ namespace Microsoft.Data.SqlClient
 
                 ChangePassword(connectionString, connectionOptions, null, newPassword, null);
             }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-            }
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ChangePasswordConnectionStringCredentialNewSecurePassword/*' />
         public static void ChangePassword(string connectionString, SqlCredential credential, SecureString newSecurePassword)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlConnection.ChangePassword | API | Password change requested.");
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.ChangePassword | API | Correlation | ActivityID {0}", ActivityCorrelator.Current);
-            try
+            using (TryEventScope.Create("SqlConnection.ChangePassword | API | Password change requested."))
             {
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.ChangePassword | API | Correlation | ActivityID {0}", ActivityCorrelator.Current);
+
                 if (string.IsNullOrEmpty(connectionString))
                 {
                     throw SQL.ChangePasswordArgumentMissing(nameof(connectionString));
@@ -2114,10 +2098,6 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 ChangePassword(connectionString, connectionOptions, credential, null, newSecurePassword);
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -153,18 +153,13 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/CreateDbCommand/*' />
         override protected DbCommand CreateDbCommand()
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<prov.DbConnectionHelper.CreateDbCommand|API> {0}", ObjectID);
-            try
+            using (TryEventScope.Create("<prov.DbConnectionHelper.CreateDbCommand|API> {0}", ObjectID))
             {
                 DbCommand command = null;
                 DbProviderFactory providerFactory = ConnectionFactory.ProviderFactory;
                 command = providerFactory.CreateCommand();
                 command.Connection = this;
                 return command;
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1301,8 +1301,7 @@ namespace Microsoft.Data.SqlClient
 
         internal SqlError ProcessSNIError(TdsParserStateObject stateObj)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.TdsParser.ProcessSNIError|ERR>");
-            try
+            using (TryEventScope.Create("<sc.TdsParser.ProcessSNIError|ERR>"))
             {
 #if DEBUG
                 // There is an exception here for MARS as its possible that another thread has closed the connection just as we see an error
@@ -1434,10 +1433,6 @@ namespace Microsoft.Data.SqlClient
 
                 return new SqlError(infoNumber: (int)details.nativeError, errorState: 0x00, TdsEnums.FATAL_ERROR_CLASS, _server,
                     errorMessage, details.function, (int)details.lineNumber, win32ErrorCode: details.nativeError, details.exception);
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
@@ -60,8 +60,7 @@ namespace Microsoft.Data.SqlClient
             // When being deactivated, we check all the sessions in the
             // cache to make sure they're cleaned up and then we dispose of
             // sessions that are past what we want to keep around.
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0} deactivating cachedCount={1}", ObjectID, _cachedCount);
-            try
+            using (TryEventScope.Create("<sc.TdsParserSessionPool.Deactivate|ADV> {0} deactivating cachedCount={1}", ObjectID, _cachedCount))
             {
                 lock (_cache)
                 {
@@ -87,10 +86,6 @@ namespace Microsoft.Data.SqlClient
                     // TODO: re-enable this assert when the connection isn't doomed.
                     //Debug.Assert (_cachedCount < MaxInactiveCount, "non-orphaned connection past initial allocation?");
                 }
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlFileStream.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlFileStream.Windows.cs
@@ -61,8 +61,7 @@ namespace Microsoft.Data.SqlTypes
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/ctor2/*' />
         public SqlFileStream(string path, byte[] transactionContext, FileAccess access, FileOptions options, long allocationSize)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("SqlFileStream.ctor | API | Object Id {0} | Access {1} | Options {2} | Path '{3}'", ObjectID, (int)access, (int)options, path);
-            try
+            using (TryEventScope.Create(SqlClientEventSource.Log.TryScopeEnterEvent("SqlFileStream.ctor | API | Object Id {0} | Access {1} | Options {2} | Path '{3}'", ObjectID, (int)access, (int)options, path)))
             {
                 //-----------------------------------------------------------------
                 // precondition validation
@@ -83,10 +82,6 @@ namespace Microsoft.Data.SqlTypes
                 // only set internal state once the file has actually been successfully opened
                 Name = path;
                 TransactionContext = transactionContext;
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -65,8 +65,7 @@ namespace Microsoft.Data.ProviderBase
 
         public void ClearAllPools()
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<prov.DbConnectionFactory.ClearAllPools|API>");
-            try
+            using (TryEventScope.Create("<prov.DbConnectionFactory.ClearAllPools|API>"))
             {
                 Dictionary<DbConnectionPoolKey, DbConnectionPoolGroup> connectionPoolGroups = _connectionPoolGroups;
                 foreach (KeyValuePair<DbConnectionPoolKey, DbConnectionPoolGroup> entry in connectionPoolGroups)
@@ -78,17 +77,13 @@ namespace Microsoft.Data.ProviderBase
                     }
                 }
             }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-            }
+
         }
 
         public void ClearPool(DbConnection connection)
         {
             ADP.CheckArgumentNull(connection, "connection");
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<prov.DbConnectionFactory.ClearPool|API> {0}", GetObjectId(connection));
-            try
+            using (TryEventScope.Create("<prov.DbConnectionFactory.ClearPool|API> {0}", GetObjectId(connection)))
             {
                 DbConnectionPoolGroup poolGroup = GetConnectionPoolGroup(connection);
                 if (null != poolGroup)
@@ -96,19 +91,13 @@ namespace Microsoft.Data.ProviderBase
                     poolGroup.Clear();
                 }
             }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-            }
         }
 
         public void ClearPool(DbConnectionPoolKey key)
         {
             Debug.Assert(key != null, "key cannot be null");
             ADP.CheckArgumentNull(key.ConnectionString, "key.ConnectionString");
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<prov.DbConnectionFactory.ClearPool|API> connectionString");
-
-            try
+            using (TryEventScope.Create("<prov.DbConnectionFactory.ClearPool|API> connectionString"))
             {
                 DbConnectionPoolGroup poolGroup;
                 Dictionary<DbConnectionPoolKey, DbConnectionPoolGroup> connectionPoolGroups = _connectionPoolGroups;
@@ -116,10 +105,6 @@ namespace Microsoft.Data.ProviderBase
                 {
                     poolGroup.Clear();
                 }
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1020,110 +1020,111 @@ namespace Microsoft.Data.SqlClient
             }
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlCommand.Prepare|API> {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.Prepare|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
-
-            statistics = SqlStatistics.StartTimer(Statistics);
-
-            // only prepare if batch with parameters
-            // MDAC BUG #'s 73776 & 72101
-            if (
-                this.IsPrepared && !this.IsDirty
-                || (this.CommandType == CommandType.StoredProcedure)
-                || (
-                        (System.Data.CommandType.Text == this.CommandType)
-                        && (0 == GetParameterCount(_parameters))
-                    )
-
-            )
+            using (TryEventScope.Create("<sc.SqlCommand.Prepare|API> {0}", ObjectID))
             {
-                if (null != Statistics)
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.Prepare|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+
+                statistics = SqlStatistics.StartTimer(Statistics);
+
+                // only prepare if batch with parameters
+                // MDAC BUG #'s 73776 & 72101
+                if (
+                    this.IsPrepared && !this.IsDirty
+                    || (this.CommandType == CommandType.StoredProcedure)
+                    || (
+                            (System.Data.CommandType.Text == this.CommandType)
+                            && (0 == GetParameterCount(_parameters))
+                        )
+
+                )
                 {
-                    Statistics.SafeIncrement(ref Statistics._prepares);
-                }
-                _hiddenPrepare = false;
-            }
-            else
-            {
-                // Validate the command outside of the try\catch to avoid putting the _stateObj on error
-                ValidateCommand(ADP.Prepare, false /*not async*/);
-
-                bool processFinallyBlock = true;
-                TdsParser bestEffortCleanupTarget = null;
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
-                {
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
-
-                    // NOTE: The state object isn't actually needed for this, but it is still here for back-compat (since it does a bunch of checks)
-                    GetStateObject();
-
-                    // Loop through parameters ensuring that we do not have unspecified types, sizes, scales, or precisions
-                    if (null != _parameters)
+                    if (null != Statistics)
                     {
-                        int count = _parameters.Count;
-                        for (int i = 0; i < count; ++i)
-                        {
-                            _parameters[i].Prepare(this); // MDAC 67063
-                        }
+                        Statistics.SafeIncrement(ref Statistics._prepares);
                     }
+                    _hiddenPrepare = false;
+                }
+                else
+                {
+                    // Validate the command outside of the try\catch to avoid putting the _stateObj on error
+                    ValidateCommand(ADP.Prepare, false /*not async*/);
 
-#if DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                    bool processFinallyBlock = true;
+                    TdsParser bestEffortCleanupTarget = null;
                     RuntimeHelpers.PrepareConstrainedRegions();
                     try
                     {
-                        tdsReliabilitySection.Start();
+                        bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
+
+                        // NOTE: The state object isn't actually needed for this, but it is still here for back-compat (since it does a bunch of checks)
+                        GetStateObject();
+
+                        // Loop through parameters ensuring that we do not have unspecified types, sizes, scales, or precisions
+                        if (null != _parameters)
+                        {
+                            int count = _parameters.Count;
+                            for (int i = 0; i < count; ++i)
+                            {
+                                _parameters[i].Prepare(this); // MDAC 67063
+                            }
+                        }
+
+#if DEBUG
+                        TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                        RuntimeHelpers.PrepareConstrainedRegions();
+                        try
+                        {
+                            tdsReliabilitySection.Start();
 #else
                     {
 #endif //DEBUG
-                        InternalPrepare();
-                    }
+                            InternalPrepare();
+                        }
 #if DEBUG
+                        finally
+                        {
+                            tdsReliabilitySection.Stop();
+                        }
+#endif //DEBUG
+                    }
+                    catch (System.OutOfMemoryException e)
+                    {
+                        processFinallyBlock = false;
+                        _activeConnection.Abort(e);
+                        throw;
+                    }
+                    catch (System.StackOverflowException e)
+                    {
+                        processFinallyBlock = false;
+                        _activeConnection.Abort(e);
+                        throw;
+                    }
+                    catch (System.Threading.ThreadAbortException e)
+                    {
+                        processFinallyBlock = false;
+                        _activeConnection.Abort(e);
+
+                        SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+                        throw;
+                    }
+                    catch (Exception e)
+                    {
+                        processFinallyBlock = ADP.IsCatchableExceptionType(e);
+                        throw;
+                    }
                     finally
                     {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif //DEBUG
-                }
-                catch (System.OutOfMemoryException e)
-                {
-                    processFinallyBlock = false;
-                    _activeConnection.Abort(e);
-                    throw;
-                }
-                catch (System.StackOverflowException e)
-                {
-                    processFinallyBlock = false;
-                    _activeConnection.Abort(e);
-                    throw;
-                }
-                catch (System.Threading.ThreadAbortException e)
-                {
-                    processFinallyBlock = false;
-                    _activeConnection.Abort(e);
+                        if (processFinallyBlock)
+                        {
+                            _hiddenPrepare = false; // The command is now officially prepared
 
-                    SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                    throw;
-                }
-                catch (Exception e)
-                {
-                    processFinallyBlock = ADP.IsCatchableExceptionType(e);
-                    throw;
-                }
-                finally
-                {
-                    if (processFinallyBlock)
-                    {
-                        _hiddenPrepare = false; // The command is now officially prepared
-
-                        ReliablePutStateObject();
+                            ReliablePutStateObject();
+                        }
                     }
                 }
+
+                SqlStatistics.StopTimer(statistics);
             }
-
-            SqlStatistics.StopTimer(statistics);
-            SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
         }
 
         private void InternalPrepare()
@@ -1197,125 +1198,126 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Cancel/*'/>
         public override void Cancel()
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlCommand.Cancel | API > {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.Cancel|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
-
-            SqlStatistics statistics = null;
-            try
+            using (TryEventScope.Create("<sc.SqlCommand.Cancel | API > {0}", ObjectID))
             {
-                statistics = SqlStatistics.StartTimer(Statistics);
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.Cancel|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
-                // If we are in reconnect phase simply cancel the waiting task
-                var reconnectCompletionSource = _reconnectionCompletionSource;
-                if (reconnectCompletionSource != null)
+                SqlStatistics statistics = null;
+                try
                 {
-                    if (reconnectCompletionSource.TrySetCanceled())
+                    statistics = SqlStatistics.StartTimer(Statistics);
+
+                    // If we are in reconnect phase simply cancel the waiting task
+                    var reconnectCompletionSource = _reconnectionCompletionSource;
+                    if (reconnectCompletionSource != null)
+                    {
+                        if (reconnectCompletionSource.TrySetCanceled())
+                        {
+                            return;
+                        }
+                    }
+
+                    // the pending data flag means that we are awaiting a response or are in the middle of processing a response
+                    // if we have no pending data, then there is nothing to cancel
+                    // if we have pending data, but it is not a result of this command, then we don't cancel either.  Note that
+                    // this model is implementable because we only allow one active command at any one time.  This code
+                    // will have to change we allow multiple outstanding batches
+                    if (null == _activeConnection)
                     {
                         return;
                     }
-                }
-
-                // the pending data flag means that we are awaiting a response or are in the middle of processing a response
-                // if we have no pending data, then there is nothing to cancel
-                // if we have pending data, but it is not a result of this command, then we don't cancel either.  Note that
-                // this model is implementable because we only allow one active command at any one time.  This code
-                // will have to change we allow multiple outstanding batches
-                if (null == _activeConnection)
-                {
-                    return;
-                }
-                SqlInternalConnectionTds connection = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
-                if (null == connection)
-                {  // Fail with out locking
-                    return;
-                }
-
-                // The lock here is to protect against the command.cancel / connection.close race condition
-                // The SqlInternalConnectionTds is set to OpenBusy during close, once this happens the cast below will fail and
-                // the command will no longer be cancelable.  It might be desirable to be able to cancel the close operation, but this is
-                // outside of the scope of Whidbey RTM.  See (SqlConnection::Close) for other lock.
-                lock (connection)
-                {
-                    if (connection != (_activeConnection.InnerConnection as SqlInternalConnectionTds))
-                    { // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
+                    SqlInternalConnectionTds connection = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
+                    if (null == connection)
+                    {  // Fail with out locking
                         return;
                     }
 
-                    TdsParser parser = connection.Parser;
-                    if (null == parser)
+                    // The lock here is to protect against the command.cancel / connection.close race condition
+                    // The SqlInternalConnectionTds is set to OpenBusy during close, once this happens the cast below will fail and
+                    // the command will no longer be cancelable.  It might be desirable to be able to cancel the close operation, but this is
+                    // outside of the scope of Whidbey RTM.  See (SqlConnection::Close) for other lock.
+                    lock (connection)
                     {
-                        return;
-                    }
+                        if (connection != (_activeConnection.InnerConnection as SqlInternalConnectionTds))
+                        { // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
+                            return;
+                        }
 
-                    TdsParser bestEffortCleanupTarget = null;
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
-                    {
-#if DEBUG
-                        TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                        TdsParser parser = connection.Parser;
+                        if (null == parser)
+                        {
+                            return;
+                        }
 
+                        TdsParser bestEffortCleanupTarget = null;
                         RuntimeHelpers.PrepareConstrainedRegions();
                         try
                         {
-                            tdsReliabilitySection.Start();
+#if DEBUG
+                            TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+
+                            RuntimeHelpers.PrepareConstrainedRegions();
+                            try
+                            {
+                                tdsReliabilitySection.Start();
 #else
                         {
 #endif //DEBUG
-                            bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
+                                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
 
-                            if (!_pendingCancel)
-                            { // Do nothing if aleady pending.
-                                // Before attempting actual cancel, set the _pendingCancel flag to false.
-                                // This denotes to other thread before obtaining stateObject from the
-                                // session pool that there is another thread wishing to cancel.
-                                // The period in question is between entering the ExecuteAPI and obtaining 
-                                // a stateObject.
-                                _pendingCancel = true;
+                                if (!_pendingCancel)
+                                { // Do nothing if aleady pending.
+                                  // Before attempting actual cancel, set the _pendingCancel flag to false.
+                                  // This denotes to other thread before obtaining stateObject from the
+                                  // session pool that there is another thread wishing to cancel.
+                                  // The period in question is between entering the ExecuteAPI and obtaining 
+                                  // a stateObject.
+                                    _pendingCancel = true;
 
-                                TdsParserStateObject stateObj = _stateObj;
-                                if (null != stateObj)
-                                {
-                                    stateObj.Cancel(ObjectID);
-                                }
-                                else
-                                {
-                                    SqlDataReader reader = connection.FindLiveReader(this);
-                                    if (reader != null)
+                                    TdsParserStateObject stateObj = _stateObj;
+                                    if (null != stateObj)
                                     {
-                                        reader.Cancel(ObjectID);
+                                        stateObj.Cancel(ObjectID);
+                                    }
+                                    else
+                                    {
+                                        SqlDataReader reader = connection.FindLiveReader(this);
+                                        if (reader != null)
+                                        {
+                                            reader.Cancel(ObjectID);
+                                        }
                                     }
                                 }
                             }
-                        }
 #if DEBUG
-                        finally
-                        {
-                            tdsReliabilitySection.Stop();
-                        }
+                            finally
+                            {
+                                tdsReliabilitySection.Stop();
+                            }
 #endif //DEBUG
-                    }
-                    catch (System.OutOfMemoryException e)
-                    {
-                        _activeConnection.Abort(e);
-                        throw;
-                    }
-                    catch (System.StackOverflowException e)
-                    {
-                        _activeConnection.Abort(e);
-                        throw;
-                    }
-                    catch (System.Threading.ThreadAbortException e)
-                    {
-                        _activeConnection.Abort(e);
-                        SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                        throw;
+                        }
+                        catch (System.OutOfMemoryException e)
+                        {
+                            _activeConnection.Abort(e);
+                            throw;
+                        }
+                        catch (System.StackOverflowException e)
+                        {
+                            _activeConnection.Abort(e);
+                            throw;
+                        }
+                        catch (System.Threading.ThreadAbortException e)
+                        {
+                            _activeConnection.Abort(e);
+                            SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+                            throw;
+                        }
                     }
                 }
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                }
             }
         }
 
@@ -1355,34 +1357,35 @@ namespace Microsoft.Data.SqlClient
             _pendingCancel = false;
             SqlStatistics statistics = null;
 
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlCommand.ExecuteScalar|API> {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.ExecuteScalar|API|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            using (TryEventScope.Create("<sc.SqlCommand.ExecuteScalar|API> {0}", ObjectID))
+            {
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.ExecuteScalar|API|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
-            bool success = false;
-            int? sqlExceptionNumber = null;
+                bool success = false;
+                int? sqlExceptionNumber = null;
 
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                WriteBeginExecuteEvent();
-                SqlDataReader ds;
-                ds = IsRetryEnabled ?
-                    RunExecuteReaderWithRetry(0, RunBehavior.ReturnImmediately, true, ADP.ExecuteScalar) :
-                    RunExecuteReader(0, RunBehavior.ReturnImmediately, true, ADP.ExecuteScalar);
-                object result = CompleteExecuteScalar(ds, false);
-                success = true;
-                return result;
-            }
-            catch (SqlException ex)
-            {
-                sqlExceptionNumber = ex.Number;
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-                WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
+                try
+                {
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    WriteBeginExecuteEvent();
+                    SqlDataReader ds;
+                    ds = IsRetryEnabled ?
+                        RunExecuteReaderWithRetry(0, RunBehavior.ReturnImmediately, true, ADP.ExecuteScalar) :
+                        RunExecuteReader(0, RunBehavior.ReturnImmediately, true, ADP.ExecuteScalar);
+                    object result = CompleteExecuteScalar(ds, false);
+                    success = true;
+                    return result;
+                }
+                catch (SqlException ex)
+                {
+                    sqlExceptionNumber = ex.Number;
+                    throw;
+                }
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                    WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
+                }
             }
         }
 
@@ -1435,37 +1438,38 @@ namespace Microsoft.Data.SqlClient
 
             SqlStatistics statistics = null;
 
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlCommand.ExecuteNonQuery|API> {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQuery|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            using (TryEventScope.Create("<sc.SqlCommand.ExecuteNonQuery|API> {0}", ObjectID))
+            {
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.ExecuteNonQuery|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
-            bool success = false;
-            int? sqlExceptionNumber = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                WriteBeginExecuteEvent();
-                bool usedCache;
-                if (IsRetryEnabled)
+                bool success = false;
+                int? sqlExceptionNumber = null;
+                try
                 {
-                    InternalExecuteNonQueryWithRetry(ADP.ExecuteNonQuery, sendToPipe: false, CommandTimeout, out usedCache, asyncWrite: false, inRetry: false);
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    WriteBeginExecuteEvent();
+                    bool usedCache;
+                    if (IsRetryEnabled)
+                    {
+                        InternalExecuteNonQueryWithRetry(ADP.ExecuteNonQuery, sendToPipe: false, CommandTimeout, out usedCache, asyncWrite: false, inRetry: false);
+                    }
+                    else
+                    {
+                        InternalExecuteNonQuery(null, ADP.ExecuteNonQuery, sendToPipe: false, CommandTimeout, out usedCache);
+                    }
+                    success = true;
+                    return _rowsAffected;
                 }
-                else
+                catch (SqlException ex)
                 {
-                    InternalExecuteNonQuery(null, ADP.ExecuteNonQuery, sendToPipe: false, CommandTimeout, out usedCache);
+                    sqlExceptionNumber = ex.Number;
+                    throw;
                 }
-                success = true;
-                return _rowsAffected;
-            }
-            catch (SqlException ex)
-            {
-                sqlExceptionNumber = ex.Number;
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-                WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                    WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
+                }
             }
         }
 
@@ -1480,17 +1484,19 @@ namespace Microsoft.Data.SqlClient
             _pendingCancel = false;
 
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlCommand.ExecuteToPipe|INFO> {0}", ObjectID);
-            try
+
+            using (TryEventScope.Create("<sc.SqlCommand.ExecuteToPipe|INFO> {0}", ObjectID))
             {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                bool usedCache;
-                InternalExecuteNonQuery(null, ADP.ExecuteNonQuery, true, CommandTimeout, out usedCache);
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
+                try
+                {
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    bool usedCache;
+                    InternalExecuteNonQuery(null, ADP.ExecuteNonQuery, true, CommandTimeout, out usedCache);
+                }
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                }
             }
         }
 
@@ -2057,35 +2063,36 @@ namespace Microsoft.Data.SqlClient
 
             SqlStatistics statistics = null;
 
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlCommand.ExecuteXmlReader|API> {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            using (TryEventScope.Create("<sc.SqlCommand.ExecuteXmlReader|API> {0}", ObjectID))
+            {
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.ExecuteXmlReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
-            bool success = false;
-            int? sqlExceptionNumber = null;
-            try
-            {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                WriteBeginExecuteEvent();
+                bool success = false;
+                int? sqlExceptionNumber = null;
+                try
+                {
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    WriteBeginExecuteEvent();
 
-                // use the reader to consume metadata
-                SqlDataReader ds;
-                ds = IsRetryEnabled ?
-                    RunExecuteReaderWithRetry(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, ADP.ExecuteXmlReader) :
-                    RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, ADP.ExecuteXmlReader);
-                XmlReader result = CompleteXmlReader(ds);
-                success = true;
-                return result;
-            }
-            catch (SqlException ex)
-            {
-                sqlExceptionNumber = ex.Number;
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-                WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
+                    // use the reader to consume metadata
+                    SqlDataReader ds;
+                    ds = IsRetryEnabled ?
+                        RunExecuteReaderWithRetry(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, ADP.ExecuteXmlReader) :
+                        RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, true, ADP.ExecuteXmlReader);
+                    XmlReader result = CompleteXmlReader(ds);
+                    success = true;
+                    return result;
+                }
+                catch (SqlException ex)
+                {
+                    sqlExceptionNumber = ex.Number;
+                    throw;
+                }
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                    WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
+                }
             }
         }
 
@@ -2390,37 +2397,33 @@ namespace Microsoft.Data.SqlClient
         new public SqlDataReader ExecuteReader()
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlCommand.ExecuteReader|API> {0}", ObjectID);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.ExecuteReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
-            try
+            using (TryEventScope.Create("<sc.SqlCommand.ExecuteReader|API> {0}", ObjectID))
             {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                return IsRetryEnabled ?
-                        ExecuteReaderWithRetry(CommandBehavior.Default, ADP.ExecuteReader) :
-                        ExecuteReader(CommandBehavior.Default, ADP.ExecuteReader);
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.ExecuteReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+                try
+                {
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    return IsRetryEnabled ?
+                            ExecuteReaderWithRetry(CommandBehavior.Default, ADP.ExecuteReader) :
+                            ExecuteReader(CommandBehavior.Default, ADP.ExecuteReader);
+                }
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                }
             }
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReader[@name="CommandBehavior"]/*'/>
         new public SqlDataReader ExecuteReader(CommandBehavior behavior)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlCommand.ExecuteReader|API> {0}, behavior={1}", ObjectID, (int)behavior);
-            SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.ExecuteReader|API|Correlation> ObjectID {0}, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
-
-            try
+            using (TryEventScope.Create("<sc.SqlCommand.ExecuteReader|API> {0}, behavior={1}", ObjectID, (int)behavior))
             {
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.ExecuteReader|API|Correlation> ObjectID {0}, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
+
                 return IsRetryEnabled ?
                        ExecuteReaderWithRetry(behavior, ADP.ExecuteReader) :
                        ExecuteReader(behavior, ADP.ExecuteReader);
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
@@ -294,9 +294,7 @@ namespace Microsoft.Data.SqlClient
         internal int ExecuteNonQuery()
         {
             SqlConnection.ExecutePermission.Demand();
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlCommandSet.ExecuteNonQuery|API> {0}", ObjectID);
-
-            try
+            using (TryEventScope.Create("<sc.SqlCommandSet.ExecuteNonQuery|API> {0}", ObjectID))
             {
                 if (Connection.IsContextConnection)
                 {
@@ -312,10 +310,6 @@ namespace Microsoft.Data.SqlClient
                     BatchCommand.AddBatchCommand(cmd.CommandText, cmd.Parameters, cmd.CmdType, cmd.ColumnEncryptionSetting);
                 }
                 return BatchCommand.ExecuteBatchRPCCommand();
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -200,19 +200,13 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlConnection.xml' path='docs/members[@name="SqlConnection"]/CreateDbCommand/*' />
         override protected DbCommand CreateDbCommand()
         {
-            DbCommand command = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<prov.DbConnectionHelper.CreateDbCommand|API> {0}", ObjectID);
-            try
+            using (TryEventScope.Create("<prov.DbConnectionHelper.CreateDbCommand|API> {0}", ObjectID))
             {
                 DbProviderFactory providerFactory = ConnectionFactory.ProviderFactory;
-                command = providerFactory.CreateCommand();
+                DbCommand command = providerFactory.CreateCommand();
                 command.Connection = this;
+                return command;
             }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-            }
-            return command;
         }
 
         private static System.Security.CodeAccessPermission CreateExecutePermission()

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -956,94 +956,94 @@ namespace Microsoft.Data.SqlClient
         override public void Close()
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlDataReader.Close|API> {0}", ObjectID);
-
-            try
+            using (TryEventScope.Create("<sc.SqlDataReader.Close|API> {0}", ObjectID))
             {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                TdsParserStateObject stateObj = _stateObj;
-
-                // Request that the current task is stopped
-                _cancelAsyncOnCloseTokenSource.Cancel();
-                var currentTask = _currentTask;
-                if ((currentTask != null) && (!currentTask.IsCompleted))
+                try
                 {
-                    try
-                    {
-                        // Wait for the task to complete
-                        ((IAsyncResult)currentTask).AsyncWaitHandle.WaitOne();
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    TdsParserStateObject stateObj = _stateObj;
 
-                        // Ensure that we've finished reading any pending data
-                        var networkPacketTaskSource = stateObj._networkPacketTaskSource;
-                        if (networkPacketTaskSource != null)
-                        {
-                            ((IAsyncResult)networkPacketTaskSource.Task).AsyncWaitHandle.WaitOne();
-                        }
-                    }
-                    catch (Exception)
+                    // Request that the current task is stopped
+                    _cancelAsyncOnCloseTokenSource.Cancel();
+                    var currentTask = _currentTask;
+                    if ((currentTask != null) && (!currentTask.IsCompleted))
                     {
-                        // If we receive any exceptions while waiting, something has gone horribly wrong and we need to doom the connection and fast-fail the reader
-                        _connection.InnerConnection.DoomThisConnection();
-                        _isClosed = true;
-
-                        if (stateObj != null)
+                        try
                         {
-                            lock (stateObj)
+                            // Wait for the task to complete
+                            ((IAsyncResult)currentTask).AsyncWaitHandle.WaitOne();
+
+                            // Ensure that we've finished reading any pending data
+                            var networkPacketTaskSource = stateObj._networkPacketTaskSource;
+                            if (networkPacketTaskSource != null)
                             {
-                                _stateObj = null;
-                                _command = null;
-                                _connection = null;
+                                ((IAsyncResult)networkPacketTaskSource.Task).AsyncWaitHandle.WaitOne();
                             }
                         }
+                        catch (Exception)
+                        {
+                            // If we receive any exceptions while waiting, something has gone horribly wrong and we need to doom the connection and fast-fail the reader
+                            _connection.InnerConnection.DoomThisConnection();
+                            _isClosed = true;
 
-                        throw;
+                            if (stateObj != null)
+                            {
+                                lock (stateObj)
+                                {
+                                    _stateObj = null;
+                                    _command = null;
+                                    _connection = null;
+                                }
+                            }
+
+                            throw;
+                        }
                     }
-                }
 
-                // Close down any active Streams and TextReaders (this will also wait for them to finish their async tasks)
-                // NOTE: This must be done outside of the lock on the stateObj otherwise it will deadlock with CleanupAfterAsyncInvocation
-                CloseActiveSequentialStreamAndTextReader();
+                    // Close down any active Streams and TextReaders (this will also wait for them to finish their async tasks)
+                    // NOTE: This must be done outside of the lock on the stateObj otherwise it will deadlock with CleanupAfterAsyncInvocation
+                    CloseActiveSequentialStreamAndTextReader();
 
-                if (stateObj != null)
-                {
-
-                    // protect against concurrent close and cancel
-                    lock (stateObj)
+                    if (stateObj != null)
                     {
 
-                        if (_stateObj != null)
-                        {  // reader not closed while we waited for the lock
+                        // protect against concurrent close and cancel
+                        lock (stateObj)
+                        {
 
-                            // TryCloseInternal will clear out the snapshot when it is done
-                            if (_snapshot != null)
-                            {
+                            if (_stateObj != null)
+                            {  // reader not closed while we waited for the lock
+
+                                // TryCloseInternal will clear out the snapshot when it is done
+                                if (_snapshot != null)
+                                {
 #if DEBUG
-                                // The stack trace for replays will differ since they weren't captured during close
-                                stateObj._permitReplayStackTraceToDiffer = true;
+                                    // The stack trace for replays will differ since they weren't captured during close
+                                    stateObj._permitReplayStackTraceToDiffer = true;
 #endif
-                                PrepareForAsyncContinuation();
+                                    PrepareForAsyncContinuation();
+                                }
+
+                                SetTimeout(_defaultTimeoutMilliseconds);
+
+                                // Close can be called from async methods in error cases,
+                                // in which case we need to switch to syncOverAsync
+                                stateObj._syncOverAsync = true;
+
+                                if (!TryCloseInternal(true /*closeReader*/))
+                                {
+                                    throw SQL.SynchronousCallMayNotPend();
+                                }
+
+                                // DO NOT USE stateObj after this point - it has been returned to the TdsParser's session pool and potentially handed out to another thread
                             }
-
-                            SetTimeout(_defaultTimeoutMilliseconds);
-
-                            // Close can be called from async methods in error cases,
-                            // in which case we need to switch to syncOverAsync
-                            stateObj._syncOverAsync = true;
-
-                            if (!TryCloseInternal(true /*closeReader*/))
-                            {
-                                throw SQL.SynchronousCallMayNotPend();
-                            }
-
-                            // DO NOT USE stateObj after this point - it has been returned to the TdsParser's session pool and potentially handed out to another thread
                         }
                     }
                 }
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                }
             }
         }
 
@@ -1687,25 +1687,25 @@ namespace Microsoft.Data.SqlClient
         override public DataTable GetSchemaTable()
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlDataReader.GetSchemaTable|API> {0}", ObjectID);
-
-            try
+            using (TryEventScope.Create("<sc.SqlDataReader.GetSchemaTable|API> {0}", ObjectID))
             {
-                statistics = SqlStatistics.StartTimer(Statistics);
-                if (null == _metaData || null == _metaData.schemaTable)
+                try
                 {
-                    if (null != this.MetaData)
+                    statistics = SqlStatistics.StartTimer(Statistics);
+                    if (null == _metaData || null == _metaData.schemaTable)
                     {
-                        _metaData.schemaTable = BuildSchemaTable();
-                        Debug.Assert(null != _metaData.schemaTable, "No schema information yet!");
+                        if (null != this.MetaData)
+                        {
+                            _metaData.schemaTable = BuildSchemaTable();
+                            Debug.Assert(null != _metaData.schemaTable, "No schema information yet!");
+                        }
                     }
+                    return _metaData?.schemaTable;
                 }
-                return _metaData?.schemaTable;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
+                finally
+                {
+                    SqlStatistics.StopTimer(statistics);
+                }
             }
         }
 
@@ -3613,120 +3613,38 @@ namespace Microsoft.Data.SqlClient
         private bool TryNextResult(out bool more)
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlDataReader.NextResult|API> {0}", ObjectID);
-            RuntimeHelpers.PrepareConstrainedRegions();
-
-            try
+            using (TryEventScope.Create("<sc.SqlDataReader.NextResult|API> {0}", ObjectID))
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
                 RuntimeHelpers.PrepareConstrainedRegions();
+
                 try
                 {
-                    tdsReliabilitySection.Start();
+#if DEBUG
+                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+
+                    RuntimeHelpers.PrepareConstrainedRegions();
+                    try
+                    {
+                        tdsReliabilitySection.Start();
 #else
                 {
 #endif //DEBUG
-                    statistics = SqlStatistics.StartTimer(Statistics);
+                        statistics = SqlStatistics.StartTimer(Statistics);
 
-                    SetTimeout(_defaultTimeoutMilliseconds);
+                        SetTimeout(_defaultTimeoutMilliseconds);
 
-                    if (IsClosed)
-                    {
-                        throw ADP.DataReaderClosed("NextResult");
-                    }
-                    _fieldNameLookup = null;
-
-                    bool success = false; // WebData 100390
-                    _hasRows = false; // reset HasRows
-
-                    // if we are specifically only processing a single result, then read all the results off the wire and detach
-                    if (IsCommandBehavior(CommandBehavior.SingleResult))
-                    {
-                        if (!TryCloseInternal(false /*closeReader*/))
+                        if (IsClosed)
                         {
-                            more = false;
-                            return false;
+                            throw ADP.DataReaderClosed("NextResult");
                         }
+                        _fieldNameLookup = null;
 
-                        // In the case of not closing the reader, null out the metadata AFTER
-                        // CloseInternal finishes - since CloseInternal may go to the wire
-                        // and use the metadata.
-                        ClearMetaData();
-                        more = success;
-                        return true;
-                    }
+                        bool success = false; // WebData 100390
+                        _hasRows = false; // reset HasRows
 
-                    if (null != _parser)
-                    {
-                        // if there are more rows, then skip them, the user wants the next result
-                        bool moreRows = true;
-                        while (moreRows)
+                        // if we are specifically only processing a single result, then read all the results off the wire and detach
+                        if (IsCommandBehavior(CommandBehavior.SingleResult))
                         {
-                            if (!TryReadInternal(false, out moreRows))
-                            { // don't reset set the timeout value
-                                more = false;
-                                return false;
-                            }
-                        }
-                    }
-
-                    // we may be done, so continue only if we have not detached ourselves from the parser
-                    if (null != _parser)
-                    {
-                        bool moreResults;
-                        if (!TryHasMoreResults(out moreResults))
-                        {
-                            more = false;
-                            return false;
-                        }
-                        if (moreResults)
-                        {
-                            _metaDataConsumed = false;
-                            _browseModeInfoConsumed = false;
-
-                            switch (_altRowStatus)
-                            {
-                                case ALTROWSTATUS.AltRow:
-                                    int altRowId;
-                                    if (!_parser.TryGetAltRowId(_stateObj, out altRowId))
-                                    {
-                                        more = false;
-                                        return false;
-                                    }
-                                    _SqlMetaDataSet altMetaDataSet = _altMetaDataSetCollection.GetAltMetaData(altRowId);
-                                    if (altMetaDataSet != null)
-                                    {
-                                        _metaData = altMetaDataSet;
-                                    }
-                                    Debug.Assert((_metaData != null), "Can't match up altrowmetadata");
-                                    break;
-                                case ALTROWSTATUS.Done:
-                                    // restore the row-metaData
-                                    _metaData = _altMetaDataSetCollection.metaDataSet;
-                                    Debug.Assert(_altRowStatus == ALTROWSTATUS.Done, "invalid AltRowStatus");
-                                    _altRowStatus = ALTROWSTATUS.Null;
-                                    break;
-                                default:
-                                    if (!TryConsumeMetaData())
-                                    {
-                                        more = false;
-                                        return false;
-                                    }
-                                    if (_metaData == null)
-                                    {
-                                        more = false;
-                                        return true;
-                                    }
-                                    break;
-                            }
-
-                            success = true;
-                        }
-                        else
-                        {
-                            // detach the parser from this reader now
                             if (!TryCloseInternal(false /*closeReader*/))
                             {
                                 more = false;
@@ -3736,62 +3654,145 @@ namespace Microsoft.Data.SqlClient
                             // In the case of not closing the reader, null out the metadata AFTER
                             // CloseInternal finishes - since CloseInternal may go to the wire
                             // and use the metadata.
-                            if (!TrySetMetaData(null, false))
+                            ClearMetaData();
+                            more = success;
+                            return true;
+                        }
+
+                        if (null != _parser)
+                        {
+                            // if there are more rows, then skip them, the user wants the next result
+                            bool moreRows = true;
+                            while (moreRows)
+                            {
+                                if (!TryReadInternal(false, out moreRows))
+                                { // don't reset set the timeout value
+                                    more = false;
+                                    return false;
+                                }
+                            }
+                        }
+
+                        // we may be done, so continue only if we have not detached ourselves from the parser
+                        if (null != _parser)
+                        {
+                            bool moreResults;
+                            if (!TryHasMoreResults(out moreResults))
                             {
                                 more = false;
                                 return false;
                             }
-                        }
-                    }
-                    else
-                    {
-                        // Clear state in case of Read calling CloseInternal() then user calls NextResult()
-                        // MDAC 81986.  Or, also the case where the Read() above will do essentially the same
-                        // thing.
-                        ClearMetaData();
-                    }
+                            if (moreResults)
+                            {
+                                _metaDataConsumed = false;
+                                _browseModeInfoConsumed = false;
 
-                    more = success;
-                    return true;
-                }
+                                switch (_altRowStatus)
+                                {
+                                    case ALTROWSTATUS.AltRow:
+                                        int altRowId;
+                                        if (!_parser.TryGetAltRowId(_stateObj, out altRowId))
+                                        {
+                                            more = false;
+                                            return false;
+                                        }
+                                        _SqlMetaDataSet altMetaDataSet = _altMetaDataSetCollection.GetAltMetaData(altRowId);
+                                        if (altMetaDataSet != null)
+                                        {
+                                            _metaData = altMetaDataSet;
+                                        }
+                                        Debug.Assert((_metaData != null), "Can't match up altrowmetadata");
+                                        break;
+                                    case ALTROWSTATUS.Done:
+                                        // restore the row-metaData
+                                        _metaData = _altMetaDataSetCollection.metaDataSet;
+                                        Debug.Assert(_altRowStatus == ALTROWSTATUS.Done, "invalid AltRowStatus");
+                                        _altRowStatus = ALTROWSTATUS.Null;
+                                        break;
+                                    default:
+                                        if (!TryConsumeMetaData())
+                                        {
+                                            more = false;
+                                            return false;
+                                        }
+                                        if (_metaData == null)
+                                        {
+                                            more = false;
+                                            return true;
+                                        }
+                                        break;
+                                }
+
+                                success = true;
+                            }
+                            else
+                            {
+                                // detach the parser from this reader now
+                                if (!TryCloseInternal(false /*closeReader*/))
+                                {
+                                    more = false;
+                                    return false;
+                                }
+
+                                // In the case of not closing the reader, null out the metadata AFTER
+                                // CloseInternal finishes - since CloseInternal may go to the wire
+                                // and use the metadata.
+                                if (!TrySetMetaData(null, false))
+                                {
+                                    more = false;
+                                    return false;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // Clear state in case of Read calling CloseInternal() then user calls NextResult()
+                            // MDAC 81986.  Or, also the case where the Read() above will do essentially the same
+                            // thing.
+                            ClearMetaData();
+                        }
+
+                        more = success;
+                        return true;
+                    }
 #if DEBUG
+                    finally
+                    {
+                        tdsReliabilitySection.Stop();
+                    }
+#endif //DEBUG
+                }
+                catch (System.OutOfMemoryException e)
+                {
+                    _isClosed = true;
+                    if (null != _connection)
+                    {
+                        _connection.Abort(e);
+                    }
+                    throw;
+                }
+                catch (System.StackOverflowException e)
+                {
+                    _isClosed = true;
+                    if (null != _connection)
+                    {
+                        _connection.Abort(e);
+                    }
+                    throw;
+                }
+                catch (System.Threading.ThreadAbortException e)
+                {
+                    _isClosed = true;
+                    if (null != _connection)
+                    {
+                        _connection.Abort(e);
+                    }
+                    throw;
+                }
                 finally
                 {
-                    tdsReliabilitySection.Stop();
+                    SqlStatistics.StopTimer(statistics);
                 }
-#endif //DEBUG
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _isClosed = true;
-                if (null != _connection)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _isClosed = true;
-                if (null != _connection)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _isClosed = true;
-                if (null != _connection)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 
@@ -3819,209 +3820,210 @@ namespace Microsoft.Data.SqlClient
         private bool TryReadInternal(bool setTimeout, out bool more)
         {
             SqlStatistics statistics = null;
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlDataReader.Read|API> {0}", ObjectID);
-            RuntimeHelpers.PrepareConstrainedRegions();
-
-            try
+            using (TryEventScope.Create("<sc.SqlDataReader.Read|API> {0}", ObjectID))
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
                 RuntimeHelpers.PrepareConstrainedRegions();
+
                 try
                 {
-                    tdsReliabilitySection.Start();
+#if DEBUG
+                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+
+                    RuntimeHelpers.PrepareConstrainedRegions();
+                    try
+                    {
+                        tdsReliabilitySection.Start();
 #else
                 {
 #endif //DEBUG
-                    statistics = SqlStatistics.StartTimer(Statistics);
+                        statistics = SqlStatistics.StartTimer(Statistics);
 
-                    if (null != _parser)
-                    {
-                        if (setTimeout)
+                        if (null != _parser)
                         {
-                            SetTimeout(_defaultTimeoutMilliseconds);
-                        }
-                        if (_sharedState._dataReady)
-                        {
-                            if (!TryCleanPartialRead())
+                            if (setTimeout)
                             {
-                                more = false;
-                                return false;
+                                SetTimeout(_defaultTimeoutMilliseconds);
                             }
-                        }
-
-                        // clear out our buffers
-                        SqlBuffer.Clear(_data);
-
-                        _sharedState._nextColumnHeaderToRead = 0;
-                        _sharedState._nextColumnDataToRead = 0;
-                        _sharedState._columnDataBytesRemaining = -1; // unknown
-                        _lastColumnWithDataChunkRead = -1;
-
-                        if (!_haltRead)
-                        {
-                            bool moreRows;
-                            if (!TryHasMoreRows(out moreRows))
+                            if (_sharedState._dataReady)
                             {
-                                more = false;
-                                return false;
-                            }
-                            if (moreRows)
-                            {
-                                // read the row from the backend (unless it's an altrow were the marker is already inside the altrow ...)
-                                while (_stateObj._pendingData)
-                                {
-                                    if (_altRowStatus != ALTROWSTATUS.AltRow)
-                                    {
-                                        // if this is an ordinary row we let the run method consume the ROW token
-                                        if (!_parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady))
-                                        {
-                                            more = false;
-                                            return false;
-                                        }
-                                        if (_sharedState._dataReady)
-                                        {
-                                            break;
-                                        }
-                                    }
-                                    else
-                                    {
-                                        // ALTROW token and AltrowId are already consumed ...
-                                        Debug.Assert(_altRowStatus == ALTROWSTATUS.AltRow, "invalid AltRowStatus");
-                                        _altRowStatus = ALTROWSTATUS.Done;
-                                        _sharedState._dataReady = true;
-                                        break;
-                                    }
-                                }
-                                if (_sharedState._dataReady)
-                                {
-                                    _haltRead = IsCommandBehavior(CommandBehavior.SingleRow);
-                                    more = true;
-                                    return true;
-                                }
-                            }
-
-                            if (!_stateObj._pendingData)
-                            {
-                                if (!TryCloseInternal(false /*closeReader*/))
+                                if (!TryCleanPartialRead())
                                 {
                                     more = false;
                                     return false;
                                 }
                             }
-                        }
-                        else
-                        {
-                            // if we did not get a row and halt is true, clean off rows of result
-                            // success must be false - or else we could have just read off row and set
-                            // halt to true
-                            bool moreRows;
-                            if (!TryHasMoreRows(out moreRows))
+
+                            // clear out our buffers
+                            SqlBuffer.Clear(_data);
+
+                            _sharedState._nextColumnHeaderToRead = 0;
+                            _sharedState._nextColumnDataToRead = 0;
+                            _sharedState._columnDataBytesRemaining = -1; // unknown
+                            _lastColumnWithDataChunkRead = -1;
+
+                            if (!_haltRead)
                             {
-                                more = false;
-                                return false;
-                            }
-                            while (moreRows)
-                            {
-                                // if we are in SingleRow mode, and we've read the first row,
-                                // read the rest of the rows, if any
-                                while (_stateObj._pendingData && !_sharedState._dataReady)
-                                {
-                                    if (!_parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady))
-                                    {
-                                        more = false;
-                                        return false;
-                                    }
-                                }
-
-                                if (_sharedState._dataReady)
-                                {
-                                    if (!TryCleanPartialRead())
-                                    {
-                                        more = false;
-                                        return false;
-                                    }
-                                }
-
-                                // clear out our buffers
-                                SqlBuffer.Clear(_data);
-
-                                _sharedState._nextColumnHeaderToRead = 0;
-
+                                bool moreRows;
                                 if (!TryHasMoreRows(out moreRows))
                                 {
                                     more = false;
                                     return false;
                                 }
+                                if (moreRows)
+                                {
+                                    // read the row from the backend (unless it's an altrow were the marker is already inside the altrow ...)
+                                    while (_stateObj._pendingData)
+                                    {
+                                        if (_altRowStatus != ALTROWSTATUS.AltRow)
+                                        {
+                                            // if this is an ordinary row we let the run method consume the ROW token
+                                            if (!_parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady))
+                                            {
+                                                more = false;
+                                                return false;
+                                            }
+                                            if (_sharedState._dataReady)
+                                            {
+                                                break;
+                                            }
+                                        }
+                                        else
+                                        {
+                                            // ALTROW token and AltrowId are already consumed ...
+                                            Debug.Assert(_altRowStatus == ALTROWSTATUS.AltRow, "invalid AltRowStatus");
+                                            _altRowStatus = ALTROWSTATUS.Done;
+                                            _sharedState._dataReady = true;
+                                            break;
+                                        }
+                                    }
+                                    if (_sharedState._dataReady)
+                                    {
+                                        _haltRead = IsCommandBehavior(CommandBehavior.SingleRow);
+                                        more = true;
+                                        return true;
+                                    }
+                                }
+
+                                if (!_stateObj._pendingData)
+                                {
+                                    if (!TryCloseInternal(false /*closeReader*/))
+                                    {
+                                        more = false;
+                                        return false;
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                // if we did not get a row and halt is true, clean off rows of result
+                                // success must be false - or else we could have just read off row and set
+                                // halt to true
+                                bool moreRows;
+                                if (!TryHasMoreRows(out moreRows))
+                                {
+                                    more = false;
+                                    return false;
+                                }
+                                while (moreRows)
+                                {
+                                    // if we are in SingleRow mode, and we've read the first row,
+                                    // read the rest of the rows, if any
+                                    while (_stateObj._pendingData && !_sharedState._dataReady)
+                                    {
+                                        if (!_parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady))
+                                        {
+                                            more = false;
+                                            return false;
+                                        }
+                                    }
+
+                                    if (_sharedState._dataReady)
+                                    {
+                                        if (!TryCleanPartialRead())
+                                        {
+                                            more = false;
+                                            return false;
+                                        }
+                                    }
+
+                                    // clear out our buffers
+                                    SqlBuffer.Clear(_data);
+
+                                    _sharedState._nextColumnHeaderToRead = 0;
+
+                                    if (!TryHasMoreRows(out moreRows))
+                                    {
+                                        more = false;
+                                        return false;
+                                    }
+                                }
+
+                                // reset haltRead
+                                _haltRead = false;
+                            }
+                        }
+                        else if (IsClosed)
+                        {
+                            throw ADP.DataReaderClosed("Read");
+                        }
+                        more = false;
+
+#if DEBUG
+                        if ((!_sharedState._dataReady) && (_stateObj._pendingData))
+                        {
+                            byte token;
+                            if (!_stateObj.TryPeekByte(out token))
+                            {
+                                return false;
                             }
 
-                            // reset haltRead
-                            _haltRead = false;
+                            Debug.Assert(TdsParser.IsValidTdsToken(token), $"DataReady is false, but next token is invalid: {token,-2:X2}");
                         }
-                    }
-                    else if (IsClosed)
-                    {
-                        throw ADP.DataReaderClosed("Read");
-                    }
-                    more = false;
-
-#if DEBUG
-                    if ((!_sharedState._dataReady) && (_stateObj._pendingData))
-                    {
-                        byte token;
-                        if (!_stateObj.TryPeekByte(out token))
-                        {
-                            return false;
-                        }
-
-                        Debug.Assert(TdsParser.IsValidTdsToken(token), $"DataReady is false, but next token is invalid: {token,-2:X2}");
-                    }
 #endif
 
-                    return true;
-                }
+                        return true;
+                    }
 #if DEBUG
+                    finally
+                    {
+                        tdsReliabilitySection.Stop();
+                    }
+#endif //DEBUG
+                }
+                catch (System.OutOfMemoryException e)
+                {
+                    _isClosed = true;
+                    SqlConnection con = _connection;
+                    if (con != null)
+                    {
+                        con.Abort(e);
+                    }
+                    throw;
+                }
+                catch (System.StackOverflowException e)
+                {
+                    _isClosed = true;
+                    SqlConnection con = _connection;
+                    if (con != null)
+                    {
+                        con.Abort(e);
+                    }
+                    throw;
+                }
+                catch (System.Threading.ThreadAbortException e)
+                {
+                    _isClosed = true;
+                    SqlConnection con = _connection;
+                    if (con != null)
+                    {
+                        con.Abort(e);
+                    }
+                    throw;
+                }
                 finally
                 {
-                    tdsReliabilitySection.Stop();
+                    SqlStatistics.StopTimer(statistics);
                 }
-#endif //DEBUG
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _isClosed = true;
-                SqlConnection con = _connection;
-                if (con != null)
-                {
-                    con.Abort(e);
-                }
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _isClosed = true;
-                SqlConnection con = _connection;
-                if (con != null)
-                {
-                    con.Abort(e);
-                }
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _isClosed = true;
-                SqlConnection con = _connection;
-                if (con != null)
-                {
-                    con.Abort(e);
-                }
-                throw;
-            }
-            finally
-            {
-                SqlStatistics.StopTimer(statistics);
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 
@@ -4808,10 +4810,9 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/NextResultAsync/*' />
         public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlDataReader.NextResultAsync|API> {0}", ObjectID);
-
-            try
+            using (TryEventScope.Create("<sc.SqlDataReader.NextResultAsync|API> {0}", ObjectID))
             {
+
                 TaskCompletionSource<bool> source = new TaskCompletionSource<bool>();
 
                 if (IsClosed)
@@ -4869,10 +4870,6 @@ namespace Microsoft.Data.SqlClient
                 };
 
                 return InvokeRetryable(moreFunc, source, registration);
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 
@@ -5107,8 +5104,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/ReadAsync/*' />
         public override Task<bool> ReadAsync(CancellationToken cancellationToken)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlDataReader.ReadAsync|API> {0}", ObjectID);
-            try
+            using (TryEventScope.Create("<sc.SqlDataReader.ReadAsync|API> {0}", ObjectID))
             {
                 if (IsClosed)
                 {
@@ -5263,10 +5259,6 @@ namespace Microsoft.Data.SqlClient
                 };
 
                 return InvokeRetryable(moreFunc, source, registration);
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
@@ -60,8 +60,7 @@ namespace Microsoft.Data.SqlClient
             // When being deactivated, we check all the sessions in the
             // cache to make sure they're cleaned up and then we dispose of
             // sessions that are past what we want to keep around.
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.TdsParserSessionPool.Deactivate|ADV> {0} deactivating cachedCount={1}", ObjectID, _cachedCount);
-            try
+            using (TryEventScope.Create("<sc.TdsParserSessionPool.Deactivate|ADV> {0} deactivating cachedCount={1}", ObjectID, _cachedCount))
             {
                 lock (_cache)
                 {
@@ -87,10 +86,6 @@ namespace Microsoft.Data.SqlClient
                     // TODO: re-enable this assert when the connection isn't doomed.
                     //Debug.Assert (_cachedCount < MaxInactiveCount, "non-orphaned connection past initial allocation?");
                 }
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
@@ -295,16 +295,15 @@ namespace Microsoft.Data.SqlClient
 
         internal void Commit()
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlInternalTransaction.Commit|API> {0}", ObjectID);
-            if (_innerConnection.IsLockedForBulkCopy)
+            using (TryEventScope.Create("<sc.SqlInternalTransaction.Commit|API> {0}", ObjectID))
             {
-                throw SQL.ConnectionLockedForBcpEvent();
-            }
+                if (_innerConnection.IsLockedForBulkCopy)
+                {
+                    throw SQL.ConnectionLockedForBcpEvent();
+                }
 
-            _innerConnection.ValidateConnectionForExecute(null);
+                _innerConnection.ValidateConnectionForExecute(null);
 
-            try
-            {
                 // If this transaction has been completed, throw exception since it is unusable.
                 try
                 {
@@ -336,10 +335,6 @@ namespace Microsoft.Data.SqlClient
 
                     throw;
                 }
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 
@@ -424,17 +419,15 @@ namespace Microsoft.Data.SqlClient
 
         internal void Rollback()
         {
-            var scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}", ObjectID);
-
-            if (_innerConnection.IsLockedForBulkCopy)
+            using (TryEventScope.Create("<sc.SqlInternalTransaction.Rollback|API> {0}", ObjectID))
             {
-                throw SQL.ConnectionLockedForBcpEvent();
-            }
+                if (_innerConnection.IsLockedForBulkCopy)
+                {
+                    throw SQL.ConnectionLockedForBcpEvent();
+                }
 
-            _innerConnection.ValidateConnectionForExecute(null);
+                _innerConnection.ValidateConnectionForExecute(null);
 
-            try
-            {
                 try
                 {
                     // If no arg is given to ROLLBACK it will rollback to the outermost begin - rolling back
@@ -463,32 +456,28 @@ namespace Microsoft.Data.SqlClient
                     }
                 }
             }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-            }
         }
 
         internal void Rollback(string transactionName)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlInternalTransaction.Rollback|API> {0}, transactionName='{1}'", ObjectID, transactionName);
-
-            if (_innerConnection.IsLockedForBulkCopy)
+            using (TryEventScope.Create("<sc.SqlInternalTransaction.Rollback|API> {0}, transactionName='{1}'", ObjectID, transactionName))
             {
-                throw SQL.ConnectionLockedForBcpEvent();
-            }
+                if (_innerConnection.IsLockedForBulkCopy)
+                {
+                    throw SQL.ConnectionLockedForBcpEvent();
+                }
 
-            _innerConnection.ValidateConnectionForExecute(null);
+                _innerConnection.ValidateConnectionForExecute(null);
 
-            try
-            {
                 // ROLLBACK takes either a save point name or a transaction name.  It will rollback the
                 // transaction to either the save point with the save point name or begin with the
                 // transaction name.  NOTE: for simplicity it is possible to give all save point names
                 // the same name, and ROLLBACK will simply rollback to the most recent save point with the
                 // save point name.
                 if (ADP.IsEmpty(transactionName))
+                {
                     throw SQL.NullEmptyTransactionName();
+                }
 
                 try
                 {
@@ -512,19 +501,14 @@ namespace Microsoft.Data.SqlClient
                     throw;
                 }
             }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
-            }
         }
 
         internal void Save(string savePointName)
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlInternalTransaction.Save|API> {0}, savePointName='{1}'", ObjectID, savePointName);
-            _innerConnection.ValidateConnectionForExecute(null);
-
-            try
+            using (TryEventScope.Create("<sc.SqlInternalTransaction.Save|API> {0}, savePointName='{1}'", ObjectID, savePointName))
             {
+                _innerConnection.ValidateConnectionForExecute(null);
+
                 // ROLLBACK takes either a save point name or a transaction name.  It will rollback the
                 // transaction to either the save point with the save point name or begin with the
                 // transaction name.  So, to rollback a nested transaction you must have a save point.
@@ -532,7 +516,9 @@ namespace Microsoft.Data.SqlClient
                 // exception from the server.  So, an overload for SaveTransaction without an arg doesn't make
                 // sense to have.  Save Transaction does not affect the transaction level.
                 if (ADP.IsEmpty(savePointName))
+                {
                     throw SQL.NullEmptyTransactionName();
+                }
 
                 try
                 {
@@ -548,10 +534,6 @@ namespace Microsoft.Data.SqlClient
 
                     throw;
                 }
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
@@ -65,17 +65,21 @@ namespace Microsoft.Data.SqlTypes
                 Int64 allocationSize
             )
         {
-            long scopeID = SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlFileStream.ctor|API> {0} access={1} options={2} path='{3}'", ObjectID, (int)access, (int)options, path);
-            try
+            using (TryEventScope.Create(SqlClientEventSource.Log.TryScopeEnterEvent("<sc.SqlFileStream.ctor|API> {0} access={1} options={2} path='{3}'", ObjectID, (int)access, (int)options, path)))
+
             {
                 //-----------------------------------------------------------------
                 // precondition validation
 
                 if (transactionContext == null)
+                {
                     throw ADP.ArgumentNull("transactionContext");
+                }
 
                 if (path == null)
+                {
                     throw ADP.ArgumentNull("path");
+                }
 
                 //-----------------------------------------------------------------
 
@@ -87,10 +91,6 @@ namespace Microsoft.Data.SqlTypes
                 // only set internal state once the file has actually been successfully opened
                 this.Name = path;
                 this.TransactionContext = transactionContext;
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TryScopeLeaveEvent(scopeID);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -1127,4 +1127,27 @@ namespace Microsoft.Data.SqlClient
             return new TrySNIEventScope(SqlClientEventSource.Log.TrySNIScopeEnterEvent(message, memberName));
         }
     }
+
+    internal readonly ref struct TryEventScope //: IDisposable
+    {
+        private readonly long _scopeId;
+
+        public TryEventScope(long scopeID) => _scopeId = scopeID;
+
+        public void Dispose()
+        {
+            if (_scopeId != 0)
+            {
+                SqlClientEventSource.Log.TryScopeLeaveEvent(_scopeId);
+            }
+        }
+
+        public static TryEventScope Create<T0>(string message, T0 args0) => new TryEventScope(SqlClientEventSource.Log.TryScopeEnterEvent(message, args0));
+
+        public static TryEventScope Create<T0, T1>(string message, T0 args0, T1 args1) => new TryEventScope(SqlClientEventSource.Log.TryScopeEnterEvent(message, args0, args1));
+
+        public static TryEventScope Create(string className, [System.Runtime.CompilerServices.CallerMemberName] string memberName = "") => new TryEventScope(SqlClientEventSource.Log.TryScopeEnterEvent(className, memberName));
+
+        public static TryEventScope Create(long scopeId) => new TryEventScope(scopeId);
+    }
 }


### PR DESCRIPTION
This replaces a lot of try finally blocks used to implement log traces with using blocks that do the same. This makes the code visually cleaner. There are a couple of minor style changes scattered around as well but there are no functional changes.