### PR TITLE
Simplify diagnostic tracing

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
@@ -346,5 +346,182 @@ namespace Microsoft.Data.SqlClient
                     });
             }
         }
+
+        public static DiagnosticScope CreateCommandScope(this SqlDiagnosticListener @this, SqlCommand command, SqlTransaction transaction, [CallerMemberName] string operationName = "")
+        {
+            return DiagnosticScope.CreateCommandScope(@this, command, transaction, operationName);
+        }
+
+        public static DiagnosticScope CreateConnectionOpenScope(this SqlDiagnosticListener @this, SqlConnection connection, [CallerMemberName] string operationName = "")
+        {
+            return DiagnosticScope.CreateConnectionOpenScope(@this, connection, operationName);
+        }
+
+        public static DiagnosticTransactionScope CreateTransactionCommitScope(this SqlDiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operationName = "")
+        {
+            return DiagnosticTransactionScope.CreateTransactionCommitScope(@this, isolationLevel, connection, transaction, operationName);
+        }
+
+        public static DiagnosticTransactionScope CreateTransactionRollbackScope(this SqlDiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName, [CallerMemberName] string operationName = "")
+        {
+            return DiagnosticTransactionScope.CreateTransactionRollbackScope(@this, isolationLevel, connection, transaction, transactionName, operationName);
+        }
+    }
+
+    internal ref struct DiagnosticScope //: IDisposable //ref structs cannot implement interfaces but the compiler will use pattern matching
+    {
+        private const int CommandOperation = 1;
+        private const int ConnectionOpenOperation = 2;
+
+        private readonly SqlDiagnosticListener _diagnostics;
+        private readonly int _operation;
+        private readonly string _operationName;
+        private readonly Guid _operationId;
+        private readonly object _context1;
+        private readonly object _context2;
+        private Exception _exception;
+
+        private DiagnosticScope(SqlDiagnosticListener diagnostics, int operation, Guid operationsId, string operationName, object context1, object context2)
+        {
+            _diagnostics = diagnostics;
+            _operation = operation;
+            _operationId = operationsId;
+            _operationName = operationName;
+            _context1 = context1;
+            _context2 = context2;
+            _exception = null;
+        }
+
+        public void Dispose()
+        {
+            switch (_operation)
+            {
+                case CommandOperation:
+                    if (_exception != null)
+                    {
+                        _diagnostics.WriteCommandError(_operationId, (SqlCommand)_context1, (SqlTransaction)_context2, _exception, _operationName);
+                    }
+                    else
+                    {
+                        _diagnostics.WriteCommandAfter(_operationId, (SqlCommand)_context1, (SqlTransaction)_context2, _operationName);
+                    }
+                    break;
+
+                case ConnectionOpenOperation:
+                    if (_exception != null)
+                    {
+                        _diagnostics.WriteConnectionOpenError(_operationId, (SqlConnection)_context1, _exception, _operationName);
+                    }
+                    else
+                    {
+                        _diagnostics.WriteConnectionOpenAfter(_operationId, (SqlConnection)_context1, _operationName);
+                    }
+                    break;
+
+                //case ConnectionCloseOperation:
+                //    if (_exception != null)
+                //    {
+                //        _diagnostics.WriteConnectionCloseError(_operationId, (Guid)_context2, (SqlConnection)_context1, _exception, _operationName);
+                //    }
+                //    else
+                //    {
+                //        _diagnostics.WriteConnectionCloseAfter(_operationId, (Guid)_context2, (SqlConnection)_context1, _operationName);
+                //    }
+                //    break;
+            }
+        }
+
+        public void SetException(Exception ex)
+        {
+            _exception = ex;
+        }
+
+        public static DiagnosticScope CreateCommandScope(SqlDiagnosticListener diagnostics, SqlCommand command, SqlTransaction transaction, [CallerMemberName] string operationName = "")
+        {
+            Guid operationId = diagnostics.WriteCommandBefore(command, transaction, operationName);
+            return new DiagnosticScope(diagnostics, CommandOperation, operationId, operationName, command, transaction);
+        }
+
+        public static DiagnosticScope CreateConnectionOpenScope(SqlDiagnosticListener diagnostics, SqlConnection connection, [CallerMemberName] string operationName = "")
+        {
+            Guid operationId = diagnostics.WriteConnectionOpenBefore(connection, operationName);
+            return new DiagnosticScope(diagnostics, ConnectionOpenOperation, operationId, operationName, connection, null);
+        }
+
+        // GetConnectionCloseScope is not implemented because it is conditionally emitted and that requires manual calls to the write apis
+    }
+
+    internal ref struct DiagnosticTransactionScope //: IDisposable //ref structs cannot implement interfaces but the compiler will use pattern matching
+    {
+        public const int TransactionCommit = 1;
+        public const int TransactionRollback = 2;
+
+        private readonly SqlDiagnosticListener _diagnostics;
+        private readonly int _operation;
+        private readonly Guid _operationId;
+        private readonly string _operationName;
+        private readonly IsolationLevel _isolationLevel;
+        private readonly SqlConnection _connection;
+        private readonly SqlInternalTransaction _transaction;
+        private readonly string _transactionName;
+        private Exception _exception;
+
+        public DiagnosticTransactionScope(SqlDiagnosticListener diagnostics, int operation, Guid operationId, string operationName, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName)
+        {
+            _diagnostics = diagnostics;
+            _operation = operation;
+            _operationId = operationId;
+            _operationName = operationName;
+            _isolationLevel = isolationLevel;
+            _connection = connection;
+            _transaction = transaction;
+            _transactionName = transactionName;
+            _exception = null;
+        }
+
+        public void Dispose()
+        {
+            switch (_operation)
+            {
+                case TransactionCommit:
+                    if (_exception != null)
+                    {
+                        _diagnostics.WriteTransactionCommitError(_operationId, _isolationLevel, _connection, _transaction, _exception, _operationName);
+                    }
+                    else
+                    {
+                        _diagnostics.WriteTransactionCommitAfter(_operationId, _isolationLevel, _connection, _transaction, _operationName);
+                    }
+                    break;
+
+                case TransactionRollback:
+                    if (_exception != null)
+                    {
+                        _diagnostics.WriteTransactionRollbackError(_operationId, _isolationLevel, _connection, _transaction, _exception, _transactionName, _operationName);
+                    }
+                    else
+                    {
+                        _diagnostics.WriteTransactionRollbackAfter(_operationId, _isolationLevel, _connection, _transaction, _transactionName, _operationName);
+                    }
+                    break;
+            }
+        }
+
+        public void SetException(Exception ex)
+        {
+            _exception = ex;
+        }
+
+        public static DiagnosticTransactionScope CreateTransactionCommitScope(SqlDiagnosticListener diagnostics, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operationName = "")
+        {
+            Guid operationId = diagnostics.WriteTransactionCommitBefore(isolationLevel, connection, transaction, operationName);
+            return new DiagnosticTransactionScope(diagnostics, TransactionCommit, operationId, operationName, isolationLevel, connection, transaction, null);
+        }
+
+        public static DiagnosticTransactionScope CreateTransactionRollbackScope(SqlDiagnosticListener diagnostics, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName, [CallerMemberName] string operationName = "")
+        {
+            Guid operationId = diagnostics.WriteTransactionRollbackBefore(isolationLevel, connection, transaction, transactionName, operationName);
+            return new DiagnosticTransactionScope(diagnostics, TransactionCommit, operationId, operationName, isolationLevel, connection, transaction, transactionName);
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
@@ -352,11 +352,6 @@ namespace Microsoft.Data.SqlClient
             return DiagnosticScope.CreateCommandScope(@this, command, transaction, operationName);
         }
 
-        public static DiagnosticScope CreateConnectionOpenScope(this SqlDiagnosticListener @this, SqlConnection connection, [CallerMemberName] string operationName = "")
-        {
-            return DiagnosticScope.CreateConnectionOpenScope(@this, connection, operationName);
-        }
-
         public static DiagnosticTransactionScope CreateTransactionCommitScope(this SqlDiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operationName = "")
         {
             return DiagnosticTransactionScope.CreateTransactionCommitScope(@this, isolationLevel, connection, transaction, operationName);
@@ -418,16 +413,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     break;
 
-                //case ConnectionCloseOperation:
-                //    if (_exception != null)
-                //    {
-                //        _diagnostics.WriteConnectionCloseError(_operationId, (Guid)_context2, (SqlConnection)_context1, _exception, _operationName);
-                //    }
-                //    else
-                //    {
-                //        _diagnostics.WriteConnectionCloseAfter(_operationId, (Guid)_context2, (SqlConnection)_context1, _operationName);
-                //    }
-                //    break;
+                    // ConnectionCloseOperation is not implemented because it is conditionally emitted and that requires manual calls to the write apis
             }
         }
 
@@ -441,14 +427,6 @@ namespace Microsoft.Data.SqlClient
             Guid operationId = diagnostics.WriteCommandBefore(command, transaction, operationName);
             return new DiagnosticScope(diagnostics, CommandOperation, operationId, operationName, command, transaction);
         }
-
-        public static DiagnosticScope CreateConnectionOpenScope(SqlDiagnosticListener diagnostics, SqlConnection connection, [CallerMemberName] string operationName = "")
-        {
-            Guid operationId = diagnostics.WriteConnectionOpenBefore(connection, operationName);
-            return new DiagnosticScope(diagnostics, ConnectionOpenOperation, operationId, operationName, connection, null);
-        }
-
-        // GetConnectionCloseScope is not implemented because it is conditionally emitted and that requires manual calls to the write apis
     }
 
     internal ref struct DiagnosticTransactionScope //: IDisposable //ref structs cannot implement interfaces but the compiler will use pattern matching

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1086,51 +1086,37 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
-            SqlStatistics statistics = null;
-            Exception e = null;
-            bool success = false;
-            int? sqlExceptionNumber = null;
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
-
+            using (DiagnosticScope diagnosticScope = _diagnosticListener.CreateCommandScope(this, _transaction))
             using (TryEventScope.Create("SqlCommand.ExecuteScalar | API | ObjectId {0}", ObjectID))
             {
+                SqlStatistics statistics = null;
+                bool success = false;
+                int? sqlExceptionNumber = null;
                 SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.ExecuteScalar | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
 
                 try
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
                     WriteBeginExecuteEvent();
-                    SqlDataReader ds;
-                    ds = IsProviderRetriable ?
+                    SqlDataReader ds = IsProviderRetriable ?
                         RunExecuteReaderWithRetry(0, RunBehavior.ReturnImmediately, returnStream: true) :
                         RunExecuteReader(0, RunBehavior.ReturnImmediately, returnStream: true, method: nameof(ExecuteScalar));
                     success = true;
-
                     return CompleteExecuteScalar(ds, false);
                 }
                 catch (Exception ex)
                 {
-                    if (ex is SqlException)
+                    diagnosticScope.SetException(ex);
+                    if (ex is SqlException sqlException)
                     {
-                        SqlException exception = (SqlException)ex;
-                        sqlExceptionNumber = exception.Number;
+                        sqlExceptionNumber = sqlException.Number;
                     }
-
-                    e = ex;
                     throw;
                 }
                 finally
                 {
                     SqlStatistics.StopTimer(statistics);
                     WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
-                    if (e != null)
-                    {
-                        _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
-                    }
-                    else
-                    {
-                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
-                    }
                 }
             }
         }
@@ -1180,12 +1166,12 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
-            SqlStatistics statistics = null;
-            Exception e = null;
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
-
+            using (var diagnosticScope = _diagnosticListener.CreateCommandScope(this, _transaction))
             using (TryEventScope.Create("SqlCommand.ExecuteNonQuery | API | Object Id {0}", ObjectID))
             {
+                SqlStatistics statistics = null;
+                bool success = false;
+                int? sqlExceptionNumber = null;
                 SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.ExecuteNonQuery | API | Correlation | Object Id {0}, ActivityID {1}, Client Connection Id {2}, Command Text {3}", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
 
                 try
@@ -1200,24 +1186,22 @@ namespace Microsoft.Data.SqlClient
                     {
                         InternalExecuteNonQuery(completion: null, sendToPipe: false, timeout: CommandTimeout, out _);
                     }
+                    success = true;
                     return _rowsAffected;
                 }
                 catch (Exception ex)
                 {
-                    e = ex;
+                    diagnosticScope.SetException(ex);
+                    if (ex is SqlException sqlException)
+                    {
+                        sqlExceptionNumber = sqlException.Number;
+                    }
                     throw;
                 }
                 finally
                 {
                     SqlStatistics.StopTimer(statistics);
-                    if (e != null)
-                    {
-                        _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
-                    }
-                    else
-                    {
-                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
-                    }
+                    WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
                 }
             }
         }
@@ -1684,14 +1668,12 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
 
-            SqlStatistics statistics = null;
-            bool success = false;
-            int? sqlExceptionNumber = null;
-            Exception e = null;
-            Guid operationId = _diagnosticListener.WriteCommandBefore(this, _transaction);
-
+            using (DiagnosticScope diagnosticScope = _diagnosticListener.CreateCommandScope(this, _transaction))
             using (TryEventScope.Create("SqlCommand.ExecuteXmlReader | API | Object Id {0}", ObjectID))
             {
+                SqlStatistics statistics = null;
+                bool success = false;
+                int? sqlExceptionNumber = null;
                 SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.ExecuteXmlReader | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
 
                 try
@@ -1699,8 +1681,7 @@ namespace Microsoft.Data.SqlClient
                     statistics = SqlStatistics.StartTimer(Statistics);
                     WriteBeginExecuteEvent();
                     // use the reader to consume metadata
-                    SqlDataReader ds;
-                    ds = IsProviderRetriable ?
+                    SqlDataReader ds = IsProviderRetriable ?
                         RunExecuteReaderWithRetry(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true) :
                         RunExecuteReader(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true);
                     success = true;
@@ -1708,27 +1689,17 @@ namespace Microsoft.Data.SqlClient
                 }
                 catch (Exception ex)
                 {
-                    e = ex;
-                    if (ex is SqlException)
+                    diagnosticScope.SetException(ex);
+                    if (ex is SqlException sqlException)
                     {
-                        SqlException exception = (SqlException)ex;
-                        sqlExceptionNumber = exception.Number;
+                        sqlExceptionNumber = sqlException.Number;
                     }
-
                     throw;
                 }
                 finally
                 {
                     SqlStatistics.StopTimer(statistics);
                     WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
-                    if (e != null)
-                    {
-                        _diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
-                    }
-                    else
-                    {
-                        _diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
-                    }
                 }
             }
         }


### PR DESCRIPTION
Adds scopes for diagnostic tracing and uses them where appropriate in sync methods. Async methods and ConnectionClose still need to do direct api calls to prevent the heap allocation of the scope data and because the close notifications can be conditional.