### PR TITLE
Perf: use manual masking on state flags to avoid boxing

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -1199,31 +1199,31 @@ namespace Microsoft.Data.SqlClient
 
         internal bool HasOpenResult
         {
-            get => _snapshottedState.HasFlag(SnapshottedStateFlags.OpenResult);
+            get => (_snapshottedState & SnapshottedStateFlags.OpenResult) == SnapshottedStateFlags.OpenResult;
             set => SetSnapshottedState(SnapshottedStateFlags.OpenResult, value);
         }
 
         internal bool HasPendingData
         {
-            get => _snapshottedState.HasFlag(SnapshottedStateFlags.PendingData);
+            get => (_snapshottedState & SnapshottedStateFlags.PendingData) == SnapshottedStateFlags.PendingData;
             set => SetSnapshottedState(SnapshottedStateFlags.PendingData, value);
         }
 
         internal bool HasReceivedError
         {
-            get => _snapshottedState.HasFlag(SnapshottedStateFlags.ErrorTokenReceived);
+            get => (_snapshottedState & SnapshottedStateFlags.ErrorTokenReceived) == SnapshottedStateFlags.ErrorTokenReceived;
             set => SetSnapshottedState(SnapshottedStateFlags.ErrorTokenReceived, value);
         }
 
         internal bool HasReceivedAttention
         {
-            get => _snapshottedState.HasFlag(SnapshottedStateFlags.AttentionReceived);
+            get => (_snapshottedState & SnapshottedStateFlags.AttentionReceived) == SnapshottedStateFlags.AttentionReceived;
             set => SetSnapshottedState(SnapshottedStateFlags.AttentionReceived, value);
         }
 
         internal bool HasReceivedColumnMetadata
         {
-            get => _snapshottedState.HasFlag(SnapshottedStateFlags.ColMetaDataReceived);
+            get => (_snapshottedState & SnapshottedStateFlags.ColMetaDataReceived) == SnapshottedStateFlags.ColMetaDataReceived;
             set => SetSnapshottedState(SnapshottedStateFlags.ColMetaDataReceived, value);
         }
 
@@ -4289,11 +4289,11 @@ namespace Microsoft.Data.SqlClient
                 _stateObj._cleanupAltMetaDataSetArray = _snapshotCleanupAltMetaDataSetArray;
 
                 // Make sure to go through the appropriate increment/decrement methods if changing the OpenResult flag
-                if (!_stateObj.HasOpenResult && _state.HasFlag(SnapshottedStateFlags.OpenResult))
+                if (!_stateObj.HasOpenResult && ((_state & SnapshottedStateFlags.OpenResult) == SnapshottedStateFlags.OpenResult))
                 {
                     _stateObj.IncrementAndObtainOpenResultCount(_stateObj._executedUnderTransaction);
                 }
-                else if (_stateObj.HasOpenResult && !_state.HasFlag(SnapshottedStateFlags.OpenResult))
+                else if (_stateObj.HasOpenResult && ((_state & SnapshottedStateFlags.OpenResult) != SnapshottedStateFlags.OpenResult))
                 {
                     _stateObj.DecrementOpenResultCount();
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -1197,33 +1197,38 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        private bool GetSnapshottedState(SnapshottedStateFlags flag)
+        {
+            return (_snapshottedState & flag) == flag;
+        }
+
         internal bool HasOpenResult
         {
-            get => (_snapshottedState & SnapshottedStateFlags.OpenResult) == SnapshottedStateFlags.OpenResult;
+            get => GetSnapshottedState(SnapshottedStateFlags.OpenResult);
             set => SetSnapshottedState(SnapshottedStateFlags.OpenResult, value);
         }
 
         internal bool HasPendingData
         {
-            get => (_snapshottedState & SnapshottedStateFlags.PendingData) == SnapshottedStateFlags.PendingData;
+            get => GetSnapshottedState(SnapshottedStateFlags.PendingData);
             set => SetSnapshottedState(SnapshottedStateFlags.PendingData, value);
         }
 
         internal bool HasReceivedError
         {
-            get => (_snapshottedState & SnapshottedStateFlags.ErrorTokenReceived) == SnapshottedStateFlags.ErrorTokenReceived;
+            get => GetSnapshottedState(SnapshottedStateFlags.ErrorTokenReceived);
             set => SetSnapshottedState(SnapshottedStateFlags.ErrorTokenReceived, value);
         }
 
         internal bool HasReceivedAttention
         {
-            get => (_snapshottedState & SnapshottedStateFlags.AttentionReceived) == SnapshottedStateFlags.AttentionReceived;
+            get => GetSnapshottedState(SnapshottedStateFlags.AttentionReceived);
             set => SetSnapshottedState(SnapshottedStateFlags.AttentionReceived, value);
         }
 
         internal bool HasReceivedColumnMetadata
         {
-            get => (_snapshottedState & SnapshottedStateFlags.ColMetaDataReceived) == SnapshottedStateFlags.ColMetaDataReceived;
+            get => GetSnapshottedState(SnapshottedStateFlags.ColMetaDataReceived);
             set => SetSnapshottedState(SnapshottedStateFlags.ColMetaDataReceived, value);
         }
 


### PR DESCRIPTION
While profiling something unrelated i noticed that the highest allocation was boxing of an enum that was being used with HasFlags. This is netcore so it should be using the optimized code path but as noted in https://github.com/dotnet/SqlClient/pull/1054 this isn't happening. This PR changes from using HasFlag to manual masking.

before:
![snaphot flags before](https://user-images.githubusercontent.com/13322696/127752467-cdcd17f6-aa95-4d07-9657-e6e623fd5fa2.PNG)

after:
![snaphot flags after](https://user-images.githubusercontent.com/13322696/127752470-87f81e4d-0e88-4ecc-b6fe-7da8f75ea88f.PNG)
