### PR TITLE
Fix | Add `System.Security.Cryptography.Cng` on functional tests with netcoreapp3.1

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -95,6 +95,9 @@
     <ProjectReference Condition="'$(TargetGroup)'=='netfx' AND $(ReferenceType)=='Project'" Include="$(NetFxSource)src\Microsoft.Data.SqlClient.csproj" />
     <ProjectReference Condition="$(ReferenceType.Contains('NetStandard'))" Include="$(TestsPath)NSLibrary\Microsoft.Data.SqlClient.NSLibrary.csproj" />
     <PackageReference Condition="$(ReferenceType)=='Package'" Include="Microsoft.Data.SqlClient" Version="$(TestMicrosoftDataSqlClientVersion)" />
+    <!-- .NET Core 3.1.2 known issue; It should be added manually! -->
+    <!-- https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1-known-issues.md#net-core-312-sdk-31102-sdk -->
+    <PackageReference Condition="'$(TargetFramework)'=='netcoreapp3.1' AND $(ReferenceType)=='Package'" Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
   </ItemGroup>
   <ItemGroup>
     <None Condition="'$(TargetGroup)'=='netfx' AND $(ReferenceType)=='Project'" Include="$(BinFolder)$(Configuration).AnyCPU\Microsoft.Data.SqlClient\netfx\**\*SNI*.dll" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
[.NET Core 3.1.2 known issue](https://github.com/dotnet/core/blob/main/release-notes/3.1/3.1-known-issues.md#net-core-312-sdk-31102-sdk)

It should be added manually for `ReferenceType = Package`.