### PR TITLE
Fix regression in CancelAsyncConnections test using Native SNI

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2527,7 +2527,8 @@ namespace Microsoft.Data.SqlClient
                     // Evaluate this condition for MANAGED_SNI. This may not be needed because the network call is happening Async and only the callback can receive a success.
                     ReadAsyncCallback(IntPtr.Zero, readPacket, 0);
 
-                    if (!IsPacketEmpty(readPacket))
+                    // Only release packet for Managed SNI as for Native SNI packet is released in finally block.
+                    if (TdsParserStateObjectFactory.UseManagedSNI && !IsPacketEmpty(readPacket))
                     {
                         ReleasePacket(readPacket);
                     }


### PR DESCRIPTION
A change in PR #933 caused `CancelAsyncConnections` test to fail for Native SNI. Using _Debug_ configuration locally helped reproduce the failing assertion consistently. This test did not fail in public CI pipelines but it failed today in our internal build, which is surprising and we're looking into it.

@Wraith2 
I'm patching the packet release code block to be applicable to only Managed SNI so we can proceed to release, but it should be investigated in Managed SNI layer as there are many debug assertion failures that indicate towards design issues when running the `CancelAsyncConnections` test.