### PR TITLE
Change NETFX predefined constant in functional tests to NETFRAMEWORK

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/ExceptionsCertStore.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/ExceptionsCertStore.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             Assert.Matches(expectedMessage, e.Message);
         }
 
-#if NETFX
+#if NETFRAMEWORK
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
         public void CertificateWithNoPrivateKey()
@@ -68,7 +68,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         public static string thumbprint;
         public static byte[] cek;
         public static byte[] encryptedCek;
-#if NETFX
+#if NETFRAMEWORK
         public static X509Certificate2 masterKeyCertificateNPK; // no private key
         public static string thumbprintNPK; // No private key
         public static string masterKeyPathNPK;
@@ -84,8 +84,8 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             certificatePath = string.Format("CurrentUser/My/{0}", thumbprint);
             cek = Utility.GenerateRandomBytes(32);
             encryptedCek = certStoreProvider.EncryptColumnEncryptionKey(certificatePath, "RSA_OAEP", cek);
-#if NETFX
-            if(masterKeyCertificateNPK == null)
+#if NETFRAMEWORK
+            if (masterKeyCertificateNPK == null)
             {
                 masterKeyCertificateNPK = Utility.CreateCertificateWithNoPrivateKey();
             }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetGroup Condition="$(TargetFramework.StartsWith('net4'))">netfx</TargetGroup>
     <TargetGroup Condition="$(TargetGroup) == ''">netcoreapp</TargetGroup>
     <RuntimeIdentifier Condition="'$(TargetGroup)'=='netfx'">win</RuntimeIdentifier>
-    <DefineConstants Condition="'$(TargetGroup)'=='netfx'">$(DefineConstants);NETFX</DefineConstants>
+    <DefineConstants Condition="'$(TargetGroup)'=='netfx'">$(DefineConstants);NETFRAMEWORK</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)'=='netcoreapp'">$(DefineConstants);NETCOREAPP</DefineConstants>
     <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp' AND !$(TargetFramework.StartsWith('netcoreapp'))">$(DefineConstants);NET50_OR_LATER</DefineConstants>
     <DefineConstants Condition="$(ReferenceType.Contains('NetStandard'))">NETSTANDARDREFERNCE</DefineConstants>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlCommandTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlCommandTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(cmd.Container);
             Assert.True(cmd.DesignTimeVisible);
             Assert.Null(cmd.Notification);
-#if NETFX
+#if NETFRAMEWORK
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif
@@ -46,7 +46,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(cmd.Container);
             Assert.True(cmd.DesignTimeVisible);
             Assert.Null(cmd.Notification);
-#if NETFX
+#if NETFRAMEWORK
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif
@@ -64,7 +64,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(cmd.Container);
             Assert.True(cmd.DesignTimeVisible);
             Assert.Null(cmd.Notification);
-#if NETFX
+#if NETFRAMEWORK
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif
@@ -89,7 +89,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(cmd.Container);
             Assert.True(cmd.DesignTimeVisible);
             Assert.Null(cmd.Notification);
-#if NETFX
+#if NETFRAMEWORK
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif
@@ -107,7 +107,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(cmd.Container);
             Assert.True(cmd.DesignTimeVisible);
             Assert.Null(cmd.Notification);
-#if NETFX
+#if NETFRAMEWORK
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif
@@ -125,7 +125,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(cmd.Container);
             Assert.True(cmd.DesignTimeVisible);
             Assert.Null(cmd.Notification);
-#if NETFX && !NETSTANDARDREFERNCE
+#if NETFRAMEWORK && !NETSTANDARDREFERNCE
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif
@@ -166,7 +166,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(cmd.Container);
             Assert.True(cmd.DesignTimeVisible);
             Assert.Null(cmd.Notification);
-#if NETFX && !NETSTANDARDREFERNCE
+#if NETFRAMEWORK && !NETSTANDARDREFERNCE
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif
@@ -184,7 +184,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(cmd.Container);
             Assert.True(cmd.DesignTimeVisible);
             Assert.Null(cmd.Notification);
-#if NETFX && !NETSTANDARDREFERNCE
+#if NETFRAMEWORK && !NETSTANDARDREFERNCE
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif
@@ -202,7 +202,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(cmd.Container);
             Assert.True(cmd.DesignTimeVisible);
             Assert.Null(cmd.Notification);
-#if NETFX && !NETSTANDARDREFERNCE
+#if NETFRAMEWORK && !NETSTANDARDREFERNCE
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif
@@ -224,7 +224,7 @@ namespace Microsoft.Data.SqlClient.Tests
             cmd.CommandType = CommandType.StoredProcedure;
             cmd.DesignTimeVisible = false;
             cmd.Notification = notificationReq;
-#if NETFX && !NETSTANDARDREFERNCE
+#if NETFRAMEWORK && !NETSTANDARDREFERNCE
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif
@@ -240,7 +240,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(cmd.Connection);
             Assert.False(cmd.DesignTimeVisible);
             Assert.Same(notificationReq, cmd.Notification);
-#if NETFX && !NETSTANDARDREFERNCE
+#if NETFRAMEWORK && !NETSTANDARDREFERNCE
             // see https://github.com/dotnet/SqlClient/issues/17
             Assert.True(cmd.NotificationAutoEnlist);
 #endif


### PR DESCRIPTION
While doing the code merges in #1261 . I accidently came across the usage of ifdef NETFX because I saw it being referenced, but it turns out NETFX is a predefined constants variable only available in the functional tests, so to avoid confusion, I changed it to NETFRAMEWORK to keep it consistent with the netfx csproj.