### PR TITLE
Port guid and primitive type data reader optimizations

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Data.SqlClient
             _object = value._object;
         }
 
-        internal bool IsEmpty => (StorageType.Empty == _type);
+        internal bool IsEmpty => _type == StorageType.Empty;
 
         internal bool IsNull => _isNull;
 
@@ -386,7 +386,6 @@ namespace Microsoft.Data.SqlClient
                     return ((SqlGuid)_object).Value;
                 }
                 return (Guid)Value;
-
             }
             set
             {
@@ -1336,13 +1335,13 @@ namespace Microsoft.Data.SqlClient
         // where typeof(T) == typeof(field) 
         //   1) RyuJIT will recognize the pattern of (T)(object)T as being redundant and eliminate 
         //   the T and object casts leaving T, so while this looks like it will put every value type instance in a box the 
-        //   enerated assembly will be short and direct
+        //   generated assembly will be short and direct
         //   2) another jit may not recognize the pattern and should emit the code as seen. this will box and then unbox the
         //   value type which is no worse than the mechanism that this code replaces
         // where typeof(T) != typeof(field)
         //   the jit will emit all the cast operations as written. this will put the value into a box and then attempt to
-        //   cast it, because it is an object even no conversions are use and this will generate the desired InvalidCastException       
-        //   so users cannot widen a short to an int preserving external expectations 
+        //   cast it, because it is an object no conversions are used and this will generate the desired InvalidCastException       
+        //   for example users cannot widen a short to an int preserving external expectations 
 
         internal T ByteAs<T>()
         {
@@ -1386,4 +1385,4 @@ namespace Microsoft.Data.SqlClient
             return (T)(object)_value._single;
         }
     }
-}// namespace
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -87,13 +87,8 @@ namespace Microsoft.Data.SqlClient
 
         private Task _currentTask;
         private Snapshot _snapshot;
-
         private CancellationTokenSource _cancelAsyncOnCloseTokenSource;
         private CancellationToken _cancelAsyncOnCloseToken;
-
-        // Used for checking if the Type parameter provided to GetValue<T> is an INullable
-        internal static readonly Type _typeofINullable = typeof(INullable);
-        private static readonly Type s_typeofSqlString = typeof(SqlString);
 
         private SqlSequentialStream _currentStream;
         private SqlSequentialTextReader _currentTextReader;
@@ -2955,7 +2950,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // If its a SQL Type or Nullable UDT
                     object rawValue = GetSqlValueFromSqlBufferInternal(data, metaData);
-                    if (typeof(T) == s_typeofSqlString)
+                    if (typeof(T) == typeof(SqlString))
                     {
                         // Special case: User wants SqlString, but we have a SqlXml
                         // SqlXml can not be typecast into a SqlString, but we need to support SqlString on XML Types - so do a manual conversion
@@ -2986,6 +2981,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     catch (InvalidCastException) when (data.IsNull)
                     {
+                        // If the value was actually null, then we should throw a SqlNullValue instead
                         throw SQL.SqlNullValue();
                     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Data.SqlClient
             Int16,
             Int32,
             Int64,
+            Guid,
             Money,
             Single,
             String,
@@ -94,6 +95,8 @@ namespace Microsoft.Data.SqlClient
             [FieldOffset(0)]
             internal long _int64;     // also used to store Money, UtcDateTime, Date , and Time
             [FieldOffset(0)]
+            internal Guid _guid;
+            [FieldOffset(0)]
             internal float _single;
             [FieldOffset(0)]
             internal TimeInfo _timeInfo;
@@ -123,7 +126,7 @@ namespace Microsoft.Data.SqlClient
             _object = value._object;
         }
 
-        internal bool IsEmpty => StorageType.Empty == _type;
+        internal bool IsEmpty => _type == StorageType.Empty;
 
         internal bool IsNull => _isNull;
 
@@ -216,16 +219,16 @@ namespace Microsoft.Data.SqlClient
                         // Only removing trailing zeros from a decimal part won't hit its value!
                         if (_value._numericInfo._scale > 0)
                         {
-                            int zeroCnt = FindTrailingZerosAndPrec((uint)_value._numericInfo._data1, (uint)_value._numericInfo._data2,
-                                                                   (uint)_value._numericInfo._data3, (uint)_value._numericInfo._data4,
+                            int zeroCnt = FindTrailingZerosAndPrec((uint)_value._numericInfo._data1, (uint)_value._numericInfo._data2, 
+                                                                   (uint)_value._numericInfo._data3, (uint)_value._numericInfo._data4, 
                                                                    _value._numericInfo._scale, out int precision);
 
                             int minScale = _value._numericInfo._scale - zeroCnt; // minimum possible sacle after removing the trailing zeros.
 
                             if (zeroCnt > 0 && minScale <= 28 && precision <= 29)
                             {
-                                SqlDecimal sqlValue = new(_value._numericInfo._precision, _value._numericInfo._scale, _value._numericInfo._positive,
-                                                          _value._numericInfo._data1, _value._numericInfo._data2,
+                                SqlDecimal sqlValue = new(_value._numericInfo._precision, _value._numericInfo._scale, _value._numericInfo._positive, 
+                                                          _value._numericInfo._data1, _value._numericInfo._data2, 
                                                           _value._numericInfo._data3, _value._numericInfo._data4);
 
                                 int integral = precision - minScale;
@@ -373,9 +376,23 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                // TODO: It is possible to further optimize this, by storing the data from the wire without constructing a SqlGuid first, however we're already twice as fast!
                 ThrowIfNull();
-                return SqlGuid.Value;
+                if (StorageType.Guid == _type)
+                {
+                    return _value._guid;
+                }
+                else if (StorageType.SqlGuid == _type)
+                {
+                    return ((SqlGuid)_object).Value;
+                }
+                return (Guid)Value;
+            }
+            set
+            {
+                Debug.Assert(IsEmpty, "setting value a second time?");
+                _type = StorageType.Guid;
+                _value._guid = value;
+                _isNull = false;
             }
         }
 
@@ -481,7 +498,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        // use static list of format strings indexed by scale for perf!
+        // use static list of format strings indexed by scale for perf
         private static readonly string[] s_katmaiDateTimeOffsetFormatByScale = new string[] {
                 "yyyy-MM-dd HH:mm:ss zzz",
                 "yyyy-MM-dd HH:mm:ss.f zzz",
@@ -757,9 +774,13 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (StorageType.SqlGuid == _type)
+                if (StorageType.Guid == _type)
                 {
-                    return (SqlGuid)_object;
+                    return new SqlGuid(_value._guid);
+                }
+                else if (StorageType.SqlGuid == _type)
+                {
+                    return IsNull ? SqlGuid.Null : (SqlGuid)_object;
                 }
                 return (SqlGuid)SqlValue; // anything else we haven't thought of goes through boxing.
             }
@@ -901,6 +922,8 @@ namespace Microsoft.Data.SqlClient
                         return SqlInt32;
                     case StorageType.Int64:
                         return SqlInt64;
+                    case StorageType.Guid:
+                        return SqlGuid;
                     case StorageType.Money:
                         return SqlMoney;
                     case StorageType.Single:
@@ -956,6 +979,10 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+
+        // these variables store pre-boxed bool values to be used when returning a boolean
+        // in a object typed location, if these are not used a new value is boxed each time
+        // one is needed which leads to a lot of garbage which needs to be collected
         private static readonly object s_cachedTrueObject = true;
         private static readonly object s_cachedFalseObject = false;
 
@@ -972,7 +999,7 @@ namespace Microsoft.Data.SqlClient
                     case StorageType.Empty:
                         return DBNull.Value;
                     case StorageType.Boolean:
-                        return Boolean ? s_cachedTrueObject : s_cachedFalseObject;
+                        return Boolean ? s_cachedTrueObject : s_cachedFalseObject; // return pre-boxed values for perf
                     case StorageType.Byte:
                         return Byte;
                     case StorageType.DateTime:
@@ -987,6 +1014,8 @@ namespace Microsoft.Data.SqlClient
                         return Int32;
                     case StorageType.Int64:
                         return Int64;
+                    case StorageType.Guid:
+                        return Guid;
                     case StorageType.Money:
                         return Decimal;
                     case StorageType.Single:
@@ -1048,6 +1077,8 @@ namespace Microsoft.Data.SqlClient
                         return typeof(SqlInt32);
                     case StorageType.Int64:
                         return typeof(SqlInt64);
+                    case StorageType.Guid:
+                        return typeof(SqlGuid);
                     case StorageType.Money:
                         return typeof(SqlMoney);
                     case StorageType.Single:
@@ -1087,6 +1118,8 @@ namespace Microsoft.Data.SqlClient
                         return typeof(int);
                     case StorageType.Int64:
                         return typeof(long);
+                    case StorageType.Guid:
+                        return typeof(Guid);
                     case StorageType.Money:
                         return typeof(decimal);
                     case StorageType.Single:
@@ -1308,6 +1341,60 @@ namespace Microsoft.Data.SqlClient
             {
                 throw new SqlNullValueException();
             }
+        }
+        // [Field]As<T> method explanation:
+        // these methods are used to bridge generic to non-generic access to value type fields on the storage struct
+        // where typeof(T) == typeof(field) 
+        //   1) RyuJIT will recognize the pattern of (T)(object)T as being redundant and eliminate 
+        //   the T and object casts leaving T, so while this looks like it will put every value type instance in a box the 
+        //   generated assembly will be short and direct
+        //   2) another jit may not recognize the pattern and should emit the code as seen. this will box and then unbox the
+        //   value type which is no worse than the mechanism that this code replaces
+        // where typeof(T) != typeof(field)
+        //   the jit will emit all the cast operations as written. this will put the value into a box and then attempt to
+        //   cast it, because it is an object no conversions are used and this will generate the desired InvalidCastException       
+        //   for example users cannot widen a short to an int preserving external expectations 
+
+        internal T ByteAs<T>()
+        {
+            ThrowIfNull();
+            return (T)(object)_value._byte;
+        }
+
+        internal T BooleanAs<T>()
+        {
+            ThrowIfNull();
+            return (T)(object)_value._boolean;
+        }
+
+        internal T Int32As<T>()
+        {
+            ThrowIfNull();
+            return (T)(object)_value._int32;
+        }
+
+        internal T Int16As<T>()
+        {
+            ThrowIfNull();
+            return (T)(object)_value._int16;
+        }
+
+        internal T Int64As<T>()
+        {
+            ThrowIfNull();
+            return (T)(object)_value._int64;
+        }
+
+        internal T DoubleAs<T>()
+        {
+            ThrowIfNull();
+            return (T)(object)_value._double;
+        }
+
+        internal T SingleAs<T>()
+        {
+            ThrowIfNull();
+            return (T)(object)_value._single;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
@@ -326,9 +326,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         sqlCommand.CommandText = "select top 1 * from " + tableName;
                         using (DbDataReader reader = sqlCommand.ExecuteReader())
                         {
-                            reader.Read();                          
+                            Assert.True(reader.Read());
                             Assert.Equal(1, reader.GetFieldValue<int>(0));
                             Assert.Equal("Microsoft", reader.GetFieldValue<string>(1));
+                            Assert.True(reader.GetFieldValue<bool>(2));
                             Assert.Equal(3274, reader.GetFieldValue<short>(3));
                             Assert.Equal(253, reader.GetFieldValue<byte>(4));
                             Assert.Equal(922222222222, reader.GetFieldValue<long>(5));
@@ -336,7 +337,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             Assert.Equal(123.546f, reader.GetFieldValue<float>(7));
                             Assert.Equal(sqlguid, reader.GetFieldValue<Guid>(8));
                             Assert.Equal(sqlguid.Value, reader.GetFieldValue<System.Data.SqlTypes.SqlGuid>(8).Value);
-                            Assert.Equal(dateTime.ToString("dd/MM/yyyy HH:mm:ss"), reader.GetFieldValue<DateTime>(9).ToString("dd/MM/yyyy HH:mm:ss"));                     
+                            Assert.Equal(dateTime.ToString("dd/MM/yyyy HH:mm:ss"), reader.GetFieldValue<DateTime>(9).ToString("dd/MM/yyyy HH:mm:ss"));
                             Assert.Equal(280, reader.GetFieldValue<decimal>(10));
                             Assert.Equal(dtoffset, reader.GetFieldValue<DateTimeOffset>(11));
                         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
@@ -272,16 +272,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// <summary>
         /// Covers GetFieldValue<T> for SqlBuffer class
         /// </summary>
-
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static void SqlDataReader_SqlBuffer_GetFieldValue()
         {
             string tableName = "Testable"+ new System.Random().Next(5000);
             
             //Arrange
-     
             DbProviderFactory provider = SqlClientFactory.Instance;
-         
+
             using (DbConnection con = provider.CreateConnection())
             {
                     con.ConnectionString = DataTestUtility.TCPConnectionString;
@@ -295,7 +293,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         command.ExecuteNonQuery();
                     }
 
-                System.Data.SqlTypes.SqlGuid sqlguid = new System.Data.SqlTypes.SqlGuid(new System.Guid());                 
+                System.Data.SqlTypes.SqlGuid sqlguid = new System.Data.SqlTypes.SqlGuid(Guid.NewGuid());                 
 
                     using (SqlCommand sqlCommand = new SqlCommand("", con as SqlConnection))
                     {
@@ -312,8 +310,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         sqlCommand.Parameters.AddWithValue(@"GUIDColumn", sqlguid);
                         sqlCommand.ExecuteNonQuery();
                     }
-                
-
                 using (SqlCommand sqlCommand = new SqlCommand("", con as SqlConnection))
                 {
                     sqlCommand.CommandText = "select top 1 * from " + tableName;
@@ -325,13 +321,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     Assert.True(reader[1].GetType() == typeof(string) && reader.GetFieldValue<string>(1) == "Microsoft1");
                     Assert.True(reader[2].GetType() == typeof(string) && reader.GetFieldValue<string>(2) == "Corporation1");
                     Assert.True(reader[3].GetType() == typeof(bool) && reader.GetFieldValue<bool>(3) == true);
-                    Assert.True(reader[4].GetType() == typeof(Int16) && reader.GetFieldValue<Int16>(4) == 3274);
+                    Assert.True(reader[4].GetType() == typeof(short) && reader.GetFieldValue<short>(4) == 3274);
                     Assert.True(reader[5].GetType() == typeof(byte) && reader.GetFieldValue<byte>(5) == 253);
-                    Assert.True(reader[6].GetType() == typeof(Int64) && reader.GetFieldValue<Int64>(6) == 922222222222);
-                    Assert.True(reader[7].GetType() == typeof(Double) && reader.GetFieldValue<Double>(7) == 10.7);
-                    Assert.True(reader[8].GetType() == typeof(Single) && reader.GetFieldValue<Single>(8) == 123.546f);
+                    Assert.True(reader[6].GetType() == typeof(long) && reader.GetFieldValue<long>(6) == 922222222222);
+                    Assert.True(reader[7].GetType() == typeof(double) && reader.GetFieldValue<double>(7) == 10.7);
+                    Assert.True(reader[8].GetType() == typeof(float) && reader.GetFieldValue<float>(8) == 123.546f);
                     Assert.True(reader[9].GetType() == typeof(Guid) && reader.GetFieldValue<System.Data.SqlTypes.SqlGuid>(9).Value == sqlguid.Value);
-
 
                     // Call Close when done reading.
                     reader.Close();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
@@ -354,9 +354,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     }
                 }
             }
-
         }
-
-
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     Assert.True(reader[0].GetType() == typeof(int) && reader.GetFieldValue<int>(0) == 1);
                     Assert.True(reader[1].GetType() == typeof(double) && reader.GetFieldValue<double>(1) == 10.7);
                     Assert.True(reader[2].GetType() == typeof(float) && reader.GetFieldValue<float>(2) == 123.546f);
-                    Assert.True(reader[3].GetType() == typeof(Guid) && reader.GetFieldValue<System.Data.SqlTypes.SqlGuid>(3).Value == sqlguid.Value);
+                    Assert.True(reader[3].GetType() == typeof(Guid) && reader.GetFieldValue<Guid>(3) == sqlguid.Value && reader.GetFieldValue<System.Data.SqlTypes.SqlGuid>(3).Value == sqlguid.Value);
                     Assert.True(reader[4].GetType() == typeof(DateTime) && reader.GetFieldValue<DateTime>(4).ToString("dd/MM/yyyy HH:mm:ss") == dateTime.ToString("dd/MM/yyyy HH:mm:ss"));
                     Assert.True(reader[5].GetType() == typeof(decimal) && reader.GetFieldValue<decimal>(5) == 280);
                     Assert.True(reader[6].GetType() == typeof(DateTimeOffset) && reader.GetFieldValue<DateTimeOffset>(6) == dtoffset);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
@@ -268,15 +268,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-
         /// <summary>
         /// Covers GetFieldValue<T> for SqlBuffer class
         /// </summary>
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static void SqlDataReader_SqlBuffer_GetFieldValue()
         {
-            string tableNameOne = DataTestUtility.GetUniqueNameForSqlServer("table");
-            string tableNameTwo = DataTestUtility.GetUniqueNameForSqlServer("table");
+            string tableName = DataTestUtility.GetUniqueNameForSqlServer("SqlBuffer_GetFieldValue");
             DateTimeOffset dtoffset = DateTimeOffset.Now;
             DateTime dateTime = DateTime.Now;
             //Arrange
@@ -286,99 +284,78 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 con.ConnectionString = DataTestUtility.TCPConnectionString;
                 con.Open();
-                string sqlQueryOne = "CREATE TABLE " + tableNameOne + " ([CustomerId] [int],[FirstName] [nvarchar](50),[BoolCol] [BIT],[ShortCol] [SMALLINT],[ByteCol] [TINYINT],[LongCol] [BIGINT]);";
-                string sqlQueryTwo = "CREATE TABLE " + tableNameTwo + " ([CustomerId] [int],[DoubleCol] [FLOAT],[SingleCol] [REAL],[GUIDCol] [uniqueidentifier],[DateTimeCol] [DateTime],[DecimalCol] [SmallMoney],[DateTimeOffsetCol] [DateTimeOffset]);";
+                string sqlQueryOne = "CREATE TABLE " + tableName + " ([CustomerId] [int],[FirstName] [nvarchar](50),[BoolCol] [BIT],[ShortCol] [SMALLINT],[ByteCol] [TINYINT],[LongCol] [BIGINT]);";
+                string sqlQueryTwo = "ALTER TABLE " + tableName + " ADD [DoubleCol] [FLOAT],[SingleCol] [REAL],[GUIDCol] [uniqueidentifier],[DateTimeCol] [DateTime],[DecimalCol] [SmallMoney],[DateTimeOffsetCol] [DateTimeOffset];";
 
-                using (DbCommand command = provider.CreateCommand())
+                try
                 {
-                    command.Connection = con;
-                    command.CommandText = sqlQueryOne;
-                    command.ExecuteNonQuery();
+                    using (DbCommand command = provider.CreateCommand())
+                    {
+                        command.Connection = con;
+                        command.CommandText = sqlQueryOne;
+                        command.ExecuteNonQuery();
+                    }
+                    using (DbCommand command = provider.CreateCommand())
+                    {
+                        command.Connection = con;
+                        command.CommandText = sqlQueryTwo;
+                        command.ExecuteNonQuery();
+                    }
+
+                    System.Data.SqlTypes.SqlGuid sqlguid = new System.Data.SqlTypes.SqlGuid(Guid.NewGuid());
+
+                    using (SqlCommand sqlCommand = new SqlCommand("", con as SqlConnection))
+                    {
+                        sqlCommand.CommandText = "INSERT INTO " + tableName + " VALUES (@CustomerId,@FirstName,@BoolCol,@ShortCol,@ByteCol,@LongCol,@DoubleCol,@SingleCol,@GUIDCol,@DateTimeCol,@DecimalCol,@DateTimeOffsetCol)";
+                        sqlCommand.Parameters.AddWithValue(@"CustomerId", 1);
+                        sqlCommand.Parameters.AddWithValue(@"FirstName", "Microsoft");
+                        sqlCommand.Parameters.AddWithValue(@"BoolCol", true);
+                        sqlCommand.Parameters.AddWithValue(@"ShortCol", 3274);
+                        sqlCommand.Parameters.AddWithValue(@"ByteCol", 253);
+                        sqlCommand.Parameters.AddWithValue(@"LongCol", 922222222222);
+                        sqlCommand.Parameters.AddWithValue(@"DoubleCol", 10.7);
+                        sqlCommand.Parameters.AddWithValue(@"SingleCol", 123.546f);
+                        sqlCommand.Parameters.AddWithValue(@"GUIDCol", sqlguid);
+                        sqlCommand.Parameters.AddWithValue(@"DateTimeCol", dateTime);
+                        sqlCommand.Parameters.AddWithValue(@"DecimalCol", 280);
+                        sqlCommand.Parameters.AddWithValue(@"DateTimeOffsetCol", dtoffset);
+                        sqlCommand.ExecuteNonQuery();
+                    }
+                    using (SqlCommand sqlCommand = new SqlCommand("", con as SqlConnection))
+                    {
+                        sqlCommand.CommandText = "select top 1 * from " + tableName;
+                        using (DbDataReader reader = sqlCommand.ExecuteReader())
+                        {
+                            reader.Read();                          
+                            Assert.Equal(1, reader.GetFieldValue<int>(0));
+                            Assert.Equal("Microsoft", reader.GetFieldValue<string>(1));
+                            Assert.Equal(3274, reader.GetFieldValue<short>(3));
+                            Assert.Equal(253, reader.GetFieldValue<byte>(4));
+                            Assert.Equal(922222222222, reader.GetFieldValue<long>(5));
+                            Assert.Equal(10.7, reader.GetFieldValue<double>(6));
+                            Assert.Equal(123.546f, reader.GetFieldValue<float>(7));
+                            Assert.Equal(sqlguid, reader.GetFieldValue<Guid>(8));
+                            Assert.Equal(sqlguid.Value, reader.GetFieldValue<System.Data.SqlTypes.SqlGuid>(8).Value);
+                            Assert.Equal(dateTime.ToString("dd/MM/yyyy HH:mm:ss"), reader.GetFieldValue<DateTime>(9).ToString("dd/MM/yyyy HH:mm:ss"));                     
+                            Assert.Equal(280, reader.GetFieldValue<decimal>(10));
+                            Assert.Equal(dtoffset, reader.GetFieldValue<DateTimeOffset>(11));
+                        }
+                    }
                 }
-                using (DbCommand command = provider.CreateCommand())
+                finally
                 {
-                    command.Connection = con;
-                    command.CommandText = sqlQueryTwo;
-                    command.ExecuteNonQuery();
-                }
-
-                System.Data.SqlTypes.SqlGuid sqlguid = new System.Data.SqlTypes.SqlGuid(Guid.NewGuid());                 
-
-                using (SqlCommand sqlCommand = new SqlCommand("", con as SqlConnection))
-                {
-                    sqlCommand.CommandText = "INSERT INTO "+ tableNameOne +" VALUES (@CustomerId,@FirstName,@BoolCol,@ShortCol,@ByteCol,@LongCol)";
-                    sqlCommand.Parameters.AddWithValue(@"CustomerId",1);
-                    sqlCommand.Parameters.AddWithValue(@"FirstName", "Microsoft");
-                    sqlCommand.Parameters.AddWithValue(@"BoolCol", true);
-                    sqlCommand.Parameters.AddWithValue(@"ShortCol", 3274);
-                    sqlCommand.Parameters.AddWithValue(@"ByteCol", 253);
-                    sqlCommand.Parameters.AddWithValue(@"LongCol", 922222222222);
-                    sqlCommand.ExecuteNonQuery();
-                }
-                using (SqlCommand sqlCommand = new SqlCommand("", con as SqlConnection))
-                {
-                    sqlCommand.CommandText = "INSERT INTO "+tableNameTwo+" VALUES (@CustomerId,@DoubleCol,@SingleCol,@GUIDCol,@DateTimeCol,@DecimalCol,@DateTimeOffsetCol)";
-                    sqlCommand.Parameters.AddWithValue(@"CustomerId", 1);                  
-                    sqlCommand.Parameters.AddWithValue(@"DoubleCol", 10.7);
-                    sqlCommand.Parameters.AddWithValue(@"SingleCol", 123.546f);
-                    sqlCommand.Parameters.AddWithValue(@"GUIDCol", sqlguid);
-                    sqlCommand.Parameters.AddWithValue(@"DateTimeCol", dateTime);
-                    sqlCommand.Parameters.AddWithValue(@"DecimalCol", 280);
-                    sqlCommand.Parameters.AddWithValue(@"DateTimeOffsetCol", dtoffset);
-                    sqlCommand.ExecuteNonQuery();
-                }
-                using (SqlCommand sqlCommand = new SqlCommand("", con as SqlConnection))
-                {
-                    sqlCommand.CommandText = "select top 1 * from " + tableNameOne;
-                    DbDataReader reader = sqlCommand.ExecuteReader();
-
-                    reader.Read();
-
-                    Assert.True(reader[0].GetType() == typeof(int) && reader.GetFieldValue<int>(0) == 1);
-                    Assert.True(reader[1].GetType() == typeof(string) && reader.GetFieldValue<string>(1) == "Microsoft");
-                    Assert.True(reader[2].GetType() == typeof(bool) && reader.GetFieldValue<bool>(2) == true);
-                    Assert.True(reader[3].GetType() == typeof(short) && reader.GetFieldValue<short>(3) == 3274);
-                    Assert.True(reader[4].GetType() == typeof(byte) && reader.GetFieldValue<byte>(4) == 253);
-                    Assert.True(reader[5].GetType() == typeof(long) && reader.GetFieldValue<long>(5) == 922222222222);
-                   
-                    // Call Close when done reading.
-                    reader.Close();
-                }
-                using (SqlCommand sqlCommand = new SqlCommand("", con as SqlConnection))
-                {
-                    sqlCommand.CommandText = "select top 1 * from " + tableNameTwo;
-                    DbDataReader reader = sqlCommand.ExecuteReader();
-
-                    reader.Read();
-
-                    Assert.True(reader[0].GetType() == typeof(int) && reader.GetFieldValue<int>(0) == 1);
-                    Assert.True(reader[1].GetType() == typeof(double) && reader.GetFieldValue<double>(1) == 10.7);
-                    Assert.True(reader[2].GetType() == typeof(float) && reader.GetFieldValue<float>(2) == 123.546f);
-                    Assert.True(reader[3].GetType() == typeof(Guid) && reader.GetFieldValue<Guid>(3) == sqlguid.Value && reader.GetFieldValue<System.Data.SqlTypes.SqlGuid>(3).Value == sqlguid.Value);
-                    Assert.True(reader[4].GetType() == typeof(DateTime) && reader.GetFieldValue<DateTime>(4).ToString("dd/MM/yyyy HH:mm:ss") == dateTime.ToString("dd/MM/yyyy HH:mm:ss"));
-                    Assert.True(reader[5].GetType() == typeof(decimal) && reader.GetFieldValue<decimal>(5) == 280);
-                    Assert.True(reader[6].GetType() == typeof(DateTimeOffset) && reader.GetFieldValue<DateTimeOffset>(6) == dtoffset);
-                   
-                    // Call Close when done reading.
-                    reader.Close();
-                }
-
-                //cleanup
-                using (DbCommand cmd = provider.CreateCommand())
-                {
-                    cmd.Connection = con;
-                    cmd.CommandText = "drop table " + tableNameOne;
-                    cmd.ExecuteNonQuery();
-                }
-                using (DbCommand cmd = provider.CreateCommand())
-                {
-                    cmd.Connection = con;
-                    cmd.CommandText = "drop table " + tableNameTwo;
-                    cmd.ExecuteNonQuery();
+                    //cleanup
+                    using (DbCommand cmd = provider.CreateCommand())
+                    {
+                        cmd.Connection = con;
+                        cmd.CommandText = "drop table " + tableName;
+                        cmd.ExecuteNonQuery();
+                    }
                 }
             }
-            
+
         }
+
 
     }
 }


### PR DESCRIPTION
Ports the guid changes from dotnet/corefx#34390 to netfx.

This brings netfx and netcore closer together leaving only datetime optimizations as the difference in SqlBuffer.cs, with those ported it should be possible to share SqlBuffer.