### PR TITLE
Tests | Address random error on AADPasswordWithWrongPassword test case

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/AADConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/AADConnectionTest.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             string[] credKeys = { "Password", "PWD" };
             string connStr = DataTestUtility.RemoveKeysInConnStr(DataTestUtility.AADPasswordConnectionString, credKeys) + "Password=TestPassword;";
 
-            SqlException e = Assert.Throws<SqlException>(() => ConnectAndDisconnect(connStr));
+            Assert.Throws<SqlException>(() => ConnectAndDisconnect(connStr));
 
             // We cannot verify error message with certainity as driver may cache token from other tests for current user
             // and error message may change accordingly.


### PR DESCRIPTION
We should not compare error message text in this case, as it may change based on when this test runs.
This is widely observed to fail randomly.

e.g. https://dev.azure.com/sqlclientdrivers-ci/sqlclient/_build/results?buildId=42647&view=results