### PR TITLE
Use Buffer.BlockCopy with byte[]

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -2047,7 +2047,7 @@ namespace Microsoft.Data.SqlClient
                                 cbytes = length;
                         }
 
-                        Array.Copy(data, ndataIndex, buffer, bufferIndex, cbytes);
+                        Buffer.BlockCopy(data, ndataIndex, buffer, bufferIndex, cbytes);
                     }
                     catch (Exception e)
                     {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -585,7 +585,7 @@ namespace Microsoft.Data.SqlClient
         private Guid GetGlobalTxnIdentifierFromToken()
         {
             byte[] txnGuid = new byte[16];
-            Array.Copy(_connection.PromotedDTCToken, _globalTransactionsTokenVersionSizeInBytes /* Skip the version */, txnGuid, 0, txnGuid.Length);
+            Buffer.BlockCopy(_connection.PromotedDTCToken, _globalTransactionsTokenVersionSizeInBytes /* Skip the version */, txnGuid, 0, txnGuid.Length);
             return new Guid(txnGuid);
         }
     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         // Otherwise, copy over the leftover buffer
                         byteBuffer = new byte[byteBufferSize];
-                        Array.Copy(_leftOverBytes, byteBuffer, _leftOverBytes.Length);
+                        Buffer.BlockCopy(_leftOverBytes, 0, byteBuffer, 0,_leftOverBytes.Length);
                         byteBufferUsed = _leftOverBytes.Length;
                     }
                 }
@@ -411,7 +411,7 @@ namespace Microsoft.Data.SqlClient
             if ((!completed) && (bytesUsed < inBufferCount))
             {
                 _leftOverBytes = new byte[inBufferCount - bytesUsed];
-                Array.Copy(inBuffer, bytesUsed, _leftOverBytes, 0, _leftOverBytes.Length);
+                Buffer.BlockCopy(inBuffer, bytesUsed, _leftOverBytes, 0, _leftOverBytes.Length);
             }
             else
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlStream.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlStream.cs
@@ -452,7 +452,7 @@ namespace Microsoft.Data.SqlClient
                 cb = _cachedBytes[_currentArrayIndex].Length - _currentPosition;
                 if (cb > count)
                     cb = count;
-                Array.Copy(_cachedBytes[_currentArrayIndex], _currentPosition, buffer, offset, cb);
+                Buffer.BlockCopy(_cachedBytes[_currentArrayIndex], _currentPosition, buffer, offset, cb);
 
                 _currentPosition += cb;
                 count -= (int)cb;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
@@ -1286,7 +1286,7 @@ namespace Microsoft.Data.SqlClient.Server
                     {
                         byte[] rgbValue = value.Value;
                         byte[] rgbNewValue = new byte[MaxLength];
-                        Array.Copy(rgbValue, rgbNewValue, rgbValue.Length);
+                        Buffer.BlockCopy(rgbValue, 0, rgbNewValue, 0, rgbValue.Length);
                         Array.Clear(rgbNewValue, rgbValue.Length, rgbNewValue.Length - rgbValue.Length);
                         return new SqlBinary(rgbNewValue);
                     }
@@ -1308,7 +1308,7 @@ namespace Microsoft.Data.SqlClient.Server
             {
                 byte[] rgbValue = value.Value;
                 byte[] rgbNewValue = new byte[MaxLength];
-                Array.Copy(rgbValue, rgbNewValue, (int)MaxLength);
+                Buffer.BlockCopy(rgbValue,0, rgbNewValue,0, (int)MaxLength);
                 value = new SqlBinary(rgbNewValue);
             }
 
@@ -1400,7 +1400,7 @@ namespace Microsoft.Data.SqlClient.Server
                         if (value.MaxLength < MaxLength)
                         {
                             byte[] rgbNew = new byte[MaxLength];
-                            Array.Copy(value.Buffer, rgbNew, (int)oldLength);
+                            Buffer.BlockCopy(value.Buffer, 0,rgbNew,0, (int)oldLength);
                             value = new SqlBytes(rgbNew);
                         }
 
@@ -1929,7 +1929,7 @@ namespace Microsoft.Data.SqlClient.Server
                     if (value.Length < MaxLength)
                     {
                         byte[] rgbNewValue = new byte[MaxLength];
-                        Array.Copy(value, rgbNewValue, value.Length);
+                        Buffer.BlockCopy(value, 0, rgbNewValue, 0, value.Length);
                         Array.Clear(rgbNewValue, value.Length, (int)rgbNewValue.Length - value.Length);
                         return rgbNewValue;
                     }
@@ -1950,7 +1950,7 @@ namespace Microsoft.Data.SqlClient.Server
             if (value.Length > MaxLength && Max != MaxLength)
             {
                 byte[] rgbNewValue = new byte[MaxLength];
-                Array.Copy(value, rgbNewValue, (int)MaxLength);
+                Buffer.BlockCopy(value, 0, rgbNewValue, 0, (int)MaxLength);
                 value = rgbNewValue;
             }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Data.SqlClient.Server
 
             length = CheckXetParameters(metaData.SqlDbType, metaData.MaxLength * sizeof(char), value.Length,
                         fieldOffset, buffer.Length, bufferOffset, length);
-            Array.Copy(value.Value, checked((int)fieldOffset), buffer, bufferOffset, length);
+            Buffer.BlockCopy(value.Value, checked((int)fieldOffset), buffer, bufferOffset, length);
             return length;
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             while (position < data.Length)
             {
                 int copyCount = Math.Min(pattern.Length, data.Length - position);
-                Array.Copy(pattern, 0, data, position, copyCount);
+                Buffer.BlockCopy(pattern, 0, data, position, copyCount);
                 position += copyCount;
             }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/StreamInputParam.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/StreamInputParam.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 }
                 if (_errorPos >= _pos && _errorPos < _pos + nRead)
                     throw new CustomStreamException();
-                Array.Copy(_data, _pos, buffer, offset, nRead);
+                Buffer.BlockCopy(_data, _pos, buffer, offset, nRead);
                 _pos += nRead;
                 return nRead;
             }

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDSStream.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDSStream.cs
@@ -349,7 +349,7 @@ namespace Microsoft.SqlServer.TDS
                 if (packetDataToWrite > 0)
                 {
                     // Append new data to the end of the packet data
-                    Array.Copy(buffer, bufferWrittenPosition + offset, _outgoingPacket, OutgoingPacketHeader.Length, packetDataToWrite);
+                    Buffer.BlockCopy(buffer, bufferWrittenPosition + offset, _outgoingPacket, OutgoingPacketHeader.Length, packetDataToWrite);
 
                     // Register that we've written new data
                     bufferWrittenPosition += packetDataToWrite;


### PR DESCRIPTION
This change is based on changes done https://github.com/dotnet/corefx/commit/3ab3bd6efcba669bf04d42f738fe5a495ec62940. I have replaced Array.Copy wherever there is byte[]. Buffer.BlockCopy has less overhead than Array.Copy when copying byte[]s.