### PR TITLE
Test - Add tests for SqlNotificationRequest

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="SqlDataRecordTest.cs" />
     <Compile Include="SqlExceptionTest.cs" />
     <Compile Include="SqlFacetAttributeTest.cs" />
+    <Compile Include="SqlNotificationRequestTest.cs" />
     <Compile Include="SqlParameterTest.cs" />
     <Compile Include="SqlClientFactoryTest.cs" />
     <Compile Include="SqlErrorCollectionTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlNotificationRequestTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlNotificationRequestTest.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.Data.Sql;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.Tests
+{
+    public class SqlNotificationRequestTest
+    {
+        [Fact]
+        public void SetOptions_OutOfRangeValue_Throws()
+        {
+            SqlNotificationRequest sqlNotification = new();
+            string outOfRangeValue = new string('a', ushort.MaxValue + 1);
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => sqlNotification.Options = outOfRangeValue);
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.ParamName);
+            Assert.True(ex.ParamName.IndexOf("Options", StringComparison.OrdinalIgnoreCase) != -1);
+        }
+
+        [Fact]
+        public void SetUserData_OutOfRangeValue_Throws()
+        {
+            SqlNotificationRequest sqlNotification = new();
+            string outOfRangeValue = new string('a', ushort.MaxValue + 1);
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => sqlNotification.UserData = outOfRangeValue);
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.ParamName);
+            Assert.True(ex.ParamName.IndexOf("UserData", StringComparison.OrdinalIgnoreCase) != -1);
+        }
+
+        [Fact]
+        public void SetTimeout_OutOfRangeValue_Throws()
+        {
+            SqlNotificationRequest sqlNotification = new();
+            int outOfRangeValue = -1;
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => sqlNotification.Timeout = outOfRangeValue);
+            Assert.Null(ex.InnerException);
+            Assert.NotNull(ex.ParamName);
+            Assert.True(ex.ParamName.IndexOf("Timeout", StringComparison.OrdinalIgnoreCase) != -1);
+        }
+    }
+}


### PR DESCRIPTION
While going through the [code coverage](https://dev.azure.com/sqlclientdrivers-ci/sqlclient/_build/results?buildId=43083&view=codecoverage-tab) , I noticed that SqlNotificationRequest has 3 uncovered cases for out of range exceptions so I added the tests to get it to 100% line coverage.  I think going forward, I'll group up more tests in one PR instead of a small one like this.