### PR TITLE
Test - Add tests for code coverage part 1

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -338,6 +338,7 @@
     </Compile>
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\SqlCommandBuilder.cs">
       <Link>Microsoft\Data\SqlClient\SqlCommandBuilder.cs</Link>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\SqlCommandSet.cs">
       <Link>Microsoft\Data\SqlClient\SqlCommandSet.cs</Link>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -338,7 +338,6 @@
     </Compile>
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\SqlCommandBuilder.cs">
       <Link>Microsoft\Data\SqlClient\SqlCommandBuilder.cs</Link>
-      <SubType>Component</SubType>
     </Compile>
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\SqlCommandSet.cs">
       <Link>Microsoft\Data\SqlClient\SqlCommandSet.cs</Link>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -28,6 +28,7 @@
     <Compile Include="DataCommon\AssemblyResourceManager.cs" />
     <Compile Include="DataCommon\SystemDataResourceManager.cs" />
     <Compile Include="MultipartIdentifierTests.cs" />
+    <Compile Include="SqlClientLoggerTest.cs" />
     <Compile Include="SqlConfigurableRetryLogicTest.cs" />
     <Compile Include="SqlCommandBuilderTest.cs" />
     <Compile Include="SqlBulkCopyTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="DataCommon\SystemDataResourceManager.cs" />
     <Compile Include="MultipartIdentifierTests.cs" />
     <Compile Include="SqlClientLoggerTest.cs" />
+    <Compile Include="SqlCommandSetTest.cs" />
     <Compile Include="SqlConfigurableRetryLogicTest.cs" />
     <Compile Include="SqlCommandBuilderTest.cs" />
     <Compile Include="SqlBulkCopyTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="SqlExceptionTest.cs" />
     <Compile Include="SqlFacetAttributeTest.cs" />
     <Compile Include="SqlNotificationRequestTest.cs" />
+    <Compile Include="SqlParameterCollectionTest.cs" />
     <Compile Include="SqlParameterTest.cs" />
     <Compile Include="SqlClientFactoryTest.cs" />
     <Compile Include="SqlErrorCollectionTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlClientFactoryTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlClientFactoryTest.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Data.Sql;
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.Tests
@@ -20,6 +22,7 @@ namespace Microsoft.Data.SqlClient.Tests
         public static readonly object[][] FactoryMethodTestData =
         {
             new object[] { new Func<object>(SqlClientFactory.Instance.CreateCommand), typeof(SqlCommand) },
+            new object[] { new Func<object>(SqlClientFactory.Instance.CreateCommandBuilder), typeof(SqlCommandBuilder) },
             new object[] { new Func<object>(SqlClientFactory.Instance.CreateConnection), typeof(SqlConnection) },
             new object[] { new Func<object>(SqlClientFactory.Instance.CreateConnectionStringBuilder), typeof(SqlConnectionStringBuilder) },
             new object[] { new Func<object>(SqlClientFactory.Instance.CreateDataAdapter), typeof(SqlDataAdapter) },
@@ -40,5 +43,26 @@ namespace Microsoft.Data.SqlClient.Tests
 
             Assert.NotSame(value1, value2);
         }
+
+#if NETFRAMEWORK
+        [Fact]
+        public void FactoryCreateDataSourceEnumerator()
+        {
+            // Unable to cover the in the FactoryMethodTest because the SqlDataSourceEnumerator is a singleton so, it's always the same.
+            object instance = SqlClientFactory.Instance.CreateDataSourceEnumerator();
+            // SqlDataSourceEnumerator is not available for .NET core 3.1 and above, so the type check is only for .NET Framework.
+            Assert.IsType<SqlDataSourceEnumerator>(instance);
+            Assert.NotNull(instance);
+        }
+
+        [Fact]
+        public void FactoryGetService()
+        {
+            Type type = typeof(SqlClientFactory);
+            MethodInfo method = type.GetMethod("System.IServiceProvider.GetService", BindingFlags.NonPublic | BindingFlags.Instance);
+            object res = method.Invoke(SqlClientFactory.Instance, new object[] { null });
+            Assert.Null(res);
+        }
+#endif
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlClientLoggerTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlClientLoggerTest.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.Tests
+{
+    public class SqlClientLoggerTest
+    {
+        [Fact]
+        public void LogWarning()
+        {
+            // There is not much to test here but to add the code coverage.
+            SqlClientLogger logger = new();
+            logger.LogWarning("test type", "test method", "test message");
+        }
+
+        [Fact]
+        public void LogAssert()
+        {
+            SqlClientLogger logger = new();
+            logger.LogAssert(true, "test type", "test method", "test message");
+        }
+
+        [Fact]
+        public void LogError()
+        {
+            SqlClientLogger logger = new();
+            logger.LogError("test type", "test method", "test message");
+        }
+
+        [Fact]
+        public void LogInfo()
+        {
+            SqlClientLogger logger = new();
+            logger.LogInfo("test type", "test method", "test message");
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlCommandSetTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlCommandSetTest.cs
@@ -175,8 +175,6 @@ namespace Microsoft.Data.SqlClient.Tests
         {
             Assert.NotNull(ex);
             Assert.IsType<T>(ex.InnerException);
-            Assert.NotNull(ex.InnerException);
-            Assert.NotEmpty(ex.InnerException.Message);
             Assert.Contains(contains, ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
         }
         #endregion

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlCommandSetTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlCommandSetTest.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Data;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.Tests
+{
+    public class SqlCommandSetTest
+    {
+        private static Assembly mds = Assembly.GetAssembly(typeof(SqlConnection));
+
+        [Theory]
+        [InlineData("BatchCommand")]
+        [InlineData("CommandList")]
+        public void GetDisposedProperty_Throws(string propertyName)
+        {
+            var cmdSet = CreateInstance();
+            CallMethod(cmdSet, "Dispose");
+            Exception ex = GetProperty_Throws(cmdSet, propertyName);
+            VerifyException<ObjectDisposedException>(ex, "disposed");
+        }
+
+        [Fact]
+        public void AppendCommandWithEmptyString_Throws()
+        {
+            var cmdSet = CreateInstance();
+            SqlCommand cmd = new SqlCommand("");
+            Exception ex = CallMethod_Throws(cmdSet, "Append", cmd);
+            VerifyException<InvalidOperationException>(ex, "CommandText property has not been initialized");
+        }
+
+        [Theory]
+        [InlineData(CommandType.TableDirect)]
+        [InlineData((CommandType)5)]
+        public void AppendBadCommandType_Throws(CommandType commandType)
+        {
+            var cmdSet = CreateInstance();
+            SqlCommand cmd = GenerateBadCommand(commandType);
+            Exception ex = CallMethod_Throws(cmdSet, "Append", cmd);
+            VerifyException<ArgumentOutOfRangeException>(ex, "CommandType");
+        }
+
+        [Fact]
+        public void AppendBadParameterName_Throws()
+        {
+            var cmdSet = CreateInstance();
+            SqlCommand cmd = new SqlCommand("Test");
+            cmd.CommandType = CommandType.Text;
+            cmd.Parameters.Add(new SqlParameter("Test1;=", "1"));
+            Exception ex = CallMethod_Throws(cmdSet, "Append", cmd);
+            VerifyException<ArgumentException>(ex, "not valid");
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 1, 2, 3 })]
+        [InlineData(new char[] { '1', '2', '3' })]
+        public void AppendParameterArrayWithSize(object array)
+        {
+            var cmdSet = CreateInstance();
+            SqlCommand cmd = new SqlCommand("Test");
+            cmd.CommandType = CommandType.StoredProcedure;
+            SqlParameter parameter = new SqlParameter("@array", array);
+            parameter.Size = 2;
+            cmd.Parameters.Add(parameter);
+            CallMethod(cmdSet, "Append", cmd);
+            object p = CallMethod(cmdSet, "GetParameter", 0, 0);
+            SqlParameter result = p as SqlParameter;
+            Assert.NotNull(result);
+            Assert.Equal("@array", result.ParameterName);
+            Assert.Equal(2, result.Size);
+        }
+
+        [Fact]
+        public void GetParameter()
+        {
+            var cmdSet = CreateInstance();
+            SqlCommand cmd = new SqlCommand("Test");
+            cmd.CommandType = CommandType.Text;
+            cmd.Parameters.Add(new SqlParameter("@text", "value"));
+            CallMethod(cmdSet, "Append", cmd);
+            object p = CallMethod(cmdSet, "GetParameter", 0, 0);
+            SqlParameter result = p as SqlParameter;
+            Assert.NotNull(result);
+            Assert.Equal("@text", result.ParameterName);
+            Assert.Equal("value", (string)result.Value);
+        }
+
+        [Fact]
+        public void GetParameterCount()
+        {
+            var commandSetType = mds.GetType("Microsoft.Data.SqlClient.SqlCommandSet");
+            var cmdSet = Activator.CreateInstance(commandSetType, true);
+            SqlCommand cmd = new SqlCommand("Test");
+            cmd.CommandType = CommandType.Text;
+            cmd.Parameters.Add(new SqlParameter("@abc", "1"));
+            cmd.Parameters.Add(new SqlParameter("@test", "2"));
+            commandSetType.GetMethod("Append", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).Invoke(cmdSet, new object[] { cmd });
+            int index = 0;
+            int count = (int)commandSetType.GetMethod("GetParameterCount", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).Invoke(cmdSet, new object[] { index });
+            Assert.Equal(2, count);
+        }
+
+        [Fact]
+        public void InvalidCommandBehaviorValidateCommandBehavior_Throws()
+        {
+            var cmdSet = CreateInstance();
+            Exception ex = CallMethod_Throws(cmdSet, "ValidateCommandBehavior", "ExecuteNonQuery", (CommandBehavior)64);
+            VerifyException<ArgumentOutOfRangeException>(ex, "CommandBehavior");
+        }
+
+        [Fact]
+        public void NotSupportedCommandBehaviorValidateCommandBehavior_Throws()
+        {
+            var cmdSet = CreateInstance();
+            Exception ex = CallMethod_Throws(cmdSet, "ValidateCommandBehavior", "ExecuteNonQuery", CommandBehavior.KeyInfo);
+            VerifyException<ArgumentOutOfRangeException>(ex, "not supported");
+        }
+
+        #region private methods
+
+        private object CallMethod(object instance, string methodName, params object[] values)
+        {
+            var commandSetType = mds.GetType("Microsoft.Data.SqlClient.SqlCommandSet");
+            object returnValue = commandSetType.GetMethod(methodName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).Invoke(instance, values);
+            return returnValue;
+        }
+
+        private object CallMethod(object instance, string methodName)
+        {
+            var commandSetType = mds.GetType("Microsoft.Data.SqlClient.SqlCommandSet");
+            object returnValue = commandSetType.GetMethod(methodName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).Invoke(instance, new object[] { });
+            return returnValue;
+        }
+
+        private Exception CallMethod_Throws(object instance, string methodName, params object[] values)
+        {
+            var commandSetType = mds.GetType("Microsoft.Data.SqlClient.SqlCommandSet");
+            Exception ex = Assert.ThrowsAny<Exception>(() =>
+            {
+                commandSetType.GetMethod(methodName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).Invoke(instance, values);
+            });
+            return ex;
+        }
+
+        private object CreateInstance()
+        {
+            var commandSetType = mds.GetType("Microsoft.Data.SqlClient.SqlCommandSet");
+            object cmdSet = Activator.CreateInstance(commandSetType, true);
+            return cmdSet;
+        }
+
+        private Exception GetProperty_Throws(object instance, string propertyName)
+        {
+            var commandSetType = mds.GetType("Microsoft.Data.SqlClient.SqlCommandSet");
+            var cmdSet = instance;
+            Exception ex = Assert.ThrowsAny<Exception>(() =>
+            {
+                commandSetType.GetProperty(propertyName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetGetMethod(true).Invoke(cmdSet, new object[] { });
+            });
+
+            return ex;
+        }
+
+        private SqlCommand GenerateBadCommand(CommandType cType)
+        {
+            SqlCommand cmd = new SqlCommand("Test");
+            Type sqlCommandType = cmd.GetType();
+            // There's validation done on the CommandType property, but we need to create one that avoids the check for the test case.
+            sqlCommandType.GetField("_commandType", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(cmd, cType);
+
+            return cmd;
+        }
+
+        private void VerifyException<T>(Exception ex, string contains)
+        {
+            Assert.NotNull(ex);
+            Assert.IsType<T>(ex.InnerException);
+            Assert.NotNull(ex.InnerException);
+            Assert.NotEmpty(ex.InnerException.Message);
+            Assert.Contains(contains, ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        #endregion
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -108,8 +108,6 @@ namespace Microsoft.Data.SqlClient.Tests
 
             ApplicationIntent invalid = (ApplicationIntent)Enum.GetValues(typeof(ApplicationIntent)).Length + 1;
             ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.ApplicationIntent = invalid);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("ApplicationIntent", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -120,8 +118,6 @@ namespace Microsoft.Data.SqlClient.Tests
 
             SqlConnectionAttestationProtocol invalid = (SqlConnectionAttestationProtocol)Enum.GetValues(typeof(SqlConnectionAttestationProtocol)).Length + 1;
             ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.AttestationProtocol = invalid);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("SqlConnectionAttestationProtocol", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -132,8 +128,6 @@ namespace Microsoft.Data.SqlClient.Tests
 
             SqlAuthenticationMethod invalid = (SqlAuthenticationMethod)Enum.GetValues(typeof(SqlAuthenticationMethod)).Length + 1;
             ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.Authentication = invalid);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("SqlAuthenticationMethod", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -144,8 +138,6 @@ namespace Microsoft.Data.SqlClient.Tests
 
             SqlConnectionColumnEncryptionSetting invalid = (SqlConnectionColumnEncryptionSetting)Enum.GetValues(typeof(SqlConnectionColumnEncryptionSetting)).Length + 1;
             ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.ColumnEncryptionSetting = invalid);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("SqlConnectionColumnEncryptionSetting", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -155,8 +147,6 @@ namespace Microsoft.Data.SqlClient.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.ConnectTimeout = -1);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("connect timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -166,8 +156,6 @@ namespace Microsoft.Data.SqlClient.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.CommandTimeout = -1);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("command timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -179,8 +167,6 @@ namespace Microsoft.Data.SqlClient.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.ConnectRetryCount = invalid);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("connect retry count", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -192,8 +178,6 @@ namespace Microsoft.Data.SqlClient.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.ConnectRetryInterval = invalid);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("connect retry interval", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -204,8 +188,6 @@ namespace Microsoft.Data.SqlClient.Tests
 
             SqlConnectionIPAddressPreference invalid = (SqlConnectionIPAddressPreference)Enum.GetValues(typeof(SqlConnectionIPAddressPreference)).Length + 1;
             ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.IPAddressPreference = invalid);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("SqlConnectionIPAddressPreference", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -216,8 +198,6 @@ namespace Microsoft.Data.SqlClient.Tests
 
             PoolBlockingPeriod invalid = (PoolBlockingPeriod)Enum.GetValues(typeof(PoolBlockingPeriod)).Length + 1;
             ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.PoolBlockingPeriod = invalid);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("PoolBlockingPeriod", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -227,8 +207,6 @@ namespace Microsoft.Data.SqlClient.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.LoadBalanceTimeout = -1);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("load balance timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -238,8 +216,6 @@ namespace Microsoft.Data.SqlClient.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.MaxPoolSize = 0);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("max pool size", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -249,8 +225,6 @@ namespace Microsoft.Data.SqlClient.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.MinPoolSize = -1);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("min pool size", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -264,8 +238,6 @@ namespace Microsoft.Data.SqlClient.Tests
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.PacketSize = invalid);
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("packet size", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -286,8 +258,6 @@ namespace Microsoft.Data.SqlClient.Tests
 
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
             ArgumentException ex = Assert.Throws<ArgumentException>(() => builder["NotSupported"] = "not important");
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("not supported", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -102,6 +102,196 @@ namespace Microsoft.Data.SqlClient.Tests
         }
 
         [Fact]
+        public void SetInvalidApplicationIntent_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            ApplicationIntent invalid = (ApplicationIntent)Enum.GetValues(typeof(ApplicationIntent)).Length + 1;
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.ApplicationIntent = invalid);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("ApplicationIntent", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SetInvalidAttestationProtocol_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            SqlConnectionAttestationProtocol invalid = (SqlConnectionAttestationProtocol)Enum.GetValues(typeof(SqlConnectionAttestationProtocol)).Length + 1;
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.AttestationProtocol = invalid);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("SqlConnectionAttestationProtocol", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SetInvalidAuthentication_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            SqlAuthenticationMethod invalid = (SqlAuthenticationMethod)Enum.GetValues(typeof(SqlAuthenticationMethod)).Length + 1;
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.Authentication = invalid);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("SqlAuthenticationMethod", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SetInvalidColumnEncryptionSetting_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            SqlConnectionColumnEncryptionSetting invalid = (SqlConnectionColumnEncryptionSetting)Enum.GetValues(typeof(SqlConnectionColumnEncryptionSetting)).Length + 1;
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.ColumnEncryptionSetting = invalid);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("SqlConnectionColumnEncryptionSetting", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SetInvalidConnectTimeout_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.ConnectTimeout = -1);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("connect timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SetInvalidCommandTimeout_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.CommandTimeout = -1);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("command timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(256)]
+        public void SetInvalidConnectRetryCount_Throws(int invalid)
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.ConnectRetryCount = invalid);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("connect retry count", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(256)]
+        public void SetInvalidConnectRetryInterval_Throws(int invalid)
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.ConnectRetryInterval = invalid);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("connect retry interval", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SetInvalidIPAddressPreference_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            SqlConnectionIPAddressPreference invalid = (SqlConnectionIPAddressPreference)Enum.GetValues(typeof(SqlConnectionIPAddressPreference)).Length + 1;
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.IPAddressPreference = invalid);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("SqlConnectionIPAddressPreference", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SetInvalidPoolBlockingPeriod_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            PoolBlockingPeriod invalid = (PoolBlockingPeriod)Enum.GetValues(typeof(PoolBlockingPeriod)).Length + 1;
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => builder.PoolBlockingPeriod = invalid);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("PoolBlockingPeriod", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SetInvalidLoadBalanceTimeout_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.LoadBalanceTimeout = -1);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("load balance timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SetInvalidMaxPoolSize_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.MaxPoolSize = 0);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("max pool size", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void SetInvalidMinPoolSize_Throws()
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.MinPoolSize = -1);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("min pool size", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(511)]
+        [InlineData(32769)]
+        [InlineData(int.MaxValue)]
+        public void SetInvalidPacketSize_Throws(int invalid)
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => builder.PacketSize = invalid);
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("packet size", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [InlineData("AttachDBFilename","somefile.db")]
+        public void SetKeyword(string keyword, string value)
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+            builder[keyword] = value;
+            Assert.Equal(builder[keyword], value);
+        }
+
+        [Fact]
+        public void SetNotSupportedKeyword_Throws()
+        {
+            // We may want to remove the unreachable code path for default in the GetIndex(keyword) method already throws UnsupportedKeyword
+            // so default: throw UnsupportedKeyword(keyword) is never reached unless it's a supported keyword, but it's not handled in the switch case.
+
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => builder["NotSupported"] = "not important");
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("not supported", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public void UnexpectedKeywordRetrieval()
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder("Data Source=localhost");

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlParameterCollectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlParameterCollectionTest.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.Tests
+{
+    public class SqlParameterCollectionTest
+    {
+        [Fact]
+        public void CollectionAddInvalidRange_Throws()
+        {
+            SqlCommand command = new SqlCommand();
+            SqlParameterCollection collection = command.Parameters;
+
+            Array invalid = null;
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => collection.AddRange(invalid));
+            Assert.NotNull(ex);
+        }
+
+        [Fact]
+        public void CollectionAddRange()
+        {
+            SqlCommand command = new SqlCommand();
+            SqlParameterCollection collection = command.Parameters;
+            Array sqlParameters = new SqlParameter[] { new("Test1", 1), new("Test2", 2) };
+
+            collection.AddRange(sqlParameters);
+
+            Assert.Equal(2, collection.Count);
+            Assert.Equal((SqlParameter)sqlParameters.GetValue(0), collection[0]);
+            Assert.Equal((SqlParameter)sqlParameters.GetValue(1), collection[1]);
+        }
+
+        [Fact]
+        public void CollectionCheckNameInvalid_Throws()
+        {
+            SqlCommand command = new SqlCommand();
+            SqlParameterCollection collection = command.Parameters;
+            collection.Add(new SqlParameter("Test1", 1));
+            collection.Add(new SqlParameter("Test2", 2));
+
+            IndexOutOfRangeException ex = Assert.Throws<IndexOutOfRangeException>(() => collection.RemoveAt("DoesNotExist"));
+            Assert.NotNull(ex);
+            Assert.NotEmpty(ex.Message);
+            Assert.Contains("DoesNotExist", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void ConnectionCopyTo()
+        {
+            SqlCommand command = new SqlCommand();
+            SqlParameterCollection collection = command.Parameters;
+            collection.Add(new SqlParameter("Test1", 1));
+            collection.Add(new SqlParameter("Test2", 2));
+
+            SqlParameter[] copied = new SqlParameter[2];
+            collection.CopyTo(copied, 0);
+
+            Assert.Equal(collection[0], copied[0]);
+            Assert.Equal(collection[1], copied[1]);
+        }
+
+        [Fact]
+        public void CollectionIndexOfCaseInsensitive()
+        {
+            SqlCommand command = new SqlCommand();
+            SqlParameterCollection collection = command.Parameters;
+            collection.Add(new SqlParameter("TEST1", 1));
+            collection.Add(new SqlParameter("Test2", 2));
+            collection.Add(new SqlParameter("Test3", 3));
+
+            int index = collection.IndexOf("test1");
+            Assert.Equal(0, index);
+        }
+
+        [Fact]
+        public void CollectionRemove()
+        {
+            SqlCommand command = new SqlCommand();
+            SqlParameterCollection collection = command.Parameters;
+            SqlParameter parameter1 = new SqlParameter("Test1", 1);
+            collection.Add(parameter1);
+            collection.Add(new SqlParameter("Test2", 2));
+            collection.Add(new SqlParameter("Test3", 3));
+
+            collection.Remove(parameter1);
+            Assert.Equal(2, collection.Count);
+            Assert.Equal("Test2", collection[0].ParameterName);
+        }
+
+        [Fact]
+        public void CollectionSetParameter()
+        {
+            SqlCommand command = new SqlCommand();
+            SqlParameterCollection collection = command.Parameters;
+            collection.Add(new SqlParameter("TestOne", 0));
+            collection.Add(new SqlParameter("Test2", 2));
+            collection.Add(new SqlParameter("Test3", 3));
+
+            collection[0] = new SqlParameter("Test1", 1);
+            Assert.Equal("Test1", collection[0].ParameterName);
+            Assert.Equal(1, (int)collection[0].Value);
+        }
+
+        [Fact]
+        public void CollectionValiateNull_Throws()
+        {
+            SqlCommand command = new SqlCommand();
+            SqlParameterCollection collection = command.Parameters;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => collection.Add(null));
+            Assert.NotNull(ex);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlParameterCollectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlParameterCollectionTest.cs
@@ -16,8 +16,7 @@ namespace Microsoft.Data.SqlClient.Tests
             SqlParameterCollection collection = command.Parameters;
 
             Array invalid = null;
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => collection.AddRange(invalid));
-            Assert.NotNull(ex);
+            Assert.Throws<ArgumentNullException>(() => collection.AddRange(invalid));
         }
 
         [Fact]
@@ -43,8 +42,6 @@ namespace Microsoft.Data.SqlClient.Tests
             collection.Add(new SqlParameter("Test2", 2));
 
             IndexOutOfRangeException ex = Assert.Throws<IndexOutOfRangeException>(() => collection.RemoveAt("DoesNotExist"));
-            Assert.NotNull(ex);
-            Assert.NotEmpty(ex.Message);
             Assert.Contains("DoesNotExist", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -111,8 +108,7 @@ namespace Microsoft.Data.SqlClient.Tests
             SqlCommand command = new SqlCommand();
             SqlParameterCollection collection = command.Parameters;
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => collection.Add(null));
-            Assert.NotNull(ex);
+            Assert.Throws<ArgumentNullException>(() => collection.Add(null));
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
@@ -659,13 +659,68 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal(DbType.DateTimeOffset, param.DbType);
         }
 
-        [Fact]
-        public void LocaleId()
+        [Theory]
+        [InlineData(15)]
+        [InlineData(1044)]
+        [InlineData(1047)]
+        [InlineData(1056)]
+        [InlineData(1065)]
+        [InlineData(1068)]
+        [InlineData(1070)]
+        [InlineData(1071)]
+        [InlineData(1081)]
+        [InlineData(1082)]
+        [InlineData(1083)]
+        [InlineData(1087)]
+        [InlineData(1090)]
+        [InlineData(1091)]
+        [InlineData(1092)]
+        [InlineData(1093)]
+        [InlineData(1101)]
+        [InlineData(1105)]
+        [InlineData(1106)]
+        [InlineData(1107)]
+        [InlineData(1108)]
+        [InlineData(1114)]
+        [InlineData(1121)]
+        [InlineData(1122)]
+        [InlineData(1123)]
+        [InlineData(1125)]
+        [InlineData(1133)]
+        [InlineData(1146)]
+        [InlineData(1148)]
+        [InlineData(1150)]
+        [InlineData(1152)]
+        [InlineData(1153)]
+        [InlineData(1155)]
+        [InlineData(1157)]
+        [InlineData(1164)]
+        [InlineData(2074)]
+        [InlineData(2092)]
+        [InlineData(2107)]
+        [InlineData(2143)]
+        [InlineData(3076)]
+        [InlineData(3098)]
+        [InlineData(5124)]
+        [InlineData(5146)]
+        [InlineData(8218)]
+        public void LocaleId(int lcid)
         {
+            // To verify all the cases in SqlCollation.FirstSupportedCollationVersion
             SqlParameter parameter = new SqlParameter();
             Assert.Equal(0, parameter.LocaleId);
-            parameter.LocaleId = 15;
-            Assert.Equal(15, parameter.LocaleId);
+            parameter.LocaleId = lcid;
+            Assert.Equal(parameter.LocaleId, lcid);
+        }
+
+        [Fact]
+        public void LocaleIdOutOfRange_Throws()
+        {
+            SqlParameter parameter = new SqlParameter();
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => { parameter.LocaleId = -1; });
+            Assert.NotNull(ex);
+            Assert.NotNull(ex.ParamName);
+            Assert.Contains("LocaleId", ex.ParamName, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlParameterTest.cs
@@ -718,7 +718,6 @@ namespace Microsoft.Data.SqlClient.Tests
         {
             SqlParameter parameter = new SqlParameter();
             ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(() => { parameter.LocaleId = -1; });
-            Assert.NotNull(ex);
             Assert.NotNull(ex.ParamName);
             Assert.Contains("LocaleId", ex.ParamName, StringComparison.OrdinalIgnoreCase);
         }


### PR DESCRIPTION
Instead of making a giant PR with as much code coverage tests as possible, I'm going to split them up into parts and try to open one PR per week or depending on the number of tests added/modified.  I added [code coverage](https://dev.azure.com/sqlclientdrivers-ci/sqlclient/_build/results?buildId=43083&view=codecoverage-tab) to the following classes:

- SqlCollation
- SqlConnectionStringBuilder
- SqlClientLogger
- SqlClientFactory
- SqlParameterCollection
- SqlCommandSet
