### PR TITLE
Avoid throwing exception when receiving invalid SqlNotificationInfo value

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -1131,37 +1131,25 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                     messageAttributes |= MessageAttributes.Source;
                                     break;
                                 case InfoAttribute:
-                                    try
+                                    string value = xmlReader.Value;
+                                    // 3 of the server info values do not match client values - map.
+                                    switch (value)
                                     {
-                                        string value = xmlReader.Value;
-                                        // 3 of the server info values do not match client values - map.
-                                        switch (value)
-                                        {
-                                            case "set options":
-                                                info = SqlNotificationInfo.Options;
-                                                break;
-                                            case "previous invalid":
-                                                info = SqlNotificationInfo.PreviousFire;
-                                                break;
-                                            case "query template limit":
-                                                info = SqlNotificationInfo.TemplateLimit;
-                                                break;
-                                            default:
-                                                SqlNotificationInfo temp = (SqlNotificationInfo)Enum.Parse(typeof(SqlNotificationInfo), value, true);
-                                                if (Enum.IsDefined(typeof(SqlNotificationInfo), temp))
-                                                {
-                                                    info = temp;
-                                                }
-                                                break;
-                                        }
-                                    }
-                                    catch (Exception e)
-                                    {
-                                        if (!ADP.IsCatchableExceptionType(e))
-                                        {
-                                            throw;
-                                        }
-                                        ADP.TraceExceptionWithoutRethrow(e); // Discard failure, if it should occur.
+                                        case "set options":
+                                            info = SqlNotificationInfo.Options;
+                                            break;
+                                        case "previous invalid":
+                                            info = SqlNotificationInfo.PreviousFire;
+                                            break;
+                                        case "query template limit":
+                                            info = SqlNotificationInfo.TemplateLimit;
+                                            break;
+                                        default:
+                                            if (Enum.TryParse(value, true, out SqlNotificationInfo temp) && Enum.IsDefined(typeof(SqlNotificationInfo), temp))
+                                            {
+                                                info = temp;
+                                            }
+                                            break;
                                     }
                                     messageAttributes |= MessageAttributes.Info;
                                     break;


### PR DESCRIPTION
Addresses #1376 

When receiving an invalid `SqlNotificationInfo` value, an exception would be thrown because the call to `Enum.Parse` fails. We can use `Enum.TryParse` to avoid this. The result will still be `SqlNotificationInfo.Unknown` either way.