### PR TITLE
Change SQL Server codenames to version names

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
@@ -391,8 +391,8 @@ namespace Microsoft.Data.SqlClient.Server
             return s_extendedTypeCodeToSqlDbTypeMap[(int)typeCode + 1];
         }
 
-        // Infer SqlDbType from Type in the general case.  Katmai-only (or later) features that need to 
-        //  infer types should use InferSqlDbTypeFromType_Katmai.
+        // Infer SqlDbType from Type in the general case. 2008-only (or later) features that need to 
+        //  infer types should use InferSqlDbTypeFromType_2008.
         internal static SqlDbType InferSqlDbTypeFromType(Type type)
         {
             ExtendedClrTypeCode typeCode = DetermineExtendedTypeCodeFromType(type);
@@ -409,12 +409,12 @@ namespace Microsoft.Data.SqlClient.Server
             return returnType;
         }
 
-        // Inference rules changed for Katmai-or-later-only cases.  Only features that are guaranteed to be 
-        //  running against Katmai and don't have backward compat issues should call this code path.
-        //      example: TVP's are a new Katmai feature (no back compat issues) so can infer DATETIME2
+        // Inference rules changed for 2008-or-later-only cases.  Only features that are guaranteed to be 
+        //  running against 2008 and don't have backward compat issues should call this code path.
+        //      example: TVP's are a new 2008 feature (no back compat issues) so can infer DATETIME2
         //          when mapping System.DateTime from DateTable or DbDataReader.  DATETIME2 is better because
         //          of greater range that can handle all DateTime values.
-        internal static SqlDbType InferSqlDbTypeFromType_Katmai(Type type)
+        internal static SqlDbType InferSqlDbTypeFromType_2008(Type type)
         {
             SqlDbType returnType = InferSqlDbTypeFromType(type);
             if (SqlDbType.DateTime == returnType)
@@ -533,7 +533,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Extract metadata for a single DataColumn
         internal static SmiExtendedMetaData SmiMetaDataFromDataColumn(DataColumn column, DataTable parent)
         {
-            SqlDbType dbType = InferSqlDbTypeFromType_Katmai(column.DataType);
+            SqlDbType dbType = InferSqlDbTypeFromType_2008(column.DataType);
             if (InvalidSqlDbType == dbType)
             {
                 throw SQL.UnsupportedColumnTypeForSqlProvider(column.ColumnName, column.DataType.Name);
@@ -733,7 +733,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
 
             Type colType = (Type)temp;
-            SqlDbType colDbType = InferSqlDbTypeFromType_Katmai(colType);
+            SqlDbType colDbType = InferSqlDbTypeFromType_2008(colType);
             if (InvalidSqlDbType == colDbType)
             {
                 // Unknown through standard mapping, use VarBinary for columns that are Object typed, otherwise error

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -499,7 +499,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // use static list of format strings indexed by scale for perf
-        private static readonly string[] s_katmaiDateTimeOffsetFormatByScale = new string[] {
+        private static readonly string[] s_2008DateTimeOffsetFormatByScale = new string[] {
                 "yyyy-MM-dd HH:mm:ss zzz",
                 "yyyy-MM-dd HH:mm:ss.f zzz",
                 "yyyy-MM-dd HH:mm:ss.ff zzz",
@@ -510,7 +510,7 @@ namespace Microsoft.Data.SqlClient
                 "yyyy-MM-dd HH:mm:ss.fffffff zzz",
         };
 
-        private static readonly string[] s_katmaiDateTime2FormatByScale = new string[] {
+        private static readonly string[] s_2008DateTime2FormatByScale = new string[] {
                 "yyyy-MM-dd HH:mm:ss",
                 "yyyy-MM-dd HH:mm:ss.f",
                 "yyyy-MM-dd HH:mm:ss.ff",
@@ -521,7 +521,7 @@ namespace Microsoft.Data.SqlClient
                 "yyyy-MM-dd HH:mm:ss.fffffff",
         };
 
-        private static readonly string[] s_katmaiTimeFormatByScale = new string[] {
+        private static readonly string[] s_2008TimeFormatByScale = new string[] {
                 "HH:mm:ss",
                 "HH:mm:ss.f",
                 "HH:mm:ss.ff",
@@ -532,7 +532,7 @@ namespace Microsoft.Data.SqlClient
                 "HH:mm:ss.fffffff",
         };
 
-        internal string KatmaiDateTimeString
+        internal string Sql2008DateTimeString
         {
             get
             {
@@ -545,24 +545,24 @@ namespace Microsoft.Data.SqlClient
                 if (StorageType.Time == _type)
                 {
                     byte scale = _value._timeInfo._scale;
-                    return new DateTime(_value._timeInfo._ticks).ToString(s_katmaiTimeFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return new DateTime(_value._timeInfo._ticks).ToString(s_2008TimeFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 if (StorageType.DateTime2 == _type)
                 {
                     byte scale = _value._dateTime2Info._timeInfo._scale;
-                    return DateTime.ToString(s_katmaiDateTime2FormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return DateTime.ToString(s_2008DateTime2FormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 if (StorageType.DateTimeOffset == _type)
                 {
                     DateTimeOffset dto = DateTimeOffset;
                     byte scale = _value._dateTimeOffsetInfo._dateTime2Info._timeInfo._scale;
-                    return dto.ToString(s_katmaiDateTimeOffsetFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return dto.ToString(s_2008DateTimeOffsetFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 return (string)Value; // anything else we haven't thought of goes through boxing.
             }
         }
 
-        internal SqlString KatmaiDateTimeSqlString
+        internal SqlString Sql2008DateTimeSqlString
         {
             get
             {
@@ -575,7 +575,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         return SqlString.Null;
                     }
-                    return new SqlString(KatmaiDateTimeString);
+                    return new SqlString(Sql2008DateTimeString);
                 }
                 return (SqlString)SqlValue; // anything else we haven't thought of goes through boxing.
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -499,7 +499,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // use static list of format strings indexed by scale for perf
-        private static readonly string[] s_2008DateTimeOffsetFormatByScale = new string[] {
+        private static readonly string[] s_sql2008DateTimeOffsetFormatByScale = new string[] {
                 "yyyy-MM-dd HH:mm:ss zzz",
                 "yyyy-MM-dd HH:mm:ss.f zzz",
                 "yyyy-MM-dd HH:mm:ss.ff zzz",
@@ -510,7 +510,7 @@ namespace Microsoft.Data.SqlClient
                 "yyyy-MM-dd HH:mm:ss.fffffff zzz",
         };
 
-        private static readonly string[] s_2008DateTime2FormatByScale = new string[] {
+        private static readonly string[] s_sql2008DateTime2FormatByScale = new string[] {
                 "yyyy-MM-dd HH:mm:ss",
                 "yyyy-MM-dd HH:mm:ss.f",
                 "yyyy-MM-dd HH:mm:ss.ff",
@@ -521,7 +521,7 @@ namespace Microsoft.Data.SqlClient
                 "yyyy-MM-dd HH:mm:ss.fffffff",
         };
 
-        private static readonly string[] s_2008TimeFormatByScale = new string[] {
+        private static readonly string[] s_sql2008TimeFormatByScale = new string[] {
                 "HH:mm:ss",
                 "HH:mm:ss.f",
                 "HH:mm:ss.ff",
@@ -545,18 +545,18 @@ namespace Microsoft.Data.SqlClient
                 if (StorageType.Time == _type)
                 {
                     byte scale = _value._timeInfo._scale;
-                    return new DateTime(_value._timeInfo._ticks).ToString(s_2008TimeFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return new DateTime(_value._timeInfo._ticks).ToString(s_sql2008TimeFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 if (StorageType.DateTime2 == _type)
                 {
                     byte scale = _value._dateTime2Info._timeInfo._scale;
-                    return DateTime.ToString(s_2008DateTime2FormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return DateTime.ToString(s_sql2008DateTime2FormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 if (StorageType.DateTimeOffset == _type)
                 {
                     DateTimeOffset dto = DateTimeOffset;
                     byte scale = _value._dateTimeOffsetInfo._dateTime2Info._timeInfo._scale;
-                    return dto.ToString(s_2008DateTimeOffsetFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return dto.ToString(s_sql2008DateTimeOffsetFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 return (string)Value; // anything else we haven't thought of goes through boxing.
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -422,7 +422,7 @@ namespace Microsoft.Data.SqlClient
             TDSCommand = "select @@trancount; SET FMTONLY ON select * from " + ADP.BuildMultiPartName(parts) + " SET FMTONLY OFF ";
 
             string TableCollationsStoredProc;
-            if (_connection.IsKatmaiOrNewer)
+            if (_connection.Is2008OrNewer)
             {
                 TableCollationsStoredProc = "sp_tablecollations_100";
             }
@@ -2184,7 +2184,7 @@ namespace Microsoft.Data.SqlClient
                 // Target type shouldn't be encrypted
                 Debug.Assert(!metadata.isEncrypted, "Can't encrypt SQL Variant type");
                 SqlBuffer.StorageType variantInternalType = SqlBuffer.StorageType.Empty;
-                if ((_sqlDataReaderRowSource != null) && (_connection.IsKatmaiOrNewer))
+                if ((_sqlDataReaderRowSource != null) && (_connection.Is2008OrNewer))
                 {
                     variantInternalType = _sqlDataReaderRowSource.GetVariantInternalStorageType(_sortedColumnMappings[col]._sourceColumnOrdinal);
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2984,7 +2984,7 @@ namespace Microsoft.Data.SqlClient
             DateTimeScale // new in 2008
         };
 
-        // Yukon- column ordinals (this array indexed by ProcParamsColIndex
+        // 2005- column ordinals (this array indexed by ProcParamsColIndex
         internal static readonly string[] PreSql2008ProcParamsNames = new string[] {
             "PARAMETER_NAME",           // ParameterName,
             "PARAMETER_TYPE",           // ParameterType,
@@ -3053,7 +3053,7 @@ namespace Microsoft.Data.SqlClient
             StringBuilder cmdText = new StringBuilder();
 
             // Build call for sp_procedure_params_rowset built of unquoted values from user:
-            // [user server, if provided].[user catalog, else current database].[sys if Yukon, else blank].[sp_procedure_params_rowset]
+            // [user server, if provided].[user catalog, else current database].[sys if 2005, else blank].[sp_procedure_params_rowset]
 
             // Server - pass only if user provided.
             if (!string.IsNullOrEmpty(parsedSProc[0]))
@@ -3070,8 +3070,8 @@ namespace Microsoft.Data.SqlClient
             SqlCommandSet.BuildStoredProcedureName(cmdText, parsedSProc[1]);
             cmdText.Append(".");
 
-            // Schema - only if Yukon, and then only pass sys.  Also - pass managed version of sproc
-            // for Yukon, else older sproc.
+            // Schema - only if 2005, and then only pass sys.  Also - pass managed version of sproc
+            // for 2005, else older sproc.
             string[] colNames;
             bool useManagedDataType;
             if (Connection.Is2008OrNewer)
@@ -3143,7 +3143,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         p.SqlDbType = (SqlDbType)(short)r[colNames[(int)ProcParamsColIndex.ManagedDataType]];
 
-                        // Yukon didn't have as accurate of information as we're getting for 2008, so re-map a couple of
+                        // 2005 didn't have as accurate of information as we're getting for 2008, so re-map a couple of
                         //  types for backward compatability.
                         switch (p.SqlDbType)
                         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2969,8 +2969,8 @@ namespace Microsoft.Data.SqlClient
         {
             ParameterName = 0,
             ParameterType,
-            DataType, // obsolete in katmai, use ManagedDataType instead
-            ManagedDataType, // new in katmai
+            DataType, // obsolete in 2008, use ManagedDataType instead
+            ManagedDataType, // new in 2008
             CharacterMaximumLength,
             NumericPrecision,
             NumericScale,
@@ -2980,16 +2980,16 @@ namespace Microsoft.Data.SqlClient
             XmlSchemaCollectionCatalogName,
             XmlSchemaCollectionSchemaName,
             XmlSchemaCollectionName,
-            UdtTypeName, // obsolete in Katmai.  Holds the actual typename if UDT, since TypeName didn't back then.
-            DateTimeScale // new in Katmai
+            UdtTypeName, // obsolete in 2008.  Holds the actual typename if UDT, since TypeName didn't back then.
+            DateTimeScale // new in 2008
         };
 
         // Yukon- column ordinals (this array indexed by ProcParamsColIndex
-        internal static readonly string[] PreKatmaiProcParamsNames = new string[] {
+        internal static readonly string[] PreSql2008ProcParamsNames = new string[] {
             "PARAMETER_NAME",           // ParameterName,
             "PARAMETER_TYPE",           // ParameterType,
             "DATA_TYPE",                // DataType
-            null,                       // ManagedDataType,     introduced in Katmai
+            null,                       // ManagedDataType,     introduced in 2008
             "CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
             "NUMERIC_PRECISION",        // NumericPrecision,
             "NUMERIC_SCALE",            // NumericScale,
@@ -3000,14 +3000,14 @@ namespace Microsoft.Data.SqlClient
             "XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
             "XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
             "UDT_NAME",                 // UdtTypeName
-            null,                       // Scale for datetime types with scale, introduced in Katmai
+            null,                       // Scale for datetime types with scale, introduced in 2008
         };
 
-        // Katmai+ column ordinals (this array indexed by ProcParamsColIndex
-        internal static readonly string[] KatmaiProcParamsNames = new string[] {
+        // 2008+ column ordinals (this array indexed by ProcParamsColIndex
+        internal static readonly string[] Sql2008ProcParamsNames = new string[] {
             "PARAMETER_NAME",           // ParameterName,
             "PARAMETER_TYPE",           // ParameterType,
-            null,                       // DataType, removed from Katmai+
+            null,                       // DataType, removed from 2008+
             "MANAGED_DATA_TYPE",        // ManagedDataType,
             "CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
             "NUMERIC_PRECISION",        // NumericPrecision,
@@ -3018,7 +3018,7 @@ namespace Microsoft.Data.SqlClient
             "XML_CATALOGNAME",          // XmlSchemaCollectionCatalogName,
             "XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
             "XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
-            null,                       // UdtTypeName, removed from Katmai+
+            null,                       // UdtTypeName, removed from 2008+
             "SS_DATETIME_PRECISION",    // Scale for datetime types with scale
         };
 
@@ -3074,12 +3074,12 @@ namespace Microsoft.Data.SqlClient
             // for Yukon, else older sproc.
             string[] colNames;
             bool useManagedDataType;
-            if (Connection.IsKatmaiOrNewer)
+            if (Connection.Is2008OrNewer)
             {
                 // Procedure - [sp_procedure_params_managed]
                 cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MGD10).Append("]");
 
-                colNames = KatmaiProcParamsNames;
+                colNames = Sql2008ProcParamsNames;
                 useManagedDataType = true;
             }
             else
@@ -3087,7 +3087,7 @@ namespace Microsoft.Data.SqlClient
                 // Procedure - [sp_procedure_params_managed]
                 cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MANAGED).Append("]");
 
-                colNames = PreKatmaiProcParamsNames;
+                colNames = PreSql2008ProcParamsNames;
                 useManagedDataType = false;
             }
 
@@ -3143,7 +3143,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         p.SqlDbType = (SqlDbType)(short)r[colNames[(int)ProcParamsColIndex.ManagedDataType]];
 
-                        // Yukon didn't have as accurate of information as we're getting for Katmai, so re-map a couple of
+                        // Yukon didn't have as accurate of information as we're getting for 2008, so re-map a couple of
                         //  types for backward compatability.
                         switch (p.SqlDbType)
                         {
@@ -3177,9 +3177,9 @@ namespace Microsoft.Data.SqlClient
                     {
                         int size = (int)a;
 
-                        // Map MAX sizes correctly.  The Katmai server-side proc sends 0 for these instead of -1.
-                        //  Should be fixed on the Katmai side, but would likely hold up the RI, and is safer to fix here.
-                        //  If we can get the server-side fixed before shipping Katmai, we can remove this mapping.
+                        // Map MAX sizes correctly.  The 2008 server-side proc sends 0 for these instead of -1.
+                        //  Should be fixed on the 2008 side, but would likely hold up the RI, and is safer to fix here.
+                        //  If we can get the server-side fixed before shipping 2008, we can remove this mapping.
                         if (0 == size &&
                                 (p.SqlDbType == SqlDbType.NVarChar ||
                                  p.SqlDbType == SqlDbType.VarBinary ||
@@ -3221,7 +3221,7 @@ namespace Microsoft.Data.SqlClient
                     // type name for Structured types (same as for Udt's except assign p.TypeName instead of p.UdtTypeName
                     if (SqlDbType.Structured == p.SqlDbType)
                     {
-                        Debug.Assert(_activeConnection.IsKatmaiOrNewer, "Invalid datatype token received from pre-katmai server");
+                        Debug.Assert(_activeConnection.Is2008OrNewer, "Invalid datatype token received from pre-2008 server");
 
                         //read the type name
                         p.TypeName = r[colNames[(int)ProcParamsColIndex.TypeCatalogName]] + "." +

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1899,15 +1899,15 @@ namespace Microsoft.Data.SqlClient
         }
 
 
-        internal bool IsKatmaiOrNewer
+        internal bool Is2008OrNewer
         {
             get
             {
                 if (_currentReconnectionTask != null)
                 { // holds true even if task is completed
-                    return true; // if CR is enabled, connection, if established, will be Katmai+
+                    return true; // if CR is enabled, connection, if established, will be 2008+
                 }
-                return GetOpenTdsConnection().IsKatmaiOrNewer;
+                return GetOpenTdsConnection().Is2008OrNewer;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -552,7 +552,7 @@ namespace Microsoft.Data.SqlClient
                 schemaRow[nonVersionedProviderType] = (int)(col.cipherMD != null ? col.baseTI.type : col.type); // SqlDbType enum value - does not change with TypeSystem.
                 schemaRow[dataTypeName] = GetDataTypeNameInternal(col);
 
-                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.IsNewKatmaiDateTimeType)
+                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.Is2008DateTimeType)
                 {
                     schemaRow[providerType] = SqlDbType.NVarChar;
                     switch (col.type)
@@ -595,12 +595,12 @@ namespace Microsoft.Data.SqlClient
 
                     if (col.type == SqlDbType.Udt)
                     { // Additional metadata for UDTs.
-                        Debug.Assert(Connection.IsKatmaiOrNewer, "Invalid Column type received from the server");
+                        Debug.Assert(Connection.Is2008OrNewer, "Invalid Column type received from the server");
                         schemaRow[udtAssemblyQualifiedName] = col.udt?.AssemblyQualifiedName;
                     }
                     else if (col.type == SqlDbType.Xml)
                     { // Additional metadata for Xml.
-                        Debug.Assert(Connection.IsKatmaiOrNewer, "Invalid DataType (Xml) for the column");
+                        Debug.Assert(Connection.Is2008OrNewer, "Invalid DataType (Xml) for the column");
                         schemaRow[xmlSchemaCollectionDatabase] = col.xmlSchemaCollection?.Database;
                         schemaRow[xmlSchemaCollectionOwningSchema] = col.xmlSchemaCollection?.OwningSchema;
                         schemaRow[xmlSchemaCollectionName] = col.xmlSchemaCollection?.Name;
@@ -635,7 +635,7 @@ namespace Microsoft.Data.SqlClient
                     schemaRow[precision] = col.metaType.Precision;
                 }
 
-                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.IsNewKatmaiDateTimeType)
+                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.Is2008DateTimeType)
                 {
                     schemaRow[scale] = MetaType.MetaNVarChar.Scale;
                 }
@@ -1170,7 +1170,7 @@ namespace Microsoft.Data.SqlClient
         {
             string dataTypeName = null;
 
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
                 dataTypeName = MetaType.MetaNVarChar.TypeName;
             }
@@ -1252,9 +1252,9 @@ namespace Microsoft.Data.SqlClient
         {
             Type fieldType = null;
 
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
-                // Return katmai types as string
+                // Return 2008 types as string
                 fieldType = MetaType.MetaNVarChar.ClassType;
             }
             else if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsLargeUdt)
@@ -1360,7 +1360,7 @@ namespace Microsoft.Data.SqlClient
         {
             Type providerSpecificFieldType = null;
 
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
                 providerSpecificFieldType = MetaType.MetaNVarChar.SqlType;
             }
@@ -2284,7 +2284,7 @@ namespace Microsoft.Data.SqlClient
 
             DateTime dt = _data[i].DateTime;
             // This accessor can be called for regular DateTime column. In this case we should not throw
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].Is2008DateTimeType)
             {
                 // TypeSystem.SQLServer2005 or less
 
@@ -2382,10 +2382,10 @@ namespace Microsoft.Data.SqlClient
         {
             ReadColumn(i);
             SqlString data;
-            // Convert Katmai types to string
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].IsNewKatmaiDateTimeType)
+            // Convert 2008 types to string
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].Is2008DateTimeType)
             {
-                data = _data[i].KatmaiDateTimeSqlString;
+                data = _data[i].Sql2008DateTimeSqlString;
             }
             else
             {
@@ -2462,9 +2462,9 @@ namespace Microsoft.Data.SqlClient
         {
             ReadColumn(i);
 
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].Is2008DateTimeType)
             {
-                return _data[i].KatmaiDateTimeSqlString;
+                return _data[i].Sql2008DateTimeSqlString;
             }
 
             return _data[i].SqlString;
@@ -2541,10 +2541,10 @@ namespace Microsoft.Data.SqlClient
         {
             Debug.Assert(!data.IsEmpty || data.IsNull || metaData.type == SqlDbType.Timestamp, "Data has been read, but the buffer is empty");
 
-            // Convert Katmai types to string
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            // Convert 2008 types to string
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
-                return data.KatmaiDateTimeSqlString;
+                return data.Sql2008DateTimeSqlString;
             }
             else if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsLargeUdt)
             {
@@ -2621,10 +2621,10 @@ namespace Microsoft.Data.SqlClient
         {
             ReadColumn(i);
 
-            // Convert katmai value to string if type system knob is 2005 or earlier
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].IsNewKatmaiDateTimeType)
+            // Convert 2008 value to string if type system knob is 2005 or earlier
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].Is2008DateTimeType)
             {
-                return _data[i].KatmaiDateTimeString;
+                return _data[i].Sql2008DateTimeString;
             }
 
             return _data[i].String;
@@ -2731,7 +2731,7 @@ namespace Microsoft.Data.SqlClient
         {
             Debug.Assert(!data.IsEmpty || data.IsNull || metaData.type == SqlDbType.Timestamp, "Data has been read, but the buffer is empty");
 
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
                 if (data.IsNull)
                 {
@@ -2739,7 +2739,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    return data.KatmaiDateTimeString;
+                    return data.Sql2008DateTimeString;
                 }
             }
             else if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsLargeUdt)
@@ -2835,11 +2835,11 @@ namespace Microsoft.Data.SqlClient
             {
                 return (T)(object)data.Decimal;
             }
-            else if (typeof(T) == typeof(DateTimeOffset) && dataType == typeof(DateTimeOffset) && _typeSystem > SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            else if (typeof(T) == typeof(DateTimeOffset) && dataType == typeof(DateTimeOffset) && _typeSystem > SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
                 return (T)(object)data.DateTimeOffset;
             }
-            else if (typeof(T) == typeof(DateTime) && dataType == typeof(DateTime) && _typeSystem > SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            else if (typeof(T) == typeof(DateTime) && dataType == typeof(DateTime) && _typeSystem > SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
                 return (T)(object)data.DateTime;
             }
@@ -5740,7 +5740,7 @@ namespace Microsoft.Data.SqlClient
                 _SqlMetaData col = md[i];
                 SqlDbColumn dbColumn = new SqlDbColumn(md[i]);
 
-                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.IsNewKatmaiDateTimeType)
+                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.Is2008DateTimeType)
                 {
                     dbColumn.SqlNumericScale = MetaType.MetaNVarChar.Scale;
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.TryAdvancedTraceEvent("SqlInternalConnection.EnlistNonNull | ADV | Object {0}, Transaction Id {1}, attempting to delegate.", ObjectID, tx?.TransactionInformation?.LocalIdentifier);
             bool hasDelegatedTransaction = false;
 
-            // Promotable transactions are only supported on Yukon
+            // Promotable transactions are only supported on 2005
             // servers or newer.
             SqlDelegatedTransaction delegatedTransaction = new SqlDelegatedTransaction(this, tx);
 
@@ -469,17 +469,17 @@ namespace Microsoft.Data.SqlClient
             EnlistedTransaction = tx; // Tell the base class about our enlistment
 
 
-            // If we're on a Yukon or newer server, and we delegate the
+            // If we're on a 2005 or newer server, and we delegate the
             // transaction successfully, we will have done a begin transaction,
             // which produces a transaction id that we should execute all requests
             // on.  The TdsParser or SmiEventSink will store this information as
             // the current transaction.
             //
-            // Likewise, propagating a transaction to a Yukon or newer server will
+            // Likewise, propagating a transaction to a 2005 or newer server will
             // produce a transaction id that The TdsParser or SmiEventSink will
             // store as the current transaction.
             //
-            // In either case, when we're working with a Yukon or newer server
+            // In either case, when we're working with a 2005 or newer server
             // we better have a current transaction by now.
 
             Debug.Assert(null != CurrentTransaction, "delegated/enlisted transaction with null current transaction?");
@@ -511,7 +511,7 @@ namespace Microsoft.Data.SqlClient
             // which causes the TdsParser or SmiEventSink should to clear the
             // current transaction.
             //
-            // In either case, when we're working with a Yukon or newer server
+            // In either case, when we're working with a 2005 or newer server
             // we better not have a current transaction at this point.
 
             Debug.Assert(null == CurrentTransaction, "unenlisted transaction with non-null current transaction?");   // verify it!
@@ -539,7 +539,7 @@ namespace Microsoft.Data.SqlClient
             // If a connection is already enlisted in a DTC transaction and you
             // try to enlist in another one, in 7.0 the existing DTC transaction
             // would roll back and then the connection would enlist in the new
-            // one. In SQL 2000 & Yukon, when you enlist in a DTC transaction
+            // one. In SQL 2000 & 2005, when you enlist in a DTC transaction
             // while the connection is already enlisted in a DTC transaction,
             // the connection simply switches enlistments.  Regardless, simply
             // enlist in the user specified distributed transaction.  This

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Data.SqlClient
         }
 
 
-        abstract internal bool IsKatmaiOrNewer
+        abstract internal bool Is2008OrNewer
         {
             get;
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1001,11 +1001,11 @@ namespace Microsoft.Data.SqlClient
 
             string transactionName = (null == name) ? string.Empty : name;
 
-            ExecuteTransactionYukon(transactionRequest, transactionName, iso, internalTransaction, isDelegateControlRequest);
+            ExecuteTransaction2005(transactionRequest, transactionName, iso, internalTransaction, isDelegateControlRequest);
         }
 
 
-        internal void ExecuteTransactionYukon(
+        internal void ExecuteTransaction2005(
                     TransactionRequest transactionRequest,
                     string transactionName,
                     System.Data.IsolationLevel iso,
@@ -1068,7 +1068,7 @@ namespace Microsoft.Data.SqlClient
                         requestType = TdsEnums.TransactionManagerRequestType.Commit;
                         break;
                     case TransactionRequest.IfRollback:
-                    // Map IfRollback to Rollback since with Yukon and beyond we should never need
+                    // Map IfRollback to Rollback since with 2005 and beyond we should never need
                     // the if since the server will inform us when transactions have completed
                     // as a result of an error on the server.
                     case TransactionRequest.Rollback:
@@ -1124,7 +1124,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     if (internalTransaction.OpenResultsCount != 0)
                     {
-                        SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.ExecuteTransactionYukon|DATA|CATCH> {0}, Connection is marked to be doomed when closed. Transaction ended with OpenResultsCount {1} > 0, MARSOn {2}",
+                        SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.ExecuteTransaction2005|DATA|CATCH> {0}, Connection is marked to be doomed when closed. Transaction ended with OpenResultsCount {1} > 0, MARSOn {2}",
                                                                ObjectID,
                                                                internalTransaction.OpenResultsCount,
                                                                _parser.MARSOn);
@@ -2065,7 +2065,7 @@ namespace Microsoft.Data.SqlClient
                     break;
 
                 case TdsEnums.ENV_TRANSACTIONMANAGERADDRESS:
-                    // For now we skip these Yukon only env change notifications
+                    // For now we skip these 2005 only env change notifications
                     break;
 
                 case TdsEnums.ENV_SPRESETCONNECTIONACK:

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -636,15 +636,15 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                return IsTransactionRoot && (!IsKatmaiOrNewer || null == Pool);
+                return IsTransactionRoot && (!Is2008OrNewer || null == Pool);
             }
         }
 
-        internal override bool IsKatmaiOrNewer
+        internal override bool Is2008OrNewer
         {
             get
             {
-                return _parser.IsKatmaiOrNewer;
+                return _parser.Is2008OrNewer;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -934,7 +934,7 @@ namespace Microsoft.Data.SqlClient
 
             if (_fResetConnection)
             {
-                // Ensure we are either going against shiloh, or we are not enlisted in a
+                // Ensure we are either going against 2000, or we are not enlisted in a
                 // distributed transaction - otherwise don't reset!
                 // Prepare the parser for the connection reset - the next time a trip
                 // to the server is made.

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Data.SqlClient
             {
                 if (processFinallyBlock)
                 {
-                    // Always ensure we're zombied; Yukon will send an EnvChange that
+                    // Always ensure we're zombied; 2005 will send an EnvChange that
                     // will cause the zombie, but only if we actually go to the wire;
                     // Sphinx and Shiloh won't send the env change, so we have to handle
                     // them ourselves.
@@ -498,7 +498,7 @@ namespace Microsoft.Data.SqlClient
 
             // NOTE: we'll be called from the TdsParser when it gets appropriate
             // ENVCHANGE events that indicate the transaction has completed, however
-            // we cannot rely upon those events occurring in the case of pre-Yukon
+            // we cannot rely upon those events occurring in the case of pre-2005
             // servers (and when we don't go to the wire because the connection
             // is broken) so we can also be called from the Commit/Rollback/Save
             // methods to handle that case as well.

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // Always ensure we're zombied; 2005 will send an EnvChange that
                     // will cause the zombie, but only if we actually go to the wire;
-                    // Sphinx and 2000 won't send the env change, so we have to handle
+                    // 7.0 and 2000 won't send the env change, so we have to handle
                     // them ourselves.
                     Zombie();
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // Always ensure we're zombied; 2005 will send an EnvChange that
                     // will cause the zombie, but only if we actually go to the wire;
-                    // Sphinx and Shiloh won't send the env change, so we have to handle
+                    // Sphinx and 2000 won't send the env change, so we have to handle
                     // them ourselves.
                     Zombie();
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -1988,7 +1988,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     // Notes:
-                    // Elevation from (n)(var)char (4001+) to (n)text succeeds without failure only with Yukon and greater.
+                    // Elevation from (n)(var)char (4001+) to (n)text succeeds without failure only with 2005 and greater.
                     // it fails in sql server 2000
                     maxSizeInBytes = (sizeInCharacters > actualSizeInBytes) ? sizeInCharacters : actualSizeInBytes;
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private bool IsYukonPartialZombie
+        private bool Is2005PartialZombie
         {
             get
             {
@@ -182,7 +182,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (disposing)
             {
-                if (!IsZombied && !IsYukonPartialZombie)
+                if (!IsZombied && !Is2005PartialZombie)
                 {
                     _internalTransaction.Dispose();
                 }
@@ -195,11 +195,11 @@ namespace Microsoft.Data.SqlClient
         {
             using (DiagnosticTransactionScope diagnosticScope = s_diagnosticListener.CreateTransactionRollbackScope(_isolationLevel, _connection, InternalTransaction, null))
             {
-                if (IsYukonPartialZombie)
+                if (Is2005PartialZombie)
                 {
                     // Put something in the trace in case a customer has an issue
                     SqlClientEventSource.Log.TryAdvancedTraceEvent("SqlTransaction.Rollback | ADV | Object Id {0}, partial zombie no rollback required", ObjectID);
-                    _internalTransaction = null; // yukon zombification
+                    _internalTransaction = null; // 2005 zombification
                 }
                 else
                 {
@@ -291,7 +291,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void Zombie()
         {
-            // For Yukon, we have to defer "zombification" until
+            // For 2005, we have to defer "zombification" until
             //                 we get past the users' next rollback, else we'll
             //                 throw an exception there that is a breaking change.
             //                 Of course, if the connection is already closed,
@@ -299,11 +299,11 @@ namespace Microsoft.Data.SqlClient
             SqlInternalConnection internalConnection = (_connection.InnerConnection as SqlInternalConnection);
             if (null != internalConnection && !_isFromAPI)
             {
-                SqlClientEventSource.Log.TryAdvancedTraceEvent("SqlTransaction.Zombie | ADV | Object Id {0} yukon deferred zombie", ObjectID);
+                SqlClientEventSource.Log.TryAdvancedTraceEvent("SqlTransaction.Zombie | ADV | Object Id {0} 2005 deferred zombie", ObjectID);
             }
             else
             {
-                _internalTransaction = null; // pre-yukon zombification
+                _internalTransaction = null; // pre-2005 zombification
             }
         }
 
@@ -316,9 +316,9 @@ namespace Microsoft.Data.SqlClient
             // If this transaction has been completed, throw exception since it is unusable.
             if (IsZombied)
             {
-                if (IsYukonPartialZombie)
+                if (Is2005PartialZombie)
                 {
-                    _internalTransaction = null; // yukon zombification
+                    _internalTransaction = null; // 2005 zombification
                 }
 
                 throw ADP.TransactionZombied(this);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -394,7 +394,7 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_ChangePasswordConflictsWithSSPI));
         }
-        internal static Exception ChangePasswordRequiresYukon()
+        internal static Exception ChangePasswordRequires2005()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ChangePasswordRequiresYukon));
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Data.SqlClient
 
         //    Message types
         public const byte MT_SQL = 1;    // SQL command batch
-        public const byte MT_LOGIN = 2;    // Login message for pre-Sphinx (before version 7.0)
+        public const byte MT_LOGIN = 2;    // Login message for pre-7.0
         public const byte MT_RPC = 3;    // Remote procedure call
         public const byte MT_TOKENS = 4;    // Table response data stream
         public const byte MT_BINARY = 5;    // Unformatted binary response data (UNUSED)
@@ -97,7 +97,7 @@ namespace Microsoft.Data.SqlClient
         public const byte MT_LOGOUT = 13;   // Logout message (UNUSED)
         public const byte MT_TRANS = 14;   // Transaction Manager Interface
         public const byte MT_OLEDB = 15;   // ? (UNUSED)
-        public const byte MT_LOGIN7 = 16;   // Login message for Sphinx (version 7) or later
+        public const byte MT_LOGIN7 = 16;   // Login message for 7.0 or later
         public const byte MT_SSPI = 17;   // SSPI message
         public const byte MT_PRELOGIN = 18;   // Pre-login handshake
 
@@ -305,13 +305,13 @@ namespace Microsoft.Data.SqlClient
         /* Versioning scheme table:
 
             Client sends:
-            0x70000000 -> Sphinx
+            0x70000000 -> 7.0
             0x71000000 -> 2000 RTM
             0x71000001 -> 2000 SP1
             0x72xx0002 -> 2005 RTM
 
             Server responds:
-            0x07000000 -> Sphinx     // Notice server response format is different for bwd compat
+            0x07000000 -> 7.0     // Notice server response format is different for bwd compat
             0x07010000 -> 2000 RTM // Notice server response format is different for bwd compat
             0x71000001 -> 2000 SP1
             0x72xx0002 -> 2005 RTM
@@ -433,7 +433,7 @@ namespace Microsoft.Data.SqlClient
 
         public const int MAX_NUMERIC_LEN = 0x11; // 17 bytes of data for max numeric/decimal length
         public const int DEFAULT_NUMERIC_PRECISION = 0x1D; // 29 is the default max numeric precision(Decimal.MaxValue) if not user set
-        public const int SPHINX_DEFAULT_NUMERIC_PRECISION = 0x1C; // 28 is the default max numeric precision for Sphinx(Decimal.MaxValue doesn't work for sphinx)
+        public const int SQL70_DEFAULT_NUMERIC_PRECISION = 0x1C; // 28 is the default max numeric precision for 7.0 (Decimal.MaxValue doesn't work for 7.0)
         public const int MAX_NUMERIC_PRECISION = 0x26; // 38 is max numeric precision;
         public const byte UNKNOWN_PRECISION_SCALE = 0xff; // -1 is value for unknown precision or scale
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -306,19 +306,19 @@ namespace Microsoft.Data.SqlClient
 
             Client sends:
             0x70000000 -> Sphinx
-            0x71000000 -> Shiloh RTM
-            0x71000001 -> Shiloh SP1
+            0x71000000 -> 2000 RTM
+            0x71000001 -> 2000 SP1
             0x72xx0002 -> 2005 RTM
 
             Server responds:
             0x07000000 -> Sphinx     // Notice server response format is different for bwd compat
-            0x07010000 -> Shiloh RTM // Notice server response format is different for bwd compat
-            0x71000001 -> Shiloh SP1
+            0x07010000 -> 2000 RTM // Notice server response format is different for bwd compat
+            0x71000001 -> 2000 SP1
             0x72xx0002 -> 2005 RTM
         */
 
 
-        // Shiloh SP1 and beyond versioning scheme:
+        // 2000 SP1 and beyond versioning scheme:
 
         // Majors:
         public const int SQL2005_MAJOR = 0x72;     // the high-byte is sufficient to distinguish later versions
@@ -437,7 +437,7 @@ namespace Microsoft.Data.SqlClient
         public const int MAX_NUMERIC_PRECISION = 0x26; // 38 is max numeric precision;
         public const byte UNKNOWN_PRECISION_SCALE = 0xff; // -1 is value for unknown precision or scale
 
-        // The following datatypes are specific to SHILOH (version 8) and later.
+        // The following datatypes are specific to 2000 (version 8) and later.
         public const int SQLINT8 = 0x7f;
         public const int SQLVARIANT = 0x62;
 
@@ -523,7 +523,7 @@ namespace Microsoft.Data.SqlClient
         public const string TRANS_SNAPSHOT = "SET TRANSACTION ISOLATION LEVEL SNAPSHOT";
 
         // Batch RPC flags
-        public const byte SHILOH_RPCBATCHFLAG = 0x80;
+        public const byte SQL2000_RPCBATCHFLAG = 0x80;
         public const byte SQL2005_RPCBATCHFLAG = 0xFF;
 
         // RPC flags

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Data.SqlClient
         public const int HEADER_LEN = 8;
         public const int HEADER_LEN_FIELD_OFFSET = 2;
         public const int SPID_OFFSET = 4;
-        public const int YUKON_HEADER_LEN = 12; //Yukon headers also include a MARS session id
+        public const int SQL2005_HEADER_LEN = 12; //2005 headers also include a MARS session id
         public const int MARS_ID_OFFSET = 8;
         public const int HEADERTYPE_QNOTIFICATION = 1;
         public const int HEADERTYPE_MARS = 2;
@@ -155,7 +155,7 @@ namespace Microsoft.Data.SqlClient
         public const byte ENV_LOCALEID = 5;  // Unicode data sorting locale id
         public const byte ENV_COMPFLAGS = 6;  // Unicode data sorting comparison flags
         public const byte ENV_COLLATION = 7;  // SQL Collation
-        // The following are environment change tokens valid for Yukon or later.
+        // The following are environment change tokens valid for 2005 or later.
         public const byte ENV_BEGINTRAN = 8;  // Transaction began
         public const byte ENV_COMMITTRAN = 9;  // Transaction committed
         public const byte ENV_ROLLBACKTRAN = 10; // Transaction rolled back
@@ -277,7 +277,7 @@ namespace Microsoft.Data.SqlClient
         public const byte SQLVARIANT_SIZE = 2;               // size of the fixed portion of a sql variant (type, cbPropBytes)
         public const byte VERSION_SIZE = 4;               // size of the tds version (4 unsigned bytes)
         public const int CLIENT_PROG_VER = 0x06000000;      // Client interface version
-        public const int YUKON_LOG_REC_FIXED_LEN = 0x5e;
+        public const int SQL2005_LOG_REC_FIXED_LEN = 0x5e;
         // misc
         public const int TEXT_TIME_STAMP_LEN = 8;
         public const int COLLATION_INFO_LEN = 4;
@@ -308,30 +308,30 @@ namespace Microsoft.Data.SqlClient
             0x70000000 -> Sphinx
             0x71000000 -> Shiloh RTM
             0x71000001 -> Shiloh SP1
-            0x72xx0002 -> Yukon RTM
+            0x72xx0002 -> 2005 RTM
 
             Server responds:
             0x07000000 -> Sphinx     // Notice server response format is different for bwd compat
             0x07010000 -> Shiloh RTM // Notice server response format is different for bwd compat
             0x71000001 -> Shiloh SP1
-            0x72xx0002 -> Yukon RTM
+            0x72xx0002 -> 2005 RTM
         */
 
 
         // Shiloh SP1 and beyond versioning scheme:
 
         // Majors:
-        public const int YUKON_MAJOR = 0x72;     // the high-byte is sufficient to distinguish later versions
+        public const int SQL2005_MAJOR = 0x72;     // the high-byte is sufficient to distinguish later versions
         public const int SQL2008_MAJOR = 0x73;
         public const int DENALI_MAJOR = 0x74;
 
         // Increments:
-        public const int YUKON_INCREMENT = 0x09;
+        public const int SQL2005_INCREMENT = 0x09;
         public const int SQL2008_INCREMENT = 0x0b;
         public const int DENALI_INCREMENT = 0x00;
 
         // Minors:
-        public const int YUKON_RTM_MINOR = 0x0002;
+        public const int SQL2005_RTM_MINOR = 0x0002;
         public const int SQL2008_MINOR = 0x0003;
         public const int DENALI_MINOR = 0x0004;
 
@@ -441,7 +441,7 @@ namespace Microsoft.Data.SqlClient
         public const int SQLINT8 = 0x7f;
         public const int SQLVARIANT = 0x62;
 
-        // The following datatypes are specific to Yukon (version 9) or later
+        // The following datatypes are specific to 2005 (version 9) or later
         public const int SQLXMLTYPE = 0xf1;
         public const int XMLUNICODEBOM = 0xfeff;
         public static readonly byte[] XMLUNICODEBOMBYTES = { 0xff, 0xfe };
@@ -456,7 +456,7 @@ namespace Microsoft.Data.SqlClient
         public const int DEFAULT_VARTIME_SCALE = 7;
 
         //Partially length prefixed datatypes constants. These apply to XMLTYPE, BIGVARCHRTYPE,
-        // NVARCHARTYPE, and BIGVARBINTYPE. Valid for Yukon or later
+        // NVARCHARTYPE, and BIGVARBINTYPE. Valid for 2005 or later
 
         public const ulong SQL_PLP_NULL = 0xffffffffffffffff;        // Represents null value
         public const ulong SQL_PLP_UNKNOWNLEN = 0xfffffffffffffffe;  // Data coming in chunks, total length unknown
@@ -524,7 +524,7 @@ namespace Microsoft.Data.SqlClient
 
         // Batch RPC flags
         public const byte SHILOH_RPCBATCHFLAG = 0x80;
-        public const byte YUKON_RPCBATCHFLAG = 0xFF;
+        public const byte SQL2005_RPCBATCHFLAG = 0xFF;
 
         // RPC flags
         public const byte RPC_RECOMPILE = 0x1;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -323,17 +323,17 @@ namespace Microsoft.Data.SqlClient
         // Majors:
         public const int SQL2005_MAJOR = 0x72;     // the high-byte is sufficient to distinguish later versions
         public const int SQL2008_MAJOR = 0x73;
-        public const int DENALI_MAJOR = 0x74;
+        public const int SQl2012_MAJOR = 0x74;
 
         // Increments:
         public const int SQL2005_INCREMENT = 0x09;
         public const int SQL2008_INCREMENT = 0x0b;
-        public const int DENALI_INCREMENT = 0x00;
+        public const int SQL2012_INCREMENT = 0x00;
 
         // Minors:
         public const int SQL2005_RTM_MINOR = 0x0002;
         public const int SQL2008_MINOR = 0x0003;
-        public const int DENALI_MINOR = 0x0004;
+        public const int SQL2012_MINOR = 0x0004;
 
         public const int ORDER_68000 = 1;
         public const int USE_DB_ON = 1;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -322,17 +322,17 @@ namespace Microsoft.Data.SqlClient
 
         // Majors:
         public const int YUKON_MAJOR = 0x72;     // the high-byte is sufficient to distinguish later versions
-        public const int KATMAI_MAJOR = 0x73;
+        public const int SQL2008_MAJOR = 0x73;
         public const int DENALI_MAJOR = 0x74;
 
         // Increments:
         public const int YUKON_INCREMENT = 0x09;
-        public const int KATMAI_INCREMENT = 0x0b;
+        public const int SQL2008_INCREMENT = 0x0b;
         public const int DENALI_INCREMENT = 0x00;
 
         // Minors:
         public const int YUKON_RTM_MINOR = 0x0002;
-        public const int KATMAI_MINOR = 0x0003;
+        public const int SQL2008_MINOR = 0x0003;
         public const int DENALI_MINOR = 0x0004;
 
         public const int ORDER_68000 = 1;
@@ -446,7 +446,7 @@ namespace Microsoft.Data.SqlClient
         public const int XMLUNICODEBOM = 0xfeff;
         public static readonly byte[] XMLUNICODEBOMBYTES = { 0xff, 0xfe };
 
-        // The following datatypes are specific to Katmai (version 10) or later
+        // The following datatypes are specific to 2008 (version 10) or later
         public const int SQLTABLE = 0xf3;
         public const int SQLDATE = 0x28;
         public const int SQLTIME = 0x29;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Data.SqlClient
 
         private bool _is2008 = false;
 
-        private bool _isDenali = false;
+        private bool _is2012 = false;
 
         private byte[][] _sniSpnBuffer = null;
 
@@ -323,7 +323,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                return (_isDenali && SqlClientEventSource.Log.IsEnabled());
+                return (_is2012 && SqlClientEventSource.Log.IsEnabled());
             }
         }
 
@@ -3611,18 +3611,18 @@ namespace Microsoft.Data.SqlClient
                     }
                     _is2008 = true;
                     break;
-                case TdsEnums.DENALI_MAJOR << 24 | TdsEnums.DENALI_MINOR:
-                    if (increment != TdsEnums.DENALI_INCREMENT)
+                case TdsEnums.SQl2012_MAJOR << 24 | TdsEnums.SQL2012_MINOR:
+                    if (increment != TdsEnums.SQL2012_INCREMENT)
                     {
                         throw SQL.InvalidTDSVersion();
                     }
-                    _isDenali = true;
+                    _is2012 = true;
                     break;
                 default:
                     throw SQL.InvalidTDSVersion();
             }
 
-            _is2008 |= _isDenali;
+            _is2008 |= _is2012;
             _is2005 |= _is2008;
 
             stateObj._outBytesUsed = stateObj._outputHeaderLen;
@@ -8091,7 +8091,7 @@ namespace Microsoft.Data.SqlClient
                 WriteInt(length, _physicalStateObj);
                 if (recoverySessionData == null)
                 {
-                    WriteInt((TdsEnums.DENALI_MAJOR << 24) | (TdsEnums.DENALI_INCREMENT << 16) | TdsEnums.DENALI_MINOR, _physicalStateObj);
+                    WriteInt((TdsEnums.SQl2012_MAJOR << 24) | (TdsEnums.SQL2012_INCREMENT << 16) | TdsEnums.SQL2012_MINOR, _physicalStateObj);
                 }
                 else
                 {
@@ -10859,7 +10859,7 @@ namespace Microsoft.Data.SqlClient
 
         private void WriteTraceHeaderData(TdsParserStateObject stateObj)
         {
-            Debug.Assert(this.IncludeTraceHeader, "WriteTraceHeaderData can only be called on a Denali or higher version server and bid trace with the control bit are on");
+            Debug.Assert(this.IncludeTraceHeader, "WriteTraceHeaderData can only be called on a 2012 or higher version server and bid trace with the control bit are on");
 
             // We may need to update the trace header length if trace header is changed in the future
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -530,7 +530,7 @@ namespace Microsoft.Data.SqlClient
                 SendPreLoginHandshake(instanceName, encrypt);
                 status = ConsumePreLoginHandshake(encrypt, trustServerCert, integratedSecurity, out marsCapable, out _connHandler._fedAuthRequired);
 
-                // Don't need to check for Sphinx failure, since we've already consumed
+                // Don't need to check for 7.0 failure, since we've already consumed
                 // one pre-login packet and know we are connecting to 2000.
                 if (status == PreLoginHandshakeStatus.InstanceFailure)
                 {
@@ -3590,7 +3590,7 @@ namespace Microsoft.Data.SqlClient
             uint increment = (a.tdsVersion >> 16) & 0xff;
 
             // Server responds:
-            // 0x07000000 -> Sphinx         // Notice server response format is different for bwd compat
+            // 0x07000000 -> 7.0         // Notice server response format is different for bwd compat
             // 0x07010000 -> 2000 RTM     // Notice server response format is different for bwd compat
             // 0x71000001 -> 2000 SP1
             // 0x72xx0002 -> 2005 RTM
@@ -3979,7 +3979,7 @@ namespace Microsoft.Data.SqlClient
             rec.type = rec.metaType.SqlDbType;
 
             // always use the nullable type for parameters if 2000 or later
-            // Sphinx sometimes sends fixed length return values
+            // 7.0 sometimes sends fixed length return values
             rec.tdsType = rec.metaType.NullableType;
             rec.IsNullable = true;
             if (tdsLen == TdsEnums.SQL_USHORTVARMAXLEN)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Data.SqlClient
         private EncryptionOptions _encryptionOption = s_sniSupportedEncryptionOption;
 
         private SqlInternalTransaction _currentTransaction;
-        private SqlInternalTransaction _pendingTransaction;    // pending transaction for Yukon and beyond.
+        private SqlInternalTransaction _pendingTransaction;    // pending transaction for 2005 and beyond.
 
         //  need to hold on to the transaction id if distributed transaction merely rolls back without defecting.
         private long _retainedTransactionId = SqlInternalTransaction.NullTransactionId;
@@ -112,7 +112,7 @@ namespace Microsoft.Data.SqlClient
 
         // Version variables
 
-        private bool _isYukon = false; // set to true if speaking to Yukon or later
+        private bool _is2005 = false; // set to true if speaking to 2005 or later
 
         private bool _is2008 = false;
 
@@ -189,7 +189,7 @@ namespace Microsoft.Data.SqlClient
 
         internal TdsParser(bool MARS, bool fAsynchronous)
         {
-            _fMARS = MARS; // may change during Connect to pre Yukon servers
+            _fMARS = MARS; // may change during Connect to pre 2005 servers
 
             _physicalStateObj = TdsParserStateObjectFactory.Singleton.CreateTdsParserStateObject(this);
             DataClassificationVersion = TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED;
@@ -805,7 +805,7 @@ namespace Microsoft.Data.SqlClient
         {
             marsCapable = _fMARS; // Assign default value
             fedAuthRequired = false;
-            bool isYukonOrLater = false;
+            bool is2005OrLater = false;
             Debug.Assert(_physicalStateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
             bool result = _physicalStateObj.TryReadNetworkPacket();
             if (!result)
@@ -864,10 +864,10 @@ namespace Microsoft.Data.SqlClient
                         int level = (payload[payloadOffset + 2] << 8) |
                                              payload[payloadOffset + 3];
 
-                        isYukonOrLater = majorVersion >= 9;
-                        if (!isYukonOrLater)
+                        is2005OrLater = majorVersion >= 9;
+                        if (!is2005OrLater)
                         {
-                            marsCapable = false;            // If pre-Yukon, MARS not supported.
+                            marsCapable = false;            // If pre-2005, MARS not supported.
                         }
 
                         break;
@@ -935,7 +935,7 @@ namespace Microsoft.Data.SqlClient
                             // Validate Certificate if Trust Server Certificate=false and Encryption forced (EncryptionOptions.ON) from Server.
                             bool shouldValidateServerCert = (_encryptionOption == EncryptionOptions.ON && !trustServerCert) || (_connHandler._accessTokenInBytes != null && !trustServerCert);
                             uint info = (shouldValidateServerCert ? TdsEnums.SNI_SSL_VALIDATE_CERTIFICATE : 0)
-                                | (isYukonOrLater ? TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE : 0);
+                                | (is2005OrLater ? TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE : 0);
 
                             if (encrypt && !integratedSecurity)
                             {
@@ -1527,7 +1527,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         Debug.Assert(!stateObj._fResetConnectionSent, "Unexpected state on WritePacket ResetConnection");
 
-                        // Otherwise if Yukon and we grabbed the event, free it.  Another execute grabbed the event and
+                        // Otherwise if 2005 and we grabbed the event, free it.  Another execute grabbed the event and
                         // took care of sending the reset.
                         stateObj._fResetEventOwned = !_resetConnectionEvent.Set();
                         Debug.Assert(!stateObj._fResetEventOwned, "Invalid AutoResetEvent state!");
@@ -1537,7 +1537,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (_fMARS && stateObj._fResetEventOwned)
                     {
-                        // If exception thrown, and we are on Yukon and own the event, release it!
+                        // If exception thrown, and we are on 2005 and own the event, release it!
                         stateObj._fResetConnectionSent = false;
                         stateObj._fResetEventOwned = !_resetConnectionEvent.Set();
                         Debug.Assert(!stateObj._fResetEventOwned, "Invalid AutoResetEvent state!");
@@ -3593,17 +3593,16 @@ namespace Microsoft.Data.SqlClient
             // 0x07000000 -> Sphinx         // Notice server response format is different for bwd compat
             // 0x07010000 -> Shiloh RTM     // Notice server response format is different for bwd compat
             // 0x71000001 -> Shiloh SP1
-            // 0x72xx0002 -> Yukon RTM
-            // information provided by S. Ashwin
+            // 0x72xx0002 -> 2005 RTM
 
             switch (majorMinor)
             {
-                case TdsEnums.YUKON_MAJOR << 24 | TdsEnums.YUKON_RTM_MINOR:     // Yukon
-                    if (increment != TdsEnums.YUKON_INCREMENT)
+                case TdsEnums.SQL2005_MAJOR << 24 | TdsEnums.SQL2005_RTM_MINOR:     // 2005
+                    if (increment != TdsEnums.SQL2005_INCREMENT)
                     {
                         throw SQL.InvalidTDSVersion();
                     }
-                    _isYukon = true;
+                    _is2005 = true;
                     break;
                 case TdsEnums.SQL2008_MAJOR << 24 | TdsEnums.SQL2008_MINOR:
                     if (increment != TdsEnums.SQL2008_INCREMENT)
@@ -3624,7 +3623,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             _is2008 |= _isDenali;
-            _isYukon |= _is2008;
+            _is2005 |= _is2008;
 
             stateObj._outBytesUsed = stateObj._outputHeaderLen;
             byte len;
@@ -3892,7 +3891,7 @@ namespace Microsoft.Data.SqlClient
         {
             returnValue = null;
             SqlReturnValue rec = new SqlReturnValue();
-            rec.length = length;        // In Yukon this length is -1
+            rec.length = length;        // In 2005 this length is -1
             ushort parameterIndex;
             if (!stateObj.TryReadUInt16(out parameterIndex))
             {
@@ -3922,7 +3921,7 @@ namespace Microsoft.Data.SqlClient
 
             uint userType;
 
-            // read user type - 4 bytes Yukon, 2 backwards
+            // read user type - 4 bytes 2005, 2 backwards
             if (!stateObj.TryReadUInt32(out userType))
             {
                 return false;
@@ -4892,7 +4891,7 @@ namespace Microsoft.Data.SqlClient
             byte byteLen;
             uint userType;
 
-            // read user type - 4 bytes Yukon, 2 backwards
+            // read user type - 4 bytes 2005, 2 backwards
             if (!stateObj.TryReadUInt32(out userType))
             {
                 return false;
@@ -7472,7 +7471,7 @@ namespace Microsoft.Data.SqlClient
         //
         internal bool TryGetDataLength(SqlMetaDataPriv colmeta, TdsParserStateObject stateObj, out ulong length)
         {
-            // Handle Yukon specific tokens
+            // Handle 2005 specific tokens
             if (colmeta.metaType.IsPlp)
             {
                 Debug.Assert(colmeta.tdsType == TdsEnums.SQLXMLTYPE ||
@@ -7526,7 +7525,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else if (token == TdsEnums.SQLRETURNVALUE)
                 {
-                    tokenLength = -1; // In Yukon, the RETURNVALUE token stream no longer has length
+                    tokenLength = -1; // In 2005, the RETURNVALUE token stream no longer has length
                     return true;
                 }
                 else if (token == TdsEnums.SQLXMLTYPE)
@@ -7986,7 +7985,7 @@ namespace Microsoft.Data.SqlClient
             _physicalStateObj._outputMessageType = TdsEnums.MT_LOGIN7;
 
             // length in bytes
-            int length = TdsEnums.YUKON_LOG_REC_FIXED_LEN;
+            int length = TdsEnums.SQL2005_LOG_REC_FIXED_LEN;
 
             string clientInterfaceName = TdsEnums.SQL_PROVIDER_NAME;
             Debug.Assert(TdsEnums.MAXLEN_CLIENTINTERFACE >= clientInterfaceName.Length, "cchCltIntName can specify at most 128 unicode characters. See Tds spec");
@@ -8176,7 +8175,7 @@ namespace Microsoft.Data.SqlClient
                 WriteInt(0, _physicalStateObj);  // LCID is unused by server
 
                 // Start writing offset and length of variable length portions
-                int offset = TdsEnums.YUKON_LOG_REC_FIXED_LEN;
+                int offset = TdsEnums.SQL2005_LOG_REC_FIXED_LEN;
 
                 // write offset/length pairs
 
@@ -9065,7 +9064,7 @@ namespace Microsoft.Data.SqlClient
                                 continue;
                             }
 
-                            if ((!_isYukon && !mt.Is80Supported) ||
+                            if ((!_is2005 && !mt.Is80Supported) ||
                                 (!_is2008 && !mt.Is90Supported))
                             {
                                 throw ADP.VersionDoesNotSupportDataType(mt.TypeName);
@@ -9129,7 +9128,7 @@ namespace Microsoft.Data.SqlClient
                         // If this is not the last RPC we are sending, add the batch flag
                         if (ii < (rpcArray.Length - 1))
                         {
-                            stateObj.WriteByte(TdsEnums.YUKON_RPCBATCHFLAG);
+                            stateObj.WriteByte(TdsEnums.SQL2005_RPCBATCHFLAG);
                         }
                     } // rpc for loop
 
@@ -9405,7 +9404,7 @@ namespace Microsoft.Data.SqlClient
                     maxsize = (size > codePageByteSize) ? size : codePageByteSize;
                     if (maxsize == 0)
                     {
-                        // Yukon doesn't like 0 as MaxSize. Change it to 2 for unicode types
+                        // 2005 doesn't like 0 as MaxSize. Change it to 2 for unicode types
                         if (mt.IsNCharType)
                             maxsize = 2;
                         else
@@ -9430,7 +9429,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else if (mt.SqlDbType == SqlDbType.Udt)
                 {
-                    Debug.Assert(_isYukon, "Invalid DataType UDT for non-Yukon or later server!");
+                    Debug.Assert(_is2005, "Invalid DataType UDT for non-2005 or later server!");
 
                     int maxSupportedSize = Is2008OrNewer ? int.MaxValue : short.MaxValue;
                     byte[] udtVal = null;
@@ -9522,9 +9521,9 @@ namespace Microsoft.Data.SqlClient
                 else if ((!mt.IsVarTime) && (mt.SqlDbType != SqlDbType.Date))
                 {   // Time, Date, DateTime2, DateTimeoffset do not have the size written out
                     maxsize = (size > actualSize) ? size : actualSize;
-                    if (maxsize == 0 && _isYukon)
+                    if (maxsize == 0 && _is2005)
                     {
-                        // Yukon doesn't like 0 as MaxSize. Change it to 2 for unicode types (SQL9 - 682322)
+                        // 2005 doesn't like 0 as MaxSize. Change it to 2 for unicode types (SQL9 - 682322)
                         if (mt.IsNCharType)
                             maxsize = 2;
                         else
@@ -9556,7 +9555,7 @@ namespace Microsoft.Data.SqlClient
 
             // write out collation or xml metadata
 
-            if (_isYukon && (mt.SqlDbType == SqlDbType.Xml))
+            if (_is2005 && (mt.SqlDbType == SqlDbType.Xml))
             {
                 if (!string.IsNullOrEmpty(param.XmlSchemaCollectionDatabase) ||
                     !string.IsNullOrEmpty(param.XmlSchemaCollectionOwningSchema) ||
@@ -10350,7 +10349,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     _SqlMetaData md = metadataCollection[i];
 
-                    // read user type - 4 bytes Yukon, 2 backwards
+                    // read user type - 4 bytes 2005, 2 backwards
                     WriteInt(0x0, stateObj);
 
                     // Write the flags
@@ -10753,7 +10752,7 @@ namespace Microsoft.Data.SqlClient
         // Write mars header data, not including the mars header length
         private void WriteMarsHeaderData(TdsParserStateObject stateObj, SqlInternalTransaction transaction)
         {
-            // Function to send over additional payload header data for Yukon and beyond only.
+            // Function to send over additional payload header data for 2005 and beyond only.
 
             // These are not necessary - can have local started in distributed.
             // Debug.Assert(!(null != sqlTransaction && null != distributedTransaction), "Error to have local (api started) and distributed transaction at the same time!");
@@ -10829,7 +10828,7 @@ namespace Microsoft.Data.SqlClient
         // Write query notificaiton header data, not including the notificaiton header length
         private void WriteQueryNotificationHeaderData(SqlNotificationRequest notificationRequest, TdsParserStateObject stateObj)
         {
-            Debug.Assert(_isYukon, "WriteQueryNotificationHeaderData called on a non-Yukon server");
+            Debug.Assert(_is2005, "WriteQueryNotificationHeaderData called on a non-2005 server");
 
             // We may need to update the notification header length if the header is changed in the future
 
@@ -12802,7 +12801,7 @@ namespace Microsoft.Data.SqlClient
                                        + "         _connHandler = {14}\n\t"
                                        + "         _fMARS = {15}\n\t"
                                        + "         _sessionPool = {16}\n\t"
-                                       + "         _isYukon = {17}\n\t"
+                                       + "         _is2005 = {17}\n\t"
                                        + "         _sniSpnBuffer = {18}\n\t"
                                        + "         _errors = {19}\n\t"
                                        + "         _warnings = {20}\n\t"
@@ -12834,7 +12833,7 @@ namespace Microsoft.Data.SqlClient
                            null == _connHandler ? "(null)" : _connHandler.ObjectID.ToString((IFormatProvider)null),
                            _fMARS ? bool.TrueString : bool.FalseString,
                            null == _sessionPool ? "(null)" : _sessionPool.TraceString(),
-                           _isYukon ? bool.TrueString : bool.FalseString,
+                           _is2005 ? bool.TrueString : bool.FalseString,
                            null == _sniSpnBuffer ? "(null)" : _sniSpnBuffer.Length.ToString((IFormatProvider)null),
                            _physicalStateObj != null ? "(null)" : _physicalStateObj.ErrorCount.ToString((IFormatProvider)null),
                            _physicalStateObj != null ? "(null)" : _physicalStateObj.WarningCount.ToString((IFormatProvider)null),

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -531,7 +531,7 @@ namespace Microsoft.Data.SqlClient
                 status = ConsumePreLoginHandshake(encrypt, trustServerCert, integratedSecurity, out marsCapable, out _connHandler._fedAuthRequired);
 
                 // Don't need to check for Sphinx failure, since we've already consumed
-                // one pre-login packet and know we are connecting to Shiloh.
+                // one pre-login packet and know we are connecting to 2000.
                 if (status == PreLoginHandshakeStatus.InstanceFailure)
                 {
                     SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.Connect|ERR|SEC> Prelogin handshake unsuccessful. Login failure");
@@ -1810,7 +1810,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void PrepareResetConnection(bool preserveTransaction)
         {
-            // Set flag to reset connection upon next use - only for use on shiloh!
+            // Set flag to reset connection upon next use - only for use on 2000!
             _fResetConnection = true;
             _fPreserveTransaction = preserveTransaction;
         }
@@ -3591,8 +3591,8 @@ namespace Microsoft.Data.SqlClient
 
             // Server responds:
             // 0x07000000 -> Sphinx         // Notice server response format is different for bwd compat
-            // 0x07010000 -> Shiloh RTM     // Notice server response format is different for bwd compat
-            // 0x71000001 -> Shiloh SP1
+            // 0x07010000 -> 2000 RTM     // Notice server response format is different for bwd compat
+            // 0x71000001 -> 2000 SP1
             // 0x72xx0002 -> 2005 RTM
 
             switch (majorMinor)
@@ -3978,7 +3978,7 @@ namespace Microsoft.Data.SqlClient
             rec.metaType = MetaType.GetSqlDataType(tdsType, userType, tdsLen);
             rec.type = rec.metaType.SqlDbType;
 
-            // always use the nullable type for parameters if Shiloh or later
+            // always use the nullable type for parameters if 2000 or later
             // Sphinx sometimes sends fixed length return values
             rec.tdsType = rec.metaType.NullableType;
             rec.IsNullable = true;
@@ -8993,7 +8993,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             if (rpcext.ProcID != 0)
                             {
-                                // Perf optimization for Shiloh and later,
+                                // Perf optimization for 2000 and later,
                                 Debug.Assert(rpcext.ProcID < 255, "rpcExec:ProcID can't be larger than 255");
                                 WriteShort(0xffff, stateObj);
                                 WriteShort((short)(rpcext.ProcID), stateObj);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Data.SqlClient
             flags = value ? flags | flag : flags & ~flag;
         }
 
-        internal bool IsNewKatmaiDateTimeType
+        internal bool Is2008DateTimeType
         {
             get
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Data.SqlClient
         internal ulong _longlen;                                     // plp data length indicator
         internal ulong _longlenleft;                                 // Length of data left to read (64 bit lengths)
         internal int[] _decimalBits;                // scratch buffer for decimal/numeric data
-        internal byte[] _bTmp = new byte[TdsEnums.YUKON_HEADER_LEN];  // Scratch buffer for misc use
+        internal byte[] _bTmp = new byte[TdsEnums.SQL2005_HEADER_LEN];  // Scratch buffer for misc use
         internal int _bTmpRead;                   // Counter for number of temporary bytes read
         internal Decoder _plpdecoder;             // Decoder object to process plp character data
         internal bool _accumulateInfoEvents;               // TRUE - accumulate info messages during TdsParser.Run, FALSE - fire them
@@ -494,7 +494,7 @@ namespace Microsoft.Data.SqlClient
             // initialize or unset null bitmap information for the current row
             if (isNullCompressed)
             {
-                // assert that NBCROW is not in use by Yukon or before
+                // assert that NBCROW is not in use by 2005 or before
                 Debug.Assert(_parser.Is2008OrNewer, "NBCROW is sent by pre-2008 server");
 
                 if (!_nullBitmapInfo.TryInitialize(this, nullBitmapColumnsCount))
@@ -3336,9 +3336,9 @@ namespace Microsoft.Data.SqlClient
             }
 
             if (
-                // This appears to be an optimization to avoid writing empty packets in Yukon
-                // However, since we don't know the version prior to login IsYukonOrNewer was always false prior to login
-                // So removing the IsYukonOrNewer check causes issues since the login packet happens to meet the rest of the conditions below
+                // This appears to be an optimization to avoid writing empty packets in 2005
+                // However, since we don't know the version prior to login Is2005OrNewer was always false prior to login
+                // So removing the Is2005OrNewer check causes issues since the login packet happens to meet the rest of the conditions below
                 // So we need to avoid this check prior to login completing
                 state == TdsParserState.OpenLoggedIn &&
                 !_bulkCopyOpperationInProgress && // ignore the condition checking for bulk copy

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -495,7 +495,7 @@ namespace Microsoft.Data.SqlClient
             if (isNullCompressed)
             {
                 // assert that NBCROW is not in use by Yukon or before
-                Debug.Assert(_parser.IsKatmaiOrNewer, "NBCROW is sent by pre-Katmai server");
+                Debug.Assert(_parser.Is2008OrNewer, "NBCROW is sent by pre-2008 server");
 
                 if (!_nullBitmapInfo.TryInitialize(this, nullBitmapColumnsCount))
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -338,6 +338,7 @@
     </Compile>
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\SqlCommandBuilder.cs">
       <Link>Microsoft\Data\SqlClient\SqlCommandBuilder.cs</Link>
+      <SubType>Component</SubType>
     </Compile>
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\SqlCommandSet.cs">
       <Link>Microsoft\Data\SqlClient\SqlCommandSet.cs</Link>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -338,7 +338,6 @@
     </Compile>
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\SqlCommandBuilder.cs">
       <Link>Microsoft\Data\SqlClient\SqlCommandBuilder.cs</Link>
-      <SubType>Component</SubType>
     </Compile>
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\SqlCommandSet.cs">
       <Link>Microsoft\Data\SqlClient\SqlCommandSet.cs</Link>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
@@ -503,8 +503,8 @@ namespace Microsoft.Data.SqlClient.Server
             }
             else
             {
-                // Yukon doesn't support Structured nor the new time types
-                Debug.Assert(SmiContextFactory.YukonVersion == smiVersion, "Other versions should have been eliminated during link stage");
+                // 2005 doesn't support Structured nor the new time types
+                Debug.Assert(SmiContextFactory.Sql2005Version == smiVersion, "Other versions should have been eliminated during link stage");
                 return md.SqlDbType != SqlDbType.Structured &&
                         md.SqlDbType != SqlDbType.Date &&
                         md.SqlDbType != SqlDbType.DateTime2 &&

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Data.SqlClient.Server
                         break;
                     case SqlDbType.Date:
                     case SqlDbType.DateTime2:
-                        if (smiVersion >= SmiContextFactory.KatmaiVersion)
+                        if (smiVersion >= SmiContextFactory.Sql2008Version)
                         {
                             goto case SqlDbType.DateTime;
                         }
@@ -364,11 +364,11 @@ namespace Microsoft.Data.SqlClient.Server
                         }
                         break;
                     case SqlDbType.Time:
-                        if (value.GetType() == typeof(TimeSpan) && smiVersion >= SmiContextFactory.KatmaiVersion)
+                        if (value.GetType() == typeof(TimeSpan) && smiVersion >= SmiContextFactory.Sql2008Version)
                             extendedCode = ExtendedClrTypeCode.TimeSpan;
                         break;
                     case SqlDbType.DateTimeOffset:
-                        if (value.GetType() == typeof(DateTimeOffset) && smiVersion >= SmiContextFactory.KatmaiVersion)
+                        if (value.GetType() == typeof(DateTimeOffset) && smiVersion >= SmiContextFactory.Sql2008Version)
                             extendedCode = ExtendedClrTypeCode.DateTimeOffset;
                         break;
                     case SqlDbType.Xml:
@@ -462,8 +462,8 @@ namespace Microsoft.Data.SqlClient.Server
             return __extendedTypeCodeToSqlDbTypeMap[(int)typeCode + 1];
         }
 
-        // Infer SqlDbType from Type in the general case.  Katmai-only (or later) features that need to 
-        //  infer types should use InferSqlDbTypeFromType_Katmai.
+        // Infer SqlDbType from Type in the general case.  2008-only (or later) features that need to 
+        //  infer types should use InferSqlDbTypeFromType_2008.
         static internal SqlDbType InferSqlDbTypeFromType(Type type)
         {
             ExtendedClrTypeCode typeCode = DetermineExtendedTypeCodeFromType(type);
@@ -480,12 +480,12 @@ namespace Microsoft.Data.SqlClient.Server
             return returnType;
         }
 
-        // Inference rules changed for Katmai-or-later-only cases.  Only features that are guaranteed to be 
-        //  running against Katmai and don't have backward compat issues should call this code path.
-        //      example: TVP's are a new Katmai feature (no back compat issues) so can infer DATETIME2
+        // Inference rules changed for 2008-or-later-only cases.  Only features that are guaranteed to be 
+        //  running against 2008 and don't have backward compat issues should call this code path.
+        //      example: TVP's are a new 2008 feature (no back compat issues) so can infer DATETIME2
         //          when mapping System.DateTime from DateTable or DbDataReader.  DATETIME2 is better because
         //          of greater range that can handle all DateTime values.
-        static internal SqlDbType InferSqlDbTypeFromType_Katmai(Type type)
+        static internal SqlDbType InferSqlDbTypeFromType_2008(Type type)
         {
             SqlDbType returnType = InferSqlDbTypeFromType(type);
             if (SqlDbType.DateTime == returnType)
@@ -697,7 +697,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Extract metadata for a single DataColumn
         static internal SmiExtendedMetaData SmiMetaDataFromDataColumn(DataColumn column, DataTable parent)
         {
-            SqlDbType dbType = InferSqlDbTypeFromType_Katmai(column.DataType);
+            SqlDbType dbType = InferSqlDbTypeFromType_2008(column.DataType);
             if (InvalidSqlDbType == dbType)
             {
                 throw SQL.UnsupportedColumnTypeForSqlProvider(column.ColumnName, column.DataType.Name);
@@ -837,7 +837,7 @@ namespace Microsoft.Data.SqlClient.Server
                 throw SQL.NullSchemaTableDataTypeNotSupported(colName);
             }
             Type colType = (Type)temp;
-            SqlDbType colDbType = InferSqlDbTypeFromType_Katmai(colType);
+            SqlDbType colDbType = InferSqlDbTypeFromType_2008(colType);
             if (InvalidSqlDbType == colDbType)
             {
                 // Unknown through standard mapping, use VarBinary for columns that are Object typed, otherwise error

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiContextFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiContextFactory.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Data.SqlClient.Server
         private readonly string _serverVersion;
         private readonly SmiEventSink_Default _eventSinkForGetCurrentContext;
 
-        internal const ulong YukonVersion = 100;
+        internal const ulong Sql2005Version = 100;
         internal const ulong Sql2008Version = 210;
         internal const ulong LatestVersion = Sql2008Version;
 
-        private readonly ulong[] __supportedSmiVersions = new ulong[] { YukonVersion, Sql2008Version };
+        private readonly ulong[] __supportedSmiVersions = new ulong[] { Sql2005Version, Sql2008Version };
 
         // Used as the key for SmiContext.GetContextValue()
         internal enum ContextKey

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiContextFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiContextFactory.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Data.SqlClient.Server
         private readonly SmiEventSink_Default _eventSinkForGetCurrentContext;
 
         internal const ulong YukonVersion = 100;
-        internal const ulong KatmaiVersion = 210;
-        internal const ulong LatestVersion = KatmaiVersion;
+        internal const ulong Sql2008Version = 210;
+        internal const ulong LatestVersion = Sql2008Version;
 
-        private readonly ulong[] __supportedSmiVersions = new ulong[] { YukonVersion, KatmaiVersion };
+        private readonly ulong[] __supportedSmiVersions = new ulong[] { YukonVersion, Sql2008Version };
 
         // Used as the key for SmiContext.GetContextValue()
         internal enum ContextKey

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -499,7 +499,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // use static list of format strings indexed by scale for perf
-        private static readonly string[] s_katmaiDateTimeOffsetFormatByScale = new string[] {
+        private static readonly string[] s_2008DateTimeOffsetFormatByScale = new string[] {
                 "yyyy-MM-dd HH:mm:ss zzz",
                 "yyyy-MM-dd HH:mm:ss.f zzz",
                 "yyyy-MM-dd HH:mm:ss.ff zzz",
@@ -510,7 +510,7 @@ namespace Microsoft.Data.SqlClient
                 "yyyy-MM-dd HH:mm:ss.fffffff zzz",
         };
 
-        private static readonly string[] s_katmaiDateTime2FormatByScale = new string[] {
+        private static readonly string[] s_2008DateTime2FormatByScale = new string[] {
                 "yyyy-MM-dd HH:mm:ss",
                 "yyyy-MM-dd HH:mm:ss.f",
                 "yyyy-MM-dd HH:mm:ss.ff",
@@ -521,7 +521,7 @@ namespace Microsoft.Data.SqlClient
                 "yyyy-MM-dd HH:mm:ss.fffffff",
         };
 
-        private static readonly string[] s_katmaiTimeFormatByScale = new string[] {
+        private static readonly string[] s_2008TimeFormatByScale = new string[] {
                 "HH:mm:ss",
                 "HH:mm:ss.f",
                 "HH:mm:ss.ff",
@@ -532,7 +532,7 @@ namespace Microsoft.Data.SqlClient
                 "HH:mm:ss.fffffff",
         };
 
-        internal string KatmaiDateTimeString
+        internal string Sql2008DateTimeString
         {
             get
             {
@@ -545,24 +545,24 @@ namespace Microsoft.Data.SqlClient
                 if (StorageType.Time == _type)
                 {
                     byte scale = _value._timeInfo._scale;
-                    return new DateTime(_value._timeInfo._ticks).ToString(s_katmaiTimeFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return new DateTime(_value._timeInfo._ticks).ToString(s_2008TimeFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 if (StorageType.DateTime2 == _type)
                 {
                     byte scale = _value._dateTime2Info._timeInfo._scale;
-                    return DateTime.ToString(s_katmaiDateTime2FormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return DateTime.ToString(s_2008DateTime2FormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 if (StorageType.DateTimeOffset == _type)
                 {
                     DateTimeOffset dto = DateTimeOffset;
                     byte scale = _value._dateTimeOffsetInfo._dateTime2Info._timeInfo._scale;
-                    return dto.ToString(s_katmaiDateTimeOffsetFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return dto.ToString(s_2008DateTimeOffsetFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 return (string)Value; // anything else we haven't thought of goes through boxing.
             }
         }
 
-        internal SqlString KatmaiDateTimeSqlString
+        internal SqlString Sql2008DateTimeSqlString
         {
             get
             {
@@ -575,7 +575,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         return SqlString.Null;
                     }
-                    return new SqlString(KatmaiDateTimeString);
+                    return new SqlString(Sql2008DateTimeString);
                 }
                 return (SqlString)SqlValue; // anything else we haven't thought of goes through boxing.
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -499,7 +499,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // use static list of format strings indexed by scale for perf
-        private static readonly string[] s_2008DateTimeOffsetFormatByScale = new string[] {
+        private static readonly string[] s_sql2008DateTimeOffsetFormatByScale = new string[] {
                 "yyyy-MM-dd HH:mm:ss zzz",
                 "yyyy-MM-dd HH:mm:ss.f zzz",
                 "yyyy-MM-dd HH:mm:ss.ff zzz",
@@ -510,7 +510,7 @@ namespace Microsoft.Data.SqlClient
                 "yyyy-MM-dd HH:mm:ss.fffffff zzz",
         };
 
-        private static readonly string[] s_2008DateTime2FormatByScale = new string[] {
+        private static readonly string[] s_sql2008DateTime2FormatByScale = new string[] {
                 "yyyy-MM-dd HH:mm:ss",
                 "yyyy-MM-dd HH:mm:ss.f",
                 "yyyy-MM-dd HH:mm:ss.ff",
@@ -521,7 +521,7 @@ namespace Microsoft.Data.SqlClient
                 "yyyy-MM-dd HH:mm:ss.fffffff",
         };
 
-        private static readonly string[] s_2008TimeFormatByScale = new string[] {
+        private static readonly string[] s_sql2008TimeFormatByScale = new string[] {
                 "HH:mm:ss",
                 "HH:mm:ss.f",
                 "HH:mm:ss.ff",
@@ -545,18 +545,18 @@ namespace Microsoft.Data.SqlClient
                 if (StorageType.Time == _type)
                 {
                     byte scale = _value._timeInfo._scale;
-                    return new DateTime(_value._timeInfo._ticks).ToString(s_2008TimeFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return new DateTime(_value._timeInfo._ticks).ToString(s_sql2008TimeFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 if (StorageType.DateTime2 == _type)
                 {
                     byte scale = _value._dateTime2Info._timeInfo._scale;
-                    return DateTime.ToString(s_2008DateTime2FormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return DateTime.ToString(s_sql2008DateTime2FormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 if (StorageType.DateTimeOffset == _type)
                 {
                     DateTimeOffset dto = DateTimeOffset;
                     byte scale = _value._dateTimeOffsetInfo._dateTime2Info._timeInfo._scale;
-                    return dto.ToString(s_2008DateTimeOffsetFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
+                    return dto.ToString(s_sql2008DateTimeOffsetFormatByScale[scale], DateTimeFormatInfo.InvariantInfo);
                 }
                 return (string)Value; // anything else we haven't thought of goes through boxing.
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -436,7 +436,7 @@ namespace Microsoft.Data.SqlClient
             string TDSCommand;
 
             TDSCommand = "select @@trancount; SET FMTONLY ON select * from " + ADP.BuildMultiPartName(parts) + " SET FMTONLY OFF ";
-            if (_connection.IsShiloh)
+            if (_connection.Is2000)
             {
                 // If its a temp DB then try to connect
 
@@ -546,7 +546,7 @@ namespace Microsoft.Data.SqlClient
 
             StringBuilder updateBulkCommandText = new StringBuilder();
 
-            if (_connection.IsShiloh && 0 == internalResults[CollationResultId].Count)
+            if (_connection.Is2000 && 0 == internalResults[CollationResultId].Count)
             {
                 throw SQL.BulkLoadNoCollation();
             }
@@ -683,9 +683,9 @@ namespace Microsoft.Data.SqlClient
                                 }
                         }
 
-                        if (_connection.IsShiloh)
+                        if (_connection.Is2000)
                         {
-                            // Shiloh or above!
+                            // 2000 or above!
                             // get collation for column i
 
                             Result rowset = internalResults[CollationResultId];

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Data.SqlClient
                 // If its a temp DB then try to connect
 
                 string TableCollationsStoredProc;
-                if (_connection.IsKatmaiOrNewer)
+                if (_connection.Is2008OrNewer)
                 {
                     TableCollationsStoredProc = "sp_tablecollations_100";
                 }
@@ -2288,7 +2288,7 @@ namespace Microsoft.Data.SqlClient
                 // Target type shouldn't be encrypted
                 Debug.Assert(!metadata.isEncrypted, "Can't encrypt SQL Variant type");
                 SqlBuffer.StorageType variantInternalType = SqlBuffer.StorageType.Empty;
-                if ((_sqlDataReaderRowSource != null) && (_connection.IsKatmaiOrNewer))
+                if ((_sqlDataReaderRowSource != null) && (_connection.Is2008OrNewer))
                 {
                     variantInternalType = _sqlDataReaderRowSource.GetVariantInternalStorageType(_sortedColumnMappings[col]._sourceColumnOrdinal);
                 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     TableCollationsStoredProc = "sp_tablecollations_100";
                 }
-                else if (_connection.IsYukonOrNewer)
+                else if (_connection.Is2005OrNewer)
                 {
                     TableCollationsStoredProc = "sp_tablecollations_90";
                 }
@@ -559,7 +559,7 @@ namespace Microsoft.Data.SqlClient
 
             bool isInTransaction;
 
-            if (_parser.IsYukonOrNewer)
+            if (_parser.Is2005OrNewer)
             {
                 isInTransaction = _connection.HasLocalTransaction;
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     SqlClientEventSource.Log.AdvancedTraceEvent("<sc.SqlCommand.CommandEventSink.ParameterAvailable|ADV> {0}, metaData[{1}] is {2}{ 3}", _command.ObjectID, ordinal, metaData?.GetType(), metaData?.TraceString());
                 }
-                Debug.Assert(SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.KatmaiVersion);
+                Debug.Assert(SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.Sql2008Version);
                 _command.OnParameterAvailableSmi(metaData, parameterValues, ordinal);
             }
         }
@@ -3374,8 +3374,8 @@ namespace Microsoft.Data.SqlClient
         {
             ParameterName = 0,
             ParameterType,
-            DataType, // obsolete in katmai, use ManagedDataType instead
-            ManagedDataType, // new in katmai
+            DataType, // obsolete in 2008, use ManagedDataType instead
+            ManagedDataType, // new in 2008
             CharacterMaximumLength,
             NumericPrecision,
             NumericScale,
@@ -3385,16 +3385,16 @@ namespace Microsoft.Data.SqlClient
             XmlSchemaCollectionCatalogName,
             XmlSchemaCollectionSchemaName,
             XmlSchemaCollectionName,
-            UdtTypeName, // obsolete in Katmai.  Holds the actual typename if UDT, since TypeName didn't back then.
-            DateTimeScale // new in Katmai
+            UdtTypeName, // obsolete in 2008.  Holds the actual typename if UDT, since TypeName didn't back then.
+            DateTimeScale // new in 2008
         };
 
         // Yukon- column ordinals (this array indexed by ProcParamsColIndex
-        internal static readonly string[] PreKatmaiProcParamsNames = new string[] {
+        internal static readonly string[] PreSql2008ProcParamsNames = new string[] {
             "PARAMETER_NAME",           // ParameterName,
             "PARAMETER_TYPE",           // ParameterType,
             "DATA_TYPE",                // DataType
-            null,                       // ManagedDataType,     introduced in Katmai
+            null,                       // ManagedDataType,     introduced in 2008
             "CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
             "NUMERIC_PRECISION",        // NumericPrecision,
             "NUMERIC_SCALE",            // NumericScale,
@@ -3405,14 +3405,14 @@ namespace Microsoft.Data.SqlClient
             "XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
             "XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
             "UDT_NAME",                 // UdtTypeName
-            null,                       // Scale for datetime types with scale, introduced in Katmai
+            null,                       // Scale for datetime types with scale, introduced in 2008
         };
 
-        // Katmai+ column ordinals (this array indexed by ProcParamsColIndex
-        internal static readonly string[] KatmaiProcParamsNames = new string[] {
+        // 2008+ column ordinals (this array indexed by ProcParamsColIndex
+        internal static readonly string[] Sql2008ProcParamsNames = new string[] {
             "PARAMETER_NAME",           // ParameterName,
             "PARAMETER_TYPE",           // ParameterType,
-            null,                       // DataType, removed from Katmai+
+            null,                       // DataType, removed from 2008+
             "MANAGED_DATA_TYPE",        // ManagedDataType,
             "CHARACTER_MAXIMUM_LENGTH", // CharacterMaximumLength,
             "NUMERIC_PRECISION",        // NumericPrecision,
@@ -3423,7 +3423,7 @@ namespace Microsoft.Data.SqlClient
             "XML_CATALOGNAME",          // XmlSchemaCollectionCatalogName,
             "XML_SCHEMANAME",           // XmlSchemaCollectionSchemaName,
             "XML_SCHEMACOLLECTIONNAME", // XmlSchemaCollectionName
-            null,                       // UdtTypeName, removed from Katmai+
+            null,                       // UdtTypeName, removed from 2008+
             "SS_DATETIME_PRECISION",    // Scale for datetime types with scale
         };
 
@@ -3479,12 +3479,12 @@ namespace Microsoft.Data.SqlClient
             // for Yukon, else older sproc.
             string[] colNames;
             bool useManagedDataType;
-            if (Connection.IsKatmaiOrNewer)
+            if (Connection.Is2008OrNewer)
             {
                 // Procedure - [sp_procedure_params_managed]
                 cmdText.Append("[sys].[").Append(TdsEnums.SP_PARAMS_MGD10).Append("]");
 
-                colNames = KatmaiProcParamsNames;
+                colNames = Sql2008ProcParamsNames;
                 useManagedDataType = true;
             }
             else
@@ -3500,7 +3500,7 @@ namespace Microsoft.Data.SqlClient
                     cmdText.Append(".[").Append(TdsEnums.SP_PARAMS).Append("]");
                 }
 
-                colNames = PreKatmaiProcParamsNames;
+                colNames = PreSql2008ProcParamsNames;
                 useManagedDataType = false;
             }
 
@@ -3556,7 +3556,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         p.SqlDbType = (SqlDbType)(short)r[colNames[(int)ProcParamsColIndex.ManagedDataType]];
 
-                        // Yukon didn't have as accurate of information as we're getting for Katmai, so re-map a couple of
+                        // Yukon didn't have as accurate of information as we're getting for 2008, so re-map a couple of
                         //  types for backward compatability.
                         switch (p.SqlDbType)
                         {
@@ -3590,9 +3590,9 @@ namespace Microsoft.Data.SqlClient
                     {
                         int size = (int)a;
 
-                        // Map MAX sizes correctly.  The Katmai server-side proc sends 0 for these instead of -1.
-                        //  Should be fixed on the Katmai side, but would likely hold up the RI, and is safer to fix here.
-                        //  If we can get the server-side fixed before shipping Katmai, we can remove this mapping.
+                        // Map MAX sizes correctly.  The 2008 server-side proc sends 0 for these instead of -1.
+                        //  Should be fixed on the 2008 side, but would likely hold up the RI, and is safer to fix here.
+                        //  If we can get the server-side fixed before shipping 2008, we can remove this mapping.
                         if (0 == size &&
                                 (p.SqlDbType == SqlDbType.NVarChar ||
                                  p.SqlDbType == SqlDbType.VarBinary ||
@@ -3637,7 +3637,7 @@ namespace Microsoft.Data.SqlClient
                     // type name for Structured types (same as for Udt's except assign p.TypeName instead of p.UdtTypeName
                     if (SqlDbType.Structured == p.SqlDbType)
                     {
-                        Debug.Assert(_activeConnection.IsKatmaiOrNewer, "Invalid datatype token received from pre-katmai server");
+                        Debug.Assert(_activeConnection.Is2008OrNewer, "Invalid datatype token received from pre-2008 server");
 
                         //read the type name
                         p.TypeName = r[colNames[(int)ProcParamsColIndex.TypeCatalogName]] + "." +
@@ -3944,7 +3944,7 @@ namespace Microsoft.Data.SqlClient
 
                     SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlCommand.RunExecuteNonQuerySmi|ADV> {0}, innerConnection={1}, transactionId=0x{2}, cmdBehavior={3}.", ObjectID, innerConnection.ObjectID, transactionId, (int)CommandBehavior.Default);
 
-                    if (SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.KatmaiVersion)
+                    if (SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.Sql2008Version)
                     {
                         eventStream = requestExecutor.Execute(
                                                           innerConnection.SmiConnection,
@@ -5571,7 +5571,7 @@ namespace Microsoft.Data.SqlClient
                 innerConnection.GetCurrentTransactionPair(out transactionId, out transaction);
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlCommand.RunExecuteReaderSmi|ADV> {0}, innerConnection={1}, transactionId=0x{2}, commandBehavior={(int)cmdBehavior}.", ObjectID, innerConnection.ObjectID, transactionId);
 
-                if (SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.KatmaiVersion)
+                if (SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.Sql2008Version)
                 {
                     eventStream = requestExecutor.Execute(
                                                     innerConnection.SmiConnection,
@@ -6375,7 +6375,7 @@ namespace Microsoft.Data.SqlClient
                     param.CompareInfo = metaData.CompareOptions;
                     SqlBuffer buffer = new SqlBuffer();
                     object result;
-                    if (_activeConnection.IsKatmaiOrNewer)
+                    if (_activeConnection.Is2008OrNewer)
                     {
                         result = ValueUtilsSmi.GetOutputParameterV200Smi(
                                 OutParamEventSink, (SmiTypedGetterSetter)parameterValues, ordinal, metaData, _smiRequestContext, buffer);
@@ -7474,7 +7474,7 @@ namespace Microsoft.Data.SqlClient
                     requestMetaData[index] = param.MetaDataForSmi(out peekAheadValues[index]);
 
                     // Check for valid type for version negotiated
-                    if (!innerConnection.IsKatmaiOrNewer)
+                    if (!innerConnection.Is2008OrNewer)
                     {
                         MetaType mt = MetaType.GetMetaTypeFromSqlDbType(requestMetaData[index].SqlDbType, requestMetaData[index].IsMultiValued);
                         if (!mt.Is90Supported)
@@ -7604,7 +7604,7 @@ namespace Microsoft.Data.SqlClient
                             }
                         }
 
-                        if (innerConnection.IsKatmaiOrNewer)
+                        if (innerConnection.Is2008OrNewer)
                         {
                             ValueUtilsSmi.SetCompatibleValueV200(EventSink, requestExecutor, index, requestMetaData[index], value, typeCode, param.Offset, param.Size, peekAheadValues[index]);
                         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -86,9 +86,9 @@ namespace Microsoft.Data.SqlClient
         internal static readonly Action<object> s_cancelIgnoreFailure = CancelIgnoreFailureCallback;
 
         // devnote: Prepare
-        // Against 7.0 Server (Sphinx) a prepare/unprepare requires an extra roundtrip to the server.
+        // Against 7.0 Server a prepare/unprepare requires an extra roundtrip to the server.
         //
-        // From 8.0 (2000) and above (2005) the preparation can be done as part of the command execution.
+        // From 8.0 (2000) and above the preparation can be done as part of the command execution.
         //
         private enum EXECTYPE
         {
@@ -6986,7 +6986,7 @@ namespace Microsoft.Data.SqlClient
                         }
                         else
                         {
-                            precision = TdsEnums.SPHINX_DEFAULT_NUMERIC_PRECISION;
+                            precision = TdsEnums.SQL70_DEFAULT_NUMERIC_PRECISION;
                         }
                     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Data.SqlClient
         // devnote: Prepare
         // Against 7.0 Server (Sphinx) a prepare/unprepare requires an extra roundtrip to the server.
         //
-        // From 8.0 (Shiloh) and above (2005) the preparation can be done as part of the command execution.
+        // From 8.0 (2000) and above (2005) the preparation can be done as part of the command execution.
         //
         private enum EXECTYPE
         {
@@ -610,14 +610,14 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private bool IsShiloh
+        private bool Is2000
         {
             get
             {
                 Debug.Assert(_activeConnection != null, "The active connection is null!");
                 if (_activeConnection == null)
                     return false;
-                return _activeConnection.IsShiloh;
+                return _activeConnection.Is2000;
             }
         }
 
@@ -5431,7 +5431,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else if (_execType == EXECTYPE.PREPAREPENDING)
                     {
-                        Debug.Assert(_activeConnection.IsShiloh, "Invalid attempt to call sp_prepexec on non 7.x server");
+                        Debug.Assert(_activeConnection.Is2000, "Invalid attempt to call sp_prepexec on non 7.x server");
                         rpc = BuildPrepExec(cmdBehavior);
                         // next time through, only do an exec
                         _execType = EXECTYPE.PREPARED;
@@ -5446,8 +5446,8 @@ namespace Microsoft.Data.SqlClient
                         BuildExecuteSql(cmdBehavior, null, _parameters, ref rpc);
                     }
 
-                    // if shiloh, then set NOMETADATA_UNLESSCHANGED flag
-                    if (_activeConnection.IsShiloh)
+                    // if 2000, then set NOMETADATA_UNLESSCHANGED flag
+                    if (_activeConnection.Is2000)
                         rpc.options = TdsEnums.RPC_NOMETADATA;
                     if (returnStream)
                     {
@@ -5461,10 +5461,10 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     Debug.Assert(this.CommandType == System.Data.CommandType.StoredProcedure, "unknown command type!");
-                    // note: invalid asserts on Shiloh. On 8.0 (Shiloh) and above a command is ALWAYS prepared
+                    // note: invalid asserts on 2000. On 8.0 (2000) and above a command is ALWAYS prepared
                     // and IsDirty is always set if there are changes and the command is marked Prepared!
-                    Debug.Assert(IsShiloh || !IsPrepared, "RPC should not be prepared!");
-                    Debug.Assert(IsShiloh || !IsDirty, "RPC should not be marked as dirty!");
+                    Debug.Assert(Is2000 || !IsPrepared, "RPC should not be prepared!");
+                    Debug.Assert(Is2000 || !IsDirty, "RPC should not be marked as dirty!");
 
                     BuildRPC(inSchema, _parameters, ref rpc);
 
@@ -6980,7 +6980,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (0 == precision)
                     {
-                        if (IsShiloh)
+                        if (Is2000)
                         {
                             precision = TdsEnums.DEFAULT_NUMERIC_PRECISION;
                         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2224,7 +2224,7 @@ namespace Microsoft.Data.SqlClient
             {
                 if (_currentReconnectionTask != null)
                 { // holds true even if task is completed
-                    return true; // if CR is enabled, connection, if established, will be Katmai+
+                    return true; // if CR is enabled, connection, if established, will be 2008+
                 }
                 return GetOpenConnection().IsShiloh;
             }
@@ -2236,21 +2236,21 @@ namespace Microsoft.Data.SqlClient
             {
                 if (_currentReconnectionTask != null)
                 { // holds true even if task is completed
-                    return true; // if CR is enabled, connection, if established, will be Katmai+
+                    return true; // if CR is enabled, connection, if established, will be 2008+
                 }
                 return GetOpenConnection().IsYukonOrNewer;
             }
         }
 
-        internal bool IsKatmaiOrNewer
+        internal bool Is2008OrNewer
         {
             get
             {
                 if (_currentReconnectionTask != null)
                 { // holds true even if task is completed
-                    return true; // if CR is enabled, connection, if established, will be Katmai+
+                    return true; // if CR is enabled, connection, if established, will be 2008+
                 }
-                return GetOpenConnection().IsKatmaiOrNewer;
+                return GetOpenConnection().Is2008OrNewer;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2230,7 +2230,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal bool IsYukonOrNewer
+        internal bool Is2005OrNewer
         {
             get
             {
@@ -2238,7 +2238,7 @@ namespace Microsoft.Data.SqlClient
                 { // holds true even if task is completed
                     return true; // if CR is enabled, connection, if established, will be 2008+
                 }
-                return GetOpenConnection().IsYukonOrNewer;
+                return GetOpenConnection().Is2005OrNewer;
             }
         }
 
@@ -2378,7 +2378,7 @@ namespace Microsoft.Data.SqlClient
 
             // check to see if we need to hook up sql-debugging if a debugger is attached
             // We only need this check for Shiloh and earlier servers.
-            if (!GetOpenConnection().IsYukonOrNewer &&
+            if (!GetOpenConnection().Is2005OrNewer &&
                     System.Diagnostics.Debugger.IsAttached)
             {
                 bool debugCheck = false;
@@ -2613,9 +2613,9 @@ namespace Microsoft.Data.SqlClient
         private void IssueSQLDebug(uint option, string machineName, uint pid, uint id, string sdiDllName, byte[] data)
         {
 
-            if (GetOpenConnection().IsYukonOrNewer)
+            if (GetOpenConnection().Is2005OrNewer)
             {
-                // TODO: When Yukon actually supports debugging, we need to modify this method to do the right thing(tm)
+                // TODO: When 2005 actually supports debugging, we need to modify this method to do the right thing(tm)
                 return;
             }
 
@@ -2780,9 +2780,9 @@ namespace Microsoft.Data.SqlClient
             //
             using (SqlInternalConnectionTds con = new SqlInternalConnectionTds(null, connectionOptions, credential, null, newPassword, newSecurePassword, false, null, null, null, null))
             {
-                if (!con.IsYukonOrNewer)
+                if (!con.Is2005OrNewer)
                 {
-                    throw SQL.ChangePasswordRequiresYukon();
+                    throw SQL.ChangePasswordRequires2005();
                 }
             }
             SqlConnectionPoolKey key = new SqlConnectionPoolKey(connectionString, credential, accessToken: null, serverCertificateValidationCallback: null, clientCertificateRetrievalCallback: null, originalNetworkAddressInfo: null);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2218,7 +2218,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal bool IsShiloh
+        internal bool Is2000
         {
             get
             {
@@ -2226,7 +2226,7 @@ namespace Microsoft.Data.SqlClient
                 { // holds true even if task is completed
                     return true; // if CR is enabled, connection, if established, will be 2008+
                 }
-                return GetOpenConnection().IsShiloh;
+                return GetOpenConnection().Is2000;
             }
         }
 
@@ -2377,7 +2377,7 @@ namespace Microsoft.Data.SqlClient
             // be sure to mark as open so SqlDebugCheck can issue Query
 
             // check to see if we need to hook up sql-debugging if a debugger is attached
-            // We only need this check for Shiloh and earlier servers.
+            // We only need this check for 2000 and earlier servers.
             if (!GetOpenConnection().Is2005OrNewer &&
                     System.Diagnostics.Debugger.IsAttached)
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -653,12 +653,12 @@ namespace Microsoft.Data.SqlClient
 
                     if (col.type == SqlDbType.Udt)
                     { // Additional metadata for UDTs.
-                        Debug.Assert(Connection.IsYukonOrNewer, "Invalid Column type received from the server");
+                        Debug.Assert(Connection.Is2005OrNewer, "Invalid Column type received from the server");
                         schemaRow[UdtAssemblyQualifiedName] = col.udt?.AssemblyQualifiedName;
                     }
                     else if (col.type == SqlDbType.Xml)
                     { // Additional metadata for Xml.
-                        Debug.Assert(Connection.IsYukonOrNewer, "Invalid DataType (Xml) for the column");
+                        Debug.Assert(Connection.Is2005OrNewer, "Invalid DataType (Xml) for the column");
                         schemaRow[XmlSchemaCollectionDatabase] = col.xmlSchemaCollection?.Database;
                         schemaRow[XmlSchemaCollectionOwningSchema] = col.xmlSchemaCollection?.OwningSchema;
                         schemaRow[XmlSchemaCollectionName] = col.xmlSchemaCollection?.Name;
@@ -1424,7 +1424,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (metaData.type == SqlDbType.Udt)
                 {
-                    Debug.Assert(Connection.IsYukonOrNewer, "Invalid Column type received from the server");
+                    Debug.Assert(Connection.Is2005OrNewer, "Invalid Column type received from the server");
                     dataTypeName = metaData.udt?.DatabaseName + "." + metaData.udt?.SchemaName + "." + metaData.udt?.TypeName;
                 }
                 else
@@ -1508,7 +1508,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (metaData.type == SqlDbType.Udt)
                 {
-                    Debug.Assert(Connection.IsYukonOrNewer, "Invalid Column type received from the server");
+                    Debug.Assert(Connection.Is2005OrNewer, "Invalid Column type received from the server");
                     Connection.CheckGetExtendedUDTInfo(metaData, false);
                     fieldType = metaData.udt?.Type;
                 }
@@ -1619,7 +1619,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (metaData.type == SqlDbType.Udt)
                 {
-                    Debug.Assert(Connection.IsYukonOrNewer, "Invalid Column type received from the server");
+                    Debug.Assert(Connection.Is2005OrNewer, "Invalid Column type received from the server");
                     Connection.CheckGetExtendedUDTInfo(metaData, false);
                     providerSpecificFieldType = metaData.udt?.Type;
                 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -610,7 +610,7 @@ namespace Microsoft.Data.SqlClient
                 schemaRow[NonVersionedProviderType] = (int)(col.cipherMD != null ? col.baseTI.type : col.type); // SqlDbType enum value - does not change with TypeSystem.
                 schemaRow[DataTypeName] = GetDataTypeNameInternal(col);
 
-                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.IsNewKatmaiDateTimeType)
+                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.Is2008DateTimeType)
                 {
                     schemaRow[ProviderType] = SqlDbType.NVarChar;
                     switch (col.type)
@@ -693,7 +693,7 @@ namespace Microsoft.Data.SqlClient
                     schemaRow[Precision] = col.metaType.Precision;
                 }
 
-                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.IsNewKatmaiDateTimeType)
+                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.Is2008DateTimeType)
                 {
                     schemaRow[Scale] = MetaType.MetaNVarChar.Scale;
                 }
@@ -1402,7 +1402,7 @@ namespace Microsoft.Data.SqlClient
         {
             string dataTypeName = null;
 
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
                 dataTypeName = MetaType.MetaNVarChar.TypeName;
             }
@@ -1485,9 +1485,9 @@ namespace Microsoft.Data.SqlClient
         {
             Type fieldType = null;
 
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
-                // Return katmai types as string
+                // Return 2008 types as string
                 fieldType = MetaType.MetaNVarChar.ClassType;
             }
             else if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsLargeUdt)
@@ -1597,7 +1597,7 @@ namespace Microsoft.Data.SqlClient
         {
             Type providerSpecificFieldType = null;
 
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
                 providerSpecificFieldType = MetaType.MetaNVarChar.SqlType;
             }
@@ -2675,7 +2675,7 @@ namespace Microsoft.Data.SqlClient
 
             DateTime dt = _data[i].DateTime;
             // This accessor can be called for regular DateTime column. In this case we should not throw
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].Is2008DateTimeType)
             {
                 // TypeSystem.SQLServer2005 or less
 
@@ -2773,10 +2773,10 @@ namespace Microsoft.Data.SqlClient
         {
             ReadColumn(i);
             SqlString data;
-            // Convert Katmai types to string
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].IsNewKatmaiDateTimeType)
+            // Convert 2008 types to string
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].Is2008DateTimeType)
             {
-                data = _data[i].KatmaiDateTimeSqlString;
+                data = _data[i].Sql2008DateTimeSqlString;
             }
             else
             {
@@ -2854,9 +2854,9 @@ namespace Microsoft.Data.SqlClient
         {
             ReadColumn(i);
 
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].Is2008DateTimeType)
             {
-                return _data[i].KatmaiDateTimeSqlString;
+                return _data[i].Sql2008DateTimeSqlString;
             }
 
             return _data[i].SqlString;
@@ -2933,10 +2933,10 @@ namespace Microsoft.Data.SqlClient
             // Due to a bug in TdsParser.GetNullSqlValue, Timestamps' IsNull is not correctly set - so we need to bypass the following check
             Debug.Assert(!data.IsEmpty || data.IsNull || metaData.type == SqlDbType.Timestamp, "Data has been read, but the buffer is empty");
 
-            // Convert Katmai types to string
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            // Convert 2008 types to string
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
-                return data.KatmaiDateTimeSqlString;
+                return data.Sql2008DateTimeSqlString;
             }
             else if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsLargeUdt)
             {
@@ -3013,10 +3013,10 @@ namespace Microsoft.Data.SqlClient
         {
             ReadColumn(i);
 
-            // Convert katmai value to string if type system knob is 2005 or earlier
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].IsNewKatmaiDateTimeType)
+            // Convert 2008 value to string if type system knob is 2005 or earlier
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && _metaData[i].Is2008DateTimeType)
             {
-                return _data[i].KatmaiDateTimeString;
+                return _data[i].Sql2008DateTimeString;
             }
 
             return _data[i].String;
@@ -3123,7 +3123,7 @@ namespace Microsoft.Data.SqlClient
             // Due to a bug in TdsParser.GetNullSqlValue, Timestamps' IsNull is not correctly set - so we need to bypass the following check
             Debug.Assert(!data.IsEmpty || data.IsNull || metaData.type == SqlDbType.Timestamp, "Data has been read, but the buffer is empty");
 
-            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
                 if (data.IsNull)
                 {
@@ -3131,7 +3131,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    return data.KatmaiDateTimeString;
+                    return data.Sql2008DateTimeString;
                 }
             }
             else if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsLargeUdt)
@@ -3227,11 +3227,11 @@ namespace Microsoft.Data.SqlClient
             {
                 return (T)(object)data.Decimal;
             }
-            else if (typeof(T) == typeof(DateTimeOffset) && dataType == typeof(DateTimeOffset) && _typeSystem > SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            else if (typeof(T) == typeof(DateTimeOffset) && dataType == typeof(DateTimeOffset) && _typeSystem > SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
                 return (T)(object)data.DateTimeOffset;
             }
-            else if (typeof(T) == typeof(DateTime) && dataType == typeof(DateTime) && _typeSystem > SqlConnectionString.TypeSystem.SQLServer2005 && metaData.IsNewKatmaiDateTimeType)
+            else if (typeof(T) == typeof(DateTime) && dataType == typeof(DateTime) && _typeSystem > SqlConnectionString.TypeSystem.SQLServer2005 && metaData.Is2008DateTimeType)
             {
                 return (T)(object)data.DateTime;
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -3523,7 +3523,7 @@ namespace Microsoft.Data.SqlClient
                             return true;
 
                         // VSTFDEVDIV 926281: DONEINPROC case is missing here; we have decided to reject this bug as it would result in breaking change
-                        // from Orcas RTM/SP1 and Dev10 RTM. See the bug for more details.
+                        // from VS2008 RTM/SP1 and Dev10 RTM. See the bug for more details.
                         // case TdsEnums.DONEINPROC:
                         case TdsEnums.SQLDONE:
                             Debug.Assert(_altRowStatus == ALTROWSTATUS.Done || _altRowStatus == ALTROWSTATUS.Null, "invalid AltRowStatus");

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReaderSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReaderSmi.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Data.SqlClient
         {
             EnsureCanGetCol("GetValue", ordinal);
             SmiQueryMetaData metaData = _currentMetaData[ordinal];
-            if (_currentConnection.IsKatmaiOrNewer)
+            if (_currentConnection.Is2008OrNewer)
             {
                 return ValueUtilsSmi.GetValue200(_readerEventSink, (SmiTypedGetterSetter)_currentColumnValuesV3, ordinal, metaData, _currentConnection.InternalContext);
             }
@@ -138,7 +138,7 @@ namespace Microsoft.Data.SqlClient
             if (typeof(INullable).IsAssignableFrom(typeof(T)))
             {
                 // If its a SQL Type or Nullable UDT
-                if (_currentConnection.IsKatmaiOrNewer)
+                if (_currentConnection.Is2008OrNewer)
                 {
                     return (T)ValueUtilsSmi.GetSqlValue200(_readerEventSink, (SmiTypedGetterSetter)_currentColumnValuesV3, ordinal, metaData, _currentConnection.InternalContext);
                 }
@@ -150,7 +150,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 // Otherwise Its a CLR or non-Nullable UDT
-                if (_currentConnection.IsKatmaiOrNewer)
+                if (_currentConnection.Is2008OrNewer)
                 {
                     return (T)ValueUtilsSmi.GetValue200(_readerEventSink, (SmiTypedGetterSetter)_currentColumnValuesV3, ordinal, metaData, _currentConnection.InternalContext);
                 }
@@ -923,13 +923,13 @@ namespace Microsoft.Data.SqlClient
         public override TimeSpan GetTimeSpan(int ordinal)
         {
             EnsureCanGetCol("GetTimeSpan", ordinal);
-            return ValueUtilsSmi.GetTimeSpan(_readerEventSink, _currentColumnValuesV3, ordinal, _currentMetaData[ordinal], _currentConnection.IsKatmaiOrNewer);
+            return ValueUtilsSmi.GetTimeSpan(_readerEventSink, _currentColumnValuesV3, ordinal, _currentMetaData[ordinal], _currentConnection.Is2008OrNewer);
         }
 
         public override DateTimeOffset GetDateTimeOffset(int ordinal)
         {
             EnsureCanGetCol("GetDateTimeOffset", ordinal);
-            return ValueUtilsSmi.GetDateTimeOffset(_readerEventSink, _currentColumnValuesV3, ordinal, _currentMetaData[ordinal], _currentConnection.IsKatmaiOrNewer);
+            return ValueUtilsSmi.GetDateTimeOffset(_readerEventSink, _currentColumnValuesV3, ordinal, _currentMetaData[ordinal], _currentConnection.Is2008OrNewer);
         }
 
         public override object GetSqlValue(int ordinal)
@@ -937,7 +937,7 @@ namespace Microsoft.Data.SqlClient
             EnsureCanGetCol("GetSqlValue", ordinal);
 
             SmiMetaData metaData = _currentMetaData[ordinal];
-            if (_currentConnection.IsKatmaiOrNewer)
+            if (_currentConnection.Is2008OrNewer)
             {
                 return ValueUtilsSmi.GetSqlValue200(_readerEventSink, (SmiTypedGetterSetter)_currentColumnValuesV3, ordinal, metaData, _currentConnection.InternalContext);
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Data.SqlClient
             get;
         }
 
-        abstract internal bool IsYukonOrNewer
+        abstract internal bool Is2005OrNewer
         {
             get;
         }
@@ -438,11 +438,11 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, transaction {1}.", ObjectID, tx.GetHashCode());
             bool hasDelegatedTransaction = false;
 
-            if (IsYukonOrNewer)
+            if (Is2005OrNewer)
             {
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnection.EnlistNonNull|ADV> {0}, attempting to delegate", ObjectID);
 
-                // Promotable transactions are only supported on Yukon
+                // Promotable transactions are only supported on 2005
                 // servers or newer.
                 SqlDelegatedTransaction delegatedTransaction = new SqlDelegatedTransaction(this, tx);
 
@@ -575,20 +575,20 @@ namespace Microsoft.Data.SqlClient
 
             EnlistedTransaction = tx; // Tell the base class about our enlistment
 
-            // If we're on a Yukon or newer server, and we we delegate the 
+            // If we're on a 2005 or newer server, and we we delegate the 
             // transaction successfully, we will have done a begin transaction, 
             // which produces a transaction id that we should execute all requests
             // on.  The TdsParser or SmiEventSink will store this information as
             // the current transaction.
             // 
-            // Likewise, propagating a transaction to a Yukon or newer server will
+            // Likewise, propagating a transaction to a 2005 or newer server will
             // produce a transaction id that The TdsParser or SmiEventSink will 
             // store as the current transaction.
             //
-            // In either case, when we're working with a Yukon or newer server 
+            // In either case, when we're working with a 2005 or newer server 
             // we better have a current transaction by now.
 
-            Debug.Assert(!IsYukonOrNewer || null != CurrentTransaction, "delegated/enlisted transaction with null current transaction?");
+            Debug.Assert(!Is2005OrNewer || null != CurrentTransaction, "delegated/enlisted transaction with null current transaction?");
         }
 
         internal void EnlistNull()
@@ -617,10 +617,10 @@ namespace Microsoft.Data.SqlClient
             // which causes the TdsParser or SmiEventSink should to clear the
             // current transaction.
             //
-            // In either case, when we're working with a Yukon or newer server 
+            // In either case, when we're working with a 2005 or newer server 
             // we better not have a current transaction at this point.
 
-            Debug.Assert(!IsYukonOrNewer || null == CurrentTransaction, "unenlisted transaction with non-null current transaction?");   // verify it!
+            Debug.Assert(!Is2005OrNewer || null == CurrentTransaction, "unenlisted transaction with non-null current transaction?");   // verify it!
         }
 
         override public void EnlistTransaction(SysTx.Transaction transaction)
@@ -647,7 +647,7 @@ namespace Microsoft.Data.SqlClient
             // If a connection is already enlisted in a DTC transaction and you
             // try to enlist in another one, in 7.0 the existing DTC transaction
             // would roll back and then the connection would enlist in the new
-            // one. In SQL 2000 & Yukon, when you enlist in a DTC transaction
+            // one. In SQL 2000 & 2005, when you enlist in a DTC transaction
             // while the connection is already enlisted in a DTC transaction,
             // the connection simply switches enlistments.  Regardless, simply
             // enlist in the user specified distributed transaction.  This

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Data.SqlClient
             get;
         }
 
-        abstract internal bool IsKatmaiOrNewer
+        abstract internal bool Is2008OrNewer
         {
             get;
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Data.SqlClient
             get;
         }
 
-        abstract internal bool IsShiloh
+        abstract internal bool Is2000
         {
             get;
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
@@ -178,11 +178,11 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool IsKatmaiOrNewer
+        override internal bool Is2008OrNewer
         {
             get
             {
-                return SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.KatmaiVersion;
+                return SmiContextFactory.Instance.NegotiatedSmiVersion >= SmiContextFactory.Sql2008Version;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
@@ -170,11 +170,11 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool IsYukonOrNewer
+        override internal bool Is2005OrNewer
         {
             get
             {
-                return true;    // Must be direct connecting to Yukon or newer.
+                return true;    // Must be direct connecting to 2005 or newer.
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
@@ -162,11 +162,11 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool IsShiloh
+        override internal bool Is2000
         {
             get
             {
-                return false;   // Can't be direct connecting to Shiloh.
+                return false;   // Can't be direct connecting to 2000.
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -743,11 +743,11 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool IsYukonOrNewer
+        override internal bool Is2005OrNewer
         {
             get
             {
-                return _parser.IsYukonOrNewer;
+                return _parser.Is2005OrNewer;
             }
         }
 
@@ -1168,18 +1168,18 @@ namespace Microsoft.Data.SqlClient
 
             string transactionName = (null == name) ? String.Empty : name;
 
-            if (!_parser.IsYukonOrNewer)
+            if (!_parser.Is2005OrNewer)
             {
-                ExecuteTransactionPreYukon(transactionRequest, transactionName, iso, internalTransaction);
+                ExecuteTransactionPre2005(transactionRequest, transactionName, iso, internalTransaction);
             }
             else
             {
-                ExecuteTransactionYukon(transactionRequest, transactionName, iso, internalTransaction, isDelegateControlRequest);
+                ExecuteTransaction2005(transactionRequest, transactionName, iso, internalTransaction, isDelegateControlRequest);
             }
         }
 
         // This function will not handle idle connection resiliency, as older servers will not support it
-        internal void ExecuteTransactionPreYukon(
+        internal void ExecuteTransactionPre2005(
                     TransactionRequest transactionRequest,
                     string transactionName,
                     IsolationLevel iso,
@@ -1229,7 +1229,7 @@ namespace Microsoft.Data.SqlClient
                     sqlBatch.Append(transactionName);
                     break;
                 case TransactionRequest.Promote:
-                    Debug.Assert(false, "Promote called with transaction name or on pre-Yukon!");
+                    Debug.Assert(false, "Promote called with transaction name or on pre-2005!");
                     break;
                 case TransactionRequest.Commit:
                     sqlBatch.Append(TdsEnums.TRANS_COMMIT);
@@ -1256,7 +1256,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
             _parser.Run(RunBehavior.UntilDone, null, null, null, _parser._physicalStateObj);
 
-            // Prior to Yukon, we didn't have any transaction tokens to manage,
+            // Prior to 2005, we didn't have any transaction tokens to manage,
             // or any feedback to know when one was created, so we just presume
             // that successful execution of the request caused the transaction
             // to be created, and we set that on the parser.
@@ -1268,7 +1268,7 @@ namespace Microsoft.Data.SqlClient
         }
 
 
-        internal void ExecuteTransactionYukon(
+        internal void ExecuteTransaction2005(
                     TransactionRequest transactionRequest,
                     string transactionName,
                     IsolationLevel iso,
@@ -1330,7 +1330,7 @@ namespace Microsoft.Data.SqlClient
                         requestType = TdsEnums.TransactionManagerRequestType.Commit;
                         break;
                     case TransactionRequest.IfRollback:
-                    // Map IfRollback to Rollback since with Yukon and beyond we should never need
+                    // Map IfRollback to Rollback since with 2005 and beyond we should never need
                     // the if since the server will inform us when transactions have completed
                     // as a result of an error on the server.
                     case TransactionRequest.Rollback:
@@ -1388,7 +1388,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     if (internalTransaction.OpenResultsCount != 0)
                     {
-                        SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.ExecuteTransactionYukon|DATA|CATCH> {0}, Connection is marked to be doomed when closed. Transaction ended with OpenResultsCount {1} > 0, MARSOn {2}",
+                        SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.ExecuteTransaction2005|DATA|CATCH> {0}, Connection is marked to be doomed when closed. Transaction ended with OpenResultsCount {1} > 0, MARSOn {2}",
                                                                ObjectID,
                                                                internalTransaction.OpenResultsCount,
                                                                _parser.MARSOn);
@@ -2513,7 +2513,7 @@ namespace Microsoft.Data.SqlClient
                     break;
 
                 case TdsEnums.ENV_TRANSACTIONMANAGERADDRESS:
-                    // For now we skip these Yukon only env change notifications
+                    // For now we skip these 2005 only env change notifications
                     break;
 
                 case TdsEnums.ENV_SPRESETCONNECTIONACK:

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -735,7 +735,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool IsShiloh
+        override internal bool Is2000
         {
             get
             {
@@ -1075,9 +1075,9 @@ namespace Microsoft.Data.SqlClient
 
             if (_fResetConnection)
             {
-                // Ensure we are either going against shiloh, or we are not enlisted in a
+                // Ensure we are either going against 2000, or we are not enlisted in a
                 // distributed transaction - otherwise don't reset!
-                if (IsShiloh)
+                if (Is2000)
                 {
                     // Prepare the parser for the connection reset - the next time a trip
                     // to the server is made.
@@ -1085,7 +1085,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else if (!IsEnlistedInTransaction)
                 {
-                    // If not Shiloh, we are going against Sphinx.  On Sphinx, we
+                    // If not 2000, we are going against Sphinx.  On Sphinx, we
                     // may only reset if not enlisted in a distributed transaction.
                     try
                     {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1085,7 +1085,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else if (!IsEnlistedInTransaction)
                 {
-                    // If not 2000, we are going against Sphinx.  On Sphinx, we
+                    // If not 2000, we are going against 7.0.  On 7.0, we
                     // may only reset if not enlisted in a distributed transaction.
                     try
                     {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -731,7 +731,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                return IsTransactionRoot && (!IsKatmaiOrNewer || null == Pool);
+                return IsTransactionRoot && (!Is2008OrNewer || null == Pool);
             }
         }
 
@@ -751,11 +751,11 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool IsKatmaiOrNewer
+        override internal bool Is2008OrNewer
         {
             get
             {
-                return _parser.IsKatmaiOrNewer;
+                return _parser.Is2008OrNewer;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -1620,7 +1620,7 @@ namespace Microsoft.Data.SqlClient
         internal SmiParameterMetaData MetaDataForSmi(out ParameterPeekAheadValue peekAhead)
         {
             peekAhead = null;
-            MetaType mt = ValidateTypeLengths(true /* Yukon or newer */ );
+            MetaType mt = ValidateTypeLengths(true /* 2005 or newer */ );
             long actualLen = GetActualSize();
             long maxLen = Size;
 
@@ -1963,7 +1963,7 @@ namespace Microsoft.Data.SqlClient
 
         // func will change type to that with a 4 byte length if the type has a two
         // byte length and a parameter length > than that expressible in 2 bytes
-        internal MetaType ValidateTypeLengths(bool yukonOrNewer)
+        internal MetaType ValidateTypeLengths(bool is2005OrNewer)
         {
             MetaType mt = InternalMetaType;
             // Since the server will automatically reject any
@@ -1984,7 +1984,7 @@ namespace Microsoft.Data.SqlClient
                 // 'this.Size' is in charaters; 
                 // 'sizeInCharacters' is in characters; 
                 // 'TdsEnums.TYPE_SIZE_LIMIT' is in bytes;
-                // For Non-NCharType and for non-Yukon or greater variables, size should be maintained;
+                // For Non-NCharType and for non-2005 or greater variables, size should be maintained;
                 // Reverting changes from bug VSTFDevDiv # 479739 as it caused an regression;
                 // Modifed variable names from 'size' to 'sizeInCharacters', 'actualSize' to 'actualSizeInBytes', and 
                 // 'maxSize' to 'maxSizeInBytes'
@@ -1995,14 +1995,14 @@ namespace Microsoft.Data.SqlClient
                 // Keeping these goals in mind - the following are the changes we are making
 
                 long maxSizeInBytes;
-                if (mt.IsNCharType && yukonOrNewer)
+                if (mt.IsNCharType && is2005OrNewer)
                 {
                     maxSizeInBytes = ((sizeInCharacters * sizeof(char)) > actualSizeInBytes) ? sizeInCharacters * sizeof(char) : actualSizeInBytes;
                 }
                 else
                 {
                     // Notes:
-                    // Elevation from (n)(var)char (4001+) to (n)text succeeds without failure only with Yukon and greater.
+                    // Elevation from (n)(var)char (4001+) to (n)text succeeds without failure only with 2005 and greater.
                     // it fails in sql server 2000
                     maxSizeInBytes = (sizeInCharacters > actualSizeInBytes) ? sizeInCharacters : actualSizeInBytes;
                 }
@@ -2014,7 +2014,7 @@ namespace Microsoft.Data.SqlClient
                     (actualSizeInBytes == -1)
                 )
                 { // is size > size able to be described by 2 bytes
-                    if (yukonOrNewer)
+                    if (is2005OrNewer)
                     {
                         // Convert the parameter to its max type
                         mt = MetaType.GetMaxMetaTypeFromMetaType(mt);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private bool IsYukonPartialZombie
+        private bool Is2005PartialZombie
         {
             get
             {
@@ -231,7 +231,7 @@ namespace Microsoft.Data.SqlClient
                     {
 #endif //DEBUG
                         bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                        if (!IsZombied && !IsYukonPartialZombie)
+                        if (!IsZombied && !Is2005PartialZombie)
                         {
                             _internalTransaction.Dispose();
                         }
@@ -266,12 +266,12 @@ namespace Microsoft.Data.SqlClient
         /// <include file='..\..\..\..\..\..\..\doc\snippets\Microsoft.Data.SqlClient\SqlTransaction.xml' path='docs/members[@name="SqlTransaction"]/Rollback2/*' />
         override public void Rollback()
         {
-            if (IsYukonPartialZombie)
+            if (Is2005PartialZombie)
             {
                 // Put something in the trace in case a customer has an issue
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlTransaction.Rollback|ADV> {0} partial zombie no rollback required", ObjectID);
 
-                _internalTransaction = null; // yukon zombification
+                _internalTransaction = null; // 2005 zombification
             }
             else
             {
@@ -465,20 +465,20 @@ namespace Microsoft.Data.SqlClient
 
         internal void Zombie()
         {
-            // SQLBUDT #402544 For Yukon, we have to defer "zombification" until
+            // SQLBUDT #402544 For 2005, we have to defer "zombification" until
             //                 we get past the users' next rollback, else we'll
             //                 throw an exception there that is a breaking change.
             //                 Of course, if the connection is aready closed, 
             //                 then we're free to zombify...
             SqlInternalConnection internalConnection = (_connection.InnerConnection as SqlInternalConnection);
 
-            if (null != internalConnection && internalConnection.IsYukonOrNewer && !_isFromAPI)
+            if (null != internalConnection && internalConnection.Is2005OrNewer && !_isFromAPI)
             {
-                SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlTransaction.Zombie|ADV> {0} yukon deferred zombie", ObjectID);
+                SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlTransaction.Zombie|ADV> {0} 2005 deferred zombie", ObjectID);
             }
             else
             {
-                _internalTransaction = null; // pre-yukon zombification
+                _internalTransaction = null; // pre-2005 zombification
             }
 
         }
@@ -493,9 +493,9 @@ namespace Microsoft.Data.SqlClient
             if (IsZombied)
             {
 
-                if (IsYukonPartialZombie)
+                if (Is2005PartialZombie)
                 {
-                    _internalTransaction = null; // yukon zombification
+                    _internalTransaction = null; // 2005 zombification
                 }
 
                 throw ADP.TransactionZombied(this);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -553,7 +553,7 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_ChangePasswordConflictsWithSSPI));
         }
-        static internal Exception ChangePasswordRequiresYukon()
+        static internal Exception ChangePasswordRequires2005()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ChangePasswordRequiresYukon));
         }
@@ -657,7 +657,7 @@ namespace Microsoft.Data.SqlClient
         //
         // SQL.DataCommand
         //
-        static internal Exception NotificationsRequireYukon()
+        static internal Exception NotificationsRequire2005()
         {
             return ADP.NotSupported(StringsHelper.GetString(Strings.SQL_NotificationsRequireYukon));
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -320,19 +320,19 @@ namespace Microsoft.Data.SqlClient
         // Majors:
         public const int SHILOHSP1_MAJOR = 0x71;     // For Shiloh SP1 and later the versioning schema changed and
         public const int YUKON_MAJOR = 0x72;     // the high-byte is sufficient to distinguish later versions
-        public const int KATMAI_MAJOR = 0x73;
+        public const int SQL2008_MAJOR = 0x73;
         public const int DENALI_MAJOR = 0x74;
 
         // Increments:
         public const int SHILOHSP1_INCREMENT = 0x00;
         public const int YUKON_INCREMENT = 0x09;
-        public const int KATMAI_INCREMENT = 0x0b;
+        public const int SQL2008_INCREMENT = 0x0b;
         public const int DENALI_INCREMENT = 0x00;
 
         // Minors:
         public const int SHILOHSP1_MINOR = 0x0001;
         public const int YUKON_RTM_MINOR = 0x0002;
-        public const int KATMAI_MINOR = 0x0003;
+        public const int SQL2008_MINOR = 0x0003;
         public const int DENALI_MINOR = 0x0004;
 
         public const int ORDER_68000 = 1;
@@ -446,7 +446,7 @@ namespace Microsoft.Data.SqlClient
         public const int XMLUNICODEBOM = 0xfeff;
         public static readonly byte[] XMLUNICODEBOMBYTES = { 0xff, 0xfe };
 
-        // The following datatypes are specific to Katmai (version 10) or later
+        // The following datatypes are specific to 2008 (version 10) or later
         public const int SQLTABLE = 0xf3;
         public const int SQLDATE = 0x28;
         public const int SQLTIME = 0x29;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -298,39 +298,39 @@ namespace Microsoft.Data.SqlClient
 
             Client sends:
             0x70000000 -> Sphinx
-            0x71000000 -> Shiloh RTM
-            0x71000001 -> Shiloh SP1
+            0x71000000 -> 2000 RTM
+            0x71000001 -> 2000 SP1
             0x72xx0002 -> 2005 RTM
 
             Server responds:
             0x07000000 -> Sphinx     // Notice server response format is different for bwd compat
-            0x07010000 -> Shiloh RTM // Notice server response format is different for bwd compat
-            0x71000001 -> Shiloh SP1
+            0x07010000 -> 2000 RTM // Notice server response format is different for bwd compat
+            0x71000001 -> 2000 SP1
             0x72xx0002 -> 2005 RTM
         */
 
-        // Pre Shiloh SP1 versioning scheme:
-        public const int SPHINXORSHILOH_MAJOR = 0x07;     // The high byte (b3) is not sufficient to distinguish
-        public const int SPHINX_INCREMENT = 0x00;     // Sphinx and Shiloh
-        public const int SHILOH_INCREMENT = 0x01;     // So we need to look at the high-mid byte (b2) as well
+        // Pre 2000 SP1 versioning scheme:
+        public const int SPHINXOR2000_MAJOR = 0x07;     // The high byte (b3) is not sufficient to distinguish
+        public const int SPHINX_INCREMENT = 0x00;     // Sphinx and 2000
+        public const int SQL2000_INCREMENT = 0x01;     // So we need to look at the high-mid byte (b2) as well
         public const int DEFAULT_MINOR = 0x0000;
 
-        // Shiloh SP1 and beyond versioning scheme:
+        // 2000 SP1 and beyond versioning scheme:
 
         // Majors:
-        public const int SHILOHSP1_MAJOR = 0x71;     // For Shiloh SP1 and later the versioning schema changed and
+        public const int SQL2000SP1_MAJOR = 0x71;     // For 2000 SP1 and later the versioning schema changed and
         public const int SQL2005_MAJOR = 0x72;     // the high-byte is sufficient to distinguish later versions
         public const int SQL2008_MAJOR = 0x73;
         public const int SQL2012_MAJOR = 0x74;
 
         // Increments:
-        public const int SHILOHSP1_INCREMENT = 0x00;
+        public const int SQL2000SP1_INCREMENT = 0x00;
         public const int SQL2005_INCREMENT = 0x09;
         public const int SQL2008_INCREMENT = 0x0b;
         public const int SQL2012_INCREMENT = 0x00;
 
         // Minors:
-        public const int SHILOHSP1_MINOR = 0x0001;
+        public const int SQL2000SP1_MINOR = 0x0001;
         public const int SQL2005_RTM_MINOR = 0x0002;
         public const int SQL2008_MINOR = 0x0003;
         public const int SQL2012_MINOR = 0x0004;
@@ -437,7 +437,7 @@ namespace Microsoft.Data.SqlClient
         public const int MAX_NUMERIC_PRECISION = 0x26; // 38 is max numeric precision;
         public const byte UNKNOWN_PRECISION_SCALE = 0xff; // -1 is value for unknown precision or scale
 
-        // The following datatypes are specific to SHILOH (version 8) and later.
+        // The following datatypes are specific to 2000 (version 8) and later.
         public const int SQLINT8 = 0x7f;
         public const int SQLVARIANT = 0x62;
 
@@ -525,7 +525,7 @@ namespace Microsoft.Data.SqlClient
         public const string TRANS_SNAPSHOT = "SET TRANSACTION ISOLATION LEVEL SNAPSHOT";
 
         // Batch RPC flags
-        public const byte SHILOH_RPCBATCHFLAG = 0x80;
+        public const byte SQL2000_RPCBATCHFLAG = 0x80;
         public const byte SQL2005_RPCBATCHFLAG = 0xFF;
 
         // RPC flags

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -321,19 +321,19 @@ namespace Microsoft.Data.SqlClient
         public const int SHILOHSP1_MAJOR = 0x71;     // For Shiloh SP1 and later the versioning schema changed and
         public const int SQL2005_MAJOR = 0x72;     // the high-byte is sufficient to distinguish later versions
         public const int SQL2008_MAJOR = 0x73;
-        public const int DENALI_MAJOR = 0x74;
+        public const int SQL2012_MAJOR = 0x74;
 
         // Increments:
         public const int SHILOHSP1_INCREMENT = 0x00;
         public const int SQL2005_INCREMENT = 0x09;
         public const int SQL2008_INCREMENT = 0x0b;
-        public const int DENALI_INCREMENT = 0x00;
+        public const int SQL2012_INCREMENT = 0x00;
 
         // Minors:
         public const int SHILOHSP1_MINOR = 0x0001;
         public const int SQL2005_RTM_MINOR = 0x0002;
         public const int SQL2008_MINOR = 0x0003;
-        public const int DENALI_MINOR = 0x0004;
+        public const int SQL2012_MINOR = 0x0004;
 
         public const int ORDER_68000 = 1;
         public const int USE_DB_ON = 1;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Data.SqlClient
         public const int HEADER_LEN = 8;
         public const int HEADER_LEN_FIELD_OFFSET = 2;
         public const int SPID_OFFSET = 4;
-        public const int YUKON_HEADER_LEN = 12; //Yukon headers also include a MARS session id
+        public const int SQL2005_HEADER_LEN = 12; //2005 headers also include a MARS session id
         public const int MARS_ID_OFFSET = 8;
         public const int HEADERTYPE_QNOTIFICATION = 1;
         public const int HEADERTYPE_MARS = 2;
@@ -169,7 +169,7 @@ namespace Microsoft.Data.SqlClient
         public const byte ENV_LOCALEID = 5;  // Unicode data sorting locale id
         public const byte ENV_COMPFLAGS = 6;  // Unicode data sorting comparison flags
         public const byte ENV_COLLATION = 7;  // SQL Collation
-        // The following are environment change tokens valid for Yukon or later.
+        // The following are environment change tokens valid for 2005 or later.
         public const byte ENV_BEGINTRAN = 8;  // Transaction began
         public const byte ENV_COMMITTRAN = 9;  // Transaction committed
         public const byte ENV_ROLLBACKTRAN = 10; // Transaction rolled back
@@ -269,7 +269,7 @@ namespace Microsoft.Data.SqlClient
         public const byte SQLVARIANT_SIZE = 2;               // size of the fixed portion of a sql variant (type, cbPropBytes)
         public const byte VERSION_SIZE = 4;               // size of the tds version (4 unsigned bytes)
         public const int CLIENT_PROG_VER = 0x06000000;      // Client interface version
-        public const int YUKON_LOG_REC_FIXED_LEN = 0x5e;
+        public const int SQL2005_LOG_REC_FIXED_LEN = 0x5e;
         // misc
         public const int TEXT_TIME_STAMP_LEN = 8;
         public const int COLLATION_INFO_LEN = 4;
@@ -300,13 +300,13 @@ namespace Microsoft.Data.SqlClient
             0x70000000 -> Sphinx
             0x71000000 -> Shiloh RTM
             0x71000001 -> Shiloh SP1
-            0x72xx0002 -> Yukon RTM
+            0x72xx0002 -> 2005 RTM
 
             Server responds:
             0x07000000 -> Sphinx     // Notice server response format is different for bwd compat
             0x07010000 -> Shiloh RTM // Notice server response format is different for bwd compat
             0x71000001 -> Shiloh SP1
-            0x72xx0002 -> Yukon RTM
+            0x72xx0002 -> 2005 RTM
         */
 
         // Pre Shiloh SP1 versioning scheme:
@@ -319,19 +319,19 @@ namespace Microsoft.Data.SqlClient
 
         // Majors:
         public const int SHILOHSP1_MAJOR = 0x71;     // For Shiloh SP1 and later the versioning schema changed and
-        public const int YUKON_MAJOR = 0x72;     // the high-byte is sufficient to distinguish later versions
+        public const int SQL2005_MAJOR = 0x72;     // the high-byte is sufficient to distinguish later versions
         public const int SQL2008_MAJOR = 0x73;
         public const int DENALI_MAJOR = 0x74;
 
         // Increments:
         public const int SHILOHSP1_INCREMENT = 0x00;
-        public const int YUKON_INCREMENT = 0x09;
+        public const int SQL2005_INCREMENT = 0x09;
         public const int SQL2008_INCREMENT = 0x0b;
         public const int DENALI_INCREMENT = 0x00;
 
         // Minors:
         public const int SHILOHSP1_MINOR = 0x0001;
-        public const int YUKON_RTM_MINOR = 0x0002;
+        public const int SQL2005_RTM_MINOR = 0x0002;
         public const int SQL2008_MINOR = 0x0003;
         public const int DENALI_MINOR = 0x0004;
 
@@ -441,7 +441,7 @@ namespace Microsoft.Data.SqlClient
         public const int SQLINT8 = 0x7f;
         public const int SQLVARIANT = 0x62;
 
-        // The following datatypes are specific to Yukon (version 9) or later
+        // The following datatypes are specific to 2005 (version 9) or later
         public const int SQLXMLTYPE = 0xf1;
         public const int XMLUNICODEBOM = 0xfeff;
         public static readonly byte[] XMLUNICODEBOMBYTES = { 0xff, 0xfe };
@@ -456,7 +456,7 @@ namespace Microsoft.Data.SqlClient
         public const int DEFAULT_VARTIME_SCALE = 7;
 
         //Partially length prefixed datatypes constants. These apply to XMLTYPE, BIGVARCHRTYPE,
-        // NVARCHARTYPE, and BIGVARBINTYPE. Valid for Yukon or later
+        // NVARCHARTYPE, and BIGVARBINTYPE. Valid for 2005 or later
 
         public const ulong SQL_PLP_NULL = 0xffffffffffffffff;        // Represents null value
         public const ulong SQL_PLP_UNKNOWNLEN = 0xfffffffffffffffe;  // Data coming in chunks, total length unknown
@@ -526,7 +526,7 @@ namespace Microsoft.Data.SqlClient
 
         // Batch RPC flags
         public const byte SHILOH_RPCBATCHFLAG = 0x80;
-        public const byte YUKON_RPCBATCHFLAG = 0xFF;
+        public const byte SQL2005_RPCBATCHFLAG = 0xFF;
 
         // RPC flags
         public const byte RPC_RECOMPILE = 0x1;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Data.SqlClient
 
         //    Message types
         public const byte MT_SQL = 1;    // SQL command batch
-        public const byte MT_LOGIN = 2;    // Login message for pre-Sphinx (before version 7.0)
+        public const byte MT_LOGIN = 2;    // Login message for pre-7.0
         public const byte MT_RPC = 3;    // Remote procedure call
         public const byte MT_TOKENS = 4;    // Table response data stream
         public const byte MT_BINARY = 5;    // Unformatted binary response data (UNUSED)
@@ -111,7 +111,7 @@ namespace Microsoft.Data.SqlClient
         public const byte MT_LOGOUT = 13;   // Logout message (UNUSED)
         public const byte MT_TRANS = 14;   // Transaction Manager Interface
         public const byte MT_OLEDB = 15;   // ? (UNUSED)
-        public const byte MT_LOGIN7 = 16;   // Login message for Sphinx (version 7) or later
+        public const byte MT_LOGIN7 = 16;   // Login message for 7.0 or later
         public const byte MT_SSPI = 17;   // SSPI message
         public const byte MT_PRELOGIN = 18;   // Pre-login handshake
 
@@ -297,21 +297,21 @@ namespace Microsoft.Data.SqlClient
         /* Versioning scheme table:
 
             Client sends:
-            0x70000000 -> Sphinx
+            0x70000000 -> 7.0
             0x71000000 -> 2000 RTM
             0x71000001 -> 2000 SP1
             0x72xx0002 -> 2005 RTM
 
             Server responds:
-            0x07000000 -> Sphinx     // Notice server response format is different for bwd compat
+            0x07000000 -> 7.0     // Notice server response format is different for bwd compat
             0x07010000 -> 2000 RTM // Notice server response format is different for bwd compat
             0x71000001 -> 2000 SP1
             0x72xx0002 -> 2005 RTM
         */
 
         // Pre 2000 SP1 versioning scheme:
-        public const int SPHINXOR2000_MAJOR = 0x07;     // The high byte (b3) is not sufficient to distinguish
-        public const int SPHINX_INCREMENT = 0x00;     // Sphinx and 2000
+        public const int SQL70OR2000_MAJOR = 0x07;     // The high byte (b3) is not sufficient to distinguish
+        public const int SQL70_INCREMENT = 0x00;     // 7.0 and 2000
         public const int SQL2000_INCREMENT = 0x01;     // So we need to look at the high-mid byte (b2) as well
         public const int DEFAULT_MINOR = 0x0000;
 
@@ -433,7 +433,7 @@ namespace Microsoft.Data.SqlClient
 
         public const int MAX_NUMERIC_LEN = 0x11; // 17 bytes of data for max numeric/decimal length
         public const int DEFAULT_NUMERIC_PRECISION = 0x1D; // 29 is the default max numeric precision(Decimal.MaxValue) if not user set
-        public const int SPHINX_DEFAULT_NUMERIC_PRECISION = 0x1C; // 28 is the default max numeric precision for Sphinx(Decimal.MaxValue doesn't work for sphinx)
+        public const int SQL70_DEFAULT_NUMERIC_PRECISION = 0x1C; // 28 is the default max numeric precision for 7.0 (Decimal.MaxValue doesn't work for 7.0)
         public const int MAX_NUMERIC_PRECISION = 0x26; // 38 is max numeric precision;
         public const byte UNKNOWN_PRECISION_SCALE = 0xff; // -1 is value for unknown precision or scale
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Data.SqlClient
 
         private bool _isYukon = false; // set to true if speaking to Yukon or later
 
-        private bool _isKatmai = false;
+        private bool _is2008 = false;
 
         private bool _isDenali = false;
 
@@ -393,11 +393,11 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal bool IsKatmaiOrNewer
+        internal bool Is2008OrNewer
         {
             get
             {
-                return _isKatmai;
+                return _is2008;
             }
         }
 
@@ -4073,10 +4073,10 @@ namespace Microsoft.Data.SqlClient
                     { throw SQL.InvalidTDSVersion(); }
                     _isYukon = true;
                     break;
-                case TdsEnums.KATMAI_MAJOR << 24 | TdsEnums.KATMAI_MINOR:
-                    if (increment != TdsEnums.KATMAI_INCREMENT)
+                case TdsEnums.SQL2008_MAJOR << 24 | TdsEnums.SQL2008_MINOR:
+                    if (increment != TdsEnums.SQL2008_INCREMENT)
                     { throw SQL.InvalidTDSVersion(); }
-                    _isKatmai = true;
+                    _is2008 = true;
                     break;
                 case TdsEnums.DENALI_MAJOR << 24 | TdsEnums.DENALI_MINOR:
                     if (increment != TdsEnums.DENALI_INCREMENT)
@@ -4087,8 +4087,8 @@ namespace Microsoft.Data.SqlClient
                     throw SQL.InvalidTDSVersion();
             }
 
-            _isKatmai |= _isDenali;
-            _isYukon |= _isKatmai;
+            _is2008 |= _isDenali;
+            _isYukon |= _is2008;
             _isShilohSP1 |= _isYukon;            // includes all lower versions
             _isShiloh |= _isShilohSP1;        //
 
@@ -9960,7 +9960,7 @@ namespace Microsoft.Data.SqlClient
                             // type (parameter record stores the MetaType class which is a helper that encapsulates all the type information we need here)
                             MetaType mt = param.InternalMetaType;
 
-                            if (mt.IsNewKatmaiType)
+                            if (mt.Is2008Type)
                             {
                                 WriteSmiParameter(param, i, 0 != (rpcext.paramoptions[i] & TdsEnums.RPC_PARAM_DEFAULT), stateObj, enableOptimizedParameterBinding, isAdvancedTraceOn);
                                 continue;
@@ -9968,7 +9968,7 @@ namespace Microsoft.Data.SqlClient
 
                             if ((!_isShiloh && !mt.Is70Supported) ||
                                 (!_isYukon && !mt.Is80Supported) ||
-                                (!_isKatmai && !mt.Is90Supported))
+                                (!_is2008 && !mt.Is90Supported))
                             {
                                 throw ADP.VersionDoesNotSupportDataType(mt.TypeName);
                             }
@@ -10217,7 +10217,7 @@ namespace Microsoft.Data.SqlClient
 
                                     Debug.Assert(_isYukon, "Invalid DataType UDT for non-Yukon or later server!");
 
-                                    int maxSupportedSize = IsKatmaiOrNewer ? int.MaxValue : short.MaxValue;
+                                    int maxSupportedSize = Is2008OrNewer ? int.MaxValue : short.MaxValue;
 
                                     if (!isNull)
                                     {
@@ -10702,7 +10702,7 @@ namespace Microsoft.Data.SqlClient
             ParameterPeekAheadValue peekAhead;
             SmiParameterMetaData metaData = param.MetaDataForSmi(out peekAhead);
 
-            if (!_isKatmai)
+            if (!_is2008)
             {
                 MetaType mt = MetaType.GetMetaTypeFromSqlDbType(metaData.SqlDbType, metaData.IsMultiValued);
                 throw ADP.VersionDoesNotSupportDataType(mt.TypeName);
@@ -10742,7 +10742,7 @@ namespace Microsoft.Data.SqlClient
             {
                 value = param.GetCoercedValue();
                 typeCode = MetaDataUtilsSmi.DetermineExtendedTypeCodeForUseWithSqlDbType(
-                                                    metaData.SqlDbType, metaData.IsMultiValued, value, null, SmiContextFactory.KatmaiVersion);
+                                                    metaData.SqlDbType, metaData.IsMultiValued, value, null, SmiContextFactory.Sql2008Version);
             }
 
             var sendDefaultValue = sendDefault ? 1 : 0;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Data.SqlClient
 
         private bool _is2008 = false;
 
-        private bool _isDenali = false;
+        private bool _is2012 = false;
 
         private byte[] _sniSpnBuffer = null;
 
@@ -458,7 +458,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                return (_isDenali && SqlClientEventSource.Log.IsEnabled());
+                return (_is2012 && SqlClientEventSource.Log.IsEnabled());
             }
         }
 
@@ -4078,16 +4078,16 @@ namespace Microsoft.Data.SqlClient
                     { throw SQL.InvalidTDSVersion(); }
                     _is2008 = true;
                     break;
-                case TdsEnums.DENALI_MAJOR << 24 | TdsEnums.DENALI_MINOR:
-                    if (increment != TdsEnums.DENALI_INCREMENT)
+                case TdsEnums.SQL2012_MAJOR << 24 | TdsEnums.SQL2012_MINOR:
+                    if (increment != TdsEnums.SQL2012_INCREMENT)
                     { throw SQL.InvalidTDSVersion(); }
-                    _isDenali = true;
+                    _is2012 = true;
                     break;
                 default:
                     throw SQL.InvalidTDSVersion();
             }
 
-            _is2008 |= _isDenali;
+            _is2008 |= _is2012;
             _is2005 |= _is2008;
             _isShilohSP1 |= _is2005;            // includes all lower versions
             _isShiloh |= _isShilohSP1;        //
@@ -8947,7 +8947,7 @@ namespace Microsoft.Data.SqlClient
                 WriteInt(length, _physicalStateObj);
                 if (recoverySessionData == null)
                 {
-                    WriteInt((TdsEnums.DENALI_MAJOR << 24) | (TdsEnums.DENALI_INCREMENT << 16) | TdsEnums.DENALI_MINOR, _physicalStateObj);
+                    WriteInt((TdsEnums.SQL2012_MAJOR << 24) | (TdsEnums.SQL2012_INCREMENT << 16) | TdsEnums.SQL2012_MINOR, _physicalStateObj);
                 }
                 else
                 {
@@ -11822,7 +11822,7 @@ namespace Microsoft.Data.SqlClient
         // Write the trace header data, not including the trace header length
         private void WriteTraceHeaderData(TdsParserStateObject stateObj)
         {
-            Debug.Assert(this.IncludeTraceHeader, "WriteTraceHeaderData can only be called on a Denali or higher version server and bid trace with the control bit are on");
+            Debug.Assert(this.IncludeTraceHeader, "WriteTraceHeaderData can only be called on a 2012 or higher version server and bid trace with the control bit are on");
 
             // We may need to update the trace header length if trace header is changed in the future
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -711,7 +711,7 @@ namespace Microsoft.Data.SqlClient
                 status = ConsumePreLoginHandshake(authType, encrypt, trustServerCert, integratedSecurity, serverCallback, clientCallback, 
                                                   out marsCapable, out _connHandler._fedAuthRequired);
 
-                // Don't need to check for Sphinx failure, since we've already consumed
+                // Don't need to check for 7.0 failure, since we've already consumed
                 // one pre-login packet and know we are connecting to 2000.
                 if (status == PreLoginHandshakeStatus.InstanceFailure)
                 {
@@ -4042,21 +4042,21 @@ namespace Microsoft.Data.SqlClient
             UInt32 increment = (a.tdsVersion >> 16) & 0xff;
 
             // Server responds:
-            // 0x07000000 -> Sphinx         // Notice server response format is different for bwd compat
+            // 0x07000000 -> 7.0         // Notice server response format is different for bwd compat
             // 0x07010000 -> 2000 RTM     // Notice server response format is different for bwd compat
             // 0x71000001 -> 2000 SP1
             // 0x72xx0002 -> 2005 RTM
             // information provided by S. Ashwin
             switch (majorMinor)
             {
-                case TdsEnums.SPHINXOR2000_MAJOR << 24 | TdsEnums.DEFAULT_MINOR:    // Sphinx & 2000 RTM
-                    // note that sphinx and 2000 can only be distinguished by the increment
+                case TdsEnums.SQL70OR2000_MAJOR << 24 | TdsEnums.DEFAULT_MINOR:    // 7.0 & 2000 RTM
+                    // note that 7.0 and 2000 can only be distinguished by the increment
                     switch (increment)
                     {
                         case TdsEnums.SQL2000_INCREMENT:
                             _is2000 = true;
                             break;
-                        case TdsEnums.SPHINX_INCREMENT:
+                        case TdsEnums.SQL70_INCREMENT:
                             // no flag will be set
                             break;
                         default:
@@ -4501,7 +4501,7 @@ namespace Microsoft.Data.SqlClient
             rec.type = rec.metaType.SqlDbType;
 
             // always use the nullable type for parameters if 2000 or later
-            // Sphinx sometimes sends fixed length return values
+            // 7.0 sometimes sends fixed length return values
             if (_is2000)
             {
                 rec.tdsType = rec.metaType.NullableType;
@@ -4513,7 +4513,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
             else
-            {      // For sphinx, keep the fixed type if that is what is returned
+            {      // For 7.0, keep the fixed type if that is what is returned
                 if (rec.metaType.NullableType == tdsType)
                     rec.IsNullable = true;
 
@@ -5380,7 +5380,7 @@ namespace Microsoft.Data.SqlClient
             col.metaType = MetaType.GetSqlDataType(tdsType, userType, col.length);
             col.type = col.metaType.SqlDbType;
 
-            // If sphinx, do not change to nullable type
+            // If 7.0, do not change to nullable type
             if (_is2000)
                 col.tdsType = (col.IsNullable ? col.metaType.NullableType : col.metaType.TDSType);
             else
@@ -10324,7 +10324,7 @@ namespace Microsoft.Data.SqlClient
                                     if (_is2000)
                                         stateObj.WriteByte(TdsEnums.DEFAULT_NUMERIC_PRECISION);
                                     else
-                                        stateObj.WriteByte(TdsEnums.SPHINX_DEFAULT_NUMERIC_PRECISION);
+                                        stateObj.WriteByte(TdsEnums.SQL70_DEFAULT_NUMERIC_PRECISION);
                                 }
                                 else
                                     stateObj.WriteByte(precision);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -497,7 +497,7 @@ namespace Microsoft.Data.SqlClient
             flags = value ? flags | flag : flags & ~flag;
         }
 
-        internal bool IsNewKatmaiDateTimeType
+        internal bool Is2008DateTimeType
         {
             get
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -1152,7 +1152,7 @@ namespace Microsoft.Data.SqlClient
     sealed internal class SqlReturnValue : SqlMetaDataPriv
     {
 
-        internal ushort parmIndex;      //Yukon or later only
+        internal ushort parmIndex;      //2005 or later only
         internal string parameter;
         internal readonly SqlBuffer value;
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -516,7 +516,7 @@ namespace Microsoft.Data.SqlClient
             if (isNullCompressed)
             {
                 // assert that NBCROW is not in use by Yukon or before
-                Debug.Assert(_parser.IsKatmaiOrNewer, "NBCROW is sent by pre-Katmai server");
+                Debug.Assert(_parser.Is2008OrNewer, "NBCROW is sent by pre-2008 server");
 
                 if (!_nullBitmapInfo.TryInitialize(this, nullBitmapColumnsCount))
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Data.SqlClient
         internal ulong _longlen;                                     // plp data length indicator
         internal ulong _longlenleft;                                 // Length of data left to read (64 bit lengths)
         internal int[] _decimalBits = null;                // scratch buffer for decimal/numeric data
-        internal byte[] _bTmp = new byte[TdsEnums.YUKON_HEADER_LEN];  // Scratch buffer for misc use
+        internal byte[] _bTmp = new byte[TdsEnums.SQL2005_HEADER_LEN];  // Scratch buffer for misc use
         internal int _bTmpRead = 0;                   // Counter for number of temporary bytes read
         internal Decoder _plpdecoder = null;             // Decoder object to process plp character data
         internal bool _accumulateInfoEvents = false;               // TRUE - accumulate info messages during TdsParser.Run, FALSE - fire them
@@ -515,7 +515,7 @@ namespace Microsoft.Data.SqlClient
             // initialize or unset null bitmap information for the current row
             if (isNullCompressed)
             {
-                // assert that NBCROW is not in use by Yukon or before
+                // assert that NBCROW is not in use by 2005 or before
                 Debug.Assert(_parser.Is2008OrNewer, "NBCROW is sent by pre-2008 server");
 
                 if (!_nullBitmapInfo.TryInitialize(this, nullBitmapColumnsCount))
@@ -1306,7 +1306,7 @@ namespace Microsoft.Data.SqlClient
                           "SetPacketSize should only be called on a stateObj with null buffers on the physicalStateObj!");
             Debug.Assert(_inBuff == null
                           ||
-                          (_parser.IsYukonOrNewer &&
+                          (_parser.Is2005OrNewer &&
                            _outBytesUsed == (_outputHeaderLen + BitConverter.ToInt32(_outBuff, _outputHeaderLen)) &&
                            _outputPacketNumber == 1)
                           ||
@@ -3373,9 +3373,9 @@ namespace Microsoft.Data.SqlClient
             }
 
             if (
-                // This appears to be an optimization to avoid writing empty packets in Yukon
-                // However, since we don't know the version prior to login IsYukonOrNewer was always false prior to login
-                // So removing the IsYukonOrNewer check causes issues since the login packet happens to meet the rest of the conditions below
+                // This appears to be an optimization to avoid writing empty packets in 2005
+                // However, since we don't know the version prior to login Is2005OrNewer was always false prior to login
+                // So removing the Is2005OrNewer check causes issues since the login packet happens to meet the rest of the conditions below
                 // So we need to avoid this check prior to login completing
                 state == TdsParserState.OpenLoggedIn &&
                 !_bulkCopyOpperationInProgress // ignore the condition checking for bulk copy (SQL BU 414551)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
@@ -286,7 +286,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // Always ensure we're zombied; 2005 will send an EnvChange that
                     // will cause the zombie, but only if we actually go to the wire;
-                    // Sphinx and Shiloh won't send the env change, so we have to handle
+                    // Sphinx and 2000 won't send the env change, so we have to handle
                     // them ourselves.
                     Zombie();
                 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Data.SqlClient
                 TdsParser.ReliabilitySection.Assert("unreliable call to CloseFromConnection");  // you need to setup for a thread abort somewhere before you call this method
                 if (processFinallyBlock)
                 {
-                    // Always ensure we're zombied; Yukon will send an EnvChange that
+                    // Always ensure we're zombied; 2005 will send an EnvChange that
                     // will cause the zombie, but only if we actually go to the wire;
                     // Sphinx and Shiloh won't send the env change, so we have to handle
                     // them ourselves.
@@ -311,10 +311,10 @@ namespace Microsoft.Data.SqlClient
                     // simply commits the transaction from the most recent BEGIN, nested or otherwise.
                     _innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, IsolationLevel.Unspecified, null, false);
 
-                    // SQL BU DT 291159 - perform full Zombie on pre-Yukon, but do not actually
-                    // complete internal transaction until informed by server in the case of Yukon
+                    // SQL BU DT 291159 - perform full Zombie on pre-2005, but do not actually
+                    // complete internal transaction until informed by server in the case of 2005
                     // or later.
-                    if (!IsZombied && !_innerConnection.IsYukonOrNewer)
+                    if (!IsZombied && !_innerConnection.Is2005OrNewer)
                     {
                         // Since nested transactions are no longer allowed, set flag to false.
                         // This transaction has been completed.
@@ -483,10 +483,10 @@ namespace Microsoft.Data.SqlClient
                 {
                     _innerConnection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Rollback, transactionName, IsolationLevel.Unspecified, null, false);
 
-                    if (!IsZombied && !_innerConnection.IsYukonOrNewer)
+                    if (!IsZombied && !_innerConnection.Is2005OrNewer)
                     {
                         // Check if Zombied before making round-trip to server.
-                        // Against Yukon we receive an envchange on the ExecuteTransaction above on the
+                        // Against 2005 we receive an envchange on the ExecuteTransaction above on the
                         // parser that calls back into SqlTransaction for the Zombie() call.
                         CheckTransactionLevelAndZombie();
                     }
@@ -545,7 +545,7 @@ namespace Microsoft.Data.SqlClient
 
             // NOTE: we'll be called from the TdsParser when it gets appropriate
             // ENVCHANGE events that indicate the transaction has completed, however
-            // we cannot rely upon those events occuring in the case of pre-Yukon
+            // we cannot rely upon those events occuring in the case of pre-2005
             // servers (and when we don't go to the wire because the connection
             // is broken) so we can also be called from the Commit/Rollback/Save
             // methods to handle that case as well.

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/sqlinternaltransaction.cs
@@ -286,7 +286,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // Always ensure we're zombied; 2005 will send an EnvChange that
                     // will cause the zombie, but only if we actually go to the wire;
-                    // Sphinx and 2000 won't send the env change, so we have to handle
+                    // 7.0 and 2000 won't send the env change, so we have to handle
                     // them ourselves.
                     Zombie();
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.netfx.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.SqlClient.Server
         private object GetValueFrameworkSpecific(int ordinal)
         {
             SmiMetaData metaData = GetSmiMetaData(ordinal);
-            if (SmiVersion >= SmiContextFactory.KatmaiVersion)
+            if (SmiVersion >= SmiContextFactory.Sql2008Version)
             {
                 return ValueUtilsSmi.GetValue200(_eventSink, _recordBuffer, ordinal, metaData, _recordContext);
             }
@@ -43,7 +43,7 @@ namespace Microsoft.Data.SqlClient.Server
         private object GetSqlValueFrameworkSpecific(int ordinal)
         {
             SmiMetaData metaData = GetSmiMetaData(ordinal);
-            if (SmiVersion >= SmiContextFactory.KatmaiVersion)
+            if (SmiVersion >= SmiContextFactory.Sql2008Version)
             {
                 return ValueUtilsSmi.GetSqlValue200(_eventSink, _recordBuffer, ordinal, metaData, _recordContext);
             }
@@ -89,7 +89,7 @@ namespace Microsoft.Data.SqlClient.Server
             //      the validation loop and here, or if an invalid UDT was sent).
             for (int i = 0; i < copyLength; i++)
             {
-                if (SmiVersion >= SmiContextFactory.KatmaiVersion)
+                if (SmiVersion >= SmiContextFactory.Sql2008Version)
                 {
                     ValueUtilsSmi.SetCompatibleValueV200(_eventSink, _recordBuffer, i, GetSmiMetaData(i), values[i], typeCodes[i], offset: 0, length: 0, peekAhead: null);
                 }
@@ -117,7 +117,7 @@ namespace Microsoft.Data.SqlClient.Server
                 throw ADP.InvalidCast();
             }
 
-            if (SmiVersion >= SmiContextFactory.KatmaiVersion)
+            if (SmiVersion >= SmiContextFactory.Sql2008Version)
             {
                 ValueUtilsSmi.SetCompatibleValueV200(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value, typeCode, offset: 0, length: 0, peekAhead: null);
             }
@@ -127,8 +127,8 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
   
-        private void SetTimeSpanFrameworkSpecific(int ordinal, TimeSpan value) => ValueUtilsSmi.SetTimeSpan(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value, SmiVersion >= SmiContextFactory.KatmaiVersion);
-        private void SetDateTimeOffsetFrameworkSpecific(int ordinal, DateTimeOffset value) => ValueUtilsSmi.SetDateTimeOffset(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value, SmiVersion >= SmiContextFactory.KatmaiVersion);
+        private void SetTimeSpanFrameworkSpecific(int ordinal, TimeSpan value) => ValueUtilsSmi.SetTimeSpan(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value, SmiVersion >= SmiContextFactory.Sql2008Version);
+        private void SetDateTimeOffsetFrameworkSpecific(int ordinal, DateTimeOffset value) => ValueUtilsSmi.SetDateTimeOffset(_eventSink, _recordBuffer, ordinal, GetSmiMetaData(ordinal), value, SmiVersion >= SmiContextFactory.Sql2008Version);
 
         private ulong SmiVersion => InOutOfProcHelper.InProc ? SmiContextFactory.Instance.NegotiatedSmiVersion : SmiContextFactory.LatestVersion;
     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
@@ -812,7 +812,7 @@ namespace Microsoft.Data.SqlClient.Server
             _sortOrdinal = sortOrdinal;
         }
 
-        // Construction for Decimal type and new Katmai Date/Time types
+        // Construction for Decimal type and new 2008 Date/Time types
         private void Construct(
             string name, 
             SqlDbType dbType, 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlUserDefinedTypeAttribute.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlUserDefinedTypeAttribute.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Data.SqlClient.Server
         private string _name;
 
         // The maximum value for the maxbytesize field, in bytes.
-        internal const int YukonMaxByteSizeValue = 8000;
+        internal const int Sql2005MaxByteSizeValue = 8000;
         private string _validationMethodName = null;
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlUserDefinedTypeAttribute.xml' path='docs/members[@name="SqlUserDefinedTypeAttribute"]/ctor/*' />

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
@@ -248,9 +248,9 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // calling GetDateTimeOffset on possibly v100 SMI
-        internal static DateTimeOffset GetDateTimeOffset(SmiEventSink_Default sink, ITypedGettersV3 getters, int ordinal, SmiMetaData metaData, bool gettersSupportKatmaiDateTime)
+        internal static DateTimeOffset GetDateTimeOffset(SmiEventSink_Default sink, ITypedGettersV3 getters, int ordinal, SmiMetaData metaData, bool gettersSupport2008DateTime)
         {
-            if (gettersSupportKatmaiDateTime)
+            if (gettersSupport2008DateTime)
             {
                 return GetDateTimeOffset(sink, (SmiTypedGetterSetter)getters, ordinal, metaData);
             }
@@ -1032,7 +1032,7 @@ namespace Microsoft.Data.SqlClient.Server
                 );
         }
 
-        // GetValue() for v200 SMI (new Katmai Date/Time types)
+        // GetValue() for v200 SMI (2008 Date/Time types)
         internal static object GetValue200(
             SmiEventSink_Default sink,
             SmiTypedGetterSetter getters,
@@ -1521,12 +1521,12 @@ namespace Microsoft.Data.SqlClient.Server
 
         internal static void SetDateTimeOffset(SmiEventSink_Default sink, ITypedSettersV3 setters, int ordinal, SmiMetaData metaData, DateTimeOffset value
 #if NETFRAMEWORK
-            , bool settersSupportKatmaiDateTime
+            , bool settersSupport2008DateTime
 #endif
             )
         {
 #if NETFRAMEWORK
-            if (!settersSupportKatmaiDateTime)
+            if (!settersSupport2008DateTime)
             {
                 throw ADP.InvalidCast();
             }
@@ -1702,12 +1702,12 @@ namespace Microsoft.Data.SqlClient.Server
 
         internal static void SetTimeSpan(SmiEventSink_Default sink, ITypedSettersV3 setters, int ordinal, SmiMetaData metaData, TimeSpan value
 #if NETFRAMEWORK
-            , bool settersSupportKatmaiDateTime
+            , bool settersSupport2008DateTime
 #endif
             )
         {
 #if NETFRAMEWORK
-            if (!settersSupportKatmaiDateTime)
+            if (!settersSupport2008DateTime)
             {
                 throw ADP.InvalidCast();
             }
@@ -1870,7 +1870,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
-        // VSTFDevDiv#479681 - Data corruption when sending Katmai Date types to the server via TVP
+        // VSTFDevDiv#479681 - Data corruption when sending 2008 Date types to the server via TVP
         // Ensures proper handling on DateTime2 sub type for Sql_Variants and TVPs.
         internal static void SetCompatibleValueV200(
             SmiEventSink_Default sink,
@@ -2218,9 +2218,9 @@ namespace Microsoft.Data.SqlClient.Server
                                 }
                                 ExtendedClrTypeCode typeCode = MetaDataUtilsSmi.DetermineExtendedTypeCodeForUseWithSqlDbType(metaData[i].SqlDbType, metaData[i].IsMultiValued, o, null
 #if NETFRAMEWORK
-                                    ,// TODO: this version works for shipping Orcas, since only Katmai (TVP) codepath calls this method at this time.
-                                    //      Need a better story for smi versioning of ValueUtilsSmi post-Orcas
-                                    SmiContextFactory.KatmaiVersion
+                                    ,// TODO: this version works for shipping Orcas, since only 2008 (TVP) codepath calls this method at this time.
+                                     //      Need a better story for smi versioning of ValueUtilsSmi post-Orcas
+                                    SmiContextFactory.Sql2008Version
 #endif
                                     );
                                 if ((storageType == SqlBuffer.StorageType.DateTime2) || (storageType == SqlBuffer.StorageType.Date))
@@ -4087,9 +4087,9 @@ namespace Microsoft.Data.SqlClient.Server
                             cellTypes[i] = MetaDataUtilsSmi.DetermineExtendedTypeCodeForUseWithSqlDbType(
                                     fieldMetaData.SqlDbType, fieldMetaData.IsMultiValued, cellValue, fieldMetaData.Type
 #if NETFRAMEWORK
-                                   ,// TODO: this version works for shipping Orcas, since only Katmai supports TVPs at this time.
+                                   ,// TODO: this version works for shipping Orcas, since only 2008 supports TVPs at this time.
                                     //      Need a better story for smi versioning of ValueUtilsSmi post-Orcas
-                                    SmiContextFactory.KatmaiVersion
+                                    SmiContextFactory.Sql2008Version
 #endif
                                     );
                         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
@@ -1906,7 +1906,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
-        //  Implements SqlClient 2.0-compatible SetValue() semantics + Orcas extensions
+        //  Implements SqlClient 2.0-compatible SetValue() semantics + VS2008 extensions
         //      Assumes caller already validated basic type against the metadata, other than trimming lengths and 
         //      checking individual field values (TVPs)
         internal static void SetCompatibleValueV200(
@@ -2218,8 +2218,8 @@ namespace Microsoft.Data.SqlClient.Server
                                 }
                                 ExtendedClrTypeCode typeCode = MetaDataUtilsSmi.DetermineExtendedTypeCodeForUseWithSqlDbType(metaData[i].SqlDbType, metaData[i].IsMultiValued, o, null
 #if NETFRAMEWORK
-                                    ,// TODO: this version works for shipping Orcas, since only 2008 (TVP) codepath calls this method at this time.
-                                     //      Need a better story for smi versioning of ValueUtilsSmi post-Orcas
+                                    ,// TODO: this version works for shipping VS2008, since only 2008 (TVP) codepath calls this method at this time.
+                                     //      Need a better story for smi versioning of ValueUtilsSmi post-VS2008
                                     SmiContextFactory.Sql2008Version
 #endif
                                     );
@@ -4087,8 +4087,8 @@ namespace Microsoft.Data.SqlClient.Server
                             cellTypes[i] = MetaDataUtilsSmi.DetermineExtendedTypeCodeForUseWithSqlDbType(
                                     fieldMetaData.SqlDbType, fieldMetaData.IsMultiValued, cellValue, fieldMetaData.Type
 #if NETFRAMEWORK
-                                   ,// TODO: this version works for shipping Orcas, since only 2008 supports TVPs at this time.
-                                    //      Need a better story for smi versioning of ValueUtilsSmi post-Orcas
+                                   ,// TODO: this version works for shipping VS2008, since only 2008 supports TVPs at this time.
+                                    //      Need a better story for smi versioning of ValueUtilsSmi post-VS2008
                                     SmiContextFactory.Sql2008Version
 #endif
                                     );

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
@@ -116,9 +116,9 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         // calling GetTimeSpan on possibly v100 SMI
-        internal static TimeSpan GetTimeSpan(SmiEventSink_Default sink, ITypedGettersV3 getters, int ordinal, SmiMetaData metaData, bool gettersSupportKatmaiDateTime)
+        internal static TimeSpan GetTimeSpan(SmiEventSink_Default sink, ITypedGettersV3 getters, int ordinal, SmiMetaData metaData, bool gettersSupport2008DateTime)
         {
-            if (gettersSupportKatmaiDateTime)
+            if (gettersSupport2008DateTime)
             {
                 return GetTimeSpan(sink, (SmiTypedGetterSetter)getters, ordinal, metaData);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCollation.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCollation.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Data.SqlClient
             int lcidValue = lcid & (int)MaskLcid;
             Debug.Assert(lcidValue == lcid, "invalid set_LCID value");
 
-            // Some new Katmai LCIDs do not have collation with version = 0
+            // Some 2008 LCIDs do not have collation with version = 0
             // since user has no way to specify collation version, we set the first (minimal) supported version for these collations
             int versionBits = FirstSupportedCollationVersion(lcidValue) << LcidVersionBitOffset;
             Debug.Assert((versionBits & MaskLcidVersion) == versionBits, "invalid version returned by FirstSupportedCollationVersion");

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlEnums.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Data.SqlClient
         internal readonly bool IsCharType;
         internal readonly bool IsNCharType;
         internal readonly bool IsSizeInCharacters;
-        internal readonly bool IsNewKatmaiType;
+        internal readonly bool Is2008Type;
         internal readonly bool IsVarTime;
 
         internal readonly bool Is70Supported;
@@ -79,7 +79,7 @@ namespace Microsoft.Data.SqlClient
             IsCharType = _IsCharType(sqldbType);
             IsNCharType = _IsNCharType(sqldbType);
             IsSizeInCharacters = _IsSizeInCharacters(sqldbType);
-            IsNewKatmaiType = _IsNewKatmaiType(sqldbType);
+            Is2008Type = _Is2008Type(sqldbType);
             IsVarTime = _IsVarTime(sqldbType);
 
             Is70Supported = _Is70Supported(SqlDbType);
@@ -145,7 +145,7 @@ namespace Microsoft.Data.SqlClient
             SqlDbType.DateTime2 == type ||
             SqlDbType.DateTimeOffset == type;
 
-        private static bool _IsNewKatmaiType(SqlDbType type) => SqlDbType.Structured == type;
+        private static bool _Is2008Type(SqlDbType type) => SqlDbType.Structured == type;
 
         internal static bool _IsVarTime(SqlDbType type) =>
             type == SqlDbType.Time || type == SqlDbType.DateTime2 || type == SqlDbType.DateTimeOffset;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlMetadataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlMetadataFactory.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.SqlClient
                 "from sys.assemblies as assemblies  join sys.assembly_types as types " +
                 "on assemblies.assembly_id = types.assembly_id ";
 
-            // pre 9.0/Yukon servers do not have UDTs
+            // pre 9.0/2005 servers do not have UDTs
             if (0 > string.Compare(ServerVersion, ServerVersionNormalized90, StringComparison.OrdinalIgnoreCase))
             {
                 return;
@@ -176,7 +176,7 @@ namespace Microsoft.Data.SqlClient
                 "where is_table_type = 1";
 
             // TODO: update this check once the server upgrades major version number!!!
-            // pre 9.0/Yukon servers do not have Table types
+            // pre 9.0/2005 servers do not have Table types
             if (0 > string.Compare(ServerVersion, ServerVersionNormalized10, StringComparison.OrdinalIgnoreCase))
             {
                 return;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private static string s_connStr;
 
         /// <summary>
-        /// Tests all Katmai DateTime types inside sql_variant to server using sql_variant parameter, SqlBulkCopy, and TVP parameter with sql_variant inside.
+        /// Tests all 2008 DateTime types inside sql_variant to server using sql_variant parameter, SqlBulkCopy, and TVP parameter with sql_variant inside.
         /// </summary>
         public static void TestAllDateTimeWithDataTypeAndVariant(string connStr)
         {
@@ -110,7 +110,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         // sql_variant parameters and sql_variant TVPs store all datetime values internally
-        // as datetime, hence breaking for katmai types
+        // as datetime, hence breaking for 2008 types
         private static void TestSimpleParameter_Variant(object paramValue, string expectedTypeName, string expectedBaseTypeName)
         {
             string tag = "TestSimpleParameter_Variant";
@@ -195,7 +195,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         // sql_variant parameters and sql_variant TVPs store all datetime values internally
-        // as datetime, hence breaking for katmai types
+        // as datetime, hence breaking for 2008 types
         private static void TestSqlDataRecordParameterToTVP_Variant(object paramValue, string expectedTypeName, string expectedBaseTypeName)
         {
             string tag = "TestSqlDataRecordParameterToTVP_Variant";
@@ -290,7 +290,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         // sql_variant parameters and sql_variant TVPs store all datetime values internally
-        // as datetime, hence breaking for katmai types
+        // as datetime, hence breaking for 2008 types
         private static void TestSqlDataReaderParameterToTVP_Variant(object paramValue, string expectedTypeName, string expectedBaseTypeName)
         {
             string tag = "TestSqlDataReaderParameterToTVP_Variant";
@@ -342,7 +342,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         // sql_variant parameters and sql_variant TVPs store all datetime values internally
-        // as datetime, hence breaking for katmai types
+        // as datetime, hence breaking for 2008 types
         private static void TestSqlDataReader_TVP_Type(object paramValue, string expectedTypeName, string expectedBaseTypeName)
         {
             string tag = "TestSqlDataReader_TVP_Type";
@@ -507,7 +507,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         // sql_variant parameters and sql_variant TVPs store all datetime values internally
-        // as datetime, hence breaking for katmai types
+        // as datetime, hence breaking for 2008 types
         private static void TestSimpleDataReader_Type(object paramValue, string expectedTypeName, string expectedBaseTypeName)
         {
             string tag = "TestSimpleDataReader_Type";
@@ -831,7 +831,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         // sql_variant parameters and sql_variant TVPs store all datetime values internally
-        // as datetime, hence breaking for katmai types
+        // as datetime, hence breaking for 2008 types
         private static void SqlBulkCopyDataTable_Variant(object paramValue, string expectedTypeName, string expectedBaseTypeName)
         {
             string tag = "SqlBulkCopyDataTable_Variant";
@@ -936,7 +936,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         // sql_variant parameters and sql_variant TVPs store all datetime values internally
-        // as datetime, hence breaking for katmai types
+        // as datetime, hence breaking for 2008 types
         private static void SqlBulkCopyDataRow_Variant(object paramValue, string expectedTypeName, string expectedBaseTypeName)
         {
             string tag = "SqlBulkCopyDataRow_Variant";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private string _operationCanceledErrorMessage;
         private string _severeErrorMessage;
 
-        private SqlRandomTypeInfoCollection _katmaiTypes;
+        private SqlRandomTypeInfoCollection _2008Types;
         private ManualResetEvent _endEvent;
         private int _runningThreads;
 
@@ -59,7 +59,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             _connectionStrings = connStrings.ToArray();
 
-            _katmaiTypes = SqlRandomTypeInfoCollection.CreateSql2008Collection();
+            _2008Types = SqlRandomTypeInfoCollection.CreateSql2008Collection();
             _endEvent = new ManualResetEvent(false);
 
             if (_randPool.ReproMode)
@@ -110,7 +110,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             using (var testScope = rootScope.NewScope<SqlRandomizer>())
                             {
                                 // run only once if repro file is provided
-                                RunTest(con, testScope, _katmaiTypes, watch);
+                                RunTest(con, testScope, _2008Types, watch);
                             }
                         }
                         else
@@ -119,7 +119,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             {
                                 using (var testScope = rootScope.NewScope<SqlRandomizer>())
                                 {
-                                    RunTest(con, testScope, _katmaiTypes, watch);
+                                    RunTest(con, testScope, _2008Types, watch);
                                 }
 
                                 if (rootScope.Current.Next(100) == 0)

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDSVersion.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDSVersion.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SqlServer.TDS
     public static class TDSVersion
     {
         /// <summary>
-        /// Yukon TDS version
+        /// 2005 (Yukon) TDS version
         /// </summary>
         public static Version SqlServer2005 = new Version(7, 2, 9, 2);
 
@@ -22,7 +22,7 @@ namespace Microsoft.SqlServer.TDS
         public static Version SqlServer2008 = new Version(7, 3, 11, 3);
 
         /// <summary>
-        /// Denali TDS version
+        /// 2012 (Denali) TDS version
         /// </summary>
         public static Version SqlServer2010 = new Version(7, 4, 0, 4);
 
@@ -36,7 +36,6 @@ namespace Microsoft.SqlServer.TDS
             // Check build version Major part
             if (buildVersion.Major == 11)
             {
-                // Denali
                 return SqlServer2010;
             }
             else if (buildVersion.Major == 10)
@@ -45,7 +44,6 @@ namespace Microsoft.SqlServer.TDS
             }
             else if (buildVersion.Major == 9)
             {
-                // Yukon
                 return SqlServer2005;
             }
             else

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDSVersion.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDSVersion.cs
@@ -24,7 +24,7 @@ namespace Microsoft.SqlServer.TDS
         /// <summary>
         /// 2012 (Denali) TDS version
         /// </summary>
-        public static Version SqlServer2010 = new Version(7, 4, 0, 4);
+        public static Version SqlServer2012 = new Version(7, 4, 0, 4);
 
         /// <summary>
         /// Map SQL Server build version to TDS version
@@ -36,7 +36,7 @@ namespace Microsoft.SqlServer.TDS
             // Check build version Major part
             if (buildVersion.Major == 11)
             {
-                return SqlServer2010;
+                return SqlServer2012;
             }
             else if (buildVersion.Major == 10)
             {
@@ -79,7 +79,7 @@ namespace Microsoft.SqlServer.TDS
         /// </summary>
         public static bool IsSupported(Version tdsVersion)
         {
-            return tdsVersion >= SqlServer2005 && tdsVersion <= SqlServer2010;
+            return tdsVersion >= SqlServer2005 && tdsVersion <= SqlServer2012;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDSVersion.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDSVersion.cs
@@ -17,7 +17,7 @@ namespace Microsoft.SqlServer.TDS
         public static Version SqlServer2005 = new Version(7, 2, 9, 2);
 
         /// <summary>
-        /// Katmai TDS version
+        /// 2008 (Katmai) TDS version
         /// </summary>
         public static Version SqlServer2008 = new Version(7, 3, 11, 3);
 
@@ -41,7 +41,6 @@ namespace Microsoft.SqlServer.TDS
             }
             else if (buildVersion.Major == 10)
             {
-                // Katmai
                 return SqlServer2008;
             }
             else if (buildVersion.Major == 9)


### PR DESCRIPTION
Take 2 of https://github.com/dotnet/SqlClient/pull/1334 from a clean main to fix weird things going on.
Each rename is an individual commit. I only did the main library not the tests and i didn't change the resource names. If they're important they can be done separately.