### PR TITLE
Prevent subtype element in project files

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
@@ -16,7 +16,7 @@ using Microsoft.Data.Sql;
 namespace Microsoft.Data.SqlClient
 {
     /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommandBuilder.xml' path='docs/members[@name="SqlCommandBuilder"]/SqlCommandBuilder/*'/>
-    [DesignerCategory()]
+    [DesignerCategory("")]
     public sealed class SqlCommandBuilder : DbCommandBuilder
     {
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommandBuilder.xml' path='docs/members[@name="SqlCommandBuilder"]/ctor1/*'/>


### PR DESCRIPTION
An empty `[DesignerCategory()]` causes to generate SubType element for the file in some cases. Replacing it with `[DesignerCategory("")]` prevents this behaviour. 

/ cc @Kaur-Parminder 