### PR TITLE
Test | Add lock when using ClearSqlConnectionGlobalProviders

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/ExceptionRegisterKeyStoreProvider.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/ExceptionRegisterKeyStoreProvider.cs
@@ -85,21 +85,24 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         [Fact]
         public void TestCanSetGlobalProvidersOnlyOnce()
         {
-            Utility.ClearSqlConnectionGlobalProviders();
+            lock (Utility.ClearSqlConnectionGlobalProvidersLock)
+            {
+                Utility.ClearSqlConnectionGlobalProviders();
 
-            IDictionary<string, SqlColumnEncryptionKeyStoreProvider> customProviders =
-                new Dictionary<string, SqlColumnEncryptionKeyStoreProvider>()
-                {
+                IDictionary<string, SqlColumnEncryptionKeyStoreProvider> customProviders =
+                    new Dictionary<string, SqlColumnEncryptionKeyStoreProvider>()
+                    {
                     { DummyKeyStoreProvider.Name, new DummyKeyStoreProvider() }
-                };
-            SqlConnection.RegisterColumnEncryptionKeyStoreProviders(customProviders);
+                    };
+                SqlConnection.RegisterColumnEncryptionKeyStoreProviders(customProviders);
 
-            InvalidOperationException e = Assert.Throws<InvalidOperationException>(
-                () => SqlConnection.RegisterColumnEncryptionKeyStoreProviders(customProviders));
-            string expectedMessage = SystemDataResourceManager.Instance.TCE_CanOnlyCallOnce;
-            Assert.Contains(expectedMessage, e.Message);
+                InvalidOperationException e = Assert.Throws<InvalidOperationException>(
+                    () => SqlConnection.RegisterColumnEncryptionKeyStoreProviders(customProviders));
+                string expectedMessage = SystemDataResourceManager.Instance.TCE_CanOnlyCallOnce;
+                Assert.Contains(expectedMessage, e.Message);
 
-            Utility.ClearSqlConnectionGlobalProviders();
+                Utility.ClearSqlConnectionGlobalProviders();
+            }
         }
 
         [Fact]

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/Utility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/Utility.cs
@@ -402,9 +402,11 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             return str.ToString();
         }
 
+        internal static object ClearSqlConnectionGlobalProvidersLock = new();
+
         /// <summary>
         /// Through reflection, clear the static provider list set on SqlConnection. 
-        /// Note- This API doesn't use locks for synchronization.
+        /// Note- Any test using this method should be wrapped in a lock statement using ClearSqlConnectionGlobalProvidersLock
         /// </summary>
         internal static void ClearSqlConnectionGlobalProviders()
         {


### PR DESCRIPTION
`s_globalCustomColumnEncryptionKeyStoreProviders` can only be set once using `SqlConnection.RegisterColumnEncryptionKeyStoreProviders()`. It has to be cleared after any test sets it, so that other tests can set it again. Because the functional tests run in parallel, we sometimes see a `Key store providers cannot be set more than once.` error. We can add a lock to ensure only one test at a time is setting and clearing `s_globalCustomColumnEncryptionKeyStoreProviders`.

Repro: 

https://github.com/johnnypham/SqlClient/tree/testfailurerepro

Run the two tests with the appropriate filter: 
```bash
dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj" -p:Platform="AnyCPU" -p:ReferenceType=Project -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" --no-build --logger:"console;verbosity=normal" --filter "TestCanSetGlobalProvidersOnlyOnce|TestExceptionsFromCustomKeyStore"


