### PR TITLE
Test | Improve MaxPoolWaitForConnectionTest waiting time

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -185,8 +185,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             ManualResetEventSlim taskAllowedToSpeak = new ManualResetEventSlim(false);
 
             Task waitTask = Task.Factory.StartNew(() => MaxPoolWaitForConnectionTask(newConnectionString, internalConnection, connectionPool, taskAllowedToSpeak));
-            int cnt = 5;
-            while (waitTask.Status == TaskStatus.WaitingToRun && cnt-- > 0)
+            int count = 5;
+            while (waitTask.Status == TaskStatus.WaitingToRun && count-- > 0)
             {
                 Thread.Sleep(200);
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -185,7 +185,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             ManualResetEventSlim taskAllowedToSpeak = new ManualResetEventSlim(false);
 
             Task waitTask = Task.Factory.StartNew(() => MaxPoolWaitForConnectionTask(newConnectionString, internalConnection, connectionPool, taskAllowedToSpeak));
-            Thread.Sleep(200);
+            int cnt = 5;
+            while (waitTask.Status == TaskStatus.WaitingToRun && cnt-- > 0)
+            {
+                Thread.Sleep(200);
+            }
             Assert.Equal(TaskStatus.Running, waitTask.Status);
 
             connection1.Close();


### PR DESCRIPTION
Increased Thread.Sleep period to MaxPoolWaitForConnectionTest to address intermittent failures on pipeline.
https://dev.azure.com/sqlclientdrivers-ci/sqlclient/_build/results?buildId=45332&view=ms.vss-test-web.build-test-results-tab