### PR TITLE
[Hotfix 4.0.1] | Update obsolete api calls in .NET 6 (#1401)

### DIFF
--- a/doc/samples/AzureKeyVaultProviderExample.cs
+++ b/doc/samples/AzureKeyVaultProviderExample.cs
@@ -130,8 +130,8 @@ namespace Microsoft.Data.SqlClient.Samples
         private static string GetEncryptedValue(SqlColumnEncryptionAzureKeyVaultProvider sqlColumnEncryptionAzureKeyVaultProvider)
         {
             byte[] plainTextColumnEncryptionKey = new byte[32];
-            RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
-            rngCsp.GetBytes(plainTextColumnEncryptionKey);
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(plainTextColumnEncryptionKey);
 
             byte[] encryptedColumnEncryptionKey = sqlColumnEncryptionAzureKeyVaultProvider.EncryptColumnEncryptionKey(s_akvUrl, s_algorithm, plainTextColumnEncryptionKey);
             string EncryptedValue = string.Concat("0x", BitConverter.ToString(encryptedColumnEncryptionKey).Replace("-", string.Empty));

--- a/doc/samples/AzureKeyVaultProviderExample_2_0.cs
+++ b/doc/samples/AzureKeyVaultProviderExample_2_0.cs
@@ -118,8 +118,8 @@ namespace Microsoft.Data.SqlClient.Samples
         private static string GetEncryptedValue(SqlColumnEncryptionAzureKeyVaultProvider sqlColumnEncryptionAzureKeyVaultProvider)
         {
             byte[] plainTextColumnEncryptionKey = new byte[32];
-            RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
-            rngCsp.GetBytes(plainTextColumnEncryptionKey);
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(plainTextColumnEncryptionKey);
 
             byte[] encryptedColumnEncryptionKey = sqlColumnEncryptionAzureKeyVaultProvider.EncryptColumnEncryptionKey(s_akvUrl, s_algorithm, plainTextColumnEncryptionKey);
             string EncryptedValue = string.Concat("0x", BitConverter.ToString(encryptedColumnEncryptionKey).Replace("-", string.Empty));

--- a/doc/samples/AzureKeyVaultProviderLegacyExample_2_0.cs
+++ b/doc/samples/AzureKeyVaultProviderLegacyExample_2_0.cs
@@ -116,8 +116,8 @@ namespace Microsoft.Data.SqlClient.Samples
         private static string GetEncryptedValue(SqlColumnEncryptionAzureKeyVaultProvider sqlColumnEncryptionAzureKeyVaultProvider)
         {
             byte[] plainTextColumnEncryptionKey = new byte[32];
-            RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
-            rngCsp.GetBytes(plainTextColumnEncryptionKey);
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(plainTextColumnEncryptionKey);
 
             byte[] encryptedColumnEncryptionKey = sqlColumnEncryptionAzureKeyVaultProvider.EncryptColumnEncryptionKey(s_akvUrl, s_algorithm, plainTextColumnEncryptionKey);
             string EncryptedValue = string.Concat("0x", BitConverter.ToString(encryptedColumnEncryptionKey).Replace("-", string.Empty));

--- a/doc/samples/AzureKeyVaultProviderWithEnclaveProviderExample.cs
+++ b/doc/samples/AzureKeyVaultProviderWithEnclaveProviderExample.cs
@@ -136,8 +136,8 @@ namespace AKVEnclaveExample
         private static string GetEncryptedValue(SqlColumnEncryptionAzureKeyVaultProvider sqlColumnEncryptionAzureKeyVaultProvider)
         {
             byte[] plainTextColumnEncryptionKey = new byte[32];
-            RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
-            rngCsp.GetBytes(plainTextColumnEncryptionKey);
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(plainTextColumnEncryptionKey);
 
             byte[] encryptedColumnEncryptionKey = sqlColumnEncryptionAzureKeyVaultProvider.EncryptColumnEncryptionKey(s_akvUrl, s_algorithm, plainTextColumnEncryptionKey);
             string EncryptedValue = string.Concat("0x", BitConverter.ToString(encryptedColumnEncryptionKey).Replace("-", string.Empty));

--- a/doc/samples/AzureKeyVaultProviderWithEnclaveProviderExample_2_0.cs
+++ b/doc/samples/AzureKeyVaultProviderWithEnclaveProviderExample_2_0.cs
@@ -123,8 +123,8 @@ namespace AKVEnclaveExample
         private static string GetEncryptedValue(SqlColumnEncryptionAzureKeyVaultProvider sqlColumnEncryptionAzureKeyVaultProvider)
         {
             byte[] plainTextColumnEncryptionKey = new byte[32];
-            RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
-            rngCsp.GetBytes(plainTextColumnEncryptionKey);
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(plainTextColumnEncryptionKey);
 
             byte[] encryptedColumnEncryptionKey = sqlColumnEncryptionAzureKeyVaultProvider.EncryptColumnEncryptionKey(s_akvUrl, s_algorithm, plainTextColumnEncryptionKey);
             string EncryptedValue = string.Concat("0x", BitConverter.ToString(encryptedColumnEncryptionKey).Replace("-", string.Empty));

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (shouldGenerateNonce)
                     {
-                        using (RandomNumberGenerator rng = new RNGCryptoServiceProvider())
+                        using (RandomNumberGenerator rng = RandomNumberGenerator.Create())
                         {
                             // Client decides to initiate the process of attesting the enclave and to establish a secure session with the enclave.
                             // To ensure that server send new attestation request instead of replaying / re-sending the old token, we will create a nonce for current attestation request.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
@@ -59,15 +59,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <summary>
-        /// Generates cryptographicall random bytes
+        /// Generates cryptographically random bytes
         /// </summary>
         /// <param name="randomBytes">No of cryptographically random bytes to be generated</param>
         /// <returns>A byte array containing cryptographically generated random bytes</returns>
         internal static void GenerateRandomBytes(byte[] randomBytes)
         {
-            // Generate random bytes cryptographically.
-            RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
-            rngCsp.GetBytes(randomBytes);
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(randomBytes);
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/Utility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/Utility.cs
@@ -95,8 +95,8 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         {
             // Generate random bytes cryptographically.
             byte[] randomBytes = new byte[length];
-            RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
-            rngCsp.GetBytes(randomBytes);
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(randomBytes);
 
             return randomBytes;
         }
@@ -348,8 +348,9 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             return decryptedData;
         }
 
+#if NETFRAMEWORK
         /// <summary>
-        /// Create a self-signed certificate without private key. NET461 only.
+        /// Create a self-signed certificate without private key.
         /// </summary>
         internal static X509Certificate2 CreateCertificateWithNoPrivateKey()
         {
@@ -376,6 +377,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
 
             return certificate;
         }
+#endif
 
         /// <summary>
         /// Gets hex representation of byte array.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ExceptionTestAKVStore.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ExceptionTestAKVStore.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             Buffer.BlockCopy(cmkSignature, 0, tamperedCmkSignature, 0, tamperedCmkSignature.Length);
 
             // Corrupt one byte at a time 10 times
-            RandomNumberGenerator rng = new RNGCryptoServiceProvider();
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
             byte[] randomIndexInCipherText = new byte[1];
             for (int i = 0; i < 10; i++)
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/DatabaseHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/DatabaseHelper.cs
@@ -174,8 +174,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         {
             // Generate random bytes cryptographically.
             byte[] randomBytes = new byte[length];
-            RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
-            rngCsp.GetBytes(randomBytes);
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(randomBytes);
             return randomBytes;
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CertificateUtilityWin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CertificateUtilityWin.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         /// </summary>
         internal static string GetCspPathFromCertificate(X509Certificate2 certificate)
         {
-            if (certificate.PrivateKey is RSACryptoServiceProvider csp)
+            if (certificate.GetRSAPrivateKey() is RSACryptoServiceProvider csp)
             {
                 return string.Concat(csp.CspKeyContainerInfo.ProviderName, @"/", csp.CspKeyContainerInfo.KeyContainerName);
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/ColumnEncryptionKey.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/ColumnEncryptionKey.cs
@@ -60,8 +60,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup
         {
             // Generate random bytes cryptographically.
             byte[] randomBytes = new byte[length];
-            RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider();
-            rngCsp.GetBytes(randomBytes);
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(randomBytes);
 
             return randomBytes;
         }

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTDSServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTDSServer.cs
@@ -739,11 +739,8 @@ namespace Microsoft.SqlServer.TDS.Servers
         private byte[] _GenerateRandomBytes(int count)
         {
             byte[] randomBytes = new byte[count];
-
-            RNGCryptoServiceProvider gen = new RNGCryptoServiceProvider();
-            // Generate bytes
-            gen.GetBytes(randomBytes);
-
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(randomBytes);
             return randomBytes;
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/Login7/TDSLogin7FedAuthOptionToken.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/Login7/TDSLogin7FedAuthOptionToken.cs
@@ -366,11 +366,8 @@ namespace Microsoft.SqlServer.TDS.Login7
         private byte[] _GenerateRandomBytes(int count)
         {
             byte[] randomBytes = new byte[count];
-
-            RNGCryptoServiceProvider gen = new RNGCryptoServiceProvider();
-            // Generate bytes
-            gen.GetBytes(randomBytes);
-
+            RandomNumberGenerator rng = RandomNumberGenerator.Create();
+            rng.GetBytes(randomBytes);
             return randomBytes;
         }
     }


### PR DESCRIPTION
Backport #1401 to v4.0.1