### PR TITLE
Release Notes 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
-- Added New Attestation Protocol `None` for enclave type `VBS` with optional `AttestationUrl`. This connection string property when set will allow users to forgo enclave attestation for VBS enclaves. [#1425](https://github.com/dotnet/SqlClient/pull/1425)
+- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1425](https://github.com/dotnet/SqlClient/pull/1425)
 
 ## [Stable release 4.0.1] - 2022-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
-- Added New Attestation Protocol `None` for enclave type `VBS` with optional `AttestationUrl`. This connection string property when set will allow users to forgo enclave attestation for VBS enclaves.
+- Added New Attestation Protocol `None` for enclave type `VBS` with optional `AttestationUrl`. This connection string property when set will allow users to forgo enclave attestation for VBS enclaves. [#1425](https://github.com/dotnet/SqlClient/pull/1425)
 
 ## [Stable release 4.0.1] - 2022-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
-- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1425](https://github.com/dotnet/SqlClient/pull/1425)
+- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1419](https://github.com/dotnet/SqlClient/pull/1419) [#1425](https://github.com/dotnet/SqlClient/pull/1425)
 
 ## [Stable release 4.0.1] - 2022-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
-## [Stable release 4.1.0] - 2022-01-28
+## [Stable release 4.1.0] - 2022-01-31
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+## [Stable release 4.1.0] - 2022-01-28
+
+### Added
+
+- Added New Attestation Protocol `None` for enclave type `VBS` with optional `AttestationUrl`. This connection string property when set will allow users to forgo enclave attestation for VBS enclaves.
+
 ## [Stable release 4.0.1] - 2022-01-17
 
 ### Added

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -6,9 +6,9 @@ This update brings the below changes over the previous preview release:
 
 ### Added
 
-- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1419](https://github.com/dotnet/SqlClient/pull/1419) [#1425](https://github.com/dotnet/SqlClient/pull/1425) [Read more](#use-attestation-protocol-none-to-skip-enclave-attestation-for-vbs-enclaves)
+- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1419](https://github.com/dotnet/SqlClient/pull/1419) [#1425](https://github.com/dotnet/SqlClient/pull/1425) [Read more](#introduce-attestation-protocol-none)
 
-### Use Attestation Protocol None to skip enclave attestation for VBS enclaves
+### Introduce Attestation Protocol None
 
 A new attestation protocol called `None` will be allowed in the connection string. This protocol will allow users to forgo enclave attestation for `VBS` enclaves. When this protocol is set, the enclave attestation URL property is optional.  
 

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -6,7 +6,7 @@ This update brings the below changes over the previous preview release:
 
 ### Added
 
-- Added New Attestation Protocol `None` for enclave type `VBS` with optional `AttestationUrl`. This connection string property when set will allow users to forgo enclave attestation for VBS enclaves.
+- Added New Attestation Protocol `None` for enclave type `VBS` with optional `AttestationUrl`. This connection string property when set will allow users to forgo enclave attestation for VBS enclaves. [#1425](https://github.com/dotnet/SqlClient/pull/1425)
 
 ## Target Platform Support
 

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -6,7 +6,7 @@ This update brings the below changes over the previous preview release:
 
 ### Added
 
-- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1425](https://github.com/dotnet/SqlClient/pull/1425)
+- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1419](https://github.com/dotnet/SqlClient/pull/1419) [#1425](https://github.com/dotnet/SqlClient/pull/1425)
 
 ## Target Platform Support
 

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -8,7 +8,7 @@ This update brings the below changes over the previous preview release:
 
 - Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1419](https://github.com/dotnet/SqlClient/pull/1419) [#1425](https://github.com/dotnet/SqlClient/pull/1425) [Read more](#use-attestation-protocol-none-to-skip-enclave-attestation-for-vbs-enclaves)
 
-### Use `Attestation Protocol = None` to skip enclave attestation for `VBS` enclaves.
+### Use Attestation Protocol None to skip enclave attestation for VBS enclaves
 
 A new attestation protocol called `None` will be allowed in the connection string. This protocol will allow users to forgo enclave attestation for `VBS` enclaves. When this protocol is set, the enclave attestation URL property is optional.  
 

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -12,7 +12,7 @@ This update brings the below changes over the previous preview release:
 
 A new attestation protocol called `None` will be allowed in the connection string. This protocol will allow users to forgo enclave attestation for `VBS` enclaves. When this protocol is set, the enclave attestation URL property is optional.  
 
-Connection string examples:
+Connection string example:
 
 ```cs
 //Attestation protocol NONE with no URL

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -6,16 +6,19 @@ This update brings the below changes over the previous preview release:
 
 ### Added
 
-- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1419](https://github.com/dotnet/SqlClient/pull/1419) [#1425](https://github.com/dotnet/SqlClient/pull/1425)
+- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1419](https://github.com/dotnet/SqlClient/pull/1419) [#1425](https://github.com/dotnet/SqlClient/pull/1425) [Read more](#Use-Attestation-Protocol-=-None-to-skip-enclave-attestation-for-VBS-enclaves)
 
-### Omit enclave attestation when using VBS enclaves: `Attestation Protocol = None`.
+### Use `Attestation Protocol = None` to skip enclave attestation for `VBS` enclaves.
 
 A new attestation protocol called `None` will be allowed in the connection string. This protocol will allow users to forgo enclave attestation for `VBS` enclaves. When this protocol is set, the enclave attestation URL property is optional.  
 
 Connection string examples:
 
 ```cs
+//Attestation protocol NONE with no URL
 "Data Source = {server}; Initial Catalog = {db}; Column Encryption Setting = Enabled; Attestation Protocol = None;"
+//Attestation protocol NONE with URL
+"Data Source = {server}; Initial Catalog = {db}; Column Encryption Setting = Enabled; Attestation Protocol = None; Enclave Attestation Url ={url};"
 ```
 
 ## Target Platform Support

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Microsoft.Data.SqlClient 4.1.0 released 28 January 2022
+## Microsoft.Data.SqlClient 4.1.0 released 31 January 2022
 
 This update brings the below changes over the previous preview release:
 

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -1,0 +1,70 @@
+# Release Notes
+
+## Microsoft.Data.SqlClient 4.1.0 released 28 January 2022
+
+This update brings the below changes over the previous preview release:
+
+### Added
+
+- Added New Attestation Protocol `None` for enclave type `VBS` with optional `AttestationUrl`. This connection string property when set will allow users to forgo enclave attestation for VBS enclaves.
+
+## Target Platform Support
+
+- .NET Framework 4.6.1+ (Windows x86, Windows x64)
+- .NET Core 3.1+ (Windows x86, Windows x64, Windows ARM64, Windows ARM, Linux, macOS)
+- .NET Standard 2.0+ (Windows x86, Windows x64, Windows ARM64, Windows ARM, Linux, macOS)
+
+### Dependencies
+
+#### .NET Framework
+
+- Microsoft.Data.SqlClient.SNI 4.0.0
+- Azure.Identity 1.3.0
+- Microsoft.Identity.Client 4.22.0
+- Microsoft.IdentityModel.JsonWebTokens 6.8.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 6.8.0
+- System.Buffers 4.5.1
+- System.Configuration.ConfigurationManager 5.0.0
+- System.IO 4.3.0
+- System.Runtime.InteropServices.RuntimeInformation 4.3.0
+- System.Security.Cryptography.Algorithms 4.3.1
+- System.Security.Cryptography.Primitives 4.3.0
+- System.Text.Encodings.Web 4.7.2
+
+#### .NET Core
+
+- Microsoft.Data.SqlClient.SNI.runtime 4.0.0
+- Azure.Identity 1.3.0
+- Microsoft.Identity.Client 4.22.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 6.8.0
+- Microsoft.IdentityModel.JsonWebTokens 6.8.0
+- Microsoft.Win32.Registry 5.0.0
+- System.Buffers 4.5.1
+- System.Configuration.ConfigurationManager 5.0.0
+- System.Diagnostics.DiagnosticSource 5.0.0
+- System.IO 4.3.0
+- System.Runtime.Caching 5.0.0
+- System.Text.Encoding.CodePages 5.0.0
+- System.Text.Encodings.Web 4.7.2
+- System.Resources.ResourceManager 4.3.0
+- System.Security.Cryptography.Cng 5.0.0
+- System.Security.Principal.Windows 5.0.0
+
+#### .NET Standard
+
+- Microsoft.Data.SqlClient.SNI.runtime 4.0.0
+- Azure.Identity 1.3.0
+- Microsoft.Identity.Client 4.22.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 6.8.0
+- Microsoft.IdentityModel.JsonWebTokens 6.8.0
+- Microsoft.Win32.Registry 5.0.0
+- System.Buffers 4.5.1
+- System.Configuration.ConfigurationManager 5.0.0
+- System.IO 4.3.0
+- System.Runtime.Caching 5.0.0
+- System.Text.Encoding.CodePages 5.0.0
+- System.Text.Encodings.Web 4.7.2
+- System.Resources.ResourceManager 4.3.0
+- System.Runtime.Loader 4.3.0
+- System.Security.Cryptography.Cng 5.0.0
+- System.Security.Principal.Windows 5.0.0

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -6,7 +6,7 @@ This update brings the below changes over the previous preview release:
 
 ### Added
 
-- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1419](https://github.com/dotnet/SqlClient/pull/1419) [#1425](https://github.com/dotnet/SqlClient/pull/1425) [Read more](#Use-Attestation-Protocol-=-None-to-skip-enclave-attestation-for-VBS-enclaves)
+- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1419](https://github.com/dotnet/SqlClient/pull/1419) [#1425](https://github.com/dotnet/SqlClient/pull/1425) [Read more](#use-attestation-protocol-none-to-skip-enclave-attestation-for-vbs-enclaves)
 
 ### Use `Attestation Protocol = None` to skip enclave attestation for `VBS` enclaves.
 

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -17,8 +17,7 @@ Connection string examples:
 ```cs
 //Attestation protocol NONE with no URL
 "Data Source = {server}; Initial Catalog = {db}; Column Encryption Setting = Enabled; Attestation Protocol = None;"
-//Attestation protocol NONE with URL
-"Data Source = {server}; Initial Catalog = {db}; Column Encryption Setting = Enabled; Attestation Protocol = None; Enclave Attestation Url ={url};"
+
 ```
 
 ## Target Platform Support

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -6,7 +6,7 @@ This update brings the below changes over the previous preview release:
 
 ### Added
 
-- Added New Attestation Protocol `None` for enclave type `VBS` with optional `AttestationUrl`. This connection string property when set will allow users to forgo enclave attestation for VBS enclaves. [#1425](https://github.com/dotnet/SqlClient/pull/1425)
+- Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1425](https://github.com/dotnet/SqlClient/pull/1425)
 
 ## Target Platform Support
 

--- a/release-notes/4.1/4.1.0.md
+++ b/release-notes/4.1/4.1.0.md
@@ -8,6 +8,16 @@ This update brings the below changes over the previous preview release:
 
 - Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. [#1419](https://github.com/dotnet/SqlClient/pull/1419) [#1425](https://github.com/dotnet/SqlClient/pull/1425)
 
+### Omit enclave attestation when using VBS enclaves: `Attestation Protocol = None`.
+
+A new attestation protocol called `None` will be allowed in the connection string. This protocol will allow users to forgo enclave attestation for `VBS` enclaves. When this protocol is set, the enclave attestation URL property is optional.  
+
+Connection string examples:
+
+```cs
+"Data Source = {server}; Initial Catalog = {db}; Column Encryption Setting = Enabled; Attestation Protocol = None;"
+```
+
 ## Target Platform Support
 
 - .NET Framework 4.6.1+ (Windows x86, Windows x64)

--- a/release-notes/4.1/4.1.md
+++ b/release-notes/4.1/4.1.md
@@ -1,0 +1,7 @@
+# Microsoft.Data.SqlClient 4.1 Releases
+
+The following Microsoft.Data.SqlClient 4.1 stable releases have been shipped:
+
+| Release Date | Version | Notes |
+| :-- | :-- | :--: |
+| 2022/01/28 | 4.1.0 | [release notes](4.1.0.md) |

--- a/release-notes/4.1/4.1.md
+++ b/release-notes/4.1/4.1.md
@@ -4,4 +4,4 @@ The following Microsoft.Data.SqlClient 4.1 stable releases have been shipped:
 
 | Release Date | Version | Notes |
 | :-- | :-- | :--: |
-| 2022/01/28 | 4.1.0 | [release notes](4.1.0.md) |
+| 2022/01/31 | 4.1.0 | [release notes](4.1.0.md) |

--- a/release-notes/4.1/README.md
+++ b/release-notes/4.1/README.md
@@ -1,0 +1,7 @@
+# Microsoft.Data.SqlClient 4.1 Releases
+
+The following Microsoft.Data.SqlClient 4.1 stable releases have been shipped:
+
+| Release Date | Version | Notes |
+| :-- | :-- | :--: |
+| 2022/01/28 | 4.1.0 | [release notes](4.1.0.md) |

--- a/release-notes/4.1/README.md
+++ b/release-notes/4.1/README.md
@@ -4,4 +4,4 @@ The following Microsoft.Data.SqlClient 4.1 stable releases have been shipped:
 
 | Release Date | Version | Notes |
 | :-- | :-- | :--: |
-| 2022/01/28 | 4.1.0 | [release notes](4.1.0.md) |
+| 2022/01/31 | 4.1.0 | [release notes](4.1.0.md) |

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,9 +1,10 @@
 # Microsoft.Data.SqlClient Release Notes
 
-The latest stable release is [Microsoft.Data.SqlClient 4.0](4.0).
+The latest stable release is [Microsoft.Data.SqlClient 4.1](4.1).
 
 ## Release Information
 
+- [Microsoft.Data.SqlClient 4.1](4.1)
 - [Microsoft.Data.SqlClient 4.0](4.0)
 - [Microsoft.Data.SqlClient 3.0](3.0)
 - [Microsoft.Data.SqlClient 2.1](2.1)


### PR DESCRIPTION
Release Notes for 4.1.0

-  Added new Attestation Protocol `None` for `VBS` enclave types. This protocol will allow users to forgo enclave attestation for VBS enclaves. #1419 , #1425