### PR TITLE
Tests - Make AE test table names consistent

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ExceptionsGenericError.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ExceptionsGenericError.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                         cmdInsert.CommandType = CommandType.Text;
                         cmdInsert.ExecuteNonQuery();
                     }
-                    using (SqlCommand cmdCreateProc = new SqlCommand($"create procedure {encryptedProcedureName}(@c1 int) as insert into {encryptedTableName} values (@c1)", conn))
+                    using (SqlCommand cmdCreateProc = new SqlCommand($"create procedure [{encryptedProcedureName}](@c1 int) as insert into {encryptedTableName} values (@c1)", conn))
                     {
                         cmdCreateProc.CommandType = CommandType.Text;
                         cmdCreateProc.ExecuteNonQuery();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/SqlNullValues.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/SqlNullValues.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                         cmd.ExecuteNonQuery();
                     }
 
-                    string sql1 = $"CREATE FUNCTION {UdfName}() RETURNS INT AS \n BEGIN \n RETURN (SELECT c1 FROM [{tableName}] WHERE c1 IS NULL)\n END";
-                    string sql2 = $"CREATE FUNCTION {UdfNameNotNull}() RETURNS INT AS \n BEGIN \n RETURN (SELECT c1 FROM [{tableName}] WHERE c1 IS NOT NULL)\n END";
+                    string sql1 = $"CREATE FUNCTION [{UdfName}]() RETURNS INT AS \n BEGIN \n RETURN (SELECT c1 FROM [{tableName}] WHERE c1 IS NULL)\n END";
+                    string sql2 = $"CREATE FUNCTION [{UdfNameNotNull}]() RETURNS INT AS \n BEGIN \n RETURN (SELECT c1 FROM [{tableName}] WHERE c1 IS NOT NULL)\n END";
                     using (SqlCommand cmd = sqlConnection.CreateCommand())
                     {
                         cmd.CommandText = sql1;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/DatabaseHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/DatabaseHelper.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             return randomBytes;
         }
 
-        internal static string GenerateUniqueName(string baseName) => string.Concat("AE_", baseName, "_", Guid.NewGuid().ToString().Replace('-', '_'));
+        internal static string GenerateUniqueName(string baseName) => string.Concat("AE-", baseName, "_", Guid.NewGuid().ToString().Replace('-', '_'));
     }
 
     public class AEConnectionStringProviderWithBooleanVariable : IEnumerable<object[]>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/DatabaseHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/DatabaseHelper.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             return randomBytes;
         }
 
-        internal static string GenerateUniqueName(string baseName) => string.Concat("AE-", baseName, "_", Guid.NewGuid().ToString().Replace('-', '_'));
+        internal static string GenerateUniqueName(string baseName) => string.Concat("AE-", baseName, "_", Guid.NewGuid().ToString());
     }
 
     public class AEConnectionStringProviderWithBooleanVariable : IEnumerable<object[]>


### PR DESCRIPTION
Some table names were created with a "AE_" prefix but the majority were made with "AE-". This will make cleaning up the CI enclave servers a little easier.