### PR TITLE
Fix | Improve code coverage using net fx

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlSer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlSer.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Data.Common;
 #if NETFRAMEWORK
@@ -91,55 +90,7 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         private static object[] GetCustomAttributes(Type t)
-        {
-            object[] attrs = t.GetCustomAttributes(typeof(SqlUserDefinedTypeAttribute), false);
-
-            // If we don't find a Microsoft.Data.SqlClient.Server.SqlUserDefinedTypeAttribute,
-            // search for a Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute from the
-            // old System.Data.SqlClient assembly and copy it to our
-            // Microsoft.Data.SqlClient.Server.SqlUserDefinedTypeAttribute for reference.
-            if (attrs == null || attrs.Length == 0)
-            {
-                object[] attr = t.GetCustomAttributes(false);
-                attrs = new object[0];
-                if (attr != null && attr.Length > 0)
-                {
-                    for (int i = 0; i < attr.Length; i++)
-                    {
-                        if (attr[i].GetType().FullName.Equals("Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute"))
-                        {
-                            SqlUserDefinedTypeAttribute newAttr = null;
-                            PropertyInfo[] sourceProps = attr[i].GetType().GetProperties();
-
-                            foreach (PropertyInfo sourceProp in sourceProps)
-                            {
-                                if (sourceProp.Name.Equals("Format"))
-                                {
-                                    newAttr = new SqlUserDefinedTypeAttribute((Format)sourceProp.GetValue(attr[i], null));
-                                    break;
-                                }
-                            }
-                            if (newAttr != null)
-                            {
-                                foreach (PropertyInfo targetProp in newAttr.GetType().GetProperties())
-                                {
-                                    if (targetProp.CanRead && targetProp.CanWrite)
-                                    {
-                                        object copyValue = attr[i].GetType().GetProperty(targetProp.Name).GetValue(attr[i]);
-                                        targetProp.SetValue(newAttr, copyValue);
-                                    }
-                                }
-                            }
-
-                            attrs = new object[1] { newAttr };
-                            break;
-                        }
-                    }
-                }
-            }
-
-            return attrs;
-        }
+            => t.GetCustomAttributes(typeof(SqlUserDefinedTypeAttribute), false);
 
         internal static SqlUserDefinedTypeAttribute GetUdtAttribute(Type t)
         {
@@ -209,16 +160,7 @@ namespace Microsoft.Data.SqlClient.Server
         public override void Serialize(Stream s, object o)
         {
             BinaryWriter w = new BinaryWriter(s);
-
-#if NETFRAMEWORK
-            if (o is SqlServer.Server.IBinarySerialize bs)
-            {
-                (bs).Write(w);
-                return;
-            }
-#endif
             ((IBinarySerialize)o).Write(w);
-            
         }
 
         // Prevent inlining so that reflection calls are not moved
@@ -229,17 +171,8 @@ namespace Microsoft.Data.SqlClient.Server
         {
             object instance = Activator.CreateInstance(_type);
             BinaryReader r = new BinaryReader(s);
-
-#if NETFRAMEWORK
-            if (instance is SqlServer.Server.IBinarySerialize bs)
-            {
-                bs.Read(r);
-                return instance;
-            }
-#endif
            ((IBinarySerialize)instance).Read(r);
             return instance;
-
         }
     }
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlDataRecordTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlDataRecordTest.cs
@@ -7,11 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlTypes;
-#if NETFRAMEWORK
-using Microsoft.SqlServer.Server;
-#else
 using Microsoft.Data.SqlClient.Server;
-#endif
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.Tests
@@ -394,9 +390,10 @@ namespace Microsoft.Data.SqlClient.Tests
             return GetEnumerator();
         }
     }
+#if NETFRAMEWORK
+    [SqlServer.Server.SqlUserDefinedType(SqlServer.Server.Format.UserDefined)]
+#else
     [SqlUserDefinedType(Format.UserDefined)]
-    public class TestUdt
-    {
-
-    }
+#endif
+    public class TestUdt {}
 }


### PR DESCRIPTION
Fixing the recent code covergage degression:

- 67.7%: [on Jan 13](https://dev.azure.com/sqlclientdrivers-ci/7540d8a3-c1bc-4428-a007-d4b50b7762f4/_apis/test/CodeCoverage/browse/15524998/Code%20Coverage%20Report_45950/index.html)

- 67%: [current status (Feb 11)](https://dev.azure.com/sqlclientdrivers-ci/7540d8a3-c1bc-4428-a007-d4b50b7762f4/_apis/test/CodeCoverage/browse/15833366/Code%20Coverage%20Report_47691/index.html)
- 67.8%: [with this PR](https://dev.azure.com/sqlclientdrivers-ci/sqlclient/_build/results?buildId=47811&view=codecoverage-tab)