### PR TITLE
Test | Do not check IsUsingManagedSNI in NonAzureNoProtocolConnectionTestWindows for netfx 

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/TcpDefaultForAzureTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/TcpDefaultForAzureTest.cs
@@ -42,7 +42,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static void NonAzureNoProtocolConnectionTestWindows()
         {
             builder.DataSource = InvalidHostname;
+#if NETFRAMEWORK
+            CheckConnectionFailure(builder.ConnectionString, NP);
+#else
             CheckConnectionFailure(builder.ConnectionString, DataTestUtility.IsUsingManagedSNI() ? TCP : NP);
+#endif
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]


### PR DESCRIPTION
Ported #1410 to address test failure on servicing pipeline.