### PR TITLE
Remove package references to runtime and ref pack files when targeting .NET 6+.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -166,3 +166,11 @@ dotnet_code_quality.ca1802.api_surface = private, internal
 
 [*.cs]
 dotnet_code_quality.CA2100.excluded_type_names_with_derived_types = Microsoft.Data.SqlClient.ManualTesting.Tests.*
+
+# SYSLIB0014: Type or member is obsolete
+dotnet_diagnostic.SYSLIB0014.severity = none
+
+# Disable these as there is no way to avoid them.
+
+# CS0109: The member 'member' does not hide an inherited member. The new keyword is not required.
+dotnet_diagnostic.CS0109.severity = none

--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
@@ -4,8 +4,6 @@
     <AssemblyName>Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider</AssemblyName>
     <AddOnName>AzureKeyVaultProvider</AddOnName>
     <ProjectGuid>{9073ABEF-92E0-4702-BB23-2C99CEF9BDD7}</ProjectGuid>
-    <TargetGroup Condition="$(TargetFramework.StartsWith('netcoreapp')) OR $(TargetFramework.StartsWith('netstandard'))">netcoreapp</TargetGroup>
-    <TargetGroup Condition="$(TargetFramework.StartsWith('net4'))">netfx</TargetGroup>
     <Configurations>Debug;Release;</Configurations>
     <Platforms>AnyCPU;x86;x64</Platforms>
     <IntermediateOutputPath>$(ObjFolder)$(Configuration).$(Platform)\$(AddOnName)</IntermediateOutputPath>
@@ -17,8 +15,8 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Condition="'$(TargetGroup)'=='netcoreapp' AND !$(ReferenceType.Contains('Package'))" Include="$(NetCoreSource)src\Microsoft.Data.SqlClient.csproj" />
-    <ProjectReference Condition="'$(TargetGroup)'=='netfx' AND !$(ReferenceType.Contains('Package'))" Include="$(NetFxSource)src\Microsoft.Data.SqlClient.csproj" />
+    <ProjectReference Condition="('$(TargetFrameworkIdentifier)' == '.NETCoreApp' OR '$(TargetFrameworkIdentifier)' == '.NETStandard') AND !$(ReferenceType.Contains('Package'))" Include="$(NetCoreSource)src\Microsoft.Data.SqlClient.csproj" />
+    <ProjectReference Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND !$(ReferenceType.Contains('Package'))" Include="$(NetFxSource)src\Microsoft.Data.SqlClient.csproj" />
     <PackageReference Condition="$(ReferenceType.Contains('Package'))" Include="Microsoft.Data.SqlClient" Version="$(TestMicrosoftDataSqlClientVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Data.SqlClient/add-ons/Directory.Build.props
+++ b/src/Microsoft.Data.SqlClient/add-ons/Directory.Build.props
@@ -28,15 +28,15 @@
     <!-- Set Default Target Framework when building for Debug and Release configurations. (Visual Studio) -->
     <When Condition="'$(TestTargetOS)' == ''">
       <PropertyGroup>
-        <TargetFrameworks Condition="'$(TargetsWindows)' == 'true'">$(TargetNetFxVersion);$(TargetNetCoreVersion);$(TargetNetStandardVersion)</TargetFrameworks>
-        <TargetFrameworks Condition="'$(TargetsUnix)' == 'true'">$(TargetNetCoreVersion);$(TargetNetStandardVersion)</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TargetsWindows)' == 'true'">$(TargetNetFxVersion);net6.0;$(TargetNetCoreVersion);$(TargetNetStandardVersion)</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TargetsUnix)' == 'true'">net6.0;$(TargetNetCoreVersion);$(TargetNetStandardVersion)</TargetFrameworks>
       </PropertyGroup>
     </When>
     <!-- Set Target Framework when TestTargetOS is not empty. (Command Line) -->
     <Otherwise>
       <PropertyGroup>
-        <TargetFrameworks Condition="'$(TestTargetOS)' == 'Windowsnetstandard' OR '$(TestTargetOS)' == 'Unixnetstandard'">netstandard2.0;netstandard2.1</TargetFrameworks>
-        <TargetFrameworks Condition="'$(TestTargetOS)' == 'Windowsnetcoreapp' OR '$(TestTargetOS)' == 'Unixnetcoreapp'">netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TestTargetOS)' == 'Windowsnetstandard' OR '$(TestTargetOS)' == 'Unixnetstandard'">net6.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TestTargetOS)' == 'Windowsnetcoreapp' OR '$(TestTargetOS)' == 'Unixnetcoreapp'">net6.0;netcoreapp3.1</TargetFrameworks>
         <TargetFrameworks Condition="'$(TestTargetOS)' == 'Windowsnetfx'">net462</TargetFrameworks>
       </PropertyGroup>
     </Otherwise>

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -1386,7 +1386,9 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/State/*'/>
         public byte State { get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/GetObjectData/*'/>
+#if !NET6_0_OR_GREATER
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Flags = System.Security.Permissions.SecurityPermissionFlag.SerializationFormatter)]
+#endif
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo si, System.Runtime.Serialization.StreamingContext context) { }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/ToString/*'/>
         public override string ToString() { throw null; }
@@ -1716,9 +1718,9 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlTransaction.xml' path='docs/members[@name="SqlTransaction"]/Rollback1/*'/>
         public override void Rollback() { }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlTransaction.xml' path='docs/members[@name="SqlTransaction"]/Rollback2/*'/>
-        public void Rollback(string transactionName) { }
+        public new void Rollback(string transactionName) { }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlTransaction.xml' path='docs/members[@name="SqlTransaction"]/Save/*'/>
-        public void Save(string savePointName) { }
+        public new void Save(string savePointName) { }
     }
     /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlRetryingEventArgs.xml' path='docs/members[@name="SqlRetryingEventArgs"]/SqlRetryingEventArgs/*' />
     public sealed class SqlRetryingEventArgs : System.EventArgs

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition="$(ReferenceType)=='NetStandard' AND $(TargetNetStandardVersion)=='netstandard2.1'">netstandard2.1</TargetFrameworks>
     <IntermediateOutputPath>$(ObjFolder)$(Configuration)\$(AssemblyName)\ref\</IntermediateOutputPath>
     <OutputPath>$(BinFolder)$(Configuration)\$(AssemblyName)\ref\</OutputPath>
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\Microsoft.Data.SqlClient.xml</DocumentationFile>
     <Product>Core $(BaseProduct)</Product>
     <Configurations>Debug;Release;</Configurations>
-    <TargetGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">netcoreapp</TargetGroup>
-    <TargetGroup Condition="$(TargetFramework.StartsWith('netstandard'))">netstandard</TargetGroup>
+    <TargetGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">netcoreapp</TargetGroup>
+    <TargetGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">netstandard</TargetGroup>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard' AND !$(TargetFramework.StartsWith('netstandard1.')) AND $(TargetFramework) != 'netstandard2.0'">

--- a/src/Microsoft.Data.SqlClient/netcore/src/.editorconfig
+++ b/src/Microsoft.Data.SqlClient/netcore/src/.editorconfig
@@ -10,3 +10,9 @@ csharp_style_implicit_object_creation_when_type_is_apparent = false
 
 # IDE0063: Use simple 'using' statement
 csharp_prefer_simple_using_statement = false
+
+[*.Windows.cs]
+
+# Suppress false positive errors in .NET 6+.
+# CA1416: Validate platform compatibility
+dotnet_diagnostic.CA1416.severity = none

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -9,10 +9,6 @@
     <TargetsUnix Condition="'$(OSGroup)'=='Unix'">true</TargetsUnix>
     <!-- Allow explicit addition of the Compile files instead of all project files to be included by Default -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <!-- special case for .NET 6+. -->
-    <TargetGroup Condition="'$(TargetFramework)' == 'net6.0'">netcoreapp</TargetGroup>
-    <TargetGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">netcoreapp</TargetGroup>
-    <TargetGroup Condition="$(TargetFramework.StartsWith('netstandard'))">netstandard</TargetGroup>
     <Configurations>Debug;Release;</Configurations>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <IntermediateOutputPath>$(ObjFolder)$(Configuration).$(Platform)\$(AssemblyName)\netcore\</IntermediateOutputPath>
@@ -21,10 +17,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Product>Core $(BaseProduct)</Product>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <DefineConstants>$(DefineConstants);NETCOREAPP;</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netstandard'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
     <DefineConstants>$(DefineConstants);NETSTANDARD;</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
@@ -502,10 +498,10 @@
       <Link>Resources\StringsHelper.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' OR '$(TargetGroup)' == 'netcoreapp' OR '$(IsUAPAssembly)' == 'true'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp' OR '$(IsUAPAssembly)' == 'true'">
     <Compile Include="Microsoft.Data.SqlClient.TypeForwards.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetGroup)' == 'netstandard' AND '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetFrameworkIdentifier)' == '.NETStandard' AND '$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\EnclaveDelegate.NotSupported.cs">
       <Link>Microsoft\Data\SqlClient\EnclaveDelegate.NotSupported.cs</Link>
     </Compile>
@@ -513,7 +509,7 @@
       <Link>Microsoft\Data\SqlClient\SqlEnclaveAttestationParameters.NotSupported.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetGroup)' == 'netstandard'">
+  <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetFrameworkIdentifier)' == '.NETStandard'">
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNIStreams.Task.cs" />    
     <Compile Include="Microsoft\Data\SqlClient\SNI\SslOverTdsStream.NetStandard.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlAuthenticationProviderManager.NetStandard.cs" />
@@ -556,7 +552,7 @@
   <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetFramework)' != 'netstandard2.0'">
     <Compile Include="Microsoft\Data\SqlClient\SqlClientEventSource.NetCoreApp.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetGroup)' == 'netcoreapp'">
+  <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <Compile Include="..\..\src\Microsoft\Data\SqlClient\SqlDependencyUtils.AssemblyLoadContext.cs">
       <Link>Microsoft\Data\SqlClient\SqlDependencyUtils.AssemblyLoadContext.cs</Link>
     </Compile>
@@ -722,7 +718,7 @@
     <Compile Include="Microsoft\Data\SqlTypes\SqlFileStream.Windows.cs" />
   </ItemGroup>
   <!-- Manage the SNI toggle for Windows netstandard and UWP -->
-  <ItemGroup Condition="('$(TargetGroup)' == 'netstandard' OR '$(TargetGroup)' == 'netcoreapp') AND '$(TargetsWindows)' == 'true'">
+  <ItemGroup Condition="('$(TargetFrameworkIdentifier)' == '.NETStandard' OR '$(TargetFrameworkIdentifier)' == '.NETCoreApp') AND '$(TargetsWindows)' == 'true'">
     <!-- Manage the SNI toggle for Windows netstandard and UWP -->
     <Compile Include="Microsoft\Data\SqlClient\PacketHandle.Windows.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SessionHandle.Windows.cs" />
@@ -932,9 +928,6 @@
     <Compile Include="Microsoft\Data\SqlClient\TdsParserStateObjectFactory.Managed.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParser.Unix.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(IsUAPAssembly)' != 'true'">
-    <Reference Include="Microsoft.Win32.Registry" />
-  </ItemGroup>
   <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(IsUAPAssembly)' == 'true'">
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Memory" />
@@ -945,24 +938,24 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(TargetsWindows)' == 'true' and '$(IsUAPAssembly)' != 'true' and '$(TargetFramework)' != 'net6.0'" Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
-    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
-    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
-    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
-    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
+    <PackageReference Condition="'$(TargetsWindows)' == 'true' and '$(IsUAPAssembly)' != 'true' and ('$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 6.0))))" Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == '.NETCoreApp'" Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 6.0)))" Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 6.0)))" Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 3.1)))" Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 3.1)))" Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI.runtime" Version="$(MicrosoftDataSqlClientSNIRuntimeVersion)" />
-    <PackageReference Condition="$(TargetGroup) == 'netcoreapp' and '$(TargetFramework)' != 'net6.0'" Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 3.1)))" Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelProtocolsOpenIdConnectVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" />
-    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.IO" Version="$(SystemIOVersion)" />
-    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Resources.ResourceManager" Version="$(SystemResourcesResourceManagerVersion)" />
-    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageReference Condition="('$(TargetFrameworkIdentifier)' == '.NETStandard' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 2.1))) or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 3.1)))" Include="System.IO" Version="$(SystemIOVersion)" />
+    <PackageReference Condition="('$(TargetFrameworkIdentifier)' == '.NETStandard' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 2.1))) or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 3.1)))" Include="System.Resources.ResourceManager" Version="$(SystemResourcesResourceManagerVersion)" />
+    <PackageReference Condition="('$(TargetFrameworkIdentifier)' == '.NETStandard' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 2.1))) or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 3.1)))" Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Runtime.Caching" Version="$(SystemRuntimeCachingVersion)" />
-    <PackageReference Condition="$(TargetGroup) == 'netstandard'" Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
-    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
+    <PackageReference Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard' or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 6.0)))" Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
     <PackageReference Condition="$(BuildForRelease) == 'true'" Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
   </ItemGroup>
   <Import Project="$(ToolsDir)targets\GenerateThisAssemblyCs.targets" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.Data.SqlClient</AssemblyName>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition="$(ReferenceType)=='NetStandard' AND $(TargetNetStandardVersion)=='netstandard2.1'">netstandard2.1</TargetFrameworks>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(OSGroup)' == 'AnyOS'">Microsoft.Data.SqlClient is not supported on this platform.</GeneratePlatformNotSupportedAssemblyMessage>
     <OSGroup Condition="'$(OSGroup)' == ''">$(OS)</OSGroup>
@@ -9,6 +9,8 @@
     <TargetsUnix Condition="'$(OSGroup)'=='Unix'">true</TargetsUnix>
     <!-- Allow explicit addition of the Compile files instead of all project files to be included by Default -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <!-- special case for .NET 6+. -->
+    <TargetGroup Condition="'$(TargetFramework)' == 'net6.0'">netcoreapp</TargetGroup>
     <TargetGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">netcoreapp</TargetGroup>
     <TargetGroup Condition="$(TargetFramework.StartsWith('netstandard'))">netstandard</TargetGroup>
     <Configurations>Debug;Release;</Configurations>
@@ -943,24 +945,24 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(TargetsWindows)' == 'true' and '$(IsUAPAssembly)' != 'true'" Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
+    <PackageReference Condition="'$(TargetsWindows)' == 'true' and '$(IsUAPAssembly)' != 'true' and '$(TargetFramework)' != 'net6.0'" Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI.runtime" Version="$(MicrosoftDataSqlClientSNIRuntimeVersion)" />
-    <PackageReference Condition="$(TargetGroup) == 'netcoreapp' " Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
+    <PackageReference Condition="$(TargetGroup) == 'netcoreapp' and '$(TargetFramework)' != 'net6.0'" Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelProtocolsOpenIdConnectVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" />
-    <PackageReference Include="System.IO" Version="$(SystemIOVersion)" />
-    <PackageReference Include="System.Resources.ResourceManager" Version="$(SystemResourcesResourceManagerVersion)" />
-    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.IO" Version="$(SystemIOVersion)" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Resources.ResourceManager" Version="$(SystemResourcesResourceManagerVersion)" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Runtime.Caching" Version="$(SystemRuntimeCachingVersion)" />
     <PackageReference Condition="$(TargetGroup) == 'netstandard'" Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
+    <PackageReference Condition="'$(TargetFramework)' != 'net6.0'" Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
     <PackageReference Condition="$(BuildForRelease) == 'true'" Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All" />
   </ItemGroup>
   <Import Project="$(ToolsDir)targets\GenerateThisAssemblyCs.targets" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SSRP.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SSRP.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Data.SqlClient.SNI
                             SqlClientEventSource.Log.TrySNITraceEvent(nameof(SSRP), EventType.INFO, "Received instnace info from UDP Client.");
                             if (receiveTask.Result.Buffer.Length < ValidResponseSizeForCLNT_BCAST_EX) //discard invalid response
                             {
-                                response.Append(Encoding.UTF7.GetString(receiveTask.Result.Buffer, ServerResponseHeaderSizeForCLNT_BCAST_EX, receiveTask.Result.Buffer.Length - ServerResponseHeaderSizeForCLNT_BCAST_EX)); //RESP_DATA(VARIABLE) - 3 (RESP_SIZE + SVR_RESP)
+                                response.Append(Encoding.UTF8.GetString(receiveTask.Result.Buffer, ServerResponseHeaderSizeForCLNT_BCAST_EX, receiveTask.Result.Buffer.Length - ServerResponseHeaderSizeForCLNT_BCAST_EX)); //RESP_DATA(VARIABLE) - 3 (RESP_SIZE + SVR_RESP)
                             }
                         }
                     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
@@ -79,7 +79,11 @@ namespace Microsoft.Data.SqlClient
 
             // Parse the path and get the X509 cert
             X509Certificate2 certificate = GetCertificateByPath(masterKeyPath, isSystemOp: true);
+#if NET6_0_OR_GREATER
+            int keySizeInBytes = certificate.PublicKey.GetRSAPublicKey().KeySize / 8;
+#else
             int keySizeInBytes = certificate.PublicKey.Key.KeySize / 8;
+#endif
 
             // Validate and decrypt the EncryptedColumnEncryptionKey
             // Format is 
@@ -172,7 +176,11 @@ namespace Microsoft.Data.SqlClient
 
             // Parse the certificate path and get the X509 cert
             X509Certificate2 certificate = GetCertificateByPath(masterKeyPath, isSystemOp: false);
+#if NET6_0_OR_GREATER
+            int keySizeInBytes = certificate.PublicKey.GetRSAPublicKey().KeySize / 8;
+#else
             int keySizeInBytes = certificate.PublicKey.Key.KeySize / 8;
+#endif
 
             // Construct the encryptedColumnEncryptionKey
             // Format is 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -3717,7 +3717,9 @@ namespace Microsoft.Data.SqlClient
                     bool processFinallyBlockAsync = true;
                     bool decrementAsyncCountInFinallyBlockAsync = true;
 
+#if NETCOREAPP3_1 || NETSTANDARD
                     RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                     try
                     {
                         // Check for any exceptions on network write, before reading.
@@ -3789,7 +3791,9 @@ namespace Microsoft.Data.SqlClient
                 bool processFinallyBlockAsync = true;
                 bool decrementAsyncCountInFinallyBlockAsync = true;
 
+#if NETCOREAPP3_1 || NETSTANDARD
                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                     // Check for any exceptions on network write, before reading.

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -3472,7 +3472,9 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = null;
             using (TryEventScope.Create("SqlDataReader.TryReadInternal | API | Object Id {0}", ObjectID))
             {
+#if NETCOREAPP3_1 || NETSTANDARD
                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
 
                 try
                 {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -81,7 +81,9 @@ namespace Microsoft.Data.SqlClient
             SqlInternalConnection connection = _connection;
             SqlConnection usersConnection = connection.Connection;
             SqlClientEventSource.Log.TryTraceEvent("SqlDelegatedTransaction.Initialize | RES | CPOOL | Object Id {0}, Client Connection Id {1}, delegating transaction.", ObjectID, usersConnection?.ClientConnectionId);
+#if NETCOREAPP3_1 || NETSTANDARD
             RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 if (connection.IsEnlistedInTransaction)
@@ -144,7 +146,9 @@ namespace Microsoft.Data.SqlClient
             {
                 SqlConnection usersConnection = connection.Connection;
                 SqlClientEventSource.Log.TryTraceEvent("SqlDelegatedTransaction.Promote | RES | CPOOL | Object Id {0}, Client Connection Id {1}, promoting transaction.", ObjectID, usersConnection?.ClientConnectionId);
+#if NETCOREAPP3_1 || NETSTANDARD
                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                     lock (connection)
@@ -252,7 +256,9 @@ namespace Microsoft.Data.SqlClient
             {
                 SqlConnection usersConnection = connection.Connection;
                 SqlClientEventSource.Log.TryTraceEvent("SqlDelegatedTransaction.Rollback | RES | CPOOL | Object Id {0}, Client Connection Id {1}, rolling back transaction.", ObjectID, usersConnection?.ClientConnectionId);
+#if NETCOREAPP3_1 || NETSTANDARD
                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                     lock (connection)
@@ -337,7 +343,9 @@ namespace Microsoft.Data.SqlClient
             {
                 SqlConnection usersConnection = connection.Connection;
                 SqlClientEventSource.Log.TryTraceEvent("SqlDelegatedTransaction.SinglePhaseCommit | RES | CPOOL | Object Id {0}, Client Connection Id {1}, committing transaction.", ObjectID, usersConnection?.ClientConnectionId);
+#if NETCOREAPP3_1 || NETSTANDARD
                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                     lock (connection)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2257,8 +2257,10 @@ namespace Microsoft.Data.SqlClient
             // Variable which indicates if we did indeed manage to acquire the lock on the authentication context, to try update it.
             bool authenticationContextLocked = false;
 
+#if NETCOREAPP3_1 || NETSTANDARD
             // Prepare CER to ensure the lock on authentication context is released.
             RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 // Try to obtain a lock on the context. If acquired, this thread got the opportunity to update.

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlTransaction.xml' path='docs/members[@name="SqlTransaction"]/RollbackTransactionName/*' />
-        public void Rollback(string transactionName)
+        public new void Rollback(string transactionName)
         {
             using (DiagnosticTransactionScope diagnosticScope = s_diagnosticListener.CreateTransactionRollbackScope(_isolationLevel, _connection, InternalTransaction, transactionName))
             {
@@ -265,7 +265,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlTransaction.xml' path='docs/members[@name="SqlTransaction"]/Save/*' />
-        public void Save(string savePointName)
+        public new void Save(string savePointName)
         {
             ZombieCheck();
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlFileStream.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlFileStream.Windows.cs
@@ -297,7 +297,9 @@ namespace Microsoft.Data.SqlTypes
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/BeginRead/*' />
+#if NETCOREAPP3_1 || NETSTANDARD
         [HostProtection(ExternalThreading = true)]
+#endif
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
             if (_m_disposed)
@@ -316,7 +318,9 @@ namespace Microsoft.Data.SqlTypes
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/BeginWrite/*' />
+#if NETCOREAPP3_1 || NETSTANDARD
         [HostProtection(ExternalThreading = true)]
+#endif
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {
             if (_m_disposed)
@@ -422,7 +426,7 @@ namespace Microsoft.Data.SqlTypes
             _m_fs.Flush();
         }
 
-        #endregion
+#endregion
 
         [Conditional("DEBUG")]
         static private void AssertPathFormat(string path)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace System {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -39,7 +39,7 @@ namespace System {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.Data.SqlClient.Resources.Strings", typeof(Strings).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("SqlClient.Resources.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -5551,6 +5551,15 @@ namespace System {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When true, enables usage of the Asynchronous functionality in the .NET Framework Data Provider..
+        /// </summary>
+        internal static string DbConnectionString_AsynchronousProcessing {
+            get {
+                return ResourceManager.GetString("DbConnectionString_AsynchronousProcessing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The name of the primary file, including the full path name, of an attachable database..
         /// </summary>
         internal static string DbConnectionString_AttachDBFilename {
@@ -8857,6 +8866,15 @@ namespace System {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This command requires an asynchronous connection. Set &quot;Asynchronous Processing=true&quot; in the connection string..
+        /// </summary>
+        internal static string SQL_AsyncConnectionRequired {
+            get {
+                return ResourceManager.GetString("SQL_AsyncConnectionRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The asynchronous operation has already completed..
         /// </summary>
         internal static string SQL_AsyncOperationCompleted {
@@ -9658,7 +9676,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error code 0x{0}..
+        ///   Looks up a localized string similar to Error code 0x{0}.
         /// </summary>
         internal static string SQL_MSALInnerException {
             get {
@@ -10536,6 +10554,15 @@ namespace System {
         internal static string SqlConnection_AccessToken {
             get {
                 return ResourceManager.GetString("SqlConnection_AccessToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to State of connection, synchronous or asynchronous.  &apos;Asynchronous Processing=x&apos; in the connection string..
+        /// </summary>
+        internal static string SqlConnection_Asynchronous {
+            get {
+                return ResourceManager.GetString("SqlConnection_Asynchronous", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -608,7 +608,9 @@ namespace Microsoft.Data.Common
         /// Note: In Longhorn you'll be able to rename a machine without
         /// rebooting.  Therefore, don't cache this machine name.
         /// </summary>
+#if NETFRAMEWORK || NETCOREAPP3_1 || NETSTANDARD
         [EnvironmentPermission(SecurityAction.Assert, Read = "COMPUTERNAME")]
+#endif
         internal static string MachineName() => Environment.MachineName;
 
         internal static Transaction GetCurrentTransaction()

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolAuthenticationContext.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolAuthenticationContext.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Diagnostics;
+#if NETFRAMEWORK || NETCOREAPP3_1 || NETSTANDARD
 using System.Runtime.ConstrainedExecution;
+#endif
 using System.Threading;
 
 namespace Microsoft.Data.ProviderBase
@@ -102,7 +104,9 @@ namespace Microsoft.Data.ProviderBase
         /// <summary>
         /// Release the lock which was obtained through LockToUpdate.
         /// </summary>
+#if NETFRAMEWORK || NETCOREAPP3_1 || NETSTANDARD
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+#endif
         internal void ReleaseLockToUpdate()
         {
             int oldValue = Interlocked.CompareExchange(ref _isUpdateInProgress, STATUS_UNLOCKED, STATUS_LOCKED);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Data.Sql
         /// <returns></returns>
         internal static DataTable GetDataSources()
         {
+#if NETFRAMEWORK || NETCOREAPP3_1 || NETSTANDARD
             (new NamedPermissionSet("FullTrust")).Demand(); // SQLBUDT 244304
+#endif
             char[] buffer = null;
             StringBuilder strbldr = new();
 
@@ -36,11 +38,15 @@ namespace Microsoft.Data.Sql
             bool failure = false;
             IntPtr handle = ADP.s_ptrZero;
 
+#if NETFRAMEWORK || NETCOREAPP3_1 || NETSTANDARD
             RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 long s_timeoutTime = TdsParserStaticMethods.GetTimeoutSeconds(ADP.DefaultCommandTimeout);
+#if NETFRAMEWORK || NETCOREAPP3_1 || NETSTANDARD
                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 { }
                 finally

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/InvalidUdtException.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/InvalidUdtException.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Data.SqlClient.Server
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/InvalidUdtException.xml' path='docs/members[@name="InvalidUdtException"]/GetObjectData/*' />
+#if !NET6_0_OR_GREATER
         [System.Security.Permissions.SecurityPermissionAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Flags = System.Security.Permissions.SecurityPermissionFlag.SerializationFormatter)]
+#endif
         public override void GetObjectData(SerializationInfo si, StreamingContext context)
         {
             base.GetObjectData(si, context);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAeadAes256CbcHmac256Algorithm.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAeadAes256CbcHmac256Algorithm.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// The pool of crypto providers to use for encrypt/decrypt operations.
         /// </summary>
-        private readonly ConcurrentQueue<AesCryptoServiceProvider> _cryptoProviderPool;
+        private readonly ConcurrentQueue<Aes> _cryptoProviderPool;
 
         /// <summary>
         /// Byte array with algorithm version used for authentication tag computation.
@@ -117,7 +117,7 @@ namespace Microsoft.Data.SqlClient
                 Debug.Assert(SqlClientEncryptionType.Randomized == encryptionType, "Invalid Encryption Type detected in SqlAeadAes256CbcHmac256Algorithm, this should've been caught in factory class");
             }
 
-            _cryptoProviderPool = new ConcurrentQueue<AesCryptoServiceProvider>();
+            _cryptoProviderPool = new ConcurrentQueue<Aes>();
         }
 
         /// <summary>
@@ -178,13 +178,13 @@ namespace Microsoft.Data.SqlClient
             outBuffer[0] = _algorithmVersion;
             Buffer.BlockCopy(iv, 0, outBuffer, ivStartIndex, iv.Length);
 
-            AesCryptoServiceProvider aesAlg;
+            Aes aesAlg;
 
             // Try to get a provider from the pool.
             // If no provider is available, create a new one.
             if (!_cryptoProviderPool.TryDequeue(out aesAlg))
             {
-                aesAlg = new AesCryptoServiceProvider();
+                aesAlg = Aes.Create();
 
                 try
                 {
@@ -342,13 +342,13 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert((count + offset) <= cipherText.Length);
 
             byte[] plainText;
-            AesCryptoServiceProvider aesAlg;
+            Aes aesAlg;
 
             // Try to get a provider from the pool.
             // If no provider is available, create a new one.
             if (!_cryptoProviderPool.TryDequeue(out aesAlg))
             {
-                aesAlg = new AesCryptoServiceProvider();
+                aesAlg = Aes.Create();
 
                 try
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
@@ -257,7 +257,9 @@ namespace Microsoft.Data.SqlClient
 #if NETFRAMEWORK
             TdsParser bestEffortCleanupTarget = null;
 #endif
+#if NETFRAMEWORK || NETCOREAPP3_1 || NETSTANDARD
             RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
 #if NETFRAMEWORK

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -630,7 +630,9 @@ namespace Microsoft.Data.SqlClient
                             string service = null;
                             bool appDomainStart = false;
 
+#if NETFRAMEWORK || NETCOREAPP3_1 || NETSTANDARD
                             RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                             try
                             { // CER to ensure that if Start succeeds we add to hash completing setup.
                               // Start using process wide default service/queue & database from connection string.
@@ -775,7 +777,9 @@ namespace Microsoft.Data.SqlClient
                             {
                                 bool appDomainStop = false;
 
+#if NETFRAMEWORK || NETCOREAPP3_1 || NETSTANDARD
                                 RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                                 try
                                 { // CER to ensure that if Stop succeeds we remove from hash completing teardown.
                                   // Start using process wide default service/queue & database from connection string.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -1441,6 +1441,9 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     }
 
     // Needed for remoting to prevent lifetime issues and default GC cleanup.
+#if NET6_0_OR_GREATER
+    [Obsolete]
+#endif
     public override object InitializeLifetimeService()
     {
         return null;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
@@ -132,6 +132,9 @@ namespace Microsoft.Data.SqlClient
 
         //  When remoted across appdomains, MarshalByRefObject links by default time out if there is no activity 
         //  within a few minutes.  Add this override to prevent marshaled links from timing out.
+#if NET6_0_OR_GREATER
+        [Obsolete]
+#endif
         public override object InitializeLifetimeService()
         {
             return null;

--- a/src/Microsoft.Data.SqlClient/tests/Docker/DockerLinuxTest/Microsoft.Data.SqlClient.DockerLinuxTest.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/Docker/DockerLinuxTest/Microsoft.Data.SqlClient.DockerLinuxTest.csproj
@@ -7,7 +7,7 @@
     <OSGroup>Unix</OSGroup>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(NetCoreSource)src\Microsoft.Data.SqlClient.csproj" />

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -26,14 +26,14 @@
   </PropertyGroup>
   <!-- NetFx and NetCore project dependencies -->
   <PropertyGroup>
-    <AzureIdentityVersion>1.5.0</AzureIdentityVersion>
-    <MicrosoftIdentityClientVersion>4.30.1</MicrosoftIdentityClientVersion>
-    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.8.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
-    <MicrosoftIdentityModelJsonWebTokensVersion>6.8.0</MicrosoftIdentityModelJsonWebTokensVersion>
+    <AzureIdentityVersion>1.6.0</AzureIdentityVersion>
+    <MicrosoftIdentityClientVersion>4.43.2</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.17.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
+    <MicrosoftIdentityModelJsonWebTokensVersion>6.17.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemIOVersion>4.3.0</SystemIOVersion>
     <SystemTextEncodingsWebVersion>4.7.2</SystemTextEncodingsWebVersion>
-    <MicrosoftSourceLinkGitHubVersion>1.0.0</MicrosoftSourceLinkGitHubVersion>
+    <MicrosoftSourceLinkGitHubVersion>1.1.1</MicrosoftSourceLinkGitHubVersion>
   </PropertyGroup>
   <!-- NetCore project dependencies -->
   <PropertyGroup>
@@ -55,14 +55,14 @@
   </PropertyGroup>
   <!-- AKV Provider project dependencies -->
   <PropertyGroup>
-    <AzureCoreVersion>[1.20.0,2.0.0)</AzureCoreVersion>
-    <AzureSecurityKeyVaultKeysVersion>[4.0.3,5.0.0)</AzureSecurityKeyVaultKeysVersion>
+    <AzureCoreVersion>[1.24.0,2.0.0)</AzureCoreVersion>
+    <AzureSecurityKeyVaultKeysVersion>[4.3.0,5.0.0)</AzureSecurityKeyVaultKeysVersion>
     <MicrosoftExtensionsCachingMemoryVersion>5.0.0</MicrosoftExtensionsCachingMemoryVersion>
   </PropertyGroup>
   <!-- Test Project Dependencies -->
   <PropertyGroup>
     <MicrosoftDotNetPlatformAbstractionsVersion>3.1.1</MicrosoftDotNetPlatformAbstractionsVersion>
-    <MicrosoftIdentityModelClientsActiveDirectoryVersion>5.2.6</MicrosoftIdentityModelClientsActiveDirectoryVersion>
+    <MicrosoftIdentityModelClientsActiveDirectoryVersion>5.2.9</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftNETTestSdkVersion>15.9.0</MicrosoftNETTestSdkVersion>
     <MicrosoftWindowsCompatibilityVersion>3.1.0</MicrosoftWindowsCompatibilityVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
@@ -71,13 +71,13 @@
     <SystemDataOdbcVersion21>4.5.0</SystemDataOdbcVersion21>
     <SystemDataOdbcVersion>4.6.0</SystemDataOdbcVersion>
     <SystemNetSocketsVersion>4.3.0</SystemNetSocketsVersion>
-    <SystemIdentityModelTokensJwtVersion>6.8.0</SystemIdentityModelTokensJwtVersion>
+    <SystemIdentityModelTokensJwtVersion>6.17.0</SystemIdentityModelTokensJwtVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20206.4</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftNETCoreRuntimeCoreCLRVersion>2.0.8</MicrosoftNETCoreRuntimeCoreCLRVersion>
-    <MicrosoftSqlServerSqlManagementObjectsVersion>161.41011.9</MicrosoftSqlServerSqlManagementObjectsVersion>
-    <MicrosoftSqlServerTypesVersion>10.50.1600.1</MicrosoftSqlServerTypesVersion>
-    <BenchmarkDotNetVersion>0.12.1</BenchmarkDotNetVersion>
+    <MicrosoftSqlServerSqlManagementObjectsVersion>161.47008.0</MicrosoftSqlServerSqlManagementObjectsVersion>
+    <MicrosoftSqlServerTypesVersion>14.0.1016.290</MicrosoftSqlServerTypesVersion>
+    <BenchmarkDotNetVersion>0.13.1</BenchmarkDotNetVersion>
     <SystemServiceProcessServiceControllerVersion>6.0.0</SystemServiceProcessServiceControllerVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -29,10 +29,10 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Microsoft.Data.SqlClient.SNI" version="5.0.0-preview2.22084.1" />
-        <dependency id="Azure.Identity" version="1.5.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.30.1" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
+        <dependency id="Azure.Identity" version="1.6.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.43.2" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.17.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.17.0" />
         <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Configuration.ConfigurationManager" version="5.0.0" exclude="Compile" />
         <dependency id="System.IO" version="4.3.0" />
@@ -43,28 +43,24 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.0.0-preview2.22084.1" exclude="Compile" />
-        <dependency id="Azure.Identity" version="1.5.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.30.1" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
+        <dependency id="Azure.Identity" version="1.6.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.43.2" exclude="Compile"/>
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.17.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.17.0" />
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
-        <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Configuration.ConfigurationManager" version="5.0.0" exclude="Compile" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="5.0.0" exclude="Compile" />
-        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.6.0" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="5.0.0" exclude="Compile" />
-        <dependency id="System.Text.Encoding.CodePages" version="5.0.0" exclude="Compile" />
         <dependency id="System.Text.Encodings.Web" version="4.7.2" />
-        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
-        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" />
         <dependency id="System.Security.Principal.Windows" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Cng" version="5.0.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.0.0-preview2.22084.1" exclude="Compile" />
-        <dependency id="Azure.Identity" version="1.5.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.30.1" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
+        <dependency id="Azure.Identity" version="1.6.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.43.2" exclude="Compile"/>
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.17.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.17.0" />
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Configuration.ConfigurationManager" version="5.0.0" exclude="Compile" />
@@ -79,10 +75,10 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       </group>
       <group targetFramework="netstandard2.1">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.0.0-preview2.22084.1" exclude="Compile" />
-        <dependency id="Azure.Identity" version="1.5.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.30.1" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
+        <dependency id="Azure.Identity" version="1.6.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.43.2" exclude="Compile"/>
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.17.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.17.0" />
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Configuration.ConfigurationManager" version="5.0.0" exclude="Compile" />
@@ -94,6 +90,15 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Resources.ResourceManager" version="4.3.0" />
         <dependency id="System.Security.Cryptography.Cng" version="5.0.0" />
         <dependency id="System.Security.Principal.Windows" version="5.0.0" exclude="Compile" />
+      </group>
+      <group targetFramework="net6.0">
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.0.0-preview2.22084.1" exclude="Compile" />
+        <dependency id="Azure.Identity" version="1.6.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.43.2" exclude="Compile"/>
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.17.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.17.0" />
+        <dependency id="System.Configuration.ConfigurationManager" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Runtime.Caching" version="5.0.0" exclude="Compile" />
       </group>
     </dependencies>
     <frameworkAssemblies>
@@ -107,6 +112,11 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
           <reference file="Microsoft.Data.SqlClient.xml" />
       </group>
       <group targetFramework="netcoreapp3.1">
+          <reference file="Microsoft.Data.SqlClient.dll" />
+          <reference file="Microsoft.Data.SqlClient.pdb" />
+          <reference file="Microsoft.Data.SqlClient.xml" />
+      </group>
+      <group targetFramework="net6.0">
           <reference file="Microsoft.Data.SqlClient.dll" />
           <reference file="Microsoft.Data.SqlClient.pdb" />
           <reference file="Microsoft.Data.SqlClient.xml" />
@@ -135,6 +145,11 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\netcoreapp3.1\Microsoft.Data.SqlClient.dll" target="ref\netcoreapp3.1\" exclude="" />
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\netcoreapp3.1\Microsoft.Data.SqlClient.pdb" target="ref\netcoreapp3.1\" exclude="" />
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\netcoreapp3.1\Microsoft.Data.SqlClient.xml" target="ref\netcoreapp3.1\" exclude="" />
+
+    <!-- ref .NET 6+ -->
+    <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\net6.0\Microsoft.Data.SqlClient.dll" target="ref\net6.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\net6.0\Microsoft.Data.SqlClient.pdb" target="ref\net6.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\net6.0\Microsoft.Data.SqlClient.xml" target="ref\net6.0\" exclude="" />
 
     <!-- ref NetStandard -->
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\netstandard2.0\Microsoft.Data.SqlClient.dll" target="ref\netstandard2.0\" exclude="" />
@@ -167,6 +182,11 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\netcoreapp3.1\Microsoft.Data.SqlClient.pdb" target="lib\netcoreapp3.1\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\netcoreapp3.1\Microsoft.Data.SqlClient.xml" target="lib\netcoreapp3.1\" exclude="" />
 
+    <!-- lib .NET 6+ -->
+    <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net6.0\Microsoft.Data.SqlClient.dll" target="lib\net6.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net6.0\Microsoft.Data.SqlClient.pdb" target="lib\net6.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net6.0\Microsoft.Data.SqlClient.xml" target="lib\net6.0\" exclude="" />
+
     <!-- lib NetStandard -->
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\netstandard2.0\Microsoft.Data.SqlClient.dll" target="lib\netstandard2.0\" exclude="" />
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\netstandard2.0\Microsoft.Data.SqlClient.pdb" target="lib\netstandard2.0\" exclude="" />
@@ -185,6 +205,12 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\netcoreapp3.1\Microsoft.Data.SqlClient.pdb" target="runtimes\win\lib\netcoreapp3.1\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Unix\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\netcoreapp3.1\Microsoft.Data.SqlClient.dll" target="runtimes\unix\lib\netcoreapp3.1\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Unix\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\netcoreapp3.1\Microsoft.Data.SqlClient.pdb" target="runtimes\unix\lib\netcoreapp3.1\" exclude="" />
+
+    <!-- runtimes .NET 6+ -->
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net6.0\Microsoft.Data.SqlClient.dll" target="runtimes\win\lib\net6.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net6.0\Microsoft.Data.SqlClient.pdb" target="runtimes\win\lib\net6.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Unix\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net6.0\Microsoft.Data.SqlClient.dll" target="runtimes\unix\lib\net6.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Unix\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net6.0\Microsoft.Data.SqlClient.pdb" target="runtimes\unix\lib\net6.0\" exclude="" />
 
     <!-- runtimes NetStandard -->
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\netstandard2.0\Microsoft.Data.SqlClient.dll" target="runtimes\win\lib\netstandard2.0\" exclude="" />


### PR DESCRIPTION
In .NET 6+ minimize network load on restore by using the ones from the ref and runtime packs over the package versions.