### PR TITLE
Fix | Improved DSEnumerator's test and fixed string format

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Data.Sql
                 finally
                 {
                     handle = SNINativeMethodWrapper.SNIServerEnumOpen();
-                    SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {3} returned handle = {4}.",
+                    SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {2} returned handle = {3}.",
                                                            nameof(SqlDataSourceEnumeratorNativeHelper),
                                                            nameof(GetDataSources),
                                                            nameof(SNINativeMethodWrapper.SNIServerEnumOpen), handle);
@@ -80,7 +80,7 @@ namespace Microsoft.Data.Sql
                 if (handle != ADP.s_ptrZero)
                 {
                     SNINativeMethodWrapper.SNIServerEnumClose(handle);
-                    SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {3} called.",
+                    SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {2} called.",
                                                            nameof(SqlDataSourceEnumeratorNativeHelper),
                                                            nameof(GetDataSources),
                                                            nameof(SNINativeMethodWrapper.SNIServerEnumClose));

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlDSEnumeratorTest/SqlDataSourceEnumeratorTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlDSEnumeratorTest/SqlDataSourceEnumeratorTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using System.ServiceProcess;
 using Microsoft.Data.Sql;
 using Xunit;
@@ -36,9 +37,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // SQL Server Browser runs as a Windows service.
             // TODO: This assessment can be done on CI.
-            ServiceController sc = new("SQLBrowser");
-            Assert.Equal(ServiceControllerStatus.Running, sc.Status);
-
+            ServiceController[] services = ServiceController.GetServices(Environment.MachineName);
+            ServiceController service = services.FirstOrDefault(s => s.ServiceName == "SQLBrowser");
+            if (service != null)
+            {
+                Assert.Equal(ServiceControllerStatus.Running, service.Status);
+            }
             return SqlDataSourceEnumerator.Instance;
         }
     }


### PR DESCRIPTION
Assesses the SQL Browser Service status in the case of existence.

Fixes the `System.InvalidOperationException : Service 'SQLBrowser' was not found on computer '.'.`