### PR TITLE
Add experimental mars IO task scheduler

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -932,6 +932,9 @@
     <Reference Include="System.Memory" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Microsoft\Data\SqlClient\SNI\SNITaskScheduler.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="Resources\Microsoft.Data.SqlClient.SqlMetaData.xml">
       <LogicalName>Microsoft.Data.SqlClient.SqlMetaData.xml</LogicalName>
     </EmbeddedResource>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 if (LocalAppContextSwitches.UseExperimentalMARSThreading
 #if NETCOREAPP31_AND_ABOVE
-                    && ThreadPool.PendingWorkItemCount>0
+                    && ThreadPool.PendingWorkItemCount > 0
 #endif 
                     )
                 {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -80,23 +80,11 @@ namespace Microsoft.Data.SqlClient.SNI
             using (TrySNIEventScope.Create(nameof(SNIMarsConnection)))
             {
                 if (LocalAppContextSwitches.UseExperimentalMARSThreading
-#if NETCOREAPP31_AND_ABOVE
-                    && ThreadPool.PendingWorkItemCount > 0
-#endif 
+//#if NETCOREAPP31_AND_ABOVE
+//                    && ThreadPool.PendingWorkItemCount > 0
+//#endif 
                     )
                 {
-                    // for debugging only, remove this
-                    if (s_scheduler is null)
-                    {
-                        AppDomain.CurrentDomain.FirstChanceException += static (object sender, System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs e) =>
-                        {
-                            if (e is not null && e.Exception is PlatformNotSupportedException pnse)
-                            {
-                                SqlClientEventSource.Log.SNITrace("PNSE in SNI: " + Environment.NewLine + pnse.StackTrace);
-                                Console.WriteLine("PNSE in SNI: " + Environment.NewLine + pnse.StackTrace);
-                            }
-                        };
-                    }
                     LazyInitializer.EnsureInitialized(ref s_scheduler, () => new QueuedTaskScheduler(3, "MARSIOScheduler", false, ThreadPriority.AboveNormal));
                     LazyInitializer.EnsureInitialized(ref s_factory, () => new TaskFactory(s_scheduler));
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Data.SqlClient.SNI
         private const string s_className = nameof(SNIMarsConnection);
 
         private static QueuedTaskScheduler s_scheduler;        
-        private TaskFactory s_factory;
 
         private readonly Guid _connectionId = Guid.NewGuid();
         private readonly Dictionary<int, SNIMarsHandle> _sessions = new Dictionary<int, SNIMarsHandle>();
@@ -85,11 +84,10 @@ namespace Microsoft.Data.SqlClient.SNI
 //#endif 
                     )
                 {
-                    LazyInitializer.EnsureInitialized(ref s_scheduler, () => new QueuedTaskScheduler(3, "MARSIOScheduler", false, ThreadPriority.AboveNormal));
-                    LazyInitializer.EnsureInitialized(ref s_factory, () => new TaskFactory(s_scheduler));
+                    LazyInitializer.EnsureInitialized(ref s_scheduler, () => new QueuedTaskScheduler(10, "MARSIOScheduler", useForegroundThreads: false, ThreadPriority.Normal));
 
                     // will start an async task on the scheduler and immediatley return so this await is safe
-                    return s_factory.StartNew(StartAsyncReceiveLoopForConnection, this).GetAwaiter().GetResult();
+                    return s_scheduler.Factory.StartNew(StartAsyncReceiveLoopForConnection, this).GetAwaiter().GetResult();
                 }
                 else
                 {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -85,6 +85,18 @@ namespace Microsoft.Data.SqlClient.SNI
 #endif 
                     )
                 {
+                    // for debugging only, remove this
+                    if (s_scheduler is null)
+                    {
+                        AppDomain.CurrentDomain.FirstChanceException += static (object sender, System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs e) =>
+                        {
+                            if (e is not null && e.Exception is PlatformNotSupportedException pnse)
+                            {
+                                SqlClientEventSource.Log.SNITrace("PNSE in SNI: " + Environment.NewLine + pnse.StackTrace);
+                                Console.WriteLine("PNSE in SNI: " + Environment.NewLine + pnse.StackTrace);
+                            }
+                        };
+                    }
                     LazyInitializer.EnsureInitialized(ref s_scheduler, () => new QueuedTaskScheduler(3, "MARSIOScheduler", false, ThreadPriority.AboveNormal));
                     LazyInitializer.EnsureInitialized(ref s_factory, () => new TaskFactory(s_scheduler));
 
@@ -111,6 +123,8 @@ namespace Microsoft.Data.SqlClient.SNI
                 return SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, 0, SNICommon.ConnNotUsableError, Strings.SNI_ERROR_19);
             };
         }
+
+
 
         /// <summary>
         /// Send a packet synchronously

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIPacket.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     state: callback,
                     CancellationToken.None,
                     TaskContinuationOptions.DenyChildAttach,
-                    TaskScheduler.Default
+                    TaskScheduler.Current // specifically continue on the current scheduler because we may override it for mars
                 );
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITaskScheduler.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITaskScheduler.cs
@@ -123,14 +123,13 @@ namespace Microsoft.Data.SqlClient.SNI
 
         /// <summary>Initializes the scheduler.</summary>
         /// <param name="threadCount">The number of threads to create and use for processing work items.</param>
-        public QueuedTaskScheduler(int threadCount) : this(threadCount, string.Empty, false, ThreadPriority.Normal, ApartmentState.MTA, 0, null, null) { }
+        public QueuedTaskScheduler(int threadCount) : this(threadCount, string.Empty, false, ThreadPriority.Normal, 0, null, null) { }
 
         /// <summary>Initializes the scheduler.</summary>
         /// <param name="threadCount">The number of threads to create and use for processing work items.</param>
         /// <param name="threadName">The name to use for each of the created threads.</param>
         /// <param name="useForegroundThreads">A Boolean value that indicates whether to use foreground threads instead of background.</param>
         /// <param name="threadPriority">The priority to assign to each thread.</param>
-        /// <param name="threadApartmentState">The apartment state to use for each thread.</param>
         /// <param name="threadMaxStackSize">The stack size to use for each thread.</param>
         /// <param name="threadInit">An initialization routine to run on each thread.</param>
         /// <param name="threadFinally">A finalization routine to run on each thread.</param>
@@ -139,7 +138,6 @@ namespace Microsoft.Data.SqlClient.SNI
             string threadName = "",
             bool useForegroundThreads = false,
             ThreadPriority threadPriority = ThreadPriority.Normal,
-            ApartmentState threadApartmentState = ApartmentState.MTA,
             int threadMaxStackSize = 0,
             Action threadInit = null,
             Action threadFinally = null)
@@ -167,7 +165,6 @@ namespace Microsoft.Data.SqlClient.SNI
                 };
                 if (threadName != null)
                     _threads[i].Name = threadName + " (" + i + ")";
-                _threads[i].SetApartmentState(threadApartmentState);
             }
 
             // Start all of the threads

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITaskScheduler.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITaskScheduler.cs
@@ -12,51 +12,9 @@ namespace Microsoft.Data.SqlClient.SNI
     /// <summary>
     /// Provides a TaskScheduler that provides control over priorities, fairness, and the underlying threads utilized.
     /// </summary>
-    [DebuggerTypeProxy(typeof(QueuedTaskSchedulerDebugView))]
     [DebuggerDisplay("Id={Id}, Queues={DebugQueueCount}, ScheduledTasks = {DebugTaskCount}")]
     internal sealed class QueuedTaskScheduler : TaskScheduler, IDisposable
     {
-        /// <summary>Debug view for the QueuedTaskScheduler.</summary>
-        private class QueuedTaskSchedulerDebugView
-        {
-            /// <summary>The scheduler.</summary>
-            private readonly QueuedTaskScheduler _scheduler;
-
-            /// <summary>Initializes the debug view.</summary>
-            /// <param name="scheduler">The scheduler.</param>
-            public QueuedTaskSchedulerDebugView(QueuedTaskScheduler scheduler) =>
-                _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
-
-            /// <summary>Gets all of the Tasks queued to the scheduler directly.</summary>
-            public IEnumerable<Task> ScheduledTasks
-            {
-                get
-                {
-                    var tasks = (_scheduler._targetScheduler != null) ?
-                        (IEnumerable<Task>)_scheduler._nonthreadsafeTaskQueue :
-                        _scheduler._blockingTaskQueue;
-                    return tasks.Where(t => t != null).ToList();
-                }
-            }
-
-            /// <summary>Gets the prioritized and fair queues.</summary>
-            public IEnumerable<TaskScheduler> Queues
-            {
-                get
-                {
-                    List<TaskScheduler> queues = new List<TaskScheduler>();
-                    foreach (var group in _scheduler._queueGroups)
-                        queues.AddRange(group.Value.Cast<TaskScheduler>());
-                    return queues;
-                }
-            }
-        }
-
-        /// <summary>
-        /// A sorted list of round-robin queue lists.  Tasks with the smallest priority value
-        /// are preferred.  Priority groups are round-robin'd through in order of priority.
-        /// </summary>
-        private readonly SortedList<int, QueueGroup> _queueGroups = new SortedList<int, QueueGroup>();
         /// <summary>Cancellation token used for disposal.</summary>
         private readonly CancellationTokenSource _disposeCancellation = new CancellationTokenSource();
         /// <summary>
@@ -67,59 +25,12 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <summary>Whether we're processing tasks on the current thread.</summary>
         private static readonly ThreadLocal<bool> s_taskProcessingThread = new ThreadLocal<bool>();
 
-        // ***
-        // *** For when using a target scheduler
-        // ***
-
-        /// <summary>The scheduler onto which actual work is scheduled.</summary>
-        private readonly TaskScheduler _targetScheduler;
-        /// <summary>The queue of tasks to process when using an underlying target scheduler.</summary>
-        private readonly Queue<Task> _nonthreadsafeTaskQueue;
-        /// <summary>The number of Tasks that have been queued or that are running whiel using an underlying scheduler.</summary>
-        private int _delegatesQueuedOrRunning = 0;
-
-        // ***
-        // *** For when using our own threads
-        // ***
-
         /// <summary>The threads used by the scheduler to process work.</summary>
         private readonly Thread[] _threads;
         /// <summary>The collection of tasks to be executed on our custom threads.</summary>
         private readonly BlockingCollection<Task> _blockingTaskQueue;
 
-        // ***
-
-        /// <summary>Initializes the scheduler.</summary>
-        public QueuedTaskScheduler() : this(Default, 0) { }
-
-        /// <summary>Initializes the scheduler.</summary>
-        /// <param name="targetScheduler">The target underlying scheduler onto which this sceduler's work is queued.</param>
-        public QueuedTaskScheduler(TaskScheduler targetScheduler) : this(targetScheduler, 0) { }
-
-        /// <summary>Initializes the scheduler.</summary>
-        /// <param name="targetScheduler">The target underlying scheduler onto which this sceduler's work is queued.</param>
-        /// <param name="maxConcurrencyLevel">The maximum degree of concurrency allowed for this scheduler's work.</param>
-        public QueuedTaskScheduler(
-            TaskScheduler targetScheduler,
-            int maxConcurrencyLevel)
-        {
-            if (maxConcurrencyLevel < 0)
-                throw new ArgumentOutOfRangeException(nameof(maxConcurrencyLevel));
-
-            // Initialize only those fields relevant to use an underlying scheduler.  We don't
-            // initialize the fields relevant to using our own custom threads.
-            _targetScheduler = targetScheduler ?? throw new ArgumentNullException("underlyingScheduler");
-            _nonthreadsafeTaskQueue = new Queue<Task>();
-
-            // If 0, use the number of logical processors.  But make sure whatever value we pick
-            // is not greater than the degree of parallelism allowed by the underlying scheduler.
-            _concurrencyLevel = maxConcurrencyLevel != 0 ? maxConcurrencyLevel : Environment.ProcessorCount;
-            if (targetScheduler.MaximumConcurrencyLevel > 0 &&
-                targetScheduler.MaximumConcurrencyLevel < _concurrencyLevel)
-            {
-                _concurrencyLevel = targetScheduler.MaximumConcurrencyLevel;
-            }
-        }
+        private readonly TaskFactory _factory;
 
         /// <summary>Initializes the scheduler.</summary>
         /// <param name="threadCount">The number of threads to create and use for processing work items.</param>
@@ -158,7 +69,7 @@ namespace Microsoft.Data.SqlClient.SNI
             _threads = new Thread[threadCount];
             for (int i = 0; i < threadCount; i++)
             {
-                _threads[i] = new Thread(() => ThreadBasedDispatchLoop(threadInit, threadFinally), threadMaxStackSize)
+                _threads[i] = new Thread(() => DispatchLoop(threadInit, threadFinally), threadMaxStackSize)
                 {
                     Priority = threadPriority,
                     IsBackground = !useForegroundThreads,
@@ -167,15 +78,19 @@ namespace Microsoft.Data.SqlClient.SNI
                     _threads[i].Name = threadName + " (" + i + ")";
             }
 
+            _factory = new TaskFactory(this);
+
             // Start all of the threads
             foreach (var thread in _threads)
                 thread.Start();
         }
 
+        public TaskFactory Factory => _factory;
+
         /// <summary>The dispatch loop run by all threads in this scheduler.</summary>
         /// <param name="threadInit">An initialization routine to run when the thread begins.</param>
         /// <param name="threadFinally">A finalization routine to run before the thread ends.</param>
-        private void ThreadBasedDispatchLoop(Action threadInit, Action threadFinally)
+        private void DispatchLoop(Action threadInit, Action threadFinally)
         {
             s_taskProcessingThread.Value = true;
             threadInit?.Invoke();
@@ -197,22 +112,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                 // Run it.
                                 if (task != null)
                                 {
-                                    TryExecuteTask(task);
-                                }
-                                // If the task is null, that means it's just a placeholder for a task
-                                // queued to one of the subschedulers.  Find the next task based on
-                                // priority and fairness and run it.
-                                else
-                                {
-                                    // Find the next task based on our ordering rules...
-                                    Task targetTask;
-                                    QueuedTaskSchedulerQueue queueForTargetTask;
-                                    lock (_queueGroups)
-                                        FindNextTask_NeedsLock(out targetTask, out queueForTargetTask);
-
-                                    // ... and if we found one, run it
-                                    if (targetTask != null)
-                                        queueForTargetTask.ExecuteTask(targetTask);
+                                    bool tried = TryExecuteTask(task);
                                 }
                             }
                         }
@@ -238,171 +138,17 @@ namespace Microsoft.Data.SqlClient.SNI
             }
         }
 
-        /// <summary>Gets the number of queues currently activated.</summary>
-        private int DebugQueueCount
-        {
-            get
-            {
-                int count = 0;
-                foreach (var group in _queueGroups)
-                    count += group.Value.Count;
-                return count;
-            }
-        }
-
-        /// <summary>Gets the number of tasks currently scheduled.</summary>
-        private int DebugTaskCount => (_targetScheduler != null ?
-                    (IEnumerable<Task>)_nonthreadsafeTaskQueue : (IEnumerable<Task>)_blockingTaskQueue)
-                    .Where(t => t != null).Count();
-
-        /// <summary>Find the next task that should be executed, based on priorities and fairness and the like.</summary>
-        /// <param name="targetTask">The found task, or null if none was found.</param>
-        /// <param name="queueForTargetTask">
-        /// The scheduler associated with the found task.  Due to security checks inside of TPL,  
-        /// this scheduler needs to be used to execute that task.
-        /// </param>
-        private void FindNextTask_NeedsLock(out Task targetTask, out QueuedTaskSchedulerQueue queueForTargetTask)
-        {
-            targetTask = null;
-            queueForTargetTask = null;
-
-            // Look through each of our queue groups in sorted order.
-            // This ordering is based on the priority of the queues.
-            foreach (var queueGroup in _queueGroups)
-            {
-                var queues = queueGroup.Value;
-
-                // Within each group, iterate through the queues in a round-robin
-                // fashion.  Every time we iterate again and successfully find a task, 
-                // we'll start in the next location in the group.
-                foreach (int i in queues.CreateSearchOrder())
-                {
-                    queueForTargetTask = queues[i];
-                    var items = queueForTargetTask._workItems;
-                    if (items.Count > 0)
-                    {
-                        targetTask = items.Dequeue();
-                        if (queueForTargetTask._disposed && items.Count == 0)
-                        {
-                            RemoveQueue_NeedsLock(queueForTargetTask);
-                        }
-                        queues.NextQueueIndex = (queues.NextQueueIndex + 1) % queueGroup.Value.Count;
-                        return;
-                    }
-                }
-            }
-        }
-
         /// <summary>Queues a task to the scheduler.</summary>
         /// <param name="task">The task to be queued.</param>
         protected override void QueueTask(Task task)
         {
             // If we've been disposed, no one should be queueing
             if (_disposeCancellation.IsCancellationRequested)
+            {
                 throw new ObjectDisposedException(GetType().Name);
-
-            // If the target scheduler is null (meaning we're using our own threads),
-            // add the task to the blocking queue
-            if (_targetScheduler == null)
-            {
-                _blockingTaskQueue.Add(task);
             }
-            // Otherwise, add the task to the non-blocking queue,
-            // and if there isn't already an executing processing task,
-            // start one up
-            else
-            {
-                // Queue the task and check whether we should launch a processing
-                // task (noting it if we do, so that other threads don't result
-                // in queueing up too many).
-                bool launchTask = false;
-                lock (_nonthreadsafeTaskQueue)
-                {
-                    _nonthreadsafeTaskQueue.Enqueue(task);
-                    if (_delegatesQueuedOrRunning < _concurrencyLevel)
-                    {
-                        ++_delegatesQueuedOrRunning;
-                        launchTask = true;
-                    }
-                }
-
-                // If necessary, start processing asynchronously
-                if (launchTask)
-                {
-                    Task.Factory.StartNew(ProcessPrioritizedAndBatchedTasks,
-                        CancellationToken.None, TaskCreationOptions.None, _targetScheduler);
-                }
-            }
+            _blockingTaskQueue.Add(task);
         }
-
-        /// <summary>
-        /// Process tasks one at a time in the best order.  
-        /// This should be run in a Task generated by QueueTask.
-        /// It's been separated out into its own method to show up better in Parallel Tasks.
-        /// </summary>
-        private void ProcessPrioritizedAndBatchedTasks()
-        {
-            bool continueProcessing = true;
-            while (!_disposeCancellation.IsCancellationRequested && continueProcessing)
-            {
-                try
-                {
-                    // Note that we're processing tasks on this thread
-                    s_taskProcessingThread.Value = true;
-
-                    // Until there are no more tasks to process
-                    while (!_disposeCancellation.IsCancellationRequested)
-                    {
-                        // Try to get the next task.  If there aren't any more, we're done.
-                        Task targetTask;
-                        lock (_nonthreadsafeTaskQueue)
-                        {
-                            if (_nonthreadsafeTaskQueue.Count == 0)
-                                break;
-                            targetTask = _nonthreadsafeTaskQueue.Dequeue();
-                        }
-
-                        // If the task is null, it's a placeholder for a task in the round-robin queues.
-                        // Find the next one that should be processed.
-                        QueuedTaskSchedulerQueue queueForTargetTask = null;
-                        if (targetTask == null)
-                        {
-                            lock (_queueGroups)
-                                FindNextTask_NeedsLock(out targetTask, out queueForTargetTask);
-                        }
-
-                        // Now if we finally have a task, run it.  If the task
-                        // was associated with one of the round-robin schedulers, we need to use it
-                        // as a thunk to execute its task.
-                        if (targetTask != null)
-                        {
-                            if (queueForTargetTask != null)
-                                queueForTargetTask.ExecuteTask(targetTask);
-                            else
-                                TryExecuteTask(targetTask);
-                        }
-                    }
-                }
-                finally
-                {
-                    // Now that we think we're done, verify that there really is
-                    // no more work to do.  If there's not, highlight
-                    // that we're now less parallel than we were a moment ago.
-                    lock (_nonthreadsafeTaskQueue)
-                    {
-                        if (_nonthreadsafeTaskQueue.Count == 0)
-                        {
-                            _delegatesQueuedOrRunning--;
-                            continueProcessing = false;
-                            s_taskProcessingThread.Value = false;
-                        }
-                    }
-                }
-            }
-        }
-
-        /// <summary>Notifies the pool that there's a new item to be executed in one of the round-robin queues.</summary>
-        private void NotifyNewWorkItem() => QueueTask(null);
 
         /// <summary>Tries to execute a task synchronously on the current thread.</summary>
         /// <param name="task">The task to execute.</param>
@@ -410,25 +156,16 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>true if the task was executed; otherwise, false.</returns>
         protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) =>
             // If we're already running tasks on this threads, enable inlining
-            s_taskProcessingThread.Value && TryExecuteTask(task);
+            false; // s_taskProcessingThread.Value && TryExecuteTask(task);
 
         /// <summary>Gets the tasks scheduled to this scheduler.</summary>
         /// <returns>An enumerable of all tasks queued to this scheduler.</returns>
         /// <remarks>This does not include the tasks on sub-schedulers.  Those will be retrieved by the debugger separately.</remarks>
         protected override IEnumerable<Task> GetScheduledTasks()
         {
-            // If we're running on our own threads, get the tasks from the blocking queue...
-            if (_targetScheduler == null)
-            {
-                // Get all of the tasks, filtering out nulls, which are just placeholders
-                // for tasks in other sub-schedulers
-                return _blockingTaskQueue.Where(t => t != null).ToList();
-            }
-            // otherwise get them from the non-blocking queue...
-            else
-            {
-                return _nonthreadsafeTaskQueue.Where(t => t != null).ToList();
-            }
+            // Get all of the tasks, filtering out nulls, which are just placeholders
+            // for tasks in other sub-schedulers
+            return _blockingTaskQueue.Where(t => t != null).ToList();
         }
 
         /// <summary>Gets the maximum concurrency level to use when processing tasks.</summary>
@@ -436,168 +173,5 @@ namespace Microsoft.Data.SqlClient.SNI
 
         /// <summary>Initiates shutdown of the scheduler.</summary>
         public void Dispose() => _disposeCancellation.Cancel();
-
-        /// <summary>Creates and activates a new scheduling queue for this scheduler.</summary>
-        /// <returns>The newly created and activated queue at priority 0.</returns>
-        public TaskScheduler ActivateNewQueue() => ActivateNewQueue(0);
-
-        /// <summary>Creates and activates a new scheduling queue for this scheduler.</summary>
-        /// <param name="priority">The priority level for the new queue.</param>
-        /// <returns>The newly created and activated queue at the specified priority.</returns>
-        public TaskScheduler ActivateNewQueue(int priority)
-        {
-            // Create the queue
-            var createdQueue = new QueuedTaskSchedulerQueue(priority, this);
-
-            // Add the queue to the appropriate queue group based on priority
-            lock (_queueGroups)
-            {
-                if (!_queueGroups.TryGetValue(priority, out QueueGroup list))
-                {
-                    list = new QueueGroup();
-                    _queueGroups.Add(priority, list);
-                }
-                list.Add(createdQueue);
-            }
-
-            // Hand the new queue back
-            return createdQueue;
-        }
-
-        /// <summary>Removes a scheduler from the group.</summary>
-        /// <param name="queue">The scheduler to be removed.</param>
-        private void RemoveQueue_NeedsLock(QueuedTaskSchedulerQueue queue)
-        {
-            // Find the group that contains the queue and the queue's index within the group
-            var queueGroup = _queueGroups[queue._priority];
-            int index = queueGroup.IndexOf(queue);
-
-            // We're about to remove the queue, so adjust the index of the next
-            // round-robin starting location if it'll be affected by the removal
-            if (queueGroup.NextQueueIndex >= index)
-                queueGroup.NextQueueIndex--;
-
-            // Remove it
-            queueGroup.RemoveAt(index);
-        }
-
-        /// <summary>A group of queues a the same priority level.</summary>
-        private class QueueGroup : List<QueuedTaskSchedulerQueue>
-        {
-            /// <summary>The starting index for the next round-robin traversal.</summary>
-            public int NextQueueIndex = 0;
-
-            /// <summary>Creates a search order through this group.</summary>
-            /// <returns>An enumerable of indices for this group.</returns>
-            public IEnumerable<int> CreateSearchOrder()
-            {
-                for (int i = NextQueueIndex; i < Count; i++)
-                    yield return i;
-                for (int i = 0; i < NextQueueIndex; i++)
-                    yield return i;
-            }
-        }
-
-        /// <summary>Provides a scheduling queue associatd with a QueuedTaskScheduler.</summary>
-        [DebuggerDisplay("QueuePriority = {_priority}, WaitingTasks = {WaitingTasks}")]
-        [DebuggerTypeProxy(typeof(QueuedTaskSchedulerQueueDebugView))]
-        private sealed class QueuedTaskSchedulerQueue : TaskScheduler, IDisposable
-        {
-            /// <summary>A debug view for the queue.</summary>
-            private sealed class QueuedTaskSchedulerQueueDebugView
-            {
-                /// <summary>The queue.</summary>
-                private readonly QueuedTaskSchedulerQueue _queue;
-
-                /// <summary>Initializes the debug view.</summary>
-                /// <param name="queue">The queue to be debugged.</param>
-                public QueuedTaskSchedulerQueueDebugView(QueuedTaskSchedulerQueue queue) =>
-                    _queue = queue ?? throw new ArgumentNullException(nameof(queue));
-
-                /// <summary>Gets the priority of this queue in its associated scheduler.</summary>
-                public int Priority => _queue._priority;
-                /// <summary>Gets the ID of this scheduler.</summary>
-                public int Id => _queue.Id;
-                /// <summary>Gets all of the tasks scheduled to this queue.</summary>
-                public IEnumerable<Task> ScheduledTasks => _queue.GetScheduledTasks();
-                /// <summary>Gets the QueuedTaskScheduler with which this queue is associated.</summary>
-                public QueuedTaskScheduler AssociatedScheduler => _queue._pool;
-            }
-
-            /// <summary>The scheduler with which this pool is associated.</summary>
-            private readonly QueuedTaskScheduler _pool;
-            /// <summary>The work items stored in this queue.</summary>
-            internal readonly Queue<Task> _workItems;
-            /// <summary>Whether this queue has been disposed.</summary>
-            internal bool _disposed;
-            /// <summary>Gets the priority for this queue.</summary>
-            internal int _priority;
-
-            /// <summary>Initializes the queue.</summary>
-            /// <param name="priority">The priority associated with this queue.</param>
-            /// <param name="pool">The scheduler with which this queue is associated.</param>
-            internal QueuedTaskSchedulerQueue(int priority, QueuedTaskScheduler pool)
-            {
-                _priority = priority;
-                _pool = pool;
-                _workItems = new Queue<Task>();
-            }
-
-            /// <summary>Gets the number of tasks waiting in this scheduler.</summary>
-            internal int WaitingTasks => _workItems.Count;
-
-            /// <summary>Gets the tasks scheduled to this scheduler.</summary>
-            /// <returns>An enumerable of all tasks queued to this scheduler.</returns>
-            protected override IEnumerable<Task> GetScheduledTasks() => _workItems.ToList();
-
-            /// <summary>Queues a task to the scheduler.</summary>
-            /// <param name="task">The task to be queued.</param>
-            protected override void QueueTask(Task task)
-            {
-                if (_disposed)
-                    throw new ObjectDisposedException(GetType().Name);
-
-                // Queue up the task locally to this queue, and then notify
-                // the parent scheduler that there's work available
-                lock (_pool._queueGroups)
-                    _workItems.Enqueue(task);
-                _pool.NotifyNewWorkItem();
-            }
-
-            /// <summary>Tries to execute a task synchronously on the current thread.</summary>
-            /// <param name="task">The task to execute.</param>
-            /// <param name="taskWasPreviouslyQueued">Whether the task was previously queued.</param>
-            /// <returns>true if the task was executed; otherwise, false.</returns>
-            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) =>
-                // If we're using our own threads and if this is being called from one of them,
-                // or if we're currently processing another task on this thread, try running it inline.
-                s_taskProcessingThread.Value && TryExecuteTask(task);
-
-            /// <summary>Runs the specified ask.</summary>
-            /// <param name="task">The task to execute.</param>
-            internal void ExecuteTask(Task task) => TryExecuteTask(task);
-
-            /// <summary>Gets the maximum concurrency level to use when processing tasks.</summary>
-            public override int MaximumConcurrencyLevel => _pool.MaximumConcurrencyLevel;
-
-            /// <summary>Signals that the queue should be removed from the scheduler as soon as the queue is empty.</summary>
-            public void Dispose()
-            {
-                if (!_disposed)
-                {
-                    lock (_pool._queueGroups)
-                    {
-                        // We only remove the queue if it's empty.  If it's not empty,
-                        // we still mark it as disposed, and the associated QueuedTaskScheduler
-                        // will remove the queue when its count hits 0 and its _disposed is true.
-                        if (_workItems.Count == 0)
-                        {
-                            _pool.RemoveQueue_NeedsLock(this);
-                        }
-                    }
-                    _disposed = true;
-                }
-            }
-        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITaskScheduler.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITaskScheduler.cs
@@ -1,0 +1,606 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.SqlClient.SNI
+{
+    /// <summary>
+    /// Provides a TaskScheduler that provides control over priorities, fairness, and the underlying threads utilized.
+    /// </summary>
+    [DebuggerTypeProxy(typeof(QueuedTaskSchedulerDebugView))]
+    [DebuggerDisplay("Id={Id}, Queues={DebugQueueCount}, ScheduledTasks = {DebugTaskCount}")]
+    public sealed class QueuedTaskScheduler : TaskScheduler, IDisposable
+    {
+        /// <summary>Debug view for the QueuedTaskScheduler.</summary>
+        private class QueuedTaskSchedulerDebugView
+        {
+            /// <summary>The scheduler.</summary>
+            private readonly QueuedTaskScheduler _scheduler;
+
+            /// <summary>Initializes the debug view.</summary>
+            /// <param name="scheduler">The scheduler.</param>
+            public QueuedTaskSchedulerDebugView(QueuedTaskScheduler scheduler) =>
+                _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
+
+            /// <summary>Gets all of the Tasks queued to the scheduler directly.</summary>
+            public IEnumerable<Task> ScheduledTasks
+            {
+                get
+                {
+                    var tasks = (_scheduler._targetScheduler != null) ?
+                        (IEnumerable<Task>)_scheduler._nonthreadsafeTaskQueue :
+                        _scheduler._blockingTaskQueue;
+                    return tasks.Where(t => t != null).ToList();
+                }
+            }
+
+            /// <summary>Gets the prioritized and fair queues.</summary>
+            public IEnumerable<TaskScheduler> Queues
+            {
+                get
+                {
+                    List<TaskScheduler> queues = new List<TaskScheduler>();
+                    foreach (var group in _scheduler._queueGroups)
+                        queues.AddRange(group.Value.Cast<TaskScheduler>());
+                    return queues;
+                }
+            }
+        }
+
+        /// <summary>
+        /// A sorted list of round-robin queue lists.  Tasks with the smallest priority value
+        /// are preferred.  Priority groups are round-robin'd through in order of priority.
+        /// </summary>
+        private readonly SortedList<int, QueueGroup> _queueGroups = new SortedList<int, QueueGroup>();
+        /// <summary>Cancellation token used for disposal.</summary>
+        private readonly CancellationTokenSource _disposeCancellation = new CancellationTokenSource();
+        /// <summary>
+        /// The maximum allowed concurrency level of this scheduler.  If custom threads are
+        /// used, this represents the number of created threads.
+        /// </summary>
+        private readonly int _concurrencyLevel;
+        /// <summary>Whether we're processing tasks on the current thread.</summary>
+        private static readonly ThreadLocal<bool> s_taskProcessingThread = new ThreadLocal<bool>();
+
+        // ***
+        // *** For when using a target scheduler
+        // ***
+
+        /// <summary>The scheduler onto which actual work is scheduled.</summary>
+        private readonly TaskScheduler _targetScheduler;
+        /// <summary>The queue of tasks to process when using an underlying target scheduler.</summary>
+        private readonly Queue<Task> _nonthreadsafeTaskQueue;
+        /// <summary>The number of Tasks that have been queued or that are running whiel using an underlying scheduler.</summary>
+        private int _delegatesQueuedOrRunning = 0;
+
+        // ***
+        // *** For when using our own threads
+        // ***
+
+        /// <summary>The threads used by the scheduler to process work.</summary>
+        private readonly Thread[] _threads;
+        /// <summary>The collection of tasks to be executed on our custom threads.</summary>
+        private readonly BlockingCollection<Task> _blockingTaskQueue;
+
+        // ***
+
+        /// <summary>Initializes the scheduler.</summary>
+        public QueuedTaskScheduler() : this(Default, 0) { }
+
+        /// <summary>Initializes the scheduler.</summary>
+        /// <param name="targetScheduler">The target underlying scheduler onto which this sceduler's work is queued.</param>
+        public QueuedTaskScheduler(TaskScheduler targetScheduler) : this(targetScheduler, 0) { }
+
+        /// <summary>Initializes the scheduler.</summary>
+        /// <param name="targetScheduler">The target underlying scheduler onto which this sceduler's work is queued.</param>
+        /// <param name="maxConcurrencyLevel">The maximum degree of concurrency allowed for this scheduler's work.</param>
+        public QueuedTaskScheduler(
+            TaskScheduler targetScheduler,
+            int maxConcurrencyLevel)
+        {
+            if (maxConcurrencyLevel < 0)
+                throw new ArgumentOutOfRangeException(nameof(maxConcurrencyLevel));
+
+            // Initialize only those fields relevant to use an underlying scheduler.  We don't
+            // initialize the fields relevant to using our own custom threads.
+            _targetScheduler = targetScheduler ?? throw new ArgumentNullException("underlyingScheduler");
+            _nonthreadsafeTaskQueue = new Queue<Task>();
+
+            // If 0, use the number of logical processors.  But make sure whatever value we pick
+            // is not greater than the degree of parallelism allowed by the underlying scheduler.
+            _concurrencyLevel = maxConcurrencyLevel != 0 ? maxConcurrencyLevel : Environment.ProcessorCount;
+            if (targetScheduler.MaximumConcurrencyLevel > 0 &&
+                targetScheduler.MaximumConcurrencyLevel < _concurrencyLevel)
+            {
+                _concurrencyLevel = targetScheduler.MaximumConcurrencyLevel;
+            }
+        }
+
+        /// <summary>Initializes the scheduler.</summary>
+        /// <param name="threadCount">The number of threads to create and use for processing work items.</param>
+        public QueuedTaskScheduler(int threadCount) : this(threadCount, string.Empty, false, ThreadPriority.Normal, ApartmentState.MTA, 0, null, null) { }
+
+        /// <summary>Initializes the scheduler.</summary>
+        /// <param name="threadCount">The number of threads to create and use for processing work items.</param>
+        /// <param name="threadName">The name to use for each of the created threads.</param>
+        /// <param name="useForegroundThreads">A Boolean value that indicates whether to use foreground threads instead of background.</param>
+        /// <param name="threadPriority">The priority to assign to each thread.</param>
+        /// <param name="threadApartmentState">The apartment state to use for each thread.</param>
+        /// <param name="threadMaxStackSize">The stack size to use for each thread.</param>
+        /// <param name="threadInit">An initialization routine to run on each thread.</param>
+        /// <param name="threadFinally">A finalization routine to run on each thread.</param>
+        public QueuedTaskScheduler(
+            int threadCount,
+            string threadName = "",
+            bool useForegroundThreads = false,
+            ThreadPriority threadPriority = ThreadPriority.Normal,
+            ApartmentState threadApartmentState = ApartmentState.MTA,
+            int threadMaxStackSize = 0,
+            Action threadInit = null,
+            Action threadFinally = null)
+        {
+            // Validates arguments (some validation is left up to the Thread type itself).
+            // If the thread count is 0, default to the number of logical processors.
+            if (threadCount < 0)
+                throw new ArgumentOutOfRangeException(nameof(threadCount));
+            else if (threadCount == 0)
+                _concurrencyLevel = Environment.ProcessorCount;
+            else
+                _concurrencyLevel = threadCount;
+
+            // Initialize the queue used for storing tasks
+            _blockingTaskQueue = new BlockingCollection<Task>();
+
+            // Create all of the threads
+            _threads = new Thread[threadCount];
+            for (int i = 0; i < threadCount; i++)
+            {
+                _threads[i] = new Thread(() => ThreadBasedDispatchLoop(threadInit, threadFinally), threadMaxStackSize)
+                {
+                    Priority = threadPriority,
+                    IsBackground = !useForegroundThreads,
+                };
+                if (threadName != null)
+                    _threads[i].Name = threadName + " (" + i + ")";
+                _threads[i].SetApartmentState(threadApartmentState);
+            }
+
+            // Start all of the threads
+            foreach (var thread in _threads)
+                thread.Start();
+        }
+
+        /// <summary>The dispatch loop run by all threads in this scheduler.</summary>
+        /// <param name="threadInit">An initialization routine to run when the thread begins.</param>
+        /// <param name="threadFinally">A finalization routine to run before the thread ends.</param>
+        private void ThreadBasedDispatchLoop(Action threadInit, Action threadFinally)
+        {
+            s_taskProcessingThread.Value = true;
+            threadInit?.Invoke();
+            try
+            {
+                // If the scheduler is disposed, the cancellation token will be set and
+                // we'll receive an OperationCanceledException.  That OCE should not crash the process.
+                try
+                {
+                    // If a thread abort occurs, we'll try to reset it and continue running.
+                    while (true)
+                    {
+                        try
+                        {
+                            // For each task queued to the scheduler, try to execute it.
+                            foreach (var task in _blockingTaskQueue.GetConsumingEnumerable(_disposeCancellation.Token))
+                            {
+                                // If the task is not null, that means it was queued to this scheduler directly.
+                                // Run it.
+                                if (task != null)
+                                {
+                                    TryExecuteTask(task);
+                                }
+                                // If the task is null, that means it's just a placeholder for a task
+                                // queued to one of the subschedulers.  Find the next task based on
+                                // priority and fairness and run it.
+                                else
+                                {
+                                    // Find the next task based on our ordering rules...
+                                    Task targetTask;
+                                    QueuedTaskSchedulerQueue queueForTargetTask;
+                                    lock (_queueGroups)
+                                        FindNextTask_NeedsLock(out targetTask, out queueForTargetTask);
+
+                                    // ... and if we found one, run it
+                                    if (targetTask != null)
+                                        queueForTargetTask.ExecuteTask(targetTask);
+                                }
+                            }
+                        }
+                        catch (ThreadAbortException)
+                        {
+                            // If we received a thread abort, and that thread abort was due to shutting down
+                            // or unloading, let it pass through.  Otherwise, reset the abort so we can
+                            // continue processing work items.
+                            if (!Environment.HasShutdownStarted && !AppDomain.CurrentDomain.IsFinalizingForUnload())
+                            {
+                                Thread.ResetAbort();
+                            }
+                        }
+                    }
+                }
+                catch (OperationCanceledException) { }
+            }
+            finally
+            {
+                // Run a cleanup routine if there was one
+                threadFinally?.Invoke();
+                s_taskProcessingThread.Value = false;
+            }
+        }
+
+        /// <summary>Gets the number of queues currently activated.</summary>
+        private int DebugQueueCount
+        {
+            get
+            {
+                int count = 0;
+                foreach (var group in _queueGroups)
+                    count += group.Value.Count;
+                return count;
+            }
+        }
+
+        /// <summary>Gets the number of tasks currently scheduled.</summary>
+        private int DebugTaskCount => (_targetScheduler != null ?
+                    (IEnumerable<Task>)_nonthreadsafeTaskQueue : (IEnumerable<Task>)_blockingTaskQueue)
+                    .Where(t => t != null).Count();
+
+        /// <summary>Find the next task that should be executed, based on priorities and fairness and the like.</summary>
+        /// <param name="targetTask">The found task, or null if none was found.</param>
+        /// <param name="queueForTargetTask">
+        /// The scheduler associated with the found task.  Due to security checks inside of TPL,  
+        /// this scheduler needs to be used to execute that task.
+        /// </param>
+        private void FindNextTask_NeedsLock(out Task targetTask, out QueuedTaskSchedulerQueue queueForTargetTask)
+        {
+            targetTask = null;
+            queueForTargetTask = null;
+
+            // Look through each of our queue groups in sorted order.
+            // This ordering is based on the priority of the queues.
+            foreach (var queueGroup in _queueGroups)
+            {
+                var queues = queueGroup.Value;
+
+                // Within each group, iterate through the queues in a round-robin
+                // fashion.  Every time we iterate again and successfully find a task, 
+                // we'll start in the next location in the group.
+                foreach (int i in queues.CreateSearchOrder())
+                {
+                    queueForTargetTask = queues[i];
+                    var items = queueForTargetTask._workItems;
+                    if (items.Count > 0)
+                    {
+                        targetTask = items.Dequeue();
+                        if (queueForTargetTask._disposed && items.Count == 0)
+                        {
+                            RemoveQueue_NeedsLock(queueForTargetTask);
+                        }
+                        queues.NextQueueIndex = (queues.NextQueueIndex + 1) % queueGroup.Value.Count;
+                        return;
+                    }
+                }
+            }
+        }
+
+        /// <summary>Queues a task to the scheduler.</summary>
+        /// <param name="task">The task to be queued.</param>
+        protected override void QueueTask(Task task)
+        {
+            // If we've been disposed, no one should be queueing
+            if (_disposeCancellation.IsCancellationRequested)
+                throw new ObjectDisposedException(GetType().Name);
+
+            // If the target scheduler is null (meaning we're using our own threads),
+            // add the task to the blocking queue
+            if (_targetScheduler == null)
+            {
+                _blockingTaskQueue.Add(task);
+            }
+            // Otherwise, add the task to the non-blocking queue,
+            // and if there isn't already an executing processing task,
+            // start one up
+            else
+            {
+                // Queue the task and check whether we should launch a processing
+                // task (noting it if we do, so that other threads don't result
+                // in queueing up too many).
+                bool launchTask = false;
+                lock (_nonthreadsafeTaskQueue)
+                {
+                    _nonthreadsafeTaskQueue.Enqueue(task);
+                    if (_delegatesQueuedOrRunning < _concurrencyLevel)
+                    {
+                        ++_delegatesQueuedOrRunning;
+                        launchTask = true;
+                    }
+                }
+
+                // If necessary, start processing asynchronously
+                if (launchTask)
+                {
+                    Task.Factory.StartNew(ProcessPrioritizedAndBatchedTasks,
+                        CancellationToken.None, TaskCreationOptions.None, _targetScheduler);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Process tasks one at a time in the best order.  
+        /// This should be run in a Task generated by QueueTask.
+        /// It's been separated out into its own method to show up better in Parallel Tasks.
+        /// </summary>
+        private void ProcessPrioritizedAndBatchedTasks()
+        {
+            bool continueProcessing = true;
+            while (!_disposeCancellation.IsCancellationRequested && continueProcessing)
+            {
+                try
+                {
+                    // Note that we're processing tasks on this thread
+                    s_taskProcessingThread.Value = true;
+
+                    // Until there are no more tasks to process
+                    while (!_disposeCancellation.IsCancellationRequested)
+                    {
+                        // Try to get the next task.  If there aren't any more, we're done.
+                        Task targetTask;
+                        lock (_nonthreadsafeTaskQueue)
+                        {
+                            if (_nonthreadsafeTaskQueue.Count == 0)
+                                break;
+                            targetTask = _nonthreadsafeTaskQueue.Dequeue();
+                        }
+
+                        // If the task is null, it's a placeholder for a task in the round-robin queues.
+                        // Find the next one that should be processed.
+                        QueuedTaskSchedulerQueue queueForTargetTask = null;
+                        if (targetTask == null)
+                        {
+                            lock (_queueGroups)
+                                FindNextTask_NeedsLock(out targetTask, out queueForTargetTask);
+                        }
+
+                        // Now if we finally have a task, run it.  If the task
+                        // was associated with one of the round-robin schedulers, we need to use it
+                        // as a thunk to execute its task.
+                        if (targetTask != null)
+                        {
+                            if (queueForTargetTask != null)
+                                queueForTargetTask.ExecuteTask(targetTask);
+                            else
+                                TryExecuteTask(targetTask);
+                        }
+                    }
+                }
+                finally
+                {
+                    // Now that we think we're done, verify that there really is
+                    // no more work to do.  If there's not, highlight
+                    // that we're now less parallel than we were a moment ago.
+                    lock (_nonthreadsafeTaskQueue)
+                    {
+                        if (_nonthreadsafeTaskQueue.Count == 0)
+                        {
+                            _delegatesQueuedOrRunning--;
+                            continueProcessing = false;
+                            s_taskProcessingThread.Value = false;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>Notifies the pool that there's a new item to be executed in one of the round-robin queues.</summary>
+        private void NotifyNewWorkItem() => QueueTask(null);
+
+        /// <summary>Tries to execute a task synchronously on the current thread.</summary>
+        /// <param name="task">The task to execute.</param>
+        /// <param name="taskWasPreviouslyQueued">Whether the task was previously queued.</param>
+        /// <returns>true if the task was executed; otherwise, false.</returns>
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) =>
+            // If we're already running tasks on this threads, enable inlining
+            s_taskProcessingThread.Value && TryExecuteTask(task);
+
+        /// <summary>Gets the tasks scheduled to this scheduler.</summary>
+        /// <returns>An enumerable of all tasks queued to this scheduler.</returns>
+        /// <remarks>This does not include the tasks on sub-schedulers.  Those will be retrieved by the debugger separately.</remarks>
+        protected override IEnumerable<Task> GetScheduledTasks()
+        {
+            // If we're running on our own threads, get the tasks from the blocking queue...
+            if (_targetScheduler == null)
+            {
+                // Get all of the tasks, filtering out nulls, which are just placeholders
+                // for tasks in other sub-schedulers
+                return _blockingTaskQueue.Where(t => t != null).ToList();
+            }
+            // otherwise get them from the non-blocking queue...
+            else
+            {
+                return _nonthreadsafeTaskQueue.Where(t => t != null).ToList();
+            }
+        }
+
+        /// <summary>Gets the maximum concurrency level to use when processing tasks.</summary>
+        public override int MaximumConcurrencyLevel => _concurrencyLevel;
+
+        /// <summary>Initiates shutdown of the scheduler.</summary>
+        public void Dispose() => _disposeCancellation.Cancel();
+
+        /// <summary>Creates and activates a new scheduling queue for this scheduler.</summary>
+        /// <returns>The newly created and activated queue at priority 0.</returns>
+        public TaskScheduler ActivateNewQueue() => ActivateNewQueue(0);
+
+        /// <summary>Creates and activates a new scheduling queue for this scheduler.</summary>
+        /// <param name="priority">The priority level for the new queue.</param>
+        /// <returns>The newly created and activated queue at the specified priority.</returns>
+        public TaskScheduler ActivateNewQueue(int priority)
+        {
+            // Create the queue
+            var createdQueue = new QueuedTaskSchedulerQueue(priority, this);
+
+            // Add the queue to the appropriate queue group based on priority
+            lock (_queueGroups)
+            {
+                if (!_queueGroups.TryGetValue(priority, out QueueGroup list))
+                {
+                    list = new QueueGroup();
+                    _queueGroups.Add(priority, list);
+                }
+                list.Add(createdQueue);
+            }
+
+            // Hand the new queue back
+            return createdQueue;
+        }
+
+        /// <summary>Removes a scheduler from the group.</summary>
+        /// <param name="queue">The scheduler to be removed.</param>
+        private void RemoveQueue_NeedsLock(QueuedTaskSchedulerQueue queue)
+        {
+            // Find the group that contains the queue and the queue's index within the group
+            var queueGroup = _queueGroups[queue._priority];
+            int index = queueGroup.IndexOf(queue);
+
+            // We're about to remove the queue, so adjust the index of the next
+            // round-robin starting location if it'll be affected by the removal
+            if (queueGroup.NextQueueIndex >= index)
+                queueGroup.NextQueueIndex--;
+
+            // Remove it
+            queueGroup.RemoveAt(index);
+        }
+
+        /// <summary>A group of queues a the same priority level.</summary>
+        private class QueueGroup : List<QueuedTaskSchedulerQueue>
+        {
+            /// <summary>The starting index for the next round-robin traversal.</summary>
+            public int NextQueueIndex = 0;
+
+            /// <summary>Creates a search order through this group.</summary>
+            /// <returns>An enumerable of indices for this group.</returns>
+            public IEnumerable<int> CreateSearchOrder()
+            {
+                for (int i = NextQueueIndex; i < Count; i++)
+                    yield return i;
+                for (int i = 0; i < NextQueueIndex; i++)
+                    yield return i;
+            }
+        }
+
+        /// <summary>Provides a scheduling queue associatd with a QueuedTaskScheduler.</summary>
+        [DebuggerDisplay("QueuePriority = {_priority}, WaitingTasks = {WaitingTasks}")]
+        [DebuggerTypeProxy(typeof(QueuedTaskSchedulerQueueDebugView))]
+        private sealed class QueuedTaskSchedulerQueue : TaskScheduler, IDisposable
+        {
+            /// <summary>A debug view for the queue.</summary>
+            private sealed class QueuedTaskSchedulerQueueDebugView
+            {
+                /// <summary>The queue.</summary>
+                private readonly QueuedTaskSchedulerQueue _queue;
+
+                /// <summary>Initializes the debug view.</summary>
+                /// <param name="queue">The queue to be debugged.</param>
+                public QueuedTaskSchedulerQueueDebugView(QueuedTaskSchedulerQueue queue) =>
+                    _queue = queue ?? throw new ArgumentNullException(nameof(queue));
+
+                /// <summary>Gets the priority of this queue in its associated scheduler.</summary>
+                public int Priority => _queue._priority;
+                /// <summary>Gets the ID of this scheduler.</summary>
+                public int Id => _queue.Id;
+                /// <summary>Gets all of the tasks scheduled to this queue.</summary>
+                public IEnumerable<Task> ScheduledTasks => _queue.GetScheduledTasks();
+                /// <summary>Gets the QueuedTaskScheduler with which this queue is associated.</summary>
+                public QueuedTaskScheduler AssociatedScheduler => _queue._pool;
+            }
+
+            /// <summary>The scheduler with which this pool is associated.</summary>
+            private readonly QueuedTaskScheduler _pool;
+            /// <summary>The work items stored in this queue.</summary>
+            internal readonly Queue<Task> _workItems;
+            /// <summary>Whether this queue has been disposed.</summary>
+            internal bool _disposed;
+            /// <summary>Gets the priority for this queue.</summary>
+            internal int _priority;
+
+            /// <summary>Initializes the queue.</summary>
+            /// <param name="priority">The priority associated with this queue.</param>
+            /// <param name="pool">The scheduler with which this queue is associated.</param>
+            internal QueuedTaskSchedulerQueue(int priority, QueuedTaskScheduler pool)
+            {
+                _priority = priority;
+                _pool = pool;
+                _workItems = new Queue<Task>();
+            }
+
+            /// <summary>Gets the number of tasks waiting in this scheduler.</summary>
+            internal int WaitingTasks => _workItems.Count;
+
+            /// <summary>Gets the tasks scheduled to this scheduler.</summary>
+            /// <returns>An enumerable of all tasks queued to this scheduler.</returns>
+            protected override IEnumerable<Task> GetScheduledTasks() => _workItems.ToList();
+
+            /// <summary>Queues a task to the scheduler.</summary>
+            /// <param name="task">The task to be queued.</param>
+            protected override void QueueTask(Task task)
+            {
+                if (_disposed)
+                    throw new ObjectDisposedException(GetType().Name);
+
+                // Queue up the task locally to this queue, and then notify
+                // the parent scheduler that there's work available
+                lock (_pool._queueGroups)
+                    _workItems.Enqueue(task);
+                _pool.NotifyNewWorkItem();
+            }
+
+            /// <summary>Tries to execute a task synchronously on the current thread.</summary>
+            /// <param name="task">The task to execute.</param>
+            /// <param name="taskWasPreviouslyQueued">Whether the task was previously queued.</param>
+            /// <returns>true if the task was executed; otherwise, false.</returns>
+            protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) =>
+                // If we're using our own threads and if this is being called from one of them,
+                // or if we're currently processing another task on this thread, try running it inline.
+                s_taskProcessingThread.Value && TryExecuteTask(task);
+
+            /// <summary>Runs the specified ask.</summary>
+            /// <param name="task">The task to execute.</param>
+            internal void ExecuteTask(Task task) => TryExecuteTask(task);
+
+            /// <summary>Gets the maximum concurrency level to use when processing tasks.</summary>
+            public override int MaximumConcurrencyLevel => _pool.MaximumConcurrencyLevel;
+
+            /// <summary>Signals that the queue should be removed from the scheduler as soon as the queue is empty.</summary>
+            public void Dispose()
+            {
+                if (!_disposed)
+                {
+                    lock (_pool._queueGroups)
+                    {
+                        // We only remove the queue if it's empty.  If it's not empty,
+                        // we still mark it as disposed, and the associated QueuedTaskScheduler
+                        // will remove the queue when its count hits 0 and its _disposed is true.
+                        if (_workItems.Count == 0)
+                        {
+                            _pool.RemoveQueue_NeedsLock(this);
+                        }
+                    }
+                    _disposed = true;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITaskScheduler.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITaskScheduler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.SqlClient.SNI
     /// </summary>
     [DebuggerTypeProxy(typeof(QueuedTaskSchedulerDebugView))]
     [DebuggerDisplay("Id={Id}, Queues={DebugQueueCount}, ScheduledTasks = {DebugTaskCount}")]
-    public sealed class QueuedTaskScheduler : TaskScheduler, IDisposable
+    internal sealed class QueuedTaskScheduler : TaskScheduler, IDisposable
     {
         /// <summary>Debug view for the QueuedTaskScheduler.</summary>
         private class QueuedTaskSchedulerDebugView

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -15,13 +15,16 @@ namespace Microsoft.Data.SqlClient
         internal const string LegacyRowVersionNullString = @"Switch.Microsoft.Data.SqlClient.LegacyRowVersionNullBehavior";
         internal const string UseSystemDefaultSecureProtocolsString = @"Switch.Microsoft.Data.SqlClient.UseSystemDefaultSecureProtocols";
         internal const string SuppressInsecureTLSWarningString = @"Switch.Microsoft.Data.SqlClient.SuppressInsecureTLSWarning";
+        internal const string UseExperimentalMARSThreadingString = @"Switch.Microsoft.Data.SqlClient.UseExperimentalMARSThreading";
 
         private static bool s_makeReadAsyncBlocking;
         private static bool? s_LegacyRowVersionNullBehavior;
         private static bool? s_UseSystemDefaultSecureProtocols;
-        private static bool? s_SuppressInsecureTLSWarning;
+        private static bool? s_SuppressInsecureTLSWarning; 
+        private static bool? s_useExperimentalMARSThreading;
 
-#if !NETFRAMEWORK
+
+#if NETCOREAPP31_AND_ABOVE
         static LocalAppContextSwitches()
         {
             IAppContextSwitchOverridesSection appContextSwitch = AppConfigManager.FetchConfigurationSection<AppContextSwitchOverridesSection>(AppContextSwitchOverridesSection.Name);
@@ -93,6 +96,20 @@ namespace Microsoft.Data.SqlClient
                     s_UseSystemDefaultSecureProtocols = result;
                 }
                 return s_UseSystemDefaultSecureProtocols.Value;
+            }
+        }
+
+        public static bool UseExperimentalMARSThreading
+        {
+            get
+            {
+                if (s_useExperimentalMARSThreading is null)
+                {
+                    bool result;
+                    result = AppContext.TryGetSwitch(UseExperimentalMARSThreadingString, out result) ? result : false;
+                    s_useExperimentalMARSThreading = result;
+                }
+                return s_useExperimentalMARSThreading.Value;
             }
         }
     }


### PR DESCRIPTION
Addresses https://github.com/dotnet/SqlClient/issues/422 but does not "fix" it, the fix is not to overload the system thread pool starving asynchronous operations of the cpu resources needed to do the requested work.

This adds a netcore3.1 or later specific task scheduler which uses dedicated threads to handle mars io when the system thread pool has queued tasks waiting. The only work done on these dedicated threads io work required to keep mars functioning and once data has been received any other async work will proceed on user threads as normal. No user code will execute on these threads.

The behaviour observed is that as soon as the system thread pool becomes overloaded the mars io threads take over and continue to do mars io work until the system thread pool becomes less saturated, A demand changes the io is diverted to the dedicated threads as needed but we prefer the system thread pool. This is a simple scheduler taken from the dotnet example code and so it does not attempt to grow or shrink the number of threads, it is hardcoded at 3 for this PR but could be changed.

![image](https://user-images.githubusercontent.com/13322696/158039247-48a7f3f1-357a-4607-a95b-91d666e94332.png)

To use this requires two appsettings, preferably in `Main`
```csharp
AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", true);
AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseExperimentalMARSThreading", true);
```