### PR TITLE
Add and use TryReadChars method

### DIFF
--- a/src/Microsoft.Data.SqlClient.sln
+++ b/src/Microsoft.Data.SqlClient.sln
@@ -205,6 +205,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4F3CD363-B1E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlServer.Server", "Microsoft.SqlServer.Server\Microsoft.SqlServer.Server.csproj", "{A314812A-7820-4565-A2A8-ABBE391C11E4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SqlBench3.0", "..\..\dev\SqlClient-Integrated\SqlBench3.0\SqlBench3.0.csproj", "{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -489,6 +491,18 @@ Global
 		{A314812A-7820-4565-A2A8-ABBE391C11E4}.Release|x64.Build.0 = Release|Any CPU
 		{A314812A-7820-4565-A2A8-ABBE391C11E4}.Release|x86.ActiveCfg = Release|Any CPU
 		{A314812A-7820-4565-A2A8-ABBE391C11E4}.Release|x86.Build.0 = Release|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|x64.Build.0 = Debug|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|x86.Build.0 = Debug|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|x64.ActiveCfg = Release|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|x64.Build.0 = Release|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|x86.ActiveCfg = Release|Any CPU
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -525,6 +539,7 @@ Global
 		{B93A3149-67E8-491E-A1E5-19D65F9D9E98} = {0CC4817A-12F3-4357-912C-09315FAAD008}
 		{599A336B-2A5F-473D-8442-1223ED37C93E} = {0CC4817A-12F3-4357-912C-09315FAAD008}
 		{A314812A-7820-4565-A2A8-ABBE391C11E4} = {4F3CD363-B1E6-4D6D-9466-97D78A56BE45}
+		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7} = {28E5EFE6-C9DD-4FF9-9FEC-532F72DFFA6E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01D48116-37A2-4D33-B9EC-94793C702431}

--- a/src/Microsoft.Data.SqlClient.sln
+++ b/src/Microsoft.Data.SqlClient.sln
@@ -205,8 +205,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4F3CD363-B1E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.SqlServer.Server", "Microsoft.SqlServer.Server\Microsoft.SqlServer.Server.csproj", "{A314812A-7820-4565-A2A8-ABBE391C11E4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SqlBench3.0", "..\..\dev\SqlClient-Integrated\SqlBench3.0\SqlBench3.0.csproj", "{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -491,18 +489,6 @@ Global
 		{A314812A-7820-4565-A2A8-ABBE391C11E4}.Release|x64.Build.0 = Release|Any CPU
 		{A314812A-7820-4565-A2A8-ABBE391C11E4}.Release|x86.ActiveCfg = Release|Any CPU
 		{A314812A-7820-4565-A2A8-ABBE391C11E4}.Release|x86.Build.0 = Release|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|x64.Build.0 = Debug|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Debug|x86.Build.0 = Debug|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|x64.ActiveCfg = Release|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|x64.Build.0 = Release|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|x86.ActiveCfg = Release|Any CPU
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -539,7 +525,6 @@ Global
 		{B93A3149-67E8-491E-A1E5-19D65F9D9E98} = {0CC4817A-12F3-4357-912C-09315FAAD008}
 		{599A336B-2A5F-473D-8442-1223ED37C93E} = {0CC4817A-12F3-4357-912C-09315FAAD008}
 		{A314812A-7820-4565-A2A8-ABBE391C11E4} = {4F3CD363-B1E6-4D6D-9466-97D78A56BE45}
-		{1BCC919A-CA34-4A5C-B0C3-69A16FA844D7} = {28E5EFE6-C9DD-4FF9-9FEC-532F72DFFA6E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01D48116-37A2-4D33-B9EC-94793C702431}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -10,6 +10,8 @@ using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
@@ -12505,14 +12507,14 @@ namespace Microsoft.Data.SqlClient
 
             // stateObj._longlenleft is in bytes
             if ((stateObj._longlenleft >> 1) < (ulong)len)
-                charsRead = (int)(stateObj._longlenleft >> 1);
-
-            for (int ii = 0; ii < charsRead; ii++)
             {
-                if (!stateObj.TryReadChar(out buff[offst + ii]))
-                {
-                    return false;
-                }
+                charsRead = (int)(stateObj._longlenleft >> 1);
+            }
+
+            if (!stateObj.TryReadChars(buff, offst, len, out charsRead))
+            {
+                charsRead = 0;
+                return false;
             }
 
             stateObj._longlenleft -= ((ulong)charsRead << 1);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -12503,15 +12503,16 @@ namespace Microsoft.Data.SqlClient
                 return true;
             }
 
-            charsRead = len;
+            int charsToRead = len;
 
             // stateObj._longlenleft is in bytes
             if ((stateObj._longlenleft >> 1) < (ulong)len)
             {
-                charsRead = (int)(stateObj._longlenleft >> 1);
+                charsToRead = (int)(stateObj._longlenleft >> 1);
             }
 
-            if (!stateObj.TryReadChars(buff, offst, len, out charsRead))
+
+            if (!stateObj.TryReadChars(buff, offst, charsToRead, out charsRead))
             {
                 charsRead = 0;
                 return false;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -10,8 +10,6 @@ using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
@@ -12510,7 +12508,6 @@ namespace Microsoft.Data.SqlClient
             {
                 charsToRead = (int)(stateObj._longlenleft >> 1);
             }
-
 
             if (!stateObj.TryReadChars(buff, offst, charsToRead, out charsRead))
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -12506,7 +12506,7 @@ namespace Microsoft.Data.SqlClient
             int charsToRead = len;
 
             // stateObj._longlenleft is in bytes
-            if ((stateObj._longlenleft >> 1) < (ulong)len)
+            if ((stateObj._longlenleft / 2) < (ulong)len)
             {
                 charsToRead = (int)(stateObj._longlenleft >> 1);
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -3,12 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Common;
@@ -488,51 +485,6 @@ namespace Microsoft.Data.SqlClient
             AssertValidState();
             value = (char)((buffer[1] << 8) + buffer[0]);
             
-            return true;
-        }
-
-        internal bool TryReadChars(char[] chars, int charsOffset, int charsCount, out int charsCopied)
-        {
-            charsCopied = 0;
-            while (charsCopied < charsCount)
-            {
-                // check if the current buffer contains some bytes we need to copy and copy them
-                //  in a block
-                int bytesToRead = Math.Min(
-                    (charsCount - charsCopied) * 2,
-                    unchecked((_inBytesRead - _inBytesUsed) & (int)0xFFFFFFFE) // it the result is odd take off the 0 to make it even
-                );
-                if (bytesToRead > 0)
-                {
-                    Buffer.BlockCopy(
-                        _inBuff,
-                        _inBytesUsed,
-                        chars,
-                        (charsOffset + charsCopied) * 2, // offset in bytes,
-                        bytesToRead
-                    );
-                    charsCopied = bytesToRead / 2;
-                    _inBytesUsed += bytesToRead;
-                    _inBytesPacket -= bytesToRead;
-                }
-
-                // if the number of chars requested is lower than the number copied then we need
-                //  to request a new packet, use TryReadChar() to do this then loop back to see
-                //  if we can copy another bulk of chars from the new buffer
-
-                if (charsCopied < charsCount)
-                {
-                    bool result = TryReadChar(out chars[charsOffset + charsCopied]);
-                    if (result)
-                    {
-                        charsCopied += 1;
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                }
-            }
             return true;
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -487,6 +487,52 @@ namespace Microsoft.Data.SqlClient
 
             AssertValidState();
             value = (char)((buffer[1] << 8) + buffer[0]);
+            
+            return true;
+        }
+
+        internal bool TryReadChars(char[] chars, int charsOffset, int charsCount, out int charsCopied)
+        {
+            charsCopied = 0;
+            while (charsCopied < charsCount)
+            {
+                // check if the current buffer contains some bytes we need to copy and copy them
+                //  in a block
+                int bytesToRead = Math.Min(
+                    (charsCount - charsCopied) * 2,
+                    unchecked((_inBytesRead - _inBytesUsed) & (int)0xFFFFFFFE) // it the result is odd take off the 0 to make it even
+                );
+                if (bytesToRead > 0)
+                {
+                    Buffer.BlockCopy(
+                        _inBuff,
+                        _inBytesUsed,
+                        chars,
+                        (charsOffset + charsCopied) * 2, // offset in bytes,
+                        bytesToRead
+                    );
+                    charsCopied = bytesToRead / 2;
+                    _inBytesUsed += bytesToRead;
+                    _inBytesPacket -= bytesToRead;
+                }
+
+                // if the number of chars requested is lower than the number copied then we need
+                //  to request a new packet, use TryReadChar() to do this then loop back to see
+                //  if we can copy another bulk of chars from the new buffer
+
+                if (charsCopied < charsCount)
+                {
+                    bool result = TryReadChar(out chars[charsOffset + charsCopied]);
+                    if (result)
+                    {
+                        charsCopied += 1;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+            }
             return true;
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -13528,7 +13528,6 @@ namespace Microsoft.Data.SqlClient
         // Returns the actual chars read
         private bool TryReadPlpUnicodeCharsChunk(char[] buff, int offst, int len, TdsParserStateObject stateObj, out int charsRead)
         {
-
             Debug.Assert((buff == null && len == 0) || (buff.Length >= offst + len), "Invalid length sent to ReadPlpUnicodeChars()!");
             Debug.Assert((stateObj._longlen != 0) && (stateObj._longlen != TdsEnums.SQL_PLP_NULL),
                         "Out of sync plp read request");
@@ -13539,18 +13538,18 @@ namespace Microsoft.Data.SqlClient
                 return true;
             }
 
-            charsRead = len;
+            int charsToRead = len;
 
             // stateObj._longlenleft is in bytes
-            if ((stateObj._longlenleft >> 1) < (ulong)len)
-                charsRead = (int)(stateObj._longlenleft >> 1);
-
-            for (int ii = 0; ii < charsRead; ii++)
+            if ((stateObj._longlenleft / 2) < (ulong)len)
             {
-                if (!stateObj.TryReadChar(out buff[offst + ii]))
-                {
-                    return false;
-                }
+                charsToRead = (int)(stateObj._longlenleft >> 1);
+            }
+
+            if (!stateObj.TryReadChars(buff, offst, charsToRead, out charsRead))
+            {
+                charsRead = 0;
+                return false;
             }
 
             stateObj._longlenleft -= ((ulong)charsRead << 1);


### PR DESCRIPTION
In https://github.com/dotnet/SqlClient/issues/593#issuecomment-1041190401 @panoskj pointed out that there was a path in the example reproduction which was copying characters from a buffer one at a time in a loop and that this was inefficient. I've done a little digging and this is an attempt to speed it up. Note that not all strings are copied this way.

Unfortunately the fix isn't as simple as copying into from the byte[]. We need to make sure that if we reach a packet boundary that we call a function capable of fetching the next packet. We also need to be aware that we could end up with a partial character in the input buffer and that needs special handling. The strategy I've settled on for this PR is to identify how much can be copied in bulk from the current packet and then pick up any remainder or simply force a new packet by calling TryReadChar() as the code currently does. This should result in most data being read in large blocks with single chars being picked up at existing boundaries which should be faster if not the fastest possible.

/cc @panoskj could you take a look and see if you agree with this and possibly run it through your benches/profiler to see if it improves the numbers you saw?