### PR TITLE
Rework `TdsParserStateObjectManaged` with nullable annotations

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -505,6 +505,9 @@
     <Compile Include="..\..\src\Resources\StringsHelper.cs">
       <Link>Resources\StringsHelper.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Diagnostics\CodeAnalysis.cs">
+      <Link>Common\System\Diagnostics\CodeAnalysis.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' OR '$(TargetGroup)' == 'netcoreapp' OR '$(IsUAPAssembly)' == 'true'">
     <Compile Include="Microsoft.Data.SqlClient.TypeForwards.cs" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -14,7 +14,7 @@ using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient.SNI
 {
-    internal class TdsParserStateObjectManaged : TdsParserStateObject
+    internal sealed class TdsParserStateObjectManaged : TdsParserStateObject
     {
         private SNIMarsConnection? _marsConnection;
         private SNIHandle? _sessionHandle;
@@ -46,7 +46,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             else
             {
-                throw ADP.InvalidOperation("physicalConnection type is incorrect");
+                throw new ArgumentException(StringsHelper.GetString(StringsHelper.SNI_IncorrectPhysicalConnectionType));
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -2,8 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Common;
 
@@ -11,17 +16,15 @@ namespace Microsoft.Data.SqlClient.SNI
 {
     internal class TdsParserStateObjectManaged : TdsParserStateObject
     {
-        private SNIMarsConnection _marsConnection;
-        private SNIHandle _sessionHandle;
-        private SspiClientContextStatus _sspiClientContextStatus;
+        private SNIMarsConnection? _marsConnection;
+        private SNIHandle? _sessionHandle;
+        private SspiClientContextStatus? _sspiClientContextStatus;
 
         public TdsParserStateObjectManaged(TdsParser parser) : base(parser) { }
 
         internal TdsParserStateObjectManaged(TdsParser parser, TdsParserStateObject physicalConnection, bool async) :
             base(parser, physicalConnection, async)
         { }
-
-        internal SNIHandle Handle => _sessionHandle;
 
         internal override uint Status => _sessionHandle != null ? _sessionHandle.Status : TdsEnums.SNI_UNINITIALIZED;
 
@@ -36,15 +39,25 @@ namespace Microsoft.Data.SqlClient.SNI
         protected override void CreateSessionHandle(TdsParserStateObject physicalConnection, bool async)
         {
             Debug.Assert(physicalConnection is TdsParserStateObjectManaged, "Expected a stateObject of type " + GetType());
-            TdsParserStateObjectManaged managedSNIObject = physicalConnection as TdsParserStateObjectManaged;
-            _sessionHandle = managedSNIObject.CreateMarsSession(this, async);
-            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.CreateSessionHandle | Info | State Object Id {0}, Session Id {1}", _objectID, _sessionHandle?.ConnectionId);
+            if (physicalConnection is TdsParserStateObjectManaged managedSNIObject)
+            {
+                _sessionHandle = managedSNIObject.CreateMarsSession(this, async);
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.CreateSessionHandle | Info | State Object Id {0}, Session Id {1}", _objectID, _sessionHandle?.ConnectionId);
+            }
+            else
+            {
+                throw ADP.InvalidOperation("physicalConnection type is incorrect");
+            }
         }
 
         internal SNIMarsHandle CreateMarsSession(object callbackObject, bool async)
         {
             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.CreateMarsSession | Info | State Object Id {0}, Session Id {1}, Async = {2}", _objectID, _sessionHandle?.ConnectionId, async);
-            return _marsConnection.CreateMarsSession(callbackObject, async);
+            if (_marsConnection is null)
+            {
+                ThrowClosedConnection();
+            }
+            return _marsConnection!.CreateMarsSession(callbackObject, async);
         }
 
         /// <summary>
@@ -62,23 +75,24 @@ namespace Microsoft.Data.SqlClient.SNI
             return TdsEnums.SNI_SUCCESS;
         }
 
-        internal override void CreatePhysicalSNIHandle(string serverName, bool ignoreSniOpenTimeout, long timerExpire, out byte[] instanceName, ref byte[][] spnBuffer, bool flushCache, bool async, bool parallel, 
+        internal override void CreatePhysicalSNIHandle(string serverName, bool ignoreSniOpenTimeout, long timerExpire, out byte[] instanceName, ref byte[][] spnBuffer, bool flushCache, bool async, bool parallel,
                                            SqlConnectionIPAddressPreference iPAddressPreference, string cachedFQDN, ref SQLDNSInfo pendingDNSInfo, bool isIntegratedSecurity)
         {
-            _sessionHandle = SNIProxy.CreateConnectionHandle(serverName, ignoreSniOpenTimeout, timerExpire, out instanceName, ref spnBuffer, flushCache, async, parallel, isIntegratedSecurity, 
+            SNIHandle? sessionHandle = SNIProxy.CreateConnectionHandle(serverName, ignoreSniOpenTimeout, timerExpire, out instanceName, ref spnBuffer, flushCache, async, parallel, isIntegratedSecurity,
                                                         iPAddressPreference, cachedFQDN, ref pendingDNSInfo);
-            if (_sessionHandle == null)
+            if (sessionHandle is not null)
             {
-                _parser.ProcessSNIError(this);
-            }
-            else
-            {
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.CreatePhysicalSNIHandle | Info | State Object Id {0}, Session Id {1}, ServerName {2}, Async = {3}", _objectID, _sessionHandle?.ConnectionId, serverName, async);
+                _sessionHandle = sessionHandle;
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.CreatePhysicalSNIHandle | Info | State Object Id {0}, Session Id {1}, ServerName {2}, Async = {3}", _objectID, sessionHandle.ConnectionId, serverName, async);
                 if (async)
                 {
                     // Create call backs and allocate to the session handle
-                    _sessionHandle.SetAsyncCallbacks(ReadAsyncCallback, WriteAsyncCallback);
+                    sessionHandle.SetAsyncCallbacks(ReadAsyncCallback, WriteAsyncCallback);
                 }
+            }
+            else
+            {
+                _parser.ProcessSNIError(this);
             }
         }
 
@@ -90,13 +104,13 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal void ReadAsyncCallback(SNIPacket packet, uint error)
         {
-            SNIHandle sessionHandle = _sessionHandle;
-            if (sessionHandle != null)
+            SNIHandle? sessionHandle = _sessionHandle;
+            if (sessionHandle is not null)
             {
                 ReadAsyncCallback(IntPtr.Zero, PacketHandle.FromManagedPacket(packet), error);
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.ReadAsyncCallback | Info | State Object Id {0}, Session Id {1}, Error code returned {2}", _objectID, _sessionHandle?.ConnectionId, error);
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.ReadAsyncCallback | Info | State Object Id {0}, Session Id {1}, Error code returned {2}", _objectID, sessionHandle.ConnectionId, error);
 #if DEBUG
-                SqlClientEventSource.Log.TryAdvancedTraceEvent("TdsParserStateObjectManaged.ReadAsyncCallback | TRC | State Object Id {0}, Session Id {1}, Packet Id = {2}, Error code returned {3}", _objectID, _sessionHandle?.ConnectionId, packet?._id, error);
+                SqlClientEventSource.Log.TryAdvancedTraceEvent("TdsParserStateObjectManaged.ReadAsyncCallback | TRC | State Object Id {0}, Session Id {1}, Packet Id = {2}, Error code returned {3}", _objectID, sessionHandle.ConnectionId, packet?._id, error);
 #endif
                 sessionHandle?.ReturnPacket(packet);
             }
@@ -110,13 +124,13 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal void WriteAsyncCallback(SNIPacket packet, uint sniError)
         {
-            SNIHandle sessionHandle = _sessionHandle;
-            if (sessionHandle != null)
+            SNIHandle? sessionHandle = _sessionHandle;
+            if (sessionHandle is not null)
             {
                 WriteAsyncCallback(IntPtr.Zero, PacketHandle.FromManagedPacket(packet), sniError);
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.WriteAsyncCallback | Info | State Object Id {0}, Session Id {1}, Error code returned {2}", _objectID, _sessionHandle?.ConnectionId, sniError);
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.WriteAsyncCallback | Info | State Object Id {0}, Session Id {1}, Error code returned {2}", _objectID, sessionHandle.ConnectionId, sniError);
 #if DEBUG
-                SqlClientEventSource.Log.TryAdvancedTraceEvent("TdsParserStateObjectManaged.WriteAsyncCallback | TRC | State Object Id {0}, Session Id {1}, Packet Id = {2}, Error code returned {3}", _objectID, _sessionHandle?.ConnectionId, packet?._id, sniError);
+                SqlClientEventSource.Log.TryAdvancedTraceEvent("TdsParserStateObjectManaged.WriteAsyncCallback | TRC | State Object Id {0}, Session Id {1}, Packet Id = {2}, Error code returned {3}", _objectID, sessionHandle.ConnectionId, packet?._id, sniError);
 #endif
                 sessionHandle?.ReturnPacket(packet);
             }
@@ -135,19 +149,24 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal override void Dispose()
         {
-            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.Dispose | Info | State Object Id {0}, Session Id {1}, Disposing session Handle and counters.", _objectID, _sessionHandle?.ConnectionId);
-            SNIHandle sessionHandle = _sessionHandle;
-
-            _sessionHandle = null;
-            _marsConnection = null;
-
-            DisposeCounters();
-
-            if (null != sessionHandle)
+            SNIHandle? sessionHandle = Interlocked.Exchange(ref _sessionHandle, null);
+            if (sessionHandle is not null)
             {
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.Dispose | Info | State Object Id {0}, Session Id {1}, sessionHandle is available, disposing session.", _objectID, _sessionHandle?.ConnectionId);
-                sessionHandle.Dispose();
-                DecrementPendingCallbacks(true); // Will dispose of GC handle.
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.Dispose | Info | State Object Id {0}, Session Id {1}, Disposing session Handle and counters.", _objectID, sessionHandle.ConnectionId);
+
+                _marsConnection = null;
+
+                DisposeCounters();
+
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.Dispose | Info | State Object Id {0}, Session Id {1}, sessionHandle is available, disposing session.", _objectID, sessionHandle.ConnectionId);
+                try
+                {
+                    sessionHandle.Dispose();
+                }
+                finally
+                {
+                    DecrementPendingCallbacks(true); // Will dispose of GC handle.
+                }
             }
             else
             {
@@ -165,21 +184,26 @@ namespace Microsoft.Data.SqlClient.SNI
             // No - op
         }
 
-        internal override bool IsFailedHandle() => _sessionHandle.Status != TdsEnums.SNI_SUCCESS;
+        internal override bool IsFailedHandle()
+        {
+            SNIHandle? sessionHandle = _sessionHandle;
+            if (sessionHandle is not null)
+            {
+                return sessionHandle.Status != TdsEnums.SNI_SUCCESS;
+            }
+            return true;
+        }
+
 
         internal override PacketHandle ReadSyncOverAsync(int timeoutRemaining, out uint error)
         {
-            SNIHandle handle = Handle;
-            if (handle == null)
-            {
-                throw ADP.ClosedConnectionError();
-            }
+            SNIHandle sessionHandle = GetSessionSNIHandleHandleOrThrow();
 
-            error = handle.Receive(out SNIPacket packet, timeoutRemaining);
+            error = sessionHandle.Receive(out SNIPacket packet, timeoutRemaining);
             
-            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.ReadSyncOverAsync | Info | State Object Id {0}, Session Id {1}", _objectID, _sessionHandle?.ConnectionId);
+            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.ReadSyncOverAsync | Info | State Object Id {0}, Session Id {1}", _objectID, sessionHandle.ConnectionId);
 #if DEBUG
-            SqlClientEventSource.Log.TryAdvancedTraceEvent("TdsParserStateObjectManaged.ReadSyncOverAsync | TRC | State Object Id {0}, Session Id {1}, Packet {2} received, Packet owner Id {3}, Packet dataLeft {4}", _objectID, _sessionHandle?.ConnectionId, packet?._id, packet?._owner.ConnectionId, packet?.DataLeft);
+            SqlClientEventSource.Log.TryAdvancedTraceEvent("TdsParserStateObjectManaged.ReadSyncOverAsync | TRC | State Object Id {0}, Session Id {1}, Packet {2} received, Packet owner Id {3}, Packet dataLeft {4}", _objectID, sessionHandle.ConnectionId, packet?._id, packet?._owner.ConnectionId, packet?.DataLeft);
 #endif
             return PacketHandle.FromManagedPacket(packet);
         }
@@ -195,22 +219,31 @@ namespace Microsoft.Data.SqlClient.SNI
 #if DEBUG
             SqlClientEventSource.Log.TryAdvancedTraceEvent("TdsParserStateObjectManaged.ReleasePacket | TRC | State Object Id {0}, Session Id {1}, Packet {2} will be released, Packet Owner Id {3}, Packet dataLeft {4}", _objectID, _sessionHandle?.ConnectionId, packet?._id, packet?._owner.ConnectionId, packet?.DataLeft);
 #endif
-            if (packet != null)
+            if (packet is not null)
             {
-                SNIHandle handle = Handle;
-                handle.ReturnPacket(packet);
+                SNIHandle? sessionHandle = _sessionHandle;
+                if (sessionHandle is not null)
+                {
+                    sessionHandle.ReturnPacket(packet);
+                }
+                else
+                {
+                    // clear the packet and drop it to GC because we no longer know how to return it to the correct owner
+                    // this can only happen if a packet is in-flight when the _sessionHandle is cleared
+                    packet.Release();
+                }
             }
         }
 
         internal override uint CheckConnection()
         {
-            SNIHandle handle = Handle;
-            return handle == null ? TdsEnums.SNI_SUCCESS : handle.CheckConnection();
+            SNIHandle? handle = GetSessionSNIHandleHandleOrThrow();
+            return handle is null ? TdsEnums.SNI_SUCCESS : handle.CheckConnection();
         }
 
         internal override PacketHandle ReadAsync(SessionHandle handle, out uint error)
         {
-            SNIPacket packet = null;
+            SNIPacket? packet = null;
             error = handle.ManagedHandle.ReceiveAsync(ref packet);
 
             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.ReadAsync | Info | State Object Id {0}, Session Id {1}, Packet DataLeft {2}", _objectID, _sessionHandle?.ConnectionId, packet?.DataLeft);
@@ -232,20 +265,21 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal override uint WritePacket(PacketHandle packetHandle, bool sync)
         {
-            uint result;
-            SNIHandle handle = Handle;
-            SNIPacket packet = packetHandle.ManagedPacket;
+            uint result = TdsEnums.SNI_UNINITIALIZED;
+            SNIHandle sessionHandle = GetSessionSNIHandleHandleOrThrow();
+            SNIPacket? packet = packetHandle.ManagedPacket;
+
             if (sync)
             {
-                result = handle.Send(packet);
-                handle.ReturnPacket(packet);
+                result = sessionHandle.Send(packet);
+                sessionHandle.ReturnPacket(packet);
             }
             else
             {
-                result = handle.SendAsync(packet);
+                result = sessionHandle.SendAsync(packet);
             }
-
-            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.WritePacket | Info | Session Id {0}, SendAsync Result {1}", handle?.ConnectionId, result);
+            
+            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.WritePacket | Info | Session Id {0}, SendAsync Result {1}", sessionHandle.ConnectionId, result);
             return result;
         }
 
@@ -264,12 +298,12 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal override PacketHandle GetResetWritePacket(int dataSize)
         {
-            SNIHandle handle = Handle;
-            SNIPacket packet = handle.RentPacket(headerSize: handle.ReserveHeaderSize, dataSize: dataSize);
+            SNIHandle sessionHandle = GetSessionSNIHandleHandleOrThrow();
+            SNIPacket packet = sessionHandle.RentPacket(headerSize: sessionHandle.ReserveHeaderSize, dataSize: dataSize);
 #if DEBUG
             Debug.Assert(packet.IsActive, "packet is not active, a serious pooling error may have occurred");
 #endif
-            Debug.Assert(packet.ReservedHeaderSize == handle.ReserveHeaderSize, "failed to reserve header");
+            Debug.Assert(packet.ReservedHeaderSize == sessionHandle.ReserveHeaderSize, "failed to reserve header");
             return PacketHandle.FromManagedPacket(packet);
         }
 
@@ -285,23 +319,24 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal override uint SniGetConnectionId(ref Guid clientConnectionId)
         {
-            clientConnectionId = Handle.ConnectionId;
+            clientConnectionId = GetSessionSNIHandleHandleOrThrow().ConnectionId;
             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.GetConnectionId | Info | Session Id {0}", clientConnectionId);
             return TdsEnums.SNI_SUCCESS;
         }
 
         internal override uint DisableSsl()
         {
-            SNIHandle handle = Handle;
-            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.DisableSsl | Info | Session Id {0}", handle?.ConnectionId);
-            handle.DisableSsl();
+            SNIHandle sessionHandle = GetSessionSNIHandleHandleOrThrow();
+            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.DisableSsl | Info | Session Id {0}", sessionHandle.ConnectionId);
+            sessionHandle.DisableSsl();
             return TdsEnums.SNI_SUCCESS;
         }
 
         internal override uint EnableMars(ref uint info)
         {
-            _marsConnection = new SNIMarsConnection(Handle);
-            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.EnableMars | Info | State Object Id {0}, Session Id {1}", _objectID, _sessionHandle?.ConnectionId);
+            SNIHandle sessionHandle = GetSessionSNIHandleHandleOrThrow();
+            _marsConnection = new SNIMarsConnection(sessionHandle);
+            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.EnableMars | Info | State Object Id {0}, Session Id {1}", _objectID, sessionHandle.ConnectionId);
 
             if (_marsConnection.StartReceive() == TdsEnums.SNI_SUCCESS_IO_PENDING)
             {
@@ -313,28 +348,28 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal override uint EnableSsl(ref uint info)
         {
-            SNIHandle handle = Handle;
+            SNIHandle sessionHandle = GetSessionSNIHandleHandleOrThrow();
             try
             {
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.EnableSsl | Info | Session Id {0}", handle?.ConnectionId);
-                return handle.EnableSsl(info);
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.EnableSsl | Info | Session Id {0}", sessionHandle.ConnectionId);
+                return sessionHandle.EnableSsl(info);
             }
             catch (Exception e)
             {
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.EnableSsl | Err | Session Id {0}, SNI Handshake failed with exception: {1}", handle?.ConnectionId, e?.Message);
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.EnableSsl | Err | Session Id {0}, SNI Handshake failed with exception: {1}", sessionHandle.ConnectionId, e.Message);
                 return SNICommon.ReportSNIError(SNIProviders.SSL_PROV, SNICommon.HandshakeFailureError, e);
             }
         }
 
         internal override uint SetConnectionBufferSize(ref uint unsignedPacketSize)
         {
-            Handle.SetBufferSize((int)unsignedPacketSize);
+            GetSessionSNIHandleHandleOrThrow().SetBufferSize((int)unsignedPacketSize);
             return TdsEnums.SNI_SUCCESS;
         }
 
         internal override uint GenerateSspiClientContext(byte[] receivedBuff, uint receivedLength, ref byte[] sendBuff, ref uint sendLength, byte[][] _sniSpnBuffer)
         {
-            if (_sspiClientContextStatus == null)
+            if (_sspiClientContextStatus is null)
             {
                 _sspiClientContextStatus = new SspiClientContextStatus();
             }
@@ -347,8 +382,26 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal override uint WaitForSSLHandShakeToComplete(out int protocolVersion)
         {
-            protocolVersion = Handle.ProtocolVersion;
+            protocolVersion = GetSessionSNIHandleHandleOrThrow().ProtocolVersion;
             return 0;
         }
+
+        private SNIHandle GetSessionSNIHandleHandleOrThrow()
+        {
+            SNIHandle? sessionHandle = _sessionHandle;
+            if (sessionHandle is null)
+            {
+                ThrowClosedConnection();
+            }
+            return sessionHandle!;
+        }
+
+#if NETCOREAPP
+        [DoesNotReturn]
+#endif 
+        [MethodImpl(MethodImplOptions.NoInlining)] // this forces the exception throwing code not to be inlined for performance
+        private void ThrowClosedConnection() => throw ADP.ClosedConnectionError();
+
+
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 ThrowClosedConnection();
             }
-            return _marsConnection!.CreateMarsSession(callbackObject, async);
+            return _marsConnection.CreateMarsSession(callbackObject, async);
         }
 
         /// <summary>
@@ -393,12 +393,10 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 ThrowClosedConnection();
             }
-            return sessionHandle!;
+            return sessionHandle;
         }
 
-#if NETCOREAPP
         [DoesNotReturn]
-#endif 
         [MethodImpl(MethodImplOptions.NoInlining)] // this forces the exception throwing code not to be inlined for performance
         private void ThrowClosedConnection() => throw ADP.ClosedConnectionError();
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             else
             {
-                throw new ArgumentException(StringsHelper.GetString(StringsHelper.SNI_IncorrectPhysicalConnectionType));
+                throw ADP.IncorrectPhysicalConnectionType();
             }
         }
 
@@ -399,7 +399,5 @@ namespace Microsoft.Data.SqlClient.SNI
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)] // this forces the exception throwing code not to be inlined for performance
         private void ThrowClosedConnection() => throw ADP.ClosedConnectionError();
-
-
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace System {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -1920,6 +1920,15 @@ namespace System {
         internal static string SNI_ERROR_9 {
             get {
                 return ResourceManager.GetString("SNI_ERROR_9", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to incorrect physicalConnection type.
+        /// </summary>
+        internal static string SNI_IncorrectPhysicalConnectionType {
+            get {
+                return ResourceManager.GetString("SNI_IncorrectPhysicalConnectionType", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.Designer.cs
@@ -1924,7 +1924,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to incorrect physicalConnection type.
+        ///   Looks up a localized string similar to Incorrect physicalConnection type.
         /// </summary>
         internal static string SNI_IncorrectPhysicalConnectionType {
             get {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.resx
@@ -1933,7 +1933,7 @@
     <value>Parameter '{0}' cannot have Direction Output or InputOutput when EnableOptimizedParameterBinding is enabled on the parent command.</value>
   </data>
   <data name="SNI_IncorrectPhysicalConnectionType" xml:space="preserve">
-    <value>incorrect physicalConnection type</value>
+    <value>Incorrect physicalConnection type.</value>
   </data>
   <data name="DataCategory_Update" xml:space="preserve">
     <value>Update</value>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Resources/Strings.resx
@@ -1932,6 +1932,9 @@
   <data name="SQL_ParameterDirectionInvalidForOptimizedBinding" xml:space="preserve">
     <value>Parameter '{0}' cannot have Direction Output or InputOutput when EnableOptimizedParameterBinding is enabled on the parent command.</value>
   </data>
+  <data name="SNI_IncorrectPhysicalConnectionType" xml:space="preserve">
+    <value>incorrect physicalConnection type</value>
+  </data>
   <data name="DataCategory_Update" xml:space="preserve">
     <value>Update</value>
   </data>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -1565,6 +1565,9 @@ namespace Microsoft.Data.Common
             return InvalidEnumerationValue(typeof(IsolationLevel), (int)value);
         }
 
+        // ConnectionUtil
+        internal static Exception IncorrectPhysicalConnectionType() => new ArgumentException(StringsHelper.GetString(StringsHelper.SNI_IncorrectPhysicalConnectionType));
+
         // IDataParameter.Direction
         internal static ArgumentOutOfRangeException InvalidParameterDirection(ParameterDirection value)
         {

--- a/src/Microsoft.Data.SqlClient/src/System/Diagnostics/CodeAnalysis.cs
+++ b/src/Microsoft.Data.SqlClient/src/System/Diagnostics/CodeAnalysis.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+#pragma warning disable 1591
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if NETSTANDARD2_0
+    [AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property)]
+    sealed class AllowNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property)]
+    sealed class DisallowNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsageAttribute(AttributeTargets.Method)]
+    sealed class DoesNotReturnAttribute : Attribute
+    {
+    }
+
+    [AttributeUsageAttribute(AttributeTargets.Parameter)]
+    sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+        public bool ParameterValue { get; }
+    }
+
+    [AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    sealed class MaybeNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsageAttribute(AttributeTargets.Parameter)]
+    sealed class MaybeNullWhenAttribute : Attribute
+    {
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+        public bool ReturnValue { get; }
+    }
+
+    [AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    sealed class NotNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsageAttribute(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true)]
+    sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+        public string ParameterName { get; }
+    }
+
+    [AttributeUsageAttribute(AttributeTargets.Parameter)]
+    sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+        public bool ReturnValue { get; }
+    }
+#endif
+
+#if !NET5_0_OR_GREATER
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    sealed class MemberNotNullAttribute : Attribute
+    {
+        public MemberNotNullAttribute(string member) => Members = new string[]
+        {
+            member
+        };
+
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        public string[] Members { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new string[1] { member };
+        }
+
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        public bool ReturnValue { get; }
+
+        public string[] Members { get; }
+    }
+#endif
+}

--- a/src/Microsoft.Data.SqlClient/src/System/Diagnostics/CodeAnalysis.cs
+++ b/src/Microsoft.Data.SqlClient/src/System/Diagnostics/CodeAnalysis.cs
@@ -1,59 +1,58 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
-
-#pragma warning disable 1591
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace System.Diagnostics.CodeAnalysis
 {
 #if NETSTANDARD2_0
-    [AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property)]
-    sealed class AllowNullAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property)]
+    internal sealed class AllowNullAttribute : Attribute
     {
     }
 
-    [AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property)]
-    sealed class DisallowNullAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property)]
+    internal sealed class DisallowNullAttribute : Attribute
     {
     }
 
-    [AttributeUsageAttribute(AttributeTargets.Method)]
-    sealed class DoesNotReturnAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Method)]
+    internal sealed class DoesNotReturnAttribute : Attribute
     {
     }
 
-    [AttributeUsageAttribute(AttributeTargets.Parameter)]
-    sealed class DoesNotReturnIfAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
     {
         public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
         public bool ParameterValue { get; }
     }
 
-    [AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]
-    sealed class MaybeNullAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    internal sealed class MaybeNullAttribute : Attribute
     {
     }
 
-    [AttributeUsageAttribute(AttributeTargets.Parameter)]
-    sealed class MaybeNullWhenAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
     {
         public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
         public bool ReturnValue { get; }
     }
 
-    [AttributeUsageAttribute(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]
-    sealed class NotNullAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    internal sealed class NotNullAttribute : Attribute
     {
     }
 
-    [AttributeUsageAttribute(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true)]
-    sealed class NotNullIfNotNullAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
     {
         public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
         public string ParameterName { get; }
     }
 
-    [AttributeUsageAttribute(AttributeTargets.Parameter)]
-    sealed class NotNullWhenAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class NotNullWhenAttribute : Attribute
     {
         public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
         public bool ReturnValue { get; }
@@ -62,7 +61,7 @@ namespace System.Diagnostics.CodeAnalysis
 
 #if !NET5_0_OR_GREATER
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
-    sealed class MemberNotNullAttribute : Attribute
+    internal sealed class MemberNotNullAttribute : Attribute
     {
         public MemberNotNullAttribute(string member) => Members = new string[]
         {
@@ -75,7 +74,7 @@ namespace System.Diagnostics.CodeAnalysis
     }
 
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
-    sealed class MemberNotNullWhenAttribute : Attribute
+    internal sealed class MemberNotNullWhenAttribute : Attribute
     {
         public MemberNotNullWhenAttribute(bool returnValue, string member)
         {


### PR DESCRIPTION
I was contacted by someone in the c# discord server who was experiencing https://github.com/dotnet/SqlClient/issues/988 with version 3.0.1 of this library. If the previous fix was correct that shouldn't be possible so I had a look at the code in `TdsParserStateObjectManaged.ReleasePacket`:

```csharp
internal override void ReleasePacket(PacketHandle syncReadPacket)
{
    SNIPacket packet = syncReadPacket.ManagedPacket;
    if (packet != null)
    {
        SNIHandle handle = Handle;
        handle.ReturnPacket(packet);
    }
}
```

There are only two variables involved and the only one we haven't checked for null is `handle` so it's pretty obvious what's going on. Looking at this it's clear that c#8 nullable reference type annotations would have shown this as a problem so I thought I'd rewrite the file with nullable enabled to see if it caused any interesting bugs or changes to show up. This PR is the result.

Nullable annotations are a compile time feature and do not add any runtime checking. It is possible to pass nulls to functions defined in nullable enabled files even if those functions are decorated with non-null context. That means that these changes only introduce new exceptions where an explicit throw is added, there are no hidden null checks.