### PR TITLE
[Tests] Remove NoneVBS connection string from test setup

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -153,7 +153,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 if (!string.IsNullOrEmpty(TCPConnectionStringNoneVBS))
                 {
                     AEConnStrings.Add(TCPConnectionStringNoneVBS);
-                    AEConnStringsSetup.Add(TCPConnectionStringNoneVBS);
                 }
 
                 if (!string.IsNullOrEmpty(TCPConnectionStringAASSGX))


### PR DESCRIPTION
All the VBS connection strings will use the same database. The setup was already being done using TCPConnectionStringHGSVBS.