### PR TITLE
Docs - update SqlDataAdapter docs re: RetryLogicProvider not being supported

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlDataAdapter.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlDataAdapter.xml
@@ -23,7 +23,7 @@
  For every column that you propagate to the data source on <xref:System.Data.Common.DbDataAdapter.Update%2A>, a parameter should be added to the `InsertCommand`, `UpdateCommand`, or `DeleteCommand`. The <xref:System.Data.Common.DbParameter.SourceColumn%2A> property of the <xref:System.Data.Common.DbParameter> object should be set to the name of the column. This setting indicates that the value of the parameter is not set manually, but is taken from the particular column in the currently processed row.  
   
 > [!NOTE]
->  An <xref:System.InvalidOperationException> will occur if the <xref:System.Data.Common.DbDataAdapter.Fill%2A> method is called and the table contains a user-defined type that is not available on the client computer. For more information, see [CLR User-Defined Types](/sql/relational-databases/clr-integration-database-objects-user-defined-types/clr-user-defined-types).
+>  An <xref:System.InvalidOperationException> will occur if the <xref:System.Data.Common.DbDataAdapter.Fill%2A> method is called and the table contains a user-defined type that is not available on the client computer. For more information, see [CLR User-Defined Types](/sql/relational-databases/clr-integration-database-objects-user-defined-types/clr-user-defined-types). In addition, the <xref:System.Data.Common.DbDataAdapter.Fill%2A> method in <xref:System.Data.Common.DbDataAdapter> is not support <see cref="T:Microsoft.Data.SqlClient.SqlCommand.RetryLogicProvider" /> property from the <xref:Microsoft.Data.SqlClient.SqlCommand>.
   
    
   


### PR DESCRIPTION
This is for issue #1591 where `RetryLogicProvider` from the `SQLCommand` is not supported for the `SqlDataAdapter.Fill` because `System.Data.Common.DbDataAdapter` does not allow it.  Therefore, we could mention in documentation the `RetryLogicProvider` is not supported.