### PR TITLE
Chore | upgrade Azure Identity from 1.5.0 to 1.6.0

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -26,8 +26,8 @@
   </PropertyGroup>
   <!-- NetFx and NetCore project dependencies -->
   <PropertyGroup>
-    <AzureIdentityVersion>1.5.0</AzureIdentityVersion>
-    <MicrosoftIdentityClientVersion>4.30.1</MicrosoftIdentityClientVersion>
+    <AzureIdentityVersion>1.6.0</AzureIdentityVersion>
+    <MicrosoftIdentityClientVersion>4.43.2</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.8.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
     <MicrosoftIdentityModelJsonWebTokensVersion>6.8.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -55,7 +55,7 @@
   </PropertyGroup>
   <!-- AKV Provider project dependencies -->
   <PropertyGroup>
-    <AzureCoreVersion>[1.20.0,2.0.0)</AzureCoreVersion>
+    <AzureCoreVersion>[1.24.0,2.0.0)</AzureCoreVersion>
     <AzureSecurityKeyVaultKeysVersion>[4.0.3,5.0.0)</AzureSecurityKeyVaultKeysVersion>
     <MicrosoftExtensionsCachingMemoryVersion>5.0.0</MicrosoftExtensionsCachingMemoryVersion>
   </PropertyGroup>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -29,8 +29,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Microsoft.Data.SqlClient.SNI" version="5.0.0-preview2.22084.1" />
-        <dependency id="Azure.Identity" version="1.5.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.30.1" />
+        <dependency id="Azure.Identity" version="1.6.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.43.2" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="System.Buffers" version="4.5.1" />
@@ -43,8 +43,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.0.0-preview2.22084.1" exclude="Compile" />
-        <dependency id="Azure.Identity" version="1.5.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.30.1" exclude="Compile"/>
+        <dependency id="Azure.Identity" version="1.6.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.43.2" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
@@ -61,8 +61,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.0.0-preview2.22084.1" exclude="Compile" />
-        <dependency id="Azure.Identity" version="1.5.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.30.1" exclude="Compile"/>
+        <dependency id="Azure.Identity" version="1.6.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.43.2" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
@@ -79,8 +79,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       </group>
       <group targetFramework="netstandard2.1">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.0.0-preview2.22084.1" exclude="Compile" />
-        <dependency id="Azure.Identity" version="1.5.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.30.1" exclude="Compile"/>
+        <dependency id="Azure.Identity" version="1.6.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.43.2" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />


### PR DESCRIPTION
As mentioned in #1601 , We can upgrade Azure Identity from 1.5.0 to 1.6.0 and it's dependency Microsoft.Identity.Client from 4.30.1 to 4.43.2