### PR TITLE
Send retained transaction descriptor in MARS TDS header for .NET Core and .NET 5+

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -10753,7 +10753,8 @@ namespace Microsoft.Data.SqlClient
             }
             else
             {
-                WriteLong(SqlInternalTransaction.NullTransactionId, stateObj);
+                // If no transaction, send over retained transaction descriptor (empty if none retained)
+                WriteLong(_retainedTransactionId, stateObj);
                 WriteInt(stateObj.IncrementAndObtainOpenResultCount(null), stateObj);
             }
         }


### PR DESCRIPTION
The retained transaction descriptor (`TdsParser._retainedTransactionId`) is send in the MARS TDS header for .NET Core and .NET 5+ applications when a distributed MSDTC transaction is explicitly rolled back without defecting. The retained transaction descriptor must be sent to the server on subsequent executions even though the transaction is considered to be rolled back. The .NET Framework driver already sends the retained transaction descriptor in this case (see [here](https://github.com/dotnet/SqlClient/blob/main/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs#L11716)).

Fixes #1623 