### PR TITLE
Change | Using default system protocols for TDS8 on Managed code

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIHandle.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 TargetHost = serverNameIndication,
                 ApplicationProtocols = s_tdsProtocols,
-                EnabledSslProtocols = s_supportedProtocols,
+                EnabledSslProtocols = SslProtocols.None,
                 ClientCertificates = certificate
             };
             await sslStream.AuthenticateAsClientAsync(sslClientOptions, token);


### PR DESCRIPTION
This simple PR changes the previous behavior of the driver and omits using supported TLS protocols and uses the latest and the most secure TLS version on the client machine on managed code.
