### PR TITLE
Fix null binary rowversion and add test coverage

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -624,6 +624,10 @@ namespace Microsoft.Data.SqlClient
             {
                 if (StorageType.SqlBinary == _type)
                 {
+                    if (IsNull)
+                    {
+                        return SqlBinary.Null;
+                    }
                     return (SqlBinary)_object;
                 }
                 return (SqlBinary)SqlValue; // anything else we haven't thought of goes through boxing.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -282,6 +282,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     Assert.IsType<DBNull>(result);
                     Assert.Equal(result, reader.GetFieldValue<DBNull>(0));
                     Assert.Throws<SqlNullValueException>(() => reader.GetFieldValue<byte[]>(0));
+
+                    SqlBinary binary = reader.GetSqlBinary(0);
+                    Assert.True(binary.IsNull);
+
+                    SqlBytes bytes = reader.GetSqlBytes(0);
+                    Assert.True(bytes.IsNull);
+                    Assert.Null(bytes.Buffer);
+
                 }
                 finally
                 {


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/1684

The fix is very simple and simply adds a a null check that was already present in all the other SqlType returning properties on SqlBuffer. Test coverage is added for SqlBinary and SqlBytes in the existing test.

/cc @rclabo, @dbrownems 