### PR TITLE
Test | Add extra conditional to the Azure_AccessToken_UserManagedIdentityTest and Azure_AccessToken_SystemManagedIdentityTest 

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/AADConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/AADConnectionTest.cs
@@ -691,7 +691,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(nameof(AreConnStringsSetup), nameof(IsAzure))]
+        [ConditionalFact(nameof(AreConnStringsSetup), nameof(IsAzure), nameof(IsAccessTokenSetup))]
         public static void Azure_AccessToken_SystemManagedIdentityTest()
         {
             string[] removeKeys = { "Authentication", "User ID", "Password", "UID", "PWD", "Trusted_Connection", "Integrated Security" };
@@ -705,7 +705,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(nameof(AreConnStringsSetup), nameof(IsAzure))]
+        [ConditionalFact(nameof(AreConnStringsSetup), nameof(IsAzure), nameof(IsAccessTokenSetup))]
         public static void Azure_AccessToken_UserManagedIdentityTest()
         {
             string[] removeKeys = { "Authentication", "User ID", "Password", "UID", "PWD", "Trusted_Connection", "Integrated Security" };


### PR DESCRIPTION
Currently some of the tests that require Azure Active Directory (AAD) have been temporarily disabled while the build/test pipeline is being fixed by excluding certain AAD variables for the connection strings.  I believe these 2 tests (Azure_AccessToken_UserManagedIdentityTest and Azure_AccessToken_SystemManagedIdentityTest) should be skipped when the AAD AccessToken is not available to resolve the failure.