### PR TITLE
Convert ExecuteNonQueryAsync to use async context object

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AAsyncCallContext.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AAsyncCallContext.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Data.SqlClient
         {
             TDisposable copyDisposable = _disposable;
             _disposable = default;
-            _isDisposed = true;
             copyDisposable?.Dispose();
         }
     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AAsyncCallContext.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AAsyncCallContext.cs
@@ -17,37 +17,68 @@ namespace Microsoft.Data.SqlClient
     // CONSIDER creating your own Set method that calls the base Set rather than providing a parameterized ctor, it is friendlier to caching
     // DO NOT use this class' state after Dispose has been called. It will not throw ObjectDisposedException but it will be a cleared object
 
-    internal abstract class AAsyncCallContext<TOwner, TTask> : IDisposable
+    internal abstract class AAsyncCallContext<TOwner, TTask, TDisposable> : AAsyncBaseCallContext<TOwner,TTask>
         where TOwner : class
+        where TDisposable : IDisposable
     {
-        protected TOwner _owner;
-        protected TaskCompletionSource<TTask> _source;
-        protected IDisposable _disposable;
+        protected TDisposable _disposable;
 
         protected AAsyncCallContext()
         {
         }
 
-        protected AAsyncCallContext(TOwner owner, TaskCompletionSource<TTask> source, IDisposable disposable = null)
+        protected AAsyncCallContext(TOwner owner, TaskCompletionSource<TTask> source, TDisposable disposable = default)
         {
             Set(owner, source, disposable);
         }
 
-        protected void Set(TOwner owner, TaskCompletionSource<TTask> source, IDisposable disposable = null)
+        protected void Set(TOwner owner, TaskCompletionSource<TTask> source, TDisposable disposable = default)
+        {
+            base.Set(owner, source);
+            _disposable = disposable;
+        }
+
+        protected override void DisposeCore()
+        {
+            TDisposable copyDisposable = _disposable;
+            _disposable = default;
+            _isDisposed = true;
+            copyDisposable?.Dispose();
+        }
+    }
+
+    internal abstract class AAsyncBaseCallContext<TOwner, TTask>
+    {
+        protected TOwner _owner;
+        protected TaskCompletionSource<TTask> _source;
+        protected bool _isDisposed;
+
+        protected AAsyncBaseCallContext()
+        {
+        }
+
+        protected void Set(TOwner owner, TaskCompletionSource<TTask> source)
         {
             _owner = owner ?? throw new ArgumentNullException(nameof(owner));
             _source = source ?? throw new ArgumentNullException(nameof(source));
-            _disposable = disposable;
+            _isDisposed = false;
         }
 
         protected void ClearCore()
         {
             _source = null;
             _owner = default;
-            IDisposable copyDisposable = _disposable;
-            _disposable = null;
-            copyDisposable?.Dispose();
+            try
+            {
+                DisposeCore();
+            }
+            finally
+            {
+                _isDisposed = true;
+            }
         }
+
+        protected abstract void DisposeCore();
 
         /// <summary>
         /// override this method to cleanup instance data before ClearCore is called which will blank the base data
@@ -65,16 +96,19 @@ namespace Microsoft.Data.SqlClient
 
         public void Dispose()
         {
-            TOwner owner = _owner;
-            try
+            if (!_isDisposed)
             {
-                Clear();
+                TOwner owner = _owner;
+                try
+                {
+                    Clear();
+                }
+                finally
+                {
+                    ClearCore();
+                }
+                AfterCleared(owner);
             }
-            finally
-            {
-                ClearCore();
-            }
-            AfterCleared(owner);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Data.SqlClient
         private static readonly Func<SqlCommand, CommandBehavior, AsyncCallback, object, int, bool, bool, IAsyncResult> s_beginExecuteXmlReaderInternal = BeginExecuteXmlReaderInternalCallback;
         private static readonly Func<SqlCommand, CommandBehavior, AsyncCallback, object, int, bool, bool, IAsyncResult> s_beginExecuteNonQueryInternal = BeginExecuteNonQueryInternalCallback;
 
-        internal sealed class ExecuteReaderAsyncCallContext : AAsyncCallContext<SqlCommand, SqlDataReader>
+        internal sealed class ExecuteReaderAsyncCallContext : AAsyncCallContext<SqlCommand, SqlDataReader, CancellationTokenRegistration>
         {
             public Guid OperationID;
             public CommandBehavior CommandBehavior;
@@ -54,7 +54,7 @@ namespace Microsoft.Data.SqlClient
             public SqlCommand Command => _owner;
             public TaskCompletionSource<SqlDataReader> TaskCompletionSource => _source;
 
-            public void Set(SqlCommand command, TaskCompletionSource<SqlDataReader> source, IDisposable disposable, CommandBehavior behavior, Guid operationID)
+            public void Set(SqlCommand command, TaskCompletionSource<SqlDataReader> source, CancellationTokenRegistration disposable, CommandBehavior behavior, Guid operationID)
             {
                 base.Set(command, source, disposable);
                 CommandBehavior = behavior;
@@ -70,6 +70,31 @@ namespace Microsoft.Data.SqlClient
             protected override void AfterCleared(SqlCommand owner)
             {
                 owner?.SetCachedCommandExecuteReaderAsyncContext(this);
+            }
+        }
+
+        internal sealed class ExecuteNonQueryAsyncCallContext : AAsyncCallContext<SqlCommand, int, CancellationTokenRegistration>
+        {
+            public Guid OperationID;
+
+            public SqlCommand Command => _owner;
+
+            public TaskCompletionSource<int> TaskCompletionSource => _source;
+
+            public void Set(SqlCommand command, TaskCompletionSource<int> source, CancellationTokenRegistration disposable,  Guid operationID)
+            {
+                base.Set(command, source, disposable);
+                OperationID = operationID;
+            }
+
+            protected override void Clear()
+            {
+                OperationID = default;
+            }
+
+            protected override void AfterCleared(SqlCommand owner)
+            {
+            
             }
         }
 
@@ -2540,23 +2565,36 @@ namespace Microsoft.Data.SqlClient
             }
 
             Task<int> returnedTask = source.Task;
+            returnedTask = RegisterForConnectionCloseNotification(returnedTask);
+
+            ExecuteNonQueryAsyncCallContext context = new ExecuteNonQueryAsyncCallContext();
+            context.Set(this, source, registration, operationId);
             try
             {
-                returnedTask = RegisterForConnectionCloseNotification(returnedTask);
-
-                Task<int>.Factory.FromAsync(BeginExecuteNonQueryAsync, EndExecuteNonQueryAsync, null)
-                    .ContinueWith((Task<int> task) =>
+                Task<int>.Factory.FromAsync(
+                    static (AsyncCallback callback, object stateObject) => ((ExecuteNonQueryAsyncCallContext)stateObject).Command.BeginExecuteNonQueryAsync(callback, stateObject),
+                    static (IAsyncResult result) => ((ExecuteNonQueryAsyncCallContext)result.AsyncState).Command.EndExecuteNonQueryAsync(result),
+                    state: context
+                ).ContinueWith(
+                    static (Task<int> task, object state) =>
                     {
-                        registration.Dispose();
+                        ExecuteNonQueryAsyncCallContext context = (ExecuteNonQueryAsyncCallContext)state;
+
+                        Guid operationId = context.OperationID;
+                        SqlCommand command = context.Command;
+                        TaskCompletionSource<int> source = context.TaskCompletionSource;
+
+                        context.Dispose();
+                        context = null;
+
                         if (task.IsFaulted)
                         {
                             Exception e = task.Exception.InnerException;
-                            s_diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
+                            s_diagnosticListener.WriteCommandError(operationId, command, command._transaction, e);
                             source.SetException(e);
                         }
                         else
                         {
-                            s_diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                             if (task.IsCanceled)
                             {
                                 source.SetCanceled();
@@ -2565,15 +2603,18 @@ namespace Microsoft.Data.SqlClient
                             {
                                 source.SetResult(task.Result);
                             }
+                            s_diagnosticListener.WriteCommandAfter(operationId, command, command._transaction);
                         }
-                    }, 
-                    TaskScheduler.Default
+                    },
+                    state: context,
+                    scheduler: TaskScheduler.Default
                 );
             }
             catch (Exception e)
             {
                 s_diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                 source.SetException(e);
+                context.Dispose();
             }
 
             return returnedTask;
@@ -2648,11 +2689,11 @@ namespace Microsoft.Data.SqlClient
             }
 
             Task<SqlDataReader> returnedTask = source.Task;
+            ExecuteReaderAsyncCallContext context = null;
             try
             {
                 returnedTask = RegisterForConnectionCloseNotification(returnedTask);
 
-                ExecuteReaderAsyncCallContext context = null;
                 if (_activeConnection?.InnerConnection is SqlInternalConnection sqlInternalConnection)
                 {
                     context = Interlocked.Exchange(ref sqlInternalConnection.CachedCommandExecuteReaderAsyncContext, null);
@@ -2680,6 +2721,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 source.SetException(e);
+                context.Dispose();
             }
 
             return returnedTask;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -4406,7 +4406,7 @@ namespace Microsoft.Data.SqlClient
                     return source.Task;
                 }
 
-                IDisposable registration = null;
+                CancellationTokenRegistration registration = default;
                 if (cancellationToken.CanBeCanceled)
                 {
                     if (cancellationToken.IsCancellationRequested)
@@ -4706,7 +4706,7 @@ namespace Microsoft.Data.SqlClient
                     Debug.Assert(context.Source != null, "context._source should not be null when continuing");
                     // setup for cleanup/completing
                     retryTask.ContinueWith(
-                        continuationAction: SqlDataReaderAsyncCallContext<int>.s_completeCallback,
+                        continuationAction: SqlDataReaderBaseAsyncCallContext<int>.s_completeCallback,
                         state: context,
                         TaskScheduler.Default
                     );
@@ -4836,6 +4836,12 @@ namespace Microsoft.Data.SqlClient
                     source.SetCanceled();
                     _currentTask = null;
                     return source.Task;
+                }
+
+                CancellationTokenRegistration registration = default;
+                if (cancellationToken.CanBeCanceled)
+                {
+                    registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
                 }
 
                 ReadAsyncCallContext context = null;
@@ -5006,7 +5012,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // Setup cancellations
-                IDisposable registration = null;
+                CancellationTokenRegistration registration = default;
                 if (cancellationToken.CanBeCanceled)
                 {
                     registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
@@ -5022,7 +5028,7 @@ namespace Microsoft.Data.SqlClient
                     context = new IsDBNullAsyncCallContext();
                 }
 
-                Debug.Assert(context.Reader == null && context.Source == null && context.Disposable == null, "cached ISDBNullAsync context not properly disposed");
+                Debug.Assert(context.Reader == null && context.Source == null && context.Disposable == default, "cached ISDBNullAsync context not properly disposed");
 
                 context.Set(this, source, registration);
                 context._columnIndex = i;
@@ -5153,7 +5159,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             // Setup cancellations
-            IDisposable registration = null;
+            CancellationTokenRegistration registration = default;
             if (cancellationToken.CanBeCanceled)
             {
                 registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
@@ -5217,49 +5223,63 @@ namespace Microsoft.Data.SqlClient
         }
 
 #endif
-
-        internal abstract class SqlDataReaderAsyncCallContext<T> : AAsyncCallContext<SqlDataReader, T>
+        
+        internal abstract class SqlDataReaderBaseAsyncCallContext<T> : AAsyncBaseCallContext<SqlDataReader, T>
         {
             internal static readonly Action<Task<T>, object> s_completeCallback = CompleteAsyncCallCallback;
 
             internal static readonly Func<Task, object, Task<T>> s_executeCallback = ExecuteAsyncCallCallback;
 
-            protected SqlDataReaderAsyncCallContext()
+            protected SqlDataReaderBaseAsyncCallContext()
             {
             }
 
-            protected SqlDataReaderAsyncCallContext(SqlDataReader owner, TaskCompletionSource<T> source, IDisposable disposable = null)
+            protected SqlDataReaderBaseAsyncCallContext(SqlDataReader owner, TaskCompletionSource<T> source)
             {
-                Set(owner, source, disposable);
+                Set(owner, source);
             }
 
             internal abstract Func<Task, object, Task<T>> Execute { get; }
 
             internal SqlDataReader Reader { get => _owner; set => _owner = value; }
 
-            public IDisposable Disposable { get => _disposable; set => _disposable = value; }
-
             public TaskCompletionSource<T> Source { get => _source; set => _source = value; }
-
-            new public void Set(SqlDataReader reader, TaskCompletionSource<T> source, IDisposable disposable)
-            {
-                base.Set(reader, source, disposable);
-            }
 
             private static Task<T> ExecuteAsyncCallCallback(Task task, object state)
             {
-                SqlDataReaderAsyncCallContext<T> context = (SqlDataReaderAsyncCallContext<T>)state;
+                SqlDataReaderBaseAsyncCallContext<T> context = (SqlDataReaderBaseAsyncCallContext<T>)state;
                 return context.Reader.ContinueAsyncCall(task, context);
             }
 
             private static void CompleteAsyncCallCallback(Task<T> task, object state)
             {
-                SqlDataReaderAsyncCallContext<T> context = (SqlDataReaderAsyncCallContext<T>)state;
+                SqlDataReaderBaseAsyncCallContext<T> context = (SqlDataReaderBaseAsyncCallContext<T>)state;
                 context.Reader.CompleteAsyncCall(task, context);
             }
         }
 
-        internal sealed class ReadAsyncCallContext : SqlDataReaderAsyncCallContext<bool>
+        internal abstract class SqlDataReaderAsyncCallContext<T, TDisposable> : SqlDataReaderBaseAsyncCallContext<T>
+            where TDisposable : IDisposable
+        {
+            private TDisposable _disposable;
+
+            public TDisposable Disposable { get => _disposable; set => _disposable = value; }
+
+            public void Set(SqlDataReader owner, TaskCompletionSource<T> source, TDisposable disposable)
+            {
+                base.Set(owner, source);
+                _disposable = disposable;
+            }
+
+            protected override void DisposeCore()
+            {
+                TDisposable copy = _disposable;
+                _disposable = default;
+                copy.Dispose();
+            }
+        }
+
+        internal sealed class ReadAsyncCallContext : SqlDataReaderAsyncCallContext<bool, CancellationTokenRegistration>
         {
             internal static readonly Func<Task, object, Task<bool>> s_execute = SqlDataReader.ReadAsyncExecute;
 
@@ -5278,7 +5298,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal sealed class IsDBNullAsyncCallContext : SqlDataReaderAsyncCallContext<bool>
+        internal sealed class IsDBNullAsyncCallContext : SqlDataReaderAsyncCallContext<bool, CancellationTokenRegistration>
         {
             internal static readonly Func<Task, object, Task<bool>> s_execute = SqlDataReader.IsDBNullAsyncExecute;
 
@@ -5294,19 +5314,19 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private sealed class HasNextResultAsyncCallContext : SqlDataReaderAsyncCallContext<bool>
+        private sealed class HasNextResultAsyncCallContext : SqlDataReaderAsyncCallContext<bool, CancellationTokenRegistration>
         {
             private static readonly Func<Task, object, Task<bool>> s_execute = SqlDataReader.NextResultAsyncExecute;
 
-            public HasNextResultAsyncCallContext(SqlDataReader reader, TaskCompletionSource<bool> source, IDisposable disposable)
-                : base(reader, source, disposable)
+            public HasNextResultAsyncCallContext(SqlDataReader reader, TaskCompletionSource<bool> source, CancellationTokenRegistration disposable)
             {
+                Set(reader, source, disposable);
             }
 
             internal override Func<Task, object, Task<bool>> Execute => s_execute;
         }
 
-        private sealed class GetBytesAsyncCallContext : SqlDataReaderAsyncCallContext<int>
+        private sealed class GetBytesAsyncCallContext : SqlDataReaderAsyncCallContext<int, CancellationTokenSource>
         {
             internal enum OperationMode
             {
@@ -5344,7 +5364,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private sealed class GetFieldValueAsyncCallContext<T> : SqlDataReaderAsyncCallContext<T>
+        private sealed class GetFieldValueAsyncCallContext<T> : SqlDataReaderAsyncCallContext<T, CancellationTokenRegistration>
         {
             private static readonly Func<Task, object, Task<T>> s_execute = SqlDataReader.GetFieldValueAsyncExecute<T>;
 
@@ -5352,9 +5372,9 @@ namespace Microsoft.Data.SqlClient
 
             internal GetFieldValueAsyncCallContext() { }
 
-            internal GetFieldValueAsyncCallContext(SqlDataReader reader, TaskCompletionSource<T> source, IDisposable disposable)
-                : base(reader, source, disposable)
+            internal GetFieldValueAsyncCallContext(SqlDataReader reader, TaskCompletionSource<T> source, CancellationTokenRegistration disposable)
             {
+                Set(reader, source, disposable);
             }
 
             protected override void Clear()
@@ -5374,7 +5394,7 @@ namespace Microsoft.Data.SqlClient
         /// <typeparam name="T"></typeparam>
         /// <param name="context"></param>
         /// <returns></returns>
-        private Task<T> InvokeAsyncCall<T>(SqlDataReaderAsyncCallContext<T> context)
+        private Task<T> InvokeAsyncCall<T>(SqlDataReaderBaseAsyncCallContext<T> context)
         {
             TaskCompletionSource<T> source = context.Source;
             try
@@ -5396,7 +5416,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     task.ContinueWith(
-                        continuationAction: SqlDataReaderAsyncCallContext<T>.s_completeCallback,
+                        continuationAction: SqlDataReaderBaseAsyncCallContext<T>.s_completeCallback,
                         state: context,
                         TaskScheduler.Default
                     );
@@ -5421,7 +5441,7 @@ namespace Microsoft.Data.SqlClient
         /// <typeparam name="T"></typeparam>
         /// <param name="context"></param>
         /// <returns></returns>
-        private Task<T> ExecuteAsyncCall<T>(SqlDataReaderAsyncCallContext<T> context)
+        private Task<T> ExecuteAsyncCall<T>(AAsyncBaseCallContext<SqlDataReader, T> context)
         {
             // _networkPacketTaskSource could be null if the connection was closed
             // while an async invocation was outstanding.
@@ -5434,7 +5454,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 return completionSource.Task.ContinueWith(
-                    continuationFunction: SqlDataReaderAsyncCallContext<T>.s_executeCallback,
+                    continuationFunction: SqlDataReaderBaseAsyncCallContext<T>.s_executeCallback,
                     state: context,
                     TaskScheduler.Default
                 ).Unwrap();
@@ -5450,7 +5470,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="task"></param>
         /// <param name="context"></param>
         /// <returns></returns>
-        private Task<T> ContinueAsyncCall<T>(Task task, SqlDataReaderAsyncCallContext<T> context)
+        private Task<T> ContinueAsyncCall<T>(Task task, SqlDataReaderBaseAsyncCallContext<T> context)
         {
             // this function must be an instance function called from the static callback because otherwise a compiler error
             // is caused by accessing the _cancelAsyncOnCloseToken field of a MarshalByRefObject derived class
@@ -5510,7 +5530,7 @@ namespace Microsoft.Data.SqlClient
         /// <typeparam name="T"></typeparam>
         /// <param name="task"></param>
         /// <param name="context"></param>
-        private void CompleteAsyncCall<T>(Task<T> task, SqlDataReaderAsyncCallContext<T> context)
+        private void CompleteAsyncCall<T>(Task<T> task, SqlDataReaderBaseAsyncCallContext<T> context)
         {
             TaskCompletionSource<T> source = context.Source;
             context.Dispose();

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -4734,7 +4734,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // Register first to catch any already expired tokens to be able to trigger cancellation event.
-                IDisposable registration = null;
+                CancellationTokenRegistration registration = default;
                 if (cancellationToken.CanBeCanceled)
                 {
                     registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
@@ -4836,12 +4836,6 @@ namespace Microsoft.Data.SqlClient
                     source.SetCanceled();
                     _currentTask = null;
                     return source.Task;
-                }
-
-                CancellationTokenRegistration registration = default;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
                 }
 
                 ReadAsyncCallContext context = null;


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/1682

This addresses the incorrect handling of cancellation token registrations in `SqlCommand` methods `ExecuteNonQuery` and `ExecuteReader`, I didn't change `ExecuteScalar` because it should be done in a separate PR and it's just `ExecuteReader` wearing a fake nose a glasses, people should use `ExexuteReader`

Background information: There are a number of async api calls on `SqlDataReader` which have been changed to avoid the use of language provided lambda closures and instead use explicit context objects. This process makes the code more complicated because it splits apart the code into multiple functions so that instance delegate allocations can be avoided. This pattern is no longer needed if we use language provided static lambdas and the code can be much cleaner and better contained. This PR converts the ExecuteNonQuery function to use this explicity context pattern and uses static lambdas to doi t.

This PR also changes all existing context objects to use an explicit type for the IDispoable so that we can avoid boxing the disposable. This change forces any existing context types which were declared like this: `AAsyncContext<TOwner,TResult>` to be split apart into two types, 
1) `AAsyncContext<TOwner,TResult,TDisposable>` which has a strong disposable type and is used at call sites that know what the disposable is, mostly setup locations.  
2)  `AAsyncBaseContext<TOwner,TResult>` which is used in the async functions that don't need to know what the type of the disposable is so we can avoid duplicating functions like `InvokeAsync`

The specific changes to fix the issue reported are 
1) change `InternalExecuteNonQueryAsync` to use an explicity context object 
2) make disposable idempotent by including a disposed flag. Previously it was not possible to reach disposable from more than one path so knowledge of disposal was implicit, now it is explicit.
3) call context dispose from catch blocks ensuring that the registration is correctly cleaned up on all paths

/cc @olegkv