### PR TITLE
[Fix 3.1] Add support for Shim gss api on Linux to delay loading libgssapi_krb5.so

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.cs
@@ -16,6 +16,9 @@ internal static partial class Interop
             IntPtr bufferPtr,
             ulong length);
 
+        [DllImport(Interop.Libraries.NetSecurityNative, EntryPoint = "NetSecurityNative_EnsureGssInitialized")]
+        private static extern int EnsureGssInitialized();
+
         [DllImport(Libraries.NetSecurityNative, EntryPoint="NetSecurityNative_DisplayMinorStatus")]
         internal static extern Status DisplayMinorStatus(
             out Status minorStatus,
@@ -108,6 +111,18 @@ internal static partial class Interop
             GSS_C_IDENTIFY_FLAG = 0x2000,
             GSS_C_EXTENDED_ERROR_FLAG = 0x4000,
             GSS_C_DELEG_POLICY_FLAG = 0x8000
+        }
+
+        // This constructor is added to address the issue with net6 regarding 
+        // Shim gss api on Linux to delay loading libgssapi_krb5.so
+        // issue https://github.com/dotnet/SqlClient/issues/1390
+        // dotnet runtime issue https://github.com/dotnet/runtime/pull/55037
+        static NetSecurityNative()
+        {
+            if (Environment.Version.Major >= 6)
+            {
+                EnsureGssInitialized();
+            }
         }
     }
 }


### PR DESCRIPTION
Porting #1411 to 3.1-servicing.