### PR TITLE
[Fix 3.1] Fix null binary rowversion and add test coverage

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -508,6 +508,10 @@ namespace Microsoft.Data.SqlClient
             {
                 if (StorageType.SqlBinary == _type)
                 {
+                    if (IsNull)
+                    {
+                        return SqlBinary.Null;
+                    }
                     return (SqlBinary)_object;
                 }
                 return (SqlBinary)SqlValue; // anything else we haven't thought of goes through boxing.

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -490,6 +490,10 @@ namespace Microsoft.Data.SqlClient
             {
                 if (StorageType.SqlBinary == _type)
                 {
+                    if (IsNull)
+                    {
+                        return SqlBinary.Null;
+                    }
                     return (SqlBinary)_object;
                 }
                 return (SqlBinary)SqlValue; // anything else we haven't thought of goes through boxing.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -282,6 +282,14 @@ alter table [{tempTableName}] add constraint pk_{tempTableName}_user_id primary 
                     Assert.IsType<DBNull>(result);
                     Assert.Equal(result, reader.GetFieldValue<DBNull>(0));
                     Assert.Throws<SqlNullValueException>(() => reader.GetFieldValue<byte[]>(0));
+
+                    SqlBinary binary = reader.GetSqlBinary(0);
+                    Assert.True(binary.IsNull);
+
+                    SqlBytes bytes = reader.GetSqlBytes(0);
+                    Assert.True(bytes.IsNull);
+                    Assert.Null(bytes.Buffer);
+
                 }
                 finally
                 {


### PR DESCRIPTION
Porting #1688 to 3.1-servicing.