### PR TITLE
[Hotfix 4.0.2] | Fix CommandText length for stored procedures (#1484)

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Data.SqlClient
     public sealed partial class SqlCommand : DbCommand, ICloneable
     {
         private static int _objectTypeCount; // EventSource Counter
+        private const int MaxRPCNameLength = 1046;
         internal readonly int ObjectID = Interlocked.Increment(ref _objectTypeCount); private string _commandText;
 
         private static readonly Func<AsyncCallback, object, IAsyncResult> s_beginExecuteReaderAsync = BeginExecuteReaderAsyncCallback;
@@ -5802,7 +5803,20 @@ namespace Microsoft.Data.SqlClient
             GetRPCObject(0, userParameterCount, ref rpc);
 
             rpc.ProcID = 0;
-            rpc.rpcName = this.CommandText; // just get the raw command text
+
+            // TDS Protocol allows rpc name with maximum length of 1046 bytes for ProcName
+            // 4-part name 1 + 128 + 1 + 1 + 1 + 128 + 1 + 1 + 1 + 128 + 1 + 1 + 1 + 128 + 1 = 523
+            // each char takes 2 bytes. 523 * 2 = 1046
+            int commandTextLength = ADP.CharSize * CommandText.Length;
+
+            if (commandTextLength <= MaxRPCNameLength)
+            {
+                rpc.rpcName = CommandText; // just get the raw command text
+            }
+            else
+            {
+                throw ADP.InvalidArgumentLength(nameof(CommandText), MaxRPCNameLength);
+            }
 
             SetUpRPCParameters(rpc, inSchema, parameters);
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Data.SqlClient
     public sealed class SqlCommand : DbCommand, ICloneable
     {
         private static int _objectTypeCount; // EventSource Counter
+        private const int MaxRPCNameLength = 1046;
         internal readonly int ObjectID = System.Threading.Interlocked.Increment(ref _objectTypeCount);
 
         private string _commandText;
@@ -1082,7 +1083,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             tdsReliabilitySection.Start();
 #else
-                    {
+                        {
 #endif //DEBUG
                             InternalPrepare();
                         }
@@ -1267,7 +1268,7 @@ namespace Microsoft.Data.SqlClient
                             {
                                 tdsReliabilitySection.Start();
 #else
-                        {
+                            {
 #endif //DEBUG
                                 bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
 
@@ -6690,7 +6691,19 @@ namespace Microsoft.Data.SqlClient
             int count = CountSendableParameters(parameters);
             GetRPCObject(count, ref rpc);
 
-            rpc.rpcName = this.CommandText; // just get the raw command text
+            // TDS Protocol allows rpc name with maximum length of 1046 bytes for ProcName
+            // 4-part name 1 + 128 + 1 + 1 + 1 + 128 + 1 + 1 + 1 + 128 + 1 + 1 + 1 + 128 + 1 = 523
+            // each char takes 2 bytes. 523 * 2 = 1046
+            int commandTextLength = ADP.CharSize * CommandText.Length;
+
+            if (commandTextLength <= MaxRPCNameLength)
+            {
+                rpc.rpcName = CommandText; // just get the raw command text
+            }
+            else
+            {
+                throw ADP.InvalidArgumentLength(nameof(CommandText), MaxRPCNameLength);
+            }
 
             SetUpRPCParameters(rpc, 0, inSchema, parameters);
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -269,6 +269,7 @@
     <Compile Include="SQL\Common\SystemDataInternals\DataReaderHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserStateObjectHelper.cs" />
+    <Compile Include="SQL\SqlCommand\SqlCommandStoredProcTest.cs" />
     <Compile Include="TracingTests\TestTdsServer.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />
     <Compile Include="$(CommonTestPath)\System\Collections\DictionaryExtensions.cs">

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandStoredProcTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandStoredProcTest.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+﻿using System;
+using System.Data;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests
+{
+    public class SqlCommandStoredProcTest
+    {
+        private static readonly string s_tcp_connStr = DataTestUtility.TCPConnectionString;
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
+        public static void ShouldFailWithExceededLengthForSP()
+        {
+            string baseCommandText = "random text\u0000\u400a\u7300\u7400\u6100\u7400\u6500\u6d00\u6500\u6e00\u7400\u0000\u0006\u01ff\u0900\uf004\u0000\uffdc\u0001";
+            string exceededLengthText = baseCommandText + new string(' ', 2000);
+            using SqlConnection conn = new(s_tcp_connStr);
+            conn.Open();
+            using SqlCommand command = new()
+            {
+                Connection = conn,
+                CommandType = CommandType.StoredProcedure,
+                CommandText = exceededLengthText
+            };
+
+            // It should fail on the driver as the length of RPC is over 1046
+            // 4-part name 1 + 128 + 1 + 1 + 1 + 128 + 1 + 1 + 1 + 128 + 1 + 1 + 1 + 128 + 1 = 523
+            // each char takes 2 bytes. 523 * 2 = 1046
+            Assert.Throws<ArgumentException>(() => command.ExecuteScalar());
+
+            command.CommandText = baseCommandText;
+            var ex = Assert.Throws<SqlException>(() => command.ExecuteScalar());
+            Assert.StartsWith("Could not find stored procedure", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
Ports #1484 