### PR TITLE
[Fix] Hang on infinite timeout and managed SNI

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
@@ -191,6 +192,15 @@ namespace Microsoft.Data.SqlClient.SNI
                 }
                 SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNICommon), EventType.INFO, "targetServerName {0}, Client certificate validated successfully.", args0: targetServerName);
                 return true;
+            }
+        }
+
+        internal static IPAddress[] GetDnsIpAddresses(string serverName)
+        {
+            using (TrySNIEventScope.Create(nameof(GetDnsIpAddresses)))
+            {
+                SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNICommon), EventType.INFO, "Getting DNS host entries for serverName {0}.", args0: serverName);
+                return Dns.GetHostAddresses(serverName);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -299,14 +299,7 @@ namespace Microsoft.Data.SqlClient.SNI
             Socket availableSocket = null;
             Task<Socket> connectTask;
 
-            Task<IPAddress[]> serverAddrTask = Dns.GetHostAddressesAsync(hostName);
-            bool complete = serverAddrTask.Wait(ts);
-
-            // DNS timed out - don't block
-            if (!complete)
-                return null;
-
-            IPAddress[] serverAddresses = serverAddrTask.Result;
+            IPAddress[] serverAddresses = SNICommon.GetDnsIpAddresses(hostName);
 
             if (serverAddresses.Length > MaxParallelIpAddresses)
             {
@@ -358,14 +351,7 @@ namespace Microsoft.Data.SqlClient.SNI
         {
             SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNITCPHandle), EventType.INFO, "IP preference : {0}", Enum.GetName(typeof(SqlConnectionIPAddressPreference), ipPreference));
 
-            Task<IPAddress[]> serverAddrTask = Dns.GetHostAddressesAsync(serverName);
-            bool complete = serverAddrTask.Wait(timeout);
-
-            // DNS timed out - don't block
-            if (!complete)
-                return null;
-
-            IPAddress[] ipAddresses = serverAddrTask.Result;
+            IPAddress[] ipAddresses = SNICommon.GetDnsIpAddresses(serverName);
 
             string IPv4String = null;
             string IPv6String = null;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -89,6 +89,21 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static async void ConnectionTimeoutInfiniteTest()
+        {
+            // Exercise the special-case infinite connect timeout code path
+            SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString)
+            {
+                ConnectTimeout = 0 // Infinite
+            };
+
+            using SqlConnection conn = new(builder.ConnectionString);
+            CancellationTokenSource cts = new(30000);
+            // Will throw TaskCanceledException and fail the test in the event of a hang
+            await conn.OpenAsync(cts.Token);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ConnectionTimeoutTestWithThread()
         {
             const int timeoutSec = 5;


### PR DESCRIPTION
Fixes #1733 - regression introduced in #1578 

I moved DNS calls into a common function and added logging for it. I decided not to use async DNS calls because the timeout logic is just wrong and I wanted to limit this fix to the issue at hand. The timeout logic will be addressed in a future PR.

I did notice and fix 2 issues in the SSRP logic right around the same DNS logic being fixed.

1. The logic for when the hostName is an IP address was missing, resulting in a NRE.
2. The cancellation token wasn't being associated with the parallelized UDP tasks so they weren't actually getting quickly canceled when Cancel() was called.