### PR TITLE
SNI version update - servicing 4.0

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/TcpDefaultForAzureTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/TcpDefaultForAzureTest.cs
@@ -42,7 +42,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static void NonAzureNoProtocolConnectionTestWindows()
         {
             builder.DataSource = InvalidHostname;
+#if NETFRAMEWORK
+            CheckConnectionFailure(builder.ConnectionString, NP);
+#else
             CheckConnectionFailure(builder.ConnectionString, DataTestUtility.IsUsingManagedSNI() ? TCP : NP);
+#endif
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <!-- NetFx project dependencies -->
   <PropertyGroup>
-    <MicrosoftDataSqlClientSniVersion>4.0.0</MicrosoftDataSqlClientSniVersion>    
+    <MicrosoftDataSqlClientSniVersion>4.0.1</MicrosoftDataSqlClientSniVersion>    
     <SystemSecurityCryptographyAlgorithmsVersion>4.3.1</SystemSecurityCryptographyAlgorithmsVersion>
     <SystemSecurityCryptographyPrimitivesVersion>4.3.0</SystemSecurityCryptographyPrimitivesVersion>
   </PropertyGroup>
@@ -29,7 +29,7 @@
   <!-- NetCore project dependencies -->
   <PropertyGroup>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
-    <MicrosoftDataSqlClientSNIRuntimeVersion>4.0.0</MicrosoftDataSqlClientSNIRuntimeVersion>
+    <MicrosoftDataSqlClientSNIRuntimeVersion>4.0.1</MicrosoftDataSqlClientSNIRuntimeVersion>
     <SystemConfigurationConfigurationManagerVersion>5.0.0</SystemConfigurationConfigurationManagerVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>5.0.0</SystemDiagnosticsDiagnosticSourceVersion>
     <SystemDiagnosticsPerformanceCounterVersion>5.0.0</SystemDiagnosticsPerformanceCounterVersion>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -28,7 +28,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <tags>sqlclient microsoft.data.sqlclient</tags>
     <dependencies>
       <group targetFramework="net461">
-        <dependency id="Microsoft.Data.SqlClient.SNI" version="4.0.0" />
+        <dependency id="Microsoft.Data.SqlClient.SNI" version="4.0.1" />
         <dependency id="Azure.Identity" version="1.3.0" />
         <dependency id="Microsoft.Identity.Client" version="4.22.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
@@ -42,7 +42,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Text.Encodings.Web" version="4.7.2" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="4.0.0" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="4.0.1" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.3.0" />
         <dependency id="Microsoft.Identity.Client" version="4.22.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
@@ -60,7 +60,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Security.Principal.Windows" version="5.0.0" exclude="Compile" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="4.0.0" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="4.0.1" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.3.0" />
         <dependency id="Microsoft.Identity.Client" version="4.22.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
@@ -78,7 +78,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Security.Principal.Windows" version="5.0.0" exclude="Compile" />
       </group>
       <group targetFramework="netstandard2.1">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="4.0.0" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="4.0.1" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.3.0" />
         <dependency id="Microsoft.Identity.Client" version="4.22.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />


### PR DESCRIPTION
SNI Release version update 4.0.1 - servicing 4.0

Changes:
security.dll replaced with secur32.dll
Fix multiple AppDomain issue due to registration of duplicate tracelogging provider