### PR TITLE
Pass sync state to ThrowExceptionAndWarning from SNIWritePacket

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -3569,7 +3569,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObject.SNIWritePacket | Info | State Object Id {0}, Write async returned error code {1}", _objectID, (int)sniError);
                     AddError(_parser.ProcessSNIError(this));
-                    ThrowExceptionAndWarning(callerHasConnectionLock);
+                    ThrowExceptionAndWarning(callerHasConnectionLock, !sync);
                 }
                 AssertValidState();
             }


### PR DESCRIPTION
From native SNI, TdsParserStateObject.ReadAsyncCallback may be called on a read completion. The native SNI code keeps a reference counter of active callbacks. This counter is waited on when the connection is closed to ensure it does not close the connection out from under any pending managed callbacks.

A potential code path is: ReadAsyncCallback -> OnTimeout (if the timeout has already occurred when the callback fires, OnTimeout is called syncronously) -> SendAttention -> SNIWritePacket -> TdsParser.ThrowExceptionAndWarning -> SqlConnection.OnError -> SqlConnection.Close. If Close is called synchronously during the async callback, we could end up in a deadlock where the native SNI code is waiting for the ReadAsyncCallback to complete, which itself is calling the SNI close method.

TODO: Figure out how to test the scenario.