### PR TITLE
Fix async deadlock issue when sending attention fails due to network failure

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Data.SqlClient
 
         private const int AttentionTimeoutSeconds = 5;
 
-        private static readonly ContextCallback s_readAdyncCallbackComplete = ReadAsyncCallbackComplete;
+        private static readonly ContextCallback s_readAsyncCallbackComplete = ReadAsyncCallbackComplete;
 
         // Ticks to consider a connection "good" after a successful I/O (10,000 ticks = 1 ms)
         // The resolution of the timer is typically in the range 10 to 16 milliseconds according to msdn.
@@ -2337,9 +2337,9 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private bool OnTimeoutSync()
+        private bool OnTimeoutSync(bool asyncClose = false)
         {
-            return OnTimeoutCore(TimeoutState.Running, TimeoutState.ExpiredSync);
+            return OnTimeoutCore(TimeoutState.Running, TimeoutState.ExpiredSync, asyncClose);
         }
 
         /// <summary>
@@ -2348,8 +2348,9 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         /// <param name="expectedState">the state that is the expected current state, state will change only if this is correct</param>
         /// <param name="targetState">the state that will be changed to if the expected state is correct</param>
+        /// <param name="asyncClose">any close action to be taken by an async task to avoid deadlock.</param>
         /// <returns>boolean value indicating whether the call changed the timeout state</returns>
-        private bool OnTimeoutCore(int expectedState, int targetState)
+        private bool OnTimeoutCore(int expectedState, int targetState, bool asyncClose = false)
         {
             Debug.Assert(targetState == TimeoutState.ExpiredAsync || targetState == TimeoutState.ExpiredSync, "OnTimeoutCore must have an expiry state as the targetState");
 
@@ -2382,7 +2383,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             try
                             {
-                                SendAttention(mustTakeWriteLock: true);
+                                SendAttention(mustTakeWriteLock: true, asyncClose);
                             }
                             catch (Exception e)
                             {
@@ -2927,7 +2928,7 @@ namespace Microsoft.Data.SqlClient
                 // synchrnously and then call OnTimeoutSync to force an atomic change of state. 
                 if (TimeoutHasExpired)
                 {
-                    OnTimeoutSync();
+                    OnTimeoutSync(true);
                 }
 
                 // try to change to the stopped state but only do so if currently in the running state
@@ -2958,7 +2959,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         if (_executionContext != null)
                         {
-                            ExecutionContext.Run(_executionContext, s_readAdyncCallbackComplete, source);
+                            ExecutionContext.Run(_executionContext, s_readAsyncCallbackComplete, source);
                         }
                         else
                         {
@@ -3441,7 +3442,7 @@ namespace Microsoft.Data.SqlClient
 
 #pragma warning disable 0420 // a reference to a volatile field will not be treated as volatile
 
-        private Task SNIWritePacket(PacketHandle packet, out uint sniError, bool canAccumulate, bool callerHasConnectionLock)
+        private Task SNIWritePacket(PacketHandle packet, out uint sniError, bool canAccumulate, bool callerHasConnectionLock, bool asyncClose = false)
         {
             // Check for a stored exception
             var delayedException = Interlocked.Exchange(ref _delayedWriteAsyncCallbackException, null);
@@ -3534,7 +3535,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObject.SNIWritePacket | Info | State Object Id {0}, Write async returned error code {1}", _objectID, (int)error);
                             AddError(_parser.ProcessSNIError(this));
-                            ThrowExceptionAndWarning();
+                            ThrowExceptionAndWarning(false, asyncClose);
                         }
                         AssertValidState();
                         completion.SetResult(null);
@@ -3569,7 +3570,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObject.SNIWritePacket | Info | State Object Id {0}, Write async returned error code {1}", _objectID, (int)sniError);
                     AddError(_parser.ProcessSNIError(this));
-                    ThrowExceptionAndWarning(callerHasConnectionLock);
+                    ThrowExceptionAndWarning(callerHasConnectionLock, asyncClose);
                 }
                 AssertValidState();
             }
@@ -3581,7 +3582,7 @@ namespace Microsoft.Data.SqlClient
         internal abstract uint WritePacket(PacketHandle packet, bool sync);
 
         // Sends an attention signal - executing thread will consume attn.
-        internal void SendAttention(bool mustTakeWriteLock = false)
+        internal void SendAttention(bool mustTakeWriteLock = false, bool asyncClose = false)
         {
             if (!_attentionSent)
             {
@@ -3623,7 +3624,7 @@ namespace Microsoft.Data.SqlClient
 
                             uint sniError;
                             _parser._asyncWrite = false; // stop async write
-                            SNIWritePacket(attnPacket, out sniError, canAccumulate: false, callerHasConnectionLock: false);
+                            SNIWritePacket(attnPacket, out sniError, canAccumulate: false, callerHasConnectionLock: false, asyncClose);
                             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObject.SendAttention | Info | State Object Id {0}, Sent Attention.", _objectID);
                         }
                         finally

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2401,9 +2401,9 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private bool OnTimeoutSync()
+        private bool OnTimeoutSync(bool asyncClose = false)
         {
-            return OnTimeoutCore(TimeoutState.Running, TimeoutState.ExpiredSync);
+            return OnTimeoutCore(TimeoutState.Running, TimeoutState.ExpiredSync, asyncClose);
         }
 
         /// <summary>
@@ -2412,8 +2412,9 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         /// <param name="expectedState">the state that is the expected current state, state will change only if this is correct</param>
         /// <param name="targetState">the state that will be changed to if the expected state is correct</param>
+        /// <param name="asyncClose">any close action to be taken by an async task to avoid deadlock.</param>
         /// <returns>boolean value indicating whether the call changed the timeout state</returns>
-        private bool OnTimeoutCore(int expectedState, int targetState)
+        private bool OnTimeoutCore(int expectedState, int targetState, bool asyncClose = false)
         {
             Debug.Assert(targetState == TimeoutState.ExpiredAsync || targetState == TimeoutState.ExpiredSync, "OnTimeoutCore must have an expiry state as the targetState");
 
@@ -2447,7 +2448,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             try
                             {
-                                SendAttention(mustTakeWriteLock: true);
+                                SendAttention(mustTakeWriteLock: true, asyncClose);
                             }
                             catch (Exception e)
                             {
@@ -2988,7 +2989,7 @@ namespace Microsoft.Data.SqlClient
                 // synchrnously and then call OnTimeoutSync to force an atomic change of state.
                 if (TimeoutHasExpired)
                 {
-                    OnTimeoutSync();
+                    OnTimeoutSync(asyncClose: true);
                 }
 
                 // try to change to the stopped state but only do so if currently in the running state
@@ -3475,7 +3476,7 @@ namespace Microsoft.Data.SqlClient
 
 #pragma warning disable 420 // a reference to a volatile field will not be treated as volatile
 
-        private Task SNIWritePacket(SNIHandle handle, SNIPacket packet, out UInt32 sniError, bool canAccumulate, bool callerHasConnectionLock)
+        private Task SNIWritePacket(SNIHandle handle, SNIPacket packet, out UInt32 sniError, bool canAccumulate, bool callerHasConnectionLock, bool asyncClose = false)
         {
             // Check for a stored exception
             var delayedException = Interlocked.Exchange(ref _delayedWriteAsyncCallbackException, null);
@@ -3566,7 +3567,7 @@ namespace Microsoft.Data.SqlClient
                             SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.WritePacket|Info> write async returned error code {0}", (int)error);
 
                             AddError(_parser.ProcessSNIError(this));
-                            ThrowExceptionAndWarning();
+                            ThrowExceptionAndWarning(false, asyncClose);
                         }
                         AssertValidState();
                         completion.SetResult(null);
@@ -3603,7 +3604,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.WritePacket|Info> write async returned error code {0}", (int)sniError);
                     AddError(_parser.ProcessSNIError(this));
-                    ThrowExceptionAndWarning(callerHasConnectionLock);
+                    ThrowExceptionAndWarning(callerHasConnectionLock, false);
                 }
                 AssertValidState();
             }
@@ -3613,7 +3614,7 @@ namespace Microsoft.Data.SqlClient
 #pragma warning restore 420 
 
         // Sends an attention signal - executing thread will consume attn.
-        internal void SendAttention(bool mustTakeWriteLock = false)
+        internal void SendAttention(bool mustTakeWriteLock = false, bool asyncClose = false)
         {
             if (!_attentionSent)
             {
@@ -3660,7 +3661,7 @@ namespace Microsoft.Data.SqlClient
 
                             UInt32 sniError;
                             _parser._asyncWrite = false; // stop async write 
-                            SNIWritePacket(Handle, attnPacket, out sniError, canAccumulate: false, callerHasConnectionLock: false);
+                            SNIWritePacket(Handle, attnPacket, out sniError, canAccumulate: false, callerHasConnectionLock: false, asyncClose);
                             SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.SendAttention|{0}> Send Attention ASync.", "Info");
                         }
                         finally


### PR DESCRIPTION
In an edge case scenario, when a network failure occurs when drives attempts to send an attention signal, the driver fails to throw exception and terminate connection, leaving the connection open indefinitely, when async APIs are used to query the database. This can cause applications to go into hang due to driver getting into a deadlock situation as the async callbacks won't clear.

The issue is associated with the synchronous timeout flow that kicks off on ReadAsyncCallback, which will only be executed when timeout threads are not able to acquire thread from Threadpool and execute until callback returns on the other thread and finds out that the timeout is expired but attention is not yet triggered.

This PR fixes the issue by enabling 'asyncClose' flag on ThrowExceptionAndWarning methods when performing timeout activity via 'ReadAsyncCallback" as the native SNI needs to clear the callback on termination of connection. This was a missed opportunity in PR #906 that caused this edge case scenario to affect a few customers.

I tried adding tests, but it won't be possible to neatly add a test, without causing a lot of code changes, therefore skipping here. Linking repro below which can be easily executed and tested with the PR.

Link to Repro App: https://gist.github.com/cheenamalhotra/94d501e093a0392520fe2095c4bb7491
