### PR TITLE
For failed connection requests in ConnectionPool in case of PoolBlock…

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.NetCoreApp.cs
@@ -11,14 +11,6 @@ namespace Microsoft.Data.ProviderBase
 {
     sealed internal partial class DbConnectionPool
     {
-        partial void CheckPoolBlockingPeriod(Exception e)
-        {
-            if (!IsBlockingPeriodEnabled())
-            {
-                throw e;
-            }
-        }
-
         private bool IsBlockingPeriodEnabled()
         {
             var poolGroupConnectionOptions = _connectionPoolGroup.ConnectionOptions as SqlConnectionString;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -776,7 +776,12 @@ namespace Microsoft.Data.ProviderBase
                     throw;
                 }
 
-                CheckPoolBlockingPeriod(e);
+#if NETCOREAPP
+                if (!IsBlockingPeriodEnabled())
+                {
+                    throw;
+                }
+#endif
 
                 // Close associated Parser if connection already established.
                 if (newObj?.IsConnectionAlive() == true)
@@ -823,9 +828,6 @@ namespace Microsoft.Data.ProviderBase
             }
             return newObj;
         }
-
-        //This method is implemented in DbConnectionPool.NetCoreApp 
-        partial void CheckPoolBlockingPeriod(Exception e);
 
         private void DeactivateObject(DbConnectionInternal obj)
         {


### PR DESCRIPTION
For failed connection requests in ConnectionPool in case of PoolBlockingPeriod not enabled, ensure stacktrace of the exception is not swallowed.
Currently, the implementation passes the exception as a parameter and rethrows it, which creates a brand new stacktrace, and hides the original stacktrace of the failed connection attempt.
With this change, the original stacktrace is kept.