### PR TITLE
Make SqlConnectionEncryptOption string parser public

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
@@ -12,6 +12,31 @@ Implicit conversions have been added to maintain backwards compatibility with bo
  ]]></format>
       </remarks>
     </SqlConnectionEncryptOption>
+    <Parse>
+      <summary>
+        Converts the specified string representation of a logical value to its <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> equivalent.
+      </summary>
+      <param name="value">A string containing the value to convert.</param>
+      <returns>
+        An object that equivalent to <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> contained in <paramref name="value"/>.
+      </returns>
+      <exception cref="T:System.Exception">
+        Throws exception if provided <paramref name="value"/> is not convertible to <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> type.
+      </exception>
+    </Parse>
+    <TryParse>
+      <summary>
+        Converts the specified string representation of a logical value to its <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> equivalent and returns a value that indicates whether the conversion succeeded.
+      </summary>
+      <param name="value">A string containing the value to convert.</param>
+      <param name="result">
+        An object that equivalent to <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> contained in <paramref name="value"/>. <see langword="null" /> if conversion fails.
+      </param>
+      <returns>
+        <see langword="true" /> if the <paramref name="value"/> parameter was converted successfully; otherwise, <see langword="false" />.
+      </returns>
+      <remarks>This method does not throw an exception if conversion fails.</remarks>
+    </TryParse>
     <Optional>
       <summary>Specifies that TLS encryption is optional when connecting to the server. If the server requires encryption, encryption will be negotiated.</summary>
     </Optional>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
@@ -18,9 +18,9 @@ Implicit conversions have been added to maintain backwards compatibility with bo
       </summary>
       <param name="value">A string containing the value to convert.</param>
       <returns>
-        An object that equivalent to <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> contained in <paramref name="value"/>.
+        An object that is equivalent to <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> contained in <paramref name="value"/>.
       </returns>
-      <exception cref="T:System.Exception">
+      <exception cref="T:System.ArgumentException">
         Throws exception if provided <paramref name="value"/> is not convertible to <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> type.
       </exception>
     </Parse>
@@ -30,7 +30,7 @@ Implicit conversions have been added to maintain backwards compatibility with bo
       </summary>
       <param name="value">A string containing the value to convert.</param>
       <param name="result">
-        An object that equivalent to <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> contained in <paramref name="value"/>. <see langword="null" /> if conversion fails.
+        An object that is equivalent to <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> contained in <paramref name="value"/>. <see langword="null" /> if conversion fails.
       </param>
       <returns>
         <see langword="true" /> if the <paramref name="value"/> parameter was converted successfully; otherwise, <see langword="false" />.

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -506,6 +506,10 @@ namespace Microsoft.Data.SqlClient
     /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/SqlConnectionEncryptOption/*'/>
     public sealed class SqlConnectionEncryptOption
     {
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Parse/*' />
+        public static SqlConnectionEncryptOption Parse(string value) => null;
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
+        public static bool? TryParse(string value, out SqlConnectionEncryptOption result) => throw null;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Optional/*' />
         public static SqlConnectionEncryptOption Optional => throw null;
 

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -507,7 +507,7 @@ namespace Microsoft.Data.SqlClient
     public sealed class SqlConnectionEncryptOption
     {
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Parse/*' />
-        public static SqlConnectionEncryptOption Parse(string value) => null;
+        public static SqlConnectionEncryptOption Parse(string value) => throw null;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
         public static bool TryParse(string value, out SqlConnectionEncryptOption result) => throw null;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Optional/*' />

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -509,7 +509,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Parse/*' />
         public static SqlConnectionEncryptOption Parse(string value) => null;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
-        public static bool? TryParse(string value, out SqlConnectionEncryptOption result) => throw null;
+        public static bool TryParse(string value, out SqlConnectionEncryptOption result) => throw null;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Optional/*' />
         public static SqlConnectionEncryptOption Optional => throw null;
 

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -927,7 +927,7 @@ namespace Microsoft.Data.SqlClient
         public static SqlConnectionEncryptOption Parse(string value) => null;
 
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
-        public static bool? TryParse(string value, out SqlConnectionEncryptOption result) => throw null;
+        public static bool TryParse(string value, out SqlConnectionEncryptOption result) => throw null;
 
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Optional/*' />
         public static SqlConnectionEncryptOption Optional => throw null;

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -924,7 +924,7 @@ namespace Microsoft.Data.SqlClient
     public sealed class SqlConnectionEncryptOption
     {
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Parse/*' />
-        public static SqlConnectionEncryptOption Parse(string value) => null;
+        public static SqlConnectionEncryptOption Parse(string value) => throw null;
 
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
         public static bool TryParse(string value, out SqlConnectionEncryptOption result) => throw null;

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -923,6 +923,12 @@ namespace Microsoft.Data.SqlClient
     /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/SqlConnectionEncryptOption/*'/>
     public sealed class SqlConnectionEncryptOption
     {
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Parse/*' />
+        public static SqlConnectionEncryptOption Parse(string value) => null;
+
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
+        public static bool? TryParse(string value, out SqlConnectionEncryptOption result) => throw null;
+
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Optional/*' />
         public static SqlConnectionEncryptOption Optional => throw null;
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient
@@ -29,9 +30,10 @@ namespace Microsoft.Data.SqlClient
             _value = value;
         }
 
-        internal static SqlConnectionEncryptOption Parse(string value)
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Parse/*' />
+        public static SqlConnectionEncryptOption Parse(string value)
         {
-            switch (value.ToLower())
+            switch (value?.ToLower())
             {
                 case TRUE_LOWER:
                 case YES_LOWER:
@@ -51,6 +53,21 @@ namespace Microsoft.Data.SqlClient
                     }
                 default:
                     throw ADP.InvalidConnectionOptionValue(SqlConnectionString.KEY.Encrypt);
+            }
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
+        public static bool TryParse(string value, out SqlConnectionEncryptOption result)
+        {
+            result = null;
+            try
+            {
+                result = Parse(value);
+                return true;
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
@@ -33,41 +33,43 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Parse/*' />
         public static SqlConnectionEncryptOption Parse(string value)
         {
-            switch (value?.ToLower())
+            if (TryParse(value, out var result))
             {
-                case TRUE_LOWER:
-                case YES_LOWER:
-                case MANDATORY_LOWER:
-                    {
-                        return Mandatory;
-                    }
-                case FALSE_LOWER:
-                case NO_LOWER:
-                case OPTIONAL_LOWER:
-                    {
-                        return Optional;
-                    }
-                case STRICT_LOWER:
-                    {
-                        return Strict;
-                    }
-                default:
-                    throw ADP.InvalidConnectionOptionValue(SqlConnectionString.KEY.Encrypt);
+                return result;
+            }
+            else
+            {
+                throw ADP.InvalidConnectionOptionValue(SqlConnectionString.KEY.Encrypt);
             }
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
         public static bool TryParse(string value, out SqlConnectionEncryptOption result)
         {
-            result = null;
-            try
+            switch (value?.ToLower())
             {
-                result = Parse(value);
-                return true;
-            }
-            catch
-            {
-                return false;
+                case TRUE_LOWER:
+                case YES_LOWER:
+                case MANDATORY_LOWER:
+                    {
+                        result = Mandatory;
+                        return true;
+                    }
+                case FALSE_LOWER:
+                case NO_LOWER:
+                case OPTIONAL_LOWER:
+                    {
+                        result = Optional;
+                        return true;
+                    }
+                case STRICT_LOWER:
+                    {
+                        result = Strict;
+                        return true;
+                    }
+                default:
+                    result = null;
+                    return false;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Parse/*' />
         public static SqlConnectionEncryptOption Parse(string value)
         {
-            if (TryParse(value, out var result))
+            if (TryParse(value, out SqlConnectionEncryptOption result))
             {
                 return result;
             }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -385,6 +385,47 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.True(builder.Encrypt);
         }
 
+        [Theory]
+        [InlineData("true", "True")]
+        [InlineData("mandatory", "True")]
+        [InlineData("yes", "True")]
+        [InlineData("false", "False")]
+        [InlineData("optional", "False")]
+        [InlineData("no", "False")]
+        [InlineData("strict", "Strict")]
+        public void EncryptParserValidValuesParsesSuccessfully(string value, string expectedValue)
+            => Assert.Equal(expectedValue, SqlConnectionEncryptOption.Parse(value).ToString());
+
+        [Theory]
+        [InlineData("something")]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("  true  ")]
+        public void EncryptParserInvalidValuesThrowsException(string value)
+            => Assert.Throws<ArgumentException>(() => SqlConnectionEncryptOption.Parse(value));
+
+        [Theory]
+        [InlineData("true", "True")]
+        [InlineData("mandatory", "True")]
+        [InlineData("yes", "True")]
+        [InlineData("false", "False")]
+        [InlineData("optional", "False")]
+        [InlineData("no", "False")]
+        [InlineData("strict", "Strict")]
+        public void EncryptTryParseValidValuesReturnsTrue(string value, string expectedValue)
+        {
+            Assert.True(SqlConnectionEncryptOption.TryParse(value, out var result));
+            Assert.Equal(expectedValue, result.ToString());
+        }
+
+        [Theory]
+        [InlineData("something")]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("  true  ")]
+        public void EncryptTryParseInvalidValuesReturnsFalse(string value)
+            => Assert.False(SqlConnectionEncryptOption.TryParse(value, out _));
+
         internal void ExecuteConnectionStringTests(string connectionString)
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);


### PR DESCRIPTION
It would be useful to have these parsers public to be able to parse string values directly when needed, instead of consumer apps writing their own.