### PR TITLE
Fix | NRE on assigning null to SqlConnectionStringBuilder.Encrypt

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
@@ -7,7 +7,7 @@
       <format type="text/markdown"><![CDATA[  
 
 ## Remarks  
-Implicit conversions have been added to maintain backwards compatibility with boolean behahavior for the <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.Encrypt%2A> property. When converting from a boolean, a value of `true` converts to <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory%2A> and a value of `false` converts to <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional%2A>. When converting to a boolean, <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory%2A> and <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Strict%2A> convert to `true` and <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional%2A> converts `false`.
+Implicit conversions have been added to maintain backwards compatibility with boolean behahavior for the <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.Encrypt%2A> property. When converting from a boolean, a value of `true` converts to <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory%2A> and a value of `false` converts to <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional%2A>. When converting to a boolean, <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory%2A>, <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Strict%2A> , and `null` convert to `true` and <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional%2A> converts `false`.
 
  ]]></format>
       </remarks>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -1237,8 +1237,9 @@ namespace Microsoft.Data.SqlClient
             get => _encrypt;
             set
             {
-                SetSqlConnectionEncryptionValue(value);
-                _encrypt = value;
+                SqlConnectionEncryptOption newValue = value ?? DbConnectionStringDefaults.Encrypt;
+                SetSqlConnectionEncryptionValue(newValue);
+                _encrypt = newValue;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -383,6 +383,10 @@ namespace Microsoft.Data.SqlClient.Tests
             builder.Encrypt = SqlConnectionEncryptOption.Strict;
             Assert.Equal("Encrypt=Strict", builder.ConnectionString);
             Assert.True(builder.Encrypt);
+
+            builder.Encrypt = null;
+            Assert.Equal("Encrypt=True", builder.ConnectionString);
+            Assert.True(builder.Encrypt);
         }
 
         [Theory]
@@ -414,7 +418,7 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("strict", "Strict")]
         public void EncryptTryParseValidValuesReturnsTrue(string value, string expectedValue)
         {
-            Assert.True(SqlConnectionEncryptOption.TryParse(value, out var result));
+            Assert.True(SqlConnectionEncryptOption.TryParse(value, out SqlConnectionEncryptOption result));
             Assert.Equal(expectedValue, result.ToString());
         }
 
@@ -424,7 +428,10 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData(null)]
         [InlineData("  true  ")]
         public void EncryptTryParseInvalidValuesReturnsFalse(string value)
-            => Assert.False(SqlConnectionEncryptOption.TryParse(value, out _));
+        {
+            Assert.False(SqlConnectionEncryptOption.TryParse(value, out SqlConnectionEncryptOption result));
+            Assert.Null(result);
+        }
 
         internal void ExecuteConnectionStringTests(string connectionString)
         {


### PR DESCRIPTION
Null Reference Exception with `SqlConnectionStringBuilder.Encrypt = null`.