### PR TITLE
Fixes ReadAsync() behavior to register Cancellation token action before streaming results

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -4733,16 +4733,17 @@ namespace Microsoft.Data.SqlClient
                     return Task.FromException<bool>(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed()));
                 }
 
-                // If user's token is canceled, return a canceled task
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return Task.FromCanceled<bool>(cancellationToken);
-                }
-
+                // Register first to catch any already expired tokens to be able to trigger cancellation event.
                 IDisposable registration = null;
                 if (cancellationToken.CanBeCanceled)
                 {
                     registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
+                }
+
+                // If user's token is canceled, return a canceled task
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return Task.FromCanceled<bool>(cancellationToken);
                 }
 
                 // Check for existing async

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -4739,6 +4739,12 @@ namespace Microsoft.Data.SqlClient
                     return Task.FromCanceled<bool>(cancellationToken);
                 }
 
+                IDisposable registration = null;
+                if (cancellationToken.CanBeCanceled)
+                {
+                    registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
+                }
+
                 // Check for existing async
                 if (_currentTask != null)
                 {
@@ -4829,12 +4835,6 @@ namespace Microsoft.Data.SqlClient
                     source.SetCanceled();
                     _currentTask = null;
                     return source.Task;
-                }
-
-                IDisposable registration = null;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
                 }
 
                 ReadAsyncCallContext context = null;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -5326,16 +5326,17 @@ namespace Microsoft.Data.SqlClient
                     return ADP.CreatedTaskWithException<bool>(ADP.ExceptionWithStackTrace(ADP.DataReaderClosed("ReadAsync")));
                 }
 
-                // If user's token is canceled, return a canceled task
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return ADP.CreatedTaskWithCancellation<bool>();
-                }
-
+                // Register first to catch any already expired tokens to be able to trigger cancellation event.
                 IDisposable registration = null;
                 if (cancellationToken.CanBeCanceled)
                 {
                     registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
+                }
+
+                // If user's token is canceled, return a canceled task
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return ADP.CreatedTaskWithCancellation<bool>();
                 }
 
                 // Check for existing async

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -5332,6 +5332,12 @@ namespace Microsoft.Data.SqlClient
                     return ADP.CreatedTaskWithCancellation<bool>();
                 }
 
+                IDisposable registration = null;
+                if (cancellationToken.CanBeCanceled)
+                {
+                    registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
+                }
+
                 // Check for existing async
                 if (_currentTask != null)
                 {
@@ -5423,12 +5429,6 @@ namespace Microsoft.Data.SqlClient
                     source.SetCanceled();
                     _currentTask = null;
                     return source.Task;
-                }
-
-                IDisposable registration = null;
-                if (cancellationToken.CanBeCanceled)
-                {
-                    registration = cancellationToken.Register(SqlCommand.s_cancelIgnoreFailure, _command);
                 }
 
                 var context = Interlocked.Exchange(ref _cachedReadAsyncContext, null) ?? new ReadAsyncCallContext();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -272,6 +272,7 @@
     <Compile Include="SQL\Common\SystemDataInternals\DataReaderHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserStateObjectHelper.cs" />
+    <Compile Include="SQL\DataReaderTest\DataReaderCancellationTest.cs" />
     <Compile Include="SQL\SqlCommand\SqlCommandStoredProcTest.cs" />
     <Compile Include="TracingTests\TestTdsServer.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="SQL\ConnectivityTests\TcpDefaultForAzureTest.cs" />
     <Compile Include="SQL\DataBaseSchemaTest\ConnectionSchemaTest.cs" />
     <Compile Include="SQL\DataClassificationTest\DataClassificationTest.cs" />
+    <Compile Include="SQL\DataReaderTest\DataReaderCancellationTest.cs" />
     <Compile Include="SQL\DataReaderTest\DataReaderStreamsTest.cs" />
     <Compile Include="SQL\DataReaderTest\DataReaderTest.cs" />
     <Compile Include="SQL\DataStreamTest\DataStreamTest.cs" />
@@ -272,7 +273,6 @@
     <Compile Include="SQL\Common\SystemDataInternals\DataReaderHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserStateObjectHelper.cs" />
-    <Compile Include="SQL\DataReaderTest\DataReaderCancellationTest.cs" />
     <Compile Include="SQL\SqlCommand\SqlCommandStoredProcTest.cs" />
     <Compile Include="TracingTests\TestTdsServer.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderCancellationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderCancellationTest.cs
@@ -42,7 +42,41 @@ from ThousandRows as A, ThousandRows as B, ThousandRows as C;";
                         }
                     }
                 });
-                Assert.True(stopwatch.ElapsedMilliseconds < 1000, "Cancellation did not trigger on time.");
+                Assert.True(stopwatch.ElapsedMilliseconds < 10000, "Cancellation did not trigger on time.");
+            }
+        }
+
+        /// <summary>
+        /// Test ensures cancellation token is registered before ReadAsync starts processing results from TDS Stream,
+        /// such that when Cancel is triggered, the token is capable of canceling reading further results.
+        /// </summary>
+        /// <returns>Async Task</returns>
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static async Task CancelledCancellationTokenIsRespected_ReadAsync()
+        {
+            const string longRunningQuery = @"
+with TenRows as (select Value from (values (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)) as TenRows (Value)),
+    ThousandRows as (select A.Value as A, B.Value as B, C.Value as C from TenRows as A, TenRows as B, TenRows as C)
+select *
+from ThousandRows as A, ThousandRows as B, ThousandRows as C;";
+
+            using (var source = new CancellationTokenSource())
+            using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            {
+                await connection.OpenAsync(source.Token);
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                {
+                    using (var command = new SqlCommand(longRunningQuery, connection))
+                    using (var reader = await command.ExecuteReaderAsync(source.Token))
+                    {
+                        source.Cancel();
+                        while (await reader.ReadAsync(source.Token))
+                        { }
+                    }
+                });
+                Assert.True(stopwatch.ElapsedMilliseconds < 10000, "Cancellation did not trigger on time.");
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderCancellationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderCancellationTest.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests
+{
+    public class DataReaderCancellationTest
+    {
+        /// <summary>
+        /// Test ensures cancellation token is registered before ReadAsync starts processing results from TDS Stream,
+        /// such that when Cancel is triggered, the token is capable of canceling reading further results.
+        /// </summary>
+        /// <returns>Async Task</returns>
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static async Task CancellationTokenIsRespected_ReadAsync()
+        {
+            const string longRunningQuery = @"
+with TenRows as (select Value from (values (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)) as TenRows (Value)),
+    ThousandRows as (select A.Value as A, B.Value as B, C.Value as C from TenRows as A, TenRows as B, TenRows as C)
+select *
+from ThousandRows as A, ThousandRows as B, ThousandRows as C;";
+
+            using (var source = new CancellationTokenSource())
+            using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            {
+                await connection.OpenAsync(source.Token);
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                {
+                    using (var command = new SqlCommand(longRunningQuery, connection))
+                    using (var reader = await command.ExecuteReaderAsync(source.Token))
+                    {
+                        while (await reader.ReadAsync(source.Token))
+                        {
+                            source.Cancel();
+                        }
+                    }
+                });
+                Assert.True(stopwatch.ElapsedMilliseconds < 1000, "Cancellation did not trigger on time.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1065 with test case added from [comment](https://github.com/dotnet/SqlClient/issues/1065#issuecomment-1262671004).

cc @jnm2 @roji would appreciate some extra validations!