### PR TITLE
[Release 5.0] Fix missing HostNameInCertificate connection string property in .NET Framework

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -1037,6 +1037,10 @@ namespace Microsoft.Data.SqlClient
         [System.ComponentModel.DisplayNameAttribute("Encrypt")]
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
         public SqlConnectionEncryptOption Encrypt { get { throw null; } set { } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/HostNameInCertificate/*'/>
+        [System.ComponentModel.DisplayNameAttribute("Host Name In Certificate")]
+        [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
+        public string HostNameInCertificate { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/Enlist/*'/>
         [System.ComponentModel.DisplayNameAttribute("Enlist")]
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -361,6 +361,17 @@ namespace Microsoft.Data.SqlClient.Tests
         }
 
         [Fact]
+        public void AbleToSetHostNameInCertificate()
+        {
+            var testhostname = "somedomain.net";
+            var builder = new SqlConnectionStringBuilder
+            {
+                HostNameInCertificate = testhostname
+            };
+            Assert.Equal(testhostname, builder.HostNameInCertificate);
+        }
+
+        [Fact]
         public void ConnectionBuilderEncryptBackwardsCompatibility()
         {
             SqlConnectionStringBuilder builder = new();


### PR DESCRIPTION
Ports #1776 to 5.0-servicing.