### PR TITLE
Release connection lock before signaling SinglePhaseCommit completion

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -348,6 +348,8 @@ namespace Microsoft.Data.SqlClient
 #endif
                 try
                 {
+                    Exception commitException = null;
+
                     lock (connection)
                     {
                         // If the connection is doomed, we can be certain that the
@@ -362,7 +364,6 @@ namespace Microsoft.Data.SqlClient
                         }
                         else
                         {
-                            Exception commitException;
                             try
                             {
                                 // Now that we've acquired the lock, make sure we still have valid state for this operation.
@@ -372,7 +373,6 @@ namespace Microsoft.Data.SqlClient
                                 _connection = null;   // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
 
                                 connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
-                                commitException = null;
                             }
                             catch (SqlException e)
                             {
@@ -420,12 +420,13 @@ namespace Microsoft.Data.SqlClient
                             }
 
                             connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
-                            if (commitException == null)
-                            {
-                                // connection.ExecuteTransaction succeeded
-                                enlistment.Committed();
-                            }
                         }
+                    }
+
+                    if (commitException == null)
+                    {
+                        // connection.ExecuteTransaction succeeded
+                        enlistment.Committed();
                     }
                 }
                 catch (System.OutOfMemoryException e)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -192,6 +192,7 @@
     <Compile Include="SQL\SqlNotificationTest\SqlNotificationTest.cs" />
     <Compile Include="SQL\SqlSchemaInfoTest\SqlSchemaInfoTest.cs" />
     <Compile Include="SQL\SqlStatisticsTest\SqlStatisticsTest.cs" />
+    <Compile Include="SQL\TransactionTest\DistributedTransactionTest.cs" />
     <Compile Include="SQL\TransactionTest\TransactionTest.cs" />
     <Compile Include="SQL\TransactionTest\TransactionEnlistmentTest.cs" />
     <Compile Include="SQL\UdtTest\SqlServerTypesTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/DistributedTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/DistributedTransactionTest.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading.Tasks;
+using System.Transactions;
+using Xunit;
+
+#if NET7_0_OR_GREATER
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests
+{
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public class DistributedTransactionTest
+    {
+        [ConditionalFact]
+        public async Task Delegated_transaction_deadlock_in_SinglePhaseCommit()
+        {
+            TransactionManager.ImplicitDistributedTransactions = true;
+            using var transaction = new CommittableTransaction();
+
+            // Uncommenting the following makes the deadlock go away as a workaround. If the transaction is promoted before
+            // the first SqlClient enlistment, it never goes into the delegated state.
+            // _ = TransactionInterop.GetTransmitterPropagationToken(transaction);
+            await using var conn = new SqlConnection(DataTestUtility.TCPConnectionString);
+            await conn.OpenAsync();
+            conn.EnlistTransaction(transaction);
+
+            // Enlisting the transaction in second connection causes the transaction to be promoted.
+            // After this, the transaction state will be "delegated" (delegated to SQL Server), and the commit below will
+            // trigger a call to SqlDelegatedTransaction.SinglePhaseCommit.
+            await using var conn2 = new SqlConnection(DataTestUtility.TCPConnectionString);
+            await conn2.OpenAsync();
+            conn2.EnlistTransaction(transaction);
+
+            transaction.Commit();
+            // We never get here because of the deadlock
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/DistributedTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/DistributedTransactionTest.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
 using System.Transactions;
 using Xunit;
 
@@ -9,7 +13,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     [PlatformSpecific(TestPlatforms.Windows)]
     public class DistributedTransactionTest
     {
-        [ConditionalFact]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer), Timeout = 10000)]
         public async Task Delegated_transaction_deadlock_in_SinglePhaseCommit()
         {
             TransactionManager.ImplicitDistributedTransactions = true;
@@ -29,8 +33,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             await conn2.OpenAsync();
             conn2.EnlistTransaction(transaction);
 
+            // Possible deadlock
             transaction.Commit();
-            // We never get here because of the deadlock
         }
     }
 }


### PR DESCRIPTION
This is a possible fix for #1800, introduced by #1042; but it may re-introduce the issue that #1042 was meant to fix.

Fixes #1800