### PR TITLE
TDS8 - Enable retrieval of TLS 1.3 SSL Protocol from SNI on .NET Core

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1024,7 +1024,7 @@ namespace Microsoft.Data.SqlClient
                                 | (is2005OrLater ? TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE : 0);
 
 
-                            EnableSsl(info, encrypt == SqlConnectionEncryptOption.Mandatory, integratedSecurity);
+                            EnableSsl(info, encrypt, integratedSecurity);
                         }
 
                         break;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -519,8 +519,20 @@ namespace Microsoft.Data.SqlClient
                 // On Instance failure re-connect and flush SNI named instance cache.
                 _physicalStateObj.SniContext = SniContext.Snix_Connect;
 
-                _physicalStateObj.CreatePhysicalSNIHandle(serverInfo.ExtendedServerName, ignoreSniOpenTimeout, timerExpire, out instanceName, ref _sniSpnBuffer, true, true, fParallel,
-                                                _connHandler.ConnectionOptions.IPAddressPreference, FQDNforDNSCache, ref _connHandler.pendingSQLDNSObject, serverInfo.ServerSPN, integratedSecurity);
+                _physicalStateObj.CreatePhysicalSNIHandle(serverInfo.ExtendedServerName,
+                    ignoreSniOpenTimeout, 
+                    timerExpire, 
+                    out instanceName, 
+                    ref _sniSpnBuffer, 
+                    true, 
+                    true, fParallel,
+                    _connHandler.ConnectionOptions.IPAddressPreference, 
+                    FQDNforDNSCache, 
+                    ref _connHandler.pendingSQLDNSObject, 
+                    serverInfo.ServerSPN, 
+                    integratedSecurity,
+                    encrypt == SqlConnectionEncryptOption.Strict,
+                    hostNameInCertificate);
 
                 if (TdsEnums.SNI_SUCCESS != _physicalStateObj.Status)
                 {
@@ -552,6 +564,7 @@ namespace Microsoft.Data.SqlClient
                     throw SQL.InstanceFailure();
                 }
             }
+            SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.Connect|SEC> Prelogin handshake successful");
 
             if (_fMARS && marsCapable)
             {
@@ -1010,7 +1023,8 @@ namespace Microsoft.Data.SqlClient
                             uint info = (shouldValidateServerCert ? TdsEnums.SNI_SSL_VALIDATE_CERTIFICATE : 0)
                                 | (is2005OrLater ? TdsEnums.SNI_SSL_USE_SCHANNEL_CACHE : 0);
 
-                            EnableSsl(info, encrypt, integratedSecurity);
+
+                            EnableSsl(info, encrypt == SqlConnectionEncryptOption.Mandatory, integratedSecurity);
                         }
 
                         break;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -425,12 +425,16 @@ namespace Microsoft.Data.SqlClient
             var nativeProtocol = (NativeProtocols)nativeProtocolVersion;
 
             /* The SslProtocols.Tls13 is supported by netcoreapp3.1 and later
-             * This driver does not support this version yet!
+             * This driver does not support this version yet! */
+#if NETCOREAPP3_1_OR_GREATER
             if (nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_3_CLIENT) || nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_3_SERVER))
             {
                 protocolVersion = (int)SslProtocols.Tls13;
-            }*/
+            }
+            else if (nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_2_CLIENT) || nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_2_SERVER))
+#else
             if (nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_2_CLIENT) || nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_2_SERVER))
+#endif
             {
                 protocolVersion = (int)SslProtocols.Tls12;
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -424,20 +424,17 @@ namespace Microsoft.Data.SqlClient
             uint returnValue = SNINativeMethodWrapper.SNIWaitForSSLHandshakeToComplete(Handle, GetTimeoutRemaining(), out uint nativeProtocolVersion);
             var nativeProtocol = (NativeProtocols)nativeProtocolVersion;
 
-            /* The SslProtocols.Tls13 is supported by netcoreapp3.1 and later
-             * This driver does not support this version yet! */
-#if NETCOREAPP3_1_OR_GREATER
-            if (nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_3_CLIENT) || nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_3_SERVER))
-            {
-                protocolVersion = (int)SslProtocols.Tls13;
-            }
-            else if (nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_2_CLIENT) || nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_2_SERVER))
-#else
             if (nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_2_CLIENT) || nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_2_SERVER))
-#endif
             {
                 protocolVersion = (int)SslProtocols.Tls12;
             }
+#if NETCOREAPP
+            else if (nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_3_CLIENT) || nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_3_SERVER))
+            {
+                /* The SslProtocols.Tls13 is supported by netcoreapp3.1 and later */
+                protocolVersion = (int)SslProtocols.Tls13;
+            }
+#endif
             else if (nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_1_CLIENT) || nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_1_SERVER))
             {
                 protocolVersion = (int)SslProtocols.Tls11;


### PR DESCRIPTION
I ran into a timeout issue during `WaitForSSLHandShakeToComplete` when I ran .NET Core with TLS 1.3 and noticed a commented-out section where it checks for TLS 1.3 and returning `SslProtocols.None`.  However, I ran into a compile error when uncommenting a check for the ssl protocol while testing .NET Core with TLS1.3 when building the MDS project on .NET standard 2.1 because `SslProtocols.Tls13` does not exist.  The `SslProtocols.Tls13` does exist on .NET Core 3.1 and above, so I added an `if-def` for it, so that I can get past the timeout issue where the retrieval of the protocol version occurs.