### PR TITLE
Change | Revert excluding unsupported protocols

### DIFF
--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -321,12 +321,6 @@ Scaled decimal parameter truncation can be enabled by enabling the below AppCont
 
 `Switch.Microsoft.Data.SqlClient.LegacyRowVersionNullBehavior`
 
-## Enabling OS secure protocols preference
-
-TLS 1.3 has been excluded due to the fact that the driver lacks full support. To enable OS preferences as before, enable the following AppContext switch on application startup:
-
-`Switch.Microsoft.Data.SqlClient.EnableSecureProtocolsByOS`
-
 ## Suppressing TLS security warning
 
 When connecting to a server, if a protocol lower than TLS 1.2 is negotiated, a security warning is output to the console. This warning can be suppressed on SQL connections with `Encrypt = false` by enabling the following AppContext switch on application startup:

--- a/src/Microsoft.Data.SqlClient/netcore/src/Interop/SNINativeMethodWrapper.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Interop/SNINativeMethodWrapper.Windows.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Data.SqlClient
         private static extern uint SNIGetInfoWrapper([In] SNIHandle pConn, SNINativeMethodWrapper.QTypes QType, out ProviderEnum provNum);
 
         [DllImport(SNI, CallingConvention = CallingConvention.Cdecl)]
-        private static extern uint SNIInitialize([In] bool useSystemDefaultSecureProtocols, [In] IntPtr pmo);
+        private static extern uint SNIInitialize([In] IntPtr pmo);
 
         [DllImport(SNI, CallingConvention = CallingConvention.Cdecl)]
         private static extern uint SNIOpenSyncExWrapper(ref SNI_CLIENT_CONSUMER_INFO pClientConsumerInfo, out IntPtr ppConn);
@@ -375,7 +375,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static uint SNIInitialize()
         {
-            return SNIInitialize(LocalAppContextSwitches.UseSystemDefaultSecureProtocols, IntPtr.Zero);
+            return SNIInitialize(IntPtr.Zero);
         }
 
         internal static unsafe uint SNIOpenMarsSession(ConsumerInfo consumerInfo, SNIHandle parent, ref IntPtr pConn, bool fSync, SqlConnectionIPAddressPreference ipPreference, SQLDNSInfo cachedDNSInfo)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIHandle.cs
@@ -17,15 +17,7 @@ namespace Microsoft.Data.SqlClient.SNI
     /// </summary>
     internal abstract class SNIHandle
     {
-        /// <summary>
-        /// Exclude TLS 1.3 in TLS-over-TDS modes (TDS 7.4 and below)
-        /// </summary>
-        protected static readonly SslProtocols s_supportedProtocols = LocalAppContextSwitches.UseSystemDefaultSecureProtocols ? SslProtocols.None : SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls
-        //protected readonly SslProtocols SupportedProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls
-#pragma warning disable CS0618 // Type or member is obsolete
-            | SslProtocols.Ssl2 | SslProtocols.Ssl3
-#pragma warning restore CS0618 // Type or member is obsolete
-            ;
+        protected static readonly SslProtocols s_supportedProtocols = SslProtocols.None;
 
 #if !NETSTANDARD2_0
         protected static readonly List<SslApplicationProtocol> s_tdsProtocols = new List<SslApplicationProtocol>(1) { new(TdsEnums.TDS8_Protocol) };

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeManagedWrapperX64.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeManagedWrapperX64.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Data.SqlClient
         internal static extern uint SNIGetInfoWrapper([In] SNIHandle pConn, SNINativeMethodWrapper.QTypes QType, out ProviderEnum provNum);
 
         [DllImport(SNI, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SNIInitialize")]
-        internal static extern uint SNIInitialize([In] bool useSystemDefaultSecureProtocols, [In] IntPtr pmo);
+        internal static extern uint SNIInitialize([In] IntPtr pmo);
 
         [DllImport(SNI, CallingConvention = CallingConvention.Cdecl)]
         internal static extern uint SNIOpenSyncExWrapper(ref SNI_CLIENT_CONSUMER_INFO pClientConsumerInfo, out IntPtr ppConn);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeManagedWrapperX86.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeManagedWrapperX86.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Data.SqlClient
         internal static extern uint SNIGetInfoWrapper([In] SNIHandle pConn, SNINativeMethodWrapper.QTypes QType, out ProviderEnum provNum);
 
         [DllImport(SNI, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SNIInitialize")]
-        internal static extern uint SNIInitialize([In] bool useSystemDefaultSecureProtocols, [In] IntPtr pmo);
+        internal static extern uint SNIInitialize([In] IntPtr pmo);
 
         [DllImport(SNI, CallingConvention = CallingConvention.Cdecl)]
         internal static extern uint SNIOpenSyncExWrapper(ref SNI_CLIENT_CONSUMER_INFO pClientConsumerInfo, out IntPtr ppConn);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeMethodWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeMethodWrapper.cs
@@ -593,11 +593,11 @@ namespace Microsoft.Data.SqlClient
                 SNINativeManagedWrapperX86.SNIGetInfoWrapper(pConn, QType, out provNum);
         }
 
-        private static uint SNIInitialize([In] bool useSystemDefaultSecureProtocols, [In] IntPtr pmo)
+        private static uint SNIInitialize([In] IntPtr pmo)
         {
             return s_is64bitProcess ?
-                SNINativeManagedWrapperX64.SNIInitialize(useSystemDefaultSecureProtocols, pmo) :
-                SNINativeManagedWrapperX86.SNIInitialize(useSystemDefaultSecureProtocols, pmo);
+                SNINativeManagedWrapperX64.SNIInitialize(pmo) :
+                SNINativeManagedWrapperX86.SNIInitialize(pmo);
         }
 
         private static uint SNIOpenSyncExWrapper(ref SNI_CLIENT_CONSUMER_INFO pClientConsumerInfo, out IntPtr ppConn)
@@ -765,7 +765,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static uint SNIInitialize()
         {
-            return SNIInitialize(LocalAppContextSwitches.UseSystemDefaultSecureProtocols, IntPtr.Zero);
+            return SNIInitialize(IntPtr.Zero);
         }
 
         internal static IntPtr SNIServerEnumOpen() => s_is64bitProcess ?

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -13,12 +13,10 @@ namespace Microsoft.Data.SqlClient
         private const string TypeName = nameof(LocalAppContextSwitches);
         internal const string MakeReadAsyncBlockingString = @"Switch.Microsoft.Data.SqlClient.MakeReadAsyncBlocking";
         internal const string LegacyRowVersionNullString = @"Switch.Microsoft.Data.SqlClient.LegacyRowVersionNullBehavior";
-        internal const string UseSystemDefaultSecureProtocolsString = @"Switch.Microsoft.Data.SqlClient.UseSystemDefaultSecureProtocols";
         internal const string SuppressInsecureTLSWarningString = @"Switch.Microsoft.Data.SqlClient.SuppressInsecureTLSWarning";
 
         private static bool s_makeReadAsyncBlocking;
         private static bool? s_LegacyRowVersionNullBehavior;
-        private static bool? s_UseSystemDefaultSecureProtocols;
         private static bool? s_SuppressInsecureTLSWarning;
 
 #if !NETFRAMEWORK
@@ -76,23 +74,6 @@ namespace Microsoft.Data.SqlClient
                     s_LegacyRowVersionNullBehavior = result;
                 }
                 return s_LegacyRowVersionNullBehavior.Value;
-            }
-        }
-
-        /// <summary>
-        /// For backward compatibility, this switch can be on to jump back on OS preferences.
-        /// </summary>
-        public static bool UseSystemDefaultSecureProtocols
-        {
-            get
-            {
-                if (s_UseSystemDefaultSecureProtocols is null)
-                {
-                    bool result;
-                    result = AppContext.TryGetSwitch(UseSystemDefaultSecureProtocolsString, out result) ? result : false;
-                    s_UseSystemDefaultSecureProtocols = result;
-                }
-                return s_UseSystemDefaultSecureProtocols.Value;
             }
         }
     }


### PR DESCRIPTION
Regarding issue #1151 and related PR #1168, the proposed changes are not required anymore since Windows 10 and/or SQL Server 2019 have fixed the issue while Microsoft.Data.SqlClient has been adding support for TLS 1.3.

- Note: Native SNI changes are proposed in the internal [Pull Request 3527](https://sqlclientdrivers.visualstudio.com/ADO.Net/_git/Microsoft.Data.SqlClient.sni/pullrequest/3527): Revert PR 2947 Remove UseSystemDefaultSecureProtocols