### PR TITLE
Test | Fix akvtest issues

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
@@ -117,9 +117,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             customProvider[SqlColumnEncryptionAzureKeyVaultProvider.ProviderName] =
                 new SqlColumnEncryptionAzureKeyVaultProvider(new ClientSecretCredential("tenant", "client", "secret"));
             sqlCommand.RegisterColumnEncryptionKeyStoreProvidersOnCommand(customProvider);
-            sqlCommand.ExecuteReader();
-            //Exception ex = Assert.Throws<SqlException>(() => sqlCommand.ExecuteReader());
-            //Assert.Contains("ClientSecretCredential authentication failed", ex.Message);
+            Exception ex = Assert.Throws<SqlException>(() => sqlCommand.ExecuteReader());
+            Assert.StartsWith("Failed to decrypt a column encryption key using key store provider", ex.InnerException.Message);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                 new SqlColumnEncryptionAzureKeyVaultProvider(new ClientSecretCredential("tenant", "client", "secret"));
             sqlCommand.RegisterColumnEncryptionKeyStoreProvidersOnCommand(customProvider);
             Exception ex = Assert.Throws<SqlException>(() => sqlCommand.ExecuteReader());
-            Assert.StartsWith("Failed to decrypt a column encryption key using key store provider", ex.InnerException.Message);
+            Assert.StartsWith("The current credential is not configured to acquire tokens for tenent", ex.InnerException.Message);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
@@ -117,8 +117,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             customProvider[SqlColumnEncryptionAzureKeyVaultProvider.ProviderName] =
                 new SqlColumnEncryptionAzureKeyVaultProvider(new ClientSecretCredential("tenant", "client", "secret"));
             sqlCommand.RegisterColumnEncryptionKeyStoreProvidersOnCommand(customProvider);
-            Exception ex = Assert.Throws<SqlException>(() => sqlCommand.ExecuteReader());
-            Assert.Contains("ClientSecretCredential authentication failed", ex.Message);
+            sqlCommand.ExecuteReader();
+            //Exception ex = Assert.Throws<SqlException>(() => sqlCommand.ExecuteReader());
+            //Assert.Contains("ClientSecretCredential authentication failed", ex.Message);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
@@ -26,10 +26,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             SqlConnection.ColumnEncryptionQueryMetadataCacheEnabled = false;
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsAKVSetupAvailable))]
-        public void TestEncryptDecryptWithAKV()
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringSetupForAE), nameof(DataTestUtility.IsAKVSetupAvailable))]
+        [ClassData(typeof(AEConnectionStringProvider))]
+        public void TestEncryptDecryptWithAKV(string connString)
         {
-            using (SqlConnection sqlConnection = new SqlConnection(string.Concat(DataTestUtility.TCPConnectionString, @";Column Encryption Setting = Enabled;")))
+            using (SqlConnection sqlConnection = new SqlConnection(string.Concat(connString, @";Column Encryption Setting = Enabled;")))
             {
                 sqlConnection.Open();
 
@@ -54,7 +55,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsAKVSetupAvailable))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAKVSetupAvailable))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void TestRoundTripWithAKVAndCertStoreProvider()
         {
@@ -72,14 +73,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsAKVSetupAvailable))]
-        public void TestLocalCekCacheIsScopedToProvider()
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringSetupForAE), nameof(DataTestUtility.IsAKVSetupAvailable))]
+        [ClassData(typeof(AEConnectionStringProvider))]
+        public void TestLocalCekCacheIsScopedToProvider(string connString)
         {
-            using (SqlConnection sqlConnection = new(string.Concat(DataTestUtility.TCPConnectionString, @";Column Encryption Setting = Enabled;")))
+            using (SqlConnection sqlConnection = new(string.Concat(connString, @";Column Encryption Setting = Enabled;")))
             {
                 sqlConnection.Open();
-
-                Customer customer = new(45, "Microsoft", "Corporation");
 
                 // Test INPUT parameter on an encrypted parameter
                 using (SqlCommand sqlCommand = new($"SELECT CustomerId, FirstName, LastName FROM [{akvTableName}] WHERE FirstName = @firstName",

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                 new SqlColumnEncryptionAzureKeyVaultProvider(new ClientSecretCredential("tenant", "client", "secret"));
             sqlCommand.RegisterColumnEncryptionKeyStoreProvidersOnCommand(customProvider);
             Exception ex = Assert.Throws<SqlException>(() => sqlCommand.ExecuteReader());
-            Assert.StartsWith("The current credential is not configured to acquire tokens for tenent", ex.InnerException.Message);
+            Assert.StartsWith("The current credential is not configured to acquire tokens for tenant", ex.InnerException.Message);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
@@ -26,10 +26,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             SqlConnection.ColumnEncryptionQueryMetadataCacheEnabled = false;
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsAKVSetupAvailable))]
-        public void TestEncryptDecryptWithAKV(string connString)
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAKVSetupAvailable))]
+        public void TestEncryptDecryptWithAKV()
         {
-            using (SqlConnection sqlConnection = new SqlConnection(string.Concat(DataTestUtility.TCPConnectionString, @";Column Encryption Setting = Enabled;")))
+            using (SqlConnection sqlConnection = new SqlConnection(string.Concat(DataTestUtility.TCPConnectionStringHGSVBS, @";Column Encryption Setting = Enabled;")))
             {
                 sqlConnection.Open();
 
@@ -72,10 +72,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsAKVSetupAvailable))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAKVSetupAvailable))]
         public void TestLocalCekCacheIsScopedToProvider()
         {
-            using (SqlConnection sqlConnection = new(string.Concat(DataTestUtility.TCPConnectionString, @";Column Encryption Setting = Enabled;")))
+            using (SqlConnection sqlConnection = new(string.Concat(DataTestUtility.TCPConnectionStringHGSVBS, @";Column Encryption Setting = Enabled;")))
             {
                 sqlConnection.Open();
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVTests.cs
@@ -26,11 +26,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             SqlConnection.ColumnEncryptionQueryMetadataCacheEnabled = false;
         }
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringSetupForAE), nameof(DataTestUtility.IsAKVSetupAvailable))]
-        [ClassData(typeof(AEConnectionStringProvider))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsAKVSetupAvailable))]
         public void TestEncryptDecryptWithAKV(string connString)
         {
-            using (SqlConnection sqlConnection = new SqlConnection(string.Concat(connString, @";Column Encryption Setting = Enabled;")))
+            using (SqlConnection sqlConnection = new SqlConnection(string.Concat(DataTestUtility.TCPConnectionString, @";Column Encryption Setting = Enabled;")))
             {
                 sqlConnection.Open();
 
@@ -73,11 +72,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             }
         }
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringSetupForAE), nameof(DataTestUtility.IsAKVSetupAvailable))]
-        [ClassData(typeof(AEConnectionStringProvider))]
-        public void TestLocalCekCacheIsScopedToProvider(string connString)
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsAKVSetupAvailable))]
+        public void TestLocalCekCacheIsScopedToProvider()
         {
-            using (SqlConnection sqlConnection = new(string.Concat(connString, @";Column Encryption Setting = Enabled;")))
+            using (SqlConnection sqlConnection = new(string.Concat(DataTestUtility.TCPConnectionString, @";Column Encryption Setting = Enabled;")))
             {
                 sqlConnection.Open();
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -36,8 +36,6 @@
     <Compile Include="AlwaysEncrypted\TestFixtures\SQLSetupStrategyCspExt.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TestSet)' == '' OR '$(TestSet)' == 'AE'">
-    <Compile Include="AlwaysEncrypted\AKVTests.cs" />
-    <Compile Include="AlwaysEncrypted\AKVUnitTests.cs" />
     <Compile Include="AlwaysEncrypted\EnclaveAzureDatabaseTests.cs" />
     <Compile Include="AlwaysEncrypted\ExceptionTestAKVStore.cs" />
     <Compile Include="AlwaysEncrypted\TestFixtures\Setup\AKVTestTable.cs" />
@@ -76,6 +74,8 @@
     <Compile Include="SQL\AsyncTest\XmlReaderAsyncTest.cs" />
     <Compile Include="SQL\AsyncTest\AsyncTest.cs" />
     <Compile Include="SQL\AsyncTest\AsyncCancelledConnectionsTest.cs" />
+    <Compile Include="AlwaysEncrypted\AKVTests.cs" />
+    <Compile Include="AlwaysEncrypted\AKVUnitTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TestSet)' == '' OR '$(TestSet)' == '2'">
     <Compile Include="SQL\AdapterTest\AdapterTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -36,6 +36,8 @@
     <Compile Include="AlwaysEncrypted\TestFixtures\SQLSetupStrategyCspExt.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TestSet)' == '' OR '$(TestSet)' == 'AE'">
+    <Compile Include="AlwaysEncrypted\AKVTests.cs" />
+    <Compile Include="AlwaysEncrypted\AKVUnitTests.cs" />
     <Compile Include="AlwaysEncrypted\EnclaveAzureDatabaseTests.cs" />
     <Compile Include="AlwaysEncrypted\ExceptionTestAKVStore.cs" />
     <Compile Include="AlwaysEncrypted\TestFixtures\Setup\AKVTestTable.cs" />
@@ -74,8 +76,6 @@
     <Compile Include="SQL\AsyncTest\XmlReaderAsyncTest.cs" />
     <Compile Include="SQL\AsyncTest\AsyncTest.cs" />
     <Compile Include="SQL\AsyncTest\AsyncCancelledConnectionsTest.cs" />
-    <Compile Include="AlwaysEncrypted\AKVTests.cs" />
-    <Compile Include="AlwaysEncrypted\AKVUnitTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TestSet)' == '' OR '$(TestSet)' == '2'">
     <Compile Include="SQL\AdapterTest\AdapterTest.cs" />


### PR DESCRIPTION
I noticed the AKVTests (3 tests in total) are skipped and have never run on our AE tests due to `nameof(DataTestUtility.AreConnStringsSetup)` in tests condition.

There will be one failure due to an exception change in Azure.Identity 1.7.0 since the expected error message has been changed.[ Read here](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/BREAKING_CHANGES.md).