### PR TITLE
Test | Change makecert to powershell

### DIFF
--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -187,7 +187,7 @@ Manual Tests require the below setup to run:
   |IsAzureSynpase | (Optional) When set to 'true', test suite runs compatible tests for Azure Synapse/Parallel Data Warehouse. | `true` OR `false`|
   |EnclaveAzureDatabaseConnString | (Optional) Connection string for Azure database with enclaves |
   |ManagedIdentitySupported | (Optional) When set to `false` **Managed Identity** related tests won't run. The default value is `true`. |
-  |MakecertPath | The full path to makecert.exe. This is not required if the path is present in the PATH environment variable. | `D:\\escaped\\absolute\\path\\to\\makecert.exe` |
+  |PowerShellPath | The full path to PowerShell.exe. This is not required if the path is present in the PATH environment variable. | `D:\\escaped\\absolute\\path\\to\\PowerShell.exe` |
 
 ### Commands to run Manual Tests
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CspProviderExt.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CspProviderExt.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup;
 using Xunit;
-using System.Net.Http;
 using System.Collections.Generic;
 using static Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.CertificateUtilityWin;
 #if NET6_0_OR_GREATER

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CspProviderExt.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CspProviderExt.cs
@@ -7,6 +7,9 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup;
 using Xunit;
+using System.Net.Http;
+using System.Collections.Generic;
+using static Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.CertificateUtilityWin;
 #if NET6_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -51,7 +54,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                     certificateName = string.Format(@"AETest - {0}", providerName);
                 }
 
-                CertificateUtilityWin.CreateCertificate(certificateName, StoreLocation.CurrentUser.ToString(), providerName, providerType);
+                var extensions = new List<Tuple<string, string, string>>();
+                CertificateOption certOption = new()
+                {
+                    Subject = certificateName,
+                    KeyExportPolicy = "Exportable",
+                    CertificateStoreLocation = $"{StoreLocation.CurrentUser}\\My",
+                    Provider = providerName,
+                    Type = providerType,
+                };
+                CreateCertificate(certOption);
                 SQLSetupStrategyCspExt sqlSetupStrategyCsp = null;
                 try
                 {
@@ -113,7 +125,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             string providerType = "24";
 
             string certificateName = string.Format(@"AETest - {0}", providerName);
-            CertificateUtilityWin.CreateCertificate(certificateName, StoreLocation.CurrentUser.ToString(), providerName, providerType);
+            CertificateOption options = new()
+            {
+                Subject = certificateName,
+                CertificateStoreLocation = StoreLocation.CurrentUser.ToString(),
+                Provider = providerName,
+                Type = providerType
+            };
+            CertificateUtilityWin.CreateCertificate(options);
             try
             {
                 X509Certificate2 cert = CertificateUtilityWin.GetCertificate(certificateName, StoreLocation.CurrentUser);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CertificateUtilityWin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CertificateUtilityWin.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             Assert.False(string.IsNullOrWhiteSpace(option.Subject), "FAILED: certificateName should not be null or empty.");
             Assert.False(string.IsNullOrWhiteSpace(option.CertificateStoreLocation), "FAILED: certificateLocation should not be null or empty.");
 
-            string powerShellPath = string.IsNullOrEmpty(DataTestUtility.MakecertPath) ? "powershell" : DataTestUtility.MakecertPath;
+            string powerShellPath = string.IsNullOrEmpty(DataTestUtility.PowerShellPath) ? "powershell.exe" : DataTestUtility.PowerShellPath;
             ProcessStartInfo processStartInfo = new ProcessStartInfo(powerShellPath)
             {
                 Arguments = $"New-SelfSignedCertificate -Subject " +
@@ -65,7 +65,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                 $"-KeyLength {option.KeyLength}  " +
                 $"-HashAlgorithm {option.HashAlgorithm} " +
                 $"-KeyUsage {option.KeyUsage} " +
-                $"{option.TestRoot}"
+                $"{option.TestRoot}",
+                Verb="runas"
             };
             Process process = new()
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CertificateUtilityWin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CertificateUtilityWin.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         }
 
         /// <summary>
-        /// Create a self-signed certificate through makecert.
+        /// Create a self-signed certificate through PowerShell.
         /// </summary>
         internal static void CreateCertificate(CertificateOption option)
         {
@@ -52,7 +52,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
 
 
-            string powerShellPath = string.IsNullOrEmpty(DataTestUtility.MakecertPath) ? "powershell" : DataTestUtility.MakecertPath;
+            string powerShellPath = string.IsNullOrEmpty(DataTestUtility.PowerShellPath) ? "powershell" : DataTestUtility.PowerShellPath;
             ProcessStartInfo processStartInfo = new ProcessStartInfo(powerShellPath)
             {
                 Arguments = $"New-SelfSignedCertificate -Subject " +

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CertificateUtilityWin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CertificateUtilityWin.cs
@@ -7,6 +7,8 @@ using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Xunit;
+using System.Collections.Generic;
+using static System.Net.Mime.MediaTypeNames;
 #if NET6_0_OR_GREATER
 using System.Runtime.Versioning;
 #endif
@@ -19,6 +21,23 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
     [PlatformSpecific(TestPlatforms.Windows)]
     class CertificateUtilityWin
     {
+
+        public class CertificateOption
+        {
+            public string Subject { get; set; }
+            public string KeyExportPolicy { get; set; } = "Exportable";
+            public string CertificateStoreLocation { get; set; }
+            public List<Tuple<string, string, string>> TextExtensions { get; set; } = new List<Tuple<string, string, string>> { new Tuple<string, string, string>("2.5.29.3", "1.3.6.1.5.5.8.2.2", "1.3.6.1.4.1.311.10.3.11") };
+            public string KeySpec { get; set; } = "KeyExchange";
+            public string Provider { get; set; } = "Microsoft Enhanced RSA and AES Cryptographic Provider";
+            public string Type { get; set; } = "24";
+            public string KeyAlgorithm { get; set; } = "rsa";
+            public string KeyLength { get; set; } = "2048";
+            public string HashAlgorithm { get; set; } = "sha256";
+            public string KeyUsage { get; set; } = "None";
+            public string TestRoot { get; set; } = "-TestRoot";
+        }
+
         private CertificateUtilityWin()
         {
         }
@@ -26,20 +45,34 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         /// <summary>
         /// Create a self-signed certificate through makecert.
         /// </summary>
-        internal static void CreateCertificate(string certificateName, string certificateLocation, string providerName, string providerType)
+        internal static void CreateCertificate(CertificateOption option)
         {
-            Assert.False(string.IsNullOrWhiteSpace(certificateName), "FAILED: certificateName should not be null or empty.");
-            Assert.False(string.IsNullOrWhiteSpace(certificateLocation), "FAILED: certificateLocation should not be null or empty.");
+            Assert.False(string.IsNullOrWhiteSpace(option.Subject), "FAILED: certificateName should not be null or empty.");
+            Assert.False(string.IsNullOrWhiteSpace(option.CertificateStoreLocation), "FAILED: certificateLocation should not be null or empty.");
 
-            string makecertPath = string.IsNullOrEmpty(DataTestUtility.MakecertPath) ? "makecert" : DataTestUtility.MakecertPath;
-            ProcessStartInfo processStartInfo = new ProcessStartInfo(makecertPath);
-            processStartInfo.Arguments = string.Format(@"-n ""CN={0}"" -pe -sr {1} -r -eku 1.3.6.1.5.5.8.2.2,1.3.6.1.4.1.311.10.3.11 -ss my -sky exchange -sp ""{2}"" -sy {3} -len 2048 -a sha256",
-                                        certificateName,
-                                        certificateLocation,
-                                        providerName,
-                                        providerType);
-            Process process = new Process();
-            process.StartInfo = processStartInfo;
+
+
+            string powerShellPath = string.IsNullOrEmpty(DataTestUtility.MakecertPath) ? "powershell" : DataTestUtility.MakecertPath;
+            ProcessStartInfo processStartInfo = new ProcessStartInfo(powerShellPath)
+            {
+                Arguments = $"New-SelfSignedCertificate -Subject " +
+                $"'CN={option.Subject}' " +
+                $"-KeyExportPolicy {option.KeyExportPolicy} " +
+                $"-CertStoreLocation '{option.CertificateStoreLocation}\\My' " +
+                $"-TextExtension @('{option.TextExtensions[0].Item1}={{text}}{option.TextExtensions[0].Item2},{option.TextExtensions[0].Item3}') " +
+                $"-KeySpec {option.KeySpec} " +
+                $"-Provider '{option.Provider}' " +
+                $"-Type {option.Type}  " +
+                $"-KeyAlgorithm {option.KeyAlgorithm} " +
+                $"-KeyLength {option.KeyLength}  " +
+                $"-HashAlgorithm {option.HashAlgorithm} " +
+                $"-KeyUsage {option.KeyUsage} " +
+                $"{option.TestRoot}"
+            };
+            Process process = new()
+            {
+                StartInfo = processStartInfo
+            };
             process.StartInfo.UseShellExecute = true;
             process.StartInfo.CreateNoWindow = true;
             process.Start();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static readonly bool UseManagedSNIOnWindows = false;
         public static readonly bool IsAzureSynapse = false;
         public static Uri AKVBaseUri = null;
-        public static readonly string MakecertPath = null;
+        public static readonly string PowerShellPath = null;
         public static string FileStreamDirectory = null;
 
         public static readonly string DNSCachingConnString = null;
@@ -110,7 +110,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             IsDNSCachingSupportedTR = c.IsDNSCachingSupportedTR;
             EnclaveAzureDatabaseConnString = c.EnclaveAzureDatabaseConnString;
             UserManagedIdentityClientId = c.UserManagedIdentityClientId;
-            MakecertPath = c.MakecertPath;
+            PowerShellPath = c.PowerShellPath;
             KerberosDomainPassword = c.KerberosDomainPassword;
             KerberosDomainUser = c.KerberosDomainUser;
             ManagedIdentitySupported = c.ManagedIdentitySupported;

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Config.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.SqlClient.TestUtilities
         public bool IsDNSCachingSupportedTR = false;  // this is for the tenant ring
         public string EnclaveAzureDatabaseConnString = null;
         public string UserManagedIdentityClientId = null;
-        public string MakecertPath = null;
+        public string PwerShellPath = null;
         public string KerberosDomainPassword = null;
         public string KerberosDomainUser = null;
 

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Config.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.SqlClient.TestUtilities
         public bool IsDNSCachingSupportedTR = false;  // this is for the tenant ring
         public string EnclaveAzureDatabaseConnString = null;
         public string UserManagedIdentityClientId = null;
-        public string PwerShellPath = null;
+        public string PowerShellPath = null;
         public string KerberosDomainPassword = null;
         public string KerberosDomainUser = null;
 

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/config.default.json
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/config.default.json
@@ -1,6 +1,6 @@
 {
-    "TCPConnectionString": "Data Source=tcp:localhost;Database=Northwind;Integrated Security=true;",
-    "NPConnectionString": "Data Source=np:localhost;Database=Northwind;Integrated Security=true;",
+    "TCPConnectionString": "Data Source=tcp:localhost;Database=Northwind;Integrated Security=true;Encrypt=false;",
+    "NPConnectionString": "Data Source=np:localhost;Database=Northwind;Integrated Security=true;Encrypt=false;",
     "TCPConnectionStringHGSVBS": "",
     "TCPConnectionStringAASVBS": "",
     "TCPConnectionStringNoneVBS": "",
@@ -30,5 +30,5 @@
     "EnclaveAzureDatabaseConnString": "",
     "ManagedIdentitySupported": true,
     "UserManagedIdentityClientId": "",
-    "MakecertPath": ""
+    "PowerShellPath": ""
 }


### PR DESCRIPTION
`makecert` is deprecated and that will cause some problems on Windows 11. Replacing `makecert` with PowerShell will solve the issue.