### PR TITLE
Fix DAC connections to localhost in managed SNI

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
@@ -581,8 +581,9 @@ namespace Microsoft.Data.SqlClient.SNI
             // If Server name is empty or localhost, then use "localhost"
             if (string.IsNullOrEmpty(ServerName) || IsLocalHost(ServerName))
             {
+                // For DAC use "localhost" instead of the server name.
                 ServerName = _connectionProtocol == Protocol.Admin ?
-                    Environment.MachineName : DefaultHostName;
+                    DefaultHostName : Environment.MachineName;
             }
         }
 
@@ -761,6 +762,7 @@ namespace Microsoft.Data.SqlClient.SNI
         }
 
         private static bool IsLocalHost(string serverName)
-            => ".".Equals(serverName) || "(local)".Equals(serverName) || "localhost".Equals(serverName);
+            => ".".Equals(serverName) || "(local)".Equals(serverName) || "localhost".Equals(serverName) ||
+            Environment.MachineName.Equals(serverName, StringComparison.CurrentCultureIgnoreCase);
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
@@ -579,11 +579,12 @@ namespace Microsoft.Data.SqlClient.SNI
         private void InferLocalServerName()
         {
             // If Server name is empty or localhost, then use "localhost"
-            if (string.IsNullOrEmpty(ServerName) || IsLocalHost(ServerName))
+            if (string.IsNullOrEmpty(ServerName) || IsLocalHost(ServerName) ||
+                (Environment.MachineName.Equals(ServerName, StringComparison.CurrentCultureIgnoreCase) &&
+                 _connectionProtocol == Protocol.Admin))
             {
                 // For DAC use "localhost" instead of the server name.
-                ServerName = _connectionProtocol == Protocol.Admin ?
-                    DefaultHostName : Environment.MachineName;
+                ServerName = DefaultHostName;
             }
         }
 
@@ -762,7 +763,6 @@ namespace Microsoft.Data.SqlClient.SNI
         }
 
         private static bool IsLocalHost(string serverName)
-            => ".".Equals(serverName) || "(local)".Equals(serverName) || "localhost".Equals(serverName) ||
-            Environment.MachineName.Equals(serverName, StringComparison.CurrentCultureIgnoreCase);
+            => ".".Equals(serverName) || "(local)".Equals(serverName) || "localhost".Equals(serverName);
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Microsoft.Data.SqlClient.TestUtilities.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Microsoft.Data.SqlClient.TestUtilities.csproj
@@ -8,10 +8,9 @@
     <Copy SourceFiles="config.default.json" DestinationFiles="config.json" Condition="!Exists('config.json')" />
   </Target>
   <ItemGroup>
-    <Content Include="config.json">
+    <None Update="config.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>config.json</Link>
-    </Content>
+    </None>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #1772. When connecting to the DAC port, the previous code was converting localhost to Environment.MachineName. Native SNI does it the other way around. It converts Environment.MachineName to localhost.