### PR TITLE
Update docs for RowsCopied property

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml
@@ -504,7 +504,7 @@ and faster to use a Transact-SQL `INSERT … SELECT` statement to copy the data.
 ## Remarks
 This value is incremented during the <xref:Microsoft.Data.SqlClient.SqlBulkCopy.SqlRowsCopied> event and does not imply that this number of rows has been sent to the server or committed.
 
-During the execution of a bulk copy operation, this value can be accessed, but it cannot be changed. Any attempt to change it will throw an <xref:System.InvalidOperationException>.
+This value can be accessed during or after the execution of a bulk copy operation.
 ]]></format>
 			</remarks>
 		</RowsCopied>


### PR DESCRIPTION
The docs referred to throwing an exception if you try to change the property, but it is read-only.