### PR TITLE
Fix | Supports thread safety with transient error list on configurable retry logic

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Data.SqlClient
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConfigurableRetryFactory.xml' path='docs/members[@name="SqlConfigurableRetryFactory"]/SqlConfigurableRetryFactory/*' />
     public sealed class SqlConfigurableRetryFactory
     {
+        private readonly static object s_syncObject = new();
         /// Default known transient error numbers.
         private static readonly HashSet<int> s_defaultTransientErrors
             = new HashSet<int>
@@ -115,7 +116,12 @@ namespace Microsoft.Data.SqlClient
             {
                 foreach (SqlError item in ex.Errors)
                 {
-                    if (retriableConditions.Contains(item.Number))
+                    bool retriable;
+                    lock (s_syncObject)
+                    {
+                        retriable = retriableConditions.Contains(item.Number);
+                    }
+                    if (retriable)
                     {
                         SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|ERR|CATCH> Found a transient error: number = <{2}>, message = <{3}>", nameof(SqlConfigurableRetryFactory), MethodBase.GetCurrentMethod().Name, item.Number, item.Message);
                         result = true;


### PR DESCRIPTION
Implementing the `IEnumerable<T>` doesn't guarantee thread safety, which would end to an inaccurate result under some circumstances.

- This fix addresses intermittent failures on the pipeline with `ConcurrentExecution` test.