### PR TITLE
Tests | Improve project reference batch file

### DIFF
--- a/RunProjectReferenceTests.cmd
+++ b/RunProjectReferenceTests.cmd
@@ -1,5 +1,24 @@
 @echo off
 
+:: Default target frameworks
+set netfxVersion=net462
+set netcoreVersion=net6.0
+
+:: Accept two parameters for .NET Framework and .NET versions.
+:: Examples: 
+::  - uses net48 and net7.0:
+::      > RunProjectReferenceTests.cmd net48 net7.0
+::  - uses default target frameworks:
+::      > RunProjectReferenceTests.cmd 
+::  - uses net48 and default target frameworks for netcore:
+::      > RunProjectReferenceTests.cmd net48
+
+if not "%~1" == "" set netfxVersion=%1
+if not "%~2" == "" set netcoreVersion=%2
+
+echo .NET Framework = %netfxVersion%
+echo .NET Core = %netcoreVersion%
+
 call :pauseOnError msbuild -t:Clean
 :: .NET FRAMEWORK - REFERENCE TYPE "PROJECT"
 :: Only Builds AnyCPU for project reference!
@@ -7,37 +26,27 @@ call :pauseOnError msbuild -t:Clean
 :: Based on `dotnet test` documentation, the `Platform` property has no effect on choosing the underlying architecture for the test execution environment.
 :: You need to install and run the `dotnet` command for a specific architecture (x64, x86, Arm64).
 
-echo Building .NET Framework Tests ...
+echo Building .NET Framework %netfxVersion% Tests ...
 call :pauseOnError msbuild -p:Configuration="Release"
 call :pauseOnError msbuild -p:Configuration="Release" -t:BuildAKVNetStAllOS
 call :pauseOnError msbuild -p:Configuration="Release" -t:BuildAKVNetFx
-call :pauseOnError msbuild -p:Configuration="Release" -t:BuildTestsNetFx -p:TargetNetFxVersion=net462
-call :pauseOnError msbuild -p:Configuration="Release" -t:BuildTestsNetFx -p:TargetNetFxVersion=net48
+call :pauseOnError msbuild -p:Configuration="Release" -t:BuildTestsNetFx -p:TargetNetFxVersion=%netfxVersion%
 
-echo Running .NET Framework Tests ...
-call pause
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetfx" -p:TargetNetFxVersion=net462 --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-net462-functional-anycpu.xml
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetfx" -p:TargetNetFxVersion=net462 --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-net462-manual-anycpu.xml
+echo Running .NET Framework %netfxVersion% Tests ...
+call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetfx" -p:TargetNetFxVersion=%netfxVersion% --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netfxVersion%-functional-anycpu.xml
+call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetfx" -p:TargetNetFxVersion=%netfxVersion% --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netfxVersion%-manual-anycpu.xml
 
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj"-p:Configuration="Release" -p:TestTargetOS="Windowsnetfx" -p:TargetNetFxVersion=net48 --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-net48-functional-anycpu.xml
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetfx"  -p:TargetNetFxVersion=net48 --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-net48-manual-anycpu.xml
-
-echo Building .NET Tests ...
+echo Building .NET %netcoreVersion% Tests ...
 call pause
 call :pauseOnError msbuild -t:Clean
 call :pauseOnError msbuild -p:Configuration="Release"
 call :pauseOnError msbuild -p:Configuration="Release" -t:BuildAKVNetStAllOS
 call :pauseOnError msbuild -p:Configuration="Release" -t:BuildAKVNetCoreAllOS
-call :pauseOnError msbuild -p:Configuration="Release" -t:BuildTestsNetCore -p:TargetNetCoreVersion=net6.0
-call :pauseOnError msbuild -p:Configuration="Release" -t:BuildTestsNetCore -p:TargetNetCoreVersion=net7.0
+call :pauseOnError msbuild -p:Configuration="Release" -t:BuildTestsNetCore -p:TargetNetCoreVersion=%netcoreVersion%
 
-echo Running .NET Tests ...
-call pause
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" -p:TargetNetCoreVersion=net6.0 --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-net6.0-functional-anycpu.xml
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" -p:TargetNetCoreVersion=net6.0 --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-net6.0-manual-anycpu.xml
-
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" -p:TargetNetCoreVersion=net7.0 --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-net7.0-functional-anycpu.xml
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" -p:TargetNetCoreVersion=net7.0 --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-net7.0-manual-anycpu.xml
+echo Running .NET %netcoreVersion% Tests ...
+call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" -p:TargetNetCoreVersion=%netcoreVersion% --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netcoreVersion%-functional-anycpu.xml
+call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" -p:TargetNetCoreVersion=%netcoreVersion% --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netcoreVersion%-manual-anycpu.xml
 
 goto :eof
 

--- a/RunProjectReferenceTests.cmd
+++ b/RunProjectReferenceTests.cmd
@@ -33,8 +33,8 @@ call :pauseOnError msbuild -p:Configuration="Release" -t:BuildAKVNetFx
 call :pauseOnError msbuild -p:Configuration="Release" -t:BuildTestsNetFx -p:TargetNetFxVersion=%netfxVersion%
 
 echo Running .NET Framework %netfxVersion% Tests ...
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetfx" -p:TargetNetFxVersion=%netfxVersion% --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netfxVersion%-functional-anycpu.xml
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetfx" -p:TargetNetFxVersion=%netfxVersion% --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netfxVersion%-manual-anycpu.xml
+call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetfx" -p:TargetNetFxVersion=%netfxVersion% --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" -l:"trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netfxVersion%-functional-anycpu.xml"
+call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetfx" -p:TargetNetFxVersion=%netfxVersion% --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" -l:"trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netfxVersion%-manual-anycpu.xml"
 
 echo Building .NET %netcoreVersion% Tests ...
 call pause
@@ -45,8 +45,8 @@ call :pauseOnError msbuild -p:Configuration="Release" -t:BuildAKVNetCoreAllOS
 call :pauseOnError msbuild -p:Configuration="Release" -t:BuildTestsNetCore -p:TargetNetCoreVersion=%netcoreVersion%
 
 echo Running .NET %netcoreVersion% Tests ...
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" -p:TargetNetCoreVersion=%netcoreVersion% --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netcoreVersion%-functional-anycpu.xml
-call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" -p:TargetNetCoreVersion=%netcoreVersion% --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests" -l:trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netcoreVersion%-manual-anycpu.xml
+call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" -p:TargetNetCoreVersion=%netcoreVersion% --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests" -l:"trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netcoreVersion%-functional-anycpu.xml"
+call :pauseOnError dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Configuration="Release" -p:TestTargetOS="Windowsnetcoreapp" -p:TargetNetCoreVersion=%netcoreVersion% --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests" -l:"trx;LogFileName=..\..\..\..\..\artifacts\Results\project-%netcoreVersion%-manual-anycpu.xml"
 
 goto :eof
 


### PR DESCRIPTION
Running build sequentially for various target frameworks breaks the artifacts for running tests.