### PR TITLE
[3.1.2] Backport: Release connection lock before signaling SinglePhaseCommit completion 

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -201,6 +201,7 @@
     <Compile Include="SQL\RandomStressTest\RandomStressTest.cs" />
     <Compile Include="SQL\SplitPacketTest\SplitPacketTest.cs" />
     <Compile Include="SQL\SqlNotificationTest\SqlNotificationTest.cs" />
+    <Compile Include="SQL\TransactionTest\DistributedTransactionTest.cs" />
     <Compile Include="SQL\TransactionTest\TransactionTest.cs" />
     <Compile Include="SQL\TransactionTest\TransactionEnlistmentTest.cs" />
     <Compile Include="SQL\UdtTest\SqlServerTypesTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/DistributedTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/DistributedTransactionTest.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Transactions;
+using Xunit;
+
+#if NET7_0_OR_GREATER
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests
+{
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public class DistributedTransactionTest
+    {
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer), Timeout = 10000)]
+        public async Task Delegated_transaction_deadlock_in_SinglePhaseCommit()
+        {
+            TransactionManager.ImplicitDistributedTransactions = true;
+            using var transaction = new CommittableTransaction();
+
+            // Uncommenting the following makes the deadlock go away as a workaround. If the transaction is promoted before
+            // the first SqlClient enlistment, it never goes into the delegated state.
+            // _ = TransactionInterop.GetTransmitterPropagationToken(transaction);
+            await using var conn = new SqlConnection(DataTestUtility.TCPConnectionString);
+            await conn.OpenAsync();
+            conn.EnlistTransaction(transaction);
+
+            // Enlisting the transaction in second connection causes the transaction to be promoted.
+            // After this, the transaction state will be "delegated" (delegated to SQL Server), and the commit below will
+            // trigger a call to SqlDelegatedTransaction.SinglePhaseCommit.
+            await using var conn2 = new SqlConnection(DataTestUtility.TCPConnectionString);
+            await conn2.OpenAsync();
+            conn2.EnlistTransaction(transaction);
+
+            // Possible deadlock
+            transaction.Commit();
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/DistributedTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/DistributedTransactionTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Threading.Tasks;
 using System.Transactions;
 using Xunit;
@@ -13,7 +14,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     [PlatformSpecific(TestPlatforms.Windows)]
     public class DistributedTransactionTest
     {
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer), Timeout = 10000)]
+        private static bool s_DelegatedTransactionCondition => DataTestUtility.AreConnStringsSetup() && DataTestUtility.IsNotAzureServer() && PlatformDetection.IsNotX86Process;
+
+        [ConditionalFact(nameof(s_DelegatedTransactionCondition), Timeout = 10000)]
         public async Task Delegated_transaction_deadlock_in_SinglePhaseCommit()
         {
             TransactionManager.ImplicitDistributedTransactions = true;

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.DotNet.XUnitExtensions/Extensions/PlatformDetection.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.DotNet.XUnitExtensions/Extensions/PlatformDetection.cs
@@ -10,5 +10,7 @@ namespace System
     {
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
+        public static bool IsX86Process => RuntimeInformation.ProcessArchitecture == Architecture.X86;
+        public static bool IsNotX86Process => !IsX86Process;
     }
 }


### PR DESCRIPTION
Backport: #1801 