### PR TITLE
Chore | Upgrade Azure Identity from 1.7.0 to 1.8.0

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -24,10 +24,10 @@
   </PropertyGroup>
   <!-- NetFx and NetCore project dependencies -->
   <PropertyGroup>
-    <AzureIdentityVersion>1.7.0</AzureIdentityVersion>
-    <MicrosoftIdentityClientVersion>4.47.2</MicrosoftIdentityClientVersion>
-    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.24.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
-    <MicrosoftIdentityModelJsonWebTokensVersion>6.24.0</MicrosoftIdentityModelJsonWebTokensVersion>
+    <AzureIdentityVersion>1.8.0</AzureIdentityVersion>
+    <MicrosoftIdentityClientVersion>4.49.1</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.26.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
+    <MicrosoftIdentityModelJsonWebTokensVersion>6.26.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
     <MicrosoftSourceLinkGitHubVersion>1.1.0</MicrosoftSourceLinkGitHubVersion>
@@ -64,7 +64,7 @@
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <SystemRuntimeInteropServicesRuntimeInformationVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationVersion>
     <SystemDataOdbcVersion>6.0.1</SystemDataOdbcVersion>
-    <SystemIdentityModelTokensJwtVersion>6.24.0</SystemIdentityModelTokensJwtVersion>
+    <SystemIdentityModelTokensJwtVersion>6.26.0</SystemIdentityModelTokensJwtVersion>
     <XunitVersion>2.4.2</XunitVersion>
     <xunitrunnervisualstudioVersion>2.4.5</xunitrunnervisualstudioVersion>
     <MicrosoftDotNetRemoteExecutorVersion>7.0.0-beta.22316.1</MicrosoftDotNetRemoteExecutorVersion>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -25,9 +25,9 @@
   <!-- NetFx and NetCore project dependencies -->
   <PropertyGroup>
     <AzureIdentityVersion>1.8.0</AzureIdentityVersion>
-    <MicrosoftIdentityClientVersion>4.49.1</MicrosoftIdentityClientVersion>
-    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.26.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
-    <MicrosoftIdentityModelJsonWebTokensVersion>6.26.0</MicrosoftIdentityModelJsonWebTokensVersion>
+    <MicrosoftIdentityClientVersion>4.47.2</MicrosoftIdentityClientVersion>
+    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.24.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
+    <MicrosoftIdentityModelJsonWebTokensVersion>6.24.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
     <MicrosoftSourceLinkGitHubVersion>1.1.0</MicrosoftSourceLinkGitHubVersion>
@@ -64,7 +64,7 @@
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <SystemRuntimeInteropServicesRuntimeInformationVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationVersion>
     <SystemDataOdbcVersion>6.0.1</SystemDataOdbcVersion>
-    <SystemIdentityModelTokensJwtVersion>6.26.0</SystemIdentityModelTokensJwtVersion>
+    <SystemIdentityModelTokensJwtVersion>6.24.0</SystemIdentityModelTokensJwtVersion>
     <XunitVersion>2.4.2</XunitVersion>
     <xunitrunnervisualstudioVersion>2.4.5</xunitrunnervisualstudioVersion>
     <MicrosoftDotNetRemoteExecutorVersion>7.0.0-beta.22316.1</MicrosoftDotNetRemoteExecutorVersion>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -29,10 +29,10 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Microsoft.Data.SqlClient.SNI" version="5.1.0" />
-        <dependency id="Azure.Identity" version="1.7.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.47.2" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
+        <dependency id="Azure.Identity" version="1.8.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.49.1" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.26.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.26.0" />
         <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
@@ -40,10 +40,10 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       </group>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.0" exclude="Compile" />
-        <dependency id="Azure.Identity" version="1.7.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.47.2" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
+        <dependency id="Azure.Identity" version="1.8.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.49.1" exclude="Compile"/>
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.26.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.26.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.0" exclude="Compile" />
@@ -55,10 +55,10 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.0" exclude="Compile" />
-        <dependency id="Azure.Identity" version="1.7.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.47.2" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
+        <dependency id="Azure.Identity" version="1.8.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.49.1" exclude="Compile"/>
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.26.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.26.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" />
@@ -72,10 +72,10 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       </group>
       <group targetFramework="netstandard2.1">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.0" exclude="Compile" />
-        <dependency id="Azure.Identity" version="1.7.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.47.2" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
+        <dependency id="Azure.Identity" version="1.8.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.49.1" exclude="Compile"/>
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.26.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.26.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -30,9 +30,9 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       <group targetFramework="net462">
         <dependency id="Microsoft.Data.SqlClient.SNI" version="5.1.0" />
         <dependency id="Azure.Identity" version="1.8.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.49.1" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.26.0" />
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.26.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.47.2" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
         <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
@@ -41,9 +41,9 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.0" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.8.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.49.1" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.26.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.26.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.47.2" exclude="Compile"/>
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.0" exclude="Compile" />
@@ -56,9 +56,9 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.0" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.8.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.49.1" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.26.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.26.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.47.2" exclude="Compile"/>
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" />
@@ -73,9 +73,9 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       <group targetFramework="netstandard2.1">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.0" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.8.0" />
-        <dependency id="Microsoft.Identity.Client" version="4.49.1" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.26.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.26.0" />
+        <dependency id="Microsoft.Identity.Client" version="4.47.2" exclude="Compile"/>
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />


### PR DESCRIPTION
This upgrade should resolve the following issues with the MSAL caching being enabled by default. 
https://github.com/dotnet/SqlClient/issues/1919
https://github.com/dotnet/SqlClient/issues/1900

Also upgraded some related dependencies.
