### PR TITLE
Add net8 compatibility

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -648,6 +648,9 @@
     <Compile Include="Microsoft\Data\SqlClient\TdsParserHelperClasses.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParserStateObject.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParserStateObjectManaged.cs" />
+  </ItemGroup>
+  <!--This will exclude SqlTypeWorkarounds.netcore.cs from Net7 and greater versions-->
+  <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
     <Compile Include="Microsoft\Data\SqlTypes\SqlTypeWorkarounds.netcore.cs" />
   </ItemGroup>
   <!-- Windows only -->

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6085,7 +6085,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
                         value.SqlBinary = SqlBinary.WrapBytes(b);
 #else
                         value.SqlBinary = SqlTypeWorkarounds.SqlBinaryCtor(b, true);   // doesn't copy the byte array
@@ -6382,7 +6382,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             return false;
                         }
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
                         value.SqlBinary = SqlBinary.WrapBytes(b);
 #else
                         value.SqlBinary = SqlTypeWorkarounds.SqlBinaryCtor(b, true);
@@ -7254,7 +7254,7 @@ namespace Microsoft.Data.SqlClient
 
 
             Span<uint> data = stackalloc uint[4];
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
             d.WriteTdsValue(data);
 #else
             SqlTypeWorkarounds.SqlDecimalExtractData(d, out data[0], out data[1], out data[2], out data[3]);
@@ -7283,7 +7283,7 @@ namespace Microsoft.Data.SqlClient
                 stateObj.WriteByte(0);
 
             Span<uint> data = stackalloc uint[4];
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
             d.WriteTdsValue(data);
 #else
             SqlTypeWorkarounds.SqlDecimalExtractData(d, out data[0], out data[1], out data[2], out data[3]);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.netcore.cs
@@ -7,7 +7,6 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Data.SqlTypes
 {
-#if !NET8_0_OR_GREATER
     /// <summary>
     /// This type provides workarounds for the separation between System.Data.Common
     /// and Microsoft.Data.SqlClient.  The latter wants to access internal members of the former, and
@@ -124,5 +123,4 @@ namespace Microsoft.Data.SqlTypes
         }
         #endregion
     }
-#endif
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.netcore.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Data.SqlTypes
 {
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// This type provides workarounds for the separation between System.Data.Common
     /// and Microsoft.Data.SqlClient.  The latter wants to access internal members of the former, and
@@ -122,31 +123,6 @@ namespace Microsoft.Data.SqlTypes
             internal SqlBinaryLookalike Fake;
         }
         #endregion
-
-        #region Work around inability to access SqlGuid.ctor(byte[], bool)
-        internal static SqlGuid SqlGuidCtor(byte[] value, bool ignored)
-        {
-            // Construct a SqlGuid without allocating/copying the byte[].  This provides
-            // the same behavior as SqlGuid.ctor(byte[], bool).
-            var c = default(SqlGuidCaster);
-            c.Fake._value = value;
-            return c.Real;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct SqlGuidLookalike
-        {
-            internal byte[] _value;
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        private struct SqlGuidCaster
-        {
-            [FieldOffset(0)]
-            internal SqlGuid Real;
-            [FieldOffset(0)]
-            internal SqlGuidLookalike Fake;
-        }
-        #endregion
     }
+#endif
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
@@ -3158,7 +3158,7 @@ namespace Microsoft.Data.SqlClient.Server
 
             long temp = getters.GetInt64(sink, ordinal);
             sink.ProcessMessagesAndThrow();
-#if NETCOREAPP && NET8_0_OR_GREATER
+#if NETCOREAPP && NET7_0_OR_GREATER
             return SqlMoney.FromTdsValue(temp);
 #else
             return SqlTypeWorkarounds.SqlMoneyCtor(temp, 1 /* ignored */ );
@@ -3642,7 +3642,7 @@ namespace Microsoft.Data.SqlClient.Server
                     sink.ProcessMessagesAndThrow();
                 }
 
-#if NET8_0_OR_GREATER
+#if NET7_0_OR_GREATER
                 setters.SetInt64(sink, ordinal, value.GetTdsValue());
 #else
                 setters.SetInt64(sink, ordinal, SqlTypeWorkarounds.SqlMoneyToSqlInternalRepresentation(value));

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
@@ -3158,7 +3158,11 @@ namespace Microsoft.Data.SqlClient.Server
 
             long temp = getters.GetInt64(sink, ordinal);
             sink.ProcessMessagesAndThrow();
+#if NETCOREAPP && NET8_0_OR_GREATER
+            return SqlMoney.FromTdsValue(temp);
+#else
             return SqlTypeWorkarounds.SqlMoneyCtor(temp, 1 /* ignored */ );
+#endif
         }
 
         private static SqlXml GetSqlXml_Unchecked(SmiEventSink_Default sink, ITypedGettersV3 getters, int ordinal, SmiContext context)
@@ -3638,7 +3642,11 @@ namespace Microsoft.Data.SqlClient.Server
                     sink.ProcessMessagesAndThrow();
                 }
 
+#if NET8_0_OR_GREATER
+                setters.SetInt64(sink, ordinal, value.GetTdsValue());
+#else
                 setters.SetInt64(sink, ordinal, SqlTypeWorkarounds.SqlMoneyToSqlInternalRepresentation(value));
+#endif
             }
             sink.ProcessMessagesAndThrow();
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -886,7 +886,11 @@ namespace Microsoft.Data.SqlClient
                     {
                         return SqlMoney.Null;
                     }
+#if NETCOREAPP && NET8_0_OR_GREATER
+                    return SqlMoney.FromTdsValue(_value._int64);
+#else
                     return SqlTypeWorkarounds.SqlMoneyCtor(_value._int64, 1/*ignored*/);
+#endif
                 }
                 return (SqlMoney)SqlValue; // anything else we haven't thought of goes through boxing.
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -886,7 +886,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         return SqlMoney.Null;
                     }
-#if NETCOREAPP && NET8_0_OR_GREATER
+#if NETCOREAPP && NET7_0_OR_GREATER
                     return SqlMoney.FromTdsValue(_value._int64);
 #else
                     return SqlTypeWorkarounds.SqlMoneyCtor(_value._int64, 1/*ignored*/);


### PR DESCRIPTION
closes https://github.com/dotnet/SqlClient/issues/1930

In netcore builds SqlGuidCaster and the type workaround that used it are not required. The problem they solved has already been change to use the ReadOnlySpan<byte> ctor. The SqlGuid workarounds in netcore are removed. Netfx builds use a more recent approach to the original problem and do not need to change.

I have also added ifdeffed use of the new api's introduced to the ryntime in https://github.com/dotnet/runtime/pull/72724 so if/when a net8 build is created the new methods will be used and the workarounds will be ifdeffed out entirely.

Testing on net was done manually with a small repro app that used reflection to force SqlGuidCaster to be compiled. Before these change the reported TypeLoadException was encountered, after them it is not.

/cc @Alerinos @MichalPetryka