### PR TITLE
Replace calls to `Method.GetCurrentMethod().Name` with `nameof()`

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -18,6 +18,8 @@
     <DocumentationFile>$(OutputPath)\$(TargetFramework)\Microsoft.Data.SqlClient.xml</DocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Product>Core $(BaseProduct)</Product>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <NoWarn>$(NoWarn);IL2026;IL2057;IL2067;IL2070;IL2072;IL2075;IL2077;IL2080;IL2093;IL2111</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>portable</DebugType>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicManager.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicManager.NetCoreApp.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.SqlClient
         /// <returns>Resolved type if it could resolve the type; otherwise, the `SqlConfigurableRetryFactory` type.</returns>
         private static Type LoadType(string fullyQualifiedName)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(LoadType);
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Entry point.", TypeName, methodName);
 
             var result = Type.GetType(fullyQualifiedName, AssemblyResolver, TypeResolver);
@@ -48,7 +48,7 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         private static string MakeFullPath(string directory, string assemblyName, string extension = ".dll")
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(MakeFullPath);
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Looking for '{2}' assembly in '{3}' directory."
                                                     , TypeName, methodName, assemblyName, directory);
             string fullPath = Path.Combine(directory, assemblyName);
@@ -60,7 +60,7 @@ namespace Microsoft.Data.SqlClient
 
         private static Assembly AssemblyResolver(AssemblyName arg)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(AssemblyResolver);
 
             string fullPath = MakeFullPath(Environment.CurrentDirectory, arg.Name);
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Looking for '{2}' assembly by '{3}' full path."
@@ -76,7 +76,7 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         private static Assembly Default_Resolving(AssemblyLoadContext arg1, AssemblyName arg2)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(Default_Resolving);
 
             string target = MakeFullPath(Environment.CurrentDirectory, arg2.Name);
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Looking for '{2}' assembly that is requested by '{3}' ALC from '{4}' path."

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -447,7 +447,7 @@ namespace Microsoft.Data.SqlClient.SNI
                         catch (Exception e)
                         {
                             SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNITCPHandle), EventType.ERR, "THIS EXCEPTION IS BEING SWALLOWED: {0}", args0: e?.Message);
-                            SqlClientEventSource.Log.TryAdvancedTraceEvent($"{nameof(SNITCPHandle)}.{System.Reflection.MethodBase.GetCurrentMethod().Name}{EventType.ERR}THIS EXCEPTION IS BEING SWALLOWED: {e}");
+                            SqlClientEventSource.Log.TryAdvancedTraceEvent($"{nameof(SNITCPHandle)}.{nameof(Connect)}{EventType.ERR}THIS EXCEPTION IS BEING SWALLOWED: {e}");
                         }
                     }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAppContextSwitchManager.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAppContextSwitchManager.NetCoreApp.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         internal static void ApplyContextSwitches(IAppContextSwitchOverridesSection appContextSwitches)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(ApplyContextSwitches);
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Entry point.", TypeName, methodName);
             if (appContextSwitches != null)
             {
@@ -32,7 +32,7 @@ namespace Microsoft.Data.SqlClient
 
         private static bool ApplySwitchValues(string[] switches)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(ApplySwitchValues);
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Entry point.", TypeName, methodName);
 
             if (switches == null || switches.Length == 0 || switches.Length % 2 == 1)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAppContextSwitchManager.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAppContextSwitchManager.NetCoreApp.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Configuration;
-using System.Reflection;
 
 namespace Microsoft.Data.SqlClient
 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicManager.LoadType.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicManager.LoadType.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient
         /// <returns>Resolved type if it could resolve the type; otherwise, the `SqlConfigurableRetryFactory` type.</returns>
         private static Type LoadType(string fullyQualifiedName)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(LoadType);
 
             var result = Type.GetType(fullyQualifiedName);
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> The '{2}' type is resolved."

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Data.SqlClient
 {
     internal static partial class LocalAppContextSwitches
     {
-        private const string TypeName = nameof(LocalAppContextSwitches);
         internal const string MakeReadAsyncBlockingString = @"Switch.Microsoft.Data.SqlClient.MakeReadAsyncBlocking";
         internal const string LegacyRowVersionNullString = @"Switch.Microsoft.Data.SqlClient.LegacyRowVersionNullBehavior";
         internal const string SuppressInsecureTLSWarningString = @"Switch.Microsoft.Data.SqlClient.SuppressInsecureTLSWarning";
@@ -30,7 +29,7 @@ namespace Microsoft.Data.SqlClient
             catch (Exception e)
             {
                 // Don't throw an exception for an invalid config file
-                SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO>: {2}", TypeName, "..ctor", e);
+                SqlClientEventSource.Log.TryTraceEvent("<sc.LocalAppContextSwitches..cctor|INFO>: {0}", e);
             }
         }
 #endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.SqlClient
             catch (Exception e)
             {
                 // Don't throw an exception for an invalid config file
-                SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO>: {2}", TypeName, MethodBase.GetCurrentMethod().Name, e);
+                SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO>: {2}", TypeName, "..ctor", e);
             }
         }
 #endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.SqlClient
             catch (Exception e)
             {
                 // Don't throw an exception for an invalid config file
-                SqlClientEventSource.Log.TryTraceEvent("<sc.LocalAppContextSwitches..cctor|INFO>: {0}", e);
+                SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.ctor|INFO>: {1}", nameof(LocalAppContextSwitches), e);
             }
         }
 #endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/AppConfigManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/AppConfigManager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.SqlClient
         /// <returns>The specified `T` object or default value of `T` if the section doesn't exist.</returns>
         public static T FetchConfigurationSection<T>(string name)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(FetchConfigurationSection);
 
             object section = null;
             try

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/AppConfigManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/AppConfigManager.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Configuration;
-using System.Reflection;
 
 namespace Microsoft.Data.SqlClient
 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/Common/SqlRetryLogic.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/Common/SqlRetryLogic.cs
@@ -68,12 +68,12 @@ namespace Microsoft.Data.SqlClient
                 RetryIntervalEnumerator.MoveNext();
                 intervalTime = RetryIntervalEnumerator.Current;
                 SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Next gap time will be '{2}' before the next retry number {3}",
-                                                       TypeName, MethodBase.GetCurrentMethod().Name, intervalTime, Current);
+                                                       TypeName, nameof(TryNextInterval), intervalTime, Current);
             }
             else
             {
                 SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Current retry ({2}) has reached the maximum attempts (total attempts excluding the first run = {3}).",
-                                                       TypeName, MethodBase.GetCurrentMethod().Name, Current, NumberOfTries - 1);
+                                                       TypeName, nameof(TryNextInterval), Current, NumberOfTries - 1);
             }
             return result;
         }
@@ -89,7 +89,7 @@ namespace Microsoft.Data.SqlClient
                         && (PreCondition == null || PreCondition.Invoke(command.CommandText)); // if it contains an invalid command to retry
 
                 SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> (retry condition = '{2}') Avoids retry if it runs in a transaction or is skipped in the command's statement checking.",
-                                                       TypeName, MethodBase.GetCurrentMethod().Name, result);
+                                                       TypeName, nameof(RetryCondition), result);
             }
             return result;
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/Common/SqlRetryLogicProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/Common/SqlRetryLogicProvider.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/Common/SqlRetryLogicProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/Common/SqlRetryLogicProvider.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Data.SqlClient
             if (!manualCancellation)
             {
                 SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|ERR|THROW> Exiting retry scope (exceeded the max allowed attempts = {2}).",
-                                                       TypeName, MethodBase.GetCurrentMethod().Name, retryLogic.NumberOfTries);
+                                                       TypeName, nameof(CreateException), retryLogic.NumberOfTries);
             }
             _retryLogicPool.Add(retryLogic);
             return result;
@@ -200,7 +200,7 @@ namespace Microsoft.Data.SqlClient
 
         private void ApplyRetryingEvent(object sender, SqlRetryLogicBase retryLogic, TimeSpan intervalTime, List<Exception> exceptions, Exception lastException)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(ApplyRetryingEvent);
             if (Retrying != null)
             {
                 var retryEventArgs = new SqlRetryingEventArgs(retryLogic.Current, intervalTime, exceptions);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     if (retriable)
                     {
-                        SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|ERR|CATCH> Found a transient error: number = <{2}>, message = <{3}>", nameof(SqlConfigurableRetryFactory), MethodBase.GetCurrentMethod().Name, item.Number, item.Message);
+                        SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|ERR|CATCH> Found a transient error: number = <{2}>, message = <{3}>", nameof(SqlConfigurableRetryFactory), nameof(TransientErrorsCondition), item.Number, item.Message);
                         result = true;
                         break;
                     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 
 namespace Microsoft.Data.SqlClient
 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicLoader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicLoader.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Data.SqlClient
 
         private static SqlRetryLogicBaseProvider CreateRetryLogicProvider(string sectionName, ISqlConfigurableRetryConnectionSection configSection)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(CreateRetryLogicProvider);
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Entry point.", TypeName, methodName);
 
             try
@@ -102,7 +102,7 @@ namespace Microsoft.Data.SqlClient
 
         private static SqlRetryLogicBaseProvider ResolveRetryLogicProvider(string configurableRetryType, string retryMethod, SqlRetryLogicOption option)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(ResolveRetryLogicProvider);
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Entry point.", TypeName, methodName);
 
             if (string.IsNullOrEmpty(retryMethod))
@@ -156,7 +156,7 @@ namespace Microsoft.Data.SqlClient
 
         private static object CreateInstance(Type type, string retryMethodName, SqlRetryLogicOption option)
         {
-            string methodName = MethodBase.GetCurrentMethod().Name;
+            string methodName = nameof(CreateInstance);
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Entry point.", TypeName, methodName);
 
             if (type == typeof(SqlConfigurableRetryFactory) || type == null)
@@ -257,7 +257,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Parameters are prepared to invoke the `{2}.{3}()` method."
-                                                  , TypeName, MethodBase.GetCurrentMethod().Name, typeof(SqlConfigurableRetryFactory).FullName, retryMethod);
+                                                  , TypeName, nameof(PrepareParamValues), typeof(SqlConfigurableRetryFactory).FullName, retryMethod);
             return funcParams;
         }
 


### PR DESCRIPTION
That reduce places which marked as trimmer unfriendly. Even if `Method.CurrentMethod().Name` will work after trimming, but tooling cannot decide that in generic cases, see: https://github.com/dotnet/runtime/issues/53242 At this point I would like to replace formatting primitives with `$""` if possible, since that allow Rolsyn build constant string for us at compile time.

Also enabled Trim Analyzer on the build, so all trim warnings can be gradually removed after proper annotations, or other work done.

/cc @Wraith2