### PR TITLE
Fix | Addressing failure on providing correct error message when symmetric key decryption fails using Always Encrypted.

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6080,7 +6080,11 @@ namespace Microsoft.Data.SqlClient
                         }
                         catch (Exception e)
                         {
-                            _physicalStateObj.HasPendingData = false;
+                            if (stateObj is not null)
+                            {
+                                DrainData(stateObj);
+                                stateObj.HasPendingData = false;
+                            }
                             throw SQL.ColumnDecryptionFailed(columnName, null, e);
                         }
                     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6080,6 +6080,7 @@ namespace Microsoft.Data.SqlClient
                         }
                         catch (Exception e)
                         {
+                            _physicalStateObj.HasPendingData = false;
                             throw SQL.ColumnDecryptionFailed(columnName, null, e);
                         }
                     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6082,7 +6082,9 @@ namespace Microsoft.Data.SqlClient
                         {
                             if (stateObj is not null)
                             {
-                                DrainData(stateObj);
+                                // call to decrypt column keys has failed. The data wont be decrypted.
+                                // Not setting the value to false, forces the driver to look for column value.
+                                // Packet received from Key Vault will throws invalid token header.
                                 stateObj.HasPendingData = false;
                             }
                             throw SQL.ColumnDecryptionFailed(columnName, null, e);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6886,7 +6886,9 @@ namespace Microsoft.Data.SqlClient
                         {
                             if (stateObj is not null)
                             {
-                                DrainData(stateObj);
+                                // call to decrypt column keys has failed. The data wont be decrypted.
+                                // Not setting the value to false, forces the driver to look for column value.
+                                // Packet received from Key Vault will throws invalid token header.
                                 stateObj._pendingData = false;
                             }
                             throw SQL.ColumnDecryptionFailed(columnName, null, e);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6884,6 +6884,7 @@ namespace Microsoft.Data.SqlClient
                         }
                         catch (Exception e)
                         {
+                            _physicalStateObj.HasPendingData = false;
                             throw SQL.ColumnDecryptionFailed(columnName, null, e);
                         }
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6884,7 +6884,11 @@ namespace Microsoft.Data.SqlClient
                         }
                         catch (Exception e)
                         {
-                            _physicalStateObj.HasPendingData = false;
+                            if (stateObj is not null)
+                            {
+                                DrainData(stateObj);
+                                stateObj._pendingData = false;
+                            }
                             throw SQL.ColumnDecryptionFailed(columnName, null, e);
                         }
                     }


### PR DESCRIPTION
The issue is happening when IsDBNull called on an encrypted column with backed keys in Azure key vault. If, for any reason, application fails to decrypt column keys, not the value the actual key for the column, the driver is waiting for the pending data to be received and throws unknown TDS token header, by setting the pending data to false, application will not process the rest to read the data.

```C#
 string command = $"SELECT [SSN] FROM [{s_schema}].[{s_table}]";
            using SqlCommand sqlCommand = new(command, connection);
            try
            {
                connection.Open();
                using SqlCommand cmd = connection.CreateCommand();
                cmd.CommandText = command;
                try
                {
                    using SqlDataReader reader = cmd.ExecuteReader();
                    if (reader.HasRows)
                    {
                        while (reader.Read())
                        {
                            if (!reader.IsDBNull(0))
                            {
                                _ = reader[0];
                                Console.WriteLine("It's not null db");
                            }
                        }
                    }
                }
                catch (Exception ex)
                {
                    Console.WriteLine(ex);
                }
~~~
