### PR TITLE
Partially annotate IL2026

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -10,6 +10,7 @@
 
 using System.Collections;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -50,6 +51,8 @@ namespace System.Net
 #endif
     internal sealed partial class NetEventSource : EventSource
     {
+        private const string EventSourceSuppressMessage = "Parameters to this method are primitive and are trimmer safe";
+
         /// <summary>The single event source instance to use for all logging.</summary>
         public static readonly NetEventSource Log = new NetEventSource();
 
@@ -518,6 +521,8 @@ namespace System.Net
         #region Custom WriteEvent overloads
 
         [NonEvent]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         private unsafe void WriteEvent(int eventId, string arg1, string arg2, string arg3, string arg4)
         {
             if (IsEnabled())
@@ -566,6 +571,8 @@ namespace System.Net
         }
 
         [NonEvent]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         private unsafe void WriteEvent(int eventId, string arg1, string arg2, byte[] arg3)
         {
             if (IsEnabled())
@@ -612,6 +619,8 @@ namespace System.Net
         }
 
         [NonEvent]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         private unsafe void WriteEvent(int eventId, string arg1, int arg2, int arg3, int arg4)
         {
             if (IsEnabled())
@@ -651,6 +660,8 @@ namespace System.Net
         }
 
         [NonEvent]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         private unsafe void WriteEvent(int eventId, string arg1, int arg2, string arg3)
         {
             if (IsEnabled())
@@ -688,6 +699,8 @@ namespace System.Net
         }
 
         [NonEvent]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         private unsafe void WriteEvent(int eventId, string arg1, string arg2, int arg3)
         {
             if (IsEnabled())
@@ -725,6 +738,8 @@ namespace System.Net
         }
 
         [NonEvent]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         private unsafe void WriteEvent(int eventId, string arg1, string arg2, string arg3, int arg4)
         {
             if (IsEnabled())

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/System/Net/Security/NetEventSource.Security.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/System/Net/Security/NetEventSource.Security.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Net.Security;
 
@@ -10,6 +11,8 @@ namespace System.Net
     internal sealed partial class NetEventSource
     {
         [Event(AcquireDefaultCredentialId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public void AcquireDefaultCredential(string packageName, Interop.SspiCli.CredentialUse intent)
         {
             if (IsEnabled())
@@ -61,6 +64,8 @@ namespace System.Net
             WriteEvent(AcceptSecurityContextId, credential, context, (int)inFlags);
 
         [Event(OperationReturnedSomethingId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public void OperationReturnedSomething(string operation, Interop.SECURITY_STATUS errorCode)
         {
             if (IsEnabled())

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicManager.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicManager.NetCoreApp.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -21,6 +22,9 @@ namespace Microsoft.Data.SqlClient
         /// and its related assemblies in default assembly load context if they aren't loaded yet.
         /// </summary>
         /// <returns>Resolved type if it could resolve the type; otherwise, the `SqlConfigurableRetryFactory` type.</returns>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("The type might be removed")]
+#endif
         private static Type LoadType(string fullyQualifiedName)
         {
             string methodName = nameof(LoadType);
@@ -58,6 +62,9 @@ namespace Microsoft.Data.SqlClient
             return File.Exists(fullPath) ? fullPath : null;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Calls System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyPath(String)")]
+#endif
         private static Assembly AssemblyResolver(AssemblyName arg)
         {
             string methodName = nameof(AssemblyResolver);
@@ -69,6 +76,10 @@ namespace Microsoft.Data.SqlClient
             return fullPath == null ? null : AssemblyLoadContext.Default.LoadFromAssemblyPath(fullPath);
         }
 
+
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Calls System.Reflection.Assembly.ExportedTypes")]
+#endif
         private static Type TypeResolver(Assembly arg1, string arg2, bool arg3)
         {
             IEnumerable<Type> types = arg1?.ExportedTypes;
@@ -97,6 +108,9 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// Load assemblies on request.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Calls System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyPath(String)")]
+#endif
         private static Assembly Default_Resolving(AssemblyLoadContext arg1, AssemblyName arg2)
         {
             string methodName = nameof(Default_Resolving);
@@ -107,6 +121,6 @@ namespace Microsoft.Data.SqlClient
 
             return target == null ? null : arg1.LoadFromAssemblyPath(target);
         }
-        #endregion
+#endregion
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Data;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.Data.SqlClient
@@ -14,6 +15,8 @@ namespace Microsoft.Data.SqlClient
     /// </summary>
     internal static class SqlClientDiagnosticListenerExtensions
     {
+        private const string EventSourceSuppressMessage = "Parameters to this method are statically known and thus are trimmer safe";
+
         public const string DiagnosticListenerName = "SqlClientDiagnosticListener";
 
         private const string SqlClientPrefix = "Microsoft.Data.SqlClient.";
@@ -38,6 +41,8 @@ namespace Microsoft.Data.SqlClient
         public const string SqlAfterRollbackTransaction = SqlClientPrefix + nameof(WriteTransactionRollbackAfter);
         public const string SqlErrorRollbackTransaction = SqlClientPrefix + nameof(WriteTransactionRollbackError);
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static Guid WriteCommandBefore(this SqlDiagnosticListener @this, SqlCommand sqlCommand, SqlTransaction transaction, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeExecuteCommand))
@@ -62,6 +67,8 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static void WriteCommandAfter(this SqlDiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, SqlTransaction transaction, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterExecuteCommand))
@@ -81,6 +88,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static void WriteCommandError(this SqlDiagnosticListener @this, Guid operationId, SqlCommand sqlCommand, SqlTransaction transaction, Exception ex, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorExecuteCommand))
@@ -100,6 +109,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static Guid WriteConnectionOpenBefore(this SqlDiagnosticListener @this, SqlConnection sqlConnection, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeOpenConnection))
@@ -123,6 +134,8 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static void WriteConnectionOpenAfter(this SqlDiagnosticListener @this, Guid operationId, SqlConnection sqlConnection, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterOpenConnection))
@@ -142,6 +155,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static void WriteConnectionOpenError(this SqlDiagnosticListener @this, Guid operationId, SqlConnection sqlConnection, Exception ex, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorOpenConnection))
@@ -161,6 +176,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static Guid WriteConnectionCloseBefore(this SqlDiagnosticListener @this, SqlConnection sqlConnection, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeCloseConnection))
@@ -185,6 +202,8 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static void WriteConnectionCloseAfter(this SqlDiagnosticListener @this, Guid operationId, Guid clientConnectionId, SqlConnection sqlConnection, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterCloseConnection))
@@ -203,6 +222,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static void WriteConnectionCloseError(this SqlDiagnosticListener @this, Guid operationId, Guid clientConnectionId, SqlConnection sqlConnection, Exception ex, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorCloseConnection))
@@ -222,6 +243,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static Guid WriteTransactionCommitBefore(this SqlDiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeCommitTransaction))
@@ -246,6 +269,8 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static void WriteTransactionCommitAfter(this SqlDiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterCommitTransaction))
@@ -264,6 +289,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static void WriteTransactionCommitError(this SqlDiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, Exception ex, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorCommitTransaction))
@@ -283,6 +310,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static Guid WriteTransactionRollbackBefore(this SqlDiagnosticListener @this, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName = null, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlBeforeRollbackTransaction))
@@ -308,6 +337,8 @@ namespace Microsoft.Data.SqlClient
                 return Guid.Empty;
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static void WriteTransactionRollbackAfter(this SqlDiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName = null, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlAfterRollbackTransaction))
@@ -327,6 +358,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         public static void WriteTransactionRollbackError(this SqlDiagnosticListener @this, Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, Exception ex, string transactionName = null, [CallerMemberName] string operation = "")
         {
             if (@this.IsEnabled(SqlErrorRollbackTransaction))

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -11,6 +11,7 @@ using System.Data;
 using System.Data.Common;
 using System.Data.SqlTypes;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -543,6 +544,9 @@ namespace Microsoft.Data.SqlClient
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public SqlRetryLogicBaseProvider RetryLogicProvider
         {
+#if NET6_0_OR_GREATER
+            [RequiresUnreferencedCode("RetryLogicProvider can be read from app.config which is unsafe for trimming")]
+#endif
             get
             {
                 if (_retryLogicProvider == null)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -121,6 +121,9 @@ namespace Microsoft.Data.SqlClient
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public SqlRetryLogicBaseProvider RetryLogicProvider
         {
+#if NET6_0_OR_GREATER
+            [RequiresUnreferencedCode("RetryLogicProvider can be read from app.config which is unsafe for trimming")]
+#endif
             get
             {
                 if (_retryLogicProvider == null)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Microsoft.Data.Common;
 using Microsoft.Data.ProviderBase;
@@ -296,6 +297,13 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+#if NET6_0_OR_GREATER
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(GroupByBehavior))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(IdentifierCase))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(SupportedJoinOperators))]
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+            Justification = "All non-primitive types which are contained in the XML stream marked as dynamic dependencies.")]
+#endif
         protected override DbMetaDataFactory CreateMetaDataFactory(DbConnectionInternal internalConnection, out bool cacheMetaDataFactory)
         {
             Debug.Assert(internalConnection != null, "internalConnection may not be null.");

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
@@ -7,6 +7,7 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 
@@ -36,6 +37,9 @@ namespace Microsoft.Data.ProviderBase
         private const string SqlCommandKey = "SQLCommand";
         private const string PrepareCollectionKey = "PrepareCollection";
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Metadata loaded from XML stream may require types which was trimmed out")]
+#endif
         public DbMetaDataFactory(Stream xmlStream, string serverVersion, string normalizedServerVersion)
         {
             ADP.CheckArgumentNull(xmlStream, nameof(xmlStream));
@@ -495,6 +499,9 @@ namespace Microsoft.Data.ProviderBase
             return result;
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("LoadDataSetFromXml uses System.Data.DataSet.ReadXml(Stream)")]
+#endif
         private void LoadDataSetFromXml(Stream XmlStream)
         {
             _metaDataCollectionsDataSet = new DataSet

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Data;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Security;
 using System.Text;
@@ -106,6 +107,10 @@ namespace Microsoft.Data.Sql
             return ParseServerEnumString(strbldr.ToString());
         }
 
+#if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+            Justification = "Filter expression uses only primitive types and trimmer safe")]
+#endif
         private static DataTable ParseServerEnumString(string serverInstances)
         {
             DataTable dataTable = PrepareDataTable();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicLoader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicLoader.cs
@@ -38,6 +38,9 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         internal SqlRetryLogicBaseProvider CommandProvider { get; private set; }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Types specified in the configuration sections may be removed by trimming")]
+#endif
         public SqlConfigurableRetryLogicLoader(ISqlConfigurableRetryConnectionSection connectionRetryConfigs,
                                                ISqlConfigurableRetryCommandSection commandRetryConfigs,
                                                string cnnSectionName = SqlConfigurableRetryConnectionSection.Name,
@@ -54,6 +57,9 @@ namespace Microsoft.Data.SqlClient
                             commandRetryConfigs == null ? null : CreateRetryLogicProvider(cmdSectionName, commandRetryConfigs));
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("The type specified in configuration section might be removed")]
+#endif
         private static SqlRetryLogicBaseProvider CreateRetryLogicProvider(string sectionName, ISqlConfigurableRetryConnectionSection configSection)
         {
             string methodName = nameof(CreateRetryLogicProvider);
@@ -101,6 +107,9 @@ namespace Microsoft.Data.SqlClient
             return SqlConfigurableRetryFactory.CreateNoneRetryProvider();
         }
 
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("The type might be removed")]
+#endif
         private static SqlRetryLogicBaseProvider ResolveRetryLogicProvider(string configurableRetryType, string retryMethod, SqlRetryLogicOption option)
         {
             string methodName = nameof(ResolveRetryLogicProvider);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryLogicManager.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Data.SqlClient
 {
@@ -15,18 +16,27 @@ namespace Microsoft.Data.SqlClient
     {
         private const string TypeName = nameof(SqlConfigurableRetryLogicManager);
 
+#if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+            Justification = "Usages of this property annotated with RequiresUnreferencedCode")]
+#endif
         private static readonly Lazy<SqlConfigurableRetryLogicLoader> s_loader =
-            new Lazy<SqlConfigurableRetryLogicLoader>(() =>
-            {
-                ISqlConfigurableRetryConnectionSection cnnConfig = null;
-                ISqlConfigurableRetryCommandSection cmdConfig = null;
+            new Lazy<SqlConfigurableRetryLogicLoader>(InitializeSqlConfigurableRetryLogicProvider);
 
-                // Fetch the section attributes values from the configuration section of the app config file.
-                cnnConfig = AppConfigManager.FetchConfigurationSection<SqlConfigurableRetryConnectionSection>(SqlConfigurableRetryConnectionSection.Name);
-                cmdConfig = AppConfigManager.FetchConfigurationSection<SqlConfigurableRetryCommandSection>(SqlConfigurableRetryCommandSection.Name);
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Calls Microsoft.Data.SqlClient.SqlConfigurableRetryLogicLoader.SqlConfigurableRetryLogicLoader(ISqlConfigurableRetryConnectionSection, ISqlConfigurableRetryCommandSection, String, String)")]
+#endif
+        private static SqlConfigurableRetryLogicLoader InitializeSqlConfigurableRetryLogicProvider()
+        {
+            ISqlConfigurableRetryConnectionSection cnnConfig = null;
+            ISqlConfigurableRetryCommandSection cmdConfig = null;
 
-                return new SqlConfigurableRetryLogicLoader(cnnConfig, cmdConfig);
-            });
+            // Fetch the section attributes values from the configuration section of the app config file.
+            cnnConfig = AppConfigManager.FetchConfigurationSection<SqlConfigurableRetryConnectionSection>(SqlConfigurableRetryConnectionSection.Name);
+            cmdConfig = AppConfigManager.FetchConfigurationSection<SqlConfigurableRetryCommandSection>(SqlConfigurableRetryCommandSection.Name);
+
+            return new SqlConfigurableRetryLogicLoader(cnnConfig, cmdConfig);
+        }
 
         private SqlConfigurableRetryLogicManager() {/*prevent external object creation*/}
 
@@ -35,6 +45,9 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         internal static SqlRetryLogicBaseProvider ConnectionProvider
         {
+#if NET6_0_OR_GREATER
+            [RequiresUnreferencedCode("ConnectionProvider may read configuration from app.config which is unsafe for trimming")]
+#endif
             get
             {
                 try
@@ -63,6 +76,9 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         internal static SqlRetryLogicBaseProvider CommandProvider
         {
+#if NET6_0_OR_GREATER
+            [RequiresUnreferencedCode("CommandProvider may read configuration from app.config which is unsafe for trimming")]
+#endif
             get
             {
                 try

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Text;
 using System.Threading;
@@ -73,6 +74,8 @@ namespace Microsoft.Data.SqlClient
     [EventSource(Name = "Microsoft.Data.SqlClient.EventSource")]
     internal partial class SqlClientEventSource : SqlClientEventSourceBase
     {
+        private const string EventSourceSuppressMessage = "Parameters to this method are primitive and are trimmer safe";
+
         // Defines the singleton instance for the Resources ETW provider
         internal static readonly SqlClientEventSource Log = new();
 
@@ -1007,6 +1010,8 @@ namespace Microsoft.Data.SqlClient
         // Do not change the first 4 arguments in this Event writer as OpenTelemetry and ApplicationInsight are relating to the same format, 
         // unless you have checked with them and they are able to change their design. Additional items could be added at the end.
         [Event(BeginExecuteEventId, Keywords = Keywords.ExecutionTrace, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Start)]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         internal void BeginExecute(int objectId, string dataSource, string database, string commandText, string message)
         {
             WriteEvent(BeginExecuteEventId, objectId, dataSource, database, commandText, message);
@@ -1015,6 +1020,8 @@ namespace Microsoft.Data.SqlClient
         // Do not change the first 3 arguments in this Event writer as OpenTelemetry and ApplicationInsight are relating to the same format, 
         // unless you have checked with them and they are able to change their design. Additional items could be added at the end.
         [Event(EndExecuteEventId, Keywords = Keywords.ExecutionTrace, Task = Tasks.ExecuteCommand, Opcode = EventOpcode.Stop)]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = EventSourceSuppressMessage)]
         internal void EndExecute(int objectId, int compositestate, int sqlExceptionNumber, string message)
         {
             WriteEvent(EndExecuteEventId, objectId, compositestate, sqlExceptionNumber, message);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlMetadataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlMetadataFactory.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using Microsoft.Data.Common;
@@ -18,7 +19,9 @@ namespace Microsoft.Data.SqlClient
         private const string ServerVersionNormalized90 = "09.00.0000";
         private const string ServerVersionNormalized10 = "10.00.0000";
 
-
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Metadata loaded from XML stream may require types which was trimmed out")]
+#endif
         public SqlMetaDataFactory(Stream XMLStream,
                                     string serverVersion,
                                     string serverVersionNormalized) :

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.Serialization.Json;
@@ -57,6 +58,8 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Makes a web request to the provided url and returns the response as a byte[]
+        [SuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
+                   Justification = "DataContractJsonSerializer used here deserialize only byte[] which is already kept.")]
         protected override byte[] MakeRequest(string url)
         {
             Exception exception = null;


### PR DESCRIPTION
I cannot get rid all of them since rety logic used everywhere in the SqlConnection and SqlCommad and I think there maybe other better ways. Other places is more or less self-contained and did not pollute anything.

/cc @Wraith2 