### PR TITLE
[5.1.1] Fix | NullReferenceException in GetBytesAsync

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -5285,7 +5285,7 @@ namespace Microsoft.Data.SqlClient
             {
                 TDisposable copy = _disposable;
                 _disposable = default;
-                copy.Dispose();
+                copy?.Dispose();
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderStreamsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderStreamsTest.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
+using System.Xml.Linq;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
@@ -470,6 +471,37 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 }
             }
         }
+
+#if NETCOREAPP
+        [ConditionalFact(typeof(DataTestUtility),nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
+        public static async void ReadAsyncContentsCompletes()
+        {
+            string expectedXml = "<test>This is a test string</test>";
+            string query = $"SELECT CAST('{expectedXml}' AS NVARCHAR(MAX))";
+
+            string returnedXml = null;
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            using (SqlCommand command = new SqlCommand(query, connection))
+            {
+                connection.Open();
+
+                await using (SqlDataReader reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess).ConfigureAwait(false))
+                {
+                    while (await reader.ReadAsync().ConfigureAwait(false))
+                    {
+                        using (TextReader textReader = reader.GetTextReader(0))
+                        using (XmlReader xmlReader = XmlReader.Create(textReader, new XmlReaderSettings() { Async = true }))
+                        {
+                            XDocument xdoc = await XDocument.LoadAsync(xmlReader, LoadOptions.None, default).ConfigureAwait(false);
+                            returnedXml = xdoc.ToString();
+                        }
+                    }
+                }
+            }
+
+            Assert.Equal(expectedXml, returnedXml, StringComparer.Ordinal);
+        }
+#endif
 
         private static async Task<SqlDataReader> ExecuteReader(SqlCommand command, CommandBehavior behavior, bool isExecuteAsync)
             => isExecuteAsync ? await command.ExecuteReaderAsync(behavior) : command.ExecuteReader(behavior);


### PR DESCRIPTION
Backporting the fix to the NullReferenceException into the 5.1-servicing branch and these changes were based on #1906