### PR TITLE
Reduce carbon footprint with better error messages

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -249,12 +249,16 @@ namespace Microsoft.Data.SqlClient
                                 }
                                 catch (OverflowException)
                                 {
-                                    throw new OverflowException(SQLResource.ConversionOverflowMessage);
+                                    throw new OverflowException(SQLResource.ConversionOverflowMessage + " for " + sqlValue.ToString());
                                 }
                             }
                         }
-                        throw new OverflowException(SQLResource.ConversionOverflowMessage);
+                        throw new OverflowException(SQLResource.ConversionOverflowMessage+ " for " + sqlValue.ToString());
                     }
+
+SqlDecimal sqlValue = new(_value._numericInfo._precision, _value._numericInfo._scale, _value._numericInfo._positive, 
+                                                          _value._numericInfo._data1, _value._numericInfo._data2, 
+                                                          _value._numericInfo._data3, _value._numericInfo._data4);
                     return new decimal(_value._numericInfo._data1, _value._numericInfo._data2, _value._numericInfo._data3, !_value._numericInfo._positive, _value._numericInfo._scale);
                 }
                 if (StorageType.Money == _type)


### PR DESCRIPTION
By decreasing the amount of time developers need to debug non descriptive error messages we can drastically reduce electricity wasted.

From phone, refactor as you like. Take it from here bye