### PR TITLE
Fix | Dropping reference to Microsoft.Win32.Registry in netcore.

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -939,9 +939,6 @@
     <Compile Include="Microsoft\Data\SqlClient\TdsParserStateObjectFactory.Managed.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParser.Unix.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' and '$(IsUAPAssembly)' != 'true'">
-    <Reference Include="Microsoft.Win32.Registry" />
-  </ItemGroup>
   <ItemGroup Condition="'$(OSGroup)' != 'AnyOS' AND '$(IsUAPAssembly)' == 'true'">
     <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Memory" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static readonly bool IsDNSCachingSupportedCR = false;  // this is for the control ring
         public static readonly bool IsDNSCachingSupportedTR = false;  // this is for the tenant ring
         public static readonly string UserManagedIdentityClientId = null;
+        public static readonly string AliasName = null;
 
 
         public static readonly string EnclaveAzureDatabaseConnString = null;
@@ -117,6 +118,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             KerberosDomainUser = c.KerberosDomainUser;
             ManagedIdentitySupported = c.ManagedIdentitySupported;
             IsManagedInstance = c.IsManagedInstance;
+            AliasName = c.AliasName;
 
             System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -302,6 +302,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return !string.IsNullOrEmpty(NPConnectionString) && !string.IsNullOrEmpty(TCPConnectionString);
         }
 
+        public static bool IsSQLAliasSetup()
+        {
+            return !string.IsNullOrEmpty(AliasName);
+        }
         public static bool IsTCPConnStringSetup()
         {
             return !string.IsNullOrEmpty(TCPConnectionString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -389,20 +389,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [PlatformSpecific(TestPlatforms.Windows)]
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsSQLAliasSetup))]
         public static void ConnectionAliasTest()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString)
             {
-                throw new Exception("Alias test only valid on Windows");
-            }
-
-            SqlConnectionStringBuilder b = new(DataTestUtility.TCPConnectionString);
+                DataSource = DataTestUtility.AliasName
+            };
+            using SqlConnection sqlConnection = new(builder.ConnectionString);
+            Assert.Equal(DataTestUtility.AliasName, builder.DataSource);
             try
             {
-                b.DataSource = DataTestUtility.AliasName;
-                using SqlConnection sqlConnection = new(b.ConnectionString);
-                Assert.Equal(DataTestUtility.AliasName, b.DataSource);
                 sqlConnection.Open();
                 Assert.Equal(ConnectionState.Open, sqlConnection.State);
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
@@ -431,11 +432,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 throw new Exception("Alias test only valid on Windows");
             }
 
-            if (!CanCreateAliases())
-            {
-                throw new Exception("Unable to create aliases in this environment. Windows + Admin + non-instance data source required.");
-            }
-
             SqlConnectionStringBuilder b = new(DataTestUtility.TCPConnectionString);
             if (!DataTestUtility.ParseDataSource(b.DataSource, out string hostname, out int port, out string instanceName) ||
                 !string.IsNullOrEmpty(instanceName))
@@ -444,17 +440,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 throw new Exception("Unable to create aliases in this configuration. Parsable data source without instance required.");
             }
 
-            b.DataSource = "TESTALIAS-" + Guid.NewGuid().ToString().Replace("-", "");
-            using RegistryKey key = Registry.LocalMachine.OpenSubKey(ConnectToPath, true);
-            key.SetValue(b.DataSource, "DBMSSOCN," + hostname + "," + (port == -1 ? 1433 : port));
             try
             {
+                b.DataSource = DataTestUtility.AliasName;
                 using SqlConnection sqlConnection = new(b.ConnectionString);
+                Assert.Equal(DataTestUtility.AliasName, b.DataSource);
                 sqlConnection.Open();
+                Assert.Equal(ConnectionState.Open, sqlConnection.State);
             }
-            finally
+            catch(SqlException ex)
             {
-                key.DeleteValue(b.DataSource);
+                Assert.Fail(ex.Message);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -6,10 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Security.Principal;
 using System.Threading;
-using Microsoft.Win32;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Config.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Data.SqlClient.TestUtilities
         public string KerberosDomainPassword = null;
         public string KerberosDomainUser = null;
         public bool IsManagedInstance = false;
-
+        public string AliasName = null;
         public static Config Load(string configPath = @"config.json")
         {
             try

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/config.default.json
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/config.default.json
@@ -30,5 +30,6 @@
     "EnclaveAzureDatabaseConnString": "",
     "ManagedIdentitySupported": true,
     "UserManagedIdentityClientId": "",
-    "PowerShellPath": ""
+    "PowerShellPath": "",
+    "AliasName": ""
 }


### PR DESCRIPTION
According to [this announcement](https://github.com/dotnet/runtime/issues/54365) Microsoft.Win32.Registry is shipped with net 6 and after versions. Removing the reference in netcore csproj will eliminate the warning.