### PR TITLE
Fix Transient fault handling issue with OpenAsync

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1856,7 +1856,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            _applyTransientFaultHandling = (!overrides.HasFlag(SqlConnectionOverrides.OpenWithoutRetry) && retry == null && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
+            _applyTransientFaultHandling = (!overrides.HasFlag(SqlConnectionOverrides.OpenWithoutRetry) && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
 
             if (connectionOptions != null &&
                 (connectionOptions.Authentication == SqlAuthenticationMethod.SqlPassword ||
@@ -1885,7 +1885,7 @@ namespace Microsoft.Data.SqlClient
             // does not require GC.KeepAlive(this) because of ReRegisterForFinalize below.
 
             // Set future transient fault handling based on connection options
-            _applyTransientFaultHandling = (retry == null && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
+            _applyTransientFaultHandling = connectionOptions != null && connectionOptions.ConnectRetryCount > 0;
 
             var tdsInnerConnection = (SqlInternalConnectionTds)InnerConnection;
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2068,7 +2068,7 @@ namespace Microsoft.Data.SqlClient
 
             bool result = false;
 
-            _applyTransientFaultHandling = (!overrides.HasFlag(SqlConnectionOverrides.OpenWithoutRetry) && retry == null && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
+            _applyTransientFaultHandling = (!overrides.HasFlag(SqlConnectionOverrides.OpenWithoutRetry) && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
 
             if (connectionOptions != null &&
                 (connectionOptions.Authentication == SqlAuthenticationMethod.SqlPassword ||
@@ -2111,7 +2111,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             // Set future transient fault handling based on connection options
-            _applyTransientFaultHandling = (retry == null && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
+            _applyTransientFaultHandling = connectionOptions != null && connectionOptions.ConnectRetryCount > 0;
 
             return result;
         }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Data.Common;
 using System.Reflection;
 using System.Security;
+using System.Threading.Tasks;
 using Microsoft.SqlServer.TDS.Servers;
 using Xunit;
 
@@ -39,6 +40,33 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData(42108)]
         [InlineData(42109)]
         [PlatformSpecific(TestPlatforms.Windows)]
+        public async Task TransientFaultTestAsync(uint errorCode)
+        {
+            using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(true, true, errorCode);
+            SqlConnectionStringBuilder builder = new()
+            {
+                DataSource = "localhost," + server.Port,
+                IntegratedSecurity = true,
+                Encrypt = SqlConnectionEncryptOption.Optional
+            };
+
+            using SqlConnection connection = new(builder.ConnectionString);
+            try
+            {
+                await connection.OpenAsync();
+                Assert.Equal(ConnectionState.Open, connection.State);
+            }
+            catch (Exception e)
+            {
+                Assert.False(true, e.Message);
+            }
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArmProcess))]
+        [InlineData(40613)]
+        [InlineData(42108)]
+        [InlineData(42109)]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void TransientFaultTest(uint errorCode)
         {
             using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(true, true, errorCode);
@@ -57,11 +85,61 @@ namespace Microsoft.Data.SqlClient.Tests
             }
             catch (Exception e)
             {
-                if (null != connection)
-                {
-                    Assert.Equal(ConnectionState.Closed, connection.State);
-                }
                 Assert.False(true, e.Message);
+            }
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArmProcess))]
+        [InlineData(40613)]
+        [InlineData(42108)]
+        [InlineData(42109)]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public async Task TransientFaultDisabledTestAsync(uint errorCode)
+        {
+            using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(false, true, errorCode);
+            SqlConnectionStringBuilder builder = new()
+            {
+                DataSource = "localhost," + server.Port,
+                IntegratedSecurity = true,
+                Encrypt = SqlConnectionEncryptOption.Optional
+            };
+
+            using SqlConnection connection = new(builder.ConnectionString);
+            try
+            {
+                await connection.OpenAsync();
+                Assert.False(true, "Connection should not have opened.");
+            }
+            catch
+            {
+                Assert.Equal(ConnectionState.Closed, connection.State);
+            }
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArmProcess))]
+        [InlineData(40613)]
+        [InlineData(42108)]
+        [InlineData(42109)]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void TransientFaultDisabledTest(uint errorCode)
+        {
+            using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(false, true, errorCode);
+            SqlConnectionStringBuilder builder = new()
+            {
+                DataSource = "localhost," + server.Port,
+                IntegratedSecurity = true,
+                Encrypt = SqlConnectionEncryptOption.Optional
+            };
+
+            using SqlConnection connection = new(builder.ConnectionString);
+            try
+            {
+                connection.Open();
+                Assert.False(true, "Connection should not have opened.");
+            }
+            catch
+            {
+                Assert.Equal(ConnectionState.Closed, connection.State);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -113,10 +113,9 @@ namespace Microsoft.Data.SqlClient.Tests
             }
             catch (SqlException e)
             {
-                if (e.Class == 20) // FATAL Error, should result in closed connection.
-                {
-                    Assert.Equal(ConnectionState.Closed, connection.State);
-                }
+                // FATAL Error, should result in closed connection.
+                Assert.Equal(20, e.Class);
+                Assert.Equal(ConnectionState.Closed, connection.State);
             }
         }
 
@@ -144,10 +143,9 @@ namespace Microsoft.Data.SqlClient.Tests
             }
             catch (SqlException e)
             {
-                if (e.Class == 20) // FATAL Error, should result in closed connection.
-                {
-                    Assert.Equal(ConnectionState.Closed, connection.State);
-                }
+                // FATAL Error, should result in closed connection.
+                Assert.Equal(20, e.Class);
+                Assert.Equal(ConnectionState.Closed, connection.State);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -96,11 +96,12 @@ namespace Microsoft.Data.SqlClient.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public async Task TransientFaultDisabledTestAsync(uint errorCode)
         {
-            using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(false, true, errorCode);
+            using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(true, true, errorCode);
             SqlConnectionStringBuilder builder = new()
             {
                 DataSource = "localhost," + server.Port,
                 IntegratedSecurity = true,
+                ConnectRetryCount = 0,
                 Encrypt = SqlConnectionEncryptOption.Optional
             };
 
@@ -110,9 +111,12 @@ namespace Microsoft.Data.SqlClient.Tests
                 await connection.OpenAsync();
                 Assert.False(true, "Connection should not have opened.");
             }
-            catch
+            catch (SqlException e)
             {
-                Assert.Equal(ConnectionState.Closed, connection.State);
+                if (e.Class == 20) // FATAL Error, should result in closed connection.
+                {
+                    Assert.Equal(ConnectionState.Closed, connection.State);
+                }
             }
         }
 
@@ -123,11 +127,12 @@ namespace Microsoft.Data.SqlClient.Tests
         [PlatformSpecific(TestPlatforms.Windows)]
         public void TransientFaultDisabledTest(uint errorCode)
         {
-            using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(false, true, errorCode);
+            using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(true, true, errorCode);
             SqlConnectionStringBuilder builder = new()
             {
                 DataSource = "localhost," + server.Port,
                 IntegratedSecurity = true,
+                ConnectRetryCount = 0,
                 Encrypt = SqlConnectionEncryptOption.Optional
             };
 
@@ -137,9 +142,12 @@ namespace Microsoft.Data.SqlClient.Tests
                 connection.Open();
                 Assert.False(true, "Connection should not have opened.");
             }
-            catch
+            catch (SqlException e)
             {
-                Assert.Equal(ConnectionState.Closed, connection.State);
+                if (e.Class == 20) // FATAL Error, should result in closed connection.
+                {
+                    Assert.Equal(ConnectionState.Closed, connection.State);
+                }
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -51,15 +51,8 @@ namespace Microsoft.Data.SqlClient.Tests
             };
 
             using SqlConnection connection = new(builder.ConnectionString);
-            try
-            {
-                await connection.OpenAsync();
-                Assert.Equal(ConnectionState.Open, connection.State);
-            }
-            catch (Exception e)
-            {
-                Assert.False(true, e.Message);
-            }
+            await connection.OpenAsync();
+            Assert.Equal(ConnectionState.Open, connection.State);
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArmProcess))]

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TransientFaultTDSServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TransientFaultTDSServer.cs
@@ -146,6 +146,7 @@ namespace Microsoft.SqlServer.TDS.Servers
             if (isDisposing)
             {
                 _endpoint?.Stop();
+                RequestCounter = 0;
             }
         }
     }


### PR DESCRIPTION
Addresses #1982 

'Retry', is a completion callback that is completed after `CreateConnection()` completes (which handles transient faults), here:

https://github.com/dotnet/SqlClient/blob/a5ad8382a390ea599740bd3ab51b19601bbd92e0/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs#L1079-L1095

So I don't see a reason to not enable transient fault handling retries when its specified.