### PR TITLE
Code Health | Cleanup `SNIMARSConnection`

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Data.SqlClient.SNI
     /// </summary>
     internal class SNIMarsConnection
     {
-        private const string s_className = nameof(SNIMarsConnection);
-
         private readonly Guid _connectionId = Guid.NewGuid();
         private readonly Dictionary<int, SNIMarsHandle> _sessions = new Dictionary<int, SNIMarsHandle>();
         private readonly byte[] _headerBytes = new byte[SNISMUXHeader.HEADER_LENGTH];
@@ -46,7 +44,7 @@ namespace Microsoft.Data.SqlClient.SNI
         public SNIMarsConnection(SNIHandle lowerHandle)
         {
             _lowerHandle = lowerHandle;
-            SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "Created MARS Session Id {0}", args0: ConnectionId);
+            SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "Created MARS Session Id {0}", args0: ConnectionId);
             _lowerHandle.SetAsyncCallbacks(HandleReceiveComplete, HandleSendComplete);
         }
 
@@ -57,7 +55,7 @@ namespace Microsoft.Data.SqlClient.SNI
                 ushort sessionId = _nextSessionId++;
                 SNIMarsHandle handle = new SNIMarsHandle(this, sessionId, callbackObject, async);
                 _sessions.Add(sessionId, handle);
-                SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, SNI MARS Handle Id {1}, created new MARS Session {2}", args0: ConnectionId, args1: handle?.ConnectionId, args2: sessionId);
+                SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "MARS Session Id {0}, SNI MARS Handle Id {1}, created new MARS Session {2}", args0: ConnectionId, args1: handle?.ConnectionId, args2: sessionId);
                 return handle;
             }
         }
@@ -68,17 +66,17 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns></returns>
         public uint StartReceive()
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
+            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
             try
             {
                 SNIPacket packet = null;
 
                 if (ReceiveAsync(ref packet) == TdsEnums.SNI_SUCCESS_IO_PENDING)
                 {
-                    SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, Success IO pending.", args0: ConnectionId);
+                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "MARS Session Id {0}, Success IO pending.", args0: ConnectionId);
                     return TdsEnums.SNI_SUCCESS_IO_PENDING;
                 }
-                SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.ERR, "MARS Session Id {0}, Connection not usable.", args0: ConnectionId);
+                SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.ERR, "MARS Session Id {0}, Connection not usable.", args0: ConnectionId);
                 return SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, 0, SNICommon.ConnNotUsableError, Strings.SNI_ERROR_19);
             }
             finally
@@ -94,7 +92,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public uint Send(SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
+            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
             try
             {
                 lock (this)
@@ -115,7 +113,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public uint SendAsync(SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
+            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
             try
             {
                 lock (this)
@@ -136,14 +134,14 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public uint ReceiveAsync(ref SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
+            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
             try
             {
                 if (packet != null)
                 {
                     ReturnPacket(packet);
 #if DEBUG
-                    SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, Packet {1} returned", args0: ConnectionId, args1: packet?._id);
+                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "MARS Session Id {0}, Packet {1} returned", args0: ConnectionId, args1: packet?._id);
 #endif
                     packet = null;
                 }
@@ -152,7 +150,7 @@ namespace Microsoft.Data.SqlClient.SNI
                 {
                     var response = _lowerHandle.ReceiveAsync(ref packet);
 #if DEBUG
-                    SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, Received new packet {1}", args0: ConnectionId, args1: packet?._id);
+                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "MARS Session Id {0}, Received new packet {1}", args0: ConnectionId, args1: packet?._id);
 #endif
                     return response;
                 }
@@ -169,7 +167,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error status</returns>
         public uint CheckConnection()
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
+            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
             try
             {
                 lock (this)
@@ -195,11 +193,11 @@ namespace Microsoft.Data.SqlClient.SNI
                 {
                     handle.HandleReceiveError(packet);
 #if DEBUG
-                    SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.ERR, "MARS Session Id {0}, Packet {1} has Completion Callback", args0: ConnectionId, args1: packet?._id);
+                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.ERR, "MARS Session Id {0}, Packet {1} has Completion Callback", args0: ConnectionId, args1: packet?._id);
                 }
                 else
                 {
-                    SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.ERR, "MARS Session Id {0}, Packet {1} does not have Completion Callback, error not handled.", args0: ConnectionId, args1: packet?._id);
+                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.ERR, "MARS Session Id {0}, Packet {1} does not have Completion Callback, error not handled.", args0: ConnectionId, args1: packet?._id);
 #endif
                 }
             }
@@ -224,7 +222,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="sniErrorCode">SNI error code</param>
         public void HandleReceiveComplete(SNIPacket packet, uint sniErrorCode)
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
+            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
             try
             {
                 SNISMUXHeader currentHeader = null;
@@ -236,7 +234,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     lock (this)
                     {
                         HandleReceiveError(packet);
-                        SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.ERR, "MARS Session Id {0}, Handled receive error code: {1}", args0: _lowerHandle?.ConnectionId, args1: sniErrorCode);
+                        SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.ERR, "MARS Session Id {0}, Handled receive error code: {1}", args0: _lowerHandle?.ConnectionId, args1: sniErrorCode);
                         return;
                     }
                 }
@@ -259,7 +257,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                 if (bytesTaken == 0)
                                 {
                                     sniErrorCode = ReceiveAsync(ref packet);
-                                    SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, Non-SMUX Header SNI Packet received with code {1}", args0: ConnectionId, args1: sniErrorCode);
+                                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "MARS Session Id {0}, Non-SMUX Header SNI Packet received with code {1}", args0: ConnectionId, args1: sniErrorCode);
 
                                     if (sniErrorCode == TdsEnums.SNI_SUCCESS_IO_PENDING)
                                     {
@@ -267,7 +265,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                     }
 
                                     HandleReceiveError(packet);
-                                    SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.ERR, "MARS Session Id {0}, Handled receive error code: {1}", args0: _lowerHandle?.ConnectionId, args1: sniErrorCode);
+                                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.ERR, "MARS Session Id {0}, Handled receive error code: {1}", args0: _lowerHandle?.ConnectionId, args1: sniErrorCode);
                                     return;
                                 }
                             }
@@ -276,7 +274,7 @@ namespace Microsoft.Data.SqlClient.SNI
                             _dataBytesLeft = (int)_currentHeader.length;
                             _currentPacket = _lowerHandle.RentPacket(headerSize: 0, dataSize: (int)_currentHeader.length);
 #if DEBUG
-                            SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, _dataBytesLeft {1}, _currentPacket {2}, Reading data of length: _currentHeader.length {3}", args0: _lowerHandle?.ConnectionId, args1: _dataBytesLeft, args2: currentPacket?._id, args3: _currentHeader?.length);
+                            SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "MARS Session Id {0}, _dataBytesLeft {1}, _currentPacket {2}, Reading data of length: _currentHeader.length {3}", args0: _lowerHandle?.ConnectionId, args1: _dataBytesLeft, args2: currentPacket?._id, args3: _currentHeader?.length);
 #endif
                         }
 
@@ -293,7 +291,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                 if (_dataBytesLeft > 0)
                                 {
                                     sniErrorCode = ReceiveAsync(ref packet);
-                                    SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, SMUX DATA Header SNI Packet received with code {1}, _dataBytesLeft {2}", args0: ConnectionId, args1: sniErrorCode, args2: _dataBytesLeft);
+                                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "MARS Session Id {0}, SMUX DATA Header SNI Packet received with code {1}, _dataBytesLeft {2}", args0: ConnectionId, args1: sniErrorCode, args2: _dataBytesLeft);
 
                                     if (sniErrorCode == TdsEnums.SNI_SUCCESS_IO_PENDING)
                                     {
@@ -301,7 +299,7 @@ namespace Microsoft.Data.SqlClient.SNI
                                     }
 
                                     HandleReceiveError(packet);
-                                    SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.ERR, "MARS Session Id {0}, Handled receive error code: {1}", args0: _lowerHandle?.ConnectionId, args1: sniErrorCode);
+                                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.ERR, "MARS Session Id {0}, Handled receive error code: {1}", args0: _lowerHandle?.ConnectionId, args1: sniErrorCode);
                                     return;
                                 }
                             }
@@ -313,7 +311,7 @@ namespace Microsoft.Data.SqlClient.SNI
                         {
                             SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.SMUX_PROV, 0, SNICommon.InvalidParameterError, Strings.SNI_ERROR_5);
                             HandleReceiveError(packet);
-                            SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.ERR, "Current Header Session Id {0} not found, MARS Session Id {1} will be destroyed, New SNI error created: {2}", args0: _currentHeader?.sessionId, args1: _lowerHandle?.ConnectionId, args2: sniErrorCode);
+                            SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.ERR, "Current Header Session Id {0} not found, MARS Session Id {1} will be destroyed, New SNI error created: {2}", args0: _currentHeader?.sessionId, args1: _lowerHandle?.ConnectionId, args2: sniErrorCode);
                             _lowerHandle.Dispose();
                             _lowerHandle = null;
                             return;
@@ -322,19 +320,19 @@ namespace Microsoft.Data.SqlClient.SNI
                         if (_currentHeader.flags == (byte)SNISMUXFlags.SMUX_FIN)
                         {
                             _sessions.Remove(_currentHeader.sessionId);
-                            SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "SMUX_FIN | MARS Session Id {0}, SMUX_FIN flag received, Current Header Session Id {1} removed", args0: _lowerHandle?.ConnectionId, args1: _currentHeader?.sessionId);
+                            SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "SMUX_FIN | MARS Session Id {0}, SMUX_FIN flag received, Current Header Session Id {1} removed", args0: _lowerHandle?.ConnectionId, args1: _currentHeader?.sessionId);
                         }
                         else
                         {
                             currentSession = _sessions[_currentHeader.sessionId];
-                            SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "MARS Session Id {0}, Current Session assigned to Session Id {1}", args0: _lowerHandle?.ConnectionId, args1: _currentHeader?.sessionId);
+                            SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "MARS Session Id {0}, Current Session assigned to Session Id {1}", args0: _lowerHandle?.ConnectionId, args1: _currentHeader?.sessionId);
                         }
                     }
 
                     if (currentHeader.flags == (byte)SNISMUXFlags.SMUX_DATA)
                     {
                         currentSession.HandleReceiveComplete(currentPacket, currentHeader);
-                        SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "SMUX_DATA | MARS Session Id {0}, Current Session {1} completed receiving Data", args0: _lowerHandle?.ConnectionId, args1: _currentHeader?.sessionId);
+                        SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "SMUX_DATA | MARS Session Id {0}, Current Session {1} completed receiving Data", args0: _lowerHandle?.ConnectionId, args1: _currentHeader?.sessionId);
                     }
 
                     if (_currentHeader.flags == (byte)SNISMUXFlags.SMUX_ACK)
@@ -342,16 +340,16 @@ namespace Microsoft.Data.SqlClient.SNI
                         try
                         {
                             currentSession.HandleAck(currentHeader.highwater);
-                            SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "SMUX_ACK | MARS Session Id {0}, Current Session {1} handled ack", args0: _lowerHandle?.ConnectionId, args1: _currentHeader?.sessionId);
+                            SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "SMUX_ACK | MARS Session Id {0}, Current Session {1} handled ack", args0: _lowerHandle?.ConnectionId, args1: _currentHeader?.sessionId);
                         }
                         catch (Exception e)
                         {
-                            SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.ERR, "SMUX_ACK | MARS Session Id {0}, Exception occurred: {2}", args0: _currentHeader?.sessionId, args1: e?.Message);
+                            SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.ERR, "SMUX_ACK | MARS Session Id {0}, Exception occurred: {2}", args0: _currentHeader?.sessionId, args1: e?.Message);
                             SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, SNICommon.InternalExceptionError, e);
                         }
 #if DEBUG
                         Debug.Assert(_currentPacket == currentPacket, "current and _current are not the same");
-                        SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.INFO, "SMUX_ACK | MARS Session Id {0}, Current Packet {1} returned", args0: _lowerHandle?.ConnectionId, args1: currentPacket?._id);
+                        SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.INFO, "SMUX_ACK | MARS Session Id {0}, Current Packet {1} returned", args0: _lowerHandle?.ConnectionId, args1: currentPacket?._id);
 #endif
                         ReturnPacket(currentPacket);
                         currentPacket = null;
@@ -370,7 +368,7 @@ namespace Microsoft.Data.SqlClient.SNI
                             }
 
                             HandleReceiveError(packet);
-                            SqlClientEventSource.Log.TrySNITraceEvent(s_className, EventType.ERR, "MARS Session Id {0}, packet.DataLeft 0, SNI error {2}", args0: _lowerHandle?.ConnectionId, args1: sniErrorCode);
+                            SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.ERR, "MARS Session Id {0}, packet.DataLeft 0, SNI error {2}", args0: _lowerHandle?.ConnectionId, args1: sniErrorCode);
                             return;
                         }
                     }
@@ -387,7 +385,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public uint EnableSsl(uint options)
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
+            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
             try
             {
                 return _lowerHandle.EnableSsl(options);
@@ -403,7 +401,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public void DisableSsl()
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
+            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
             try
             {
                 _lowerHandle.DisableSsl();
@@ -430,7 +428,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public void KillConnection()
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(s_className);
+            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
             try
             {
                 _lowerHandle.KillConnection();

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -27,13 +27,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <summary>
         /// Connection ID
         /// </summary>
-        public Guid ConnectionId
-        {
-            get
-            {
-                return _connectionId;
-            }
-        }
+        public Guid ConnectionId => _connectionId;
 
         public int ProtocolVersion => _lowerHandle.ProtocolVersion;
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -66,8 +66,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns></returns>
         public uint StartReceive()
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
-            try
+            using (TrySNIEventScope.Create(nameof(SNIMarsConnection)))
             {
                 SNIPacket packet = null;
 
@@ -79,10 +78,6 @@ namespace Microsoft.Data.SqlClient.SNI
                 SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNIMarsConnection), EventType.ERR, "MARS Session Id {0}, Connection not usable.", args0: ConnectionId);
                 return SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, 0, SNICommon.ConnNotUsableError, Strings.SNI_ERROR_19);
             }
-            finally
-            {
-                SqlClientEventSource.Log.TrySNIScopeLeaveEvent(scopeID);
-            }
         }
 
         /// <summary>
@@ -92,17 +87,12 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public uint Send(SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
-            try
+            using (TrySNIEventScope.Create(nameof(SNIMarsConnection)))
             {
                 lock (this)
                 {
                     return _lowerHandle.Send(packet);
                 }
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TrySNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -113,17 +103,12 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public uint SendAsync(SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
-            try
+            using (TrySNIEventScope.Create(nameof(SNIMarsConnection)))
             {
                 lock (this)
                 {
                     return _lowerHandle.SendAsync(packet);
                 }
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TrySNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -134,8 +119,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public uint ReceiveAsync(ref SNIPacket packet)
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
-            try
+            using (TrySNIEventScope.Create(nameof(SNIMarsConnection)))
             {
                 if (packet != null)
                 {
@@ -155,10 +139,6 @@ namespace Microsoft.Data.SqlClient.SNI
                     return response;
                 }
             }
-            finally
-            {
-                SqlClientEventSource.Log.TrySNIScopeLeaveEvent(scopeID);
-            }
         }
 
         /// <summary>
@@ -167,17 +147,12 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <returns>SNI error status</returns>
         public uint CheckConnection()
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
-            try
+            using (TrySNIEventScope.Create(nameof(SNIMarsConnection)))
             {
                 lock (this)
                 {
                     return _lowerHandle.CheckConnection();
                 }
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TrySNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -222,8 +197,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="sniErrorCode">SNI error code</param>
         public void HandleReceiveComplete(SNIPacket packet, uint sniErrorCode)
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
-            try
+            using (TrySNIEventScope.Create(nameof(SNIMarsConnection)))
             {
                 SNISMUXHeader currentHeader = null;
                 SNIPacket currentPacket = null;
@@ -374,10 +348,6 @@ namespace Microsoft.Data.SqlClient.SNI
                     }
                 }
             }
-            finally
-            {
-                SqlClientEventSource.Log.TrySNIScopeLeaveEvent(scopeID);
-            }
         }
 
         /// <summary>
@@ -385,14 +355,9 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public uint EnableSsl(uint options)
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
-            try
+            using (TrySNIEventScope.Create(nameof(SNIMarsConnection)))
             {
                 return _lowerHandle.EnableSsl(options);
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TrySNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -401,14 +366,9 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public void DisableSsl()
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
-            try
+            using (TrySNIEventScope.Create(nameof(SNIMarsConnection)))
             {
                 _lowerHandle.DisableSsl();
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TrySNIScopeLeaveEvent(scopeID);
             }
         }
 
@@ -428,14 +388,9 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         public void KillConnection()
         {
-            long scopeID = SqlClientEventSource.Log.TrySNIScopeEnterEvent(nameof(SNIMarsConnection));
-            try
+            using (TrySNIEventScope.Create(nameof(SNIMarsConnection)))
             {
                 _lowerHandle.KillConnection();
-            }
-            finally
-            {
-                SqlClientEventSource.Log.TrySNIScopeLeaveEvent(scopeID);
             }
         }
 #endif


### PR DESCRIPTION
In https://github.com/dotnet/SqlClient/pull/933 many changes were made to SNIMarsConnection which were then lost when that PR was reverted. This PR implements the harmless and side-effect-less changes such as using scoped event tracing like the rest of SNI does, cleaning up a class name variable and adding a dedicated sync object (there are no locks on instances of this class outside this file, i've checked).

This does not change the demuxing code in any way. I want to get the files cleaned up and then try again with the muxing code in a future PR. this is a simple way to get easy changes in place minimizing review complexity.