### PR TITLE
[4.0.3] Fix | TDS RPC error on large queries in SqlCommand.ExecuteReaderAsync

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -9907,10 +9907,10 @@ namespace Microsoft.Data.SqlClient
 
                             // Options
                             WriteShort((short)rpcext.options, stateObj);
-                        }
 
-                        byte[] enclavePackage = cmd.enclavePackage != null ? cmd.enclavePackage.EnclavePackageBytes : null;
-                        WriteEnclaveInfo(stateObj, enclavePackage);
+                            byte[] enclavePackage = cmd.enclavePackage != null ? cmd.enclavePackage.EnclavePackageBytes : null;
+                            WriteEnclaveInfo(stateObj, enclavePackage);
+                        }
 
                         // Stream out parameters
                         SqlParameter[] parameters = rpcext.parameters;


### PR DESCRIPTION
Backporting the fix to the 4.0-servicing branch. This fixes the TDS RPC error on large queries in SqlCommand.ExecuteReaderAysnc and these changes are based on #1936