### PR TITLE
Fix activity correlator to continue using same GUID for connection activity

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ActivityCorrelator.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ActivityCorrelator.cs
@@ -19,16 +19,14 @@ namespace Microsoft.Data.Common
             internal readonly Guid Id;
             internal readonly uint Sequence;
 
-            internal ActivityId(uint sequence)
+            internal ActivityId(Guid? currentActivityId, uint sequence = 1)
             {
-                this.Id = Guid.NewGuid();
-                this.Sequence = sequence;
+                Id = currentActivityId ?? Guid.NewGuid();
+                Sequence = sequence;
             }
 
             public override string ToString()
-            {
-                return string.Format(CultureInfo.InvariantCulture, "{0}:{1}", this.Id, this.Sequence);
-            }
+                => string.Format(CultureInfo.InvariantCulture, "{0}:{1}", Id, Sequence);
         }
 
         // Declare the ActivityId which will be stored in TLS. The Id is unique for each thread.
@@ -40,27 +38,12 @@ namespace Microsoft.Data.Common
         /// <summary>
         /// Get the current ActivityId
         /// </summary>
-        internal static ActivityId Current
-        {
-            get
-            {
-                if (t_tlsActivity == null)
-                {
-                    t_tlsActivity = new ActivityId(1);
-                }
-                return t_tlsActivity;
-            }
-        }
+        internal static ActivityId Current => t_tlsActivity ??= new ActivityId(null);
 
         /// <summary>
         /// Increment the sequence number and generate the new ActivityId
         /// </summary>
         /// <returns>ActivityId</returns>
-        internal static ActivityId Next()
-        {
-            t_tlsActivity = new ActivityId( (t_tlsActivity?.Sequence ?? 0) + 1);
-
-            return t_tlsActivity;
-        }
+        internal static ActivityId Next() => t_tlsActivity = new ActivityId(t_tlsActivity?.Id, (t_tlsActivity?.Sequence ?? 0) + 1);
     }
 }


### PR DESCRIPTION
I learnt about this issue internally that Activity Id Correlation was not working properly, and Activity Id GUID was not being reused when connecting to Azure SQL with 'redirection', as that is expected for the same connection activity.
Activity Id should be retained for the physical connection as is also the case with the ODBC driver with sequence increments.

Below code can be used to test the bug and verify the fix:

```csharp
// EXPECTED: When pooling is disabled, 2 physical connections are made, activity Id should be different 
// for both connections but should be same within the redirect flow when performing 2 prelogin handshakes.
// conn1: ClientConnectionID 804265c3-79b1-4c6c-8392-678226b4ec46, ActivityID 1aadd57b-c181-489f-a0d4-5ae9c3f50c86:1
// conn2: ClientConnectionID d535123b-a74b-4731-a08d-abe098dea191, ActivityID 25c04c57-d9b5-4720-ade7-dc6a9dbd3852:1
// conn1: ClientConnectionID fa1f0881-6eaa-4688-9d66-6d22dafbf1c0, ActivityID 1aadd57b-c181-489f-a0d4-5ae9c3f50c86:2
// conn2: ClientConnectionID 58309c6d-56d3-4d35-9cd0-0b1f01347985, ActivityID 25c04c57-d9b5-4720-ade7-dc6a9dbd3852:2

// EXPECTED: When pooling is enabled, 1 physical connection is made, activity Id is same for all prelogin handshakes.
// conn1: ClientConnectionID 04ca1d05-039b-4318-b852-1404edf8c9dc, ActivityID 7fe62ff5-82bd-4c5f-8773-652e3e3e2ccb:1
// conn1: ClientConnectionID e8da8405-0fd7-4b4a-81c1-d4f142c0a3e7, ActivityID 7fe62ff5-82bd-4c5f-8773-652e3e3e2ccb:2
// conn2: ClientConnectionID e3c8823e-077e-498d-83e3-aa1f4f54518e, ActivityID 7fe62ff5-82bd-4c5f-8773-652e3e3e2ccb:3
// conn2: ClientConnectionID 09e83e05-c442-4a3f-b0b3-ea5501606edb, ActivityID 7fe62ff5-82bd-4c5f-8773-652e3e3e2ccb:4

const string CONN_STRING= "Server=*****.database.windows.net; Initial Catalog=***; UID=***; PWD=***; Pooling=false;";

static async Task Main(string[] args)
{
    using SqlClientListener listener = new();
    await RunTest(); // conn1
    await RunTest(); // conn2
}

static async Task RunTest()
{
    using SqlConnection conn1 = new(CONN_STRING);
    await conn1.OpenAsync();
}

public class SqlClientListener : EventListener
{
    protected override void OnEventSourceCreated(EventSource eventSource)
    {
        // Only enable events from SqlClientEventSource.
        if (eventSource.Name.Equals("Microsoft.Data.SqlClient.EventSource"))
        {
            EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
        }
    }

    /// <summary>
    /// This callback runs whenever an event is written by SqlClientEventSource.
    /// </summary>
    /// <param name="eventData">Event data captured.</param>
    protected override void OnEventWritten(EventWrittenEventArgs eventData)
    {
        if (eventData.Payload == null)
        {
            return;
        }
        foreach (object payload in eventData.Payload)
        {
            if (payload != null)
            {
                Console.WriteLine(payload.ToString());
            }
        }
    }
}
```

When looking into traces, notice the activity Id associated with `<sc.TdsParser.SendPreLoginHandshake|INFO>` event.

Capturing activity Id correlated with connection activity is helpful for troubleshooting purposes.