### PR TITLE
[4.0.3] | Upgrade "System.Drawing.Common" version

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -915,7 +915,6 @@
   <ItemGroup>
     <PackageReference Condition="'$(TargetsWindows)' == 'true' and '$(IsUAPAssembly)' != 'true'" Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
-    <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesVersion)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -30,13 +30,12 @@
   <PropertyGroup>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
     <MicrosoftDataSqlClientSNIRuntimeVersion>4.0.1</MicrosoftDataSqlClientSNIRuntimeVersion>
-    <SystemConfigurationConfigurationManagerVersion>5.0.0</SystemConfigurationConfigurationManagerVersion>
+    <SystemConfigurationConfigurationManagerVersion>6.0.1</SystemConfigurationConfigurationManagerVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>5.0.0</SystemDiagnosticsDiagnosticSourceVersion>
     <SystemDiagnosticsPerformanceCounterVersion>5.0.0</SystemDiagnosticsPerformanceCounterVersion>
     <SystemResourcesResourceManagerVersion>4.3.0</SystemResourcesResourceManagerVersion>
-    <SystemRuntimeCachingVersion>5.0.0</SystemRuntimeCachingVersion>
+    <SystemRuntimeCachingVersion>6.0.0</SystemRuntimeCachingVersion>
     <SystemSecurityCryptographyCngVersion>5.0.0</SystemSecurityCryptographyCngVersion>
-    <SystemSecurityPermissionsVersion>5.0.0</SystemSecurityPermissionsVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemTextEncodingCodePagesVersion>5.0.0</SystemTextEncodingCodePagesVersion>
   </PropertyGroup>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -34,7 +34,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.8.0" />
         <dependency id="System.Buffers" version="4.5.1" />
-        <dependency id="System.Configuration.ConfigurationManager" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.IO" version="4.3.0" />
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
         <dependency id="System.Security.Cryptography.Algorithms" version="4.3.1" />
@@ -49,10 +49,10 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" />
-        <dependency id="System.Configuration.ConfigurationManager" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Diagnostics.DiagnosticSource" version="5.0.0" exclude="Compile" />
         <dependency id="System.IO" version="4.3.0" />
-        <dependency id="System.Runtime.Caching" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="5.0.0" exclude="Compile" />
         <dependency id="System.Text.Encodings.Web" version="4.7.2" />
         <dependency id="System.Resources.ResourceManager" version="4.3.0" />
@@ -67,9 +67,9 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" />
-        <dependency id="System.Configuration.ConfigurationManager" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.IO" version="4.3.0" />
-        <dependency id="System.Runtime.Caching" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="5.0.0" exclude="Compile" />
         <dependency id="System.Text.Encodings.Web" version="4.7.2" />
         <dependency id="System.Runtime.Loader" version="4.3.0" />
@@ -85,9 +85,9 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" />
-        <dependency id="System.Configuration.ConfigurationManager" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.IO" version="4.3.0" />
-        <dependency id="System.Runtime.Caching" version="5.0.0" exclude="Compile" />
+        <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="5.0.0" exclude="Compile" />
         <dependency id="System.Text.Encodings.Web" version="4.7.2" />
         <dependency id="System.Runtime.Loader" version="4.3.0" />


### PR DESCRIPTION
- Addresses the [remote code execution vulnerability](https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0.3/5.0.3.md) that is reported in `System.Drawing.Common` by increasing the version of dependent packages. The following packages depend on this package:
  - System.Configuration.ConfigurationManager
  - System.Runtime.Caching
  - System.Security.Permissions

- `System.Security.Permissions` is added indirectly with `System.Configuration.ConfigurationManager`.