### PR TITLE
Add RowsCopied64 property, refs, and docs

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml
@@ -503,14 +503,15 @@ and faster to use a Transact-SQL `INSERT … SELECT` statement to copy the data.
 				property.
 			</value>
 			<remarks>
-				<format type="text/markdown"><![CDATA[
+				<format type="text/markdown">
+  <![CDATA[
 
 ## Remarks
 This value is incremented during the <xref:Microsoft.Data.SqlClient.SqlBulkCopy.SqlRowsCopied> event and does not imply that this number of rows has been sent to the server or committed.
 
 This value can be accessed during or after the execution of a bulk copy operation.
 
-This value can become negative if the number of rows exceelds int.MaxValue. If this may happen use the RowsCopied64 property.
+This value will wrap around and become negative if the number of rows exceeds int.MaxValue. Consider using the <xref:Microsoft.Data.SqlClient.SqlBulkCopy.RowsCopied64> property.
 ]]></format>
 			</remarks>
 		</RowsCopied>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml
@@ -509,9 +509,30 @@ and faster to use a Transact-SQL `INSERT … SELECT` statement to copy the data.
 This value is incremented during the <xref:Microsoft.Data.SqlClient.SqlBulkCopy.SqlRowsCopied> event and does not imply that this number of rows has been sent to the server or committed.
 
 This value can be accessed during or after the execution of a bulk copy operation.
+
+This value can become negative if the number of rows exceelds int.MaxValue. If this may happen use the RowsCopied64 property.
 ]]></format>
 			</remarks>
 		</RowsCopied>
+    <RowsCopied64>
+      <summary>
+        The number of rows processed in the ongoing bulk copy operation.
+      </summary>
+      <value>
+        The long value of the <see cref="P:Microsoft.Data.SqlClient.SqlBulkCopy.RowsCopied64" /> property.
+      </value>
+      <remarks>
+        <format type="text/markdown">
+          <![CDATA[
+
+## Remarks
+This value is incremented during the <xref:Microsoft.Data.SqlClient.SqlBulkCopy.SqlRowsCopied> event and does not imply that this number of rows has been sent to the server or committed.
+
+This value can be accessed during or after the execution of a bulk copy operation.
+]]>
+        </format>
+      </remarks>
+    </RowsCopied64>
 		<System.IDisposable.Dispose>
 			<summary>
 				Releases all resources used by the current instance of the

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -259,6 +259,8 @@ namespace Microsoft.Data.SqlClient
         public int NotifyAfter { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/RowsCopied/*'/>
         public int RowsCopied { get { throw null; } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/RowsCopied64/*'/>
+        public long RowsCopied64 { get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/SqlRowsCopied/*'/>
         public event Microsoft.Data.SqlClient.SqlRowsCopiedEventHandler SqlRowsCopied { add { } remove { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/Close/*'/>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Data.SqlClient
         private readonly SqlBulkCopyOptions _copyOptions;
         private int _timeout = DefaultCommandTimeout;
         private string _destinationTableName;
-        private int _rowsCopied;
+        private long _rowsCopied;
         private int _notifyAfter;
         private int _rowsUntilNotification;
         private bool _insideRowsCopiedEvent;
@@ -222,8 +222,8 @@ namespace Microsoft.Data.SqlClient
         private TdsParserStateObject _stateObj;
         private List<_ColumnMapping> _sortedColumnMappings;
 
-        private static int _objectTypeCount; // EventSource Counter
-        internal readonly int _objectID = Interlocked.Increment(ref _objectTypeCount);
+        private static int s_objectTypeCount; // EventSource Counter
+        internal readonly int _objectID = Interlocked.Increment(ref s_objectTypeCount);
 
         // Newly added member variables for Async modification, m = member variable to bcp.
         private int _savedBatchSize = 0; // Save the batchsize so that changes are not affected unexpectedly.
@@ -376,7 +376,10 @@ namespace Microsoft.Data.SqlClient
         internal int ObjectID => _objectID;
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/RowsCopied/*'/>
-        public int RowsCopied => _rowsCopied;
+        public int RowsCopied => unchecked((int)_rowsCopied);
+
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/RowsCopied64/*'/>
+        public long RowsCopied64 => _rowsCopied;
 
         internal SqlStatistics Statistics
         {

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -215,6 +215,8 @@ namespace Microsoft.Data.SqlClient
         public int NotifyAfter { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/RowsCopied/*'/>
         public int RowsCopied { get { throw null; } }
+        /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/RowsCopied64/*'/>
+        public long RowsCopied64 { get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/SqlRowsCopied/*'/>
         public event Microsoft.Data.SqlClient.SqlRowsCopiedEventHandler SqlRowsCopied { add { } remove { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/Close/*'/>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Data.SqlClient
         private readonly SqlBulkCopyOptions _copyOptions;
         private int _timeout = DefaultCommandTimeout;
         private string _destinationTableName;
-        private int _rowsCopied;
+        private long _rowsCopied;
         private int _notifyAfter;
         private int _rowsUntilNotification;
         private bool _insideRowsCopiedEvent;
@@ -238,8 +238,8 @@ namespace Microsoft.Data.SqlClient
         private TdsParserStateObject _stateObj;
         private List<_ColumnMapping> _sortedColumnMappings;
 
-        private static int _objectTypeCount; // EventSource Counter
-        internal readonly int _objectID = Interlocked.Increment(ref _objectTypeCount);
+        private static int s_objectTypeCount; // EventSource Counter
+        internal readonly int _objectID = Interlocked.Increment(ref s_objectTypeCount);
 
         // Newly added member variables for Async modification, m = member variable to bcp.
         private int _savedBatchSize = 0; // Save the batchsize so that changes are not affected unexpectedly.
@@ -392,7 +392,10 @@ namespace Microsoft.Data.SqlClient
         internal int ObjectID => _objectID;
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/RowsCopied/*'/>
-        public int RowsCopied => _rowsCopied;
+        public int RowsCopied => unchecked((int)_rowsCopied);
+
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlBulkCopy.xml' path='docs/members[@name="SqlBulkCopy"]/RowsCopied64/*'/>
+        public long RowsCopied64 => _rowsCopied;
 
         internal SqlStatistics Statistics
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/RowsCopiedEventArgs.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/RowsCopiedEventArgs.cs
@@ -8,34 +8,19 @@ namespace Microsoft.Data.SqlClient
     public class SqlRowsCopiedEventArgs : System.EventArgs
     {
         private bool _abort;
-        private long _rowsCopied;
+        private readonly long _rowsCopied;
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlRowsCopiedEventArgs.xml' path='docs/members[@name="SqlRowsCopiedEventArgs"]/ctor/*' />
-        public SqlRowsCopiedEventArgs(long rowsCopied)
-        {
-            _rowsCopied = rowsCopied;
-        }
+        public SqlRowsCopiedEventArgs(long rowsCopied) => _rowsCopied = rowsCopied;
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlRowsCopiedEventArgs.xml' path='docs/members[@name="SqlRowsCopiedEventArgs"]/Abort/*' />
         public bool Abort
         {
-            get
-            {
-                return _abort;
-            }
-            set
-            {
-                _abort = value;
-            }
+            get => _abort;
+            set => _abort = value;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlRowsCopiedEventArgs.xml' path='docs/members[@name="SqlRowsCopiedEventArgs"]/RowsCopied/*' />
-        public long RowsCopied
-        {
-            get
-            {
-                return _rowsCopied;
-            }
-        }
+        public long RowsCopied => unchecked((int)_rowsCopied);
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReader1.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReader1.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                                 bulkcopy.WriteToServer(reader);
                                 
                                 DataTestUtility.AssertEqualsWithDescription(bulkcopy.RowsCopied, 5, "Unexpected number of rows.");
+                                DataTestUtility.AssertEqualsWithDescription(bulkcopy.RowsCopied64, (long)5, "Unexpected number of rows.");
                             }
                             Helpers.VerifyResults(dstConn, dstTable, 3, 5);
                         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReaderAsync.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReaderAsync.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                                 await outputSemaphore.WaitAsync();
                                 
                                 DataTestUtility.AssertEqualsWithDescription(bulkcopy.RowsCopied, 5, "Unexpected number of rows.");
+                                DataTestUtility.AssertEqualsWithDescription(bulkcopy.RowsCopied64, (long)5, "Unexpected number of rows.");
                             }
                             Helpers.VerifyResults(dstConn, dstTable, 3, 5);
                         }


### PR DESCRIPTION
Closes https://github.com/dotnet/SqlClient/issues/2001

Changes the `SqlBulkCopy._rowscopied` variable to a long and adds a new `long SqlBulkCopy.RowsCopied64` property to the class. 
The existing `int SqlBulkCopy.RowsCopied` behaviour of going negative is preserved. I have changed the implementation to be `unchecked((int)_rowsCopied);` to make it clear in the source that the unchecked behaviour is deliberate. The unchecked is not strictly required because it is the default compile option. 
Is keeping the existing behaviour desiable? It could be changed to throw an overflow exception. Keeping the existing behaviour is most compatible in case someone has taken a dependency on the existing behaviour. It is not the most correct.

