### PR TITLE
Fix | Adding non-string support to SqlConnectionStringBuilder property indexer

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
@@ -26,7 +26,7 @@ Implicit conversions have been added to maintain backwards compatibility with bo
     </Parse>
     <TryParse>
       <summary>
-        Converts the specified string, boolean representation of a logical value to its <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> equivalent and returns a value that indicates whether the conversion succeeded.
+        Converts the specified string representation of a logical value to its <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> equivalent and returns a value that indicates whether the conversion succeeded.
       </summary>
       <param name="value">A string containing the value to convert.</param>
       <param name="result">

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
@@ -26,7 +26,7 @@ Implicit conversions have been added to maintain backwards compatibility with bo
     </Parse>
     <TryParse>
       <summary>
-        Converts the specified string representation of a logical value to its <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> equivalent and returns a value that indicates whether the conversion succeeded.
+        Converts the specified string, boolean representation of a logical value to its <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption"/> equivalent and returns a value that indicates whether the conversion succeeded.
       </summary>
       <param name="value">A string containing the value to convert.</param>
       <param name="result">

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
@@ -816,9 +816,17 @@ namespace Microsoft.Data.Common
             {
                 return DbConnectionStringDefaults.Encrypt;
             }
+            else if(value is SqlConnectionEncryptOption eValue)
+            {
+                return eValue;
+            }
             else if (value is string sValue)
             {
                 return SqlConnectionEncryptOption.Parse(sValue);
+            }
+            else if(value is bool bValue)
+            {
+                return SqlConnectionEncryptOption.Parse(bValue);
             }
 
             throw ADP.InvalidConnectionOptionValue(keyword);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
@@ -43,6 +43,20 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Parse/*' />
+
+        public static SqlConnectionEncryptOption Parse(bool value)
+        {
+            if (TryParse(value, out SqlConnectionEncryptOption result))
+            {
+                return result;
+            }
+            else
+            {
+                throw ADP.InvalidConnectionOptionValue(SqlConnectionString.KEY.Encrypt);
+            }
+        }
+
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
         public static bool TryParse(string value, out SqlConnectionEncryptOption result)
         {
@@ -70,6 +84,21 @@ namespace Microsoft.Data.SqlClient
                 default:
                     result = null;
                     return false;
+            }
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
+
+        public static bool TryParse(bool value, out SqlConnectionEncryptOption result)
+        {
+            switch(value)
+            {
+                case true:
+                    result = Mandatory;
+                    return true;
+                        case false:
+                    result = Optional;
+                    return true;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
@@ -43,9 +43,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/Parse/*' />
-
-        public static SqlConnectionEncryptOption Parse(bool value)
+        internal static SqlConnectionEncryptOption Parse(bool value)
         {
             if (TryParse(value, out SqlConnectionEncryptOption result))
             {
@@ -87,9 +85,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
-
-        public static bool TryParse(bool value, out SqlConnectionEncryptOption result)
+        internal static bool TryParse(bool value, out SqlConnectionEncryptOption result)
         {
             switch(value)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionEncryptOption.cs
@@ -45,14 +45,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static SqlConnectionEncryptOption Parse(bool value)
         {
-            if (TryParse(value, out SqlConnectionEncryptOption result))
-            {
-                return result;
-            }
-            else
-            {
-                throw ADP.InvalidConnectionOptionValue(SqlConnectionString.KEY.Encrypt);
-            }
+            return value ? Mandatory : Optional;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml' path='docs/members[@name="SqlConnectionEncryptOption"]/TryParse/*' />
@@ -82,19 +75,6 @@ namespace Microsoft.Data.SqlClient
                 default:
                     result = null;
                     return false;
-            }
-        }
-
-        internal static bool TryParse(bool value, out SqlConnectionEncryptOption result)
-        {
-            switch(value)
-            {
-                case true:
-                    result = Mandatory;
-                    return true;
-                        case false:
-                    result = Optional;
-                    return true;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Data.SqlClient.Tests
         }
 
         [Theory]
-        [InlineData("AttachDBFilename","somefile.db")]
+        [InlineData("AttachDBFilename", "somefile.db")]
         public void SetKeyword(string keyword, string value)
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
@@ -380,7 +380,7 @@ namespace Microsoft.Data.SqlClient.Tests
             builder.Encrypt = false;
             Assert.Equal("Encrypt=False", builder.ConnectionString);
             Assert.False(builder.Encrypt);
-            
+
             builder.Encrypt = true;
             Assert.Equal("Encrypt=True", builder.ConnectionString);
             Assert.True(builder.Encrypt);
@@ -402,6 +402,25 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.True(builder.Encrypt);
         }
 
+        [Fact]
+        public void EncryptParserValidValuesPropertyIndexerForEncryptionOption()
+        {
+            SqlConnectionStringBuilder builder = new();
+            try
+            {
+                builder["Encrypt"] = SqlConnectionEncryptOption.Strict;
+                CheckEncryptType(builder, SqlConnectionEncryptOption.Strict);
+                builder["Encrypt"] = SqlConnectionEncryptOption.Optional;
+                CheckEncryptType(builder, SqlConnectionEncryptOption.Optional);
+                builder["Encrypt"] = SqlConnectionEncryptOption.Mandatory;
+                CheckEncryptType(builder, SqlConnectionEncryptOption.Mandatory);
+            }
+            catch (SqlException ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+        }
+
         [Theory]
         [InlineData("true", "True")]
         [InlineData("mandatory", "True")]
@@ -412,6 +431,30 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("strict", "Strict")]
         public void EncryptParserValidValuesParsesSuccessfully(string value, string expectedValue)
             => Assert.Equal(expectedValue, SqlConnectionEncryptOption.Parse(value).ToString());
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EncryptParserValidValuesPropertyIndexerForBoolean(bool value)
+        {
+            SqlConnectionStringBuilder builder = new();
+            try
+            {
+                builder["Encrypt"] = value;
+                if(value == true)
+                {
+                    CheckEncryptType(builder, SqlConnectionEncryptOption.Mandatory);
+                }
+                else
+                {
+                    CheckEncryptType(builder, SqlConnectionEncryptOption.Optional);
+                }
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.Message);
+            }
+        }
 
         [Theory]
         [InlineData("something")]
@@ -466,6 +509,12 @@ namespace Microsoft.Data.SqlClient.Tests
             {
                 Assert.NotNull(connection);
             }
+        }
+
+        internal void CheckEncryptType(SqlConnectionStringBuilder builder, SqlConnectionEncryptOption expectedValue)
+        {
+            Assert.IsType<SqlConnectionEncryptOption>(builder.Encrypt);
+            Assert.Equal(expectedValue, builder.Encrypt);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -406,19 +406,12 @@ namespace Microsoft.Data.SqlClient.Tests
         public void EncryptParserValidValuesPropertyIndexerForEncryptionOption()
         {
             SqlConnectionStringBuilder builder = new();
-            try
-            {
-                builder["Encrypt"] = SqlConnectionEncryptOption.Strict;
-                CheckEncryptType(builder, SqlConnectionEncryptOption.Strict);
-                builder["Encrypt"] = SqlConnectionEncryptOption.Optional;
-                CheckEncryptType(builder, SqlConnectionEncryptOption.Optional);
-                builder["Encrypt"] = SqlConnectionEncryptOption.Mandatory;
-                CheckEncryptType(builder, SqlConnectionEncryptOption.Mandatory);
-            }
-            catch (SqlException ex)
-            {
-                Assert.Fail(ex.Message);
-            }
+            builder["Encrypt"] = SqlConnectionEncryptOption.Strict;
+            CheckEncryptType(builder, SqlConnectionEncryptOption.Strict);
+            builder["Encrypt"] = SqlConnectionEncryptOption.Optional;
+            CheckEncryptType(builder, SqlConnectionEncryptOption.Optional);
+            builder["Encrypt"] = SqlConnectionEncryptOption.Mandatory;
+            CheckEncryptType(builder, SqlConnectionEncryptOption.Mandatory);
         }
 
         [Theory]
@@ -438,22 +431,8 @@ namespace Microsoft.Data.SqlClient.Tests
         public void EncryptParserValidValuesPropertyIndexerForBoolean(bool value)
         {
             SqlConnectionStringBuilder builder = new();
-            try
-            {
-                builder["Encrypt"] = value;
-                if(value == true)
-                {
-                    CheckEncryptType(builder, SqlConnectionEncryptOption.Mandatory);
-                }
-                else
-                {
-                    CheckEncryptType(builder, SqlConnectionEncryptOption.Optional);
-                }
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail(ex.Message);
-            }
+            builder["Encrypt"] = value;
+            CheckEncryptType(builder, value ? SqlConnectionEncryptOption.Mandatory : SqlConnectionEncryptOption.Optional);
         }
 
         [Theory]
@@ -511,7 +490,7 @@ namespace Microsoft.Data.SqlClient.Tests
             }
         }
 
-        internal void CheckEncryptType(SqlConnectionStringBuilder builder, SqlConnectionEncryptOption expectedValue)
+        internal static void CheckEncryptType(SqlConnectionStringBuilder builder, SqlConnectionEncryptOption expectedValue)
         {
             Assert.IsType<SqlConnectionEncryptOption>(builder.Encrypt);
             Assert.Equal(expectedValue, builder.Encrypt);


### PR DESCRIPTION
Fixes #2015 