### PR TITLE
Code Merge | TdsParserStateObject alignment

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -564,7 +564,7 @@ namespace Microsoft.Data.SqlClient
                 // then use ReadByteArray since the logic is there to take care of that.
 
                 int bytesRead;
-                if (!TryReadByteArray(_bTmp.AsSpan(_bTmpRead), 8 - _bTmpRead, out bytesRead))
+                if (!TryReadByteArray(_bTmp.AsSpan(start: _bTmpRead), 8 - _bTmpRead, out bytesRead))
                 {
                     Debug.Assert(_bTmpRead + bytesRead <= 8, "Read more data than required");
                     _bTmpRead += bytesRead;
@@ -642,7 +642,7 @@ namespace Microsoft.Data.SqlClient
                 // then use ReadByteArray since the logic is there to take care of that.
 
                 int bytesRead;
-                if (!TryReadByteArray(_bTmp.AsSpan(_bTmpRead), 4 - _bTmpRead, out bytesRead))
+                if (!TryReadByteArray(_bTmp.AsSpan(start: _bTmpRead), 4 - _bTmpRead, out bytesRead))
                 {
                     Debug.Assert(_bTmpRead + bytesRead <= 4, "Read more data than required");
                     _bTmpRead += bytesRead;
@@ -1896,7 +1896,6 @@ namespace Microsoft.Data.SqlClient
             //    to the outstanding GCRoot until AppDomain.Unload.
             // We live with the above for the time being due to the constraints of the current
             // reliability infrastructure provided by the CLR.
-            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObject.ReadAsyncCallback | Info | State Object Id {0}, received error {1} on idle connection", _objectID, (int)error);
 
             TaskCompletionSource<object> source = _networkPacketTaskSource;
 #if DEBUG
@@ -1931,7 +1930,7 @@ namespace Microsoft.Data.SqlClient
                 // synchrnously and then call OnTimeoutSync to force an atomic change of state.
                 if (TimeoutHasExpired)
                 {
-                    OnTimeoutSync(true);
+                    OnTimeoutSync(asyncClose: true);
                 }
 
                 // try to change to the stopped state but only do so if currently in the running state

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -860,7 +860,7 @@ namespace Microsoft.Data.SqlClient
             }
 
 #if DEBUG
-            if (_stateObj._pendingData)
+            if (_stateObj.HasPendingData)
             {
                 byte token;
                 if (!_stateObj.TryPeekByte(out token))
@@ -1067,7 +1067,7 @@ namespace Microsoft.Data.SqlClient
 #else
                 {
 #endif //DEBUG
-                    if ((!_isClosed) && (parser != null) && (stateObj != null) && (stateObj._pendingData))
+                    if ((!_isClosed) && (parser != null) && (stateObj != null) && (stateObj.HasPendingData))
                     {
 
                         // It is possible for this to be called during connection close on a
@@ -1333,7 +1333,7 @@ namespace Microsoft.Data.SqlClient
         {
             // warning:  Don't check the MetaData property within this function
             // warning:  as it will be a reentrant call
-            while (_parser != null && _stateObj != null && _stateObj._pendingData && !_metaDataConsumed)
+            while (_parser != null && _stateObj != null && _stateObj.HasPendingData && !_metaDataConsumed)
             {
                 if (_parser.State == TdsParserState.Broken || _parser.State == TdsParserState.Closed)
                 {
@@ -3473,7 +3473,7 @@ namespace Microsoft.Data.SqlClient
 
                 Debug.Assert(null != _command, "unexpected null command from the data reader!");
 
-                while (_stateObj._pendingData)
+                while (_stateObj.HasPendingData)
                 {
                     byte token;
                     if (!_stateObj.TryPeekByte(out token))
@@ -3563,7 +3563,7 @@ namespace Microsoft.Data.SqlClient
                         moreRows = false;
                         return true;
                 }
-                if (_stateObj._pendingData)
+                if (_stateObj.HasPendingData)
                 {
                     // Consume error's, info's, done's on HasMoreRows, so user obtains error on Read.
                     // Previous bug where Read() would return false with error on the wire in the case
@@ -3620,7 +3620,7 @@ namespace Microsoft.Data.SqlClient
                             moreRows = false;
                             return false;
                         }
-                        if (_stateObj._pendingData)
+                        if (_stateObj.HasPendingData)
                         {
                             if (!_stateObj.TryPeekByte(out b))
                             {
@@ -3964,7 +3964,7 @@ namespace Microsoft.Data.SqlClient
                                 if (moreRows)
                                 {
                                     // read the row from the backend (unless it's an altrow were the marker is already inside the altrow ...)
-                                    while (_stateObj._pendingData)
+                                    while (_stateObj.HasPendingData)
                                     {
                                         if (_altRowStatus != ALTROWSTATUS.AltRow)
                                         {
@@ -3996,7 +3996,7 @@ namespace Microsoft.Data.SqlClient
                                     }
                                 }
 
-                                if (!_stateObj._pendingData)
+                                if (!_stateObj.HasPendingData)
                                 {
                                     if (!TryCloseInternal(false /*closeReader*/))
                                     {
@@ -4020,7 +4020,7 @@ namespace Microsoft.Data.SqlClient
                                 {
                                     // if we are in SingleRow mode, and we've read the first row,
                                     // read the rest of the rows, if any
-                                    while (_stateObj._pendingData && !_sharedState._dataReady)
+                                    while (_stateObj.HasPendingData && !_sharedState._dataReady)
                                     {
                                         if (!_parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady))
                                         {
@@ -4061,7 +4061,7 @@ namespace Microsoft.Data.SqlClient
                         more = false;
 
 #if DEBUG
-                        if ((!_sharedState._dataReady) && (_stateObj._pendingData))
+                        if ((!_sharedState._dataReady) && (_stateObj.HasPendingData))
                         {
                             byte token;
                             if (!_stateObj.TryPeekByte(out token))

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -915,11 +915,11 @@ namespace Microsoft.Data.SqlClient
                     // or if MARS is off, then a datareader exists
                     throw ADP.OpenReaderExists(parser.MARSOn); // MDAC 66411
                 }
-                else if (!parser.MARSOn && parser._physicalStateObj._pendingData)
+                else if (!parser.MARSOn && parser._physicalStateObj.HasPendingData)
                 {
                     parser.DrainData(parser._physicalStateObj);
                 }
-                Debug.Assert(!parser._physicalStateObj._pendingData, "Should not have a busy physicalStateObject at this point!");
+                Debug.Assert(!parser._physicalStateObj.HasPendingData, "Should not have a busy physicalStateObject at this point!");
 
                 parser.RollbackOrphanedAPITransactions();
             }
@@ -1078,7 +1078,7 @@ namespace Microsoft.Data.SqlClient
             // obtains a clone.
 
             Debug.Assert(!HasLocalTransactionFromAPI, "Upon ResetConnection SqlInternalConnectionTds has a currently ongoing local transaction.");
-            Debug.Assert(!_parser._physicalStateObj._pendingData, "Upon ResetConnection SqlInternalConnectionTds has pending data.");
+            Debug.Assert(!_parser._physicalStateObj.HasPendingData, "Upon ResetConnection SqlInternalConnectionTds has pending data.");
 
             if (_fResetConnection)
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -678,7 +678,7 @@ namespace Microsoft.Data.SqlClient
                 // then use ReadByteArray since the logic is there to take care of that.
 
                 int bytesRead;
-                if (!TryReadByteArray(_bTmp.AsSpan(_bTmpRead), 8 - _bTmpRead, out bytesRead))
+                if (!TryReadByteArray(_bTmp.AsSpan(start: _bTmpRead), 8 - _bTmpRead, out bytesRead))
                 {
                     Debug.Assert(_bTmpRead + bytesRead <= 8, "Read more data than required");
                     _bTmpRead += bytesRead;
@@ -765,7 +765,7 @@ namespace Microsoft.Data.SqlClient
                 // then use ReadByteArray since the logic is there to take care of that.
 
                 int bytesRead;
-                if (!TryReadByteArray(_bTmp.AsSpan(_bTmpRead), 4 - _bTmpRead, out bytesRead))
+                if (!TryReadByteArray(_bTmp.AsSpan(start: _bTmpRead), 4 - _bTmpRead, out bytesRead))
                 {
                     Debug.Assert(_bTmpRead + bytesRead <= 4, "Read more data than required");
                     _bTmpRead += bytesRead;
@@ -1994,7 +1994,6 @@ namespace Microsoft.Data.SqlClient
             //    to the outstanding GCRoot until AppDomain.Unload.
             // We live with the above for the time being due to the constraints of the current
             // reliability infrastructure provided by the CLR.
-            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObject.ReadAsyncCallback | Info | State Object Id {0}, received error {1} on idle connection", _objectID, (int)error);
 
             TaskCompletionSource<object> source = _networkPacketTaskSource;
 #if DEBUG
@@ -2030,7 +2029,7 @@ namespace Microsoft.Data.SqlClient
                 // synchrnously and then call OnTimeoutSync to force an atomic change of state.
                 if (TimeoutHasExpired)
                 {
-                    OnTimeoutSync(true);
+                    OnTimeoutSync(asyncClose: true);
                 }
 
                 // try to change to the stopped state but only do so if currently in the running state

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Data.SqlClient
                     // Session is good to re-use and our cache has space
                     SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParserSessionPool.PutSession|ADV> {0} keeping session {1} cachedCount={2}", ObjectID, session.ObjectID, _cachedCount);
 #if NETFRAMEWORK
-                    Debug.Assert(!session._pendingData, "pending data on a pooled session?");
+                    Debug.Assert(!session.HasPendingData, "pending data on a pooled session?");
 #else
                     Debug.Assert(!session.HasPendingData, "pending data on a pooled session?");
 #endif


### PR DESCRIPTION
Making TdsParserStateObject.cs look closer between netcore and netfx prior to actual merge.

This was done by going through a diff between netfx and netcore TdsParserStateObject.cs and merging the easy items like code formatting, typos, white space, trace messages, simple variable refactor.

This diff should be easy to digest for PR reviewers. 5-10 minutes.