### PR TITLE
Fix Kerberos kinit command execution

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/KerberosTests/KerberosTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/KerberosTests/KerberosTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ClassData(typeof(ConnectionStringsProvider))]
         public void IsKerBerosSetupTestAsync(string connectionStr)
         {
-            KerberosTicketManagemnt.Init(DataTestUtility.KerberosDomainUser);
+            KerberosTicketManagemnt.Init(DataTestUtility.KerberosDomainUser, DataTestUtility.KerberosDomainPassword);
             using SqlConnection conn = new(connectionStr);
 
             conn.Open();


### PR DESCRIPTION
Previous code spawned a child process that could hang msbuild if the child process never exited. Modified the code to ensure the process exits and will throw an exception with the process output if it hangs in the future.