### PR TITLE
Simplify internal async callback code

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Data.SqlClient
 #if NETCOREAPP || NETSTANDARD
         internal SqlCommand.ExecuteReaderAsyncCallContext CachedCommandExecuteReaderAsyncContext;
         internal SqlCommand.ExecuteNonQueryAsyncCallContext CachedCommandExecuteNonQueryAsyncContext;
+        internal SqlCommand.ExecuteXmlReaderAsyncCallContext CachedCommandExecuteXmlReaderAsyncContext;
+
         internal SqlDataReader.Snapshot CachedDataReaderSnapshot;
         internal SqlDataReader.IsDBNullAsyncCallContext CachedDataReaderIsDBNullContext;
         internal SqlDataReader.ReadAsyncCallContext CachedDataReaderReadAsyncContext;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Data.SqlClient
 
 #if NETCOREAPP || NETSTANDARD
         internal SqlCommand.ExecuteReaderAsyncCallContext CachedCommandExecuteReaderAsyncContext;
+        internal SqlCommand.ExecuteNonQueryAsyncCallContext CachedCommandExecuteNonQueryAsyncContext;
         internal SqlDataReader.Snapshot CachedDataReaderSnapshot;
         internal SqlDataReader.IsDBNullAsyncCallContext CachedDataReaderIsDBNullContext;
         internal SqlDataReader.ReadAsyncCallContext CachedDataReaderReadAsyncContext;


### PR DESCRIPTION
In previous PR's I optimized async paths to use state objects and cached delegates to static functions to avoid instance delegate invocations. The c# compiler now implements delegate caching directly for static lambdas and produces easier to read code. This PR converts the existing manual delegate caching to the compiler provided method.

It converts ExecuteXmlReaderAsync to use the cached context object pattern.
It converts ExecuteNonQueryAsync to use a cached context object, it was already using a context object so this just adds caching.

I suggest reviewing each commit individually. Side by side diffs make the changes look more confusing than they really are. Netcore only because when sqlcommand is merged I expect the netcore versions to be used since they're generally better for perf.