### PR TITLE
Reimplement rework cancel

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1479,19 +1479,13 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                // If we have already initiate the End call internally, we have already done that, so no point doing it again.
-                if (!_internalEndExecuteInitiated)
+                if (!_internalEndExecuteInitiated && _stateObj != null)
                 {
-                    lock (_stateObj)
-                    {
-                        return EndExecuteNonQueryInternal(asyncResult);
-                    }
+                    // call SetCancelStateClosed on the stateobject to ensure that cancel cannot 
+                    // happen after we have changed started the end processing
+                    _stateObj.SetCancelStateClosed();
                 }
-                else
-                {
-                    return EndExecuteNonQueryInternal(asyncResult);
-                }
+                return EndExecuteNonQueryInternal(asyncResult);
             }
         }
 
@@ -1900,19 +1894,14 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                // If we have already initiate the End call internally, we have already done that, so no point doing it again.
-                if (!_internalEndExecuteInitiated)
+                if (!_internalEndExecuteInitiated && _stateObj != null)
                 {
-                    lock (_stateObj)
-                    {
-                        return EndExecuteXmlReaderInternal(asyncResult);
-                    }
+                    // call SetCancelStateClosed on the stateobject to ensure that cancel cannot 
+                    // happen after we have changed started the end processing
+                    _stateObj.SetCancelStateClosed();
                 }
-                else
-                {
-                    return EndExecuteXmlReaderInternal(asyncResult);
-                }
+
+                return EndExecuteXmlReaderInternal(asyncResult);
             }
         }
 
@@ -2097,18 +2086,14 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 ThrowIfReconnectionHasBeenCanceled();
-                // lock on _stateObj prevents races with close/cancel.
-                if (!_internalEndExecuteInitiated)
+                if (!_internalEndExecuteInitiated && _stateObj != null)
                 {
-                    lock (_stateObj)
-                    {
-                        return EndExecuteReaderInternal(asyncResult);
-                    }
+                    // call SetCancelStateClosed on the stateobject to ensure that cancel cannot happen after
+                    // we have changed started the end processing
+                    _stateObj.SetCancelStateClosed();
                 }
-                else
-                {
-                    return EndExecuteReaderInternal(asyncResult);
-                }
+
+                return EndExecuteReaderInternal(asyncResult);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient
         // Timeout variables
         private readonly WeakReference _cancellationOwner = new WeakReference(null);
 
-		// Async
+        // Async
         private StateSnapshot _cachedSnapshot;
         private SnapshottedStateFlags _snapshottedState;
 
@@ -108,6 +108,10 @@ namespace Microsoft.Data.SqlClient
         /////////////////////
         // General methods //
         /////////////////////
+        internal bool SetCancelStateClosed()
+        {
+            return Interlocked.CompareExchange(ref _cancelState, CancelState.Closed, CancelState.Unset) == CancelState.Unset && _cancelState == CancelState.Closed;
+        }
 
         // This method is only called by the command or datareader as a result of a user initiated
         // cancel request.
@@ -116,59 +120,36 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(caller != null, "Null caller for Cancel!");
             Debug.Assert(caller is SqlCommand || caller is SqlDataReader, "Calling API with invalid caller type: " + caller.GetType());
 
-            bool hasLock = false;
-            try
+            // only change state if it is Unset, so don't check the return value
+            Interlocked.CompareExchange(ref _cancelState, CancelState.Cancelled, CancelState.Unset);
+
+            if ((_parser.State != TdsParserState.Closed) && (_parser.State != TdsParserState.Broken)
+                && (_cancellationOwner.Target == caller) && HasPendingData && !_attentionSent)
             {
-                // Keep looping until we either grabbed the lock (and therefore sent attention) or the connection closes\breaks
-                while ((!hasLock) && (_parser.State != TdsParserState.Closed) && (_parser.State != TdsParserState.Broken))
+                bool hasParserLock = false;
+                // Keep looping until we have the parser lock (and so are allowed to write), or the connection closes\breaks
+                while ((!hasParserLock) && (_parser.State != TdsParserState.Closed) && (_parser.State != TdsParserState.Broken))
                 {
-                    Monitor.TryEnter(this, WaitForCancellationLockPollTimeout, ref hasLock);
-                    if (hasLock)
-                    { // Lock for the time being - since we need to synchronize the attention send.
-                      // This lock is also protecting against concurrent close and async continuations
-
-                        // Ensure that, once we have the lock, that we are still the owner
-                        if ((!_cancelled) && (_cancellationOwner.Target == caller))
+                    try
+                    {
+                        _parser.Connection._parserLock.Wait(canReleaseFromAnyThread: false, timeout: WaitForCancellationLockPollTimeout, lockTaken: ref hasParserLock);
+                        if (hasParserLock)
                         {
-                            _cancelled = true;
-
-                            if (HasPendingData && !_attentionSent)
-                            {
-                                bool hasParserLock = false;
-                                // Keep looping until we have the parser lock (and so are allowed to write), or the connection closes\breaks
-                                while ((!hasParserLock) && (_parser.State != TdsParserState.Closed) && (_parser.State != TdsParserState.Broken))
-                                {
-                                    try
-                                    {
-                                        _parser.Connection._parserLock.Wait(canReleaseFromAnyThread: false, timeout: WaitForCancellationLockPollTimeout, lockTaken: ref hasParserLock);
-                                        if (hasParserLock)
-                                        {
-                                            _parser.Connection.ThreadHasParserLockForClose = true;
-                                            SendAttention();
-                                        }
-                                    }
-                                    finally
-                                    {
-                                        if (hasParserLock)
-                                        {
-                                            if (_parser.Connection.ThreadHasParserLockForClose)
-                                            {
-                                                _parser.Connection.ThreadHasParserLockForClose = false;
-                                            }
-                                            _parser.Connection._parserLock.Release();
-                                        }
-                                    }
-                                }
-                            }
+                            _parser.Connection.ThreadHasParserLockForClose = true;
+                            SendAttention();
                         }
                     }
-                }
-            }
-            finally
-            {
-                if (hasLock)
-                {
-                    Monitor.Exit(this);
+                    finally
+                    {
+                        if (hasParserLock)
+                        {
+                            if (_parser.Connection.ThreadHasParserLockForClose)
+                            {
+                                _parser.Connection.ThreadHasParserLockForClose = false;
+                            }
+                            _parser.Connection._parserLock.Release();
+                        }
+                    }
                 }
             }
         }
@@ -181,7 +162,7 @@ namespace Microsoft.Data.SqlClient
             lock (this)
             {
                 // Reset cancel state.
-                _cancelled = false;
+                _cancelState = CancelState.Unset;
                 _cancellationOwner.Target = null;
 
                 if (_attentionSent)
@@ -2383,7 +2364,7 @@ namespace Microsoft.Data.SqlClient
             byte packetNumber = _outputPacketNumber;
 
             // Set Status byte based whether this is end of message or not
-            bool willCancel = (_cancelled) && (_parser._asyncWrite);
+            bool willCancel = (_cancelState != CancelState.Unset) && (_parser._asyncWrite);
             if (willCancel)
             {
                 status = TdsEnums.ST_EOM | TdsEnums.ST_IGNORE;
@@ -2432,7 +2413,7 @@ namespace Microsoft.Data.SqlClient
 
         private void CancelWritePacket()
         {
-            Debug.Assert(_cancelled, "Should not call CancelWritePacket if _cancelled is not set");
+            Debug.Assert(_cancelState != CancelState.Unset, "Should not call CancelWritePacket if _cancelled is not set");
 
             _parser.Connection.ThreadHasParserLockForClose = true;      // In case of error, let the connection know that we are holding the lock
             try
@@ -3014,7 +2995,7 @@ namespace Microsoft.Data.SqlClient
                 Debug.Assert(_delayedWriteAsyncCallbackException == null, "StateObj has an unobserved exceptions from an async write");
                 // Attention\Cancellation\Timeouts
                 Debug.Assert(!HasReceivedAttention && !_attentionSent && !_attentionSending, $"StateObj is still dealing with attention: Sent: {_attentionSent}, Received: {HasReceivedAttention}, Sending: {_attentionSending}");
-                Debug.Assert(!_cancelled, "StateObj still has cancellation set");
+                Debug.Assert(_cancelState == CancelState.Unset, "StateObj still has cancellation set");
                 Debug.Assert(_timeoutState == TimeoutState.Stopped, "StateObj still has internal timeout set");
                 // Errors and Warnings
                 Debug.Assert(!_hasErrorOrWarning, "StateObj still has stored errors or warnings");

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCancelTest.cs
@@ -221,6 +221,20 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             AsyncCancelDoesNotWait(np_connStr).Wait();
         }
 
+        // Synapse: WAITFOR not supported + ';' not supported.
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
+        public static void AsyncCancelDoesNotWait2()
+        {
+            AsyncCancelDoesNotWait2(tcp_connStr);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public static void AsyncCancelDoesNotWaitNP2()
+        {
+            AsyncCancelDoesNotWait2(np_connStr);
+        }
+
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void TCPAttentionPacketTestTransaction()
         {
@@ -556,6 +570,55 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 Assert.NotNull(exception);
                 Assert.InRange((ended - started).TotalSeconds, cancelSeconds, delaySeconds - 1);
+            }
+        }
+
+        private static void AsyncCancelDoesNotWait2(string connStr)
+        {
+            const int delaySeconds = 30;
+            const int cancelSeconds = 1;
+
+            var cancellationTokenSource = new CancellationTokenSource();
+            DateTime started = DateTime.UtcNow;
+            DateTime ended = DateTime.UtcNow;
+            Exception exception = null;
+
+            Task executing = ExecuteWaitForAsync(cancellationTokenSource.Token, connStr, delaySeconds);
+
+            cancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(cancelSeconds + 1));
+
+            try
+            {
+                executing.Wait();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+            ended = DateTime.UtcNow;
+
+            Assert.NotNull(exception);
+            Assert.IsType<AggregateException>(exception);
+            Assert.NotNull(exception.InnerException);
+            Assert.IsType<SqlException>(exception.InnerException);
+            Assert.Contains("Operation cancelled by user.", exception.InnerException.Message);
+            Assert.InRange((ended - started).TotalSeconds, cancelSeconds, delaySeconds - 1);
+        }
+
+        private static async Task ExecuteWaitForAsync(CancellationToken cancellationToken, string connectionString, int delaySeconds)
+        {
+            using (var connection = new SqlConnection(connectionString))
+            {
+                await connection.OpenAsync().ConfigureAwait(false);
+                using (var command = new SqlCommand(@"
+WHILE 1 = 1
+BEGIN
+    DECLARE @x INT = 1
+END", connection))
+                {
+                    command.CommandTimeout = delaySeconds + 10;
+                    await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
             }
         }
     }


### PR DESCRIPTION
Reimplementation of https://github.com/dotnet/SqlClient/pull/956 to see what fails and why. The extra test added in https://github.com/dotnet/SqlClient/pull/1352 passes locally.

/cc @cheenamalhotra in case you're interested or can help pinpoint what's going on here