### PR TITLE
Fix access violation when using Express user instances

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -703,6 +703,7 @@ namespace Microsoft.Data.SqlClient
             _attestationProtocol = connectionOptions._attestationProtocol;
             _serverSPN = connectionOptions._serverSPN;
             _failoverPartnerSPN = connectionOptions._failoverPartnerSPN;
+            _hostNameInCertificate = connectionOptions._hostNameInCertificate;
 #if NETFRAMEWORK
             _connectionReset = connectionOptions._connectionReset;
             _contextConnection = connectionOptions._contextConnection;

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -946,6 +946,15 @@ namespace Microsoft.Data.SqlClient.Tests
         }
 
         [Fact]
+        public void Open_ConnectionString_UserInstance()
+        {
+            SqlConnection cn = new SqlConnection("User Instance=true;");
+            SqlException ex = Assert.Throws<SqlException>(() => cn.Open());
+            // Throws without access violation
+            Assert.NotNull(ex.Message);
+        }
+
+        [Fact]
         public void ServerVersion_Connection_Closed()
         {
             SqlConnection cn = new SqlConnection();


### PR DESCRIPTION
Fixes #1944

When [SQL Server Express user instances](https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql/sql-server-express-user-instances) are used, this constructor is called from a special code path at SQLConnectionFactory.cs#L98.

Because the _hostNameInCertificate option is not set in the constructor, the cloned connection at line 99 fails with an access violation somewhere on the native side. 

Releases after PR #1608 (which initially added this option) are affected - Express user instances won't work at all in any of them.