### PR TITLE
Make array rental return after TryReadPlpUnicodeChars unconditional

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -5683,18 +5683,20 @@ namespace Microsoft.Data.SqlClient
                         {
                             char[] cc = null;
                             bool buffIsRented = false;
-                            if (!TryReadPlpUnicodeChars(ref cc, 0, length >> 1, stateObj, out length, supportRentedBuff: true, rentedBuff: ref buffIsRented))
+                            bool result = TryReadPlpUnicodeChars(ref cc, 0, length >> 1, stateObj, out length, supportRentedBuff: true, rentedBuff: ref buffIsRented);
+
+                            if (result)
                             {
-                                return false;
+                                if (length > 0)
+                                {
+                                    s = new string(cc, 0, length);
+                                }
+                                else
+                                {
+                                    s = "";
+                                }
                             }
-                            if (length > 0)
-                            {
-                                s = new string(cc, 0, length);
-                            }
-                            else
-                            {
-                                s = "";
-                            }
+                            
                             if (buffIsRented)
                             {
                                 // do not use clearArray:true on the rented array because it can be massively larger
@@ -5704,6 +5706,11 @@ namespace Microsoft.Data.SqlClient
                                 cc.AsSpan(0, length).Clear();
                                 ArrayPool<char>.Shared.Return(cc, clearArray: false);
                                 cc = null;
+                            }
+
+                            if (!result)
+                            {
+                                return false;
                             }
                         }
                         else


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/2120

In PR https://github.com/dotnet/SqlClient/pull/1866 I introduced the ability for TryReadPlpUnicodeChars to use rented buffers to store the intermediate char[]'s that are needed before a string can be created. That change works well in sync calls but has a problem in async calls.

When used in async mode with a string that spans multiple packets the async replay mechanism causes the TryReadPlpUnicodeChars to be called repeatedly until it has all the data available in the buffered packets. An oversight in the method means that in the fail case a rented buffer is dropped to the GC. The rented buffers' size converge on the size of the requested string which means that as more packets are buffered into the snapshot larger and larger arrays will be allocated through the arraypool and then not returned. 
This leads to performance which is no better than using newly allocated arrays and which contributes GC pressure (through the arrays it is dropping being on the LOH) leading to Gen2 GC which causes arraypools to be cleaned up which works against the use of rented buffers.

This change causes the caller of TryReadPlpUnicodeChars to return the rented array on failed paths as well as successful ones.

The test program is derived from the one provided in the issue. It uses the profiler api to get accurate results for small periods where trying to manually getting time snapshot would be error prone:
```csharp
using Microsoft.EntityFrameworkCore;
using MsSqlDriverBug;

using (var context = new GarbageDbContext())
{
    JetBrains.Profiler.Api.MemoryProfiler.GetSnapshot();

    await context.Garbages.AsNoTracking().FirstOrDefaultAsync();

    JetBrains.Profiler.Api.MemoryProfiler.GetSnapshot();

    for (int i = 0; i < 10; i++)
    {
        await context.Garbages.AsNoTracking().FirstOrDefaultAsync(x => x.ID == i);
    }

    JetBrains.Profiler.Api.MemoryProfiler.GetSnapshot();
}
```

before this change:
![before](https://github.com/dotnet/SqlClient/assets/13322696/84f65f4a-f754-4df2-8af2-24db560cf674)

after:
![after](https://github.com/dotnet/SqlClient/assets/13322696/58a2a65d-9e78-4441-8d6c-ac6477b985cb)


The GC time and run frequency are vastly reduced. This makes the overall repro faster.
The change is very simple. The difficulty was in finding and understanding it. 

/cc @Havunen , @roji 