### PR TITLE
Update native SNI version

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <!-- NetFx project dependencies -->
   <PropertyGroup>
-    <MicrosoftDataSqlClientSniVersion>5.1.0</MicrosoftDataSqlClientSniVersion>
+    <MicrosoftDataSqlClientSniVersion>5.1.1</MicrosoftDataSqlClientSniVersion>
   </PropertyGroup>
   <!-- NetFx and NetCore project dependencies -->
   <PropertyGroup>
@@ -38,7 +38,7 @@
   <!-- NetCore project dependencies -->
   <PropertyGroup>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
-    <MicrosoftDataSqlClientSNIRuntimeVersion>5.1.0</MicrosoftDataSqlClientSNIRuntimeVersion>
+    <MicrosoftDataSqlClientSNIRuntimeVersion>5.1.1</MicrosoftDataSqlClientSNIRuntimeVersion>
     <SystemConfigurationConfigurationManagerVersion>6.0.1</SystemConfigurationConfigurationManagerVersion>
     <MicrosoftSqlServerServerVersion>1.0.0</MicrosoftSqlServerServerVersion>
     <SystemDiagnosticsPerformanceCounterVersion>6.0.1</SystemDiagnosticsPerformanceCounterVersion>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -28,7 +28,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <tags>sqlclient microsoft.data.sqlclient</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Data.SqlClient.SNI" version="5.1.0" />
+        <dependency id="Microsoft.Data.SqlClient.SNI" version="5.1.1" />
         <dependency id="Azure.Identity" version="1.8.0" />
         <dependency id="Microsoft.Identity.Client" version="4.53.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
@@ -39,7 +39,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
       </group>
       <group targetFramework="net7.0">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.0" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.1" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.8.0" />
         <dependency id="Microsoft.Identity.Client" version="4.53.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
@@ -54,7 +54,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Security.Principal.Windows" version="5.0.0" exclude="Compile" />
       </group>
       <group targetFramework="net6.0">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.0" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.1" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.8.0" />
         <dependency id="Microsoft.Identity.Client" version="4.53.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
@@ -68,7 +68,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Security.Principal.Windows" version="5.0.0" exclude="Compile" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.0" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.1" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.8.0" />
         <dependency id="Microsoft.Identity.Client" version="4.53.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
@@ -86,7 +86,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Security.Principal.Windows" version="5.0.0" exclude="Compile" />
       </group>
       <group targetFramework="netstandard2.1">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.0" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.1" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.8.0" />
         <dependency id="Microsoft.Identity.Client" version="4.53.0" exclude="Compile"/>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />


### PR DESCRIPTION
This hotfix (5.1.1) addressed an issue introduced with HNIC, which is an edge case that requires adding HNIC with the same value of Data Source in order to make it work.