### PR TITLE
SqlSequentialStream position

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlSequentialStreamSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlSequentialStreamSmi.cs
@@ -50,8 +50,16 @@ namespace Microsoft.Data.SqlClient
 
         public override long Position
         {
-            get { throw ADP.NotSupported(); }
-            set { throw ADP.NotSupported(); }
+            get => _position;
+            set
+            {
+                if (_position == value)
+                {
+                    return;
+                }
+
+                throw ADP.NotSupported();
+            }
         }
 
         internal int ColumnIndex

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -1515,9 +1515,11 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
                             // Basic case
                             using (stream = reader.GetStream(0))
                             {
+                                Assert.Equal(0, stream.Position);
                                 stream.Read(smallBuffer, 0, smallBuffer.Length);
                                 stream.Read(buffer, 2, 2);
 
+                                Assert.Equal(4, stream.Position);
                                 // Testing stream properties
                                 stream.Flush();
                                 DataTestUtility.AssertThrowsWrapper<NotSupportedException>(() => stream.SetLength(1));
@@ -1526,15 +1528,13 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
                                 if (behavior == CommandBehavior.SequentialAccess)
                                 {
                                     DataTestUtility.AssertThrowsWrapper<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
-                                    performOnStream = ((s) => { long i = s.Position; });
-                                    DataTestUtility.AssertThrowsWrapper<NotSupportedException>(() => performOnStream(stream));
                                     performOnStream = ((s) => { long i = s.Length; });
                                     DataTestUtility.AssertThrowsWrapper<NotSupportedException>(() => performOnStream(stream));
                                 }
                                 else
                                 {
                                     stream.Seek(0, SeekOrigin.Begin);
-                                    long position = stream.Position;
+                                    Assert.Equal(0, stream.Position);
                                     long length = stream.Length;
                                 }
                             }


### PR DESCRIPTION
Add support for [Stream.Position](https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.position) to SqlSequentialStream 

currently `SqlSequentialStream.Position` throws a NotSupported.

Many APIs that consume Stream assume that a get on `position` will not throw. Most recently for me is the Aspose suite of libraries. But i have been hit by this at least 3 times in the past. each time i have had to wrap SqlSequentialStream in another  stream that keeps track of the position.

i figured i would finally fix the root cause