### PR TITLE
Merge TDSParserStateObject.StateSnapshot state flags

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
@@ -3168,45 +3168,6 @@ namespace Microsoft.Data.SqlClient
                 PushBuffer(_stateObj._inBuff, _stateObj._inBytesRead);
             }
 
-            internal void ResetSnapshotState()
-            {
-                // go back to the beginning
-                _snapshotInBuffCurrent = 0;
-
-                Replay();
-
-                _stateObj._inBytesUsed = _snapshotInBytesUsed;
-                _stateObj._inBytesPacket = _snapshotInBytesPacket;
-
-                _stateObj._messageStatus = _snapshotMessageStatus;
-                _stateObj._nullBitmapInfo = _snapshotNullBitmapInfo;
-                _stateObj._cleanupMetaData = _snapshotCleanupMetaData;
-                _stateObj._cleanupAltMetaDataSetArray = _snapshotCleanupAltMetaDataSetArray;
-
-                // Make sure to go through the appropriate increment/decrement methods if changing the OpenResult flag
-                if (!_stateObj.HasOpenResult && ((_state & SnapshottedStateFlags.OpenResult) == SnapshottedStateFlags.OpenResult))
-                {
-                    _stateObj.IncrementAndObtainOpenResultCount(_stateObj._executedUnderTransaction);
-                }
-                else if (_stateObj.HasOpenResult && ((_state & SnapshottedStateFlags.OpenResult) != SnapshottedStateFlags.OpenResult))
-                {
-                    _stateObj.DecrementOpenResultCount();
-                }
-                _stateObj._snapshottedState = _state;
-
-                // Reset partially read state (these only need to be maintained if doing async without snapshot)
-                _stateObj._bTmpRead = 0;
-                _stateObj._partialHeaderBytesRead = 0;
-
-                // reset plp state
-                _stateObj._longlen = _plpData?.SnapshotLongLen ?? 0;
-                _stateObj._longlenleft = _plpData?.SnapshotLongLenLeft ?? 0;
-
-                _stateObj._snapshotReplay = true;
-
-                _stateObj.AssertValidState();
-            }
-
             internal void Clear()
             {
                 PacketData packet = _snapshotInBuffList;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Data.SqlClient
         private readonly WeakReference _cancellationOwner = new WeakReference(null);
 
 		// Async
-        private SnapshottedStateFlags _snapshottedState;
 
         //////////////////
         // Constructors //
@@ -277,53 +276,6 @@ namespace Microsoft.Data.SqlClient
         internal void StartSession(object cancellationOwner)
         {
             _cancellationOwner.Target = cancellationOwner;
-        }
-
-        private void SetSnapshottedState(SnapshottedStateFlags flag, bool value)
-        {
-            if (value)
-            {
-                _snapshottedState |= flag;
-            }
-            else
-            {
-                _snapshottedState &= ~flag;
-            }
-        }
-
-        private bool GetSnapshottedState(SnapshottedStateFlags flag)
-        {
-            return (_snapshottedState & flag) == flag;
-        }
-
-        internal bool HasOpenResult
-        {
-            get => GetSnapshottedState(SnapshottedStateFlags.OpenResult);
-            set => SetSnapshottedState(SnapshottedStateFlags.OpenResult, value);
-        }
-
-        internal bool HasPendingData
-        {
-            get => GetSnapshottedState(SnapshottedStateFlags.PendingData);
-            set => SetSnapshottedState(SnapshottedStateFlags.PendingData, value);
-        }
-
-        internal bool HasReceivedError
-        {
-            get => GetSnapshottedState(SnapshottedStateFlags.ErrorTokenReceived);
-            set => SetSnapshottedState(SnapshottedStateFlags.ErrorTokenReceived, value);
-        }
-
-        internal bool HasReceivedAttention
-        {
-            get => GetSnapshottedState(SnapshottedStateFlags.AttentionReceived);
-            set => SetSnapshottedState(SnapshottedStateFlags.AttentionReceived, value);
-        }
-
-        internal bool HasReceivedColumnMetadata
-        {
-            get => GetSnapshottedState(SnapshottedStateFlags.ColMetaDataReceived);
-            set => SetSnapshottedState(SnapshottedStateFlags.ColMetaDataReceived, value);
         }
 
         ///////////////////////////////////////
@@ -3113,8 +3065,6 @@ namespace Microsoft.Data.SqlClient
 
 
             private int _snapshotInBuffCount;
-
-            private SnapshottedStateFlags _state;
 
 #if DEBUG
             internal void AssertCurrent()

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2480,7 +2480,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             if (token == TdsEnums.SQLERROR)
                             {
-                                stateObj._errorTokenReceived = true; // Keep track of the fact error token was received - for Done processing.
+                                stateObj.HasReceivedError = true; // Keep track of the fact error token was received - for Done processing.
                             }
 
                             SqlError error;
@@ -3538,13 +3538,13 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // Skip the bogus DONE counts sent by the server
-                if (stateObj._receivedColMetaData || (curCmd != TdsEnums.SELECT))
+                if (stateObj.HasReceivedColumnMetadata || (curCmd != TdsEnums.SELECT))
                 {
                     cmd.OnStatementCompleted(count);
                 }
             }
 
-            stateObj._receivedColMetaData = false;
+            stateObj.HasReceivedColumnMetadata = false;
 
             // Surface exception for DONE_ERROR in the case we did not receive an error token
             // in the stream, but an error occurred.  In these cases, we throw a general server error.  The
@@ -3553,7 +3553,7 @@ namespace Microsoft.Data.SqlClient
             // the server has reached its max connection limit.  Bottom line, we need to throw general
             // error in the cases where we did not receive a error token along with the DONE_ERROR.
             if ((TdsEnums.DONE_ERROR == (TdsEnums.DONE_ERROR & status)) && stateObj.ErrorCount == 0 &&
-                  stateObj._errorTokenReceived == false && (RunBehavior.Clean != (RunBehavior.Clean & run)))
+                  stateObj.HasReceivedError == false && (RunBehavior.Clean != (RunBehavior.Clean & run)))
             {
                 stateObj.AddError(new SqlError(0, 0, TdsEnums.MIN_ERROR_CLASS, _server, SQLMessage.SevereError(), "", 0));
 
@@ -3587,7 +3587,7 @@ namespace Microsoft.Data.SqlClient
             // stop if the DONE_MORE bit isn't set (see above for attention handling)
             if (TdsEnums.DONE_MORE != (status & TdsEnums.DONE_MORE))
             {
-                stateObj._errorTokenReceived = false;
+                stateObj.HasReceivedError = false;
                 if (stateObj._inBytesUsed >= stateObj._inBytesRead)
                 {
                     stateObj.HasPendingData = false;
@@ -3597,7 +3597,7 @@ namespace Microsoft.Data.SqlClient
             // _pendingData set by e.g. 'TdsExecuteSQLBatch'
             // _hasOpenResult always set to true by 'WriteMarsHeader'
             //
-            if (!stateObj.HasPendingData && stateObj._hasOpenResult)
+            if (!stateObj.HasPendingData && stateObj.HasOpenResult)
             {
                 /*
                                 Debug.Assert(!((sqlTransaction != null               && _distributedTransaction != null) ||
@@ -5743,7 +5743,7 @@ namespace Microsoft.Data.SqlClient
 
             // We get too many DONE COUNTs from the server, causing too meany StatementCompleted event firings.
             // We only need to fire this event when we actually have a meta data stream with 0 or more rows.
-            stateObj._receivedColMetaData = true;
+            stateObj.HasReceivedColumnMetadata = true;
             return true;
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
@@ -3298,45 +3298,6 @@ namespace Microsoft.Data.SqlClient
                 PushBuffer(_stateObj._inBuff, _stateObj._inBytesRead);
             }
 
-            internal void ResetSnapshotState()
-            {
-                // go back to the beginning
-                _snapshotInBuffCurrent = 0;
-
-                Replay();
-
-                _stateObj._inBytesUsed = _snapshotInBytesUsed;
-                _stateObj._inBytesPacket = _snapshotInBytesPacket;
-                _stateObj._messageStatus = _snapshotMessageStatus;
-                _stateObj._nullBitmapInfo = _snapshotNullBitmapInfo;
-                _stateObj._cleanupMetaData = _snapshotCleanupMetaData;
-                _stateObj._cleanupAltMetaDataSetArray = _snapshotCleanupAltMetaDataSetArray;
-
-                // Make sure to go through the appropriate increment/decrement methods if changing HasOpenResult
-                if (!_stateObj.HasOpenResult && ((_state & SnapshottedStateFlags.OpenResult) == SnapshottedStateFlags.OpenResult))
-                {
-                    _stateObj.IncrementAndObtainOpenResultCount(_stateObj._executedUnderTransaction);
-                }
-                else if (_stateObj.HasOpenResult && ((_state & SnapshottedStateFlags.OpenResult) != SnapshottedStateFlags.OpenResult))
-                {
-                    _stateObj.DecrementOpenResultCount();
-                }
-                //else _stateObj._hasOpenResult is already == _snapshotHasOpenResult
-                _stateObj._snapshottedState = _state;
-
-                // Reset partially read state (these only need to be maintained if doing async without snapshot)
-                _stateObj._bTmpRead = 0;
-                _stateObj._partialHeaderBytesRead = 0;
-
-                // reset plp state
-                _stateObj._longlen = _plpData?.SnapshotLongLen ?? 0;
-                _stateObj._longlenleft = _plpData?.SnapshotLongLenLeft ?? 0;
-
-                _stateObj._snapshotReplay = true;
-
-                _stateObj.AssertValidState();
-            }
-
             internal void Clear()
             {
                 _snapshotInBuffs.Clear();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -1246,6 +1246,45 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
+            internal void ResetSnapshotState()
+            {
+                // go back to the beginning
+                _snapshotInBuffCurrent = 0;
+
+                Replay();
+
+                _stateObj._inBytesUsed = _snapshotInBytesUsed;
+                _stateObj._inBytesPacket = _snapshotInBytesPacket;
+                _stateObj._messageStatus = _snapshotMessageStatus;
+                _stateObj._nullBitmapInfo = _snapshotNullBitmapInfo;
+                _stateObj._cleanupMetaData = _snapshotCleanupMetaData;
+                _stateObj._cleanupAltMetaDataSetArray = _snapshotCleanupAltMetaDataSetArray;
+
+                // Make sure to go through the appropriate increment/decrement methods if changing HasOpenResult
+                if (!_stateObj.HasOpenResult && ((_state & SnapshottedStateFlags.OpenResult) == SnapshottedStateFlags.OpenResult))
+                {
+                    _stateObj.IncrementAndObtainOpenResultCount(_stateObj._executedUnderTransaction);
+                }
+                else if (_stateObj.HasOpenResult && ((_state & SnapshottedStateFlags.OpenResult) != SnapshottedStateFlags.OpenResult))
+                {
+                    _stateObj.DecrementOpenResultCount();
+                }
+                //else _stateObj._hasOpenResult is already == _snapshotHasOpenResult
+                _stateObj._snapshottedState = _state;
+
+                // Reset partially read state (these only need to be maintained if doing async without snapshot)
+                _stateObj._bTmpRead = 0;
+                _stateObj._partialHeaderBytesRead = 0;
+
+                // reset plp state
+                _stateObj._longlen = _plpData?.SnapshotLongLen ?? 0;
+                _stateObj._longlenleft = _plpData?.SnapshotLongLenLeft ?? 0;
+
+                _stateObj._snapshotReplay = true;
+
+                _stateObj.AssertValidState();
+            }
+
             internal void PrepareReplay()
             {
                 ResetSnapshotState();


### PR DESCRIPTION
Slightly more complex because there are more call sites for this change. I recommend reviewing each single commit.
In netfx remove a bunch of state variables and replace them with SnapshottedStateFlags, move the get/set functions and the properties that use them to shared. Update the snapshot functions to use the state flags. Update uses of the state flags and finally move the now functionally identical function ResetSnapshotState to shared.