### PR TITLE
SDL | Changing ReadXml to a more secure overload.

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
@@ -506,7 +506,7 @@ namespace Microsoft.Data.ProviderBase
             {
                 XmlResolver = null
             };
-            XmlReader reader = XmlReader.Create(XmlStream, settings);
+            using XmlReader reader = XmlReader.Create(XmlStream, settings);
             _metaDataCollectionsDataSet.ReadXml(reader);
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
@@ -9,6 +9,7 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Xml;
 
 namespace Microsoft.Data.ProviderBase
 {
@@ -499,9 +500,14 @@ namespace Microsoft.Data.ProviderBase
         {
             _metaDataCollectionsDataSet = new DataSet
             {
-                Locale = System.Globalization.CultureInfo.InvariantCulture
+                Locale = CultureInfo.InvariantCulture
             };
-            _metaDataCollectionsDataSet.ReadXml(XmlStream);
+            XmlReaderSettings settings = new()
+            {
+                XmlResolver = null
+            };
+            XmlReader reader = XmlReader.Create(XmlStream, settings);
+            _metaDataCollectionsDataSet.ReadXml(reader);
         }
 
         protected virtual DataTable PrepareCollection(string collectionName, string[] restrictions, DbConnection connection)


### PR DESCRIPTION
Code Analysis detected CA3075, Unsafe overload of 'ReadXml' method, for [LoadDataSetFromXml](https://github.com/dotnet/SqlClient/blob/f384d4a25d5c8bb23e8033cc9eec365e5b385cb5/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs#L498). Changing the XmlRead to a more secure overload will solve that issue, by setting XmlResolver to null.

