### PR TITLE
Merge TDSParserStateObject.StateSnapshot stateObj fields to a new class in shared

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
@@ -3063,7 +3063,6 @@ namespace Microsoft.Data.SqlClient
 
             internal byte[] _plpBuffer;
 
-
             private int _snapshotInBuffCount;
 
 #if DEBUG
@@ -3138,34 +3137,11 @@ namespace Microsoft.Data.SqlClient
 
             internal void Snap(TdsParserStateObject state)
             {
-                _stateObj = state;
                 _snapshotInBuffList = null;
                 _snapshotInBuffCount = 0;
                 _snapshotInBuffCurrent = 0;
-                _snapshotInBytesUsed = _stateObj._inBytesUsed;
-                _snapshotInBytesPacket = _stateObj._inBytesPacket;
 
-                _snapshotMessageStatus = _stateObj._messageStatus;
-                // _nullBitmapInfo must be cloned before it is updated
-                _snapshotNullBitmapInfo = _stateObj._nullBitmapInfo;
-                if (_stateObj._longlen != 0 || _stateObj._longlenleft != 0)
-                {
-                    _plpData = new PLPData(_stateObj._longlen, _stateObj._longlenleft);
-                }
-                _snapshotCleanupMetaData = _stateObj._cleanupMetaData;
-                // _cleanupAltMetaDataSetArray must be cloned before it is updated
-                _snapshotCleanupAltMetaDataSetArray = _stateObj._cleanupAltMetaDataSetArray;
-
-                _state = _stateObj._snapshottedState;
-#if DEBUG
-                _rollingPend = 0;
-                _rollingPendCount = 0;
-                _stateObj._lastStack = null;
-                Debug.Assert(_stateObj._bTmpRead == 0, "Has partially read data when snapshot taken");
-                Debug.Assert(_stateObj._partialHeaderBytesRead == 0, "Has partially read header when snapshot taken");
-#endif
-
-                PushBuffer(_stateObj._inBuff, _stateObj._inBytesRead);
+                CaptureAsStart(state);
             }
 
             internal void Clear()
@@ -3173,8 +3149,6 @@ namespace Microsoft.Data.SqlClient
                 PacketData packet = _snapshotInBuffList;
                 _snapshotInBuffList = null;
                 _snapshotInBuffCount = 0;
-                
-                _state = SnapshottedStateFlags.None;
 
                 packet.Clear();
                 _sparePacket = packet;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
@@ -3202,7 +3202,6 @@ namespace Microsoft.Data.SqlClient
         {
             private List<PacketData> _snapshotInBuffs;
 
-
             public StateSnapshot()
             {
                 _snapshotInBuffs = new List<PacketData>();
@@ -3270,32 +3269,10 @@ namespace Microsoft.Data.SqlClient
 
             internal void Snap(TdsParserStateObject state)
             {
-                _stateObj = state;
                 _snapshotInBuffs.Clear();
                 _snapshotInBuffCurrent = 0;
-                _snapshotInBytesUsed = _stateObj._inBytesUsed;
-                _snapshotInBytesPacket = _stateObj._inBytesPacket;
-                _snapshotMessageStatus = _stateObj._messageStatus;
-                // _nullBitmapInfo must be cloned before it is updated
-                _snapshotNullBitmapInfo = _stateObj._nullBitmapInfo;
-                if (_stateObj._longlen != 0 || _stateObj._longlenleft != 0)
-                {
-                    _plpData = new PLPData(_stateObj._longlen, _stateObj._longlenleft);
-                }
-                _snapshotCleanupMetaData = _stateObj._cleanupMetaData;
-                // _cleanupAltMetaDataSetArray must be cloned bofore it is updated
-                _snapshotCleanupAltMetaDataSetArray = _stateObj._cleanupAltMetaDataSetArray;
 
-                _state = _stateObj._snapshottedState;
-#if DEBUG
-                _rollingPend = 0;
-                _rollingPendCount = 0;
-                _stateObj._lastStack = null;
-                Debug.Assert(_stateObj._bTmpRead == 0, "Has partially read data when snapshot taken");
-                Debug.Assert(_stateObj._partialHeaderBytesRead == 0, "Has partially read header when snapshot taken");
-#endif
-
-                PushBuffer(_stateObj._inBuff, _stateObj._inBytesRead);
+                CaptureAsStart(state);
             }
 
             internal void Clear()


### PR DESCRIPTION
There are a number of fields which are used to store data about the state object that are captured and then restored as the snapshot is replayed. Moving these fields to a new object has two benefits. 1) the maintenance of the packet list and the state is separated logically making both easier to understand and 2) if we introduce a continue option to improve performance we will need to be able to store stateobject state for both the replay start and the replay continue points.