### PR TITLE
Ports Fix deadlock in transaction (#1242) to .NET

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -363,7 +363,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        Exception commitException = null;
+                        Exception commitException;
                         lock (connection)
                         {
                             try
@@ -371,13 +371,11 @@ namespace Microsoft.Data.SqlClient
                                 // Now that we've acquired the lock, make sure we still have valid state for this operation.
                                 ValidateActiveOnConnection(connection);
 
-                                _active =
-                                    false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
-                                _connection =
-                                    null; // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
+                                _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
+                                _connection = null; // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
 
-                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null,
-                                    System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
+                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
+                                commitException = null;
                             }
                             catch (SqlException e)
                             {
@@ -426,7 +424,6 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
-                        
                         if (commitException == null)
                         {
                             // connection.ExecuteTransaction succeeded

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -348,31 +348,36 @@ namespace Microsoft.Data.SqlClient
 #endif
                 try
                 {
-                    Exception commitException = null;
-
-                    lock (connection)
+                    // If the connection is doomed, we can be certain that the
+                    // transaction will eventually be rolled back or has already been aborted externally, and we shouldn't
+                    // attempt to commit it.
+                    if (connection.IsConnectionDoomed)
                     {
-                        // If the connection is doomed, we can be certain that the
-                        // transaction will eventually be rolled back or has already been aborted externally, and we shouldn't
-                        // attempt to commit it.
-                        if (connection.IsConnectionDoomed)
+                        lock (connection)
                         {
                             _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
                             _connection = null;
-
-                            enlistment.Aborted(SQL.ConnectionDoomed());
                         }
-                        else
+
+                        enlistment.Aborted(SQL.ConnectionDoomed());
+                    }
+                    else
+                    {
+                        Exception commitException = null;
+                        lock (connection)
                         {
                             try
                             {
                                 // Now that we've acquired the lock, make sure we still have valid state for this operation.
                                 ValidateActiveOnConnection(connection);
 
-                                _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
-                                _connection = null;   // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
+                                _active =
+                                    false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
+                                _connection =
+                                    null; // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
 
-                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
+                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null,
+                                    System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
                             }
                             catch (SqlException e)
                             {
@@ -391,42 +396,42 @@ namespace Microsoft.Data.SqlClient
                                 ADP.TraceExceptionWithoutRethrow(e);
                                 connection.DoomThisConnection();
                             }
-                            if (commitException != null)
+                        }
+                        if (commitException != null)
+                        {
+                            // connection.ExecuteTransaction failed with exception
+                            if (_internalTransaction.IsCommitted)
                             {
-                                // connection.ExecuteTransaction failed with exception
-                                if (_internalTransaction.IsCommitted)
-                                {
-                                    // Even though we got an exception, the transaction
-                                    // was committed by the server.
-                                    enlistment.Committed();
-                                }
-                                else if (_internalTransaction.IsAborted)
-                                {
-                                    // The transaction was aborted, report that to
-                                    // SysTx.
-                                    enlistment.Aborted(commitException);
-                                }
-                                else
-                                {
-                                    // The transaction is still active, we cannot
-                                    // know the state of the transaction.
-                                    enlistment.InDoubt(commitException);
-                                }
-
-                                // We eat the exception.  This is called on the SysTx
-                                // thread, not the applications thread.  If we don't
-                                // eat the exception an UnhandledException will occur,
-                                // causing the process to FailFast.
+                                // Even though we got an exception, the transaction
+                                // was committed by the server.
+                                enlistment.Committed();
+                            }
+                            else if (_internalTransaction.IsAborted)
+                            {
+                                // The transaction was aborted, report that to
+                                // SysTx.
+                                enlistment.Aborted(commitException);
+                            }
+                            else
+                            {
+                                // The transaction is still active, we cannot
+                                // know the state of the transaction.
+                                enlistment.InDoubt(commitException);
                             }
 
-                            connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
+                            // We eat the exception.  This is called on the SysTx
+                            // thread, not the applications thread.  If we don't
+                            // eat the exception an UnhandledException will occur,
+                            // causing the process to FailFast.
                         }
-                    }
 
-                    if (commitException == null)
-                    {
-                        // connection.ExecuteTransaction succeeded
-                        enlistment.Committed();
+                        connection.CleanupConnectionOnTransactionCompletion(_atomicTransaction);
+                        
+                        if (commitException == null)
+                        {
+                            // connection.ExecuteTransaction succeeded
+                            enlistment.Committed();
+                        }
                     }
                 }
                 catch (System.OutOfMemoryException e)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -387,7 +387,6 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(null != enlistment, "null enlistment?");
             SqlInternalConnection connection = GetValidConnection();
 
-
             if (null != connection)
             {
                 SqlConnection usersConnection = connection.Connection;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -442,7 +442,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static bool IsSupportingDistributedTransactions()
         {
 #if NET7_0_OR_GREATER
-            return OperatingSystem.IsWindows() && IsNotAzureServer();
+            return OperatingSystem.IsWindows() && System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture != System.Runtime.InteropServices.Architecture.X86 && IsNotAzureServer();
 #elif NETFRAMEWORK
             return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) && IsNotAzureServer();
 #else

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -444,7 +444,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 #if NET7_0_OR_GREATER
             return OperatingSystem.IsWindows() && System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture != System.Runtime.InteropServices.Architecture.X86 && IsNotAzureServer();
 #elif NETFRAMEWORK
-            return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) && IsNotAzureServer();
+            return IsNotAzureServer();
 #else
             return false;
 #endif

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -439,6 +439,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 ;
         }
 
+        public static bool IsSupportingDistributedTransactions()
+        {
+#if NET7_0_OR_GREATER
+            return OperatingSystem.IsWindows() && IsNotAzureServer();
+#elif NETFRAMEWORK
+            return System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) && IsNotAzureServer();
+#else
+            return false;
+#endif
+        }
+
         public static bool IsUsingManagedSNI() => UseManagedSNIOnWindows;
 
         public static bool IsNotUsingManagedSNIOnWindows() => !UseManagedSNIOnWindows;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             RunTestSet(TestCase_ManualEnlistment_Enlist_TxScopeComplete);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsSupportingDistributedTransactions))]
         public static void TestEnlistmentPrepare_TxScopeComplete()
         {
             Assert.Throws<TransactionAbortedException>( () =>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             RunTestSet(TestCase_ManualEnlistment_Enlist_TxScopeComplete);
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
         public static void TestEnlistmentPrepare_TxScopeComplete()
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/TransactionTest/TransactionEnlistmentTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
         public static void TestEnlistmentPrepare_TxScopeComplete()
         {
-            try
+            Assert.Throws<TransactionAbortedException>( () =>
             {
                 using TransactionScope txScope = new(TransactionScopeOption.RequiresNew, new TransactionOptions()
                 {
@@ -62,12 +62,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 connection.Open();
                 System.Transactions.Transaction.Current.EnlistDurable(EnlistmentForPrepare.s_id, new EnlistmentForPrepare(), EnlistmentOptions.None);
                 txScope.Complete();
-                Assert.False(true, "Expected exception not thrown.");
-            }
-            catch (Exception e)
-            {
-                Assert.True(e is TransactionAbortedException);
-            }
+            });
         }
 
         private static void TestCase_AutoEnlistment_TxScopeComplete()


### PR DESCRIPTION
.NET 7 and higher supports distributed transactions on Windows. For more details see https://github.com/dotnet/runtime/issues/715.

Unfortunately, the code that is responsible for the transactions in the Netcore part of the SqlClient has not been adopted to address https://github.com/dotnet/SqlClient/issues/1124 which was fixed with https://github.com/dotnet/SqlClient/pull/1242. This PR brings over the changes from https://github.com/dotnet/SqlClient/pull/1242 and makes sure the distributed transaction on .NET running on Windows are not deadlocking.

We ran into the same issue as described in https://github.com/dotnet/SqlClient/issues/1124 when trying to enable distributed transaction support on NET8 on Windows.