### PR TITLE
Initialize DbCommand.Transaction in DbConnection.CreateDbCommand()

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -159,6 +159,11 @@ namespace Microsoft.Data.SqlClient
                 DbProviderFactory providerFactory = ConnectionFactory.ProviderFactory;
                 command = providerFactory.CreateCommand();
                 command.Connection = this;
+                if (InnerConnection is SqlInternalConnection { CurrentTransaction: { Parent: {} transaction} })
+                {
+                    command.Transaction = transaction;
+                }
+
                 return command;
             }
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -205,6 +205,11 @@ namespace Microsoft.Data.SqlClient
                 DbProviderFactory providerFactory = ConnectionFactory.ProviderFactory;
                 DbCommand command = providerFactory.CreateCommand();
                 command.Connection = this;
+                if (InnerConnection is SqlInternalConnection { CurrentTransaction: { Parent: {} transaction} })
+                {
+                    command.Transaction = transaction;
+                }
+
                 return command;
             }
         }


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/2162