### PR TITLE
Merge TDSParserStateObject.StateSnapshot packet list mangement and reimplment

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.SqlClient
         // Timeout variables
         private readonly WeakReference _cancellationOwner = new WeakReference(null);
 
-		// Async
+        // Async
 
         //////////////////
         // Constructors //
@@ -1072,12 +1072,18 @@ namespace Microsoft.Data.SqlClient
             {
                 if (_snapshotReplay)
                 {
-                    if (_snapshot.Replay())
+#if DEBUG
+                    // in debug builds stack traces contain line numbers so if we want to be
+                    // able to compare the stack traces they must all be created in the same
+                    // location in the code
+                    string stackTrace = Environment.StackTrace;
+#endif
+                    if (_snapshot.MoveNext())
                     {
 #if DEBUG
                         if (s_checkNetworkPacketRetryStacks)
                         {
-                            _snapshot.CheckStack(Environment.StackTrace);
+                            _snapshot.CheckStack(stackTrace);
                         }
 #endif
                         return true;
@@ -1087,7 +1093,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         if (s_checkNetworkPacketRetryStacks)
                         {
-                            _lastStack = Environment.StackTrace;
+                            _lastStack = stackTrace;
                         }
                     }
 #endif
@@ -1123,7 +1129,7 @@ namespace Microsoft.Data.SqlClient
         internal void PrepareReplaySnapshot()
         {
             _networkPacketTaskSource = null;
-            _snapshot.PrepareReplay();
+            _snapshot.MoveToStart();
         }
 
         internal void ReadSniSyncOverAsync()
@@ -1434,7 +1440,7 @@ namespace Microsoft.Data.SqlClient
                     Timeout.Infinite,
                     Timeout.Infinite
                 );
-                
+
 
                 // -1 == Infinite
                 //  0 == Already timed out (NOTE: To simulate the same behavior as sync we will only timeout on 0 if we receive an IO Pending from SNI)
@@ -1740,10 +1746,10 @@ namespace Microsoft.Data.SqlClient
 
                     if (_snapshot != null)
                     {
-                        _snapshot.PushBuffer(_inBuff, _inBytesRead);
+                        _snapshot.AppendPacketData(_inBuff, _inBytesRead);
                         if (_snapshotReplay)
                         {
-                            _snapshot.Replay();
+                            _snapshot.MoveNext();
 #if DEBUG
                             _snapshot.AssertCurrent();
 #endif
@@ -3024,137 +3030,7 @@ namespace Microsoft.Data.SqlClient
 
         sealed partial class StateSnapshot
         {
-            private sealed partial class PacketData
-            {
-                public byte[] Buffer;
-                public int Read;
-                public PacketData Prev;
-
-                public void SetStack(string value)
-                {
-                    SetStackInternal(value);
-                }
-                partial void SetStackInternal(string value);
-
-                public void Clear()
-                {
-                    Buffer = null;
-                    Read = 0;
-                    Prev = null;
-                    SetStackInternal(null);
-                }
-            }
-
-#if DEBUG
-            private sealed partial class PacketData
-            {
-                public string Stack;
-
-                partial void SetStackInternal(string value)
-                {
-                    Stack = value;
-                }
-            }
-
-
-#endif
-            private PacketData _snapshotInBuffList;
-            private PacketData _sparePacket;
-
             internal byte[] _plpBuffer;
-
-            private int _snapshotInBuffCount;
-
-#if DEBUG
-            internal void AssertCurrent()
-            {
-                Debug.Assert(_snapshotInBuffCurrent == _snapshotInBuffCount, "Should not be reading new packets when not replaying last packet");
-            }
-
-            internal void CheckStack(string trace)
-            {
-                PacketData prev = _snapshotInBuffList?.Prev;
-                if (prev.Stack == null)
-                {
-                    prev.Stack = trace;
-                }
-                else
-                {
-                    Debug.Assert(_stateObj._permitReplayStackTraceToDiffer || prev.Stack.ToString() == trace.ToString(), "The stack trace on subsequent replays should be the same");
-                }
-            }
-#endif
-            internal void PushBuffer(byte[] buffer, int read)
-            {
-#if DEBUG
-                for (PacketData current = _snapshotInBuffList; current != null; current = current.Prev)
-                {
-                    Debug.Assert(!object.ReferenceEquals(current.Buffer, buffer));
-                }
-#endif
-
-                PacketData packetData = _sparePacket;
-                if (packetData is null)
-                {
-                    packetData = new PacketData();
-                }
-                else
-                {
-                    _sparePacket = null;
-                }
-                packetData.Buffer = buffer;
-                packetData.Read = read;
-                packetData.Prev = _snapshotInBuffList;
-#if DEBUG
-                packetData.SetStack(_stateObj._lastStack);
-#endif
-                _snapshotInBuffList = packetData;
-                _snapshotInBuffCount++;
-            }
-
-            internal bool Replay()
-            {
-                if (_snapshotInBuffCurrent < _snapshotInBuffCount)
-                {
-                    PacketData next = _snapshotInBuffList;
-                    for (
-                        int position = (_snapshotInBuffCount - 1);
-                        position != _snapshotInBuffCurrent;
-                        position -= 1
-                    )
-                    {
-                        next = next.Prev;
-                    }
-                    _stateObj._inBuff = next.Buffer;
-                    _stateObj._inBytesUsed = 0;
-                    _stateObj._inBytesRead = next.Read;
-                    _snapshotInBuffCurrent++;
-                    return true;
-                }
-
-                return false;
-            }
-
-            internal void Snap(TdsParserStateObject state)
-            {
-                _snapshotInBuffList = null;
-                _snapshotInBuffCount = 0;
-                _snapshotInBuffCurrent = 0;
-
-                CaptureAsStart(state);
-            }
-
-            internal void Clear()
-            {
-                PacketData packet = _snapshotInBuffList;
-                _snapshotInBuffList = null;
-                _snapshotInBuffCount = 0;
-
-                packet.Clear();
-                _sparePacket = packet;
-
-                ClearCore();
-            }
         }
     }
 }


### PR DESCRIPTION
In the async state snapshot netfx and netcore currently use different approaches. Netfx uses a `List<PacketData>` and int counter to identify the current location as it moves forward. Netcore uses a singly linked list and a counter for when it needs to know the current position which is calculated by iterating. Both approaches have different perf issues, the list approach causes repeated array expansions when accumulating packets and the singly linked list causes an unpleasant cpu perf scaling issue when it iterates to calculate the position.

This PR replaces both methods with a shared doubly linked list. The double linking allows easy access to the start of the list for iteration, the end of the list for accumulation and easy navigation in either direction which will be useful later when continue mode is added.

This PR also makes some other changes in this area:
1) fixes the stack trace checking feature so it if is ever used it will work. I can't see us using this feature currently.
2) changes some function names to treat the snapshot more like an enumerable thing and uses MoveNext to advance.
3) adds debugger visualization support for packets (will not be covered since it is vs only) and the ability to identify each packet uniquely in debug mode.

The changes yield good perf results for async strings. They effectively reduce the scaling factor that is applied by the repeated replay of the packet list and keep the memory footprint almost identical to the current async version. Note that there is still an unfavourable scaling factor for async over sync, this does not linearize the operation.

BDN perf results, Async-cm31 is current main branch, The table lists the sizes from 1 to 20 meg in interesting increments. 

| size | sync  | async-cm31 | async-cm32 |
| ---- | ----- | ---------- | ---------- |
| 1    | 5.692 | 10.382     | 9.228      |
| 5    | 19.78 | 293.99     | 96.88      |
| 10   | 39.5  | 2,297.18   | 495.26     |
| 15   | 53.92 | 9,409.01   | 1,401.61   |
| 20   | 80.46 | 28,579.30  | 2,867.15   |

![image](https://github.com/dotnet/SqlClient/assets/13322696/9c4caae2-3d90-4aff-a27f-8ada953c109d)