### PR TITLE
Deprioritize ALTMETADATA and ALTROW tokens

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -3147,21 +3147,6 @@ namespace Microsoft.Data.SqlClient
 
                     switch (token)
                     {
-                        case TdsEnums.SQLALTROW:
-                            if (_altRowStatus == ALTROWSTATUS.Null)
-                            {
-                                // cache the regular metadata
-                                _altMetaDataSetCollection.metaDataSet = _metaData;
-                                _metaData = null;
-                            }
-                            else
-                            {
-                                Debug.Assert(_altRowStatus == ALTROWSTATUS.Done, "invalid AltRowStatus");
-                            }
-                            _altRowStatus = ALTROWSTATUS.AltRow;
-                            _hasRows = true;
-                            moreResults = true;
-                            return true;
                         case TdsEnums.SQLROW:
                         case TdsEnums.SQLNBCROW:
                             // always happens if there is a row following an altrow
@@ -3175,6 +3160,23 @@ namespace Microsoft.Data.SqlClient
                             moreResults = true;
                             return true;
                         case TdsEnums.SQLCOLMETADATA:
+                            moreResults = true;
+                            return true;
+
+                        // deprecated
+                        case TdsEnums.SQLALTROW:
+                            if (_altRowStatus == ALTROWSTATUS.Null)
+                            {
+                                // cache the regular metadata
+                                _altMetaDataSetCollection.metaDataSet = _metaData;
+                                _metaData = null;
+                            }
+                            else
+                            {
+                                Debug.Assert(_altRowStatus == ALTROWSTATUS.Done, "invalid AltRowStatus");
+                            }
+                            _altRowStatus = ALTROWSTATUS.AltRow;
+                            _hasRows = true;
                             moreResults = true;
                             return true;
                     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2183,68 +2183,6 @@ namespace Microsoft.Data.SqlClient
                             break;
                         }
 
-                    case TdsEnums.SQLALTMETADATA:
-                        {
-                            stateObj.CloneCleanupAltMetaDataSetArray();
-
-                            if (stateObj._cleanupAltMetaDataSetArray == null)
-                            {
-                                // create object on demand (lazy creation)
-                                stateObj._cleanupAltMetaDataSetArray = new _SqlMetaDataSetCollection();
-                            }
-
-                            _SqlMetaDataSet cleanupAltMetaDataSet;
-                            if (!TryProcessAltMetaData(tokenLength, stateObj, out cleanupAltMetaDataSet))
-                            {
-                                return false;
-                            }
-
-                            stateObj._cleanupAltMetaDataSetArray.SetAltMetaData(cleanupAltMetaDataSet);
-                            if (null != dataStream)
-                            {
-                                byte metadataConsumedByte;
-                                if (!stateObj.TryPeekByte(out metadataConsumedByte))
-                                {
-                                    return false;
-                                }
-                                if (!dataStream.TrySetAltMetaDataSet(cleanupAltMetaDataSet, (TdsEnums.SQLALTMETADATA != metadataConsumedByte)))
-                                {
-                                    return false;
-                                }
-                            }
-
-                            break;
-                        }
-
-                    case TdsEnums.SQLALTROW:
-                        {
-                            if (!stateObj.TryStartNewRow(isNullCompressed: false))
-                            { // altrows are not currently null compressed
-                                return false;
-                            }
-
-                            // read will call run until dataReady. Must not read any data if ReturnImmediately set
-                            if (RunBehavior.ReturnImmediately != (RunBehavior.ReturnImmediately & runBehavior))
-                            {
-                                ushort altRowId;
-                                if (!stateObj.TryReadUInt16(out altRowId))
-                                { // get altRowId
-                                    return false;
-                                }
-
-                                if (!TrySkipRow(stateObj._cleanupAltMetaDataSetArray.GetAltMetaData(altRowId), stateObj))
-                                { // skip altRow
-                                    return false;
-                                }
-                            }
-                            else
-                            {
-                                dataReady = true;
-                            }
-
-                            break;
-                        }
-
                     case TdsEnums.SQLENVCHANGE:
                         {
                             // ENVCHANGE must be processed synchronously (since it can modify the state of many objects)
@@ -2556,6 +2494,69 @@ namespace Microsoft.Data.SqlClient
                             }
                             break;
                         }
+
+                    // deprecated
+                    case TdsEnums.SQLALTMETADATA:
+                        {
+                            stateObj.CloneCleanupAltMetaDataSetArray();
+
+                            if (stateObj._cleanupAltMetaDataSetArray == null)
+                            {
+                                // create object on demand (lazy creation)
+                                stateObj._cleanupAltMetaDataSetArray = new _SqlMetaDataSetCollection();
+                            }
+
+                            _SqlMetaDataSet cleanupAltMetaDataSet;
+                            if (!TryProcessAltMetaData(tokenLength, stateObj, out cleanupAltMetaDataSet))
+                            {
+                                return false;
+                            }
+
+                            stateObj._cleanupAltMetaDataSetArray.SetAltMetaData(cleanupAltMetaDataSet);
+                            if (null != dataStream)
+                            {
+                                byte metadataConsumedByte;
+                                if (!stateObj.TryPeekByte(out metadataConsumedByte))
+                                {
+                                    return false;
+                                }
+                                if (!dataStream.TrySetAltMetaDataSet(cleanupAltMetaDataSet, (TdsEnums.SQLALTMETADATA != metadataConsumedByte)))
+                                {
+                                    return false;
+                                }
+                            }
+
+                            break;
+                        }
+                    case TdsEnums.SQLALTROW:
+                        {
+                            if (!stateObj.TryStartNewRow(isNullCompressed: false))
+                            { // altrows are not currently null compressed
+                                return false;
+                            }
+
+                            // read will call run until dataReady. Must not read any data if ReturnImmediately set
+                            if (RunBehavior.ReturnImmediately != (RunBehavior.ReturnImmediately & runBehavior))
+                            {
+                                ushort altRowId;
+                                if (!stateObj.TryReadUInt16(out altRowId))
+                                { // get altRowId
+                                    return false;
+                                }
+
+                                if (!TrySkipRow(stateObj._cleanupAltMetaDataSetArray.GetAltMetaData(altRowId), stateObj))
+                                { // skip altRow
+                                    return false;
+                                }
+                            }
+                            else
+                            {
+                                dataReady = true;
+                            }
+
+                            break;
+                        }
+
                     default:
                         Debug.Fail("Unhandled token:  " + token.ToString(CultureInfo.InvariantCulture));
                         break;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -3484,21 +3484,6 @@ namespace Microsoft.Data.SqlClient
 
                     switch (token)
                     {
-                        case TdsEnums.SQLALTROW:
-                            if (_altRowStatus == ALTROWSTATUS.Null)
-                            {
-                                // cache the regular metadata
-                                _altMetaDataSetCollection.metaDataSet = _metaData;
-                                _metaData = null;
-                            }
-                            else
-                            {
-                                Debug.Assert(_altRowStatus == ALTROWSTATUS.Done, "invalid AltRowStatus");
-                            }
-                            _altRowStatus = ALTROWSTATUS.AltRow;
-                            _hasRows = true;
-                            moreResults = true;
-                            return true;
                         case TdsEnums.SQLROW:
                         case TdsEnums.SQLNBCROW:
                             // always happens if there is a row following an altrow
@@ -3516,6 +3501,23 @@ namespace Microsoft.Data.SqlClient
                             moreResults = true;
                             return true;
                         case TdsEnums.SQLCOLMETADATA:
+                            moreResults = true;
+                            return true;
+
+                        // deprecated
+                        case TdsEnums.SQLALTROW:
+                            if (_altRowStatus == ALTROWSTATUS.Null)
+                            {
+                                // cache the regular metadata
+                                _altMetaDataSetCollection.metaDataSet = _metaData;
+                                _metaData = null;
+                            }
+                            else
+                            {
+                                Debug.Assert(_altRowStatus == ALTROWSTATUS.Done, "invalid AltRowStatus");
+                            }
+                            _altRowStatus = ALTROWSTATUS.AltRow;
+                            _hasRows = true;
                             moreResults = true;
                             return true;
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -2624,68 +2624,6 @@ namespace Microsoft.Data.SqlClient
                             break;
                         }
 
-                    case TdsEnums.SQLALTMETADATA:
-                        {
-                            stateObj.CloneCleanupAltMetaDataSetArray();
-
-                            if (stateObj._cleanupAltMetaDataSetArray == null)
-                            {
-                                // create object on demand (lazy creation)
-                                stateObj._cleanupAltMetaDataSetArray = new _SqlMetaDataSetCollection();
-                            }
-
-                            _SqlMetaDataSet cleanupAltMetaDataSet;
-                            if (!TryProcessAltMetaData(tokenLength, stateObj, out cleanupAltMetaDataSet))
-                            {
-                                return false;
-                            }
-
-                            stateObj._cleanupAltMetaDataSetArray.SetAltMetaData(cleanupAltMetaDataSet);
-                            if (null != dataStream)
-                            {
-                                byte metadataConsumedByte;
-                                if (!stateObj.TryPeekByte(out metadataConsumedByte))
-                                {
-                                    return false;
-                                }
-                                if (!dataStream.TrySetAltMetaDataSet(cleanupAltMetaDataSet, (TdsEnums.SQLALTMETADATA != metadataConsumedByte)))
-                                {
-                                    return false;
-                                }
-                            }
-
-                            break;
-                        }
-
-                    case TdsEnums.SQLALTROW:
-                        {
-                            if (!stateObj.TryStartNewRow(isNullCompressed: false))
-                            { // altrows are not currently null compressed
-                                return false;
-                            }
-
-                            // read will call run until dataReady. Must not read any data if return immediately set
-                            if (RunBehavior.ReturnImmediately != (RunBehavior.ReturnImmediately & runBehavior))
-                            {
-                                ushort altRowId;
-                                if (!stateObj.TryReadUInt16(out altRowId))
-                                { // get altRowId
-                                    return false;
-                                }
-
-                                if (!TrySkipRow(stateObj._cleanupAltMetaDataSetArray.GetAltMetaData(altRowId), stateObj))
-                                { // skip altRow
-                                    return false;
-                                }
-                            }
-                            else
-                            {
-                                dataReady = true;
-                            }
-
-                            break;
-                        }
-
                     case TdsEnums.SQLENVCHANGE:
                         {
                             // ENVCHANGE must be processed synchronously (since it can modify the state of many objects)
@@ -3002,6 +2940,68 @@ namespace Microsoft.Data.SqlClient
                             {
                                 return false;
                             }
+                            break;
+                        }
+
+                    // deprecated
+                    case TdsEnums.SQLALTMETADATA:
+                        {
+                            stateObj.CloneCleanupAltMetaDataSetArray();
+
+                            if (stateObj._cleanupAltMetaDataSetArray == null)
+                            {
+                                // create object on demand (lazy creation)
+                                stateObj._cleanupAltMetaDataSetArray = new _SqlMetaDataSetCollection();
+                            }
+
+                            _SqlMetaDataSet cleanupAltMetaDataSet;
+                            if (!TryProcessAltMetaData(tokenLength, stateObj, out cleanupAltMetaDataSet))
+                            {
+                                return false;
+                            }
+
+                            stateObj._cleanupAltMetaDataSetArray.SetAltMetaData(cleanupAltMetaDataSet);
+                            if (null != dataStream)
+                            {
+                                byte metadataConsumedByte;
+                                if (!stateObj.TryPeekByte(out metadataConsumedByte))
+                                {
+                                    return false;
+                                }
+                                if (!dataStream.TrySetAltMetaDataSet(cleanupAltMetaDataSet, (TdsEnums.SQLALTMETADATA != metadataConsumedByte)))
+                                {
+                                    return false;
+                                }
+                            }
+
+                            break;
+                        }
+                    case TdsEnums.SQLALTROW:
+                        {
+                            if (!stateObj.TryStartNewRow(isNullCompressed: false))
+                            { // altrows are not currently null compressed
+                                return false;
+                            }
+
+                            // read will call run until dataReady. Must not read any data if return immediately set
+                            if (RunBehavior.ReturnImmediately != (RunBehavior.ReturnImmediately & runBehavior))
+                            {
+                                ushort altRowId;
+                                if (!stateObj.TryReadUInt16(out altRowId))
+                                { // get altRowId
+                                    return false;
+                                }
+
+                                if (!TrySkipRow(stateObj._cleanupAltMetaDataSetArray.GetAltMetaData(altRowId), stateObj))
+                                { // skip altRow
+                                    return false;
+                                }
+                            }
+                            else
+                            {
+                                dataReady = true;
+                            }
+
                             break;
                         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Diagnostics;
 using Microsoft.Data.Common;
@@ -143,6 +144,9 @@ namespace Microsoft.Data.SqlClient
         public const byte SQLALTCONTROL = 0xaf;
         public const byte SQLROW = 0xd1;
         public const byte SQLNBCROW = 0xd2;    // same as ROW with null-bit-compression support
+        /// <summary>
+        /// Deprecated in TDS7.4 (2010)
+        /// </summary>
         public const byte SQLALTROW = 0xd3;
         public const byte SQLDONE = 0xfd;
         public const byte SQLDONEPROC = 0xfe;
@@ -157,6 +161,9 @@ namespace Microsoft.Data.SqlClient
         public const byte SQLSECLEVEL = 0xed;    // Security level token ???
         public const byte SQLROWCRC = 0x39;    // ROWCRC datastream???
         public const byte SQLCOLMETADATA = 0x81;    // Column metadata including name
+        /// <summary>
+        /// Deprecated in TDS7.4 (2010)
+        /// </summary>
         public const byte SQLALTMETADATA = 0x88;    // Alt column metadata including name
         public const byte SQLSSPI = 0xed;    // SSPI data
         public const byte SQLFEDAUTHINFO = 0xee;    // Info for client to generate fed auth token


### PR DESCRIPTION
The MS-TDS spec identifies that two sql tokens were deprecated in TDS 7.4 which is from around 2010. We still support these tokens in the code but they're checked in a few switch statements before tokens which are still in use and this is a waste of time. This PR moves the two deprecated tokens to the bottom of the list so they'll still work if we somehow encounter them but they'll be the last things checked for. It also puts a note on the definition and uses of the token to indicate that it is deprecated.