### PR TITLE
Fix | Updating version for Azure.Identity

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -27,7 +27,7 @@
   </PropertyGroup>
   <!-- NetFx and NetCore project dependencies -->
   <PropertyGroup>
-    <AzureIdentityVersion>1.8.0</AzureIdentityVersion>
+    <AzureIdentityVersion>1.10.2</AzureIdentityVersion>
     <MicrosoftIdentityClientVersion>4.53.0</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.24.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
     <MicrosoftIdentityModelJsonWebTokensVersion>6.24.0</MicrosoftIdentityModelJsonWebTokensVersion>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -55,7 +55,7 @@
   </PropertyGroup>
   <!-- AKV Provider project dependencies -->
   <PropertyGroup>
-    <AzureCoreVersion>[1.25.0,2.0.0)</AzureCoreVersion>
+    <AzureCoreVersion>[1.35.0,2.0.0)</AzureCoreVersion>
     <AzureSecurityKeyVaultKeysVersion>[4.4.0,5.0.0)</AzureSecurityKeyVaultKeysVersion>
     <MicrosoftExtensionsCachingMemoryVersion>6.0.1</MicrosoftExtensionsCachingMemoryVersion>
   </PropertyGroup>


### PR DESCRIPTION
Older versions than 1.10.2 are vulnerable. https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-36414

Also fixes #2181 