### PR TITLE
SqlBatch: Add missing overrides and tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1775,6 +1775,14 @@ namespace Microsoft.Data.SqlClient
             return InnerConnection.GetSchema(ConnectionFactory, PoolGroup, this, collectionName, restrictionValues);
         }
 
+#if NET6_0_OR_GREATER
+        /// <inheritdoc />
+        public override bool CanCreateBatch => true;
+
+        /// <inheritdoc />
+        protected override DbBatch CreateDbBatch() => new SqlBatch(this);
+#endif
+
         private class OpenAsyncRetry
         {
             private SqlConnection _parent;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Batch/BatchTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Batch/BatchTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
     public static class BatchTests
     {
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void MissingCommandTextThrows()
         {
@@ -24,7 +24,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void MissingConnectionThrows()
         {
@@ -34,7 +33,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ConnectionCanCreateBatch()
         {
@@ -54,7 +52,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
 #if NET8_0_OR_GREATER
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void SqlBatchCanCreateParameter()
         {
@@ -76,7 +73,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 #endif 
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void StoredProcedureBatchSupported()
         {
@@ -88,7 +84,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void CommandTextBatchSupported()
         {
@@ -100,14 +95,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void TableDirectBatchNotSupported()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new SqlBatchCommand("Categories", CommandType.TableDirect));
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void MixedBatchSupported()
         {
@@ -127,7 +120,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void DisposedThrows()
         {
@@ -136,7 +128,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.Throws<ObjectDisposedException>(() => batch.ExecuteNonQuery());
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ProviderApi()
         {
@@ -209,7 +200,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void DirectApi()
         {
@@ -281,7 +271,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.NotNull(exception.BatchCommand);
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ExceptionInBatchContainsBatch()
         {
@@ -319,7 +308,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.NotNull(exception.BatchCommand);
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ExceptionWithoutBatchContainsNoBatch()
         {
@@ -349,7 +337,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.Null(exception.BatchCommand);
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ParameterInOutAndReturn()
         {
@@ -402,7 +389,6 @@ END";
             Assert.Equal(2, Convert.ToInt32(returned.Value));
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ExecuteNonQuery()
         {
@@ -465,7 +451,6 @@ END";
             Assert.Equal(1, batch.Commands[2].RecordsAffected);
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static async Task ExecuteNonQueryAsync()
         {
@@ -528,7 +513,6 @@ END";
             Assert.Equal(1, batch.Commands[2].RecordsAffected);
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ExecuteScalarMultiple()
         {
@@ -548,7 +532,6 @@ END";
             Assert.Equal(9, value);
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static async Task ExecuteScalarAsyncMultiple()
         {
@@ -568,7 +551,6 @@ END";
             Assert.Equal(9, value);
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void ExecuteReaderMultiple()
         {
@@ -600,7 +582,6 @@ END";
             Assert.Equal(10, resultRowCount);
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static async Task ExecuteReaderAsyncMultiple()
         {


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/2222

Add missing overrides for SqlConnection CanCreateBatch and CreateDbBatch() and tests
Add test for SqlBatchCommand CanCreateParameter and CreateParameter() wrapped in #ifdef
Adding a net8 build is out of scope for this PR. That needs approval at very least from the MS side. When it is added the net8 features and tests related to the sql batch feature should light up automatically.

@David-Engel we'll want to get this in before the next preview. 

/cc @mgravell