### PR TITLE
Fix | Linux SPN port number using named instance and Kerberos authentication does not return port#

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             else if (!string.IsNullOrWhiteSpace(dataSource.InstanceName))
             {
-                postfix = (dataSource._connectionProtocol == DataSource.Protocol.TCP ? dataSource.ResolvedPort.ToString() : dataSource.InstanceName);
+                postfix = dataSource._connectionProtocol == DataSource.Protocol.TCP ? dataSource.ResolvedPort.ToString() : dataSource.InstanceName;
             }
 
             SqlClientEventSource.Log.TryTraceEvent("SNIProxy.GetSqlServerSPN | Info | ServerName {0}, InstanceName {1}, Port {2}, postfix {3}", dataSource?.ServerName, dataSource?.InstanceName, dataSource?.Port, postfix);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Data.SqlClient.SNI
             }
             else if (!string.IsNullOrWhiteSpace(dataSource.InstanceName))
             {
-                postfix = dataSource.InstanceName;
+                postfix = (dataSource._connectionProtocol == DataSource.Protocol.TCP ? dataSource.ResolvedPort.ToString() : dataSource.InstanceName);
             }
 
             SqlClientEventSource.Log.TryTraceEvent("SNIProxy.GetSqlServerSPN | Info | ServerName {0}, InstanceName {1}, Port {2}, postfix {3}", dataSource?.ServerName, dataSource?.InstanceName, dataSource?.Port, postfix);
@@ -317,7 +317,7 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 try
                 {
-                    port = isAdminConnection ?
+                    details.ResolvedPort = port = isAdminConnection ?
                             SSRP.GetDacPortByInstanceName(hostName, details.InstanceName, timeout, parallel, ipPreference) :
                             SSRP.GetPortByInstanceName(hostName, details.InstanceName, timeout, parallel, ipPreference);
                 }
@@ -435,6 +435,11 @@ namespace Microsoft.Data.SqlClient.SNI
         /// Provides the port on which the TCP connection should be made if one was specified in Data Source
         /// </summary>
         internal int Port { get; private set; } = -1;
+
+        /// <summary>
+        /// The port resolved by SSRP when InstanceName is specified
+        /// </summary>
+        internal int ResolvedPort { get; set; } = -1;
 
         /// <summary>
         /// Provides the inferred Instance Name from Server Data Source

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -1073,28 +1073,24 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return fqdn.ToString();
         }
 
-        public static bool IsIntegratedSecurity()
-        {
-            SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString);
-            return builder.IntegratedSecurity;  
-        }
-
         public static bool IsNotLocalhost()
         {
             // get the tcp connection string
             SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString);
 
-            // remove tcp from connection string
-            string dataSourceStr = builder.DataSource.Replace("tcp:", "");
-            // create a string array
-            string[] serverNamePartsByBackSlash = dataSourceStr.Split('\\');
-            // first element of array is the hostname
-            string hostname = serverNamePartsByBackSlash[0];
+            string hostname = "";
 
-            // check if hostname = localhost or . or 127.0.0.1 or ::1
-            if (hostname == "localhost" || hostname == "." || hostname == "127.0.0.1" || hostname == "::1") return false;
+            // parse the datasource
+            ParseDataSource(builder.DataSource, out hostname, out _, out _);
 
-            return true;
+            // hostname must not be localhost, ., 127.0.0.1 nor ::1
+            return !(new string[] { "localhost", ".", "127.0.0.1", "::1" }).Contains(hostname.ToLowerInvariant());
+
+        }
+
+        public static bool IsKerberosManagedSNI() 
+        {
+            return (AreConnStringsSetup() && IsUsingManagedSNI() && IsNotLocalhost() && IsKerberosTest && IsNotAzureServer() && IsNotAzureSynapse());
         }
 
         private static bool RunningAsUWPApp()

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -1073,6 +1073,27 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return fqdn.ToString();
         }
 
+        public static bool IsManagedSNI()
+        {
+            return UseManagedSNIOnWindows;
+        }
+
+        public static bool IsNotLocalhost()
+        {
+            // get the tcp connection string
+            SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString);
+
+            // remove tcp from connection string
+            string dataSourceStr = builder.DataSource.Replace("tcp:", "");
+            // create a string array
+            string[] serverNamePartsByBackSlash = dataSourceStr.Split('\\');
+            // first element of array is the hostname
+            string hostname = serverNamePartsByBackSlash[0];
+
+            // check if hostname = localhost
+            return hostname.Equals("localhost", StringComparison.OrdinalIgnoreCase);
+        }
+
         private static bool RunningAsUWPApp()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -1091,8 +1091,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             // first element of array is the hostname
             string hostname = serverNamePartsByBackSlash[0];
 
-            // check if hostname = localhost
-            return !hostname.Equals("localhost", StringComparison.OrdinalIgnoreCase);
+            // check if hostname = localhost or . or 127.0.0.1 or ::1
+            if (hostname == "localhost" || hostname == "." || hostname == "127.0.0.1" || hostname == "::1") return false;
+
+            return true;
         }
 
         private static bool RunningAsUWPApp()

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -1078,6 +1078,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return UseManagedSNIOnWindows;
         }
 
+        public static bool IsIntegratedSecurity()
+        {
+            SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString);
+            return builder.IntegratedSecurity;  
+        }
+
         public static bool IsNotLocalhost()
         {
             // get the tcp connection string

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -1073,11 +1073,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return fqdn.ToString();
         }
 
-        public static bool IsManagedSNI()
-        {
-            return UseManagedSNIOnWindows;
-        }
-
         public static bool IsIntegratedSecurity()
         {
             SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -1088,11 +1088,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         }
 
-        public static bool IsKerberosManagedSNI() 
-        {
-            return (AreConnStringsSetup() && IsUsingManagedSNI() && IsNotLocalhost() && IsKerberosTest && IsNotAzureServer() && IsNotAzureSynapse());
-        }
-
         private static bool RunningAsUWPApp()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -1097,7 +1097,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             string hostname = serverNamePartsByBackSlash[0];
 
             // check if hostname = localhost
-            return hostname.Equals("localhost", StringComparison.OrdinalIgnoreCase);
+            return !hostname.Equals("localhost", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool RunningAsUWPApp()

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -115,46 +115,37 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private static string GetSPNInfo(string datasource, out int out_port)
         {
-            Assembly systemData = Assembly.GetAssembly(typeof(SqlConnection));
+            Assembly sqlConnectionAssembly = Assembly.GetAssembly(typeof(SqlConnection));
 
             // Get all required types using reflection
-            Type SniProxy = systemData.GetType("Microsoft.Data.SqlClient.SNI.SNIProxy");
-            Type SSRP = systemData.GetType("Microsoft.Data.SqlClient.SNI.SSRP");
-            Type DataSource = systemData.GetType("Microsoft.Data.SqlClient.SNI.DataSource");
-            Type TimeoutTimer = systemData.GetType("Microsoft.Data.ProviderBase.TimeoutTimer");
+            Type sniProxyType = sqlConnectionAssembly.GetType("Microsoft.Data.SqlClient.SNI.SNIProxy");
+            Type ssrpType = sqlConnectionAssembly.GetType("Microsoft.Data.SqlClient.SNI.SSRP");
+            Type dataSourceType = sqlConnectionAssembly.GetType("Microsoft.Data.SqlClient.SNI.DataSource");
+            Type timeoutTimerType = sqlConnectionAssembly.GetType("Microsoft.Data.ProviderBase.TimeoutTimer");
 
             // Used in Datasource constructor param type array 
-            Type[] types = new Type[1];
-            types[0] = typeof(string);
+            Type[] types = new Type[1] { typeof(string) };
 
             // Used in GetSqlServerSPNs function param types array
-            Type[] types2 = new Type[2];
-            types2[0] = DataSource;
-            types2[1] = typeof(string);
+            Type[] types2 = new Type[2] { dataSourceType, typeof(string) };
 
             // GetPortByInstanceName parameters array
-            Type[] types3 = new Type[5];
-            types3[0] = typeof(string);
-            types3[1] = typeof(string);
-            types3[2] = TimeoutTimer;
-            types3[3] = typeof(bool);
-            types3[4] = typeof(Microsoft.Data.SqlClient.SqlConnectionIPAddressPreference);
+            Type[] types3 = new Type[5] { typeof(string), typeof(string), timeoutTimerType, typeof(bool), typeof(Microsoft.Data.SqlClient.SqlConnectionIPAddressPreference) };
 
             // TimeoutTimer.StartSecondsTimeout params
-            Type[] types4 = new Type[1];
-            types4[0] = typeof(int);
+            Type[] types4 = new Type[1] { typeof(int) };
 
             // Get all types constructors
-            ConstructorInfo sniProxyCtor = SniProxy.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, Type.EmptyTypes, null);
-            ConstructorInfo SSRPCtor = SSRP.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, Type.EmptyTypes, null);
-            ConstructorInfo datasSourceCtor = DataSource.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, types , null);
-            ConstructorInfo timeoutTimerCtor = TimeoutTimer.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, Type.EmptyTypes, null);
+            ConstructorInfo sniProxyCtor = sniProxyType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, Type.EmptyTypes, null);
+            ConstructorInfo SSRPCtor = ssrpType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, Type.EmptyTypes, null);
+            ConstructorInfo dataSourceCtor = dataSourceType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, types , null);
+            ConstructorInfo timeoutTimerCtor = timeoutTimerType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, Type.EmptyTypes, null);
 
             // Instantiate SNIProxy
             var sniProxy =  sniProxyCtor.Invoke(new object[] { });
 
-            // Instatntiate datasource 
-            var details = datasSourceCtor.Invoke(new object[] { datasource });
+            // Instantiate datasource 
+            var details = dataSourceCtor.Invoke(new object[] { datasource });
 
             // Instantiate SSRP
             var ssrp = SSRPCtor.Invoke(new object[] { });    

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         // Note: This Unit test was tested in a domain-joined VM connecting to a remote
         //       SQL Server using Kerberos in the same domain.
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsKerberosManagedSNI))]
+        [ConditionalFact(nameof(IsKerberosManagedSNI))]
         public static void PortNumberInSPNTest()
         {
             string connStr = DataTestUtility.TCPConnectionString;
@@ -202,6 +202,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             out_port = (int)port;
 
             return spnInfo;
+        }
+
+        private static bool IsKerberosManagedSNI()
+        {
+            return (DataTestUtility.AreConnStringsSetup() && DataTestUtility.IsUsingManagedSNI() && DataTestUtility.IsNotLocalhost() && DataTestUtility.IsKerberosTest && DataTestUtility.IsNotAzureServer() && DataTestUtility.IsNotAzureSynapse());
         }
 
         private static bool IsBrowserAlive(string browserHostname)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -166,8 +166,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             // Get TimeoutTimer.StartSecondsTimeout Method
             MethodInfo startSecondsTimeout = timeoutTimer.GetType().GetMethod("StartSecondsTimeout", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, types4, null);
-            // Create a timeoutTimer that expires in 100,000 milliseconds
-            timeoutTimer = startSecondsTimeout.Invoke(details, new object[] { 100000 });
+            // Create a timeoutTimer that expires in 30 seconds
+            timeoutTimer = startSecondsTimeout.Invoke(details, new object[] { 30 });
 
             // Parse the datasource to separate the server name and instance name
             MethodInfo ParseServerName = details.GetType().GetMethod("ParseServerName", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, types, null);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -83,6 +83,22 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsManagedSNI), nameof(DataTestUtility.IsNotLocalhost), nameof(DataTestUtility.IsKerberosTest), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotAzureSynapse))]
+        public static void PortNumberInSPNTest()
+        {
+            SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString);
+
+            Assert.True(DataTestUtility.ParseDataSource(builder.DataSource, out string hostname, out _, out string instanceName));
+
+            if (IsBrowserAlive(hostname) && IsValidInstance(hostname, instanceName))
+            {
+                builder.DataSource = hostname + "\\" + instanceName;
+                using SqlConnection connection = new(builder.ConnectionString);
+                connection.Open();
+            }
+        }
+
         private static bool IsBrowserAlive(string browserHostname)
         {
             const byte ClntUcastEx = 0x03;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         // Note: This Unit test was tested in a VM within the sqldrv.ad domain. i.e. from server sqldrv-win22 and
         //       is connecting to a Sql Server using Kerberos at sqldrv-sql22 server in the same domain.
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsManagedSNI), nameof(DataTestUtility.IsNotLocalhost), nameof(DataTestUtility.IsKerberosTest), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotAzureSynapse))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsUsingManagedSNI), nameof(DataTestUtility.IsNotLocalhost), nameof(DataTestUtility.IsKerberosTest), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static void PortNumberInSPNTest()
         {
             SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         // Note: This Unit test was tested in a domain-joined VM connecting to a remote
         //       SQL Server using Kerberos in the same domain.
-        [ConditionalFact(nameof(IsKerberosManagedSNI))]
+        [ConditionalFact(nameof(IsKerberos))]
         public static void PortNumberInSPNTest()
         {
             string connStr = DataTestUtility.TCPConnectionString;
@@ -204,9 +204,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return spnInfo;
         }
 
-        private static bool IsKerberosManagedSNI()
+        private static bool IsKerberos()
         {
-            return (DataTestUtility.AreConnStringsSetup() && DataTestUtility.IsUsingManagedSNI() && DataTestUtility.IsNotLocalhost() && DataTestUtility.IsKerberosTest && DataTestUtility.IsNotAzureServer() && DataTestUtility.IsNotAzureSynapse());
+            return (DataTestUtility.AreConnStringsSetup() && DataTestUtility.IsNotLocalhost() && DataTestUtility.IsKerberosTest && DataTestUtility.IsNotAzureServer() && DataTestUtility.IsNotAzureSynapse());
         }
 
         private static bool IsBrowserAlive(string browserHostname)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 int port = -1;
                 string spnInfo = GetSPNInfo(builder.DataSource, out port);
 
-                // sample output to validate = MSSQLSvc/sqldrv-sql22.sqldrv.ad:1433"
+                // sample output to validate = MSSQLSvc/machine.domain.tld:port"
                 Assert.Contains($"MSSQLSvc/{hostname}", spnInfo);
                 // the local_tcp_port Port is the same as the inferred port from instance name
                 Assert.Equal(Port, port);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -102,7 +103,19 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 Assert.Equal("KERBEROS", reader.GetString(0));
                 int Port = reader.GetInt32(1);
                 Assert.True( Port > 0);
+                Port = GetSPNPort(builder.DataSource);
             }
+        }
+
+        private static int GetSPNPort(string datasource)
+        {
+            Assembly systemData = Assembly.GetAssembly(typeof(SqlConnection));
+            Type SniProxy = systemData.GetType("Microsoft.Data.SqlClient.SNI.SNIProxy");
+            ConstructorInfo sniProxyConstructor = SniProxy.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { }, null);
+
+            Object sniProxy = sniProxyConstructor.Invoke(new object[] { });
+
+            return 0;
         }
 
         private static bool IsBrowserAlive(string browserHostname)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -3,13 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Azure.Core;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -142,16 +142,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             ConstructorInfo timeoutTimerCtor = timeoutTimerType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, Type.EmptyTypes, null);
 
             // Instantiate SNIProxy
-            var sniProxy =  sniProxyCtor.Invoke(new object[] { });
+            object sniProxy =  sniProxyCtor.Invoke(new object[] { });
 
             // Instantiate datasource 
-            var details = dataSourceCtor.Invoke(new object[] { datasource });
+            object details = dataSourceCtor.Invoke(new object[] { datasource });
 
             // Instantiate SSRP
-            var ssrp = SSRPCtor.Invoke(new object[] { });    
+            object ssrp = SSRPCtor.Invoke(new object[] { });    
 
             // Instantiate TimeoutTimer
-            var timeoutTimer = timeoutTimerCtor.Invoke(new object[] { });
+            object timeoutTimer = timeoutTimerCtor.Invoke(new object[] { });
 
             // Get TimeoutTimer.StartSecondsTimeout Method
             MethodInfo startSecondsTimeout = timeoutTimer.GetType().GetMethod("StartSecondsTimeout", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, startSecondsTimeoutTypesArray, null);
@@ -160,7 +160,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             // Parse the datasource to separate the server name and instance name
             MethodInfo ParseServerName = details.GetType().GetMethod("ParseServerName", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, dataSourceConstructorTypesArray, null);
-            var dataSrcInfo = ParseServerName.Invoke(details, new object[] { datasource });
+            object dataSrcInfo = ParseServerName.Invoke(details, new object[] { datasource });
 
             // Get the GetPortByInstanceName method of SSRP
             MethodInfo getPortByInstanceName = ssrp.GetType().GetMethod("GetPortByInstanceName", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, getPortByInstanceNameTypesArray, null);
@@ -174,7 +174,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             string instanceName = instanceNameInfo.GetValue(dataSrcInfo, null).ToString();
 
             // Get the port number using the GetPortByInstanceName method of SSRP
-            var port = getPortByInstanceName.Invoke(ssrp, parameters: new object[] { serverName, instanceName, timeoutTimer, false, 0 } );
+            object port = getPortByInstanceName.Invoke(ssrp, parameters: new object[] { serverName, instanceName, timeoutTimer, false, 0 } );
 
             // Set the resolved port property of datasource
             PropertyInfo resolvedPortInfo = dataSrcInfo.GetType().GetProperty("ResolvedPort", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
@@ -185,6 +185,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             MethodInfo getSqlServerSPNs = sniProxy.GetType().GetMethod("GetSqlServerSPNs", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, getSqlServerSPNsTypesArray, null);
 
             // Finally call GetSqlServerSPNs
+            // Use dynamic type for indexing to work at design time
             dynamic result = getSqlServerSPNs.Invoke(sniProxy, new object[] { dataSrcInfo, serverSPN });
 
             // Example result: MSSQLSvc/sqldrv-sql22.sqldrv.ad:1433"

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -86,8 +86,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         // Note: This Unit test was tested in a domain-joined VM connecting to a remote
         //       SQL Server using Kerberos in the same domain.
-        // Disable this test for now as Davoud said there is an issue.
-        [ActiveIssue("27824")] // Per Davoud, "With specifying instance name and port number, this method call always returns false!"
+        [ActiveIssue("27824")] // When specifying instance name and port number, this method call always returns false
         [ConditionalFact(nameof(IsKerberos))]
         public static void PortNumberInSPNTest()
         {


### PR DESCRIPTION
Fixes Linux SPN to return port number in managed SNI when using named instance and Kerberos authentication.