### PR TITLE
Fix | Fix driver to not send expired token and refresh token first before sending it.

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2257,9 +2257,6 @@ namespace Microsoft.Data.SqlClient
 
                     if (_newDbConnectionPoolAuthenticationContext != null)
                     {
-                        // Try adding this new _newDbConnectionPoolAuthenticationContext to the _dbConnectionPool's AuthenticationContextKeys if it is not in there yet.
-                        // The DbConnectionPoolAuthenticationContextKeys collection is used to refresh a cached token just before it expires within 10 minutes.
-                        //_dbConnectionPool.AuthenticationContexts.TryAdd(new DbConnectionPoolAuthenticationContextKey(fedAuthInfo.stsurl, fedAuthInfo.spn), _newDbConnectionPoolAuthenticationContext);
                         _dbConnectionPool.AuthenticationContexts.TryAdd(_dbConnectionPoolAuthenticationContextKey, _newDbConnectionPoolAuthenticationContext);
                     }
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2259,7 +2259,8 @@ namespace Microsoft.Data.SqlClient
                     {
                         // Try adding this new _newDbConnectionPoolAuthenticationContext to the _dbConnectionPool's AuthenticationContextKeys if it is not in there yet.
                         // The DbConnectionPoolAuthenticationContextKeys collection is used to refresh a cached token just before it expires within 10 minutes.
-                        _dbConnectionPool.AuthenticationContexts.TryAdd(new DbConnectionPoolAuthenticationContextKey(fedAuthInfo.stsurl, fedAuthInfo.spn), _newDbConnectionPoolAuthenticationContext);
+                        //_dbConnectionPool.AuthenticationContexts.TryAdd(new DbConnectionPoolAuthenticationContextKey(fedAuthInfo.stsurl, fedAuthInfo.spn), _newDbConnectionPoolAuthenticationContext);
+                        _dbConnectionPool.AuthenticationContexts.TryAdd(_dbConnectionPoolAuthenticationContextKey, _newDbConnectionPoolAuthenticationContext);
                     }
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2254,6 +2254,13 @@ namespace Microsoft.Data.SqlClient
                 {
                     // GetFedAuthToken should have updated _newDbConnectionPoolAuthenticationContext.
                     Debug.Assert(_newDbConnectionPoolAuthenticationContext != null, "_newDbConnectionPoolAuthenticationContext should not be null.");
+
+                    if (_newDbConnectionPoolAuthenticationContext != null)
+                    {
+                        // Try adding this new _newDbConnectionPoolAuthenticationContext to the _dbConnectionPool's AuthenticationContextKeys if it is not in there yet.
+                        // The DbConnectionPoolAuthenticationContextKeys collection is used to refresh a cached token just before it expires within 10 minutes.
+                        _dbConnectionPool.AuthenticationContexts.TryAdd(new DbConnectionPoolAuthenticationContextKey(fedAuthInfo.stsurl, fedAuthInfo.spn), _newDbConnectionPoolAuthenticationContext);
+                    }
                 }
             }
             else if (!attemptRefreshTokenLocked)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2683,9 +2683,6 @@ namespace Microsoft.Data.SqlClient
 
                     if (_newDbConnectionPoolAuthenticationContext != null)
                     {
-                        // Try adding this new _newDbConnectionPoolAuthenticationContext to the _dbConnectionPool's AuthenticationContextKeys if it is not in there yet.
-                        // The DbConnectionPoolAuthenticationContextKeys collection is used to refresh a cached token just before it expires within 10 minutes.
-                        // _dbConnectionPool.AuthenticationContexts.TryAdd(new DbConnectionPoolAuthenticationContextKey(fedAuthInfo.stsurl, fedAuthInfo.spn), _newDbConnectionPoolAuthenticationContext);
                          _dbConnectionPool.AuthenticationContexts.TryAdd(_dbConnectionPoolAuthenticationContextKey, _newDbConnectionPoolAuthenticationContext);
                     }
                 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2680,6 +2680,13 @@ namespace Microsoft.Data.SqlClient
                 {
                     // GetFedAuthToken should have updated _newDbConnectionPoolAuthenticationContext.
                     Debug.Assert(_newDbConnectionPoolAuthenticationContext != null, "_newDbConnectionPoolAuthenticationContext should not be null.");
+
+                    if (_newDbConnectionPoolAuthenticationContext != null)
+                    {
+                        // Try adding this new _newDbConnectionPoolAuthenticationContext to the _dbConnectionPool's AuthenticationContextKeys if it is not in there yet.
+                        // The DbConnectionPoolAuthenticationContextKeys collection is used to refresh a cached token just before it expires within 10 minutes.
+                        _dbConnectionPool.AuthenticationContexts.TryAdd(new DbConnectionPoolAuthenticationContextKey(fedAuthInfo.stsurl, fedAuthInfo.spn), _newDbConnectionPoolAuthenticationContext);
+                    }
                 }
             }
             else if (!attemptRefreshTokenLocked)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2685,7 +2685,8 @@ namespace Microsoft.Data.SqlClient
                     {
                         // Try adding this new _newDbConnectionPoolAuthenticationContext to the _dbConnectionPool's AuthenticationContextKeys if it is not in there yet.
                         // The DbConnectionPoolAuthenticationContextKeys collection is used to refresh a cached token just before it expires within 10 minutes.
-                        _dbConnectionPool.AuthenticationContexts.TryAdd(new DbConnectionPoolAuthenticationContextKey(fedAuthInfo.stsurl, fedAuthInfo.spn), _newDbConnectionPoolAuthenticationContext);
+                        // _dbConnectionPool.AuthenticationContexts.TryAdd(new DbConnectionPoolAuthenticationContextKey(fedAuthInfo.stsurl, fedAuthInfo.spn), _newDbConnectionPoolAuthenticationContext);
+                         _dbConnectionPool.AuthenticationContexts.TryAdd(_dbConnectionPoolAuthenticationContextKey, _newDbConnectionPoolAuthenticationContext);
                     }
                 }
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -170,6 +170,7 @@
     <Compile Include="ProviderAgnostic\MultipleResultsTest\MultipleResultsTest.cs" />
     <Compile Include="ProviderAgnostic\ReaderTest\ReaderTest.cs" />
     <Compile Include="TracingTests\EventSourceTest.cs" />
+    <Compile Include="SQL\AADFedAuthTokenRefreshTest\AADFedAuthTokenRefreshTest.cs" />
     <Compile Include="SQL\ConnectionPoolTest\ConnectionPoolTest.cs" />
     <Compile Include="SQL\ConnectionPoolTest\PoolBlockPeriodTest.cs" />
     <Compile Include="SQL\InstanceNameTest\InstanceNameTest.cs" />
@@ -267,6 +268,7 @@
     <Compile Include="DataCommon\ProxyServer.cs" />
     <Compile Include="DataCommon\SqlClientCustomTokenCredential.cs" />
     <Compile Include="DataCommon\SystemDataResourceManager.cs" />
+    <Compile Include="SQL\AADFedAuthTokenRefreshTest\AADFedAuthTokenRefreshTest.cs" />
     <Compile Include="SQL\Common\AsyncDebugScope.cs" />
     <Compile Include="SQL\Common\ConnectionPoolWrapper.cs" />
     <Compile Include="SQL\Common\InternalConnectionWrapper.cs" />
@@ -298,30 +300,19 @@
     <ProjectReference Include="$(TestsPath)tools\TDS\TDS.EndPoint\TDS.EndPoint.csproj" />
     <ProjectReference Include="$(TestsPath)tools\TDS\TDS.Servers\TDS.Servers.csproj" />
     <ProjectReference Include="$(TestsPath)tools\TDS\TDS\TDS.csproj" />
-    <ProjectReference
-      Include="$(TestsPath)tools\Microsoft.Data.SqlClient.TestUtilities\Microsoft.Data.SqlClient.TestUtilities.csproj" />
-    <ProjectReference Condition="'$(TargetGroup)'=='netcoreapp' AND $(ReferenceType)=='Project'"
-      Include="$(NetCoreSource)src\Microsoft.Data.SqlClient.csproj" />
-    <ProjectReference Condition="'$(TargetGroup)'=='netfx' AND $(ReferenceType)=='Project'"
-      Include="$(NetFxSource)src\Microsoft.Data.SqlClient.csproj" />
-    <ProjectReference Condition="$(ReferenceType.Contains('NetStandard'))"
-      Include="$(TestsPath)NSLibrary\Microsoft.Data.SqlClient.NSLibrary.csproj" />
-    <ProjectReference Condition="!$(ReferenceType.Contains('Package'))"
-      Include="$(SqlServerSource)Microsoft.SqlServer.Server.csproj" />
-    <PackageReference Condition="$(ReferenceType.Contains('Package'))"
-      Include="Microsoft.Data.SqlClient" Version="$(TestMicrosoftDataSqlClientVersion)" />
-    <ProjectReference
-      Include="$(TestsPath)CustomConfigurableRetryLogic\CustomRetryLogicProvider.csproj" />
+    <ProjectReference Include="$(TestsPath)tools\Microsoft.Data.SqlClient.TestUtilities\Microsoft.Data.SqlClient.TestUtilities.csproj" />
+    <ProjectReference Condition="'$(TargetGroup)'=='netcoreapp' AND $(ReferenceType)=='Project'" Include="$(NetCoreSource)src\Microsoft.Data.SqlClient.csproj" />
+    <ProjectReference Condition="'$(TargetGroup)'=='netfx' AND $(ReferenceType)=='Project'" Include="$(NetFxSource)src\Microsoft.Data.SqlClient.csproj" />
+    <ProjectReference Condition="$(ReferenceType.Contains('NetStandard'))" Include="$(TestsPath)NSLibrary\Microsoft.Data.SqlClient.NSLibrary.csproj" />
+    <ProjectReference Condition="!$(ReferenceType.Contains('Package'))" Include="$(SqlServerSource)Microsoft.SqlServer.Server.csproj" />
+    <PackageReference Condition="$(ReferenceType.Contains('Package'))" Include="Microsoft.Data.SqlClient" Version="$(TestMicrosoftDataSqlClientVersion)" />
+    <ProjectReference Include="$(TestsPath)CustomConfigurableRetryLogic\CustomRetryLogicProvider.csproj" />
   </ItemGroup>
   <!-- XUnit and XUnit extensions -->
   <ItemGroup>
-    <PackageReference Condition="$(TargetGroup) == 'netfx'"
-      Include="System.Runtime.InteropServices.RuntimeInformation"
-      Version="$(SystemRuntimeInteropServicesRuntimeInformationVersion)" />
+    <PackageReference Condition="$(TargetGroup) == 'netfx'" Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(SystemRuntimeInteropServicesRuntimeInformationVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies"
-      Version="$(MicrosoftNETFrameworkReferenceAssembliesVersion)"
-      Condition="'$(TargetGroup)' == 'netfx'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="$(MicrosoftNETFrameworkReferenceAssembliesVersion)" Condition="'$(TargetGroup)' == 'netfx'">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -334,8 +325,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit.runner.utility" Version="$(XunitVersion)" />
-    <PackageReference Include="Microsoft.DotNet.XUnitExtensions"
-      Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -170,7 +170,6 @@
     <Compile Include="ProviderAgnostic\MultipleResultsTest\MultipleResultsTest.cs" />
     <Compile Include="ProviderAgnostic\ReaderTest\ReaderTest.cs" />
     <Compile Include="TracingTests\EventSourceTest.cs" />
-    <Compile Include="SQL\AADFedAuthTokenRefreshTest\AADFedAuthTokenRefreshTest.cs" />
     <Compile Include="SQL\ConnectionPoolTest\ConnectionPoolTest.cs" />
     <Compile Include="SQL\ConnectionPoolTest\PoolBlockPeriodTest.cs" />
     <Compile Include="SQL\InstanceNameTest\InstanceNameTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -170,6 +170,7 @@
     <Compile Include="ProviderAgnostic\MultipleResultsTest\MultipleResultsTest.cs" />
     <Compile Include="ProviderAgnostic\ReaderTest\ReaderTest.cs" />
     <Compile Include="TracingTests\EventSourceTest.cs" />
+    <Compile Include="SQL\AADFedAuthTokenRefreshTest\AADFedAuthTokenRefreshTest.cs" />
     <Compile Include="SQL\ConnectionPoolTest\ConnectionPoolTest.cs" />
     <Compile Include="SQL\ConnectionPoolTest\PoolBlockPeriodTest.cs" />
     <Compile Include="SQL\InstanceNameTest\InstanceNameTest.cs" />
@@ -267,7 +268,6 @@
     <Compile Include="DataCommon\ProxyServer.cs" />
     <Compile Include="DataCommon\SqlClientCustomTokenCredential.cs" />
     <Compile Include="DataCommon\SystemDataResourceManager.cs" />
-    <Compile Include="SQL\AADFedAuthTokenRefreshTest\AADFedAuthTokenRefreshTest.cs" />
     <Compile Include="SQL\Common\AsyncDebugScope.cs" />
     <Compile Include="SQL\Common\ConnectionPoolWrapper.cs" />
     <Compile Include="SQL\Common\InternalConnectionWrapper.cs" />
@@ -276,6 +276,7 @@
     <Compile Include="SQL\Common\SystemDataInternals\ConnectionHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\ConnectionPoolHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\DataReaderHelper.cs" />
+    <Compile Include="SQL\Common\SystemDataInternals\FedAuthTokenHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserHelper.cs" />
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserStateObjectHelper.cs" />
     <Compile Include="SQL\ConnectionTestWithSSLCert\CertificateTest.cs" />
@@ -341,7 +342,7 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtVersion)" />
     <PackageReference Condition="'$(TargetGroup)'=='netfx'" Include="Microsoft.SqlServer.Types" Version="$(MicrosoftSqlServerTypesVersion)" />
     <PackageReference Condition="'$(TargetGroup)'=='netcoreapp'" Include="Microsoft.SqlServer.Types" Version="$(MicrosoftSqlServerTypesVersionNet)" />
-    <PackageReference Condition="'$(TargetGroup)'=='netcoreapp'" Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotnetRemoteExecutorVersion)" /> 
+    <PackageReference Condition="'$(TargetGroup)'=='netcoreapp'" Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotnetRemoteExecutorVersion)" />
     <PackageReference Condition="'$(TargetGroup)'!='netfx'" Include="System.ServiceProcess.ServiceController" Version="$(SystemServiceProcessServiceControllerVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 DateTime oldLocalExpiryTime = TimeZoneInfo.ConvertTimeFromUtc((DateTime)oldExpiryDateTime, TimeZoneInfo.Local);
                 LogInfo($"Token: {oldTokenHash}   Old Expiry: {oldLocalExpiryTime}");
                 TimeSpan timeDiff = oldLocalExpiryTime - DateTime.Now;
-                Assert.True(timeDiff.TotalSeconds <= 60, "Failed to set expiry after 1 minute from current time.");
+                Assert.InRange(timeDiff.TotalSeconds, 0, 60);
 
                 // Check if connection is still alive to continue further testing
                 string result = "";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
@@ -21,82 +21,57 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAADPasswordConnStrSetup))]
         public void FedAuthTokenRefreshTest()
         {
-            // ------------------  Use settings below for local environment testing  ------------------------
-            //SqlConnectionStringBuilder builder = new(DataTestUtility.AADPasswordConnectionString);
-            //string dataSourceStr = builder.DataSource;
-
-            //// set user id and password from AADPasswordConnectionString
-            //string user = builder.UserID;
-            //string password = builder.Password;
-
-            //// Set Environment variables used for ActiveDirectoryDefault authentication type
-            //Environment.SetEnvironmentVariable("AZURE_USERNAME", $"{user}");
-            //Environment.SetEnvironmentVariable("AZURE_PASSWORD", $"{password}");
-
-            //string userEnvVar = Environment.GetEnvironmentVariable("AZURE_USERNAME");
-            //string passwordEnvVar = Environment.GetEnvironmentVariable("AZURE_PASSWORD");
-            //Assert.True($"{user}" == userEnvVar, @"AZURE_USERNAME environment variable must be set");
-            //Assert.True($"{password}" == passwordEnvVar, @"AZURE_PASSWORD environment variable must be set");
-
-            //// Local environment connection string
-            //string connStr = $"Server={dataSourceStr};Persist Security Info=False;User ID={user};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Authentication=ActiveDirectoryDefault;Timeout=90";
-           
-            // ------------------ End of local environment settings ----------------------------------------------------
-
-            // ------------------ Pipeline environment setting ---------------------------------------------------------
-            // Use this connection string when running in a pipeline
             string connStr = DataTestUtility.AADPasswordConnectionString;
-            // -------------------End of Pipeline environment setting --------------------------------------------------
 
             // Create a new connection object and open it
-            SqlConnection connection = new SqlConnection(connStr);
-            connection.Open();
+            using (SqlConnection connection = new SqlConnection(connStr))
+            {
+                connection.Open();
 
-            // Set the token expiry to expire in 1 minute from now to force token refresh
-            string tokenHash1 = "";
-            DateTime? oldExpiry = GetOrSetTokenExpiryDateTime(connection, true, out tokenHash1);
-            Assert.True(oldExpiry != null, "Failed to make token expiry to expire in one minute.");
+                // Set the token expiry to expire in 1 minute from now to force token refresh
+                string tokenHash1 = "";
+                DateTime? oldExpiry = GetOrSetTokenExpiryDateTime(connection, true, out tokenHash1);
+                Assert.True(oldExpiry != null, "Failed to make token expiry to expire in one minute.");
 
-            // Display old expiry in local time which should be in 1 minute from now
-            DateTime oldLocalExpiryTime = TimeZoneInfo.ConvertTimeFromUtc((DateTime)oldExpiry, TimeZoneInfo.Local);
-            LogInfo($"Token: {tokenHash1}   Old Expiry: {oldLocalExpiryTime}");
-            TimeSpan timeDiff = oldLocalExpiryTime - DateTime.Now;
-            Assert.True(timeDiff.TotalSeconds <= 60, "Failed to set expiry after 1 minute from current time.");
+                // Display old expiry in local time which should be in 1 minute from now
+                DateTime oldLocalExpiryTime = TimeZoneInfo.ConvertTimeFromUtc((DateTime)oldExpiry, TimeZoneInfo.Local);
+                LogInfo($"Token: {tokenHash1}   Old Expiry: {oldLocalExpiryTime}");
+                TimeSpan timeDiff = oldLocalExpiryTime - DateTime.Now;
+                Assert.True(timeDiff.TotalSeconds <= 60, "Failed to set expiry after 1 minute from current time.");
 
-            // Check if connection is alive
-            string result = "";
-            SqlCommand cmd = connection.CreateCommand();
-            cmd.CommandText = "select @@version";
-            result = $"{cmd.ExecuteScalar()}";
-            Assert.True(result != string.Empty, "The connection's command must return a value");
+                // Check if connection is alive
+                string result = "";
+                SqlCommand cmd = connection.CreateCommand();
+                cmd.CommandText = "select @@version";
+                result = $"{cmd.ExecuteScalar()}";
+                Assert.True(result != string.Empty, "The connection's command must return a value");
 
-            // The new connection will use the same FedAuthToken but will refresh it first as it will expire in 1 minute.
-            SqlConnection connection2 = new SqlConnection(connStr);
-            connection2.Open();
+                // The new connection will use the same FedAuthToken but will refresh it first as it will expire in 1 minute.
+                using (SqlConnection connection2 = new SqlConnection(connStr))
+                {
+                    connection2.Open();
 
-            // Check again if connection is alive
-            cmd = connection2.CreateCommand();
-            cmd.CommandText = "select 1";
-            result = $"{cmd.ExecuteScalar()}";
-            Assert.True(result != string.Empty, "The connection's command must return a value after a token refresh.");
+                    // Check again if connection is alive
+                    cmd = connection2.CreateCommand();
+                    cmd.CommandText = "select 1";
+                    result = $"{cmd.ExecuteScalar()}";
+                    Assert.True(result != string.Empty, "The connection's command must return a value after a token refresh.");
 
-            // Get the refreshed token expiry
-            string tokenHash2 = "";
-            DateTime? newExpiry = GetOrSetTokenExpiryDateTime(connection2, false, out tokenHash2);
-            // Display new expiry in local time
-            DateTime newLocalExpiryTime = TimeZoneInfo.ConvertTimeFromUtc((DateTime)newExpiry, TimeZoneInfo.Local);
-            LogInfo($"Token: {tokenHash2}   New Expiry: {newLocalExpiryTime}");
+                    // Get the refreshed token expiry
+                    string tokenHash2 = "";
+                    DateTime? newExpiry = GetOrSetTokenExpiryDateTime(connection2, false, out tokenHash2);
+                    // Display new expiry in local time
+                    DateTime newLocalExpiryTime = TimeZoneInfo.ConvertTimeFromUtc((DateTime)newExpiry, TimeZoneInfo.Local);
+                    LogInfo($"Token: {tokenHash2}   New Expiry: {newLocalExpiryTime}");
 
-            Assert.True(tokenHash1 == tokenHash2, "The token's hash before and after token refresh must be identical.");
-            Assert.True(newLocalExpiryTime > oldLocalExpiryTime, "The refreshed token must have a new or later expiry time.");
-            
-            connection.Close();
-            connection2.Close();
+                    Assert.True(tokenHash1 == tokenHash2, "The token's hash before and after token refresh must be identical.");
+                    Assert.True(newLocalExpiryTime > oldLocalExpiryTime, "The refreshed token must have a new or later expiry time.");
+                }
+            }
         }
 
         private void LogInfo(string message)
         {
-            //Console.WriteLine(message);
             _testOutputHelper.WriteLine(message);
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             // Display old expiry in local time which should be in 1 minute from now
             DateTime oldLocalExpiryTime = TimeZoneInfo.ConvertTimeFromUtc((DateTime)oldExpiry, TimeZoneInfo.Local);
-            _output?.WriteLine($"Token: {tokenHash1}   Old Expiry: {oldLocalExpiryTime}");
+            LogInfo($"Token: {tokenHash1}   Old Expiry: {oldLocalExpiryTime}");
             TimeSpan timeDiff = oldLocalExpiryTime - DateTime.Now;
             Assert.True(timeDiff.TotalSeconds <= 60, "Failed to set expiry after 1 minute from current time.");
 
@@ -83,13 +83,18 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             DateTime? newExpiry = GetOrSetTokenExpiryDateTime(connection2, false, out tokenHash2);
             // Display new expiry in local time
             DateTime newLocalTime = TimeZoneInfo.ConvertTimeFromUtc((DateTime)newExpiry, TimeZoneInfo.Local);
-            _output?.WriteLine($"Token: {tokenHash2}   New Expiry: {newLocalTime}");
+            LogInfo($"Token: {tokenHash2}   New Expiry: {newLocalTime}");
 
             Assert.True(tokenHash1 == tokenHash2, "The token's hash before and after token refresh must be identical.");
             Assert.True(newLocalTime > oldLocalExpiryTime, "The refreshed token must have a later expiry time.");
             
             connection.Close();
             connection2.Close();
+        }
+
+        private void LogInfo(string message)
+        {
+            _output?.WriteLine(message);
         }
 
         private DateTime? GetOrSetTokenExpiryDateTime(SqlConnection connection, bool setExpiry, out string tokenHash)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
@@ -11,17 +11,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
     public class AADFedAuthTokenRefreshTest
     {
-        //private readonly ITestOutputHelper _output;
+        private readonly ITestOutputHelper _output;
 
-        //public AADFedAuthTokenRefreshTest(ITestOutputHelper output)
-        //{
-        //    _output = output;
-        //}
+        public AADFedAuthTokenRefreshTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAADPasswordConnStrSetup))]
-        public void FedAuthTokenRefreshTest(ITestOutputHelper output)
+        public void FedAuthTokenRefreshTest()
         {
-            // ------------------  Use settings below for local environment testing in your PC ------------------------
+            // ------------------  Use settings below for local environment testing  ------------------------
             //SqlConnectionStringBuilder builder = new(DataTestUtility.AADPasswordConnectionString);
             //string dataSourceStr = builder.DataSource;
 
@@ -38,13 +38,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             //Assert.True($"{user}" == userEnvVar, @"AZURE_USERNAME environment variable must be set");
             //Assert.True($"{password}" == passwordEnvVar, @"AZURE_PASSWORD environment variable must be set");
 
-            //// This is the format of connection string that works for me
+            //// Local environment connection string
             //string connStr = $"Server={dataSourceStr};Persist Security Info=False;User ID={user};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Authentication=ActiveDirectoryDefault;Timeout=90";
            
             // ------------------ End of local environment settings ----------------------------------------------------
 
+            // ------------------ Pipeline environment setting ---------------------------------------------------------
             // Use this connection string when running in a pipeline
             string connStr = DataTestUtility.AADPasswordConnectionString;
+            // -------------------End of Pipeline environment setting --------------------------------------------------
 
             // Create a new connection object and open it
             SqlConnection connection = new SqlConnection(connStr);
@@ -94,8 +96,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private void LogInfo(string message)
         {
-            //_output?.WriteLine(message);
-            Console.WriteLine(message);
+            //Console.WriteLine(message);
+            _output.WriteLine(message);
         }
 
         private DateTime? GetOrSetTokenExpiryDateTime(SqlConnection connection, bool setExpiry, out string tokenHash)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
@@ -33,13 +33,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 DateTime? oldExpiry = GetOrSetTokenExpiryDateTime(connection, true, out tokenHash1);
                 Assert.True(oldExpiry != null, "Failed to make token expiry to expire in one minute.");
 
-                // Display old expiry in local time which should be in 1 minute from now
+                // Convert and display the old expiry into local time which should be in 1 minute from now
                 DateTime oldLocalExpiryTime = TimeZoneInfo.ConvertTimeFromUtc((DateTime)oldExpiry, TimeZoneInfo.Local);
                 LogInfo($"Token: {tokenHash1}   Old Expiry: {oldLocalExpiryTime}");
                 TimeSpan timeDiff = oldLocalExpiryTime - DateTime.Now;
                 Assert.True(timeDiff.TotalSeconds <= 60, "Failed to set expiry after 1 minute from current time.");
 
-                // Check if connection is alive
+                // Check if connection is still alive to continue further testing
                 string result = "";
                 SqlCommand cmd = connection.CreateCommand();
                 cmd.CommandText = "select @@version";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
     public class AADFedAuthTokenRefreshTest
     {
-        private readonly ITestOutputHelper _output;
+        //private readonly ITestOutputHelper _output;
 
-        public AADFedAuthTokenRefreshTest(ITestOutputHelper output)
-        {
-            _output = output;
-        }
+        //public AADFedAuthTokenRefreshTest(ITestOutputHelper output)
+        //{
+        //    _output = output;
+        //}
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAADPasswordConnStrSetup))]
         public void FedAuthTokenRefreshTest(ITestOutputHelper output)
@@ -94,7 +94,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private void LogInfo(string message)
         {
-            _output?.WriteLine(message);
+            //_output?.WriteLine(message);
+            Console.WriteLine(message);
         }
 
         private DateTime? GetOrSetTokenExpiryDateTime(SqlConnection connection, bool setExpiry, out string tokenHash)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests
+{
+    public class AADFedAuthTokenRefreshTest
+    {
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAADPasswordConnStrSetup))]
+        public void FedAuthTokenRefreshTest()
+        {
+            SqlConnectionStringBuilder builder = new(DataTestUtility.AADPasswordConnectionString);
+            string dataSourceStr = builder.DataSource;
+            // Clean up tcp info as it will always be added later on and we don't want to duplicate if it is there already.
+            dataSourceStr = dataSourceStr.Replace("tcp:", "");
+            dataSourceStr = dataSourceStr.Replace(",1433", "");
+            dataSourceStr = dataSourceStr.Replace(", 1433", "");
+
+            // set user id and password from AADPasswordConnectionString
+            string user = builder.UserID;
+            string password = builder.Password;
+
+            // Set Environment variables used for ActiveDirectoryDefault authentication type
+            Environment.SetEnvironmentVariable("AZURE_USERNAME", $"{user}");
+            Environment.SetEnvironmentVariable("AZURE_PASSWORD", $"{password}");
+
+            string userEnvVar = Environment.GetEnvironmentVariable("AZURE_USERNAME");
+            string passwordEnvVar = Environment.GetEnvironmentVariable("AZURE_PASSWORD");
+            Assert.True($"{user}" == userEnvVar, @"AZURE_USERNAME environment variable must be set");
+            Assert.True($"{password}" == passwordEnvVar, @"AZURE_PASSWORD environment variable must be set");
+
+            // This is the format of connection string that works
+            string connStr = $"Server=tcp:{dataSourceStr},1433;Persist Security Info=False;User ID={user};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Authentication=ActiveDirectoryDefault;Timeout=90";
+
+            using var connection = new SqlConnection(connStr);
+            connection.Open();
+
+            // Set the token expiry to expire in 1 minute from now to force token refresh
+            string tokenHash1 = "";
+            DateTime? oldExpiry = GetOrSetTokenExpiryDateTime(connection, true, out tokenHash1);
+            Assert.True(oldExpiry != null, "Failed to make token expiry to expire in one minute.");
+
+            // Display old expiry in local time which should be in 1 minutes from now
+            DateTime oldLocalTime = TimeZoneInfo.ConvertTimeFromUtc((DateTime)oldExpiry, TimeZoneInfo.Local);
+            Console.WriteLine($"Token: {tokenHash1}   Old Expiry: {oldLocalTime}");
+            TimeSpan diff = oldLocalTime - DateTime.Now;
+            Assert.True(diff.TotalSeconds <= 60, "Failed to set expiry after 1 minute from current time.");
+
+            // Check if connection is alive
+            string result = "";
+            var cmd = connection.CreateCommand();
+            cmd.CommandText = "select @@version";
+            result = $"{cmd.ExecuteScalar()}";
+            Assert.True(result != string.Empty, "The connection's command must return a value");
+
+            // The new connection will use the same FedAuthToken but will refresh first
+            using var connection2 = new SqlConnection(connStr);
+            connection2.Open();
+
+            // Check again if connection is alive
+            cmd = connection2.CreateCommand();
+            cmd.CommandText = "select 1";
+            result = $"{cmd.ExecuteScalar()}";
+            Assert.True(result != string.Empty, "The connection's command must return a value after a token refresh.");
+
+            // Get the refreshed token expiry
+            string tokenHash2 = "";
+            DateTime? newExpiry = GetOrSetTokenExpiryDateTime(connection2, false, out tokenHash2);
+            // Display new expiry in local time
+            DateTime newLocalTime = TimeZoneInfo.ConvertTimeFromUtc((DateTime)newExpiry, TimeZoneInfo.Local);
+            Console.WriteLine($"Token: {tokenHash2}   New Expiry: {newLocalTime}");
+
+            Assert.True(tokenHash1 == tokenHash2, "The FedAuthToken failed to refresh correctly.");
+            Assert.True(newLocalTime > oldLocalTime, "The FedAuthToken failed to refresh correctly.");
+            
+            connection.Close();
+            connection2.Close();
+        }
+
+        private DateTime? GetOrSetTokenExpiryDateTime(SqlConnection connection, bool setExpiry, out string tokenHash)
+        {
+            try
+            {
+                // Get the inner connection
+                object innerConnectionObj = connection.GetType().GetProperty("InnerConnection", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(connection);
+
+                // Get the db connection pool
+                object poolObj = innerConnectionObj.GetType().GetProperty("Pool", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(innerConnectionObj);
+
+                // Get the Authentication Contexts
+                IEnumerable authContextCollection = (IEnumerable)poolObj.GetType().GetProperty("AuthenticationContexts", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(poolObj, null);
+
+                // Get the first authentication context
+                object authContextObj = authContextCollection.Cast<object>().FirstOrDefault();
+
+                // Get the token object from the authentication context
+                object tokenObj = authContextObj.GetType().GetProperty("Value").GetValue(authContextObj, null);
+
+                DateTime expiry = (DateTime)tokenObj.GetType().GetProperty("ExpirationTime", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(tokenObj, null);
+
+                if (setExpiry)
+                {
+                    // Token refresh trigger is within 10 minutes. So, 1 minute expiry should trigger token refresh.
+                    expiry = DateTime.UtcNow.AddMinutes(1);
+
+                    // Apply the expiry to the token object
+                    FieldInfo expirationTime = tokenObj.GetType().GetField("_expirationTime", BindingFlags.NonPublic | BindingFlags.Instance);
+                    expirationTime.SetValue(tokenObj, expiry);
+
+                }
+
+                byte[] tokenBytes = (byte[])tokenObj.GetType().GetProperty("AccessToken", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(tokenObj, null);
+
+                tokenHash = GetTokenHash(tokenBytes);
+
+                return expiry;
+            }
+            catch (Exception)
+            {
+                tokenHash = "";
+                return null;
+            }
+        }
+
+        private string GetTokenHash(byte[] tokenBytes)
+        {
+            string token = Encoding.Unicode.GetString(tokenBytes);
+            var bytesInUtf8 = Encoding.UTF8.GetBytes(token);
+            using (var sha256 = SHA256.Create())
+            {
+                var hash = sha256.ComputeHash(bytesInUtf8);
+                return Convert.ToBase64String(hash);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AADFedAuthTokenRefreshTest/AADFedAuthTokenRefreshTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 ﻿using System;
 using Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.Common.SystemDataInternals;
 using Xunit;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/FedAuthTokenHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/FedAuthTokenHelper.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.Common.SystemDataInternals
+{
+    internal static class FedAuthTokenHelper
+    {
+        internal static DateTime? GetTokenExpiryDateTime(SqlConnection connection, out string tokenHash)
+        {
+            try
+            {
+                object authenticationContextValueObj = GetAuthenticationContextValue(connection);
+
+                DateTime expirationTimeProperty = (DateTime)authenticationContextValueObj.GetType().GetProperty("ExpirationTime", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(authenticationContextValueObj, null);
+
+                tokenHash = GetTokenHash(authenticationContextValueObj);
+
+                return expirationTimeProperty;
+            }
+            catch (Exception)
+            {
+                tokenHash = "";
+                return null;
+            }
+        }
+
+        internal static DateTime? SetTokenExpiryDateTime(SqlConnection connection, int minutesToExpire, out string tokenHash)
+        {
+            try
+            {
+                object authenticationContextValueObj = GetAuthenticationContextValue(connection);
+
+                DateTime expirationTimeProperty = (DateTime)authenticationContextValueObj.GetType().GetProperty("ExpirationTime", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(authenticationContextValueObj, null);
+
+                expirationTimeProperty = DateTime.UtcNow.AddMinutes(minutesToExpire);
+
+                FieldInfo expirationTimeInfo = authenticationContextValueObj.GetType().GetField("_expirationTime", BindingFlags.NonPublic | BindingFlags.Instance);
+                expirationTimeInfo.SetValue(authenticationContextValueObj, expirationTimeProperty);
+
+                tokenHash = GetTokenHash(authenticationContextValueObj);
+
+                return expirationTimeProperty;
+            }
+            catch (Exception)
+            {
+                tokenHash = "";
+                return null;
+            }
+        }
+
+        internal static string GetTokenHash(object authenticationContextValueObj)
+        {
+            try
+            {
+                Assembly sqlConnectionAssembly = Assembly.GetAssembly(typeof(SqlConnection));
+
+                Type sqlFedAuthTokenType = sqlConnectionAssembly.GetType("Microsoft.Data.SqlClient.SqlFedAuthToken");
+
+                Type[] sqlFedAuthTokenTypeArray = new Type[] { sqlFedAuthTokenType };
+
+                ConstructorInfo sqlFedAuthTokenConstructorInfo = sqlFedAuthTokenType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, Type.EmptyTypes, null);
+
+                Type activeDirectoryAuthenticationTimeoutRetryHelperType = sqlConnectionAssembly.GetType("Microsoft.Data.SqlClient.ActiveDirectoryAuthenticationTimeoutRetryHelper");
+
+                ConstructorInfo activeDirectoryAuthenticationTimeoutRetryHelperConstructorInfo = activeDirectoryAuthenticationTimeoutRetryHelperType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, Type.EmptyTypes, null);
+
+                object activeDirectoryAuthenticationTimeoutRetryHelperObj = activeDirectoryAuthenticationTimeoutRetryHelperConstructorInfo.Invoke(new object[] { });
+
+                MethodInfo tokenHashInfo = activeDirectoryAuthenticationTimeoutRetryHelperObj.GetType().GetMethod("GetTokenHash", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, CallingConventions.Any, sqlFedAuthTokenTypeArray, null);
+
+                byte[] tokenBytes = (byte[])authenticationContextValueObj.GetType().GetProperty("AccessToken", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(authenticationContextValueObj, null);
+
+                object sqlFedAuthTokenObj = sqlFedAuthTokenConstructorInfo.Invoke(new object[] { });
+                FieldInfo accessTokenInfo = sqlFedAuthTokenObj.GetType().GetField("accessToken", BindingFlags.NonPublic | BindingFlags.Instance);
+                accessTokenInfo.SetValue(sqlFedAuthTokenObj, tokenBytes);
+
+                string tokenHash = (string)tokenHashInfo.Invoke(activeDirectoryAuthenticationTimeoutRetryHelperObj, new object[] { sqlFedAuthTokenObj });
+
+                return tokenHash;
+            }
+            catch (Exception)
+            {
+                return "";
+            }
+        }
+
+        internal static object GetAuthenticationContextValue(SqlConnection connection)
+        {
+            object innerConnectionObj = connection.GetType().GetProperty("InnerConnection", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(connection);
+
+            object databaseConnectionPoolObj = innerConnectionObj.GetType().GetProperty("Pool", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(innerConnectionObj);
+
+            IEnumerable authenticationContexts = (IEnumerable)databaseConnectionPoolObj.GetType().GetProperty("AuthenticationContexts", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(databaseConnectionPoolObj, null);
+
+            object authenticationContextObj = authenticationContexts.Cast<object>().FirstOrDefault();
+
+            object authenticationContextValueObj = authenticationContextObj.GetType().GetProperty("Value").GetValue(authenticationContextObj, null);
+
+            return authenticationContextValueObj;
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/FedAuthTokenHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Common/SystemDataInternals/FedAuthTokenHelper.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 ﻿using System;
 using System.Collections;
 using System.Linq;


### PR DESCRIPTION
This PR fixes issue #2238.

The SqlClient driver is supposed to be refreshing AuthFedTokens within 10 minutes before they expire so that they do not get sent to the server in a expired state.  However, the cache, _dbConnectionPool.AuthenticationContexts, of AuthFedTokens to be refreshed was always empty because newly created AuthFedTokens are not getting added to it. Thus, no AuthFedTokens are getting refreshed.

This fix ensures that all newly created AuthFedTokens are added to the cache,  _dbConnectionPool.AuthenticationContexts, and thereby gets refreshed within 10 minutes of them expiring. This ensures that no AuthFedTokens gets sent to the server in a expired state.