### PR TITLE
WeakRef's test fails on  s390x

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -155,6 +155,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             ConnectionPoolWrapper connectionPool = internalConnection.ConnectionPool;
             GC.Collect();
             GC.WaitForPendingFinalizers();
+            GC.Collect();
 
             DataTestUtility.AssertEqualsWithDescription(1, connectionPool.ConnectionCount, "Wrong number of connections in the pool.");
             DataTestUtility.AssertEqualsWithDescription(0, connectionPool.FreeConnectionCount, "Wrong number of free connections in the pool.");

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             weak = OpenNullifyReader(cmd);
                             GC.Collect();
                             GC.WaitForPendingFinalizers();
+                            GC.Collect();
                             Assert.False(weak.IsAlive, "Reader is still alive!");
                             break;
 
@@ -132,6 +133,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             weak = OpenNullifyReader(cmd);
                             GC.Collect();
                             GC.WaitForPendingFinalizers();
+                            GC.Collect();
 
                             Assert.False(weak.IsAlive, "Reader is still alive!");
                             con.Close();
@@ -202,6 +204,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         weak = OpenNullifyTransaction(con);
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
+                        GC.Collect();
 
                         Assert.False(weak.IsAlive, "Transaction is still alive!");
                         break;
@@ -215,6 +218,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         weak = OpenNullifyTransaction(con);
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
+                        GC.Collect();
 
                         Assert.False(weak.IsAlive, "Transaction is still alive!");
                         con.Close();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/WeakRefTestYukonSpecific/WeakRefTestYukonSpecific.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/WeakRefTestYukonSpecific/WeakRefTestYukonSpecific.cs
@@ -133,6 +133,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             weak = OpenNullifyReader(cmd[i]);
                             GC.Collect();
                             GC.WaitForPendingFinalizers();
+                            GC.Collect();
                             Assert.False(weak.IsAlive, "Transaction is still alive on TestReaderMars: ReaderGC");
                             break;
 
@@ -146,6 +147,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             weak = OpenNullifyReader(cmd[i]);
                             GC.Collect();
                             GC.WaitForPendingFinalizers();
+                            GC.Collect();
                             Assert.False(weak.IsAlive, "Transaction is still alive on TestReaderMars: ReaderGCConnectionClose");
                             con.Close();
                             con.Open();
@@ -221,6 +223,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         weak = OpenNullifyTransaction(con);
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
+                        GC.Collect();
                         Assert.False(weak.IsAlive, "Transaction is still alive on TestTransactionSingle: TransactionGC");
                         break;
 
@@ -234,6 +237,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         weak = OpenNullifyTransaction(con);
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
+                        GC.Collect();
                         Assert.False(weak.IsAlive, "Transaction is still alive on TestTransactionSingle: TransactionGCConnectionClose");
                         con.Close();
                         con.Open();


### PR DESCRIPTION
There were some WeakRef's test case failure's related to garbage collection that were failing on the s390x. these similar test cases were also failing on x86 mono runtime.

```
[xUnit.net 00:15:43.12]     Microsoft.Data.SqlClient.ManualTesting.Tests.WeakRefTest.TestReaderNonMars [FAIL]
[xUnit.net 00:15:43.14]     Microsoft.Data.SqlClient.ManualTesting.Tests.WeakRefTest.TestTransactionSingle [FAIL]
[xUnit.net 00:15:43.20]     Microsoft.Data.SqlClient.ManualTesting.Tests.WeakRefTestYukonSpecific.TestTransactionSingle [FAIL]
  Failed Microsoft.Data.SqlClient.ManualTesting.Tests.WeakRefTest.TestReaderNonMars [125 ms]
  Error Message:
   Reader is still alive!
  Stack Trace:
     at Microsoft.Data.SqlClient.ManualTesting.Tests.WeakRefTest.TestReaderNonMarsCase(String caseName, String connectionString, ReaderTestType testType, ReaderVerificationType verificationType) in /root/SqlClient/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs:line 122
   at Microsoft.Data.SqlClient.ManualTesting.Tests.WeakRefTest.TestReaderNonMars() in /root/SqlClient/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs:line 57
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
  Failed Microsoft.Data.SqlClient.ManualTesting.Tests.WeakRefTest.TestTransactionSingle [17 ms]
  Error Message:
   Transaction is still alive!
  Stack Trace:
     at Microsoft.Data.SqlClient.ManualTesting.Tests.WeakRefTest.TestTransactionSingleCase(String caseName, String connectionString, TransactionTestType testType) in /root/SqlClient/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs:line 206
   at Microsoft.Data.SqlClient.ManualTesting.Tests.WeakRefTest.TestTransactionSingle() in /root/SqlClient/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/WeakRefTest/WeakRefTest.cs:line 88
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   ```