### PR TITLE
use System.Configuration.ConfigurationManager 8.0,

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -39,7 +39,7 @@
   <PropertyGroup>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
     <MicrosoftDataSqlClientSNIRuntimeVersion>5.2.0-preview1.23340.1</MicrosoftDataSqlClientSNIRuntimeVersion>
-    <SystemConfigurationConfigurationManagerVersion>6.0.1</SystemConfigurationConfigurationManagerVersion>
+    <SystemConfigurationConfigurationManagerVersion>8.0.0</SystemConfigurationConfigurationManagerVersion>
     <MicrosoftSqlServerServerVersion>1.0.0</MicrosoftSqlServerServerVersion>
     <SystemDiagnosticsPerformanceCounterVersion>6.0.1</SystemDiagnosticsPerformanceCounterVersion>
     <SystemRuntimeCachingVersion>6.0.0</SystemRuntimeCachingVersion>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -34,7 +34,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
         <dependency id="System.Buffers" version="4.5.1" />
-        <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
+        <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Compile" />
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
       </group>
@@ -45,7 +45,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
-        <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
+        <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Compile" />
         <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="6.0.0" exclude="Compile" />
@@ -58,7 +58,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
-        <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
+        <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
@@ -72,7 +72,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" />
-        <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
+        <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Compile" />
         <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="6.0.0" exclude="Compile" />
@@ -89,7 +89,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
-        <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
+        <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Compile" />
         <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="6.0.0" exclude="Compile" />


### PR DESCRIPTION
as it has less dependencies than previous versions

fixes #2232