### PR TITLE
Merge common code bases for TdsParserStateObject.cs (5)

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
@@ -262,38 +262,6 @@ namespace Microsoft.Data.SqlClient
             _cancellationOwner.Target = cancellationOwner;
         }
 
-        /// <summary>
-        /// Checks to see if the underlying connection is still valid (used by idle connection resiliency - for active connections)
-        /// NOTE: This is not safe to do on a connection that is currently in use
-        /// NOTE: This will mark the connection as broken if it is found to be dead
-        /// </summary>
-        /// <returns>True if the connection is still alive, otherwise false</returns>
-        internal bool ValidateSNIConnection()
-        {
-            if ((_parser == null) || ((_parser.State == TdsParserState.Broken) || (_parser.State == TdsParserState.Closed)))
-            {
-                return false;
-            }
-
-            if (DateTime.UtcNow.Ticks - _lastSuccessfulIOTimer._value <= CheckConnectionWindow)
-            {
-                return true;
-            }
-
-            uint error = TdsEnums.SNI_SUCCESS;
-            SniContext = SniContext.Snix_Connect;
-            try
-            {
-                Interlocked.Increment(ref _readingCount);
-                error = CheckConnection();
-            }
-            finally
-            {
-                Interlocked.Decrement(ref _readingCount);
-            }
-            return (error == TdsEnums.SNI_SUCCESS) || (error == TdsEnums.SNI_WAIT_TIMEOUT);
-        }
-
         // This method should only be called by ReadSni!  If not - it may have problems with timeouts!
         private void ReadSniError(TdsParserStateObject stateObj, uint error)
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
@@ -392,38 +392,6 @@ namespace Microsoft.Data.SqlClient
             _allowObjectID = objectID;
         }
 
-        /// <summary>
-        /// Checks to see if the underlying connection is still valid (used by idle connection resiliency - for active connections)
-        /// NOTE: This is not safe to do on a connection that is currently in use
-        /// NOTE: This will mark the connection as broken if it is found to be dead
-        /// </summary>
-        /// <returns>True if the connection is still alive, otherwise false</returns>
-        internal bool ValidateSNIConnection()
-        {
-            if ((_parser == null) || ((_parser.State == TdsParserState.Broken) || (_parser.State == TdsParserState.Closed)))
-            {
-                return false;
-            }
-
-            if (DateTime.UtcNow.Ticks - _lastSuccessfulIOTimer._value <= CheckConnectionWindow)
-            {
-                return true;
-            }
-
-            uint error = TdsEnums.SNI_SUCCESS;
-            SniContext = SniContext.Snix_Connect;
-            try
-            {
-                Interlocked.Increment(ref _readingCount);
-                error = CheckConnection();
-            }
-            finally
-            {
-                Interlocked.Decrement(ref _readingCount);
-            }
-            return (error == TdsEnums.SNI_SUCCESS) || (error == TdsEnums.SNI_WAIT_TIMEOUT);
-        }
-
         // This method should only be called by ReadSni!  If not - it may have problems with timeouts!
         private void ReadSniError(TdsParserStateObject stateObj, uint error)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2477,6 +2477,38 @@ namespace Microsoft.Data.SqlClient
             return isAlive;
         }
 
+        /// <summary>
+        /// Checks to see if the underlying connection is still valid (used by idle connection resiliency - for active connections)
+        /// NOTE: This is not safe to do on a connection that is currently in use
+        /// NOTE: This will mark the connection as broken if it is found to be dead
+        /// </summary>
+        /// <returns>True if the connection is still alive, otherwise false</returns>
+        internal bool ValidateSNIConnection()
+        {
+            if ((_parser == null) || ((_parser.State == TdsParserState.Broken) || (_parser.State == TdsParserState.Closed)))
+            {
+                return false;
+            }
+
+            if (DateTime.UtcNow.Ticks - _lastSuccessfulIOTimer._value <= CheckConnectionWindow)
+            {
+                return true;
+            }
+
+            uint error = TdsEnums.SNI_SUCCESS;
+            SniContext = SniContext.Snix_Connect;
+            try
+            {
+                Interlocked.Increment(ref _readingCount);
+                error = CheckConnection();
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _readingCount);
+            }
+            return (error == TdsEnums.SNI_SUCCESS) || (error == TdsEnums.SNI_WAIT_TIMEOUT);
+        }
+
         /*
 
         // leave this in. comes handy if you have to do Console.WriteLine style debugging ;)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2495,18 +2495,17 @@ namespace Microsoft.Data.SqlClient
                 return true;
             }
 
-            uint error = TdsEnums.SNI_SUCCESS;
             SniContext = SniContext.Snix_Connect;
             try
             {
                 Interlocked.Increment(ref _readingCount);
-                error = CheckConnection();
+                uint error = CheckConnection();
+                return (error == TdsEnums.SNI_SUCCESS) || (error == TdsEnums.SNI_WAIT_TIMEOUT);
             }
             finally
             {
                 Interlocked.Decrement(ref _readingCount);
             }
-            return (error == TdsEnums.SNI_SUCCESS) || (error == TdsEnums.SNI_WAIT_TIMEOUT);
         }
 
         /*


### PR DESCRIPTION
This is a draft PR as I intend to add a few more commits. But let me know if you think this should be merged by itself.

So, in [this comment](https://github.com/dotnet/SqlClient/pull/2254#issuecomment-1889668295), I asked about ValidateSNIConnection (3rd question, 4 possible solutions are suggested). @David-Engel [responded](https://github.com/dotnet/SqlClient/pull/2254#issuecomment-1890132155) and it looks like we both agree on the implementation of this PR.

To sum up, this PR effectively changes the implementation of IsConnectionAlive in netfx to check if the handle is null before passing it to SNICheckConnection. If it is null, the connection will be considered alive. This behavior is in line with netcore implementation for native. 

Moreover, it appears that:
1. Native SNICheckConnection doesn't expect null values.
2. The handle in question will only be null if the TdsParserStateObject has been disposed.
3. We assume IsConnectionAlive is not called if TdsParserStateObject has been disposed (otherwise you would have noticed the bug already). 

Therefore, an even better implementation would be to throw an exception (or at least use a debug assertion) to make sure the handle is never null when CheckConnection is called. Note that netcore [already does this](https://github.com/dotnet/SqlClient/blob/b12b15d6f61d99870e420c169e4a58711ebf9e0c/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs#L262) for the managed implementation (which reinforces the assumption (3)). The null check below the linked line is redundant by the way (I guess the null check predated throwing the exception).

Let me know what you think @Wraith2 @DavoudEshtehari @JRahnama @David-Engel 