### PR TITLE
Perf | various performance improvements for SqlDataReader, TdsParser, SqlGuid and SqlBinary 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,6 +353,9 @@ healthchecksdb
 # Backup folder for Package Reference Convert tool in Visual Studio 2017
 MigrationBackup/
 
+# JetBrains Rider (cross platform .NET IDE) working folder
+.idea/
+
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -1573,7 +1573,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     // Grab already read data
-                    data = _data[i].SqlBinary.Value;
+                    data = _data[i].ByteArray;
                 }
 
                 // If non-sequential then we just have a read-only MemoryStream
@@ -2969,7 +2969,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    byte[] value = data.IsNull ? Array.Empty<byte>() : data.SqlBinary.Value;
+                    byte[] value = data.IsNull ? Array.Empty<byte>() : data.ByteArray;
                     return (T)(object)new MemoryStream(value, writable: false);
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -5504,7 +5504,7 @@ namespace Microsoft.Data.SqlClient
                     break;
 
                 case SqlDbType.UniqueIdentifier:
-                    nullVal.SqlGuid = SqlGuid.Null;
+                    nullVal.SetToNullOfType(SqlBuffer.StorageType.SqlGuid);
                     break;
 
                 case SqlDbType.Bit:

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -5957,7 +5957,11 @@ namespace Microsoft.Data.SqlClient
                             unencryptedBytes = bytes;
                         }
 
-                        value.SqlBinary = new SqlBinary(unencryptedBytes);   // doesn't copy the byte array
+#if NET7_0_OR_GREATER
+                        value.SqlBinary = SqlBinary.WrapBytes(unencryptedBytes);
+#else
+                        value.SqlBinary = SqlTypeWorkarounds.SqlBinaryCtor(unencryptedBytes, true);   // doesn't copy the byte array
+#endif
                         break;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -5932,7 +5932,11 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.SQLUNIQUEID:
                     {
                         Debug.Assert(length == 16, "invalid length for SqlGuid type!");
+#if NET8_0_OR_GREATER
                         value.SqlGuid = new SqlGuid(unencryptedBytes);   // doesn't copy the byte array
+#else
+                        value.SqlGuid = SqlTypeWorkarounds.SqlGuidCtor(unencryptedBytes, true);   // doesn't copy the byte array
+#endif
                         break;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -5500,7 +5500,7 @@ namespace Microsoft.Data.SqlClient
                 case SqlDbType.Binary:
                 case SqlDbType.VarBinary:
                 case SqlDbType.Image:
-                    nullVal.SqlBinary = SqlBinary.Null;
+                    nullVal.SetToNullOfType(SqlBuffer.StorageType.SqlBinary);
                     break;
 
                 case SqlDbType.UniqueIdentifier:

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -5957,11 +5957,7 @@ namespace Microsoft.Data.SqlClient
                             unencryptedBytes = bytes;
                         }
 
-#if NET7_0_OR_GREATER
-                        value.SqlBinary = SqlBinary.WrapBytes(unencryptedBytes);
-#else
-                        value.SqlBinary = SqlTypeWorkarounds.SqlBinaryCtor(unencryptedBytes, true);   // doesn't copy the byte array
-#endif
+                        value.ByteArray = unencryptedBytes;   // doesn't copy the byte array
                         break;
                     }
 
@@ -6154,11 +6150,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-#if NET7_0_OR_GREATER
-                        value.SqlBinary = SqlBinary.WrapBytes(b);
-#else
-                        value.SqlBinary = SqlTypeWorkarounds.SqlBinaryCtor(b, true);   // doesn't copy the byte array
-#endif
+                        value.ByteArray = b;   // doesn't copy the byte array
                     }
                     break;
 
@@ -6451,12 +6443,8 @@ namespace Microsoft.Data.SqlClient
                         {
                             return false;
                         }
-#if NET7_0_OR_GREATER
-                        value.SqlBinary = SqlBinary.WrapBytes(b);
-#else
-                        value.SqlBinary = SqlTypeWorkarounds.SqlBinaryCtor(b, true);
-#endif
 
+                        value.ByteArray = b;   // doesn't copy byte array
                         break;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.netcore.cs
@@ -122,5 +122,31 @@ namespace Microsoft.Data.SqlTypes
             internal SqlBinaryLookalike Fake;
         }
         #endregion
+
+        #region Work around inability to access SqlGuid.ctor(byte[], bool)
+        internal static SqlGuid SqlGuidCtor(byte[] value, bool ignored)
+        {
+            // Construct a SqlGuid without allocating/copying the byte[].  This provides
+            // the same behavior as SqlGuid.ctor(byte[], bool).
+            var c = default(SqlGuidCaster);
+            c.Fake._value = value;
+            return c.Real;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SqlGuidLookalike
+        {
+            internal byte[] _value;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct SqlGuidCaster
+        {
+            [FieldOffset(0)]
+            internal SqlGuid Real;
+            [FieldOffset(0)]
+            internal SqlGuidLookalike Fake;
+        }
+        #endregion
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -1770,7 +1770,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     // Grab already read data
-                    data = _data[i].SqlBinary.Value;
+                    data = _data[i].ByteArray;
                 }
 
                 // If non-sequential then we just have a read-only MemoryStream
@@ -3308,7 +3308,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    byte[] value = data.IsNull ? Array.Empty<byte>() : data.SqlBinary.Value;
+                    byte[] value = data.IsNull ? Array.Empty<byte>() : data.ByteArray;
                     return (T)(object)new MemoryStream(value, writable: false);
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -1720,7 +1720,7 @@ namespace Microsoft.Data.SqlClient
                 if (_data[i].IsNull)
                 {
                     // A 'null' stream
-                    return SqlTypeWorkarounds.SqlXmlCreateSqlXmlReader(new MemoryStream(new byte[0], writable: false), closeInput: true, async: false);
+                    return SqlTypeWorkarounds.SqlXmlCreateSqlXmlReader(new MemoryStream(Array.Empty<byte>(), writable: false), closeInput: true, async: false);
                 }
                 else
                 {
@@ -1765,7 +1765,7 @@ namespace Microsoft.Data.SqlClient
                 if (_data[i].IsNull)
                 {
                     // A 'null' stream
-                    data = new byte[0];
+                    data = Array.Empty<byte>();
                 }
                 else
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6306,7 +6306,7 @@ namespace Microsoft.Data.SqlClient
                 case SqlDbType.Binary:
                 case SqlDbType.VarBinary:
                 case SqlDbType.Image:
-                    nullVal.SqlBinary = SqlBinary.Null;
+                    nullVal.SetToNullOfType(SqlBuffer.StorageType.SqlBinary);
                     break;
 
                 case SqlDbType.UniqueIdentifier:

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6741,7 +6741,7 @@ namespace Microsoft.Data.SqlClient
                             unencryptedBytes = bytes;
                         }
 
-                        value.SqlBinary = SqlTypeWorkarounds.SqlBinaryCtor(unencryptedBytes, true);   // doesn't copy the byte array
+                        value.ByteArray = unencryptedBytes;   // doesn't copy the byte array
                         break;
                     }
 
@@ -6938,7 +6938,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        value.SqlBinary = SqlTypeWorkarounds.SqlBinaryCtor(b, true);   // doesn't copy the byte array
+                        value.ByteArray = b;   // doesn't copy the byte array
                     }
                     break;
 
@@ -7238,8 +7238,8 @@ namespace Microsoft.Data.SqlClient
                         {
                             return false;
                         }
-                        value.SqlBinary = SqlTypeWorkarounds.SqlBinaryCtor(b, true);   // doesn't copy the byte array
 
+                        value.ByteArray = b;   // doesn't copy the byte array
                         break;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6310,7 +6310,7 @@ namespace Microsoft.Data.SqlClient
                     break;
 
                 case SqlDbType.UniqueIdentifier:
-                    nullVal.SqlGuid = SqlGuid.Null;
+                    nullVal.SetToNullOfType(SqlBuffer.StorageType.SqlGuid);
                     break;
 
                 case SqlDbType.Bit:

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Data.SqlClient.Server
             if (isDbNull)
             {
                 // "null" stream
-                data = new byte[0];
+                data = Array.Empty<byte>();
             }
             else
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
@@ -152,10 +152,6 @@ namespace Microsoft.Data.SqlClient.Server
                     // special case SqlBinary, 'cause tds parser never sets SqlBuffer to null, just to empty!
                     targetBuffer.SqlBinary = SqlBinary.Null;
                 }
-                else if (SqlBuffer.StorageType.SqlGuid == stype)
-                {
-                    targetBuffer.SqlGuid = SqlGuid.Null;
-                }
                 else
                 {
                     targetBuffer.SetToNullOfType(stype);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
@@ -147,11 +147,6 @@ namespace Microsoft.Data.SqlClient.Server
                 {
                     result = DBNull.Value;
                 }
-                else if (SqlBuffer.StorageType.SqlBinary == stype)
-                {
-                    // special case SqlBinary, 'cause tds parser never sets SqlBuffer to null, just to empty!
-                    targetBuffer.SqlBinary = SqlBinary.Null;
-                }
                 else
                 {
                     targetBuffer.SetToNullOfType(stype);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Data.SqlClient.Server
                     case SqlDbType.Image:
                     case SqlDbType.Timestamp:
                     case SqlDbType.VarBinary:
-                        targetBuffer.SqlBinary = GetSqlBinary_Unchecked(sink, getters, ordinal);
+                        targetBuffer.ByteArray = GetByteArray_Unchecked(sink, getters, ordinal);
                         break;
                     case SqlDbType.Bit:
                         targetBuffer.Boolean = GetBoolean_Unchecked(sink, getters, ordinal);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Data.SqlClient
         private bool _isNull;
         private StorageType _type;
         private Storage _value;
-        private object _object;    // String, SqlBinary, SqlCachedBuffer, SqlGuid, SqlString, SqlXml
+        private object _object;    // String, SqlBinary, SqlCachedBuffer, SqlString, SqlXml
 
         internal SqlBuffer()
         {
@@ -815,14 +815,17 @@ namespace Microsoft.Data.SqlClient
                 }
                 else if (StorageType.SqlGuid == _type)
                 {
-                    return IsNull ? SqlGuid.Null : (SqlGuid)_object;
+                    return IsNull ? SqlGuid.Null : new SqlGuid(_value._guid);
                 }
                 return (SqlGuid)SqlValue; // anything else we haven't thought of goes through boxing.
             }
             set
             {
                 Debug.Assert(IsEmpty, "setting value a second time?");
-                _object = value;
+                if (!value.IsNull)
+                {
+                    _value._guid = value.Value;
+                }
                 _type = StorageType.SqlGuid;
                 _isNull = value.IsNull;
             }


### PR DESCRIPTION
I was working on boxing of `SqlBinary` particularly, but found more kinda related issues.
The PR fixes:
- boxing of `SqlBinary` struct;
- copying of `SqlBinary`'s internal array of bytes back and forth;
- creating of empty arrays for null values in SqlDataReader;
- copying of an array of bytes for `SqlGuid`.