### PR TITLE
[5.1.5] CVE | Version bump Microsoft.IdentityModel.JsonWebTokens to 6.35.0 (#2290)

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -30,7 +30,7 @@
     <AzureIdentityVersion>1.10.3</AzureIdentityVersion>
     <MicrosoftIdentityClientVersion>4.56.0</MicrosoftIdentityClientVersion>
     <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.35.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
-    <MicrosoftIdentityModelJsonWebTokensVersion>6.24.0</MicrosoftIdentityModelJsonWebTokensVersion>
+    <MicrosoftIdentityModelJsonWebTokensVersion>6.35.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
     <MicrosoftSourceLinkGitHubVersion>1.1.0</MicrosoftSourceLinkGitHubVersion>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -29,7 +29,7 @@
   <PropertyGroup>
     <AzureIdentityVersion>1.10.3</AzureIdentityVersion>
     <MicrosoftIdentityClientVersion>4.56.0</MicrosoftIdentityClientVersion>
-    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.24.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
+    <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.35.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
     <MicrosoftIdentityModelJsonWebTokensVersion>6.24.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
@@ -67,7 +67,7 @@
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <SystemRuntimeInteropServicesRuntimeInformationVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationVersion>
     <SystemDataOdbcVersion>6.0.1</SystemDataOdbcVersion>
-    <SystemIdentityModelTokensJwtVersion>6.24.0</SystemIdentityModelTokensJwtVersion>
+    <SystemIdentityModelTokensJwtVersion>6.35.0</SystemIdentityModelTokensJwtVersion>
     <XunitVersion>2.4.2</XunitVersion>
     <xunitrunnervisualstudioVersion>2.4.5</xunitrunnervisualstudioVersion>
     <MicrosoftDotNetRemoteExecutorVersion>7.0.0-beta.22316.1</MicrosoftDotNetRemoteExecutorVersion>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -31,8 +31,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.Data.SqlClient.SNI" version="5.1.1" />
         <dependency id="Azure.Identity" version="1.10.3" />
         <dependency id="Microsoft.Identity.Client" version="4.56.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.35.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.35.0" />
         <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
@@ -42,8 +42,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.1" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.10.3" />
         <dependency id="Microsoft.Identity.Client" version="4.56.0" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.35.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.35.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.1" exclude="Compile" />
@@ -57,8 +57,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.1" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.10.3" />
         <dependency id="Microsoft.Identity.Client" version="4.56.0" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.35.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.35.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" />
@@ -74,8 +74,8 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.1" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.10.3" />
         <dependency id="Microsoft.Identity.Client" version="4.56.0" exclude="Compile"/>
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.24.0" />
-        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.24.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.35.0" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.35.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="Microsoft.Win32.Registry" version="5.0.0" exclude="Compile" />
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />


### PR DESCRIPTION
This commit backports PR #2290 changes to 5.1.5.

Microsoft Security Advisory [CVE-2024-21319](https://github.com/advisories/GHSA-8g9c-28fc-mcx2): .NET Denial of Service Vulnerability

Extra link: [CVE-2024-21319](https://www.cve.org/CVERecord?id=CVE-2024-21319)