### PR TITLE
[5.1.5] Fix | Invalid transaction exception against the connections and distributed transactions (#2301)

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -159,17 +159,17 @@ namespace Microsoft.Data.SqlClient
                             ValidateActiveOnConnection(connection);
 
                             connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Promote, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
-                            returnValue = _connection.PromotedDTCToken;
+                            returnValue = connection.PromotedDTCToken;
 
                             // For Global Transactions, we need to set the Transaction Id since we use a Non-MSDTC Promoter type.
-                            if (_connection.IsGlobalTransaction)
+                            if (connection.IsGlobalTransaction)
                             {
                                 if (SysTxForGlobalTransactions.SetDistributedTransactionIdentifier == null)
                                 {
                                     throw SQL.UnsupportedSysTxForGlobalTransactions();
                                 }
 
-                                if (!_connection.IsGlobalTransactionsEnabledForServer)
+                                if (!connection.IsGlobalTransactionsEnabledForServer)
                                 {
                                     throw SQL.GlobalTransactionsNotEnabled();
                                 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -192,17 +192,17 @@ namespace Microsoft.Data.SqlClient
                                 ValidateActiveOnConnection(connection);
 
                                 connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Promote, null, IsolationLevel.Unspecified, _internalTransaction, true);
-                                returnValue = _connection.PromotedDTCToken;
+                                returnValue = connection.PromotedDTCToken;
 
                                 // For Global Transactions, we need to set the Transaction Id since we use a Non-MSDTC Promoter type.
-                                if (_connection.IsGlobalTransaction)
+                                if (connection.IsGlobalTransaction)
                                 {
                                     if (SysTxForGlobalTransactions.SetDistributedTransactionIdentifier == null)
                                     {
                                         throw SQL.UnsupportedSysTxForGlobalTransactions();
                                     }
 
-                                    if (!_connection.IsGlobalTransactionsEnabledForServer)
+                                    if (!connection.IsGlobalTransactionsEnabledForServer)
                                     {
                                         throw SQL.GlobalTransactionsNotEnabled();
                                     }


### PR DESCRIPTION
Backport PR #2301 to 5.1.5
Unsubscribing from a transaction completion event before returning it to the pool is done to prevent potential signals from the previous state.

Fixes https://github.com/dotnet/SqlClient/issues/1675