### PR TITLE
Test | Docker test enhancement

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/Docker/DockerLinuxTest/Dockerfile
+++ b/src/Microsoft.Data.SqlClient/tests/Docker/DockerLinuxTest/Dockerfile
@@ -1,9 +1,9 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0@sha256:bb9e61f07f93945ab97391b1dcbcc41136b03310583f36e52b3ec2815111e58a AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:8e77ad6fb7c33c17f026424d3bef05ea2ee15d1621e28f312adeab4dc1005866 AS build
 WORKDIR /sqlclient
 COPY . .
 
@@ -11,7 +11,7 @@ ARG PROJNAME="Microsoft.Data.SqlClient.DockerLinuxTest"
 ARG PROJFILE=$PROJNAME".csproj"
 ARG DLLFILE=$PROJNAME".dll"
 
-WORKDIR /sqlclient/src/Microsoft.Data.SqlClient/tests/DockerLinuxTest
+WORKDIR /sqlclient/src/Microsoft.Data.SqlClient/tests/Docker/DockerLinuxTest
 RUN dotnet build $PROJFILE -c Release -o /app/build 
 
 FROM build AS publish

--- a/src/Microsoft.Data.SqlClient/tests/Docker/DockerLinuxTest/Microsoft.Data.SqlClient.DockerLinuxTest.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/Docker/DockerLinuxTest/Microsoft.Data.SqlClient.DockerLinuxTest.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <DockerfileContext>..\..\..\..</DockerfileContext>
+    <DockerfileContext>..\..\..\..\..</DockerfileContext>
     <OSGroup>Unix</OSGroup>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(NetCoreSource)src\Microsoft.Data.SqlClient.csproj" />

--- a/src/Microsoft.Data.SqlClient/tests/Docker/DockerLinuxTest/Program.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Docker/DockerLinuxTest/Program.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Data.SqlClient.DockerLinuxTest
 {

--- a/src/docker-compose.dcproj
+++ b/src/docker-compose.dcproj
@@ -10,9 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include=".dockerignore" />
-    <None Include="docker-compose.override.yml">
-      <DependentUpon>docker-compose.yml</DependentUpon>
-    </None>
     <None Include="docker-compose.yml" />
   </ItemGroup>
 </Project>

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -1,3 +1,0 @@
-version: '3.4'
-services:
-  microsoft.data.sqlclient.dockertests:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.9'
 
 services:
   microsoft.data.sqlclient.dockertests:


### PR DESCRIPTION
**WHY PINNING TO A SPECIFIC VERSION OF THE IMAGE?** The pinning strategy is used to keep container images up to date by pinning them to specific image digests, which improves security, compliance, and compatibility.