### PR TITLE
SDL | Removing DSA public key from SqlColumnEncryptionProvider to address CodeQL flag

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
@@ -81,13 +81,7 @@ namespace Microsoft.Data.SqlClient
             X509Certificate2 certificate = GetCertificateByPath(masterKeyPath, isSystemOp: true);
             
             RSA RSAPublicKey = certificate.GetRSAPublicKey();
-            int keySizeInBytes;
-#if NETCOREAPP || NETSTANDARD2_1
-            DSA DSAPublicKey = certificate.GetDSAPublicKey();
-            keySizeInBytes = RSAPublicKey is not null ? RSAPublicKey.KeySize / 8 : DSAPublicKey.KeySize / 8;
-#else
-            keySizeInBytes= RSAPublicKey.KeySize / 8;
-#endif
+            int keySizeInBytes= RSAPublicKey.KeySize / 8;
 
             // Validate and decrypt the EncryptedColumnEncryptionKey
             // Format is 
@@ -182,13 +176,7 @@ namespace Microsoft.Data.SqlClient
             X509Certificate2 certificate = GetCertificateByPath(masterKeyPath, isSystemOp: false);
             
             RSA RSAPublicKey = certificate.GetRSAPublicKey();
-            int keySizeInBytes;
-#if NETCOREAPP || NETSTANDARD2_1
-            DSA DSAPublicKey = certificate.GetDSAPublicKey();
-            keySizeInBytes = RSAPublicKey is not null ? RSAPublicKey.KeySize / 8 : DSAPublicKey.KeySize / 8;
-#else
-            keySizeInBytes= RSAPublicKey.KeySize / 8;
-#endif
+            int keySizeInBytes= RSAPublicKey.KeySize / 8;
 
             // Construct the encryptedColumnEncryptionKey
             // Format is 


### PR DESCRIPTION
This PR removes GetDSAPublicKey from SqlColumnEncryptionCertificateStoreProvider.Windows.cs as DSA is never used with AE.