### PR TITLE
Fix | Mismatch System.Diagnostics.DiagnosticSource between versions.props and nuspec 

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -51,7 +51,7 @@
   <!-- NetStandard project dependencies -->
   <PropertyGroup>
     <SystemRuntimeLoaderVersion>4.3.0</SystemRuntimeLoaderVersion>
-    <SystemDiagnosticsDiagnosticSourceVersion>7.0.2</SystemDiagnosticsDiagnosticSourceVersion>
+    <SystemDiagnosticsDiagnosticSourceVersion>6.0.1</SystemDiagnosticsDiagnosticSourceVersion>
   </PropertyGroup>
   <!-- AKV Provider project dependencies -->
   <PropertyGroup>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -79,7 +79,7 @@
     <MicrosoftSqlServerTypesVersionNet>160.1000.6</MicrosoftSqlServerTypesVersionNet>
     <BenchmarkDotNetVersion>0.13.2</BenchmarkDotNetVersion>
     <SystemServiceProcessServiceControllerVersion>6.0.0</SystemServiceProcessServiceControllerVersion>
-    <MicrosoftExtensionsHosting>7.0.1</MicrosoftExtensionsHosting>
+    <MicrosoftExtensionsHosting>6.0.1</MicrosoftExtensionsHosting>
   </PropertyGroup>
   <PropertyGroup>
     <TestAKVProviderVersion>$(NugetPackageVersion)</TestAKVProviderVersion>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -46,7 +46,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.35.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="System.Configuration.ConfigurationManager" version="8.0.0" exclude="Compile" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="8.0.0" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="8.0.0" exclude="Compile" />
       </group>
       <group targetFramework="net6.0">
@@ -57,7 +56,6 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.35.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
       </group>
       <group targetFramework="netstandard2.0">


### PR DESCRIPTION
#2322

Changed System.Diagnostics.DiagnosticSource version from 7.0.1 to 6.0.1 in versions.props.

Removed System.Diagnostics.DiagnosticSource from Net8 and Net6 in the nuspec file.