### PR TITLE
Doc | Update Release Documentation for Contributors

### DIFF
--- a/release-notes/5.0/5.0.0-preview1.md
+++ b/release-notes/5.0/5.0.0-preview1.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 - [EngRajabi](https://github.com/EngRajabi)
 

--- a/release-notes/5.0/5.0.0-preview1.md
+++ b/release-notes/5.0/5.0.0-preview1.md
@@ -6,8 +6,8 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [EngRajabi](https://github.com/EngRajabi)
 - [Wraith2](https://github.com/Wraith2)
+- [EngRajabi](https://github.com/EngRajabi)
 
 ### Added
 

--- a/release-notes/5.0/5.0.0-preview1.md
+++ b/release-notes/5.0/5.0.0-preview1.md
@@ -4,6 +4,15 @@
 
 This update brings the below changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [EngRajabi](https://github.com/EngRajabi)
+- [johnnypham](https://github.com/johnnypham)
+- [Kaur-Parminder](https://github.com/Kaur-Parminder)
+- [lcheunglci](https://github.com/lcheunglci)
+- [Wraith2](https://github.com/Wraith2)
+
 ### Added
 
 - Added SqlDataSourceEnumerator. [#1430](https://github.com/dotnet/SqlClient/pull/1430), [Read more](#sql-data-source-enumerator-support)

--- a/release-notes/5.0/5.0.0-preview1.md
+++ b/release-notes/5.0/5.0.0-preview1.md
@@ -6,11 +6,7 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
 - [EngRajabi](https://github.com/EngRajabi)
-- [johnnypham](https://github.com/johnnypham)
-- [Kaur-Parminder](https://github.com/Kaur-Parminder)
-- [lcheunglci](https://github.com/lcheunglci)
 - [Wraith2](https://github.com/Wraith2)
 
 ### Added

--- a/release-notes/5.0/5.0.0-preview2.md
+++ b/release-notes/5.0/5.0.0-preview2.md
@@ -6,12 +6,7 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
 - [ErikEJ](https://github.com/ErikEJ)
-- [johnnypham](https://github.com/johnnypham)
-- [JRahnama](https://github.com/JRahnama)
-- [Kaur-Parminder](https://github.com/Kaur-Parminder)
-- [lcheunglci](https://github.com/lcheunglci)
 - [Wraith2](https://github.com/Wraith2)
 
 ### Breaking changes over preview release v5.0.0-preview1

--- a/release-notes/5.0/5.0.0-preview2.md
+++ b/release-notes/5.0/5.0.0-preview2.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 - [ErikEJ](https://github.com/ErikEJ)
 

--- a/release-notes/5.0/5.0.0-preview2.md
+++ b/release-notes/5.0/5.0.0-preview2.md
@@ -4,6 +4,16 @@
 
 This update brings the below changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [ErikEJ](https://github.com/ErikEJ)
+- [johnnypham](https://github.com/johnnypham)
+- [JRahnama](https://github.com/JRahnama)
+- [Kaur-Parminder](https://github.com/Kaur-Parminder)
+- [lcheunglci](https://github.com/lcheunglci)
+- [Wraith2](https://github.com/Wraith2)
+
 ### Breaking changes over preview release v5.0.0-preview1
 
 - Dropped support for .NET Framework 4.6.1 [#1574](https://github.com/dotnet/SqlClient/pull/1574)

--- a/release-notes/5.0/5.0.0-preview2.md
+++ b/release-notes/5.0/5.0.0-preview2.md
@@ -6,8 +6,8 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [ErikEJ](https://github.com/ErikEJ)
 - [Wraith2](https://github.com/Wraith2)
+- [ErikEJ](https://github.com/ErikEJ)
 
 ### Breaking changes over preview release v5.0.0-preview1
 

--- a/release-notes/5.0/5.0.0-preview3.md
+++ b/release-notes/5.0/5.0.0-preview3.md
@@ -4,6 +4,18 @@
 
 This update brings the below changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [David-Engel](https://github.com/David-Engel)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [EngRajabi](https://github.com/EngRajabi)
+- [JRahnama](https://github.com/JRahnama)
+- [Kaur-Parminder](https://github.com/Kaur-Parminder)
+- [lcheunglci](https://github.com/lcheunglci)
+- [swh-cb](https://github.com/swh-cb)
+- [tf-micwil](https://github.com/tf-micwil)
+- [Wraith2](https://github.com/Wraith2)
+
 ### Breaking changes over preview release v5.0.0-preview2
 
 - Added a dependency on the [Microsoft.SqlServer.Server](https://github.com/dotnet/SqlClient/tree/main/src/Microsoft.SqlServer.Server) package. This new dependency may cause namespace conflicts if your application references that namespace and still has package references (direct or indirect) to System.Data.SqlClient from .NET Core.

--- a/release-notes/5.0/5.0.0-preview3.md
+++ b/release-notes/5.0/5.0.0-preview3.md
@@ -6,10 +6,10 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [EngRajabi](https://github.com/EngRajabi)
-- [swh-cb](https://github.com/swh-cb)
-- [tf-micwil](https://github.com/tf-micwil)
 - [Wraith2](https://github.com/Wraith2)
+- [EngRajabi](https://github.com/EngRajabi)
+- [tf-micwil](https://github.com/tf-micwil)
+- [swh-cb](https://github.com/swh-cb)
 
 ### Breaking changes over preview release v5.0.0-preview2
 

--- a/release-notes/5.0/5.0.0-preview3.md
+++ b/release-notes/5.0/5.0.0-preview3.md
@@ -6,12 +6,7 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [David-Engel](https://github.com/David-Engel)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
 - [EngRajabi](https://github.com/EngRajabi)
-- [JRahnama](https://github.com/JRahnama)
-- [Kaur-Parminder](https://github.com/Kaur-Parminder)
-- [lcheunglci](https://github.com/lcheunglci)
 - [swh-cb](https://github.com/swh-cb)
 - [tf-micwil](https://github.com/tf-micwil)
 - [Wraith2](https://github.com/Wraith2)

--- a/release-notes/5.0/5.0.0-preview3.md
+++ b/release-notes/5.0/5.0.0-preview3.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 - [EngRajabi](https://github.com/EngRajabi)
 - [tf-micwil](https://github.com/tf-micwil)

--- a/release-notes/5.0/5.0.0.md
+++ b/release-notes/5.0/5.0.0.md
@@ -6,14 +6,8 @@ This update includes the following changes over the 4.1 release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [David-Engel](https://github.com/David-Engel)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
 - [EngRajabi](https://github.com/EngRajabi)
 - [ErikEJ](https://github.com/ErikEJ)
-- [johnnypham](https://github.com/johnnypham)
-- [JRahnama](https://github.com/JRahnama)
-- [Kaur-Parminder](https://github.com/Kaur-Parminder)
-- [lcheunglci](https://github.com/lcheunglci)
 - [swh-cb](https://github.com/swh-cb)
 - [tf-micwil](https://github.com/tf-micwil)
 - [Wraith2](https://github.com/Wraith2)

--- a/release-notes/5.0/5.0.0.md
+++ b/release-notes/5.0/5.0.0.md
@@ -4,6 +4,20 @@
 
 This update includes the following changes over the 4.1 release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [David-Engel](https://github.com/David-Engel)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [EngRajabi](https://github.com/EngRajabi)
+- [ErikEJ](https://github.com/ErikEJ)
+- [johnnypham](https://github.com/johnnypham)
+- [JRahnama](https://github.com/JRahnama)
+- [Kaur-Parminder](https://github.com/Kaur-Parminder)
+- [lcheunglci](https://github.com/lcheunglci)
+- [swh-cb](https://github.com/swh-cb)
+- [tf-micwil](https://github.com/tf-micwil)
+- [Wraith2](https://github.com/Wraith2)
+
 ### Breaking changes
 
 - As part of the [`TDS 8` feature](#tds-8-enhanced-security), the `SqlConnectionStringBuilder.Encrypt` property has changed from a `bool` to a `SqlConnectionEncryptOption`. `SqlConnectionEncryptOption` has implicit conversion rules to convert to/from a `bool` so that existing code remains backwards compatible, however this is a binary-breaking change and a recompile is required against this version.

--- a/release-notes/5.0/5.0.0.md
+++ b/release-notes/5.0/5.0.0.md
@@ -5,7 +5,7 @@
 This update includes the following changes over the 4.1 release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 - [ErikEJ](https://github.com/ErikEJ)
 - [EngRajabi](https://github.com/EngRajabi)

--- a/release-notes/5.0/5.0.0.md
+++ b/release-notes/5.0/5.0.0.md
@@ -6,11 +6,11 @@ This update includes the following changes over the 4.1 release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [EngRajabi](https://github.com/EngRajabi)
-- [ErikEJ](https://github.com/ErikEJ)
-- [swh-cb](https://github.com/swh-cb)
-- [tf-micwil](https://github.com/tf-micwil)
 - [Wraith2](https://github.com/Wraith2)
+- [ErikEJ](https://github.com/ErikEJ)
+- [EngRajabi](https://github.com/EngRajabi)
+- [tf-micwil](https://github.com/tf-micwil)
+- [swh-cb](https://github.com/swh-cb)
 
 ### Breaking changes
 

--- a/release-notes/5.0/5.0.1.md
+++ b/release-notes/5.0/5.0.1.md
@@ -4,6 +4,12 @@
 
 This update includes the following changes over the 5.0.0 release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [cheenamalhotra](https://github.com/cheenamalhotra)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [JRahnama](https://github.com/JRahnama)
+
 ### Fixed
 
 - Fixed missing `HostNameInCertificate` connection string property in .NET Framework. [#1782](https://github.com/dotnet/SqlClient/pull/1782)

--- a/release-notes/5.0/5.0.1.md
+++ b/release-notes/5.0/5.0.1.md
@@ -6,9 +6,6 @@ This update includes the following changes over the 5.0.0 release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [cheenamalhotra](https://github.com/cheenamalhotra)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
-- [JRahnama](https://github.com/JRahnama)
 
 ### Fixed
 

--- a/release-notes/5.0/5.0.1.md
+++ b/release-notes/5.0/5.0.1.md
@@ -5,7 +5,7 @@
 This update includes the following changes over the 5.0.0 release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 
 ### Fixed
 

--- a/release-notes/5.0/5.0.2.md
+++ b/release-notes/5.0/5.0.2.md
@@ -4,6 +4,13 @@
 
 This update includes the following changes over the 5.0.1 release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [cheenamalhotra](https://github.com/cheenamalhotra)
+- [JRahnama](https://github.com/JRahnama)
+- [lcheunglci](https://github.com/lcheunglci)
+- [Wraith2](https://github.com/Wraith2)
+
 ### Fixed
 
 - Fixed memory leak regression from [#1785](https://github.com/dotnet/SqlClient/pull/1785) using a `DisposableTemporaryOnStack` struct. [#1980](https://github.com/dotnet/SqlClient/pull/1980)

--- a/release-notes/5.0/5.0.2.md
+++ b/release-notes/5.0/5.0.2.md
@@ -6,9 +6,6 @@ This update includes the following changes over the 5.0.1 release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [cheenamalhotra](https://github.com/cheenamalhotra)
-- [JRahnama](https://github.com/JRahnama)
-- [lcheunglci](https://github.com/lcheunglci)
 - [Wraith2](https://github.com/Wraith2)
 
 ### Fixed

--- a/release-notes/5.0/5.0.2.md
+++ b/release-notes/5.0/5.0.2.md
@@ -5,7 +5,7 @@
 This update includes the following changes over the 5.0.1 release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 
 ### Fixed

--- a/release-notes/5.1/5.1.0-preview1.md
+++ b/release-notes/5.1/5.1.0-preview1.md
@@ -6,8 +6,8 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [sorensenmatias](https://github.com/sorensenmatias)
 - [Wraith2](https://github.com/Wraith2)
+- [sorensenmatias](https://github.com/sorensenmatias)
 
 ### Fixed
 

--- a/release-notes/5.1/5.1.0-preview1.md
+++ b/release-notes/5.1/5.1.0-preview1.md
@@ -4,6 +4,16 @@
 
 This update brings the below changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [cheenamalhotra](https://github.com/cheenamalhotra)
+- [David-Engel](https://github.com/David-Engel)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [JRahnama](https://github.com/JRahnama)
+- [lcheunglci](https://github.com/lcheunglci)
+- [sorensenmatias](https://github.com/sorensenmatias)
+- [Wraith2](https://github.com/Wraith2)
+
 ### Fixed
 
 - Fixed `ReadAsync()` behavior to register Cancellation token action before streaming results. [#1781](https://github.com/dotnet/SqlClient/pull/1781)

--- a/release-notes/5.1/5.1.0-preview1.md
+++ b/release-notes/5.1/5.1.0-preview1.md
@@ -6,11 +6,6 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [cheenamalhotra](https://github.com/cheenamalhotra)
-- [David-Engel](https://github.com/David-Engel)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
-- [JRahnama](https://github.com/JRahnama)
-- [lcheunglci](https://github.com/lcheunglci)
 - [sorensenmatias](https://github.com/sorensenmatias)
 - [Wraith2](https://github.com/Wraith2)
 

--- a/release-notes/5.1/5.1.0-preview1.md
+++ b/release-notes/5.1/5.1.0-preview1.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 - [sorensenmatias](https://github.com/sorensenmatias)
 

--- a/release-notes/5.1/5.1.0-preview2.md
+++ b/release-notes/5.1/5.1.0-preview2.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.\
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 - [ErikEJ](https://github.com/ErikEJ)
 - [panoskj](https://github.com/panoskj)

--- a/release-notes/5.1/5.1.0-preview2.md
+++ b/release-notes/5.1/5.1.0-preview2.md
@@ -4,6 +4,17 @@
 
 This update brings the below changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.\
+- [cheenamalhotra](https://github.com/cheenamalhotra)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [ErikEJ](https://github.com/ErikEJ)
+- [JRahnama](https://github.com/JRahnama)
+- [Kaur-Parminder](https://github.com/Kaur-Parminder)
+- [lcheunglci](https://github.com/lcheunglci)
+- [panoskj](https://github.com/panoskj)
+- [Wraith2](https://github.com/Wraith2)
+
 ### Breaking changes over preview release v5.1.0-preview1
 
 - Add support for .NET 6.0 and Dropped support for .NET Core 3.1. [#1704](https://github.com/dotnet/SqlClient/pull/1704) [#1823](https://github.com/dotnet/SqlClient/pull/1823)

--- a/release-notes/5.1/5.1.0-preview2.md
+++ b/release-notes/5.1/5.1.0-preview2.md
@@ -6,12 +6,7 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.\
-- [cheenamalhotra](https://github.com/cheenamalhotra)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
 - [ErikEJ](https://github.com/ErikEJ)
-- [JRahnama](https://github.com/JRahnama)
-- [Kaur-Parminder](https://github.com/Kaur-Parminder)
-- [lcheunglci](https://github.com/lcheunglci)
 - [panoskj](https://github.com/panoskj)
 - [Wraith2](https://github.com/Wraith2)
 

--- a/release-notes/5.1/5.1.0-preview2.md
+++ b/release-notes/5.1/5.1.0-preview2.md
@@ -6,9 +6,9 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.\
+- [Wraith2](https://github.com/Wraith2)
 - [ErikEJ](https://github.com/ErikEJ)
 - [panoskj](https://github.com/panoskj)
-- [Wraith2](https://github.com/Wraith2)
 
 ### Breaking changes over preview release v5.1.0-preview1
 

--- a/release-notes/5.1/5.1.0.md
+++ b/release-notes/5.1/5.1.0.md
@@ -4,6 +4,19 @@
 
 This update includes the following changes over the 5.0 release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [cheenamalhotra](https://github.com/cheenamalhotra)
+- [David-Engel](https://github.com/David-Engel)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [ErikEJ](https://github.com/ErikEJ)
+- [JRahnama](https://github.com/JRahnama)
+- [Kaur-Parminder](https://github.com/Kaur-Parminder)
+- [lcheunglci](https://github.com/lcheunglci)
+- [panoskj](https://github.com/panoskj)
+- [sorensenmatias](https://github.com/sorensenmatias)
+- [Wraith2](https://github.com/Wraith2)
+
 ### Breaking changes
 
 - Dropped support for .NET Core 3.1. [#1704](https://github.com/dotnet/SqlClient/pull/1704) [#1823](https://github.com/dotnet/SqlClient/pull/1823)

--- a/release-notes/5.1/5.1.0.md
+++ b/release-notes/5.1/5.1.0.md
@@ -14,7 +14,9 @@ Thanks to the following public contributors. Their efforts toward this project a
 - [Kaur-Parminder](https://github.com/Kaur-Parminder)
 - [lcheunglci](https://github.com/lcheunglci)
 - [panoskj](https://github.com/panoskj)
+- [roji](https://github.com/roji)
 - [sorensenmatias](https://github.com/sorensenmatias)
+- [teo-tsirpanis](https://github.com/teo-tsirpanis)
 - [Wraith2](https://github.com/Wraith2)
 
 ### Breaking changes

--- a/release-notes/5.1/5.1.0.md
+++ b/release-notes/5.1/5.1.0.md
@@ -6,13 +6,7 @@ This update includes the following changes over the 5.0 release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [cheenamalhotra](https://github.com/cheenamalhotra)
-- [David-Engel](https://github.com/David-Engel)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
 - [ErikEJ](https://github.com/ErikEJ)
-- [JRahnama](https://github.com/JRahnama)
-- [Kaur-Parminder](https://github.com/Kaur-Parminder)
-- [lcheunglci](https://github.com/lcheunglci)
 - [panoskj](https://github.com/panoskj)
 - [roji](https://github.com/roji)
 - [sorensenmatias](https://github.com/sorensenmatias)

--- a/release-notes/5.1/5.1.0.md
+++ b/release-notes/5.1/5.1.0.md
@@ -5,7 +5,7 @@
 This update includes the following changes over the 5.0 release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 - [ErikEJ](https://github.com/ErikEJ)
 - [roji](https://github.com/roji)

--- a/release-notes/5.1/5.1.0.md
+++ b/release-notes/5.1/5.1.0.md
@@ -6,12 +6,12 @@ This update includes the following changes over the 5.0 release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [ErikEJ](https://github.com/ErikEJ)
-- [panoskj](https://github.com/panoskj)
-- [roji](https://github.com/roji)
-- [sorensenmatias](https://github.com/sorensenmatias)
-- [teo-tsirpanis](https://github.com/teo-tsirpanis)
 - [Wraith2](https://github.com/Wraith2)
+- [ErikEJ](https://github.com/ErikEJ)
+- [roji](https://github.com/roji)
+- [panoskj](https://github.com/panoskj)
+- [teo-tsirpanis](https://github.com/teo-tsirpanis)
+- [sorensenmatias](https://github.com/sorensenmatias)
 
 ### Breaking changes
 

--- a/release-notes/5.1/5.1.1.md
+++ b/release-notes/5.1/5.1.1.md
@@ -4,6 +4,10 @@
 
 This update includes the following changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [lcheunglci](https://github.com/lcheunglci)
+
 ### Fixed
 
 - Fixed an incorrect exception when a symmetric key fails to decrypt a column using Always Encrypted. [#1968](https://github.com/dotnet/SqlClient/pull/1968)

--- a/release-notes/5.1/5.1.1.md
+++ b/release-notes/5.1/5.1.1.md
@@ -5,7 +5,7 @@
 This update includes the following changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 
 ### Fixed
 

--- a/release-notes/5.1/5.1.1.md
+++ b/release-notes/5.1/5.1.1.md
@@ -6,7 +6,6 @@ This update includes the following changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [lcheunglci](https://github.com/lcheunglci)
 
 ### Fixed
 

--- a/release-notes/5.1/5.1.2.md
+++ b/release-notes/5.1/5.1.2.md
@@ -6,12 +6,7 @@ This update includes the following changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [arellegue](https://github.com/arellegue)
-- [cheenamalhotra](https://github.com/cheenamalhotra)
 - [emidah](https://github.com/emidah)
-- [David-Engel](https://github.com/David-Engel)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
-- [JRahnama](https://github.com/JRahnama)
 
 ### Fixed
 

--- a/release-notes/5.1/5.1.2.md
+++ b/release-notes/5.1/5.1.2.md
@@ -5,7 +5,7 @@
 This update includes the following changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [emidah](https://github.com/emidah)
 
 ### Fixed

--- a/release-notes/5.1/5.1.2.md
+++ b/release-notes/5.1/5.1.2.md
@@ -4,6 +4,15 @@
 
 This update includes the following changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [arellegue](https://github.com/arellegue)
+- [cheenamalhotra](https://github.com/cheenamalhotra)
+- [emidah](https://github.com/emidah)
+- [David-Engel](https://github.com/David-Engel)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [JRahnama](https://github.com/JRahnama)
+
 ### Fixed
 
 - Fixed access violation when using SQL Express user instance. [#2101](https://github.com/dotnet/SqlClient/pull/2101)

--- a/release-notes/5.1/5.1.3.md
+++ b/release-notes/5.1/5.1.3.md
@@ -4,6 +4,9 @@
 
 This update includes the following changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+
 ### Fixed
 
 - Fixed encryption downgrade issue. [CVE-2024-0056](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-0056)

--- a/release-notes/5.1/5.1.3.md
+++ b/release-notes/5.1/5.1.3.md
@@ -5,7 +5,7 @@
 This update includes the following changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 
 ### Fixed
 

--- a/release-notes/5.1/5.1.4.md
+++ b/release-notes/5.1/5.1.4.md
@@ -4,6 +4,9 @@
 
 This update includes the following changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+
 ### Fixed
 
 - Fixed a deadlock problem for distributed transactions when on .NET.

--- a/release-notes/5.1/5.1.4.md
+++ b/release-notes/5.1/5.1.4.md
@@ -5,7 +5,7 @@
 This update includes the following changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 
 ### Fixed
 

--- a/release-notes/5.1/5.1.5.md
+++ b/release-notes/5.1/5.1.5.md
@@ -6,9 +6,7 @@ This update includes the following changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
 - [ErikEJ](https://github.com/ErikEJ)
-- [JRahnama](https://github.com/JRahnama)
 
 ### Fixed
 

--- a/release-notes/5.1/5.1.5.md
+++ b/release-notes/5.1/5.1.5.md
@@ -5,7 +5,7 @@
 This update includes the following changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [ErikEJ](https://github.com/ErikEJ)
 
 ### Fixed

--- a/release-notes/5.1/5.1.5.md
+++ b/release-notes/5.1/5.1.5.md
@@ -4,6 +4,12 @@
 
 This update includes the following changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [ErikEJ](https://github.com/ErikEJ)
+- [JRahnama](https://github.com/JRahnama)
+
 ### Fixed
 
 - Fixed connection to unsubscribe from transaction completion events before returning it to the connection pool [#2321](https://github.com/dotnet/SqlClient/pull/2321)

--- a/release-notes/5.2/5.2.0-preview1.md
+++ b/release-notes/5.2/5.2.0-preview1.md
@@ -6,13 +6,8 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [cheenamalhotra](https://github.com/cheenamalhotra)
-- [David-Engel](https://github.com/David-Engel)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
 - [ErikEJ](https://github.com/ErikEJ)
-- [JRahnama](https://github.com/JRahnama)
 - [kant2002](https://github.com/kant2002)
-- [lcheunglci](https://github.com/lcheunglci)
 - [mattjohnsonpint](https://github.com/mattjohnsonpint)
 - [Wraith2](https://github.com/Wraith2)
 

--- a/release-notes/5.2/5.2.0-preview1.md
+++ b/release-notes/5.2/5.2.0-preview1.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 - [ErikEJ](https://github.com/ErikEJ)
 - [kant2002](https://github.com/kant2002)

--- a/release-notes/5.2/5.2.0-preview1.md
+++ b/release-notes/5.2/5.2.0-preview1.md
@@ -4,6 +4,18 @@
 
 This update brings the below changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [cheenamalhotra](https://github.com/cheenamalhotra)
+- [David-Engel](https://github.com/David-Engel)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [ErikEJ](https://github.com/ErikEJ)
+- [JRahnama](https://github.com/JRahnama)
+- [kant2002](https://github.com/kant2002)
+- [lcheunglci](https://github.com/lcheunglci)
+- [mattjohnsonpint](https://github.com/mattjohnsonpint)
+- [Wraith2](https://github.com/Wraith2)
+
 ### Added
 
 - Added support of `SqlDiagnosticListener` on **.NET Standard**. [#1931](https://github.com/dotnet/SqlClient/pull/1931)

--- a/release-notes/5.2/5.2.0-preview1.md
+++ b/release-notes/5.2/5.2.0-preview1.md
@@ -6,10 +6,10 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [Wraith2](https://github.com/Wraith2)
 - [ErikEJ](https://github.com/ErikEJ)
 - [kant2002](https://github.com/kant2002)
 - [mattjohnsonpint](https://github.com/mattjohnsonpint)
-- [Wraith2](https://github.com/Wraith2)
 
 ### Added
 

--- a/release-notes/5.2/5.2.0-preview2.md
+++ b/release-notes/5.2/5.2.0-preview2.md
@@ -6,9 +6,9 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [Wraith2](https://github.com/Wraith2)
 - [azerios](https://github.com/azerios)
 - [jinek](https://github.com/jinek)
-- [Wraith2](https://github.com/Wraith2)
 
 ### Added
 

--- a/release-notes/5.2/5.2.0-preview2.md
+++ b/release-notes/5.2/5.2.0-preview2.md
@@ -7,8 +7,6 @@ This update brings the below changes over the previous release:
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
 - [azerios](https://github.com/azerios)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
-- [JRahnama](https://github.com/JRahnama)
 - [jinek](https://github.com/jinek)
 - [Wraith2](https://github.com/Wraith2)
 

--- a/release-notes/5.2/5.2.0-preview2.md
+++ b/release-notes/5.2/5.2.0-preview2.md
@@ -4,6 +4,14 @@
 
 This update brings the below changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [azerios](https://github.com/azerios)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [JRahnama](https://github.com/JRahnama)
+- [jinek](https://github.com/jinek)
+- [Wraith2](https://github.com/Wraith2)
+
 ### Added
 
 - Added new property `RowsCopied64` to `SqlBulkCopy`. [#2004](https://github.com/dotnet/SqlClient/pull/2004) [Read more](#added-new-property-rowscopied64-to-sqlbulkcopy)

--- a/release-notes/5.2/5.2.0-preview2.md
+++ b/release-notes/5.2/5.2.0-preview2.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 - [azerios](https://github.com/azerios)
 - [jinek](https://github.com/jinek)

--- a/release-notes/5.2/5.2.0-preview3.md
+++ b/release-notes/5.2/5.2.0-preview3.md
@@ -6,11 +6,7 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [arellegue](https://github.com/arellegue)
 - [christothes](https://github.com/christothes)
-- [David-Engel](https://github.com/David-Engel)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
-- [JRahnama](https://github.com/JRahnama)
 - [kant2002](https://github.com/kant2002)
 
 ### Added

--- a/release-notes/5.2/5.2.0-preview3.md
+++ b/release-notes/5.2/5.2.0-preview3.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [kant2002](https://github.com/kant2002)
 - [christothes](https://github.com/christothes)
 

--- a/release-notes/5.2/5.2.0-preview3.md
+++ b/release-notes/5.2/5.2.0-preview3.md
@@ -4,6 +4,15 @@
 
 This update brings the below changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [arellegue](https://github.com/arellegue)
+- [christothes](https://github.com/christothes)
+- [David-Engel](https://github.com/David-Engel)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [JRahnama](https://github.com/JRahnama)
+- [kant2002](https://github.com/kant2002)
+
 ### Added
 
 - Added a new `AccessTokenCallBack` API to `SqlConnection`. [#1260](https://github.com/dotnet/SqlClient/pull/1260)

--- a/release-notes/5.2/5.2.0-preview3.md
+++ b/release-notes/5.2/5.2.0-preview3.md
@@ -6,8 +6,8 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [christothes](https://github.com/christothes)
 - [kant2002](https://github.com/kant2002)
+- [christothes](https://github.com/christothes)
 
 ### Added
 

--- a/release-notes/5.2/5.2.0-preview4.md
+++ b/release-notes/5.2/5.2.0-preview4.md
@@ -4,6 +4,21 @@
 
 This update brings the below changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [arellegue](https://github.com/arellegue)
+- [danielmarbach](https://github.com/danielmarbach)
+- [David-Engel](https://github.com/David-Engel)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [emidah](https://github.com/emidah)
+- [ErikEJ](https://github.com/ErikEJ)
+- [JRahnama](https://github.com/JRahnama)
+- [panoskj](https://github.com/panoskj)
+- [saitama951](https://github.com/saitama951)
+- [ViktorHofer](https://github.com/ViktorHofer)
+- [Wraith2](https://github.com/Wraith2)
+- [wsugarman](https://github.com/wsugarman)
+
 ### Added
 
 - Added `SqlBatch` support on .NET 6+[#1825](https://github.com/dotnet/SqlClient/pull/1825), [#2223](https://github.com/dotnet/SqlClient/pull/2223)

--- a/release-notes/5.2/5.2.0-preview4.md
+++ b/release-notes/5.2/5.2.0-preview4.md
@@ -6,14 +6,14 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [danielmarbach](https://github.com/danielmarbach)
-- [emidah](https://github.com/emidah)
+- [Wraith2](https://github.com/Wraith2)
 - [ErikEJ](https://github.com/ErikEJ)
 - [panoskj](https://github.com/panoskj)
 - [saitama951](https://github.com/saitama951)
-- [ViktorHofer](https://github.com/ViktorHofer)
-- [Wraith2](https://github.com/Wraith2)
+- [danielmarbach](https://github.com/danielmarbach)
 - [wsugarman](https://github.com/wsugarman)
+- [ViktorHofer](https://github.com/ViktorHofer)
+- [emidah](https://github.com/emidah)
 
 ### Added
 

--- a/release-notes/5.2/5.2.0-preview4.md
+++ b/release-notes/5.2/5.2.0-preview4.md
@@ -6,13 +6,9 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [arellegue](https://github.com/arellegue)
 - [danielmarbach](https://github.com/danielmarbach)
-- [David-Engel](https://github.com/David-Engel)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
 - [emidah](https://github.com/emidah)
 - [ErikEJ](https://github.com/ErikEJ)
-- [JRahnama](https://github.com/JRahnama)
 - [panoskj](https://github.com/panoskj)
 - [saitama951](https://github.com/saitama951)
 - [ViktorHofer](https://github.com/ViktorHofer)

--- a/release-notes/5.2/5.2.0-preview4.md
+++ b/release-notes/5.2/5.2.0-preview4.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [Wraith2](https://github.com/Wraith2)
 - [ErikEJ](https://github.com/ErikEJ)
 - [panoskj](https://github.com/panoskj)

--- a/release-notes/5.2/5.2.0-preview5.md
+++ b/release-notes/5.2/5.2.0-preview5.md
@@ -4,6 +4,13 @@
 
 This update brings the below changes over the previous release:
 
+### Contributors
+Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+- [arellegue](https://github.com/arellegue)
+- [DavoudEshtehari](https://github.com/DavoudEshtehari)
+- [ErikEJ](https://github.com/ErikEJ)
+- [JRahnama](https://github.com/JRahnama)
+
 ### Added
 
 - Added .NET 8 support [#2230](https://github.com/dotnet/SqlClient/pull/2230)

--- a/release-notes/5.2/5.2.0-preview5.md
+++ b/release-notes/5.2/5.2.0-preview5.md
@@ -5,7 +5,7 @@
 This update brings the below changes over the previous release:
 
 ### Contributors
-Thanks to the following public contributors. Their efforts toward this project are very appreciated.
+Thanks to the following public contributors. Their efforts toward this project are very much appreciated.
 - [ErikEJ](https://github.com/ErikEJ)
 
 ### Added

--- a/release-notes/5.2/5.2.0-preview5.md
+++ b/release-notes/5.2/5.2.0-preview5.md
@@ -6,10 +6,7 @@ This update brings the below changes over the previous release:
 
 ### Contributors
 Thanks to the following public contributors. Their efforts toward this project are very appreciated.
-- [arellegue](https://github.com/arellegue)
-- [DavoudEshtehari](https://github.com/DavoudEshtehari)
 - [ErikEJ](https://github.com/ErikEJ)
-- [JRahnama](https://github.com/JRahnama)
 
 ### Added
 


### PR DESCRIPTION
It would be nice to indicate for releases contributors to the Microsoft.Data.SqlClient repository.
Updates are for PR's listed in release notes for Releases:
5.0.x
5.1.x
5.2.x

Relates to this community issue:
[#2341](https://github.com/dotnet/SqlClient/issues/2341)

