### PR TITLE
Rent byte buffers in SqlSequentialTextReader

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Data.SqlClient
         private readonly int _columnIndex;       // The index of out column in the table
         private readonly Encoding _encoding;     // Encoding for this character stream
         private readonly Decoder _decoder;       // Decoder based on the encoding (NOTE: Decoders are stateful as they are designed to process streams of data)
-        private byte[] _leftOverBytes;  // Bytes leftover from the last Read() operation - this can be null if there were no bytes leftover (Possible optimization: re-use the same array?)
+        private byte[] _leftOverBytes;  // Bytes leftover from the last Read() operation - this can be null if there were no bytes leftover
+        private int _leftOverByteBufferUsed; //Number of bytes used from _leftOverBytes buffer - will be zero in case of null buffer
         private int _peekedChar;        // The last character that we peeked at (or -1 if we haven't peeked at anything)
         private Task _currentTask;      // The current async task
         private readonly CancellationTokenSource _disposalTokenSource;    // Used to indicate that a cancellation is requested due to disposal
@@ -358,19 +359,14 @@ namespace Microsoft.Data.SqlClient
 
                 if (_leftOverBytes != null)
                 {
-                    // If we have more leftover bytes than we need for this conversion, then just re-use the leftover buffer
-                    if (_leftOverBytes.Length > byteBufferSize)
-                    {
-                        byteBuffer = _leftOverBytes;
-                        byteBufferUsed = byteBuffer.Length;
-                    }
-                    else
-                    {
-                        // Otherwise, copy over the leftover buffer
-                        byteBuffer = ArrayPool<byte>.Shared.Rent(byteBufferSize);
-                        Buffer.BlockCopy(_leftOverBytes, 0, byteBuffer, 0, _leftOverBytes.Length);
-                        byteBufferUsed = _leftOverBytes.Length;
-                    }
+                    // Copy over the leftover buffer
+                    byteBuffer = ArrayPool<byte>.Shared.Rent(byteBufferSize);
+                    Buffer.BlockCopy(_leftOverBytes, 0, byteBuffer, 0, _leftOverByteBufferUsed);
+                    byteBufferUsed = _leftOverByteBufferUsed;
+                    //return _leftOverBytes and clean _leftOverBytes reference
+                    ArrayPool<byte>.Shared.Return(_leftOverBytes);
+                    _leftOverBytes = null;
+                    _leftOverByteBufferUsed = 0;
                 }
                 else
                 {
@@ -403,22 +399,26 @@ namespace Microsoft.Data.SqlClient
             // completed may be false and there is no spare bytes if the Decoder has stored bytes to use later
             if ((!completed) && (bytesUsed < inBufferCount))
             {
-                bool isLeftOverBufferSameAsInBuffer = _leftOverBytes == inBuffer;
-                if (_leftOverBytes != null)
-                    ArrayPool<byte>.Shared.Return(_leftOverBytes);
-                _leftOverBytes = ArrayPool<byte>.Shared.Rent(inBufferCount - bytesUsed);
-                Buffer.BlockCopy(inBuffer, bytesUsed, _leftOverBytes, 0, _leftOverBytes.Length);
-
-                if (!isLeftOverBufferSameAsInBuffer && inBuffer.Length > 0)
-                    ArrayPool<byte>.Shared.Return(inBuffer);
+                _leftOverByteBufferUsed = inBufferCount - bytesUsed;
+                _leftOverBytes = ArrayPool<byte>.Shared.Rent(_leftOverByteBufferUsed);
+                
+                Buffer.BlockCopy(inBuffer, bytesUsed, _leftOverBytes, 0, _leftOverByteBufferUsed);
             }
             else
             {
                 // If Convert() sets completed to true, then it must have used all of the bytes we gave it
                 Debug.Assert(bytesUsed >= inBufferCount, "Converted completed, but not all bytes were used");
-                _leftOverBytes = null;
-                if (inBuffer.Length > 0)
-                    ArrayPool<byte>.Shared.Return(inBuffer);
+                if (_leftOverBytes != null)
+                {
+                    ArrayPool<byte>.Shared.Return(_leftOverBytes);
+                    _leftOverBytes = null;
+                    _leftOverByteBufferUsed = 0;
+                }
+            }
+
+            if (inBuffer.Length > 0)
+            {
+                ArrayPool<byte>.Shared.Return(inBuffer);
             }
 
             Debug.Assert(((_reader == null) || (_reader.ColumnDataBytesRemaining() > 0) || (!completed) || (_leftOverBytes == null)), "Stream has run out of data and the decoder finished, but there are leftover bytes");


### PR DESCRIPTION
While profiling our code I saw a lot of allocations when using reader.GetTextReader() over big string column when reader is opened with CommandBehavior.SequentialAccess.

![image](https://github.com/dotnet/SqlClient/assets/12857389/754148c7-780f-4edb-a178-53c1eaa41a0b)

This PR tries to fix this by renting byte[] from shared pool.