### PR TITLE
Fix | Removing non-breaking space from links inside some of exception messages.

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -1897,7 +1897,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The validation of an attestation token failed. The token signature does not match the signature omputed using a public key retrieved from the attestation public key endpoint at &apos;{0}&apos;. Verify the DNS apping for the endpoint - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If correct, contact Customer Support Services..
+        ///   Looks up a localized string similar to The validation of an attestation token failed. The token signature does not match the computed signature using a public key retrieved from the attestation public key endpoint at &apos;{0}&apos;. Verify the DNS mapping for the endpoint - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If correct, contact Customer Support Services..
         /// </summary>
         internal static string AttestationTokenSignatureValidationFailed {
             get {
@@ -6802,7 +6802,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The attestation service returned an expired HGS root certificate for attestation URL &apos;{0}&apos;. Check the HGS root certificate configured for your HGS instance - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details..
+        ///   Looks up a localized string similar to The attestation service returned an expired HGS root certificate for attestation URL &apos;{0}&apos;. Check the HGS root certificate configured for your HGS instance - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details..
         /// </summary>
         internal static string GetAttestationSigningCertificateFailedInvalidCertificate {
             get {
@@ -6811,7 +6811,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The obtained HGS root certificate for attestation URL &apos;{0}&apos; has an invalid format. Verify the attestation URL is correct and the HGS server is online and fully initialized - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. For additional support contact Customer Support Services. Error details: &apos;{1}&apos;..
+        ///   Looks up a localized string similar to The obtained HGS root certificate for attestation URL &apos;{0}&apos; has an invalid format. Verify the attestation URL is correct and the HGS server is online and fully initialized - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. For additional support contact Customer Support Services. Error details: &apos;{1}&apos;..
         /// </summary>
         internal static string GetAttestationSigningCertificateRequestFailedFormat {
             get {
@@ -6892,7 +6892,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The validation of an attestation token failed. Claim &apos;{0}&apos; in the token has an invalid value of &apos;{1}&apos;. Verify the attestation policy - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If the policy is correct, contact Customer Support Services..
+        ///   Looks up a localized string similar to The validation of an attestation token failed. Claim &apos;{0}&apos; in the token has an invalid value of &apos;{1}&apos;. Verify the attestation policy - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If the policy is correct, contact Customer Support Services..
         /// </summary>
         internal static string InvalidClaimInAttestationToken {
             get {
@@ -7171,7 +7171,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The validation of the attestation token failed. Claim &apos;{0}&apos; is missing in the token. Verify the attestation policy - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If the policy is correct, contact Customer Support Services..
+        ///   Looks up a localized string similar to The validation of the attestation token failed. Claim &apos;{0}&apos; is missing in the token. Verify the attestation policy - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If the policy is correct, contact Customer Support Services..
         /// </summary>
         internal static string MissingClaimInAttestationToken {
             get {
@@ -13564,7 +13564,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not verify enclave policy due to a difference between the expected and actual values of the policy on property &apos;{0}&apos;. Actual: &apos;{1}&apos;, Expected: &apos;{2}&apos; - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details..
+        ///   Looks up a localized string similar to Could not verify enclave policy due to a difference between the expected and actual values of the policy on property &apos;{0}&apos;. Actual: &apos;{1}&apos;, Expected: &apos;{2}&apos; - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details..
         /// </summary>
         internal static string VerifyEnclavePolicyFailedFormat {
             get {

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -4465,7 +4465,7 @@
     <value>Execution Timeout Expired.  The timeout period elapsed prior to completion of the operation or the server is not responding.</value>
   </data>
   <data name="AttestationTokenSignatureValidationFailed" xml:space="preserve">
-    <value>The validation of an attestation token failed. The token signature does not match the computed signature using a public key retrieved from the attestation public key endpoint at '{0}'. Verify the DNS mapping for the endpoint - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If correct, contact Customer Support Services.</value>
+    <value>The validation of an attestation token failed. The token signature does not match the computed signature using a public key retrieved from the attestation public key endpoint at '{0}'. Verify the DNS mapping for the endpoint - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If correct, contact Customer Support Services.</value>
   </data>
   <data name="EnclaveRetrySleepInSecondsValueException" xml:space="preserve">
     <value>Internal error occurred when retrying the download of the HGS root certificate after the initial request failed. Contact Customer Support Services.</value>
@@ -4486,10 +4486,10 @@
     <value>The validation of an attestation token failed. The token has an invalid format. Contact Customer Support Services. Error details: '{0}'.</value>
   </data>
   <data name="GetAttestationSigningCertificateFailedInvalidCertificate" xml:space="preserve">
-    <value>The attestation service returned an expired HGS root certificate for attestation URL '{0}'. Check the HGS root certificate configured for your HGS instance - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details.</value>
+    <value>The attestation service returned an expired HGS root certificate for attestation URL '{0}'. Check the HGS root certificate configured for your HGS instance - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details.</value>
   </data>
   <data name="GetAttestationSigningCertificateRequestFailedFormat" xml:space="preserve">
-    <value>The obtained HGS root certificate for attestation URL '{0}' has an invalid format. Verify the attestation URL is correct and the HGS server is online and fully initialized - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. For additional support contact Customer Support Services. Error details: '{1}'.</value>
+    <value>The obtained HGS root certificate for attestation URL '{0}' has an invalid format. Verify the attestation URL is correct and the HGS server is online and fully initialized - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. For additional support contact Customer Support Services. Error details: '{1}'.</value>
   </data>
   <data name="GetAttestationTokenSigningKeysFailed" xml:space="preserve">
     <value>The validation of an attestation token failed. Cannot retrieve a public key from the attestation public key endpoint, or the retrieved key has an invalid format. Error details: '{0}'.</value>
@@ -4507,16 +4507,16 @@
     <value>The validation of the attestation token has failed during signature validation. Exception: '{0}'.</value>
   </data>
   <data name="InvalidClaimInAttestationToken" xml:space="preserve">
-    <value>The validation of an attestation token failed. Claim '{0}' in the token has an invalid value of '{1}'. Verify the attestation policy - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If the policy is correct, contact Customer Support Services.</value>
+    <value>The validation of an attestation token failed. Claim '{0}' in the token has an invalid value of '{1}'. Verify the attestation policy - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If the policy is correct, contact Customer Support Services.</value>
   </data>
   <data name="MissingClaimInAttestationToken" xml:space="preserve">
-    <value>The validation of the attestation token failed. Claim '{0}' is missing in the token. Verify the attestation policy - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If the policy is correct, contact Customer Support Services.</value>
+    <value>The validation of the attestation token failed. Claim '{0}' is missing in the token. Verify the attestation policy - see https://go.microsoft.com/fwlink/?linkid=2157649 for more details. If the policy is correct, contact Customer Support Services.</value>
   </data>
   <data name="VerifyEnclaveDebuggable" xml:space="preserve">
     <value>Failed to check if the enclave is running in the production mode. Contact Customer Support Services.</value>
   </data>
   <data name="VerifyEnclavePolicyFailedFormat" xml:space="preserve">
-    <value>Could not verify enclave policy due to a difference between the expected and actual values of the policy on property '{0}'. Actual: '{1}', Expected: '{2}' - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details.</value>
+    <value>Could not verify enclave policy due to a difference between the expected and actual values of the policy on property '{0}'. Actual: '{1}', Expected: '{2}' - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details.</value>
   </data>
   <data name="VerifyEnclaveReportFailed" xml:space="preserve">
     <value>Signature verification of the enclave report failed. The report signature does not match the signature computed using the HGS root certificate. Verify the DNS mapping for the endpoint - see https://go.microsoft.com/fwlink/?linkid=2160553 for more details. If correct, contact Customer Support Services.</value>

--- a/src/Microsoft.Data.SqlClient/tests/Directory.Build.props
+++ b/src/Microsoft.Data.SqlClient/tests/Directory.Build.props
@@ -4,8 +4,7 @@
 
   <!-- Import parent Directory.build.props -->
   <Import Project="..\..\Directory.Build.props" />
-  <Import Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" Project="$(ToolsDir)props\VersionsNet8OrLater.props" />
-  
+    
   <PropertyGroup>
     <OSGroup Condition="$(OSGroup) == ''">$(OS)</OSGroup>
     <TargetsWindows Condition="'$(OSGroup)'=='Windows_NT'">true</TargetsWindows>

--- a/src/Microsoft.Data.SqlClient/tests/Directory.Build.props
+++ b/src/Microsoft.Data.SqlClient/tests/Directory.Build.props
@@ -4,7 +4,7 @@
 
   <!-- Import parent Directory.build.props -->
   <Import Project="..\..\Directory.Build.props" />
-    
+  
   <PropertyGroup>
     <OSGroup Condition="$(OSGroup) == ''">$(OS)</OSGroup>
     <TargetsWindows Condition="'$(OSGroup)'=='Windows_NT'">true</TargetsWindows>

--- a/src/Microsoft.Data.SqlClient/tests/Directory.Build.props
+++ b/src/Microsoft.Data.SqlClient/tests/Directory.Build.props
@@ -4,6 +4,7 @@
 
   <!-- Import parent Directory.build.props -->
   <Import Project="..\..\Directory.Build.props" />
+  <Import Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" Project="$(ToolsDir)props\VersionsNet8OrLater.props" />
   
   <PropertyGroup>
     <OSGroup Condition="$(OSGroup) == ''">$(OS)</OSGroup>


### PR DESCRIPTION
Non-breaking spaces (u+202F) was inserted before and after some of the links inside exception messages. That made the links to be broken.