### PR TITLE
Fix | ExecuteReaderAsync API return type in ref file

### DIFF
--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.Batch.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.Batch.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlBatch.xml' path='docs/members[@name="SqlBatch"]/ExecuteReader/*'/>
         public Microsoft.Data.SqlClient.SqlDataReader ExecuteReader() => throw null;       
         /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlBatch.xml' path='docs/members[@name="SqlBatch"]/ExecuteReaderAsync/*'/>
-        public Microsoft.Data.SqlClient.SqlDataReader ExecuteReaderAsync() => throw null;
+        public System.Threading.Tasks.Task<Microsoft.Data.SqlClient.SqlDataReader> ExecuteReaderAsync() => throw null;
         /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlBatch.xml' path='docs/members[@name="SqlBatch"]/ExecuteScalar/*'/>
         public override object ExecuteScalar() => throw null;
         /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlBatch.xml' path='docs/members[@name="SqlBatch"]/ExecuteScalarAsync/*'/>


### PR DESCRIPTION
Relevant to #2371