### PR TITLE
Doc | Fix typo in SqlConnectionEncryptOption.xml

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
@@ -49,13 +49,13 @@ Implicit conversions have been added to maintain backwards compatibility with bo
     <BoolToOption>
       <param name="value">The boolean value to be used for implicit comparison.</param>
       <summary>
-        Enables implicit converstion of a boolean to a <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption" />. A value of <see langword="true" /> converts to <see cref="P:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory" />. A value of <see langword="false" /> converts to <see cref="P:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional" />.
+        Enables implicit conversion of a boolean to a <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption" />. A value of <see langword="true" /> converts to <see cref="P:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory" />. A value of <see langword="false" /> converts to <see cref="P:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional" />.
       </summary>
     </BoolToOption>
     <OptionToBool>
       <param name="value">The <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption" /> value to be used for implicit comparison.</param>
       <summary>
-        Enables implicit converstion of a <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption" /> to a boolean. <see cref="P:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory" /> and <see cref="P:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Strict" /> convert to <see langword="true" />. <see cref="P:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional" /> converts to <see langword="false" />.
+        Enables implicit conversion of a <see cref="T:Microsoft.Data.SqlClient.SqlConnectionEncryptOption" /> to a boolean. <see cref="P:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory" /> and <see cref="P:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Strict" /> convert to <see langword="true" />. <see cref="P:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional" /> converts to <see langword="false" />.
       </summary>
     </OptionToBool>
     <ToString>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionEncryptOption.xml
@@ -7,7 +7,7 @@
       <format type="text/markdown"><![CDATA[  
 
 ## Remarks  
-Implicit conversions have been added to maintain backwards compatibility with boolean behahavior for the <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.Encrypt%2A> property. When converting from a boolean, a value of `true` converts to <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory%2A> and a value of `false` converts to <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional%2A>. When converting to a boolean, <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory%2A>, <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Strict%2A> , and `null` convert to `true` and <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional%2A> converts `false`.
+Implicit conversions have been added to maintain backwards compatibility with boolean behavior for the <xref:Microsoft.Data.SqlClient.SqlConnectionStringBuilder.Encrypt%2A> property. When converting from a boolean, a value of `true` converts to <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory%2A> and a value of `false` converts to <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional%2A>. When converting to a boolean, <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Mandatory%2A>, <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Strict%2A> , and `null` convert to `true` and <xref:Microsoft.Data.SqlClient.SqlConnectionEncryptOption.Optional%2A> converts `false`.
 
  ]]></format>
       </remarks>


### PR DESCRIPTION
Found a typo in https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconnectionencryptoption?view=sqlclient-dotnet-standard-5.1.

This is the only occurrence of this typo, as you can see in https://github.com/search?q=repo%3Adotnet%2FSqlClient%20behahavior&type=code