### PR TITLE
fix: Making open operation async first

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -8108,7 +8108,7 @@ namespace Microsoft.Data.SqlClient
             return len;
         }
 
-        internal void TdsLogin(SqlLogin rec, TdsEnums.FeatureExtension requestedFeatures, SessionData recoverySessionData, FederatedAuthenticationFeatureExtensionData fedAuthFeatureExtensionData, SqlConnectionEncryptOption encrypt)
+        internal async Task TdsLogin(SqlLogin rec, TdsEnums.FeatureExtension requestedFeatures, SessionData recoverySessionData, FederatedAuthenticationFeatureExtensionData fedAuthFeatureExtensionData, SqlConnectionEncryptOption encrypt)
         {
             _physicalStateObj.SetTimeoutSeconds(rec.timeout);
 
@@ -8261,7 +8261,7 @@ namespace Microsoft.Data.SqlClient
                 ArrayPool<byte>.Shared.Return(rentedSSPIBuff, clearArray: true);
             }
 
-            _physicalStateObj.WritePacket(TdsEnums.HARDFLUSH);
+            await _physicalStateObj.WritePacket(TdsEnums.HARDFLUSH);
             _physicalStateObj.ResetSecurePasswordsInformation();
             _physicalStateObj.HasPendingData = true;
             _physicalStateObj._messageStatus = 0;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2698,7 +2698,7 @@ namespace Microsoft.Data.SqlClient
             // Normally we would simply create a regular connectoin and open it but there is no other way to pass the
             // new password down to the constructor. Also it would have an unwanted impact on the connection pool
             //
-            using (SqlInternalConnectionTds con = new SqlInternalConnectionTds(null, connectionOptions, credential, null, newPassword, newSecurePassword, false, null, null, null, null))
+            using (SqlInternalConnectionTds con = SqlInternalConnectionTds.Create(null, connectionOptions, credential, null, newPassword, newSecurePassword, false, null, null, null, null).GetAwaiter().GetResult())
             {
                 if (!con.Is2005OrNewer)
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1711,7 +1711,10 @@ namespace Microsoft.Data.SqlClient
             {
                 SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlConnection.Open|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
-                InternalOpenAsync(CancellationToken.None, overrides).GetAwaiter().GetResult();
+                InternalOpenAsync(CancellationToken.None, overrides)
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
             }
         }
 
@@ -1958,7 +1961,10 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OpenAsync/*' />
         public override Task OpenAsync(CancellationToken cancellationToken)
-            => InternalOpenAsync(cancellationToken, SqlConnectionOverrides.None);
+        {
+            SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlConnection.Open|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
+            return InternalOpenAsync(cancellationToken, SqlConnectionOverrides.None);
+        }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OpenAsyncWithOverrides/*' />
         public async Task OpenAsync(CancellationToken cancellationToken, SqlConnectionOverrides overrides)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -3277,9 +3277,9 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal override bool TryReplaceConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
+        internal override Task<bool> TryReplaceConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory, CancellationToken cancellationToken, DbConnectionOptions userOptions)
         {
-            return base.TryOpenConnectionInternal(outerConnection, connectionFactory, retry, userOptions);
+            return base.TryOpenConnectionInternal(outerConnection, connectionFactory, cancellationToken, userOptions);
         }
     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -493,7 +493,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal void Connect(ServerInfo serverInfo,
+        internal async Task Connect(ServerInfo serverInfo,
                               SqlInternalConnectionTds connHandler,
                               TimeoutTimer timeout,
                               SqlConnectionString connectionOptions,
@@ -711,7 +711,7 @@ namespace Microsoft.Data.SqlClient
             // UNDONE - send "" for instance now, need to fix later
             SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.Connect|SEC> Sending prelogin handshake");
 
-            SendPreLoginHandshake(
+            await SendPreLoginHandshake(
                 instanceName,
                 encrypt,
                 integratedSecurity,
@@ -775,7 +775,7 @@ namespace Microsoft.Data.SqlClient
                 // for DNS Caching phase 1
                 AssignPendingDNSInfo(serverInfo.UserProtocol, FQDNforDNSCache);
 
-                SendPreLoginHandshake(
+                await SendPreLoginHandshake(
                     instanceName,
                     encrypt,
                     integratedSecurity,
@@ -1038,7 +1038,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private void SendPreLoginHandshake(
+        private async Task SendPreLoginHandshake(
             byte[] instanceName,
             SqlConnectionEncryptOption encrypt,
             bool integratedSecurity,
@@ -1229,10 +1229,10 @@ namespace Microsoft.Data.SqlClient
             _physicalStateObj.WriteByte((byte)PreLoginOptions.LASTOPT);
 
             // Write out payload
-            _physicalStateObj.WriteByteArray(payload, payloadLength, 0);
+            await _physicalStateObj.WriteByteArray(payload, payloadLength, 0);
 
             // Flush packet
-            _physicalStateObj.WritePacket(TdsEnums.HARDFLUSH);
+            await _physicalStateObj.WritePacket(TdsEnums.HARDFLUSH);
         }
 
         private void EnableSsl(uint info, SqlConnectionEncryptOption encrypt, bool integratedSecurity, string serverCertificate, ServerCertificateValidationCallback serverCallback, ClientCertificateRetrievalCallback clientCallback)
@@ -2547,7 +2547,7 @@ namespace Microsoft.Data.SqlClient
                                     (error.Class <= TdsEnums.MAX_USER_CORRECTABLE_ERROR_CLASS))
                                 {
                                     // Fire SqlInfoMessage here
-                                    FireInfoMessageEvent(connection,cmdHandler, stateObj, error);
+                                    FireInfoMessageEvent(connection, cmdHandler, stateObj, error);
                                 }
                                 else
                                 {
@@ -8904,7 +8904,7 @@ namespace Microsoft.Data.SqlClient
             return len;
         }
 
-        internal void TdsLogin(SqlLogin rec,
+        internal async Task TdsLogin(SqlLogin rec,
                                TdsEnums.FeatureExtension requestedFeatures,
                                SessionData recoverySessionData,
                                FederatedAuthenticationFeatureExtensionData fedAuthFeatureExtensionData,
@@ -9078,7 +9078,7 @@ namespace Microsoft.Data.SqlClient
                            outSSPIBuff,
                            outSSPILength);
 
-            _physicalStateObj.WritePacket(TdsEnums.HARDFLUSH);
+            await _physicalStateObj.WritePacket(TdsEnums.HARDFLUSH);
             _physicalStateObj.ResetSecurePasswordsInformation();     // Password information is needed only from Login process; done with writing login packet and should clear information
             _physicalStateObj.HasPendingData = true;
             _physicalStateObj._messageStatus = 0;


### PR DESCRIPTION
Attempt to fix https://github.com/dotnet/SqlClient/issues/979
The general idea is to make the **open** operation async first, so it simplifies the OpenAsync flow and allows the use of the same logic for the sync Open through **GetAwaiter**.

I'm still figuring out how to handle and to test this project, so I'm opening it as a draft hoping anyone can validate if this is a valid approach or if the idea is not feasible because it can introduce some breaking changes I haven't noticed.