### PR TITLE
Regression | Revert PR #2281 SNIProxy code change

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIProxy.cs
@@ -654,7 +654,7 @@ namespace Microsoft.Data.SqlClient.SNI
                 Port = port;
             }
             // Instance Name Handling. 
-            if (backSlashIndex > -1)
+            else if (backSlashIndex > -1)
             {
                 // This means that there is a part separated by '\'
                 InstanceName = tokensByCommaAndSlash[1].Trim();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/InstanceNameTest/InstanceNameTest.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
 #if NETCOREAPP
+        [ActiveIssue("27824")] // When specifying instance name and port number, this method call always returns false
         [ConditionalFact(nameof(IsSPNPortNumberTestForTCP))]
         public static void PortNumberInSPNTestForTCP()
         {


### PR DESCRIPTION
This PR reverts back the code change from #2281 to address regression in v5.2.0
