### PR TITLE
Proof of concept: OpenTelemetry metrics

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Common;
 using System;
 using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient.Telemetry;
 
 namespace Microsoft.Data.ProviderBase
 {
@@ -88,6 +89,32 @@ namespace Microsoft.Data.ProviderBase
                     poolGroup.Clear();
                 }
             }
+        }
+
+        public Dictionary<string, DbConnectionFactoryTelemetry> GetFactoryMetrics()
+        {
+            Dictionary<DbConnectionPoolKey, DbConnectionPoolGroup> connectionPoolGroups = _connectionPoolGroups;
+            Dictionary<string, DbConnectionFactoryTelemetry> telemetry = new(connectionPoolGroups.Count);
+
+            foreach (DbConnectionPoolGroup poolGroup in connectionPoolGroups.Values)
+            {
+                // This will ensure that the connection string has does not reveal its credentials
+                string connectionString = poolGroup.ConnectionOptions.UsersConnectionStringForTrace();
+
+                // This will return true if the connection string uses integrated authentication and a second connection has
+                // been opened in an impersonated context. The specification doesn't handle this well, so the only thing to
+                // do is to roll all of the contexts up into a single connection string.
+                if (telemetry.ContainsKey(connectionString))
+                {
+                    telemetry[connectionString].AddConnectionPool(poolGroup.Telemetry);
+                }
+                else
+                {
+                    telemetry.Add(connectionString, new DbConnectionFactoryTelemetry(poolGroup.Telemetry));
+                }
+            }
+
+            return telemetry;
         }
 
         internal virtual DbConnectionPoolProviderInfo CreateConnectionPoolProviderInfo(DbConnectionOptions connectionOptions)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -246,6 +246,24 @@
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Server\SqlRecordBuffer.cs">
       <Link>Microsoft\Data\SqlClient\Server\SqlRecordBuffer.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\ComponentTelemetry.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\ComponentTelemetry.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\MetricConstants.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\MetricConstants.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\SqlClientMetrics.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\SqlClientMetrics.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\SqlClientTelemetry.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\SqlClientTelemetry.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\DbConnectionFactoryTelemetry.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\DbConnectionFactoryTelemetry.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\TelemetryInterfaces.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\TelemetryInterfaces.cs</Link>
+    </Compile>
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\SqlTransaction.Common.cs">
       <Link>Microsoft\Data\SqlClient\SqlTransaction.Common.cs</Link>
     </Compile>
@@ -646,6 +664,7 @@
     <Compile Include="Microsoft\Data\SqlClient\SNI\SslOverTdsStream.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SNICommon.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\SSRP.cs" />
+    <Compile Include="Microsoft\Data\SqlClient\Telemetry\SqlClientMetrics.NetCoreApp.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlAppContextSwitchManager.NetCoreApp.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlAuthenticationProviderManager.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlBulkCopy.cs" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -1010,7 +1010,6 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'netstandard'">
     <PackageReference Condition="'$(TargetsWindows)' == 'true' and '$(IsUAPAssembly)' != 'true'" Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
     <PackageReference Include="System.Security.Principal.Windows" Version="$(SystemSecurityPrincipalWindowsVersion)" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
@@ -1019,6 +1018,9 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsVersion)" />
     <PackageReference Include="System.Runtime.Caching" Version="$(SystemRuntimeCachingVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netstandard' OR '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.NetCoreApp.cs
@@ -1,0 +1,378 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using Microsoft.Data.Common;
+
+namespace Microsoft.Data.SqlClient.Telemetry
+{
+    internal sealed partial class SqlClientMetrics
+    {
+#if NETSTANDARD2_0
+        private void InitializePlatformSpecificMetrics() { }
+
+        private void IncrementPlatformSpecificMetric(string metricName, in TagList tagList) { }
+
+        private void DecrementPlatformSpecificMetric(string metricName, in TagList tagList) { }
+
+        private void DisposePlatformSpecificMetrics() { }
+#else
+
+        private PollingCounter _activeHardConnections;
+        private IncrementingPollingCounter _hardConnectsPerSecond;
+        private IncrementingPollingCounter _hardDisconnectsPerSecond;
+
+        private PollingCounter _activeSoftConnections;
+        private IncrementingPollingCounter _softConnects;
+        private IncrementingPollingCounter _softDisconnects;
+
+        private PollingCounter _numberOfNonPooledConnections;
+        private PollingCounter _numberOfPooledConnections;
+
+        private PollingCounter _numberOfActiveConnectionPoolGroups;
+        private PollingCounter _numberOfInactiveConnectionPoolGroups;
+
+        private PollingCounter _numberOfActiveConnectionPools;
+        private PollingCounter _numberOfInactiveConnectionPools;
+
+        private PollingCounter _numberOfActiveConnections;
+        private PollingCounter _numberOfFreeConnections;
+        private PollingCounter _numberOfStasisConnections;
+        private IncrementingPollingCounter _numberOfReclaimedConnections;
+
+        private long _activeHardConnectionsCounter = 0;
+        private long _hardConnectsCounter = 0;
+        private long _hardDisconnectsCounter = 0;
+
+        private long _activeSoftConnectionsCounter = 0;
+        private long _softConnectsCounter = 0;
+        private long _softDisconnectsCounter = 0;
+
+        private long _nonPooledConnectionsCounter = 0;
+        private long _pooledConnectionsCounter = 0;
+
+        private long _activeConnectionPoolGroupsCounter = 0;
+        private long _inactiveConnectionPoolGroupsCounter = 0;
+
+        private long _activeConnectionPoolsCounter = 0;
+        private long _inactiveConnectionPoolsCounter = 0;
+
+        private long _activeConnectionsCounter = 0;
+        private long _freeConnectionsCounter = 0;
+        private long _stasisConnectionsCounter = 0;
+        private long _reclaimedConnectionsCounter = 0;
+
+        // This counter is simply used as a placeholder - GetPlatformSpecificMetric has to return a ref to something.
+        // It should always be zero.
+        private long _watchdogCounter = 0;
+
+        private void InitializePlatformSpecificMetrics()
+        {
+            _activeHardConnections = new PollingCounter("active-hard-connections", SqlClientEventSource.Log, () => _activeHardConnectionsCounter)
+            {
+                DisplayName = "Actual active connections currently made to servers",
+                DisplayUnits = "count"
+            };
+
+            _hardConnectsPerSecond = new IncrementingPollingCounter("hard-connects", SqlClientEventSource.Log, () => _hardConnectsCounter)
+            {
+                DisplayName = "Actual connection rate to servers",
+                DisplayUnits = "count / sec",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+
+            _hardDisconnectsPerSecond = new IncrementingPollingCounter("hard-disconnects", SqlClientEventSource.Log, () => _hardDisconnectsCounter)
+            {
+                DisplayName = "Actual disconnection rate from servers",
+                DisplayUnits = "count / sec",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+
+            _activeSoftConnections = new PollingCounter("active-soft-connects", SqlClientEventSource.Log, () => _activeSoftConnectionsCounter)
+            {
+                DisplayName = "Active connections retrieved from the connection pool",
+                DisplayUnits = "count"
+            };
+
+            _softConnects = new IncrementingPollingCounter("soft-connects", SqlClientEventSource.Log, () => _softConnectsCounter)
+            {
+                DisplayName = "Rate of connections retrieved from the connection pool",
+                DisplayUnits = "count / sec",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+
+            _softDisconnects = new IncrementingPollingCounter("soft-disconnects", SqlClientEventSource.Log, () => _softDisconnectsCounter)
+            {
+                DisplayName = "Rate of connections returned to the connection pool",
+                DisplayUnits = "count / sec",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+
+            _numberOfNonPooledConnections = new PollingCounter("number-of-non-pooled-connections", SqlClientEventSource.Log, () => _nonPooledConnectionsCounter)
+            {
+                DisplayName = "Number of connections not using connection pooling",
+                DisplayUnits = "count"
+            };
+
+            _numberOfPooledConnections = new PollingCounter("number-of-pooled-connections", SqlClientEventSource.Log, () => _pooledConnectionsCounter)
+            {
+                DisplayName = "Number of connections managed by the connection pool",
+                DisplayUnits = "count"
+            };
+
+            _numberOfActiveConnectionPoolGroups = new PollingCounter("number-of-active-connection-pool-groups", SqlClientEventSource.Log, () => _activeConnectionPoolGroupsCounter)
+            {
+                DisplayName = "Number of active unique connection strings",
+                DisplayUnits = "count"
+            };
+
+            _numberOfInactiveConnectionPoolGroups = new PollingCounter("number-of-inactive-connection-pool-groups", SqlClientEventSource.Log, () => _inactiveConnectionPoolGroupsCounter)
+            {
+                DisplayName = "Number of unique connection strings waiting for pruning",
+                DisplayUnits = "count"
+            };
+
+            _numberOfActiveConnectionPools = new PollingCounter("number-of-active-connection-pools", SqlClientEventSource.Log, () => _activeConnectionPoolsCounter)
+            {
+                DisplayName = "Number of active connection pools",
+                DisplayUnits = "count"
+            };
+
+            _numberOfInactiveConnectionPools = new PollingCounter("number-of-inactive-connection-pools", SqlClientEventSource.Log, () => _inactiveConnectionPoolsCounter)
+            {
+                DisplayName = "Number of inactive connection pools",
+                DisplayUnits = "count"
+            };
+
+            _numberOfActiveConnections = new PollingCounter("number-of-active-connections", SqlClientEventSource.Log, () => _activeConnectionsCounter)
+            {
+                DisplayName = "Number of active connections",
+                DisplayUnits = "count"
+            };
+
+            _numberOfFreeConnections = new PollingCounter("number-of-free-connections", SqlClientEventSource.Log, () => _freeConnectionsCounter)
+            {
+                DisplayName = "Number of ready connections in the connection pool",
+                DisplayUnits = "count"
+            };
+
+            _numberOfStasisConnections = new PollingCounter("number-of-stasis-connections", SqlClientEventSource.Log, () => _stasisConnectionsCounter)
+            {
+                DisplayName = "Number of connections currently waiting to be ready",
+                DisplayUnits = "count"
+            };
+
+            _numberOfReclaimedConnections = new IncrementingPollingCounter("number-of-reclaimed-connections", SqlClientEventSource.Log, () => _reclaimedConnectionsCounter)
+            {
+                DisplayName = "Number of reclaimed connections from GC",
+                DisplayUnits = "count",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+        }
+
+        private KeyValuePair<string, object> GetTagByName(string tagName, int likelyIndex, in TagList tagList)
+        {
+            KeyValuePair<string, object> tagValue;
+
+            // We have control over the initial tag list, so in almost every circumstance this shortcut will be used.
+            // It spares us from a loop, however small.
+            // In most cases, index 0 is the connection pool name.
+            if (likelyIndex > 0 && likelyIndex < tagList.Count)
+            {
+                tagValue = tagList[likelyIndex];
+
+                if (string.Equals(tagValue.Key, tagName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return tagValue;
+                }
+            }
+
+            for(int i = 0; i < tagList.Count; i++)
+            {
+                tagValue = tagList[i];
+
+                if (string.Equals(tagValue.Key, tagName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return tagValue;
+                }
+            }
+
+            throw ADP.CollectionIndexString(typeof(KeyValuePair<string, object>), nameof(KeyValuePair<string, object>.Key), tagName, typeof(TagList));
+        }
+
+        private ref long GetPlatformSpecificMetric(string metricName, in TagList tagList, out bool successful)
+        {
+            KeyValuePair<string, object> associatedTag;
+
+            successful = true;
+
+            switch (metricName)
+            {
+                case MetricNames.Connections.Usage:
+                    associatedTag = GetTagByName(MetricAttributes.State, 1, in tagList);
+
+                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.ActiveState, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _activeConnectionsCounter;
+                    }
+                    else if(string.Equals((string)associatedTag.Value, MetricAttributeValues.IdleState, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _freeConnectionsCounter;
+                    }
+                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.StasisState, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _stasisConnectionsCounter;
+                    }
+                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.ReclaimedState, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _reclaimedConnectionsCounter;
+                    }
+                    break;
+                case MetricNames.ConnectionPoolGroups.Usage:
+                    associatedTag = GetTagByName(MetricAttributes.State, 1, in tagList);
+
+                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.ActiveState, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _activeConnectionPoolGroupsCounter;
+                    }
+                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.IdleState, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _inactiveConnectionPoolGroupsCounter;
+                    }
+                    break;
+                case MetricNames.ConnectionPools.Usage:
+                    associatedTag = GetTagByName(MetricAttributes.State, 1, in tagList);
+
+                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.ActiveState, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _activeConnectionPoolsCounter;
+                    }
+                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.IdleState, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _inactiveConnectionPoolsCounter;
+                    }
+                    break;
+                case MetricNames.Connections.HardUsage:
+                    associatedTag = GetTagByName(MetricAttributes.Type, 1, in tagList);
+
+                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.PooledConnectionType, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _pooledConnectionsCounter;
+                    }
+                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.NonPooledConnectionType, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _nonPooledConnectionsCounter;
+                    }
+                    break;
+                case MetricNames.Connections.Connects:
+                    associatedTag = GetTagByName(MetricAttributes.Type, 1, in tagList);
+
+                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.HardActionType, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _hardConnectsCounter;
+                    }
+                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.SoftActionType, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _softConnectsCounter;
+                    }
+                    break;
+                case MetricNames.Connections.Disconnects:
+                    associatedTag = GetTagByName(MetricAttributes.Type, 1, in tagList);
+
+                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.HardActionType, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _hardDisconnectsCounter;
+                    }
+                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.SoftActionType, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return ref _softDisconnectsCounter;
+                    }
+                    break;
+                case MetricNames.Connections.HardTotal:
+                    return ref _activeHardConnectionsCounter;
+                case MetricNames.Connections.SoftTotal:
+                    return ref _activeSoftConnectionsCounter;
+            }
+
+            successful = false;
+            return ref _watchdogCounter;
+        }
+
+        private void IncrementPlatformSpecificMetric(string metricName, in TagList tagList)
+        {
+            ref long counterPointer = ref GetPlatformSpecificMetric(metricName, in tagList, out bool successful);
+
+            if (successful)
+            {
+                Interlocked.Increment(ref counterPointer);
+            }
+        }
+
+        private void DecrementPlatformSpecificMetric(string metricName, in TagList tagList)
+        {
+            ref long counterPointer = ref GetPlatformSpecificMetric(metricName, in tagList, out bool successful);
+
+            if (successful)
+            {
+                Interlocked.Decrement(ref counterPointer);
+            }
+        }
+
+        private void DisposePlatformSpecificMetrics()
+        {
+            _activeHardConnections?.Dispose();
+            _activeHardConnections = null;
+
+            _hardConnectsPerSecond?.Dispose();
+            _hardConnectsPerSecond = null;
+
+            _hardDisconnectsPerSecond?.Dispose();
+            _hardDisconnectsPerSecond = null;
+
+            _activeSoftConnections?.Dispose();
+            _activeSoftConnections = null;
+
+            _softConnects?.Dispose();
+            _softConnects = null;
+
+            _softDisconnects?.Dispose();
+            _softDisconnects = null;
+
+            _numberOfNonPooledConnections?.Dispose();
+            _numberOfNonPooledConnections = null;
+
+            _numberOfPooledConnections?.Dispose();
+            _numberOfPooledConnections = null;
+
+            _numberOfActiveConnectionPoolGroups?.Dispose();
+            _numberOfActiveConnectionPoolGroups = null;
+
+            _numberOfInactiveConnectionPoolGroups?.Dispose();
+            _numberOfInactiveConnectionPoolGroups = null;
+
+            _numberOfActiveConnectionPools?.Dispose();
+            _numberOfActiveConnectionPools = null;
+
+            _numberOfInactiveConnectionPools?.Dispose();
+            _numberOfInactiveConnectionPools = null;
+
+            _numberOfActiveConnections?.Dispose();
+            _numberOfActiveConnections = null;
+
+            _numberOfFreeConnections?.Dispose();
+            _numberOfFreeConnections = null;
+
+            _numberOfStasisConnections?.Dispose();
+            _numberOfStasisConnections = null;
+
+            _numberOfReclaimedConnections?.Dispose();
+            _numberOfReclaimedConnections = null;
+        }
+#endif
+    }
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.NetCoreApp.cs
@@ -214,81 +214,81 @@ namespace Microsoft.Data.SqlClient.Telemetry
             switch (metricName)
             {
                 case MetricNames.Connections.Usage:
-                    associatedTag = GetTagByName(MetricAttributes.State, 1, in tagList);
+                    associatedTag = GetTagByName(MetricTagNames.State, 1, in tagList);
 
-                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.ActiveState, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals((string)associatedTag.Value, MetricTagValues.ActiveState, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _activeConnectionsCounter;
                     }
-                    else if(string.Equals((string)associatedTag.Value, MetricAttributeValues.IdleState, StringComparison.OrdinalIgnoreCase))
+                    else if(string.Equals((string)associatedTag.Value, MetricTagValues.IdleState, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _freeConnectionsCounter;
                     }
-                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.StasisState, StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals((string)associatedTag.Value, MetricTagValues.StasisState, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _stasisConnectionsCounter;
                     }
-                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.ReclaimedState, StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals((string)associatedTag.Value, MetricTagValues.ReclaimedState, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _reclaimedConnectionsCounter;
                     }
                     break;
                 case MetricNames.ConnectionPoolGroups.Usage:
-                    associatedTag = GetTagByName(MetricAttributes.State, 1, in tagList);
+                    associatedTag = GetTagByName(MetricTagNames.State, 1, in tagList);
 
-                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.ActiveState, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals((string)associatedTag.Value, MetricTagValues.ActiveState, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _activeConnectionPoolGroupsCounter;
                     }
-                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.IdleState, StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals((string)associatedTag.Value, MetricTagValues.IdleState, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _inactiveConnectionPoolGroupsCounter;
                     }
                     break;
                 case MetricNames.ConnectionPools.Usage:
-                    associatedTag = GetTagByName(MetricAttributes.State, 1, in tagList);
+                    associatedTag = GetTagByName(MetricTagNames.State, 1, in tagList);
 
-                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.ActiveState, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals((string)associatedTag.Value, MetricTagValues.ActiveState, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _activeConnectionPoolsCounter;
                     }
-                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.IdleState, StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals((string)associatedTag.Value, MetricTagValues.IdleState, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _inactiveConnectionPoolsCounter;
                     }
                     break;
                 case MetricNames.Connections.HardUsage:
-                    associatedTag = GetTagByName(MetricAttributes.Type, 1, in tagList);
+                    associatedTag = GetTagByName(MetricTagNames.Type, 1, in tagList);
 
-                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.PooledConnectionType, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals((string)associatedTag.Value, MetricTagValues.PooledConnectionType, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _pooledConnectionsCounter;
                     }
-                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.NonPooledConnectionType, StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals((string)associatedTag.Value, MetricTagValues.NonPooledConnectionType, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _nonPooledConnectionsCounter;
                     }
                     break;
                 case MetricNames.Connections.Connects:
-                    associatedTag = GetTagByName(MetricAttributes.Type, 1, in tagList);
+                    associatedTag = GetTagByName(MetricTagNames.Type, 1, in tagList);
 
-                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.HardActionType, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals((string)associatedTag.Value, MetricTagValues.HardActionType, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _hardConnectsCounter;
                     }
-                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.SoftActionType, StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals((string)associatedTag.Value, MetricTagValues.SoftActionType, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _softConnectsCounter;
                     }
                     break;
                 case MetricNames.Connections.Disconnects:
-                    associatedTag = GetTagByName(MetricAttributes.Type, 1, in tagList);
+                    associatedTag = GetTagByName(MetricTagNames.Type, 1, in tagList);
 
-                    if (string.Equals((string)associatedTag.Value, MetricAttributeValues.HardActionType, StringComparison.OrdinalIgnoreCase))
+                    if (string.Equals((string)associatedTag.Value, MetricTagValues.HardActionType, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _hardDisconnectsCounter;
                     }
-                    else if (string.Equals((string)associatedTag.Value, MetricAttributeValues.SoftActionType, StringComparison.OrdinalIgnoreCase))
+                    else if (string.Equals((string)associatedTag.Value, MetricTagValues.SoftActionType, StringComparison.OrdinalIgnoreCase))
                     {
                         return ref _softDisconnectsCounter;
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -346,6 +346,24 @@
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Server\SqlSer.cs">
       <Link>Microsoft\Data\SqlClient\Server\SqlSer.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\ComponentTelemetry.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\ComponentTelemetry.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\MetricConstants.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\MetricConstants.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\SqlClientMetrics.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\SqlClientMetrics.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\SqlClientTelemetry.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\SqlClientTelemetry.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\DbConnectionFactoryTelemetry.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\DbConnectionFactoryTelemetry.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\Telemetry\TelemetryInterfaces.cs">
+      <Link>Microsoft\Data\SqlClient\Telemetry\TelemetryInterfaces.cs</Link>
+    </Compile>
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\SignatureVerificationCache.cs">
       <Link>Microsoft\Data\SqlClient\SignatureVerificationCache.cs</Link>
     </Compile>
@@ -648,6 +666,7 @@
     <Compile Include="Microsoft\Data\SqlClient\Server\SmiRequestExecutor.cs" />
     <Compile Include="Microsoft\Data\SqlClient\Server\SmiStream.cs" />
     <Compile Include="Microsoft\Data\SqlClient\Server\TriggerAction.cs" />
+    <Compile Include="Microsoft\Data\SqlClient\Telemetry\SqlClientMetrics.netfx.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlAuthenticationProviderManager.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlBuffer.netfx.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlBulkCopy.cs" />
@@ -744,6 +763,9 @@
     </PackageReference>
     <PackageReference Include="System.Buffers">
       <Version>$(SystemBuffersVersion)</Version>
+    </PackageReference>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource">
+      <Version>$(SystemDiagnosticsDiagnosticSourceVersion)</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.netfx.cs
@@ -2,18 +2,188 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.Versioning;
+using System.Security.Permissions;
+using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient.Telemetry
 {
+    [PermissionSet(SecurityAction.LinkDemand, Name = "FullTrust")]
     internal sealed partial class SqlClientMetrics
     {
-        private void InitializePlatformSpecificMetrics() { }
+        private const string PerformanceCounterCategoryName = ".NET Data Provider for SqlServer";
+        private const string PerformanceCounterCategoryHelp = "Counters for Microsoft.Data.SqlClient";
+
+        private const int PerformanceCounterInstanceNameMaxLength = 127;
+
+        private static string s_assemblyName = GetAssemblyName();
+        private static string s_instanceName = GetInstanceName();
+
+        private PerformanceCounter _hardConnectsPerSecond;
+        private PerformanceCounter _hardDisconnectsPerSecond;
+
+        private PerformanceCounter _softConnectsPerSecond;
+        private PerformanceCounter _softDisconnectsPerSecond;
+
+        private PerformanceCounter _numberOfNonPooledConnections;
+        private PerformanceCounter _numberOfPooledConnections;
+
+        private PerformanceCounter _numberOfActiveConnectionPoolGroups;
+        private PerformanceCounter _numberOfInactiveConnectionPoolGroups;
+
+        private PerformanceCounter _numberOfActiveConnectionPools;
+        private PerformanceCounter _numberOfInactiveConnectionPools;
+
+        private PerformanceCounter _numberOfActiveConnections;
+        private PerformanceCounter _numberOfFreeConnections;
+
+        private PerformanceCounter _numberOfStasisConnections;
+        private PerformanceCounter _numberOfReclaimedConnections;
+
+        private void InitializePlatformSpecificMetrics()
+        {
+            AppDomain.CurrentDomain.DomainUnload += UnloadEventHandler;
+            AppDomain.CurrentDomain.ProcessExit += ExitEventHandler;
+            AppDomain.CurrentDomain.UnhandledException += ExceptionEventHandler;
+
+            _hardConnectsPerSecond = CreatePerformanceCounter("HardConnectsPerSecond", PerformanceCounterType.RateOfCountsPerSecond64);
+            _hardDisconnectsPerSecond = CreatePerformanceCounter("HardDisconnectsPerSecond", PerformanceCounterType.RateOfCountsPerSecond64);
+
+            _softConnectsPerSecond = CreatePerformanceCounter("SoftConnectsPerSecond", PerformanceCounterType.RateOfCountsPerSecond64);
+            _softDisconnectsPerSecond = CreatePerformanceCounter("SoftDisconnectsPerSecond", PerformanceCounterType.RateOfCountsPerSecond64);
+
+            _numberOfNonPooledConnections = CreatePerformanceCounter("NumberOfNonPooledConnections", PerformanceCounterType.NumberOfItems64);
+            _numberOfPooledConnections = CreatePerformanceCounter("NumberOfPooledConnections", PerformanceCounterType.NumberOfItems64);
+
+            _numberOfActiveConnectionPoolGroups = CreatePerformanceCounter("NumberOfActiveConnectionPoolGroups", PerformanceCounterType.NumberOfItems64);
+            _numberOfInactiveConnectionPoolGroups = CreatePerformanceCounter("NumberOfInactiveConnectionPoolGroups", PerformanceCounterType.NumberOfItems64);
+
+            _numberOfActiveConnectionPools = CreatePerformanceCounter("NumberOfActiveConnectionPools", PerformanceCounterType.NumberOfItems64);
+            _numberOfInactiveConnectionPools = CreatePerformanceCounter("NumberOfInactiveConnectionPools", PerformanceCounterType.NumberOfItems64);
+
+            _numberOfActiveConnections = CreatePerformanceCounter("NumberOfActiveConnections", PerformanceCounterType.NumberOfItems64);
+            _numberOfFreeConnections = CreatePerformanceCounter("NumberOfFreeConnections", PerformanceCounterType.NumberOfItems64);
+
+            _numberOfStasisConnections = CreatePerformanceCounter("NumberOfStasisConnections", PerformanceCounterType.NumberOfItems64);
+            _numberOfReclaimedConnections = CreatePerformanceCounter("NumberOfReclaimedConnections", PerformanceCounterType.NumberOfItems64);
+        }
 
         private void IncrementPlatformSpecificMetric(string metricName, in TagList tagList) { }
 
         private void DecrementPlatformSpecificMetric(string metricName, in TagList tagList) { }
 
-        private void DisposePlatformSpecificMetrics() { }
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        private void DisposePlatformSpecificMetrics()
+        {
+            _hardConnectsPerSecond?.Dispose();
+            _hardDisconnectsPerSecond?.Dispose();
+
+            _softConnectsPerSecond?.Dispose();
+            _softDisconnectsPerSecond?.Dispose();
+
+            _numberOfNonPooledConnections?.Dispose();
+            _numberOfPooledConnections?.Dispose();
+
+            _numberOfActiveConnectionPoolGroups?.Dispose();
+            _numberOfInactiveConnectionPoolGroups?.Dispose();
+
+            _numberOfActiveConnectionPools?.Dispose();
+            _numberOfInactiveConnectionPools?.Dispose();
+
+            _numberOfActiveConnections?.Dispose();
+            _numberOfFreeConnections?.Dispose();
+
+            _numberOfStasisConnections?.Dispose();
+            _numberOfReclaimedConnections?.Dispose();
+        }
+
+        [FileIOPermission(SecurityAction.Assert, Unrestricted = true)]
+        private static string GetAssemblyName()
+            => Assembly.GetExecutingAssembly()?.GetName()?.Name
+            ?? AppDomain.CurrentDomain?.FriendlyName;
+
+        // SxS: this method uses GetCurrentProcessId to construct the instance name.
+        // TODO: VSDD 534795 - remove the Resource* attributes if you do not use GetCurrentProcessId after the fix
+        [ResourceExposure(ResourceScope.None)]
+        [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
+        private static string GetInstanceName()
+        {
+            // TODO: If you do not use GetCurrentProcessId after fixing VSDD 534795, please remove Resource* attributes from this method
+            int pid = Microsoft.Data.Common.SafeNativeMethods.GetCurrentProcessId();
+
+            // SQLBUDT #366157 -there are several characters which have special meaning
+            // to PERFMON.  They recommend that we translate them as shown below, to 
+            // prevent problems.
+
+            string result = string.Format(null, "{0}[{1}]", s_assemblyName, pid);
+            result = result.Replace('(', '[').Replace(')', ']').Replace('#', '_').Replace('/', '_').Replace('\\', '_');
+
+            // SQLBUVSTS #94625 - counter instance name cannot be greater than 127
+            if (result.Length > PerformanceCounterInstanceNameMaxLength)
+            {
+                // Replacing the middle part with "[...]"
+                // For example: if path is c:\long_path\very_(Ax200)_long__path\perftest.exe and process ID is 1234 than the resulted instance name will be: 
+                // c:\long_path\very_(AxM)[...](AxN)_long__path\perftest.exe[1234]
+                // while M and N are adjusted to make each part before and after the [...] = 61 (making the total = 61 + 5 + 61 = 127)
+                const string insertString = "[...]";
+                int firstPartLength = (PerformanceCounterInstanceNameMaxLength - insertString.Length) / 2;
+                int lastPartLength = PerformanceCounterInstanceNameMaxLength - firstPartLength - insertString.Length;
+                result = string.Format(null, "{0}{1}{2}",
+                    result.Substring(0, firstPartLength),
+                    insertString,
+                    result.Substring(result.Length - lastPartLength, lastPartLength));
+
+                Debug.Assert(result.Length == PerformanceCounterInstanceNameMaxLength,
+                    string.Format(null, "wrong calculation of the instance name: expected {0}, actual: {1}", PerformanceCounterInstanceNameMaxLength, result.Length));
+            }
+
+            return result;
+        }
+
+        private PerformanceCounter CreatePerformanceCounter(string counterName, PerformanceCounterType counterType)
+        {
+            try
+            {
+                return new PerformanceCounter()
+                {
+                    CategoryName = PerformanceCounterCategoryName,
+                    CounterName = counterName,
+                    InstanceName = s_instanceName,
+                    InstanceLifetime = PerformanceCounterInstanceLifetime.Process,
+                    ReadOnly = false,
+                    RawValue = 0
+                };
+            }
+            catch(InvalidOperationException e)
+            {
+                ADP.TraceExceptionWithoutRethrow(e);
+                return null;
+            }
+        }
+
+        [PrePrepareMethod]
+        void ExceptionEventHandler(object sender, UnhandledExceptionEventArgs e)
+        {
+            if ((null != e) && e.IsTerminating)
+            {
+                Dispose();
+            }
+        }
+
+        [PrePrepareMethod]
+        void ExitEventHandler(object sender, EventArgs e)
+        {
+            Dispose();
+        }
+
+        [PrePrepareMethod]
+        void UnloadEventHandler(object sender, EventArgs e)
+        {
+            Dispose();
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.netfx.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.Data.SqlClient.Telemetry
+{
+    internal sealed partial class SqlClientMetrics
+    {
+        private void InitializePlatformSpecificMetrics() { }
+
+        private void IncrementPlatformSpecificMetric(string metricName, in TagList tagList) { }
+
+        private void DecrementPlatformSpecificMetric(string metricName, in TagList tagList) { }
+
+        private void DisposePlatformSpecificMetrics() { }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/ComponentTelemetry.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/ComponentTelemetry.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Data.SqlClient.Telemetry
+{
+    internal class ComponentTelemetry
+    {
+        public SqlClientEventSource Tracing { get; }
+
+        public ComponentTelemetry(SqlClientEventSource tracing)
+        {
+            Tracing = tracing;
+        }
+    }
+
+    internal sealed class ComponentTelemetry<TMetrics> : ComponentTelemetry
+        where TMetrics : class, IMetrics
+    {
+        public TMetrics Metrics { get; }
+
+        public ComponentTelemetry(SqlClientEventSource tracing, TMetrics metrics)
+            : base(tracing)
+        {
+            Metrics = metrics;
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/DbConnectionFactoryTelemetry.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/DbConnectionFactoryTelemetry.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Data.ProviderBase;
+
+namespace Microsoft.Data.SqlClient.Telemetry
+{
+    // Stores telemetry for a single DbConnectionPoolGroup. Maintained by the connection pool group itself
+    internal sealed class DbConnectionPoolTelemetry
+    {
+        private readonly DbConnectionPoolGroupOptions _options;
+        private long _poolCount;
+
+        public long TotalMaxPoolSize => _poolCount * (long)_options.MaxPoolSize;
+
+        public long TotalMinPoolSize => _poolCount * (long)_options.MinPoolSize;
+
+        public DbConnectionPoolTelemetry(DbConnectionPoolGroupOptions poolGroupOptions)
+        {
+            _options = poolGroupOptions;
+        }
+
+        public void ReportNewPool()
+        {
+            Interlocked.Increment(ref _poolCount);
+        }
+
+        public void ReportRemovedPool()
+        {
+            Interlocked.Decrement(ref _poolCount);
+        }
+
+        public void Reset()
+        {
+            Interlocked.Exchange(ref _poolCount, 0);
+        }
+    }
+
+    internal struct DbConnectionFactoryTelemetry
+    {
+        public long TotalMinPoolSize { get; private set; }
+
+        public long TotalMaxPoolSize { get; private set; }
+
+        public DbConnectionFactoryTelemetry(DbConnectionPoolTelemetry telemetry)
+        {
+            TotalMinPoolSize = telemetry.TotalMinPoolSize;
+            TotalMaxPoolSize = telemetry.TotalMaxPoolSize;
+        }
+
+        public void AddConnectionPool(DbConnectionPoolTelemetry telemetry)
+        {
+            TotalMinPoolSize += telemetry.TotalMinPoolSize;
+            TotalMaxPoolSize += telemetry.TotalMaxPoolSize;
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/MetricConstants.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/MetricConstants.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Data.SqlClient.Telemetry
         }
     }
 
-    internal static class MetricAttributes
+    internal static class MetricTagNames
     {
         public const string PoolName = "pool.name";
 
@@ -111,7 +111,7 @@ namespace Microsoft.Data.SqlClient.Telemetry
         public const string Type = "type";
     }
 
-    internal static class MetricAttributeValues
+    internal static class MetricTagValues
     {
         public const string IdleState = "idle";
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/MetricConstants.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/MetricConstants.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Data.SqlClient.Telemetry
+{
+    internal static class MetricNames
+    {
+        // Metric names prefixed with "db.client." are documented at
+        // https://opentelemetry.io/docs/specs/semconv/database/database-metrics/
+        private const string StandardsPrefix = "db.client.";
+        private const string LibrarySpecificPrefix = "sqlclient.db.client.";
+
+        public static class Connections
+        {
+            private const string StandardsPrefix = MetricNames.StandardsPrefix + "connections.";
+            private const string LibrarySpecificPrefix = MetricNames.LibrarySpecificPrefix + "connections.";
+
+            public const string Usage = StandardsPrefix + "usage";
+
+            public const string MaxIdle = StandardsPrefix + "idle.max";
+
+            public const string MinIdle = StandardsPrefix + "idle.min";
+
+            public const string Max = StandardsPrefix + "max";
+
+            public const string PendingRequests = StandardsPrefix + "pending_requests";
+
+            public const string Timeouts = StandardsPrefix + "timeouts";
+
+            public const string CreationTime = StandardsPrefix + "create_time";
+
+            public const string WaitTime = StandardsPrefix + "wait_time";
+
+            public const string UsageTime = StandardsPrefix + "use_time";
+
+            public const string HardUsage = LibrarySpecificPrefix + "hard.usage";
+
+            public const string Connects = LibrarySpecificPrefix + "connects";
+
+            public const string Disconnects = LibrarySpecificPrefix + "disconnects";
+
+            public const string ServerCommandTime = LibrarySpecificPrefix + "server_command_time";
+
+            public const string NetworkWaitTime = LibrarySpecificPrefix + "network_wait_time";
+
+            public const string ByteIo = LibrarySpecificPrefix + "io";
+
+            public const string BuffersIo = LibrarySpecificPrefix + "buffers";
+
+            public const string HardTotal = LibrarySpecificPrefix + "hard.total";
+
+            public const string SoftTotal = LibrarySpecificPrefix + "soft.total";
+        }
+
+        public static class ConnectionPools
+        {
+            private const string LibrarySpecificPrefix = MetricNames.LibrarySpecificPrefix + "connection_pools.";
+
+            public const string Usage = LibrarySpecificPrefix + "usage";
+        }
+
+        public static class ConnectionPoolGroups
+        {
+            private const string LibrarySpecificPrefix = MetricNames.LibrarySpecificPrefix + "connection_pool_groups.";
+
+            public const string Usage = LibrarySpecificPrefix + "usage";
+        }
+
+        public static class Commands
+        {
+            private const string LibrarySpecificPrefix = MetricNames.LibrarySpecificPrefix + "commands.";
+
+            public const string Failed = LibrarySpecificPrefix + ".failed";
+
+            public const string UsageTime = LibrarySpecificPrefix + "use_time";
+
+            public const string PreparedRatio = LibrarySpecificPrefix + "prepared_ratio";
+
+            public const string Total = LibrarySpecificPrefix + "total";
+        }
+
+        public static class Transactions
+        {
+            private const string LibrarySpecificPrefix = MetricNames.LibrarySpecificPrefix + "transactions.";
+
+            public const string Committed = LibrarySpecificPrefix + ".committed";
+
+            public const string Active = LibrarySpecificPrefix + ".active";
+
+            public const string RolledBack = LibrarySpecificPrefix + ".rolled_back";
+
+            public const string Total = LibrarySpecificPrefix + "total";
+
+            public const string CommitTime = LibrarySpecificPrefix + "commit_time";
+
+            public const string RollbackTime = LibrarySpecificPrefix + "rollback_time";
+
+            public const string ActiveTime = LibrarySpecificPrefix + "active_time";
+        }
+    }
+
+    internal static class MetricAttributes
+    {
+        public const string PoolName = "pool.name";
+
+        public const string State = "state";
+
+        public const string Direction = "direction";
+
+        public const string Type = "type";
+    }
+
+    internal static class MetricAttributeValues
+    {
+        public const string IdleState = "idle";
+
+        public const string ActiveState = "active";
+
+        public const string StasisState = "stasis";
+
+        public const string ReclaimedState = "reclaimed";
+
+        public const string TransmitDirection = "transmit";
+
+        public const string ReceiveDirection = "receive";
+
+        public const string PooledConnectionType = "pooled";
+
+        public const string NonPooledConnectionType = "unpooled";
+
+        public const string HardConnectionType = "hard";
+
+        public const string SoftConnectionType = "soft";
+
+        public const string HardActionType = "hard";
+
+        public const string SoftActionType = "soft";
+    }
+
+    internal static class MetricUnits
+    {
+        public const string Connection = "{connection}";
+
+        public const string ConnectionPool = "{connection_pool}";
+
+        public const string ConnectionPoolGroup = "{connection_pool_group}";
+
+        public const string Command = "{command}";
+
+        public const string Transaction = "{transaction}";
+
+        public const string Request = "{request}";
+
+        public const string Timeout = "{timeout}";
+
+        public const string Connect = "{connect}";
+
+        public const string Disconnect = "{disconnect}";
+
+        public const string Buffer = "{buffer}";
+
+        public const string Millisecond = "ms";
+
+        public const string Byte = "By";
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.cs
@@ -1,0 +1,309 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Numerics;
+
+namespace Microsoft.Data.SqlClient.Telemetry
+{
+    internal sealed partial class SqlClientMetrics : IDisposable, IConnectionMetrics, ICommandMetrics, ITransactionMetrics
+    {
+        // This version is separate to the assembly version, following semantic versioning.
+        public const string MeteringVersion = "0.1.0";
+
+        private bool _disposedValue;
+
+        private readonly bool _enablePlatformSpecificMetrics;
+
+        private readonly Meter _meter;
+        /// <summary>
+        /// Standard: db.client.connections.usage{pool.name="", state="active|idle"}
+        /// Extended: db.client.connections.usage{pool.name="", state="stasis"}
+        /// Extended: db.client.connections.usage{pool.name="", type="hard|soft"}
+        /// </summary>
+        private readonly Counter<long> _connectionUsageCounter;
+        /// <summary>
+        /// Standard: db.client.connections.idle.max{pool.name=""}
+        /// </summary>
+        private readonly ObservableCounter<long> _connectionMaxIdleCounter;
+        /// <summary>
+        /// Standard: db.client.connections.idle.min{pool.name=""}
+        /// </summary>
+        private readonly ObservableCounter<long> _connectionMinIdleCounter;
+        /// <summary>
+        /// Standard: db.client.connections.max{pool.name=""}
+        /// </summary>
+        private readonly ObservableCounter<long> _connectionMaxCounter;
+        /// <summary>
+        /// Standard: db.client.connections.pending_requests{pool.name=""}
+        /// </summary>
+        private readonly Counter<long> _connectionPendingRequestsCounter;
+        /// <summary>
+        /// Standard: db.client.connections.timeouts{pool.name=""}
+        /// </summary>
+        private readonly Counter<long> _connectionTimeoutsCounter;
+        /// <summary>
+        /// Standard: db.client.connections.create_time{pool.name=""}
+        /// </summary>
+        private readonly Histogram<double> _connectionCreationTimeHistogram;
+        /// <summary>
+        /// Standard: db.client.connections.wait_time{pool.name=""}
+        /// </summary>
+        private readonly Histogram<double> _connectionWaitTimeHistogram;
+        /// <summary>
+        /// Standard: db.client.connections.use_time{pool.name=""}
+        /// </summary>
+        private readonly Histogram<double> _connectionUsageTimeHistogram;
+        /// <summary>
+        /// Extended: sqlclient.db.client.connection_pools.usage{pool.name="", state="active|idle"}
+        /// </summary>
+        private readonly Counter<long> _connectionPoolUsageCounter;
+        /// <summary>
+        /// Extended: sqlclient.db.client.connection_pool_groups.usage{pool.name="", state="active|idle"}
+        /// </summary>
+        private readonly Counter<long> _connectionPoolGroupUsageCounter;
+        /// <summary>
+        /// Extended: sqlclient.db.client.connections.hard.usage{pool.name="", type="pooled|unpooled"}
+        /// </summary>
+        private readonly Counter<long> _connectionHardUsageCounter;
+        /// <summary>
+        /// Extended: sqlclient.db.client.connections.connects{pool.name="", type="hard|soft"}
+        /// </summary>
+        private readonly Counter<long> _connectionConnectCounter;
+        /// <summary>
+        /// Extended: sqlclient.db.client.connections.disconnects{pool.name="", type="hard|soft"}
+        /// </summary>
+        private readonly Counter<long> _connectionDisconnectCounter;
+
+        public SqlClientMetrics(bool enablePlatformSpecificMetrics)
+        {
+            _enablePlatformSpecificMetrics = enablePlatformSpecificMetrics;
+
+            _meter = new Meter("Microsoft.Data.SqlClient", MeteringVersion);
+            _connectionUsageCounter = _meter.CreateCounter<long>(MetricNames.Connections.Usage, MetricUnits.Connection);
+            _connectionMaxIdleCounter = _meter.CreateObservableCounter<long>(MetricNames.Connections.MaxIdle, GetMaxConnectionPoolSizes, MetricUnits.Connection);
+            _connectionMinIdleCounter = _meter.CreateObservableCounter<long>(MetricNames.Connections.MinIdle, GetMinConnectionPoolSizes, MetricUnits.Connection);
+            _connectionMaxCounter = _meter.CreateObservableCounter<long>(MetricNames.Connections.Max, GetMaxConnectionPoolSizes, MetricUnits.Connection);
+
+            // The five metrics below are new, and have not yet been integrated.
+
+            // This must be reported from a SqlCommand. The connection string will need to come from Command.Connection.ConnectionOptions.UsersConnectionStringForTrace
+            // A command begins a pending request when it starts. It leaves the pending request when one of the four states below occurs:
+            // 1. It completes successfully
+            // 2. It completes, having encountered server-side errors
+            // 3. It times out
+            // 4. Its underlying connection times out/is broken
+            // It does not leave and re-enter the pending state when it's being retried.
+            _connectionPendingRequestsCounter = _meter.CreateCounter<long>(MetricNames.Connections.PendingRequests, MetricUnits.Request);
+            
+            // This is to be reported from TdsParserStateObject.OnTimeoutCore for both .NET Core and Framework. The connection string will come from
+            // _parser.Connection.ConnectionOptions.UsersConnectionStringForTrace.
+            // Besides OnTimeoutCore, two other places add a SqlError with an error core of TdsEnums.TIMEOUT_EXPIRED. These are:
+            // 1. TdsParserStateObject.ReadSniError
+            // 2. TdsParserStateObject.WriteSni
+            // 3. TdsParserStateObject.CheckResetConnection
+            // If they are only generated when a connection timeout (rather than a command timeout) occurs, they will also report a timeout.
+            // The client's connection resiliency functionality could result in multiple connection timeouts, but still result in an open connection.
+            _connectionTimeoutsCounter = _meter.CreateCounter<long>(MetricNames.Connections.Timeouts, MetricUnits.Timeout);
+
+            // This creation time refers specifically refers to the time taken to open a new hard connection. It is to be reported as the time
+            // taken to execute the body of SqlConnectionFactory.CreateConnection.
+            _connectionCreationTimeHistogram = _meter.CreateHistogram<double>(MetricNames.Connections.CreationTime, MetricUnits.Millisecond);
+
+            // The connection wait time refers to the time taken to obtain an open connection from the connection pool. It thus encompasses the creation time.
+            // It's reported from SqlConnection.Open, but the data reported by this metric (and the one below it) is also reported by SqlStatistics.
+            // With that in mind, SqlStatistics will now always be collected. SqlConnection.StatisticsEnabled will control whether or not GetStatistics
+            // returns these values. Setting its value to false will set the connection's closed timestamp in the statistics, (if the connection is open)
+            // and setting its value to true will set the connection's open timestamp (if the connection is open)
+            _connectionWaitTimeHistogram = _meter.CreateHistogram<double>(MetricNames.Connections.WaitTime, MetricUnits.Millisecond);
+
+            // This is the time difference between the connection's open and close timestamps. It is not affected by disabling and enabling SqlStatistics.
+            _connectionUsageTimeHistogram = _meter.CreateHistogram<double>(MetricNames.Connections.UsageTime, MetricUnits.Millisecond);
+
+            _connectionPoolUsageCounter = _meter.CreateCounter<long>(MetricNames.ConnectionPools.Usage, MetricUnits.ConnectionPool);
+            _connectionPoolGroupUsageCounter = _meter.CreateCounter<long>(MetricNames.ConnectionPoolGroups.Usage, MetricUnits.ConnectionPoolGroup);
+            _connectionHardUsageCounter = _meter.CreateCounter<long>(MetricNames.Connections.HardUsage, MetricUnits.Connection);
+            _connectionConnectCounter = _meter.CreateCounter<long>(MetricNames.Connections.Connects, MetricUnits.Connect);
+            _connectionDisconnectCounter = _meter.CreateCounter<long>(MetricNames.Connections.Disconnects, MetricUnits.Disconnect);
+
+            if (_enablePlatformSpecificMetrics)
+            {
+                InitializePlatformSpecificMetrics();
+            }
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    if (_enablePlatformSpecificMetrics)
+                    {
+                        DisposePlatformSpecificMetrics();
+                    }
+
+                    _meter.Dispose();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        // This method is designed to handle backwards compatibility with the older performance counters (.NET Framework) and event counters.
+        // Since they're all counters, we only need to implement the compatibility layer here.
+        private void WriteInstrumentValue(Counter<long> counter, long value, in TagList tagList)
+        {
+            counter.Add(value, in tagList);
+            if (_enablePlatformSpecificMetrics)
+            {
+                if (value < 0)
+                {
+                    DecrementPlatformSpecificMetric(counter.Name, in tagList);
+                }
+                else if (value > 0)
+                {
+                    IncrementPlatformSpecificMetric(counter.Name, in tagList);
+                }
+            }
+        }
+
+        #region IConnectionMetrics implementation
+
+        void IConnectionMetrics.HardConnectRequest(ConnectionMetricTagListCollection tagList)
+        {
+            WriteInstrumentValue(_connectionUsageCounter, 1, in tagList.HardConnectionsTags);
+            WriteInstrumentValue(_connectionConnectCounter, 1, in tagList.HardConnectsTags);
+        }
+
+        void IConnectionMetrics.HardDisconnectRequest(ConnectionMetricTagListCollection tagList)
+        {
+            WriteInstrumentValue(_connectionUsageCounter, -1, in tagList.HardConnectionsTags);
+            WriteInstrumentValue(_connectionDisconnectCounter, 1, in tagList.HardDisconnectsTags);
+        }
+
+        void IConnectionMetrics.SoftConnectRequest(ConnectionMetricTagListCollection tagList)
+        {
+            WriteInstrumentValue(_connectionUsageCounter, 1, in tagList.SoftConnectionsTags);
+            WriteInstrumentValue(_connectionConnectCounter, 1, in tagList.SoftConnectsTags);
+        }
+
+        void IConnectionMetrics.SoftDisconnectRequest(ConnectionMetricTagListCollection tagList)
+        {
+            WriteInstrumentValue(_connectionUsageCounter, -1, in tagList.SoftConnectionsTags);
+            WriteInstrumentValue(_connectionDisconnectCounter, 1, in tagList.SoftDisconnectsTags);
+        }
+
+        void IConnectionMetrics.Timeout(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionTimeoutsCounter, 1, in tagList.TimeoutsTags);
+
+        void IConnectionMetrics.ConnectionCreationTime(in TimeSpan creationTime, ConnectionMetricTagListCollection tagList)
+            => _connectionCreationTimeHistogram.Record(creationTime.TotalMilliseconds, in tagList.ConnectionCreationTimeTags);
+
+        void IConnectionMetrics.ConnectionWaitTime(in TimeSpan waitTime, ConnectionMetricTagListCollection tagList)
+            => _connectionWaitTimeHistogram.Record(waitTime.TotalMilliseconds, in tagList.ConnectionWaitTimeTags);
+
+        void IConnectionMetrics.ConnectionUsageTime(in TimeSpan usageTime, ConnectionMetricTagListCollection tagList)
+            => _connectionUsageTimeHistogram.Record(usageTime.TotalMilliseconds, in tagList.ConnectionUsageTimeTags);
+
+        void IConnectionMetrics.EnterPendingRequest(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionPendingRequestsCounter, 1, in tagList.PendingRequestTags);
+
+        void IConnectionMetrics.ExitPendingRequest(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionPendingRequestsCounter, -1, in tagList.PendingRequestTags);
+
+        void IConnectionMetrics.EnterNonPooledConnection(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionHardUsageCounter, 1, in tagList.NonPooledHardConnectionUsageTags);
+
+        void IConnectionMetrics.ExitNonPooledConnection(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionHardUsageCounter, -1, in tagList.NonPooledHardConnectionUsageTags);
+
+        void IConnectionMetrics.EnterPooledConnection(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionHardUsageCounter, 1, in tagList.PooledHardConnectionUsageTags);
+
+        void IConnectionMetrics.ExitPooledConnection(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionHardUsageCounter, -1, in tagList.PooledHardConnectionUsageTags);
+
+        void IConnectionMetrics.EnterActiveConnectionPoolGroup(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionPoolGroupUsageCounter, 1, in tagList.ActiveConnectionPoolGroupsTags);
+
+        void IConnectionMetrics.ExitActiveConnectionPoolGroup(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionPoolGroupUsageCounter, -1, in tagList.ActiveConnectionPoolGroupsTags);
+
+        void IConnectionMetrics.EnterInactiveConnectionPoolGroup(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionPoolGroupUsageCounter, 1, in tagList.IdleConnectionPoolGroupsTags);
+
+        void IConnectionMetrics.ExitInactiveConnectionPoolGroup(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionPoolGroupUsageCounter, -1, in tagList.IdleConnectionPoolGroupsTags);
+
+        void IConnectionMetrics.EnterActiveConnectionPool(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionPoolUsageCounter, 1, in tagList.ActiveConnectionPoolsTags);
+
+        void IConnectionMetrics.ExitActiveConnectionPool(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionPoolUsageCounter, -1, in tagList.ActiveConnectionPoolsTags);
+
+        void IConnectionMetrics.EnterInactiveConnectionPool(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionPoolUsageCounter, 1, in tagList.IdleConnectionPoolsTags);
+
+        void IConnectionMetrics.ExitInactiveConnectionPool(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionPoolUsageCounter, -1, in tagList.IdleConnectionPoolsTags);
+
+        void IConnectionMetrics.EnterActiveConnection(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionUsageCounter, 1, in tagList.ActiveConnectionsTags);
+
+        void IConnectionMetrics.ExitActiveConnection(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionUsageCounter, -1, in tagList.ActiveConnectionsTags);
+
+        void IConnectionMetrics.EnterFreeConnection(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionUsageCounter, 1, in tagList.IdleConnectionsTags);
+
+        void IConnectionMetrics.ExitFreeConnection(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionUsageCounter, -1, in tagList.IdleConnectionsTags);
+
+        void IConnectionMetrics.EnterStasisConnection(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionUsageCounter, 1, in tagList.StasisConnectionsTags);
+
+        void IConnectionMetrics.ExitStasisConnection(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionUsageCounter, -1, in tagList.StasisConnectionsTags);
+
+        void IConnectionMetrics.ReclaimedConnectionRequest(ConnectionMetricTagListCollection tagList)
+            => WriteInstrumentValue(_connectionUsageCounter, 1, in tagList.ReclaimedConnectionsTags);
+        #endregion
+
+        #region Observable metrics implementation
+        // TotalMinPoolSize and TotalMaxPoolSize are grouped by connection string, and thus come from DbConnectionPoolGroup. This can result in inaccurate metrics
+        // if Windows (or Kerberos, or a future authentication mechanism which permits process-level impersonation) authentication is used. A client could connect
+        // to one database using one connection string, impersonate a different Windows/Kerberos identity at the process level, then use the same connection string
+        // to connect to a different database. In this situation, both connection pools will be rolled up into a single metric.
+        private IEnumerable<Measurement<long>> GetMinConnectionPoolSizes()
+        {
+            Dictionary<string, DbConnectionFactoryTelemetry> connectionPoolMetrics = SqlConnectionFactory.SingletonInstance.GetFactoryMetrics();
+
+            foreach (KeyValuePair<string, DbConnectionFactoryTelemetry> poolMetric in connectionPoolMetrics)
+                yield return new Measurement<long>(poolMetric.Value.TotalMinPoolSize,
+                    new KeyValuePair<string, object>(MetricAttributes.PoolName, poolMetric.Key));
+        }
+
+        private IEnumerable<Measurement<long>> GetMaxConnectionPoolSizes()
+        {
+            Dictionary<string, DbConnectionFactoryTelemetry> connectionPoolMetrics = SqlConnectionFactory.SingletonInstance.GetFactoryMetrics();
+
+            foreach (KeyValuePair<string, DbConnectionFactoryTelemetry> poolMetric in connectionPoolMetrics)
+                yield return new Measurement<long>(poolMetric.Value.TotalMaxPoolSize,
+                    new KeyValuePair<string, object>(MetricAttributes.PoolName, poolMetric.Key));
+        }
+        #endregion
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/SqlClientMetrics.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Data.SqlClient.Telemetry
 
             foreach (KeyValuePair<string, DbConnectionFactoryTelemetry> poolMetric in connectionPoolMetrics)
                 yield return new Measurement<long>(poolMetric.Value.TotalMinPoolSize,
-                    new KeyValuePair<string, object>(MetricAttributes.PoolName, poolMetric.Key));
+                    new KeyValuePair<string, object>(MetricTagNames.PoolName, poolMetric.Key));
         }
 
         private IEnumerable<Measurement<long>> GetMaxConnectionPoolSizes()
@@ -302,7 +302,7 @@ namespace Microsoft.Data.SqlClient.Telemetry
 
             foreach (KeyValuePair<string, DbConnectionFactoryTelemetry> poolMetric in connectionPoolMetrics)
                 yield return new Measurement<long>(poolMetric.Value.TotalMaxPoolSize,
-                    new KeyValuePair<string, object>(MetricAttributes.PoolName, poolMetric.Key));
+                    new KeyValuePair<string, object>(MetricTagNames.PoolName, poolMetric.Key));
         }
         #endregion
     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/SqlClientTelemetry.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/SqlClientTelemetry.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Data.SqlClient.Telemetry
+{
+    internal sealed class SqlClientTelemetry
+    {
+        private static SqlClientTelemetry s_instance;
+
+        public static SqlClientTelemetry Instance => s_instance ??= new SqlClientTelemetry();
+
+        public ComponentTelemetry General { get; private set; }
+
+        public ComponentTelemetry<IConnectionMetrics> Connection { get; private set; }
+
+        public ComponentTelemetry<ICommandMetrics> Command { get; private set; }
+
+        public ComponentTelemetry<ITransactionMetrics> Transaction { get; private set; }
+
+        private SqlClientTelemetry()
+        {
+            SqlClientMetrics clientMetrics = new(enablePlatformSpecificMetrics: true);
+
+            General = new ComponentTelemetry(SqlClientEventSource.Log);
+            Connection = new ComponentTelemetry<IConnectionMetrics>(SqlClientEventSource.Log, clientMetrics);
+            Command = new ComponentTelemetry<ICommandMetrics>(SqlClientEventSource.Log, clientMetrics);
+            Transaction = new ComponentTelemetry<ITransactionMetrics>(SqlClientEventSource.Log, clientMetrics);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/TelemetryInterfaces.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/TelemetryInterfaces.cs
@@ -1,0 +1,196 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.Data.SqlClient.Telemetry
+{
+    // These are to be allocated at the connection pool level by default, and passed down to the connections
+    // which come from it. If somebody specifies additional tags then it'll need to be created on a per-connection
+    // basis.
+    // These are marked as fields to avoid the copies which come from calling property accessors.
+    internal sealed class ConnectionMetricTagListCollection
+    {
+        public readonly TagList GenericConnectionPoolTags;
+
+        public readonly TagList ActiveConnectionsTags;
+
+        public readonly TagList IdleConnectionsTags;
+
+        public readonly TagList StasisConnectionsTags;
+
+        public readonly TagList ReclaimedConnectionsTags;
+
+        public readonly TagList HardConnectionsTags;
+
+        public readonly TagList SoftConnectionsTags;
+
+        public readonly TagList TimeoutsTags;
+
+        public readonly TagList PendingRequestTags;
+
+        public readonly TagList ConnectionCreationTimeTags;
+
+        public readonly TagList ConnectionWaitTimeTags;
+
+        public readonly TagList ConnectionUsageTimeTags;
+
+        public readonly TagList ActiveConnectionPoolGroupsTags;
+
+        public readonly TagList IdleConnectionPoolGroupsTags;
+
+        public readonly TagList ActiveConnectionPoolsTags;
+
+        public readonly TagList IdleConnectionPoolsTags;
+
+        public readonly TagList PooledHardConnectionUsageTags;
+
+        public readonly TagList NonPooledHardConnectionUsageTags;
+
+        public readonly TagList HardConnectsTags;
+
+        public readonly TagList SoftConnectsTags;
+
+        public readonly TagList HardDisconnectsTags;
+
+        public readonly TagList SoftDisconnectsTags;
+
+        public ConnectionMetricTagListCollection(string poolName, params KeyValuePair<string, object>[] additionalTags)
+        {
+            KeyValuePair<string, object> poolNameKVP = new(MetricAttributes.PoolName, poolName);
+
+            GenericConnectionPoolTags = new TagList() { poolNameKVP };
+
+            ActiveConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.ActiveState } };
+            IdleConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.IdleState } };
+            StasisConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.StasisState } };
+            ReclaimedConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.ReclaimedState } };
+
+            HardConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.HardConnectionType } };
+            SoftConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.SoftConnectionType } };
+
+            TimeoutsTags = new TagList() { poolNameKVP };
+
+            PendingRequestTags = new TagList() { poolNameKVP };
+
+            ConnectionCreationTimeTags = new TagList() { poolNameKVP };
+            ConnectionWaitTimeTags = new TagList() { poolNameKVP };
+            ConnectionUsageTimeTags = new TagList() { poolNameKVP };
+
+            ActiveConnectionPoolGroupsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.ActiveState } };
+            IdleConnectionPoolGroupsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.IdleState } };
+
+            ActiveConnectionPoolsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.ActiveState } };
+            IdleConnectionPoolsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.IdleState } };
+
+            PooledHardConnectionUsageTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.PooledConnectionType } };
+            NonPooledHardConnectionUsageTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.NonPooledConnectionType } };
+
+            HardConnectsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.HardActionType } };
+            SoftConnectsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.SoftActionType } };
+            HardDisconnectsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.HardActionType } };
+            SoftDisconnectsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.SoftActionType } };
+
+            foreach (KeyValuePair<string, object> additionalTag in additionalTags)
+            {
+                GenericConnectionPoolTags.Add(additionalTag);
+
+                ActiveConnectionsTags.Add(additionalTag);
+                IdleConnectionsTags.Add(additionalTag);
+                StasisConnectionsTags.Add(additionalTag);
+                ReclaimedConnectionsTags.Add(additionalTag);
+
+                ActiveConnectionPoolGroupsTags.Add(additionalTag);
+                IdleConnectionPoolGroupsTags.Add(additionalTag);
+
+                ActiveConnectionPoolsTags.Add(additionalTag);
+                IdleConnectionPoolsTags.Add(additionalTag);
+
+                PooledHardConnectionUsageTags.Add(additionalTag);
+                NonPooledHardConnectionUsageTags.Add(additionalTag);
+
+                HardConnectsTags.Add(additionalTag);
+                SoftConnectsTags.Add(additionalTag);
+                HardDisconnectsTags.Add(additionalTag);
+                SoftDisconnectsTags.Add(additionalTag);
+            }
+        }
+    }
+
+    internal interface IMetrics
+    { }
+
+    internal interface IConnectionMetrics : IMetrics
+    {
+        void HardConnectRequest(ConnectionMetricTagListCollection tagList);
+
+        void HardDisconnectRequest(ConnectionMetricTagListCollection tagList);
+
+        void SoftConnectRequest(ConnectionMetricTagListCollection tagList);
+
+        void SoftDisconnectRequest(ConnectionMetricTagListCollection tagList);
+
+        void Timeout(ConnectionMetricTagListCollection tagList);
+
+        void ConnectionCreationTime(in TimeSpan creationTime, ConnectionMetricTagListCollection tagList);
+
+        void ConnectionWaitTime(in TimeSpan waitTime, ConnectionMetricTagListCollection tagList);
+
+        void ConnectionUsageTime(in TimeSpan usageTime, ConnectionMetricTagListCollection tagList);
+
+        void EnterPendingRequest(ConnectionMetricTagListCollection tagList);
+
+        void ExitPendingRequest(ConnectionMetricTagListCollection tagList);
+
+        void EnterNonPooledConnection(ConnectionMetricTagListCollection tagList);
+
+        void ExitNonPooledConnection(ConnectionMetricTagListCollection tagList);
+
+        void EnterPooledConnection(ConnectionMetricTagListCollection tagList);
+
+        void ExitPooledConnection(ConnectionMetricTagListCollection tagList);
+
+        void EnterActiveConnectionPoolGroup(ConnectionMetricTagListCollection tagList);
+
+        void ExitActiveConnectionPoolGroup(ConnectionMetricTagListCollection tagList);
+
+        void EnterInactiveConnectionPoolGroup(ConnectionMetricTagListCollection tagList);
+
+        void ExitInactiveConnectionPoolGroup(ConnectionMetricTagListCollection tagList);
+
+        void EnterActiveConnectionPool(ConnectionMetricTagListCollection tagList);
+
+        void ExitActiveConnectionPool(ConnectionMetricTagListCollection tagList);
+
+        void EnterInactiveConnectionPool(ConnectionMetricTagListCollection tagList);
+
+        void ExitInactiveConnectionPool(ConnectionMetricTagListCollection tagList);
+
+        void EnterActiveConnection(ConnectionMetricTagListCollection tagList);
+
+        void ExitActiveConnection(ConnectionMetricTagListCollection tagList);
+
+        void EnterFreeConnection(ConnectionMetricTagListCollection tagList);
+
+        void ExitFreeConnection(ConnectionMetricTagListCollection tagList);
+
+        void EnterStasisConnection(ConnectionMetricTagListCollection tagList);
+
+        void ExitStasisConnection(ConnectionMetricTagListCollection tagList);
+
+        void ReclaimedConnectionRequest(ConnectionMetricTagListCollection tagList);
+    }
+
+    internal interface ITransactionMetrics : IMetrics
+    {
+        //
+    }
+
+    internal interface ICommandMetrics : IMetrics
+    {
+        //
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/TelemetryInterfaces.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Telemetry/TelemetryInterfaces.cs
@@ -60,17 +60,17 @@ namespace Microsoft.Data.SqlClient.Telemetry
 
         public ConnectionMetricTagListCollection(string poolName, params KeyValuePair<string, object>[] additionalTags)
         {
-            KeyValuePair<string, object> poolNameKVP = new(MetricAttributes.PoolName, poolName);
+            KeyValuePair<string, object> poolNameKVP = new(MetricTagNames.PoolName, poolName);
 
             GenericConnectionPoolTags = new TagList() { poolNameKVP };
 
-            ActiveConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.ActiveState } };
-            IdleConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.IdleState } };
-            StasisConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.StasisState } };
-            ReclaimedConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.ReclaimedState } };
+            ActiveConnectionsTags = new TagList() { poolNameKVP, { MetricTagNames.State, MetricTagValues.ActiveState } };
+            IdleConnectionsTags = new TagList() { poolNameKVP, { MetricTagNames.State, MetricTagValues.IdleState } };
+            StasisConnectionsTags = new TagList() { poolNameKVP, { MetricTagNames.State, MetricTagValues.StasisState } };
+            ReclaimedConnectionsTags = new TagList() { poolNameKVP, { MetricTagNames.State, MetricTagValues.ReclaimedState } };
 
-            HardConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.HardConnectionType } };
-            SoftConnectionsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.SoftConnectionType } };
+            HardConnectionsTags = new TagList() { poolNameKVP, { MetricTagNames.Type, MetricTagValues.HardConnectionType } };
+            SoftConnectionsTags = new TagList() { poolNameKVP, { MetricTagNames.Type, MetricTagValues.SoftConnectionType } };
 
             TimeoutsTags = new TagList() { poolNameKVP };
 
@@ -80,19 +80,19 @@ namespace Microsoft.Data.SqlClient.Telemetry
             ConnectionWaitTimeTags = new TagList() { poolNameKVP };
             ConnectionUsageTimeTags = new TagList() { poolNameKVP };
 
-            ActiveConnectionPoolGroupsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.ActiveState } };
-            IdleConnectionPoolGroupsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.IdleState } };
+            ActiveConnectionPoolGroupsTags = new TagList() { poolNameKVP, { MetricTagNames.State, MetricTagValues.ActiveState } };
+            IdleConnectionPoolGroupsTags = new TagList() { poolNameKVP, { MetricTagNames.State, MetricTagValues.IdleState } };
 
-            ActiveConnectionPoolsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.ActiveState } };
-            IdleConnectionPoolsTags = new TagList() { poolNameKVP, { MetricAttributes.State, MetricAttributeValues.IdleState } };
+            ActiveConnectionPoolsTags = new TagList() { poolNameKVP, { MetricTagNames.State, MetricTagValues.ActiveState } };
+            IdleConnectionPoolsTags = new TagList() { poolNameKVP, { MetricTagNames.State, MetricTagValues.IdleState } };
 
-            PooledHardConnectionUsageTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.PooledConnectionType } };
-            NonPooledHardConnectionUsageTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.NonPooledConnectionType } };
+            PooledHardConnectionUsageTags = new TagList() { poolNameKVP, { MetricTagNames.Type, MetricTagValues.PooledConnectionType } };
+            NonPooledHardConnectionUsageTags = new TagList() { poolNameKVP, { MetricTagNames.Type, MetricTagValues.NonPooledConnectionType } };
 
-            HardConnectsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.HardActionType } };
-            SoftConnectsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.SoftActionType } };
-            HardDisconnectsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.HardActionType } };
-            SoftDisconnectsTags = new TagList() { poolNameKVP, { MetricAttributes.Type, MetricAttributeValues.SoftActionType } };
+            HardConnectsTags = new TagList() { poolNameKVP, { MetricTagNames.Type, MetricTagValues.HardActionType } };
+            SoftConnectsTags = new TagList() { poolNameKVP, { MetricTagNames.Type, MetricTagValues.SoftActionType } };
+            HardDisconnectsTags = new TagList() { poolNameKVP, { MetricTagNames.Type, MetricTagValues.HardActionType } };
+            SoftDisconnectsTags = new TagList() { poolNameKVP, { MetricTagNames.Type, MetricTagValues.SoftActionType } };
 
             foreach (KeyValuePair<string, object> additionalTag in additionalTags)
             {

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -51,7 +51,7 @@
   <!-- NetStandard project dependencies -->
   <PropertyGroup>
     <SystemRuntimeLoaderVersion>4.3.0</SystemRuntimeLoaderVersion>
-    <SystemDiagnosticsDiagnosticSourceVersion>6.0.1</SystemDiagnosticsDiagnosticSourceVersion>
+    <SystemDiagnosticsDiagnosticSourceVersion>8.0.0</SystemDiagnosticsDiagnosticSourceVersion>
   </PropertyGroup>
   <!-- AKV Provider project dependencies -->
   <PropertyGroup>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -24,6 +24,7 @@
   <!-- NetFx project dependencies -->
   <PropertyGroup>
     <MicrosoftDataSqlClientSniVersion>5.2.0</MicrosoftDataSqlClientSniVersion>
+    <SystemDiagnosticsDiagnosticSourceVersion>8.0.0</SystemDiagnosticsDiagnosticSourceVersion>
   </PropertyGroup>
   <!-- NetFx and NetCore project dependencies -->
   <PropertyGroup>


### PR DESCRIPTION
Contributes to #2211.

This adds an initial framework for updated telemetry using .NET's new metrics API. Leaving it in draft because I'm conscious that the issue hasn't yet had design approval from the SqlClient team, but this should be a reasonably generic and performant base to feedback on build on for the metrics design. It also provides a spot to put the eventual tracing APIs (when those are eventually standardised) and allows us to remove the project-specific connection pool counters.

I've added instrumentation for the metrics laid out in the OTel specifications, and for the existing .NET Core event counters. In most cases, this isn't wired up to anything.

From some very basic benchmarking, this has no measurable GC or CPU overhead. I don't think it has any explicit lock contention either - just a bundle of Interlocked.Increment/.Decrement calls. The OpenTelemetry SDK is another matter!

Although there's going to be some memory overhead here, it should be minimal. Since most of the tags only vary at the connection pool group level, I'm planning to cache them there and allow SqlConnection and SqlCommand to draw on that reference (unless pooling is disabled, or a specific SqlConnection wants to specify a custom tag.)

There are two trivial points, one piece of additional work, and one specification design decision which I'm not sure I agree with.
* The documentation for `Counter<T>` states that it's only supposed to increase. I'm decrementing this type of counter because we currently have to target .NET Standard and .NET 6.0, and `UpDownCounter<T>` is only available in .NET 7+.
* I've left integration points for custom tags for a connection, and for the disablement of the legacy metrics. There's space for a feature request there, but I'm leaving it alone for now.
* Measuring the connection's usage time, open time, wait time might need some rework of `SqlStatistics`. Since the collection overhead of SqlStatistics is practically nil, I'd like to always enable such and push the data into the corresponding metrics. The precision of `DateTime.UtcNow` (used by SqlStatistics) is 0.5ms-15ms, so this might need to start using stopwatches instead, particularly for local or LAN SQL Server instances. 

The specification design decision surrounds the use of the `pool.name` tag. In cases where the connection string uses Windows authentication (or, in future, perhaps some other kind of process-/thread-level identity impersonation mechanism) it's possible for two connections to have the same connection string, but to be in different connection pools because they've been opened under an impersonation context. The specification rolls both of these up by their connection string. I'm thinking about whether or not to add a `db.user` tag to handle this - it'd make it clearer that multiple pools are involved, but might break compatibility with downstream clients which expect one metric per `pool.name`.

Tagging @roji and @JRahnama for any comments on the topic, direction or methodology. There aren't that many ways to implement these metrics, but I'd prefer to have some feedback from the SqlClient team so that I'm not surprising anyone with an x000-line PR for merge.