### PR TITLE
serialise scale for vartime has been explicitly set by the user to zero

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -583,7 +583,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private bool ShouldSerializeScale() => _scale != 0; // V1.0 compat, ignore _hasScale
+        private bool ShouldSerializeScale() => _scale != 0 || (GetMetaTypeOnly().IsVarTime && HasFlag(SqlParameterFlags.HasScale));
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlParameter.xml' path='docs/members[@name="SqlParameter"]/SqlDbType/*' />
         [
@@ -1509,8 +1509,7 @@ namespace Microsoft.Data.SqlClient
                 return ScaleInternal;
             }
 
-            // issue: how could a user specify 0 as the actual scale?
-            if (GetMetaTypeOnly().IsVarTime)
+            if (GetMetaTypeOnly().IsVarTime && !HasFlag(SqlParameterFlags.HasScale))
             {
                 return TdsEnums.DEFAULT_VARTIME_SCALE;
             }


### PR DESCRIPTION
revive old pull request #1381 that got stuck in limbo due to a code freeze
