### PR TITLE
Revert default value of UseMinimumLoginTimeout context switch to 'true'

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -164,10 +164,10 @@ namespace Microsoft.Data.SqlClient
             {
                 if (s_useMinimumLoginTimeout == Tristate.NotInitialized)
                 {
-                    if (AppContext.TryGetSwitch(UseMinimumLoginTimeoutString, out bool returnedValue) && returnedValue)
+                    if (!AppContext.TryGetSwitch(UseMinimumLoginTimeoutString, out bool returnedValue) || returnedValue)
                     {
                         s_useMinimumLoginTimeout = Tristate.True;
-                    }
+                    }                    
                     else
                     {
                         s_useMinimumLoginTimeout = Tristate.False;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Data.SqlClient
                     if (!AppContext.TryGetSwitch(UseMinimumLoginTimeoutString, out bool returnedValue) || returnedValue)
                     {
                         s_useMinimumLoginTimeout = Tristate.True;
-                    }                    
+                    }
                     else
                     {
                         s_useMinimumLoginTimeout = Tristate.False;

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/LocalAppContextSwitchesTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/LocalAppContextSwitchesTests.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.Tests
+{
+    public class LocalAppContextSwitchesTests
+    {
+        [Theory]
+        [InlineData("SuppressInsecureTLSWarning", false)]
+        [InlineData("LegacyRowVersionNullBehavior", false)]
+        [InlineData("MakeReadAsyncBlocking", false)]
+        [InlineData("UseMinimumLoginTimeout", true)]
+        public void DefaultSwitchValue(string property, bool expectedDefaultValue)
+        {
+            var switchesType = typeof(SqlCommand).Assembly.GetType("Microsoft.Data.SqlClient.LocalAppContextSwitches");
+
+            var switchValue = (bool)switchesType.GetProperty(property, BindingFlags.Public | BindingFlags.Static).GetValue(null);
+
+            Assert.Equal(expectedDefaultValue, switchValue);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -34,6 +34,7 @@
     <Compile Include="SqlAuthenticationProviderTest.cs" />
     <Compile Include="SqlClientLoggerTest.cs" />
     <Compile Include="SqlCommandSetTest.cs" />
+    <Compile Include="LocalAppContextSwitchesTests.cs" />
     <Compile Include="SqlConfigurableRetryLogicTest.cs" />
     <Compile Include="SqlCommandBuilderTest.cs" />
     <Compile Include="SqlBulkCopyTest.cs" />


### PR DESCRIPTION
Fixes #2415 