### PR TITLE
feat: change to singleton instance for TdsParser.cs and TdsParserStat…

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1536,7 +1536,7 @@ namespace Microsoft.Data.SqlClient
                 if (_parser != null)
                     _parser.Disconnect();
 
-                _parser = new TdsParser(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
+                _parser = TdsParser.Instance(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
                 Debug.Assert(SniContext.Undefined == Parser._physicalStateObj.SniContext, $"SniContext should be Undefined; actual Value: {Parser._physicalStateObj.SniContext}");
 
                 try
@@ -1754,7 +1754,7 @@ namespace Microsoft.Data.SqlClient
                 if (_parser != null)
                     _parser.Disconnect();
 
-                _parser = new TdsParser(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
+                _parser = TdsParser.Instance(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
                 Debug.Assert(SniContext.Undefined == Parser._physicalStateObj.SniContext, $"SniContext should be Undefined; actual Value: {Parser._physicalStateObj.SniContext}");
 
                 ServerInfo currentServerInfo;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -209,6 +209,9 @@ namespace Microsoft.Data.SqlClient
             DataClassificationVersion = TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED;
         }
 
+        public static TdsParser Instance(bool MARS, bool fAsynchronous)
+            => new TdsParser(MARS, fAsynchronous);
+
         internal SqlInternalConnectionTds Connection
         {
             get

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Managed.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Managed.cs
@@ -24,12 +24,12 @@ namespace Microsoft.Data.SqlClient
 
         public TdsParserStateObject CreateTdsParserStateObject(TdsParser parser)
         {
-            return new TdsParserStateObjectManaged(parser);
+            return TdsParserStateObjectManaged.Instance(parser);
         }
 
         internal TdsParserStateObject CreateSessionObject(TdsParser tdsParser, TdsParserStateObject _pMarsPhysicalConObj, bool v)
         {
-            return new TdsParserStateObjectManaged(tdsParser, _pMarsPhysicalConObj, true);
+            return TdsParserStateObjectManaged.Instance(tdsParser, _pMarsPhysicalConObj, true);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -34,13 +34,13 @@ namespace Microsoft.Data.SqlClient
             {
                 SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | Found AppContext switch '{0}' enabled, managed networking implementation will be used."
                    , UseManagedNetworkingOnWindows);
-                return new TdsParserStateObjectManaged(parser);
+                return TdsParserStateObjectManaged.Instance(parser);
             }
             else
             {
                 SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | AppContext switch '{0}' not enabled, native networking implementation will be used."
                    , UseManagedNetworkingOnWindows);
-                return new TdsParserStateObjectNative(parser);
+                return TdsParserStateObjectNative.Instance(parser);
             }
         }
 
@@ -48,11 +48,11 @@ namespace Microsoft.Data.SqlClient
         {
             if (TdsParserStateObjectFactory.UseManagedSNI)
             {
-                return new TdsParserStateObjectManaged(tdsParser, _pMarsPhysicalConObj, true);
+                return TdsParserStateObjectManaged.Instance(tdsParser, _pMarsPhysicalConObj, true);
             }
             else
             {
-                return new TdsParserStateObjectNative(tdsParser, _pMarsPhysicalConObj, true);
+                return TdsParserStateObjectNative.Instance(tdsParser, _pMarsPhysicalConObj, true);
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -28,10 +28,17 @@ namespace Microsoft.Data.SqlClient.SNI
 #endif
         public TdsParserStateObjectManaged(TdsParser parser) : base(parser) { }
 
+        public static TdsParserStateObjectManaged Instance(TdsParser parser) 
+            => new TdsParserStateObjectManaged(parser);
+
         internal TdsParserStateObjectManaged(TdsParser parser, TdsParserStateObject physicalConnection, bool async) :
             base(parser, physicalConnection, async)
         { }
-
+        
+        
+        public static TdsParserStateObjectManaged Instance(TdsParser parser, TdsParserStateObject physicalConnection, bool async) 
+            => new TdsParserStateObjectManaged(parser, physicalConnection, async);
+        
         internal override uint Status => _sessionHandle != null ? _sessionHandle.Status : TdsEnums.SNI_UNINITIALIZED;
 
         internal override SessionHandle SessionHandle => SessionHandle.FromManagedSession(_sessionHandle);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -44,6 +44,9 @@ namespace Microsoft.Data.SqlClient
 
         public TdsParserStateObjectNative(TdsParser parser) : base(parser) { }
 
+        public static TdsParserStateObjectNative Instance(TdsParser parser)
+            => new TdsParserStateObjectNative(parser);
+
         private GCHandle _gcHandle;                                    // keeps this object alive until we're closed.
 
         private Dictionary<IntPtr, SNIPacket> _pendingWritePackets = new Dictionary<IntPtr, SNIPacket>(); // Stores write packets that have been sent to SNI, but have not yet finished writing (i.e. we are waiting for SNI's callback)
@@ -52,6 +55,10 @@ namespace Microsoft.Data.SqlClient
             base(parser, physicalConnection, async)
         {
         }
+
+        public static TdsParserStateObjectNative Instance(TdsParser parser, TdsParserStateObject physicalConnection,
+            bool async)
+            => new TdsParserStateObjectNative(parser, physicalConnection, async);
 
         internal SNIHandle Handle => _sessionHandle;
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1845,7 +1845,7 @@ namespace Microsoft.Data.SqlClient
                 if (_parser != null)
                     _parser.Disconnect();
 
-                _parser = new TdsParser(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
+                _parser = TdsParser.Instance(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
                 Debug.Assert(SniContext.Undefined == Parser._physicalStateObj.SniContext, String.Format((IFormatProvider)null, "SniContext should be Undefined; actual Value: {0}", Parser._physicalStateObj.SniContext));
 
                 try
@@ -2104,7 +2104,7 @@ namespace Microsoft.Data.SqlClient
                 if (_parser != null)
                     _parser.Disconnect();
 
-                _parser = new TdsParser(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
+                _parser = TdsParser.Instance(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
                 Debug.Assert(SniContext.Undefined == Parser._physicalStateObj.SniContext, String.Format((IFormatProvider)null, "SniContext should be Undefined; actual Value: {0}", Parser._physicalStateObj.SniContext));
 
                 ServerInfo currentServerInfo;
@@ -2156,7 +2156,7 @@ namespace Microsoft.Data.SqlClient
                         if (_parser != null)
                             _parser.Disconnect();
 
-                        _parser = new TdsParser(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
+                        _parser = TdsParser.Instance(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
                         Debug.Assert(SniContext.Undefined == Parser._physicalStateObj.SniContext, $"SniContext should be Undefined; actual Value: {Parser._physicalStateObj.SniContext}");
 
                         currentServerInfo = new ServerInfo(ConnectionOptions, _routingInfo, currentServerInfo.ResolvedServerName, currentServerInfo.ServerSPN);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -325,6 +325,10 @@ namespace Microsoft.Data.SqlClient
             _physicalStateObj = new TdsParserStateObject(this);
             DataClassificationVersion = TdsEnums.DATA_CLASSIFICATION_NOT_ENABLED;
         }
+        
+        public static TdsParser Instance(bool MARS, bool fAsynchronous)
+            => new TdsParser(MARS, fAsynchronous);
+
 
         internal SqlInternalConnectionTds Connection
         {


### PR DESCRIPTION
Change to singleton instance for TdsParser.cs and TdsParserStateObjectManaged.cs, TdsParserStateObjectNative.cs to reduce memory leaks for those objects.

Evidence:

Before the changes, each execution generated instances of TdsParser and TdsParserStateObjectManaged, which remained **unused** in memory, leading to a **memory leak**.
Before changes
![before changes](https://github.com/dotnet/SqlClient/assets/37485620/50307b13-23c5-48c5-8d8e-78d937bddde5)

This memory leak was observed in services deployed on k8s with Linux pods.
Memory leak
![memory leak](https://github.com/dotnet/SqlClient/assets/37485620/59f4f12e-78b4-4653-ac45-98d8a780db3f)

After the changes, each execution **reused** the objects **TdsParser** and **TdsParserStateObjectManaged**.
After changes
![after changes](https://github.com/dotnet/SqlClient/assets/37485620/a5acda2b-0e93-4e65-ab14-6dee8bd7501d)

![after changes pods](https://github.com/dotnet/SqlClient/assets/37485620/b36b3493-50ac-4745-b469-95dcf9775509)
