### PR TITLE
Fix | Make Functional and Manual Test Projects be Test Projects

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -11,6 +11,7 @@
     <DefineConstants Condition="$(ReferenceType.Contains('NetStandard'))">NETSTANDARDREFERNCE</DefineConstants>
     <IntermediateOutputPath>$(ObjFolder)$(Configuration).$(Platform).$(AssemblyName)</IntermediateOutputPath>
     <OutputPath>$(BinFolder)$(Configuration).$(Platform).$(AssemblyName)</OutputPath>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AlwaysEncryptedTests\ExceptionsAlgorithmErrors.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -12,6 +12,7 @@
     <DefineConstants Condition="'$(TargetGroup)'=='netfx'">$(DefineConstants);NETFRAMEWORK</DefineConstants>
     <IntermediateOutputPath>$(ObjFolder)$(Configuration).$(Platform).$(AssemblyName)</IntermediateOutputPath>
     <OutputPath>$(BinFolder)$(Configuration).$(Platform).$(AssemblyName)</OutputPath>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup Condition="!$(ReferenceType.Contains('NetStandard')) and ('$(TestSet)' == '' or '$(TestSet)' == 'AE')">
     <Compile Include="AlwaysEncrypted\CoreCryptoTests.cs" />


### PR DESCRIPTION
_Feel free to tell me this isn't necessary_

**Description**: When trying to run netstandard tests from the commandline, the `dotnet test` commands didn't run any tests. When repeating with detailed verbosity, VSTest warned that the project was not a test project, so it did not even try to run any tests. The fix was suggested in the logs, add `<IsTestProject>true</IsTestProject>` to the test csproj's. This PR does just that.

**Testing**:
* `msbuild -t:RunTests -p:TF=net8.0 -p:TestSet=3 /p:platform="AnyCPU" /p:configuration="Release"` now runs tests locally