### PR TITLE
Fix | Fix ArrayPool usages in TdsParser.ProcessSSPI

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.SynchronousCallMayNotPend();
             }
 
+            receivedBuff.AsSpan(receivedLength, receivedBuff.Length - receivedLength).Clear();
+
             // allocate send buffer and initialize length
             byte[] rentedSendBuff = ArrayPool<byte>.Shared.Rent((int)_authenticationProvider!.MaxSSPILength);
             byte[] sendBuff = rentedSendBuff; // need to track these separately in case someone updates the ref parameter


### PR DESCRIPTION
Reapply the implementation of `TdsParser.ProcessSSPI` from the netfx implementation which does not utilize the `ArrayPool.Shared.Rent(...)` mechanism, as the `ArrayPool` received `byte[]` is not guaranteed to be zero-initialized as specified [in the docs](https://learn.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1.rent?view=net-8.0), and also has not the correct size, as the given `receivedLength` is only specifying the minimum-size of the returned `byte[]`.

Old netfx implementation in version 5.2.0:
https://github.com/dotnet/SqlClient/blob/faf9b95995e6200a980bb6b1980f1d7af9f46cef/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs#L9495-L9524

If the `ArrayPool.Shared.Rent(...)` array is non-zero-initialized and oversized, this further causes invalid genTokenResp to be passed to the underlying `GSSAPI#InitSecContext` implementation.

fixes #2441 