### PR TITLE
eng | Fix production pipeline

### DIFF
--- a/eng/pipelines/common/templates/steps/update-nuget-config-local-feed-step.yml
+++ b/eng/pipelines/common/templates/steps/update-nuget-config-local-feed-step.yml
@@ -27,13 +27,13 @@ steps:
 
     #Set the Nuget.config file in the project to use extracted package
     $rootFolder = Get-location
-    [Xml] $nugetConfig = Get-Content -Path "src\Nuget.config"
+    [Xml] $nugetConfig = Get-Content -Path "Nuget.config"
     $Value = Resolve-Path ${{parameters.downloadedNugetPath }}
     $newAdd = $nugetConfig.CreateElement("add")
     $newAdd.SetAttribute("key","Package source")
     $newAdd.SetAttribute("value", "$Value\" )
     $nugetConfig.configuration.packageSources.AppendChild($newAdd)
-    $nugetConfig.Save("$rootFolder\src\Nuget.config")
+    $nugetConfig.Save("$rootFolder\Nuget.config")
   displayName: 'Update NuGet config file to read from Nuget folder'
 
 - task: MSBuild@1

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -256,7 +256,9 @@ namespace Microsoft.Data.SqlClient
             // A certificate is simply used as a key pair consisting of a public and private key. This is by design.
 
             // CodeQL [SM00395] By design. Always Encrypted certificates should not be checked.
+            #pragma warning disable IA5352
             chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+            #pragma warning restore IA5352
 
             if (!chain.Build(healthReportCert))
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -255,8 +255,8 @@ namespace Microsoft.Data.SqlClient
             // An Always Encrypted-enabled driver doesn't verify an expiration date or a certificate authority chain.
             // A certificate is simply used as a key pair consisting of a public and private key. This is by design.
 
-            // CodeQL [SM00395] By design. Always Encrypted certificates should not be checked.
             #pragma warning disable IA5352
+            // CodeQL [SM00395] By design. Always Encrypted certificates should not be checked.
             chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
             #pragma warning restore IA5352
 


### PR DESCRIPTION
Suppressing X509RevocationMode warning and applying the Nuget.config path change in the pipeline.