### PR TITLE
Fix open async performance issue

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1730,7 +1730,7 @@ namespace Microsoft.Data.SqlClient
                         }
                         OpenAsyncRetry retry = new OpenAsyncRetry(this, completion, result, registration);
                         _currentCompletion = new Tuple<TaskCompletionSource<DbConnectionInternal>, Task>(completion, result.Task);
-                        completion.Task.ContinueWith(retry.Retry, TaskScheduler.Default);
+                        retry.Retry(completion.Task);
                         return result.Task;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2045,7 +2045,7 @@ namespace Microsoft.Data.SqlClient
                         }
                         OpenAsyncRetry retry = new OpenAsyncRetry(this, completion, result, registration);
                         _currentCompletion = new Tuple<TaskCompletionSource<DbConnectionInternal>, Task>(completion, result.Task);
-                        completion.Task.ContinueWith(retry.Retry, TaskScheduler.Default);
+                        retry.Retry(completion.Task);
                         return result.Task;
                     }
 


### PR DESCRIPTION
Fixes #601 

Noticed significant delay due to continuation within OpenAsync API to perform retry, that ends up scheduling more and more tasks (3-4 internal tasks per OpenAsync() scheduled task):

![image](https://github.com/dotnet/SqlClient/assets/13396919/196cbcd3-e04f-45eb-ab60-8ad47ef84b67)

If we schedule this synchronously by directly calling method here, we save lot of time and resources by running retry on the same task (i.e. 1 internal async task per OpenAsync() scheduled task):

![image](https://github.com/dotnet/SqlClient/assets/13396919/4d441516-0547-4f12-af7f-95ba74d3230a)

Which essentially means, when opening 100 parallel connections:
* Before fix, 500+ tasks are scheduled and completed.
* With fix, 200 (fixed number of tasks) are scheduled and completed.

Log for 100 parallel failed connection attempts:
* Before fix:
  <img src="https://github.com/dotnet/SqlClient/assets/13396919/28135e97-f503-48e0-a746-48f945746808" width=300 />
* After Fix:
  <img src="https://github.com/dotnet/SqlClient/assets/13396919/1b5d614b-4fae-4f3a-8948-3e1310f55002" width=300 />

Open for feedback if I'm missing any consequences of this change.
