### PR TITLE
Test | Adding option to clean tests output folder for manual and functional tests

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -199,6 +199,11 @@
     <RemoveDir Directories='$([System.IO.Directory]::GetDirectories(".",".nuget", SearchOption.AllDirectories))' />
   </Target>
 
+  <Target Name="CleanTests">
+     <RemoveDir Directories='$([System.IO.Directory]::GetDirectories("artifacts\Project\","$(Configuration).$(Platform).FunctionalTests", SearchOption.AllDirectories))' />
+     <RemoveDir Directories='$([System.IO.Directory]::GetDirectories("artifacts\Project\","$(Configuration).$(Platform).ManualTests", SearchOption.AllDirectories))' />
+  </Target>
+
   <Target Name="BuildAKVNetFx" Condition="'$(IsEnabledWindows)' == 'true'">
     <MSBuild Projects="@(AKVProvider)" Targets="restore" Properties="TestTargetOS=$(TestOS)netfx" />
     <Message Text=">>> Building AKVNetFx [$(CI);TestTargetOS=$(TestOS)netfx;Platform=AnyCPU;$(TestProjectProperties)] ..." Condition="!$(ReferenceType.Contains('Package'))"/>


### PR DESCRIPTION
When debugging, we often find that we don't need to rebuild the entire solution when making changes solely to tests. This presents opportunities to tidy up the tests output directory.