### PR TITLE
Test | Address XUnit failure on  Windows Principal functionality is not supported on this platform

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
@@ -490,7 +490,9 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             }
         }
 
-        [PlatformSpecific(TestPlatforms.Windows)]
+#if NETCOREAPP
+    [SupportedOSPlatform("Windows")]
+#endif
         public class CEKEncryptionReversalParameters : DataAttribute
         {
             public override IEnumerable<Object[]> GetData(MethodInfo testMethod)
@@ -632,6 +634,9 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         }
     }
 
+#if NETCOREAPP
+    [SupportedOSPlatform("Windows")]
+#endif
     public class CertificateFixture : IDisposable
     {
         public static bool IsAdmin

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Text;
@@ -489,6 +490,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             }
         }
 
+        [PlatformSpecific(TestPlatforms.Windows)]
         public class CEKEncryptionReversalParameters : DataAttribute
         {
             public override IEnumerable<Object[]> GetData(MethodInfo testMethod)
@@ -502,8 +504,10 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             }
         }
 
+
         public class ValidCertificatePathsParameters : DataAttribute
         {
+
             public override IEnumerable<Object[]> GetData(MethodInfo testMethod)
             {
                 yield return new object[2] { CurrentUserMyPathPrefix, StoreLocation.CurrentUser };

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
@@ -523,7 +523,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
                 yield return new object[2] { MyPathPrefix, null };
                 yield return new object[2] { @"", null };
                 // use localmachine cert path only when current user is Admin.
-                if (CertificateFixture.IsAdmin)
+                if (RuntimeInformation.IsOSPlatform(OSPlatform) && CertificateFixture.IsAdmin)
                 {
                     yield return new object[2] { LocalMachineMyPathPrefix, StoreLocation.LocalMachine };
                 }
@@ -641,9 +641,6 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         }
     }
 
-#if NETCOREAPP
-    [SupportedOSPlatform("Windows")]
-#endif
     public class CertificateFixture : IDisposable
     {
         public static bool IsAdmin
@@ -669,7 +666,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             AddCertificateToStore(certificate1, StoreLocation.CurrentUser);
             AddCertificateToStore(certificate2, StoreLocation.CurrentUser);
             AddCertificateToStore(certificate3, StoreLocation.CurrentUser);
-            if (IsAdmin)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && IsAdmin)
             {
                 AddCertificateToStore(certificate3, StoreLocation.LocalMachine);
             }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Text;

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(TestUtility), nameof(TestUtility.IsWindows))]
         [PlatformSpecific(TestPlatforms.Windows)]
         [ValidCertificatePathsParameters]
         public void TestValidCertificatePaths(string certificateStoreNameAndLocation, object location)

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
@@ -7,10 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-
-#if NETCOREAPP
-using System.Runtime.Versioning;
-#endif
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Text;
@@ -20,9 +16,6 @@ using static Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests.TestFixtures;
 
 namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
 {
-#if NETCOREAPP
-    [SupportedOSPlatform("Windows")]
-#endif
     public class SqlColumnEncryptionCertificateStoreProviderWindowsShould : IClassFixture<CertificateFixture>
     {
         private const string MASTER_KEY_PATH = "CurrentUser/My/C74D53B816A971E3FF9714FE1DD2E57E1710D946";
@@ -223,7 +216,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             Assert.Equal(input, output);
         }
 
-        [ConditionalTheory(typeof(TestUtility), nameof(TestUtility.IsWindows))]
+        [Theory]
         [CEKEncryptionReversalParameters]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void TestCEKEncryptionReversal(StoreLocation certificateStoreLocation, String certificateStoreNameAndLocation)
@@ -376,7 +369,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             }
         }
 
-        [ConditionalTheory(typeof(TestUtility), nameof(TestUtility.IsWindows))]
+        [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
         [ValidCertificatePathsParameters]
         public void TestValidCertificatePaths(string certificateStoreNameAndLocation, object location)
@@ -497,9 +490,6 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             }
         }
 
-#if NETCOREAPP
-    [SupportedOSPlatform("Windows")]
-#endif
         public class CEKEncryptionReversalParameters : DataAttribute
         {
             public override IEnumerable<Object[]> GetData(MethodInfo testMethod)

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
@@ -6,8 +6,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
+#if NETCOREAPP
 using System.Runtime.Versioning;
+#endif
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Text;
@@ -17,6 +18,9 @@ using static Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests.TestFixtures;
 
 namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
 {
+#if NETCOREAPP
+    [SupportedOSPlatform("Windows")]
+#endif
     public class SqlColumnEncryptionCertificateStoreProviderWindowsShould : IClassFixture<CertificateFixture>
     {
         private const string MASTER_KEY_PATH = "CurrentUser/My/C74D53B816A971E3FF9714FE1DD2E57E1710D946";
@@ -217,7 +221,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             Assert.Equal(input, output);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(TestUtility), nameof(TestUtility.IsWindows))]
         [CEKEncryptionReversalParameters]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void TestCEKEncryptionReversal(StoreLocation certificateStoreLocation, String certificateStoreNameAndLocation)

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+
 #if NETCOREAPP
 using System.Runtime.Versioning;
 #endif
@@ -504,7 +506,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             {
                 yield return new object[2] { StoreLocation.CurrentUser, CurrentUserMyPathPrefix };
                 // use localmachine cert path only when current user is Admin.
-                if (CertificateFixture.IsAdmin)
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && CertificateFixture.IsAdmin)
                 {
                     yield return new object[2] { StoreLocation.LocalMachine, LocalMachineMyPathPrefix };
                 }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionCertificateStoreProviderShould.cs
@@ -523,7 +523,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
                 yield return new object[2] { MyPathPrefix, null };
                 yield return new object[2] { @"", null };
                 // use localmachine cert path only when current user is Admin.
-                if (RuntimeInformation.IsOSPlatform(OSPlatform) && CertificateFixture.IsAdmin)
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && CertificateFixture.IsAdmin)
                 {
                     yield return new object[2] { LocalMachineMyPathPrefix, StoreLocation.LocalMachine };
                 }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/DataCommon/TestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/DataCommon/TestUtility.cs
@@ -12,6 +12,5 @@ namespace Microsoft.Data.SqlClient.Tests
         public static readonly bool IsNotArmProcess = RuntimeInformation.ProcessArchitecture != Architecture.Arm;
         public static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
         public static bool NetNative => RuntimeInformation.FrameworkDescription.StartsWith(".NET Native");
-        public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/DataCommon/TestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/DataCommon/TestUtility.cs
@@ -12,5 +12,6 @@ namespace Microsoft.Data.SqlClient.Tests
         public static readonly bool IsNotArmProcess = RuntimeInformation.ProcessArchitecture != Architecture.Arm;
         public static bool IsFullFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
         public static bool NetNative => RuntimeInformation.FrameworkDescription.StartsWith(".NET Native");
+        public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 }


### PR DESCRIPTION
This is to address `PlatformNotSupportedException: Windows Principal functionality is not supported on this platform` on Functional Tests. Exception could be seen at [this link](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=85752&view=logs&j=80aee245-cbb0-5dc0-3f7d-d4bf7d8be040&t=9e82de5f-8311-5381-111a-c9d17ba80bd7&l=31).