### PR TITLE
[5.1.6] Test | Updating tests to acquire token from user-assigned managed identity (#2360) (#2473)

### DIFF
--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -176,8 +176,6 @@ Manual Tests require the below setup to run:
   |AADSecurePrincipalSecret | (Optional) A Secret defined for a registered application which has been granted permission to the database defined in the AADPasswordConnectionString. | {Secret} |
   |AzureKeyVaultURL | (Optional) Azure Key Vault Identifier URL | `https://{keyvaultname}.vault.azure.net/` |
   |AzureKeyVaultTenantId | (Optional) The Azure Active Directory tenant (directory) Id of the service principal. | _{Tenant ID of Active Directory}_ |
-  |AzureKeyVaultClientId | (Optional) "Application (client) ID" of an Active Directory registered application, granted access to the Azure Key Vault specified in `AZURE_KEY_VAULT_URL`. Requires the key permissions Get, List, Import, Decrypt, Encrypt, Unwrap, Wrap, Verify, and Sign. | _{Client Application ID}_ |
-  |AzureKeyVaultClientSecret | (Optional) "Client Secret" of the Active Directory registered application, granted access to the Azure Key Vault specified in `AZURE_KEY_VAULT_URL` | _{Client Application Secret}_ |
   |SupportsIntegratedSecurity | (Optional) Whether or not the USER running tests has integrated security access to the target SQL Server.| `true` OR `false`|  
   |LocalDbAppName | (Optional) If Local Db Testing is supported, this property configures the name of Local DB App instance available in client environment. Empty string value disables Local Db testing. | Name of Local Db App to connect to.|
   |LocalDbSharedInstanceName | (Optional) If LocalDB testing is supported and the instance is shared, this property configures the name of the shared instance of LocalDB to connect to. | Name of shared instance of LocalDB. |

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVUnitTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/AKVUnitTests.cs
@@ -3,12 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider;
-using Azure.Identity;
 using Xunit;
 using Azure.Security.KeyVault.Keys;
 using System.Reflection;
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.Threading;
 using System.Diagnostics.Tracing;
@@ -86,8 +84,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             Guid activityId = Trace.CorrelationManager.ActivityId = Guid.NewGuid();
             using DataTestUtility.AKVEventListener AKVListener = new();
 
-            ClientSecretCredential clientSecretCredential = new ClientSecretCredential(DataTestUtility.AKVTenantId, DataTestUtility.AKVClientId, DataTestUtility.AKVClientSecret);
-            SqlColumnEncryptionAzureKeyVaultProvider akvProvider = new SqlColumnEncryptionAzureKeyVaultProvider(clientSecretCredential);
+            SqlColumnEncryptionAzureKeyVaultProvider akvProvider = new SqlColumnEncryptionAzureKeyVaultProvider(DataTestUtility.GetTokenCredential());
             byte[] encryptedCek = akvProvider.EncryptColumnEncryptionKey(DataTestUtility.AKVUrl, EncryptionAlgorithm, s_columnEncryptionKey);
             byte[] decryptedCek = akvProvider.DecryptColumnEncryptionKey(DataTestUtility.AKVUrl, EncryptionAlgorithm, encryptedCek);
 
@@ -104,8 +101,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             // SqlClientCustomTokenCredential implements a legacy authentication callback to request the access token from the client-side.
             SqlColumnEncryptionAzureKeyVaultProvider oldAkvProvider = new SqlColumnEncryptionAzureKeyVaultProvider(new SqlClientCustomTokenCredential());
 
-            ClientSecretCredential clientSecretCredential = new ClientSecretCredential(DataTestUtility.AKVTenantId, DataTestUtility.AKVClientId, DataTestUtility.AKVClientSecret);
-            SqlColumnEncryptionAzureKeyVaultProvider newAkvProvider = new SqlColumnEncryptionAzureKeyVaultProvider(clientSecretCredential);
+            SqlColumnEncryptionAzureKeyVaultProvider newAkvProvider = new SqlColumnEncryptionAzureKeyVaultProvider(DataTestUtility.GetTokenCredential());
 
             byte[] encryptedCekWithNewProvider = newAkvProvider.EncryptColumnEncryptionKey(DataTestUtility.AKVUrl, EncryptionAlgorithm, s_columnEncryptionKey);
             byte[] decryptedCekWithOldProvider = oldAkvProvider.DecryptColumnEncryptionKey(DataTestUtility.AKVUrl, EncryptionAlgorithm, encryptedCekWithNewProvider);
@@ -129,15 +125,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             {
                 string keyName = keyPathUri.Segments[2];
                 string keyVersion = keyPathUri.Segments[3];
-                ClientSecretCredential clientSecretCredential = new ClientSecretCredential(DataTestUtility.AKVTenantId, DataTestUtility.AKVClientId, DataTestUtility.AKVClientSecret);
-                KeyClient keyClient = new KeyClient(vaultUri, clientSecretCredential);
+                KeyClient keyClient = new KeyClient(vaultUri, DataTestUtility.GetTokenCredential());
                 KeyVaultKey currentVersionKey = keyClient.GetKey(keyName);
                 KeyVaultKey specifiedVersionKey = keyClient.GetKey(keyName, keyVersion);
 
                 //If specified versioned key is the most recent version of the key then we cannot test.
                 if (!KeyIsLatestVersion(specifiedVersionKey, currentVersionKey))
                 {
-                    SqlColumnEncryptionAzureKeyVaultProvider azureKeyProvider = new SqlColumnEncryptionAzureKeyVaultProvider(clientSecretCredential);
+                    SqlColumnEncryptionAzureKeyVaultProvider azureKeyProvider = new SqlColumnEncryptionAzureKeyVaultProvider(DataTestUtility.GetTokenCredential());
                     // Perform an operation to initialize the internal caches
                     azureKeyProvider.EncryptColumnEncryptionKey(DataTestUtility.AKVOriginalUrl, EncryptionAlgorithm, s_columnEncryptionKey);
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CertificateUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CertificateUtility.cs
@@ -141,8 +141,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
         private static async Task SetupAKVKeysAsync()
         {
-            ClientSecretCredential clientSecretCredential = new ClientSecretCredential(DataTestUtility.AKVTenantId, DataTestUtility.AKVClientId, DataTestUtility.AKVClientSecret);
-            KeyClient keyClient = new KeyClient(DataTestUtility.AKVBaseUri, clientSecretCredential);
+            KeyClient keyClient = new KeyClient(DataTestUtility.AKVBaseUri, DataTestUtility.GetTokenCredential());
             AsyncPageable<KeyProperties> keys = keyClient.GetPropertiesOfKeysAsync();
             IAsyncEnumerator<KeyProperties> enumerator = keys.GetAsyncEnumerator();
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/AADUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/AADUtility.cs
@@ -7,25 +7,11 @@ using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
     public static class AADUtility
     {
-        public static async Task<string> AzureActiveDirectoryAuthenticationCallback(string authority, string resource, string scope)
-        {
-            var authContext = new AuthenticationContext(authority);
-            ClientCredential clientCred = new ClientCredential(DataTestUtility.AKVClientId, DataTestUtility.AKVClientSecret);
-            AuthenticationResult result = await authContext.AcquireTokenAsync(resource, clientCred);
-            if (result == null)
-            {
-                throw new Exception($"Failed to retrieve an access token for {resource}");
-            }
-
-            return result.AccessToken;
-        }
-
         public static async Task<string> GetManagedIdentityToken(string clientId = null) =>
             await new MockManagedIdentityTokenProvider().AcquireTokenAsync(clientId).ConfigureAwait(false);
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -20,6 +20,9 @@ using Microsoft.Identity.Client;
 using Xunit;
 using System.Net.NetworkInformation;
 using System.Text;
+using System.Security.Principal;
+using Azure.Identity;
+using Azure.Core;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
@@ -39,8 +42,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static readonly string AKVUrl = null;
         public static readonly string AKVOriginalUrl = null;
         public static readonly string AKVTenantId = null;
-        public static readonly string AKVClientId = null;
-        public static readonly string AKVClientSecret = null;
         public static readonly string LocalDbAppName = null;
         public static readonly string LocalDbSharedInstanceName = null;
         public static List<string> AEConnStrings = new List<string>();
@@ -139,8 +140,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
 
             AKVTenantId = c.AzureKeyVaultTenantId;
-            AKVClientId = c.AzureKeyVaultClientId;
-            AKVClientSecret = c.AzureKeyVaultClientSecret;
 
             if (EnclaveEnabled)
             {
@@ -337,7 +336,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         //          Ref: https://feedback.azure.com/forums/307516-azure-synapse-analytics/suggestions/17858869-support-always-encrypted-in-sql-data-warehouse
         public static bool IsAKVSetupAvailable()
         {
-            return !string.IsNullOrEmpty(AKVUrl) && !string.IsNullOrEmpty(AKVClientId) && !string.IsNullOrEmpty(AKVClientSecret) && !string.IsNullOrEmpty(AKVTenantId) && IsNotAzureSynapse();
+            return !string.IsNullOrEmpty(AKVUrl) && !string.IsNullOrEmpty(UserManagedIdentityClientId) && !string.IsNullOrEmpty(AKVTenantId) && IsNotAzureSynapse();
+        }
+
+        private static readonly DefaultAzureCredential s_defaultCredential = new(new DefaultAzureCredentialOptions { ManagedIdentityClientId = UserManagedIdentityClientId });
+
+        public static TokenCredential GetTokenCredential()
+        {
+            return s_defaultCredential;
         }
 
         public static bool IsTargetReadyForAeWithKeyStore()

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/SqlClientCustomTokenCredential.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/SqlClientCustomTokenCredential.cs
@@ -106,9 +106,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             string authorityHost = authority.Remove(separatorIndex + 1);
             string audience = authority.Substring(separatorIndex + 1);
             TokenCredentialOptions tokenCredentialOptions = new TokenCredentialOptions() { AuthorityHost = new Uri(authorityHost) };
-            ClientSecretCredential clientSecretCredential = s_clientSecretCredentials.GetOrAdd(authority + "|--|" + resource,
-                new ClientSecretCredential(audience, DataTestUtility.AKVClientId, DataTestUtility.AKVClientSecret, tokenCredentialOptions));
-            AccessToken accessToken = await clientSecretCredential.GetTokenAsync(tokenRequestContext, cts.Token).ConfigureAwait(false);
+            AccessToken accessToken = await DataTestUtility.GetTokenCredential().GetTokenAsync(tokenRequestContext, cts.Token).ConfigureAwait(false);
             return accessToken;
         }
     }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/SqlClientCustomTokenCredential.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/SqlClientCustomTokenCredential.cs
@@ -3,20 +3,21 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IdentityModel.Tokens.Jwt;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using Azure.Identity;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
     public class SqlClientCustomTokenCredential : TokenCredential
     {
+        private const string DEFAULT_PREFIX = "/.default";
+        private static readonly ConcurrentDictionary<string, ClientSecretCredential> s_clientSecretCredentials = new();
+
         string _authority = "";
         string _resource = "";
         string _akvUrl = "";
@@ -70,40 +71,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 _akvUrl = DataTestUtility.AKVUrl;
             }
 
-            string strAccessToken = await AzureActiveDirectoryAuthenticationCallback(_authority, _resource);
-            DateTime expiryTime = InterceptAccessTokenForExpiry(strAccessToken);
-            return new AccessToken(strAccessToken, new DateTimeOffset(expiryTime));
-        }
-
-        private DateTime InterceptAccessTokenForExpiry(string accessToken)
-        {
-            if (null == accessToken)
-            {
-                throw new ArgumentNullException(accessToken);
-            }
-
-            var jwtHandler = new JwtSecurityTokenHandler();
-            var jwtOutput = string.Empty;
-
-            // Check Token Format
-            if (!jwtHandler.CanReadToken(accessToken))
-                throw new FormatException(accessToken);
-
-            JwtSecurityToken token = jwtHandler.ReadJwtToken(accessToken);
-
-            // Re-serialize the Token Headers to just Key and Values
-            var jwtHeader = JsonConvert.SerializeObject(token.Header.Select(h => new { h.Key, h.Value }));
-            jwtOutput = $"{{\r\n\"Header\":\r\n{JToken.Parse(jwtHeader)},";
-
-            // Re-serialize the Token Claims to just Type and Values
-            var jwtPayload = JsonConvert.SerializeObject(token.Claims.Select(c => new { c.Type, c.Value }));
-            jwtOutput += $"\r\n\"Payload\":\r\n{JToken.Parse(jwtPayload)}\r\n}}";
-
-            // Output the whole thing to pretty JSON object formatted.
-            string jToken = JToken.Parse(jwtOutput).ToString(Formatting.Indented);
-            JToken payload = JObject.Parse(jToken).GetValue("Payload");
-
-            return new DateTime(1970, 1, 1).AddSeconds((long)payload[4]["Value"]);
+            AccessToken accessToken = await AzureActiveDirectoryAuthenticationCallback(_authority, _resource);
+            return accessToken;
         }
 
         private static string ValidateChallenge(string challenge)
@@ -127,16 +96,20 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// <param name="authority">Authorization URL</param>
         /// <param name="resource">Resource</param>
         /// <returns></returns>
-        public static async Task<string> AzureActiveDirectoryAuthenticationCallback(string authority, string resource)
+        public static async Task<AccessToken> AzureActiveDirectoryAuthenticationCallback(string authority, string resource)
         {
-            var authContext = new AuthenticationContext(authority);
-            ClientCredential clientCred = new ClientCredential(DataTestUtility.AKVClientId, DataTestUtility.AKVClientSecret);
-            AuthenticationResult result = await authContext.AcquireTokenAsync(resource, clientCred);
-            if (result == null)
-            {
-                throw new InvalidOperationException($"Failed to retrieve an access token for {resource}");
-            }
-            return result.AccessToken;
+            using CancellationTokenSource cts = new();
+            cts.CancelAfter(30000); // Hard coded for tests
+            string[] scopes = new string[] { resource + DEFAULT_PREFIX };
+            TokenRequestContext tokenRequestContext = new(scopes);
+            int separatorIndex = authority.LastIndexOf('/');
+            string authorityHost = authority.Remove(separatorIndex + 1);
+            string audience = authority.Substring(separatorIndex + 1);
+            TokenCredentialOptions tokenCredentialOptions = new TokenCredentialOptions() { AuthorityHost = new Uri(authorityHost) };
+            ClientSecretCredential clientSecretCredential = s_clientSecretCredentials.GetOrAdd(authority + "|--|" + resource,
+                new ClientSecretCredential(audience, DataTestUtility.AKVClientId, DataTestUtility.AKVClientSecret, tokenCredentialOptions));
+            AccessToken accessToken = await clientSecretCredential.GetTokenAsync(tokenRequestContext, cts.Token).ConfigureAwait(false);
+            return accessToken;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/SqlClientCustomTokenCredential.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/SqlClientCustomTokenCredential.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     public class SqlClientCustomTokenCredential : TokenCredential
     {
         private const string DEFAULT_PREFIX = "/.default";
-        private static readonly ConcurrentDictionary<string, ClientSecretCredential> s_clientSecretCredentials = new();
 
         string _authority = "";
         string _resource = "";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -314,18 +314,14 @@
     <ProjectReference Include="$(TestsPath)CustomConfigurableRetryLogic\CustomRetryLogicProvider.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Condition="$(ReferenceType.Contains('Package'))" Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
     <PackageReference Condition="$(ReferenceType.Contains('Package'))" Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(AddOnsPath)AzureKeyVaultProvider\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj" />
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="$(MicrosoftIdentityModelClientsActiveDirectoryVersion)" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
     <PackageReference Include="System.Runtime.Caching" Version="$(SystemRuntimeCachingVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(SystemIdentityModelTokensJwtVersion)" />
     <PackageReference Condition="'$(TargetGroup)'=='netfx'" Include="Microsoft.SqlServer.Types" Version="$(MicrosoftSqlServerTypesVersion)" />
     <PackageReference Condition="'$(TargetGroup)'=='netcoreapp'" Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotnetRemoteExecutorVersion)" /> 
     <PackageReference Condition="'$(TargetGroup)'!='netfx'" Include="System.ServiceProcess.ServiceController" Version="$(SystemServiceProcessServiceControllerVersion)" />

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Config.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Data.SqlClient.TestUtilities
         public string AADServicePrincipalSecret = null;
         public string AzureKeyVaultURL = null;
         public string AzureKeyVaultTenantId = null;
-        public string AzureKeyVaultClientId = null;
-        public string AzureKeyVaultClientSecret = null;
         public string LocalDbAppName = null;
         public string LocalDbSharedInstanceName = null;
         public bool EnclaveEnabled = false;

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/config.default.json
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/config.default.json
@@ -13,8 +13,6 @@
     "AADServicePrincipalSecret": "",
     "AzureKeyVaultURL": "",
     "AzureKeyVaultTenantId": "",
-    "AzureKeyVaultClientId": "",
-    "AzureKeyVaultClientSecret": "",
     "SupportsIntegratedSecurity": true,
     "LocalDbAppName": "",
     "LocalDbSharedInstanceName": "",

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -62,12 +62,10 @@
   <!-- Test Project Dependencies -->
   <PropertyGroup>
     <MicrosoftDotNetPlatformAbstractionsVersion>3.1.6</MicrosoftDotNetPlatformAbstractionsVersion>
-    <MicrosoftIdentityModelClientsActiveDirectoryVersion>5.2.9</MicrosoftIdentityModelClientsActiveDirectoryVersion>
     <MicrosoftNETTestSdkVersion>17.4.1</MicrosoftNETTestSdkVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <SystemRuntimeInteropServicesRuntimeInformationVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationVersion>
     <SystemDataOdbcVersion>6.0.1</SystemDataOdbcVersion>
-    <SystemIdentityModelTokensJwtVersion>6.35.0</SystemIdentityModelTokensJwtVersion>
     <XunitVersion>2.4.2</XunitVersion>
     <xunitrunnervisualstudioVersion>2.4.5</xunitrunnervisualstudioVersion>
     <MicrosoftDotNetRemoteExecutorVersion>7.0.0-beta.22316.1</MicrosoftDotNetRemoteExecutorVersion>


### PR DESCRIPTION
Backporting https://github.com/dotnet/SqlClient/pull/2473 to 5.1

Subsequently we are also backporting: https://github.com/dotnet/SqlClient/pull/2360