### PR TITLE
[5.1.6] SDL | Changing ReadXml to a more secure overload (#2147) 

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
@@ -9,6 +9,7 @@ using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Xml;
 
 namespace Microsoft.Data.ProviderBase
 {
@@ -499,9 +500,14 @@ namespace Microsoft.Data.ProviderBase
         {
             _metaDataCollectionsDataSet = new DataSet
             {
-                Locale = System.Globalization.CultureInfo.InvariantCulture
+                Locale = CultureInfo.InvariantCulture
             };
-            _metaDataCollectionsDataSet.ReadXml(XmlStream);
+            XmlReaderSettings settings = new()
+            {
+                XmlResolver = null
+            };
+            using XmlReader reader = XmlReader.Create(XmlStream, settings);
+            _metaDataCollectionsDataSet.ReadXml(reader);
         }
 
         protected virtual DataTable PrepareCollection(string collectionName, string[] restrictions, DbConnection connection)


### PR DESCRIPTION
Backporting: https://github.com/dotnet/SqlClient/pull/2147 to 5.1