### PR TITLE
[5.1.6] | Revert the fix transient fault handling issue with OpenAsync (#1983)

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1820,7 +1820,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            _applyTransientFaultHandling = (!overrides.HasFlag(SqlConnectionOverrides.OpenWithoutRetry) && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
+            _applyTransientFaultHandling = (!overrides.HasFlag(SqlConnectionOverrides.OpenWithoutRetry) && retry == null && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
 
             if (connectionOptions != null &&
                 (connectionOptions.Authentication == SqlAuthenticationMethod.SqlPassword ||
@@ -1849,7 +1849,7 @@ namespace Microsoft.Data.SqlClient
             // does not require GC.KeepAlive(this) because of ReRegisterForFinalize below.
 
             // Set future transient fault handling based on connection options
-            _applyTransientFaultHandling = connectionOptions != null && connectionOptions.ConnectRetryCount > 0;
+            _applyTransientFaultHandling = (retry == null && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
 
             var tdsInnerConnection = (SqlInternalConnectionTds)InnerConnection;
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2059,7 +2059,7 @@ namespace Microsoft.Data.SqlClient
 
             bool result = false;
 
-            _applyTransientFaultHandling = (!overrides.HasFlag(SqlConnectionOverrides.OpenWithoutRetry) && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
+            _applyTransientFaultHandling = (!overrides.HasFlag(SqlConnectionOverrides.OpenWithoutRetry) && retry == null && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
 
             if (connectionOptions != null &&
                 (connectionOptions.Authentication == SqlAuthenticationMethod.SqlPassword ||
@@ -2102,7 +2102,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             // Set future transient fault handling based on connection options
-            _applyTransientFaultHandling = connectionOptions != null && connectionOptions.ConnectRetryCount > 0;
+            _applyTransientFaultHandling = (retry == null && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);
 
             return result;
         }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Data.Common;
 using System.Reflection;
 using System.Security;
+using System.Threading.Tasks;
 using Microsoft.SqlServer.TDS.Servers;
 using Xunit;
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -7,7 +7,6 @@ using System.Data;
 using System.Data.Common;
 using System.Reflection;
 using System.Security;
-using System.Threading.Tasks;
 using Microsoft.SqlServer.TDS.Servers;
 using Xunit;
 
@@ -59,26 +58,6 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData(42108)]
         [InlineData(42109)]
         [PlatformSpecific(TestPlatforms.Windows)]
-        public async Task TransientFaultTestAsync(uint errorCode)
-        {
-            using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(true, true, errorCode);
-            SqlConnectionStringBuilder builder = new()
-            {
-                DataSource = "localhost," + server.Port,
-                IntegratedSecurity = true,
-                Encrypt = SqlConnectionEncryptOption.Optional
-            };
-
-            using SqlConnection connection = new(builder.ConnectionString);
-            await connection.OpenAsync();
-            Assert.Equal(ConnectionState.Open, connection.State);
-        }
-
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArmProcess))]
-        [InlineData(40613)]
-        [InlineData(42108)]
-        [InlineData(42109)]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void TransientFaultTest(uint errorCode)
         {
             using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(true, true, errorCode);
@@ -97,67 +76,11 @@ namespace Microsoft.Data.SqlClient.Tests
             }
             catch (Exception e)
             {
+                if (null != connection)
+                {
+                    Assert.Equal(ConnectionState.Closed, connection.State);
+                }
                 Assert.False(true, e.Message);
-            }
-        }
-
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArmProcess))]
-        [InlineData(40613)]
-        [InlineData(42108)]
-        [InlineData(42109)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public async Task TransientFaultDisabledTestAsync(uint errorCode)
-        {
-            using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(true, true, errorCode);
-            SqlConnectionStringBuilder builder = new()
-            {
-                DataSource = "localhost," + server.Port,
-                IntegratedSecurity = true,
-                ConnectRetryCount = 0,
-                Encrypt = SqlConnectionEncryptOption.Optional
-            };
-
-            using SqlConnection connection = new(builder.ConnectionString);
-            try
-            {
-                await connection.OpenAsync();
-                Assert.False(true, "Connection should not have opened.");
-            }
-            catch (SqlException e)
-            {
-                // FATAL Error, should result in closed connection.
-                Assert.Equal(20, e.Class);
-                Assert.Equal(ConnectionState.Closed, connection.State);
-            }
-        }
-
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArmProcess))]
-        [InlineData(40613)]
-        [InlineData(42108)]
-        [InlineData(42109)]
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public void TransientFaultDisabledTest(uint errorCode)
-        {
-            using TransientFaultTDSServer server = TransientFaultTDSServer.StartTestServer(true, true, errorCode);
-            SqlConnectionStringBuilder builder = new()
-            {
-                DataSource = "localhost," + server.Port,
-                IntegratedSecurity = true,
-                ConnectRetryCount = 0,
-                Encrypt = SqlConnectionEncryptOption.Optional
-            };
-
-            using SqlConnection connection = new(builder.ConnectionString);
-            try
-            {
-                connection.Open();
-                Assert.False(true, "Connection should not have opened.");
-            }
-            catch (SqlException e)
-            {
-                // FATAL Error, should result in closed connection.
-                Assert.Equal(20, e.Class);
-                Assert.Equal(ConnectionState.Closed, connection.State);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TransientFaultTDSServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TransientFaultTDSServer.cs
@@ -146,7 +146,6 @@ namespace Microsoft.SqlServer.TDS.Servers
             if (isDisposing)
             {
                 _endpoint?.Stop();
-                RequestCounter = 0;
             }
         }
     }


### PR DESCRIPTION
Reverts #1983 that was backported by [#4035](https://github.com/dotnet/SqlClient/commit/80d1f47be7a4f0a86d87b1d5ca1e962aa780077d) due to this [comment](https://github.com/dotnet/SqlClient/issues/2481#issuecomment-2108103984).