### PR TITLE
[3.1.6] | Address GenAPI tool CVE 2019-0545 & 2021-34485

### DIFF
--- a/tools/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
+++ b/tools/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1.29</TargetFrameworks>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <PackageType>MSBuildSdk</PackageType>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
GenAPI build requires this patch.
- [CVE-2019-0545](https://github.com/advisories/GHSA-2xjx-v99w-gqf3)
- [CVE-2021-34485](https://github.com/advisories/GHSA-vgwq-hfqc-58wv)