### PR TITLE
[4.0.6] | Fix Roslyn Analyzer Warning in 4.0

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNIHandle.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Data.SqlClient.SNI
         /// </summary>
         protected readonly SslProtocols SupportedProtocols = LocalAppContextSwitches.UseSystemDefaultSecureProtocols ? SslProtocols.None : SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls
         //protected readonly SslProtocols SupportedProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618, CA5397 // Type or member is obsolete
             | SslProtocols.Ssl2 | SslProtocols.Ssl3
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618, CA5397 // Type or member is obsolete
             ;
 
         /// <summary>


### PR DESCRIPTION
Fix Roslyn Analyzer Warning in SNIHandle.cs.