### PR TITLE
[5.2.1] | Clone of SqlConnection should include AccessTokenCallback

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -227,6 +227,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             _accessToken = connection._accessToken;
+            _accessTokenCallback = connection._accessTokenCallback;
             CacheConnectionStringProperties();
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -429,6 +429,7 @@ namespace Microsoft.Data.SqlClient
                 _credential = new SqlCredential(connection._credential.UserId, password);
             }
             _accessToken = connection._accessToken;
+            _accessTokenCallback = connection._accessTokenCallback;
             _serverCertificateValidationCallback = connection._serverCertificateValidationCallback;
             _clientCertificateRetrievalCallback = connection._clientCertificateRetrievalCallback;
             _originalNetworkAddressInfo = connection._originalNetworkAddressInfo;

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/CloneTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/CloneTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Data;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.Tests
@@ -18,10 +19,19 @@ namespace Microsoft.Data.SqlClient.Tests
             builder.ConnectTimeout = 1;
             builder.InitialCatalog = "northwinddb";
             SqlConnection connection = new SqlConnection(builder.ConnectionString);
+            connection.AccessToken = Guid.NewGuid().ToString();
 
             SqlConnection clonedConnection = (connection as ICloneable).Clone() as SqlConnection;
             Assert.Equal(connection.ConnectionString, clonedConnection.ConnectionString);
             Assert.Equal(connection.ConnectionTimeout, clonedConnection.ConnectionTimeout);
+            Assert.Equal(connection.AccessToken, clonedConnection.AccessToken);
+            Assert.NotEqual(connection, clonedConnection);
+
+            connection = new SqlConnection(builder.ConnectionString);
+            connection.AccessTokenCallback = (ctx, token) =>
+                        Task.FromResult(new SqlAuthenticationToken(Guid.NewGuid().ToString(), DateTimeOffset.MaxValue));
+            clonedConnection = (connection as ICloneable).Clone() as SqlConnection;
+            Assert.Equal(connection.AccessTokenCallback, clonedConnection.AccessTokenCallback);
             Assert.NotEqual(connection, clonedConnection);
         }
 


### PR DESCRIPTION
Backport of #2525 to 5.2.1.