### PR TITLE
Fix | TvpTest Split Phase 1

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -222,6 +222,7 @@
     <Compile Include="SQL\ParameterTest\SteTypeBoundaries.cs" />
     <Compile Include="SQL\ParameterTest\StreamInputParam.cs" />
     <Compile Include="SQL\ParameterTest\TvpTest.cs" />
+    <Compile Include="SQL\ParameterTest\StreamInputParam.cs" />
     <Content Include="SQL\ParameterTest\SqlParameterTest_DebugMode.bsl">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>SqlParameterTest_DebugMode.bsl</Link>


### PR DESCRIPTION
This is the first phase of the TvpTest split.

In this PR, the AsyncDebugScope tests were extracted from the Run function of StreamInputParam class and new unit tests were created from it. The TvpTest Main test calls StreamInputParam.Run() to run the tests.

 





 