### PR TITLE
Fix | Fixed GenerateSspiClientContext to retry negotiation with default port

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.SqlClient
                 _negotiateAuth ??= new(new NegotiateAuthenticationClientOptions { Package = "Negotiate", TargetName = spnName });
                 sendBuff = _negotiateAuth.GetOutgoingBlob(received.Span, out statusCode)!;
                 // Log session id, status code and the actual SPN used in the negotiation
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.GenerateSspiClientContext | Info | Session Id {0}, StatusCode={1}, SPN={2}", _physicalStateObj.SessionId, statusCode, _negotiateAuth.TargetName);
+                SqlClientEventSource.Log.TryTraceEvent($"TdsParserStateObjectManaged.GenerateSspiClientContext | Info | Session Id {_physicalStateObj.SessionId}, StatusCode={statusCode}, SPN={_negotiateAuth.TargetName}");
 
                 if (statusCode == NegotiateAuthenticationStatusCode.Completed || statusCode == NegotiateAuthenticationStatusCode.ContinueNeeded)
                     break; // Successful case, exit the loop with current SPN.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
@@ -21,8 +21,7 @@ namespace Microsoft.Data.SqlClient
                 _negotiateAuth ??= new(new NegotiateAuthenticationClientOptions { Package = "Negotiate", TargetName = Encoding.Unicode.GetString(_sniSpnBuffer[i]) });
                 sendBuff = _negotiateAuth.GetOutgoingBlob(received.Span, out statusCode)!;
                 // Log session id, status code and the actual SPN used in the negotiation
-                SqlClientEventSource.Log.TryTraceEvent($"TdsParserStateObjectManaged.GenerateSspiClientContext | Info | Session Id {_physicalStateObj.SessionId}, StatusCode={statusCode}, SPN={_negotiateAuth.TargetName}");
-
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.GenerateSspiClientContext | Info | Session Id {0}, StatusCode={1}, SPN={2}", _physicalStateObj.SessionId, statusCode, _negotiateAuth.TargetName);
                 if (statusCode == NegotiateAuthenticationStatusCode.Completed || statusCode == NegotiateAuthenticationStatusCode.ContinueNeeded)
                     break; // Successful case, exit the loop with current SPN.
                 else

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
@@ -18,8 +18,7 @@ namespace Microsoft.Data.SqlClient
 
             for (int i = 0; i < _sniSpnBuffer.Length; i++)
             {
-                string spnName = Encoding.Unicode.GetString(_sniSpnBuffer[i]);
-                _negotiateAuth ??= new(new NegotiateAuthenticationClientOptions { Package = "Negotiate", TargetName = spnName });
+                _negotiateAuth ??= new(new NegotiateAuthenticationClientOptions { Package = "Negotiate", TargetName = Encoding.Unicode.GetString(_sniSpnBuffer[i]) });
                 sendBuff = _negotiateAuth.GetOutgoingBlob(received.Span, out statusCode)!;
                 // Log session id, status code and the actual SPN used in the negotiation
                 SqlClientEventSource.Log.TryTraceEvent($"TdsParserStateObjectManaged.GenerateSspiClientContext | Info | Session Id {_physicalStateObj.SessionId}, StatusCode={statusCode}, SPN={_negotiateAuth.TargetName}");

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
@@ -14,13 +14,25 @@ namespace Microsoft.Data.SqlClient
 
         internal override void GenerateSspiClientContext(ReadOnlyMemory<byte> received, ref byte[] sendBuff, ref uint sendLength, byte[][] _sniSpnBuffer)
         {
-            _negotiateAuth ??= new(new NegotiateAuthenticationClientOptions { Package = "Negotiate", TargetName = Encoding.Unicode.GetString(_sniSpnBuffer[0]) });
-            sendBuff = _negotiateAuth.GetOutgoingBlob(received.Span, out NegotiateAuthenticationStatusCode statusCode)!;
-            SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.GenerateSspiClientContext | Info | Session Id {0}, StatusCode={1}", _physicalStateObj.SessionId, statusCode);
+            NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.UnknownCredentials;
+
+            foreach (byte[] spn in _sniSpnBuffer)
+            {
+                _negotiateAuth ??= new(new NegotiateAuthenticationClientOptions { Package = "Negotiate", TargetName = Encoding.Unicode.GetString(spn) });
+                sendBuff = _negotiateAuth.GetOutgoingBlob(received.Span, out statusCode)!;
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.GenerateSspiClientContext | Info | Session Id {0}, StatusCode={1}", _physicalStateObj.SessionId, statusCode);
+
+                if (statusCode == NegotiateAuthenticationStatusCode.Completed || statusCode == NegotiateAuthenticationStatusCode.ContinueNeeded)
+                    break;
+                else
+                    _negotiateAuth = null;
+            }
+
             if (statusCode is not NegotiateAuthenticationStatusCode.Completed and not NegotiateAuthenticationStatusCode.ContinueNeeded)
             {
                 throw new InvalidOperationException(SQLMessage.SSPIGenerateError() + Environment.NewLine + statusCode);
             }
+
             sendLength = (uint)(sendBuff != null ? sendBuff.Length : 0);
         }
     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.SqlClient
                 if (statusCode == NegotiateAuthenticationStatusCode.Completed || statusCode == NegotiateAuthenticationStatusCode.ContinueNeeded)
                     break;
                 else
-                    _negotiateAuth = null;
+                    _negotiateAuth = null; // Reset _negotiateAuth to be generated again for next SPN.
             }
 
             if (statusCode is not NegotiateAuthenticationStatusCode.Completed and not NegotiateAuthenticationStatusCode.ContinueNeeded)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NegotiateSSPIContextProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.SqlClient
                 _negotiateAuth ??= new(new NegotiateAuthenticationClientOptions { Package = "Negotiate", TargetName = spnName });
                 sendBuff = _negotiateAuth.GetOutgoingBlob(received.Span, out statusCode)!;
                 // Log session id, status code and the actual SPN used in the negotiation
-                SqlClientEventSource.Log.TryTraceEvent($"TdsParserStateObjectManaged.GenerateSspiClientContext | Info | Session Id {_physicalStateObj.SessionId}, StatusCode={statusCode}, SPN={_negotiateAuth.TargetName}");
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectManaged.GenerateSspiClientContext | Info | Session Id {0}, StatusCode={1}, SPN={2}", _physicalStateObj.SessionId, statusCode, _negotiateAuth.TargetName);
 
                 if (statusCode == NegotiateAuthenticationStatusCode.Completed || statusCode == NegotiateAuthenticationStatusCode.ContinueNeeded)
                     break; // Successful case, exit the loop with current SPN.


### PR DESCRIPTION
This PR fixes Issue #2394 

When an application is targeting .Net 6.0, the application connects to the database successfully from Linux because the application is using System.Net.Security.NegotiateStreamPal.Unix.InitializeSecurityContext function which is retrying the negotiation with default port number 1433. However, when the application is targeting .Net8.0, the application fails to connect to the database from Linux because the newer implementation, MDS.SSPI.NegotiateSSPIContextProvider, did not retry with default port number. This issue is fixed in this PR.
 