### PR TITLE
Code Health | Remove alias for referenced libraries in netfx to address APIScan failure on unknown references

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Data.ProviderBase
     using System.Diagnostics;
     using System.Threading.Tasks;
     using Microsoft.Data.Common;
-    using SysTx = System.Transactions;
+    using System.Transactions;
 
     abstract internal class DbConnectionClosed : DbConnectionInternal
     {
@@ -26,12 +26,12 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        override protected void Activate(SysTx.Transaction transaction)
+        override protected void Activate(Transaction transaction)
         {
             throw ADP.ClosedConnectionError();
         }
 
-        override public DbTransaction BeginTransaction(IsolationLevel il)
+        override public DbTransaction BeginTransaction(System.Data.IsolationLevel il)
         {
             throw ADP.ClosedConnectionError();
         }
@@ -51,7 +51,7 @@ namespace Microsoft.Data.ProviderBase
             throw ADP.ClosedConnectionError();
         }
 
-        override public void EnlistTransaction(SysTx.Transaction transaction)
+        override public void EnlistTransaction(Transaction transaction)
         {
             throw ADP.ClosedConnectionError();
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -22,7 +22,7 @@ using System.Buffers;
 using Microsoft.Data.Common;
 using Microsoft.Data.Sql;
 using Microsoft.Data.SqlClient.Server;
-using SysTx = System.Transactions;
+using System.Transactions;
 using System.Collections.Concurrent;
 
 // NOTE: The current Microsoft.VSDesigner editor attributes are implemented for System.Data.SqlClient, and are not publicly available.
@@ -4046,7 +4046,7 @@ namespace Microsoft.Data.SqlClient
                 try
                 {
                     long transactionId;
-                    SysTx.Transaction transaction;
+                    Transaction transaction;
                     innerConnection.GetCurrentTransactionPair(out transactionId, out transaction);
 
                     SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlCommand.RunExecuteNonQuerySmi|ADV> {0}, innerConnection={1}, transactionId=0x{2}, cmdBehavior={3}.", ObjectID, innerConnection.ObjectID, transactionId, (int)CommandBehavior.Default);
@@ -5696,7 +5696,7 @@ namespace Microsoft.Data.SqlClient
                 requestExecutor = SetUpSmiRequest(innerConnection);
 
                 long transactionId;
-                SysTx.Transaction transaction;
+                Transaction transaction;
                 innerConnection.GetCurrentTransactionPair(out transactionId, out transaction);
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlCommand.RunExecuteReaderSmi|ADV> {0}, innerConnection={1}, transactionId=0x{2}, commandBehavior={(int)cmdBehavior}.", ObjectID, innerConnection.ObjectID, transactionId);
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -12,8 +12,7 @@ namespace Microsoft.Data.SqlClient
     using System.Threading;
     using Microsoft.Data.Common;
     using Microsoft.Data.ProviderBase;
-
-    using SysTx = System.Transactions;
+    using System.Transactions;
 
     public sealed partial class SqlConnection : DbConnection
     {
@@ -242,11 +241,11 @@ namespace Microsoft.Data.SqlClient
             permissionSet.Demand();
 
             SqlClientEventSource.Log.TryTraceEvent("<prov.DbConnectionHelper.EnlistDistributedTransactionHelper|RES|TRAN> {0}, Connection enlisting in a transaction.", ObjectID);
-            SysTx.Transaction indigoTransaction = null;
+            Transaction indigoTransaction = null;
 
             if (null != transaction)
             {
-                indigoTransaction = SysTx.TransactionInterop.GetTransactionFromDtcTransaction((SysTx.IDtcTransaction)transaction);
+                indigoTransaction = TransactionInterop.GetTransactionFromDtcTransaction((IDtcTransaction)transaction);
             }
 
             RepairInnerConnection();
@@ -263,7 +262,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/EnlistTransaction/*' />
-        override public void EnlistTransaction(SysTx.Transaction transaction)
+        override public void EnlistTransaction(Transaction transaction)
         {
             SqlConnection.ExecutePermission.Demand();
             SqlClientEventSource.Log.TryTraceEvent("<prov.DbConnectionHelper.EnlistTransaction|RES|TRAN> {0}, Connection enlisting in a transaction.", ObjectID);
@@ -277,7 +276,7 @@ namespace Microsoft.Data.SqlClient
             // NOTE: since transaction enlistment involves round trips to the
             // server, we don't want to lock here, we'll handle the race conditions
             // elsewhere.
-            SysTx.Transaction enlistedTransaction = innerConnection.EnlistedTransaction;
+            Transaction enlistedTransaction = innerConnection.EnlistedTransaction;
             if (enlistedTransaction != null)
             {
                 // Allow calling enlist if already enlisted (no-op)
@@ -287,7 +286,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // Allow enlisting in a different transaction if the enlisted transaction has completed.
-                if (enlistedTransaction.TransactionInformation.Status == SysTx.TransactionStatus.Active)
+                if (enlistedTransaction.TransactionInformation.Status == TransactionStatus.Active)
                 {
                     throw ADP.TransactionPresent();
                 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -8,13 +8,12 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Data.Common;
-
-using SysTx = System.Transactions;
+using System.Transactions;
 
 namespace Microsoft.Data.SqlClient
 {
 
-    sealed internal class SqlDelegatedTransaction : SysTx.IPromotableSinglePhaseNotification
+    sealed internal class SqlDelegatedTransaction : IPromotableSinglePhaseNotification
     {
         private static int _objectTypeCount;
         private readonly int _objectID = Interlocked.Increment(ref _objectTypeCount);
@@ -34,19 +33,19 @@ namespace Microsoft.Data.SqlClient
         //  may be initiated here AFTER the connection lock is released, but should NOT fall under this class's locking strategy.
 
         private SqlInternalConnection _connection;            // the internal connection that is the root of the transaction
-        private IsolationLevel _isolationLevel;        // the IsolationLevel of the transaction we delegated to the server
+        private System.Data.IsolationLevel _isolationLevel;        // the IsolationLevel of the transaction we delegated to the server
         private SqlInternalTransaction _internalTransaction;   // the SQL Server transaction we're delegating to
-        private SysTx.Transaction _atomicTransaction;
+        private Transaction _atomicTransaction;
 
         private bool _active;                // Is the transaction active?
 
-        internal SqlDelegatedTransaction(SqlInternalConnection connection, SysTx.Transaction tx)
+        internal SqlDelegatedTransaction(SqlInternalConnection connection, Transaction tx)
         {
             Debug.Assert(null != connection, "null connection?");
             _connection = connection;
             _atomicTransaction = tx;
             _active = false;
-            SysTx.IsolationLevel systxIsolationLevel = tx.IsolationLevel;
+            System.Transactions.IsolationLevel systxIsolationLevel = tx.IsolationLevel;
 
             // We need to map the System.Transactions IsolationLevel to the one
             // that System.Data uses and communicates to SqlServer.  We could
@@ -57,27 +56,27 @@ namespace Microsoft.Data.SqlClient
             // place.
             switch (systxIsolationLevel)
             {
-                case SysTx.IsolationLevel.ReadCommitted:
-                    _isolationLevel = IsolationLevel.ReadCommitted;
+                case System.Transactions.IsolationLevel.ReadCommitted:
+                    _isolationLevel = System.Data.IsolationLevel.ReadCommitted;
                     break;
-                case SysTx.IsolationLevel.ReadUncommitted:
-                    _isolationLevel = IsolationLevel.ReadUncommitted;
+                case System.Transactions.IsolationLevel.ReadUncommitted:
+                    _isolationLevel = System.Data.IsolationLevel.ReadUncommitted;
                     break;
-                case SysTx.IsolationLevel.RepeatableRead:
-                    _isolationLevel = IsolationLevel.RepeatableRead;
+                case System.Transactions.IsolationLevel.RepeatableRead:
+                    _isolationLevel = System.Data.IsolationLevel.RepeatableRead;
                     break;
-                case SysTx.IsolationLevel.Serializable:
-                    _isolationLevel = IsolationLevel.Serializable;
+                case System.Transactions.IsolationLevel.Serializable:
+                    _isolationLevel = System.Data.IsolationLevel.Serializable;
                     break;
-                case SysTx.IsolationLevel.Snapshot:
-                    _isolationLevel = IsolationLevel.Snapshot;
+                case System.Transactions.IsolationLevel.Snapshot:
+                    _isolationLevel = System.Data.IsolationLevel.Snapshot;
                     break;
                 default:
                     throw SQL.UnknownSysTxIsolationLevel(systxIsolationLevel);
             }
         }
 
-        internal SysTx.Transaction Transaction
+        internal Transaction Transaction
         {
             get { return _atomicTransaction; }
         }
@@ -191,7 +190,7 @@ namespace Microsoft.Data.SqlClient
                                 // Now that we've acquired the lock, make sure we still have valid state for this operation.
                                 ValidateActiveOnConnection(connection);
 
-                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Promote, null, IsolationLevel.Unspecified, _internalTransaction, true);
+                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Promote, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
                                 returnValue = connection.PromotedDTCToken;
 
                                 // For Global Transactions, we need to set the Transaction Id since we use a Non-MSDTC Promoter type.
@@ -260,12 +259,12 @@ namespace Microsoft.Data.SqlClient
                     try
                     {
                         // Safely access Transction status - as it's possible Transaction is not in right state.
-                        if(Transaction?.TransactionInformation?.Status == SysTx.TransactionStatus.Aborted)
+                        if(Transaction?.TransactionInformation?.Status == System.Transactions.TransactionStatus.Aborted)
                         {
                             throw SQL.PromotionFailed(promoteException);
                         }
                     }
-                    catch(SysTx.TransactionException te)
+                    catch(TransactionException te)
                     {
                         SqlClientEventSource.Log.TryTraceEvent("SqlDelegatedTransaction.Promote | RES | CPOOL | Object Id {0}, Client Connection Id {1}, Transaction exception occurred: {2}.", ObjectID, usersConnection?.ClientConnectionId, te.Message);
                         // Throw promote exception if transaction state is unknown.
@@ -287,7 +286,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Called by transaction to initiate abort sequence
-        public void Rollback(SysTx.SinglePhaseEnlistment enlistment)
+        public void Rollback(SinglePhaseEnlistment enlistment)
         {
             Debug.Assert(null != enlistment, "null enlistment?");
             SqlInternalConnection connection = GetValidConnection();
@@ -315,7 +314,7 @@ namespace Microsoft.Data.SqlClient
                             // If we haven't already rolled back (or aborted) then tell the SQL Server to roll back
                             if (!_internalTransaction.IsAborted)
                             {
-                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Rollback, null, IsolationLevel.Unspecified, _internalTransaction, true);
+                                connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Rollback, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
                             }
                         }
                         catch (SqlException e)
@@ -382,7 +381,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Called by the transaction to initiate commit sequence
-        public void SinglePhaseCommit(SysTx.SinglePhaseEnlistment enlistment)
+        public void SinglePhaseCommit(SinglePhaseEnlistment enlistment)
         {
             Debug.Assert(null != enlistment, "null enlistment?");
             SqlInternalConnection connection = GetValidConnection();
@@ -428,7 +427,7 @@ namespace Microsoft.Data.SqlClient
                                     _active = false; // set to inactive first, doesn't matter how the rest completes, this transaction is done.
                                     _connection = null;   // Set prior to ExecuteTransaction call in case this initiates a TransactionEnd event
 
-                                    connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, IsolationLevel.Unspecified, _internalTransaction, true);
+                                    connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Commit, null, System.Data.IsolationLevel.Unspecified, _internalTransaction, true);
                                     commitException = null;
                                 }
                                 catch (SqlException e)
@@ -461,7 +460,7 @@ namespace Microsoft.Data.SqlClient
                                 else if (_internalTransaction.IsAborted)
                                 {
                                     // The transaction was aborted, report that to
-                                    // SysTx.
+                                    // System.Transactions.
                                     enlistment.Aborted(commitException);
                                 }
                                 else
@@ -520,7 +519,7 @@ namespace Microsoft.Data.SqlClient
         //  ended event via the internal connection. If it occurs without a prior Rollback or SinglePhaseCommit call,
         //  it indicates the transaction was ended externally (generally that one the the DTC participants aborted
         //  the transaction).
-        internal void TransactionEnded(SysTx.Transaction transaction)
+        internal void TransactionEnded(Transaction transaction)
         {
             SqlInternalConnection connection = _connection;
 
@@ -547,7 +546,7 @@ namespace Microsoft.Data.SqlClient
         private SqlInternalConnection GetValidConnection()
         {
             SqlInternalConnection connection = _connection;
-            if (null == connection && _atomicTransaction.TransactionInformation.Status != SysTx.TransactionStatus.Aborted)
+            if (null == connection && _atomicTransaction.TransactionInformation.Status != TransactionStatus.Aborted)
             {
                 throw ADP.ObjectDisposed(this);
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
@@ -8,7 +8,7 @@ using System.Data.Common;
 using System.Diagnostics;
 using Microsoft.Data.Common;
 using Microsoft.Data.SqlClient.Server;
-using SysTx = System.Transactions;
+using System.Transactions;
 
 namespace Microsoft.Data.SqlClient
 {
@@ -222,20 +222,20 @@ namespace Microsoft.Data.SqlClient
         // Context transactions SHOULD be considered enlisted.
         //   This works for now only because we can't unenlist from the context transaction
         // DON'T START USING THIS ANYWHERE EXCEPT IN InternalTransaction and in InternalConnectionSmi!!!
-        private SysTx.Transaction ContextTransaction
+        private Transaction ContextTransaction
         {
             get;
             set;
         }
 
-        private SysTx.Transaction InternalEnlistedTransaction
+        private Transaction InternalEnlistedTransaction
         {
             get
             {
                 // Workaround to access context transaction without rewriting connection pool & internalconnections properly.
                 // This SHOULD be a simple wrapper around EnlistedTransaction.
                 //   This works for now only because we can't unenlist from the context transaction
-                SysTx.Transaction tx = EnlistedTransaction;
+                Transaction tx = EnlistedTransaction;
 
                 if (null == tx)
                 {
@@ -246,7 +246,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected void Activate(SysTx.Transaction transaction)
+        override protected void Activate(Transaction transaction)
         {
             Debug.Assert(false, "Activating an internal SMI connection?"); // we should never be activating, because that would indicate we're being pooled.
         }
@@ -266,8 +266,8 @@ namespace Microsoft.Data.SqlClient
 
         internal void AutomaticEnlistment()
         {
-            SysTx.Transaction currentSystemTransaction = ADP.GetCurrentTransaction();      // NOTE: Must be first to ensure _smiContext.ContextTransaction is set!
-            SysTx.Transaction contextTransaction = _smiContext.ContextTransaction; // returns the transaction that was handed to SysTx that wraps the ContextTransactionId.
+            Transaction currentSystemTransaction = ADP.GetCurrentTransaction();      // NOTE: Must be first to ensure _smiContext.ContextTransaction is set!
+            Transaction contextTransaction = _smiContext.ContextTransaction; // returns the transaction that was handed to SysTx that wraps the ContextTransactionId.
             long contextTransactionId = _smiContext.ContextTransactionId;
             SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}, contextTransactionId=0x{1}, contextTransaction={2}, currentSystemTransaction={3}.", ObjectID, contextTransactionId, (null != contextTransaction) ? contextTransaction.GetHashCode() : 0, (null != currentSystemTransaction) ? currentSystemTransaction.GetHashCode() : 0);
 
@@ -357,7 +357,7 @@ namespace Microsoft.Data.SqlClient
         override internal void ExecuteTransaction(
                     TransactionRequest transactionRequest,
                     string transactionName,
-                    IsolationLevel iso,
+                    System.Data.IsolationLevel iso,
                     SqlInternalTransaction internalTransaction,
                     bool isDelegateControlRequest)
         {
@@ -429,7 +429,7 @@ namespace Microsoft.Data.SqlClient
             return whereAbouts;
         }
 
-        internal void GetCurrentTransactionPair(out long transactionId, out SysTx.Transaction transaction)
+        internal void GetCurrentTransactionPair(out long transactionId, out Transaction transaction)
         {
             // SQLBU 214740: Transaction state could change between obtaining tranid and transaction
             //  due to background SqlDelegatedTransaction processing. Lock the connection to prevent that.

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Common;
 using Microsoft.Data.ProviderBase;
 using Microsoft.Identity.Client;
-using SysTx = System.Transactions;
+using System.Transactions;
 
 
 namespace Microsoft.Data.SqlClient
@@ -952,7 +952,7 @@ namespace Microsoft.Data.SqlClient
         {
             // If we are enlisted in a transaction, check that transaction is active.
             // When using explicit transaction unbinding, also verify that the enlisted transaction is the current transaction.
-            SysTx.Transaction enlistedTransaction = EnlistedTransaction;
+            Transaction enlistedTransaction = EnlistedTransaction;
 
             if (enlistedTransaction != null)
             {
@@ -960,16 +960,16 @@ namespace Microsoft.Data.SqlClient
 
                 if (requireExplicitTransactionUnbind)
                 {
-                    SysTx.Transaction currentTransaction = SysTx.Transaction.Current;
+                    Transaction currentTransaction = Transaction.Current;
 
-                    if (SysTx.TransactionStatus.Active != enlistedTransaction.TransactionInformation.Status || !enlistedTransaction.Equals(currentTransaction))
+                    if (TransactionStatus.Active != enlistedTransaction.TransactionInformation.Status || !enlistedTransaction.Equals(currentTransaction))
                     {
                         throw ADP.TransactionConnectionMismatch();
                     }
                 }
                 else // implicit transaction unbind
                 {
-                    if (SysTx.TransactionStatus.Active != enlistedTransaction.TransactionInformation.Status)
+                    if (TransactionStatus.Active != enlistedTransaction.TransactionInformation.Status)
                     {
                         if (EnlistedTransactionDisposed)
                         {
@@ -1012,7 +1012,7 @@ namespace Microsoft.Data.SqlClient
         // POOLING METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        override protected void Activate(SysTx.Transaction transaction)
+        override protected void Activate(Transaction transaction)
         {
             FailoverPermissionDemand(); // Demand for unspecified failover pooled connections
 
@@ -1146,12 +1146,12 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal void ExecuteTransaction(TransactionRequest transactionRequest, string name, IsolationLevel iso)
+        internal void ExecuteTransaction(TransactionRequest transactionRequest, string name, System.Data.IsolationLevel iso)
         {
             ExecuteTransaction(transactionRequest, name, iso, null, false);
         }
 
-        override internal void ExecuteTransaction(TransactionRequest transactionRequest, string name, IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest)
+        override internal void ExecuteTransaction(TransactionRequest transactionRequest, string name, System.Data.IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest)
         {
             if (IsConnectionDoomed)
             {  // doomed means we can't do anything else...
@@ -1189,35 +1189,35 @@ namespace Microsoft.Data.SqlClient
         internal void ExecuteTransactionPre2005(
                     TransactionRequest transactionRequest,
                     string transactionName,
-                    IsolationLevel iso,
+                    System.Data.IsolationLevel iso,
                     SqlInternalTransaction internalTransaction)
         {
             StringBuilder sqlBatch = new StringBuilder();
 
             switch (iso)
             {
-                case IsolationLevel.Unspecified:
+                case System.Data.IsolationLevel.Unspecified:
                     break;
-                case IsolationLevel.ReadCommitted:
+                case System.Data.IsolationLevel.ReadCommitted:
                     sqlBatch.Append(TdsEnums.TRANS_READ_COMMITTED);
                     sqlBatch.Append(";");
                     break;
-                case IsolationLevel.ReadUncommitted:
+                case System.Data.IsolationLevel.ReadUncommitted:
                     sqlBatch.Append(TdsEnums.TRANS_READ_UNCOMMITTED);
                     sqlBatch.Append(";");
                     break;
-                case IsolationLevel.RepeatableRead:
+                case System.Data.IsolationLevel.RepeatableRead:
                     sqlBatch.Append(TdsEnums.TRANS_REPEATABLE_READ);
                     sqlBatch.Append(";");
                     break;
-                case IsolationLevel.Serializable:
+                case System.Data.IsolationLevel.Serializable:
                     sqlBatch.Append(TdsEnums.TRANS_SERIALIZABLE);
                     sqlBatch.Append(";");
                     break;
-                case IsolationLevel.Snapshot:
-                    throw SQL.SnapshotNotSupported(IsolationLevel.Snapshot);
+                case System.Data.IsolationLevel.Snapshot:
+                    throw SQL.SnapshotNotSupported(System.Data.IsolationLevel.Snapshot);
 
-                case IsolationLevel.Chaos:
+                case System.Data.IsolationLevel.Chaos:
                     throw SQL.NotSupportedIsolationLevel(iso);
 
                 default:
@@ -1278,7 +1278,7 @@ namespace Microsoft.Data.SqlClient
         internal void ExecuteTransaction2005(
                     TransactionRequest transactionRequest,
                     string transactionName,
-                    IsolationLevel iso,
+                    System.Data.IsolationLevel iso,
                     SqlInternalTransaction internalTransaction,
                     bool isDelegateControlRequest)
         {
@@ -1287,25 +1287,25 @@ namespace Microsoft.Data.SqlClient
 
             switch (iso)
             {
-                case IsolationLevel.Unspecified:
+                case System.Data.IsolationLevel.Unspecified:
                     isoLevel = TdsEnums.TransactionManagerIsolationLevel.Unspecified;
                     break;
-                case IsolationLevel.ReadCommitted:
+                case System.Data.IsolationLevel.ReadCommitted:
                     isoLevel = TdsEnums.TransactionManagerIsolationLevel.ReadCommitted;
                     break;
-                case IsolationLevel.ReadUncommitted:
+                case System.Data.IsolationLevel.ReadUncommitted:
                     isoLevel = TdsEnums.TransactionManagerIsolationLevel.ReadUncommitted;
                     break;
-                case IsolationLevel.RepeatableRead:
+                case System.Data.IsolationLevel.RepeatableRead:
                     isoLevel = TdsEnums.TransactionManagerIsolationLevel.RepeatableRead;
                     break;
-                case IsolationLevel.Serializable:
+                case System.Data.IsolationLevel.Serializable:
                     isoLevel = TdsEnums.TransactionManagerIsolationLevel.Serializable;
                     break;
-                case IsolationLevel.Snapshot:
+                case System.Data.IsolationLevel.Snapshot:
                     isoLevel = TdsEnums.TransactionManagerIsolationLevel.Snapshot;
                     break;
-                case IsolationLevel.Chaos:
+                case System.Data.IsolationLevel.Chaos:
                     throw SQL.NotSupportedIsolationLevel(iso);
                 default:
                     throw ADP.InvalidIsolationLevel(iso);
@@ -1508,7 +1508,7 @@ namespace Microsoft.Data.SqlClient
             if (enlistOK && ConnectionOptions.Enlist && _routingInfo == null)
             {
                 _parser._physicalStateObj.SniContext = SniContext.Snix_AutoEnlist;
-                SysTx.Transaction tx = ADP.GetCurrentTransaction();
+                Transaction tx = ADP.GetCurrentTransaction();
                 Enlist(tx);
             }
             _parser._physicalStateObj.SniContext = SniContext.Snix_Login;


### PR DESCRIPTION
This PR removes alias reference in netfx to address APIScan failures.