### PR TITLE
Adding the Tds Stream APIs

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -919,6 +919,8 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
+    <Compile Include="Microsoft\Data\SqlClientX\IO\TdsStreamPacketType.cs" />
+    <Compile Include="Microsoft\Data\SqlClientX\IO\TdsStream.cs" />
     <EmbeddedResource Include="$(CommonSourceRoot)Resources\Strings.resx">
       <Link>Resources\Strings.resx</Link>
       <LogicalName>Microsoft.Data.SqlClient.Resources.Strings.resources</LogicalName>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStream.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStream.cs
@@ -30,6 +30,19 @@ namespace Microsoft.Data.SqlClientX.IO
         }
 
         /// <summary>
+        /// Replaces the underlying stream. This is useful while changing between SSL stream and non-SSL stream. 
+        /// e.g. Prelogin ends with TLS handshake, which is done on a different stream. Once the handshake is done,
+        /// login is sent in the TLS stream. However at the end of the login exchange, the stream may be switched 
+        /// back to the non-SSL stream, which is either the pipe stream or the TCP stream.
+        /// </summary>
+        /// <param name="stream"></param>
+        /// <exception cref="NotImplementedException"></exception>
+        public void ReplaceUnderlyingStream(Stream stream)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// When writing the packet, the caller needs to 
         /// specify the packet type. 
         /// TODO: Consider accepting an enum of packet types

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStream.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStream.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.SqlClient.SqlClientX.IO
+{
+    /// <summary>
+    /// A Stream abstraction over the TDS protocol.
+    /// The stream can be used to read and write TDS messages on a 
+    /// SQL Server physical connection.
+    /// </summary>
+    internal class TdsStream : Stream
+    {
+        public override bool CanRead => throw new NotImplementedException();
+
+        public override bool CanSeek => throw new NotImplementedException();
+
+        public override bool CanWrite => throw new NotImplementedException();
+
+        public override long Length => throw new NotImplementedException();
+
+        public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public TdsStream(Stream underLyingStream) : base()
+        {
+        }
+
+        /// <summary>
+        /// When writing the packet, the caller needs to 
+        /// specify the packet type. 
+        /// TODO: Consider accepting an enum of packet types
+        /// instead of the byte.
+        /// </summary>
+        /// <param name="packetType"></param>
+        public void SetWritePacketType(TdsStreamPacketType packetType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(
+            byte[] buffer, 
+            int offset, 
+            int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// We only support ValueTask based overloads for async IO.
+        /// This overload makes sure that the method throws, instead 
+        /// of using the unoptimized path.
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <exception cref="NotSupportedException"></exception>
+        public override Task WriteAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Called explicitly by the consumers to flush the stream,
+        /// which marks the TDS packet as the last packet in the message
+        /// and sends it to the server.
+        /// </summary>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public override Task FlushAsync(CancellationToken ct)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Peeks the next byte in the stream, without consuming it.
+        /// The next call to read will return the same byte but it 
+        /// will consume it.
+        /// </summary>
+        /// <param name="isAsync"></param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public ValueTask<byte> PeekByteAsync(bool isAsync,
+            CancellationToken ct)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// A convenience method to skip the bytes in the stream,
+        /// by allowing buffer manipulation, instead of making the consumer
+        /// allocate buffers to read and discard the packets.
+        /// </summary>
+        /// <param name="skipCount"></param>
+        /// <param name="isAsync"></param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public ValueTask SkipReadBytesAsync(int skipCount,
+            bool isAsync, 
+            CancellationToken ct)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Needed to reset the stream.
+        /// Useful in some cases for TDS implementation, where we 
+        /// dont want to consume all the data in the stream, but 
+        /// want to make it available for the next set of operations.
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        public void Reset()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStream.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStream.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Data.SqlClient.SqlClientX.IO
+namespace Microsoft.Data.SqlClientX.IO
 {
     /// <summary>
     /// A Stream abstraction over the TDS protocol.

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStreamPacketType.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStreamPacketType.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.Data.SqlClient.SqlClientX.IO
+﻿namespace Microsoft.Data.SqlClientX.IO
 {
     internal enum TdsStreamPacketType
     {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStreamPacketType.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStreamPacketType.cs
@@ -4,13 +4,13 @@
     {
         PreLogin = 0x12,
         Login7 = 0x10,
-        SQLBatch = 0x01,
-        RPC = 0x03,
+        SqlBatch = 0x01,
+        Rpc = 0x03,
         Attention = 0x06,
-        BulkLoadBCP = 0x07,
+        BulkLoadBcp = 0x07,
         FederatedAuth = 0x08,
         FedAuthInfo = 0x19,
-        SSPIMessage = 0x0A,
+        SspiMessage = 0x0A,
         TransactionManagerRequest = 0x0E,
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStreamPacketType.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStreamPacketType.cs
@@ -4,12 +4,13 @@
     {
         PreLogin = 0x12,
         Login7 = 0x10,
-        TransactionManagerRequest = 0x0E,
         SQLBatch = 0x01,
         RPC = 0x03,
         Attention = 0x06,
         BulkLoadBCP = 0x07,
-        FederatedAuth = 0x18,
+        FederatedAuth = 0x08,
         FedAuthInfo = 0x19,
+        SSPIMessage = 0x0A,
+        TransactionManagerRequest = 0x0E,
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStreamPacketType.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/IO/TdsStreamPacketType.cs
@@ -1,0 +1,15 @@
+﻿namespace Microsoft.Data.SqlClient.SqlClientX.IO
+{
+    internal enum TdsStreamPacketType
+    {
+        PreLogin = 0x12,
+        Login7 = 0x10,
+        TransactionManagerRequest = 0x0E,
+        SQLBatch = 0x01,
+        RPC = 0x03,
+        Attention = 0x06,
+        BulkLoadBCP = 0x07,
+        FederatedAuth = 0x18,
+        FedAuthInfo = 0x19,
+    }
+}


### PR DESCRIPTION
This PR introduces the Tds Stream, which will be consumed by the upper layers of the Tds Stream to read data, without needing to worry about the Tds header or the packet structure.
The Stream will allow reads and writes of the data. 

There are few additional method in the API which are especially interesting for the consumers of the TDS protocol.

1. PeekByteAsync : Some callsites like the Sql Data Reader would need to peek the next byte (token) before it can really decide what action to take. 
2. SkipReadBytesAsync: In some cases the Tds consumer needs to skip some bytes in the stream.
3. Reset() : This method allows resetting the buffer pointers in the stream. 

Adding only the APIs, and not the implementation, to allow the reviewers to understand the usage of this stream. 

There will be some of the APIs from the stream which will not be implemented at all.
