### PR TITLE
Fix | Remove Azure.Identity hidden properties

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
@@ -572,9 +572,7 @@ namespace Microsoft.Data.SqlClient
                 DefaultAzureCredentialOptions defaultAzureCredentialOptions = new()
                 {
                     AuthorityHost = new Uri(tokenCredentialKey._authority),
-                    SharedTokenCacheTenantId = tokenCredentialKey._audience,
-                    VisualStudioCodeTenantId = tokenCredentialKey._audience,
-                    VisualStudioTenantId = tokenCredentialKey._audience,
+                    TenantId = tokenCredentialKey._audience,
                     ExcludeInteractiveBrowserCredential = true // Force disabled, even though it's disabled by default to respect driver specifications.
                 };
 


### PR DESCRIPTION
Azure.Identity does not have a public reference to SharedTokenCacheTenantId, VisualStudioCodeTenantId and VisualStudioTenantId. More could be seen at [this](https://github.com/Azure/azure-sdk-for-net/issues/44482) issue.