### PR TITLE
Adding DbDataSource Scaffolding

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -920,6 +920,8 @@
     </Compile>
     <Compile Include="Microsoft\Data\SqlClientX\Handlers\ConnectionHandlerContext.cs" />
     <Compile Include="Microsoft\Data\SqlClientX\Handlers\DataSourceParsingHandler.cs" />
+    <Compile Include="Microsoft\Data\SqlClientX\SqlDataSource.cs" />
+    <Compile Include="Microsoft\Data\SqlClientX\SqlInternalConnectionX.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Microsoft\Data\SqlClientX\IO\ITdsReadStream.cs" />
     <Compile Include="Microsoft\Data\SqlClientX\IO\ITdsStream.cs" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlConnectionX.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlConnectionX.cs
@@ -144,23 +144,19 @@ namespace Microsoft.Data.SqlClientX
             => throw new NotImplementedException();
 
         /// <inheritdoc/>
-        public override void Open() => Open(false, CancellationToken.None).GetAwaiter().GetResult();
+        public override void Open() => _Open(false, CancellationToken.None).GetAwaiter().GetResult();
 
         /// <inheritdoc/>
-        public override Task OpenAsync(CancellationToken cancellationToken) => Open(true, cancellationToken);
+        public override Task OpenAsync(CancellationToken cancellationToken) => _Open(true, cancellationToken);
 
-        private Task Open(bool async, CancellationToken cancellationToken)
+        private async Task _Open(bool async, CancellationToken cancellationToken)
         {
             if (_dataSource == null)
             {
                 throw new InvalidOperationException("No data source or connection string set");
             }
 
-            return OpenAsync(async, cancellationToken);
-
-            async Task OpenAsync(bool async, CancellationToken cancellationToken) {
-                _connection = await _dataSource.GetInternalConnection();
-            }
+            _connection = await _dataSource.GetInternalConnection(async, cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlDataSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlDataSource.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET8_0_OR_GREATER 
+
+using Microsoft.Data.SqlClient;
+using System.Data.Common;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.SqlClientX
+{
+    internal abstract class SqlDataSource : DbDataSource
+    {
+        private SqlCredential _credential;
+        private string _connectionString;
+        public override string ConnectionString => _connectionString;
+        internal SqlCredential Credential => _credential;
+
+        internal SqlDataSource(string connectionString, SqlCredential credential)
+        {
+            _connectionString = connectionString;
+            _credential = credential;
+        }
+
+        protected override SqlConnectionX CreateDbConnection()
+        {
+            return SqlConnectionX.FromDataSource(this);
+        }
+
+        internal abstract protected ValueTask<SqlInternalConnectionX> GetInternalConnection();
+    }
+}
+
+#endif

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlDataSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlDataSource.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.Data.SqlClient;
 using System.Data.Common;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Data.SqlClientX
@@ -28,7 +29,7 @@ namespace Microsoft.Data.SqlClientX
             return SqlConnectionX.FromDataSource(this);
         }
 
-        internal abstract protected ValueTask<SqlInternalConnectionX> GetInternalConnection();
+        internal abstract ValueTask<SqlInternalConnectionX> GetInternalConnection(bool async, CancellationToken cancellationToken);
     }
 }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlInternalConnectionX.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlInternalConnectionX.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET7_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.SqlClientX
+{
+    internal class SqlInternalConnectionX : DbConnection
+    {
+        public SqlInternalConnectionX() { }
+
+        public override string ConnectionString 
+        { 
+            get => throw new NotImplementedException(); 
+            set => throw new NotImplementedException(); 
+        }
+
+        public override string Database => throw new NotImplementedException();
+
+        public override string DataSource => throw new NotImplementedException();
+
+        public override string ServerVersion => throw new NotImplementedException();
+
+        public override ConnectionState State => throw new NotImplementedException();
+
+        public override void ChangeDatabase(string databaseName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Close()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Open()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DbCommand CreateDbCommand()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
This PR adds the SqlDataSource and SqlInternalConnectionX classes and establishes the basic relationships between them for connection creation. Next PR will establish a basic disposal flow that returns internal connections to their originating data source.

See the image below for an overview of the class architecture. Green items are new. White items are existing, from the System.Data.Common library.
<img width="1897" alt="SqlClient Connection Pool (8)" src="https://github.com/dotnet/SqlClient/assets/4722049/14890f86-946b-4985-bc5e-a9bb62c447f7">
