### PR TITLE
Fix | Fix decrypt failure to drain data

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3141,12 +3141,6 @@ namespace Microsoft.Data.SqlClient
                 stateObj.HasReceivedError = false;
                 if (stateObj._inBytesUsed >= stateObj._inBytesRead)
                 {
-                    if (stateObj.HasPendingData)
-                    {
-                        // Drain the pending data now if forcing the HasPendingData flag to false since the
-                        // SqlDataReader.TryCloseInternal will not be able to do so as it checks first if that flag is set.
-                        DrainData(stateObj);
-                    }
                     stateObj.HasPendingData = false;
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6142,8 +6142,8 @@ namespace Microsoft.Data.SqlClient
                                 // Packet received from Key Vault will throws invalid token header.
                                 if (stateObj.HasPendingData)
                                 {
-                                    // Drain the pending data now if forcing the HasPendingData flag to false since the
-                                    // SqlDataReader.TryCloseInternal will not be able to do so as it checks first if that flag is set.
+                                    // Drain the pending data now if setting the HasPendingData to false.
+                                    // SqlDataReader.TryCloseInternal can not drain if HasPendingData = false.
                                     DrainData(stateObj);
                                 }
                                 stateObj.HasPendingData = false;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6140,6 +6140,12 @@ namespace Microsoft.Data.SqlClient
                                 // call to decrypt column keys has failed. The data wont be decrypted.
                                 // Not setting the value to false, forces the driver to look for column value.
                                 // Packet received from Key Vault will throws invalid token header.
+                                if (stateObj.HasPendingData)
+                                {
+                                    // Drain the pending data now if forcing the HasPendingData flag to false since the
+                                    // SqlDataReader.TryCloseInternal will not be able to do so as it checks first if that flag is set.
+                                    DrainData(stateObj);
+                                }
                                 stateObj.HasPendingData = false;
                             }
                             throw SQL.ColumnDecryptionFailed(columnName, null, e);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3141,6 +3141,12 @@ namespace Microsoft.Data.SqlClient
                 stateObj.HasReceivedError = false;
                 if (stateObj._inBytesUsed >= stateObj._inBytesRead)
                 {
+                    if (stateObj.HasPendingData)
+                    {
+                        // Drain the pending data now if forcing the HasPendingData flag to false since the
+                        // SqlDataReader.TryCloseInternal will not be able to do so as it checks first if that flag is set.
+                        DrainData(stateObj);
+                    }
                     stateObj.HasPendingData = false;
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6935,6 +6935,12 @@ namespace Microsoft.Data.SqlClient
                                 // call to decrypt column keys has failed. The data wont be decrypted.
                                 // Not setting the value to false, forces the driver to look for column value.
                                 // Packet received from Key Vault will throws invalid token header.
+                                if (stateObj.HasPendingData)
+                                {
+                                    // Drain the pending data now if setting the HasPendingData to false.
+                                    // SqlDataReader.TryCloseInternal can not drain if HasPendingData = false.
+                                    DrainData(stateObj);
+                                }
                                 stateObj.HasPendingData = false;
                             }
                             throw SQL.ColumnDecryptionFailed(columnName, null, e);


### PR DESCRIPTION
This fix is to fix the side effect of PR #1968.

When the SqlDataReader fails to decrypt an Encrypted column, a "Failed to decrypt" error is thrown. When that connection is returned to the pool and is used again, another error follows, "Internal error". This fix will ensure that when the "Failed to decrypt" error is thrown, it will drain that connection's buffer first before returning it to the connection pool.

