### PR TITLE
Add a pooling data source

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -920,6 +920,7 @@
     </Compile>
     <Compile Include="Microsoft\Data\SqlClientX\Handlers\ConnectionHandlerContext.cs" />
     <Compile Include="Microsoft\Data\SqlClientX\Handlers\DataSourceParsingHandler.cs" />
+    <Compile Include="Microsoft\Data\SqlClientX\PoolingDataSource.cs" />
     <Compile Include="Microsoft\Data\SqlClientX\SqlDataSource.cs" />
     <Compile Include="Microsoft\Data\SqlClientX\SqlConnector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -966,6 +967,9 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelProtocolsOpenIdConnectVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="microsoft.data.sqlclient\netcore\src\microsoft\data\sqlclientx\" />
   </ItemGroup>
   <Import Project="$(ToolsDir)targets\GenerateThisAssemblyCs.targets" />
   <Import Project="$(ToolsDir)targets\ResolveContract.targets" Condition="'$(OSGroup)' == 'AnyOS'" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -979,9 +979,6 @@
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelProtocolsOpenIdConnectVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="microsoft.data.sqlclient\netcore\src\microsoft\data\sqlclientx\" />
-  </ItemGroup>
   <Import Project="$(ToolsDir)targets\GenerateThisAssemblyCs.targets" />
   <Import Project="$(ToolsDir)targets\ResolveContract.targets" Condition="'$(OSGroup)' == 'AnyOS'" />
   <Import Project="$(ToolsDir)targets\NotSupported.targets" Condition="'$(OSGroup)' == 'AnyOS'" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/PoolingDataSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/PoolingDataSource.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET8_0_OR_GREATER
+
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.ProviderBase;
+using Microsoft.Data.SqlClient;
+
+namespace Microsoft.Data.SqlClientX
+{
+    internal sealed class PoolingDataSource : SqlDataSource
+    {
+        private SemaphoreSlim poolSemaphore;
+        private ConcurrentQueue<SqlConnector> _sqlConnectors;
+
+        private DbConnectionPoolGroupOptions _connectionPoolGroupOptions;
+
+        internal int MinPoolSize => _connectionPoolGroupOptions.MinPoolSize;
+        internal int MaxPoolSize => _connectionPoolGroupOptions.MaxPoolSize;
+
+        //TODO: support auth contexts and provider info
+        PoolingDataSource(string connectionString, SqlCredential credential, DbConnectionPoolGroupOptions options) : base(connectionString, credential)
+        {
+            _connectionPoolGroupOptions = options;
+            poolSemaphore = new SemaphoreSlim(MaxPoolSize);
+        }
+
+        internal override ValueTask<SqlConnector> GetInternalConnection(bool async, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (async)
+                {
+                    poolSemaphore.WaitAsync();
+                } else
+                {
+                    poolSemaphore.Wait();
+                }
+
+
+            }
+            catch
+            {
+                poolSemaphore.Release(1);
+            }
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/PoolingDataSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/PoolingDataSource.cs
@@ -4,49 +4,73 @@
 
 #if NET8_0_OR_GREATER
 
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Data.ProviderBase;
 using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Data.SqlClientX
 {
+    /// <summary>
+    /// A pooling implementation of SqlDataSource. Connections are recycled upon return to be reused by another operation.
+    /// </summary>
     internal sealed class PoolingDataSource : SqlDataSource
     {
-        private SemaphoreSlim poolSemaphore;
-        private ConcurrentQueue<SqlConnector> _sqlConnectors;
-
+        private Channel<SqlConnector> _sqlConnectors;
         private DbConnectionPoolGroupOptions _connectionPoolGroupOptions;
 
         internal int MinPoolSize => _connectionPoolGroupOptions.MinPoolSize;
         internal int MaxPoolSize => _connectionPoolGroupOptions.MaxPoolSize;
 
+        /// <summary>
+        /// Initializes a new PoolingDataSource.
+        /// </summary>
+        /// <param name="connectionString">The connection string used for connections.</param>
+        /// <param name="credential">The credential used for connections.</param>
+        /// <param name="options">The options used for this pool.</param>
         //TODO: support auth contexts and provider info
         PoolingDataSource(string connectionString, SqlCredential credential, DbConnectionPoolGroupOptions options) : base(connectionString, credential)
         {
             _connectionPoolGroupOptions = options;
-            poolSemaphore = new SemaphoreSlim(MaxPoolSize);
+            //TODO: other construction
         }
 
+        /// <inheritdoc/>
         internal override ValueTask<SqlConnector> GetInternalConnection(bool async, CancellationToken cancellationToken)
         {
-            try
-            {
-                if (async)
-                {
-                    poolSemaphore.WaitAsync();
-                } else
-                {
-                    poolSemaphore.Wait();
-                }
+            throw new NotImplementedException();
+        }
 
+        internal ValueTask<SqlConnector> OpenNewInternalConnection(bool async, CancellationToken cancellationToken)
+        {
 
-            }
-            catch
-            {
-                poolSemaphore.Release(1);
-            }
+        }
+
+        /// <inheritdoc/>
+        internal override void ReturnInternalConnection(SqlConnector connection)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Closes extra idle connections.
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        internal void PruneIdleConnections()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Warms up the pool to bring it up to min pool size.
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        internal void WarmUp()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/PoolingDataSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/PoolingDataSource.cs
@@ -6,6 +6,8 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -19,7 +21,6 @@ namespace Microsoft.Data.SqlClientX
     /// </summary>
     internal sealed class PoolingDataSource : SqlDataSource
     {
-        private Channel<SqlConnector> _sqlConnectors;
         private DbConnectionPoolGroupOptions _connectionPoolGroupOptions;
 
         internal int MinPoolSize => _connectionPoolGroupOptions.MinPoolSize;
@@ -28,29 +29,31 @@ namespace Microsoft.Data.SqlClientX
         /// <summary>
         /// Initializes a new PoolingDataSource.
         /// </summary>
-        /// <param name="connectionString">The connection string used for connections.</param>
-        /// <param name="credential">The credential used for connections.</param>
-        /// <param name="options">The options used for this pool.</param>
         //TODO: support auth contexts and provider info
-        PoolingDataSource(string connectionString, SqlCredential credential, DbConnectionPoolGroupOptions options) : base(connectionString, credential)
+        PoolingDataSource(SqlConnectionStringBuilder connectionStringBuilder,
+            SqlCredential credential,
+            RemoteCertificateValidationCallback userCertificateValidationCallback,
+            Action<X509CertificateCollection> clientCertificatesCallback,
+            DbConnectionPoolGroupOptions options) : base(connectionStringBuilder, credential, userCertificateValidationCallback, clientCertificatesCallback)
         {
             _connectionPoolGroupOptions = options;
             //TODO: other construction
         }
 
         /// <inheritdoc/>
-        internal override ValueTask<SqlConnector> GetInternalConnection(bool async, CancellationToken cancellationToken)
+        internal override ValueTask<SqlConnector> GetInternalConnection(SqlConnectionX owningConnection, TimeSpan timeout, bool async, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
 
-        internal ValueTask<SqlConnector> OpenNewInternalConnection(bool async, CancellationToken cancellationToken)
+        /// <inheritdoc/>
+        internal override ValueTask<SqlConnector> OpenNewInternalConnection(SqlConnectionX owningConnection, TimeSpan timeout, bool async, CancellationToken cancellationToken)
         {
-
+            throw new NotImplementedException();
         }
 
         /// <inheritdoc/>
-        internal override void ReturnInternalConnection(SqlConnector connection)
+        internal override ValueTask ReturnInternalConnection(bool async, SqlConnector connection)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlConnectionX.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlConnectionX.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.SqlClientX
     {
         private SqlCredential? _credential;
         private SqlDataSource? _dataSource;
-        private SqlConnector? _connection;
+        private SqlConnector? _internalConnection;
 
         //TODO: Investigate if we can just use dataSource.ConnectionString. Do this when this class can resolve its own data source.
         private string _connectionString = string.Empty;
@@ -184,13 +184,20 @@ namespace Microsoft.Data.SqlClientX
 
             async Task CloseAsync(bool async)
             {
-                Debug.Assert(_connection != null);
-                var internalConnection = _connection;
+                Debug.Assert(_internalConnection != null);
+                Debug.Assert(_dataSource != null);
 
-                //TODO: cancel outstanding operations on connection before close
-                await internalConnection.Close(async).ConfigureAwait(false);
+                var internalConnection = _internalConnection;
 
-                //TODO: remove the internal connection's reference to this wrapper connection
+                if (internalConnection != null)
+                {
+                    //TODO: cancel outstanding operations on connection before close
+                    //TODO: if pooling, reset the connector
+
+                    await internalConnection.Return(async).ConfigureAwait(false);
+                    internalConnection.OwningConnection = null;
+                    _internalConnection = null;
+                }
 
                 _connectionState = ConnectionState.Closed;
             }
@@ -245,7 +252,7 @@ namespace Microsoft.Data.SqlClientX
                 throw ADP.NoConnectionString();
             }
 
-            _connection = await _dataSource.GetInternalConnection(this, TimeSpan.FromSeconds(ConnectionTimeout), async, cancellationToken).ConfigureAwait(false);
+            _internalConnection = await _dataSource.GetInternalConnection(this, TimeSpan.FromSeconds(ConnectionTimeout), async, cancellationToken).ConfigureAwait(false);
         }
 
         #endregion

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlConnectionX.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlConnectionX.cs
@@ -194,8 +194,8 @@ namespace Microsoft.Data.SqlClientX
                     //TODO: cancel outstanding operations on connection before close
                     //TODO: if pooling, reset the connector
 
-                    await internalConnection.Return(async).ConfigureAwait(false);
                     internalConnection.OwningConnection = null;
+                    await internalConnection.Return(async).ConfigureAwait(false);
                     _internalConnection = null;
                 }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlConnector.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlConnector.cs
@@ -10,6 +10,8 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Microsoft.Data.SqlClientX
 {
     /// <summary>
@@ -17,25 +19,27 @@ namespace Microsoft.Data.SqlClientX
     /// </summary>
     internal class SqlConnector
     {
-        private WeakReference<SqlConnectionX> _owningConnection;
+        internal SqlConnectionX? OwningConnection { get; set; }
+
         /// <summary>
-        /// The datasource accessed by this connector.
+        /// The data source that generated this connector.
         /// </summary>
-        public string DataSource => throw new NotImplementedException();
+        internal SqlDataSource DataSource { get; }
 
         /// <summary>
         /// The server version this connector is connected to.
         /// </summary>
-        public string ServerVersion => throw new NotImplementedException();
+        internal string ServerVersion => throw new NotImplementedException();
 
         /// <summary>
         /// Represents the current state of this connection.
         /// </summary>
-        public ConnectionState State => throw new NotImplementedException();
+        internal ConnectionState State => throw new NotImplementedException();
 
-        internal SqlConnector(SqlConnectionX owningConnection)
+        internal SqlConnector(SqlConnectionX owningConnection, SqlDataSource dataSource)
         {
-            _owningConnection = new WeakReference<SqlConnectionX>(owningConnection);
+            OwningConnection = owningConnection;
+            DataSource = dataSource;
         }
 
         /// <summary>
@@ -44,7 +48,7 @@ namespace Microsoft.Data.SqlClientX
         /// <param name = "async" > Whether this method should run asynchronously.</param>
         /// <returns>A Task indicating the result of the operation.</returns>
         /// <exception cref="NotImplementedException"></exception>
-        public Task Close(bool async)
+        internal ValueTask Close(bool async)
         {
             throw new NotImplementedException();
         }
@@ -57,10 +61,17 @@ namespace Microsoft.Data.SqlClientX
         /// <param name = "cancellationToken">The token used to cancel an ongoing asynchronous call.</param>
         /// <returns>A Task indicating the result of the operation.</returns>
         /// <exception cref="NotImplementedException"></exception>
-        public Task Open(TimeSpan timeout, bool async, CancellationToken cancellationToken)
+        internal ValueTask Open(TimeSpan timeout, bool async, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Returns this connection to the data source that generated it.
+        /// </summary>
+        /// <param name="async">Whether this method should run asynchronously.</param>
+        /// <returns></returns>
+        internal ValueTask Return(bool async) => DataSource.ReturnInternalConnection(async, this);
     }
 }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlDataSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlDataSource.cs
@@ -51,6 +51,12 @@ namespace Microsoft.Data.SqlClientX
         /// <param name="cancellationToken">The token used to cancel an ongoing asynchronous call.</param>
         /// <returns></returns>
         internal abstract ValueTask<SqlConnector> GetInternalConnection(bool async, CancellationToken cancellationToken);
+        
+        /// <summary>
+        /// Returns a SqlConnector to the data source for recycling or finalization.
+        /// </summary>
+        /// <param name="connection">The connection returned to the data source.</param>
+        internal abstract void ReturnInternalConnection(SqlConnector connection)
     }
 }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlDataSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/SqlDataSource.cs
@@ -105,12 +105,23 @@ namespace Microsoft.Data.SqlClientX
         /// <param name="cancellationToken">Cancels an outstanding asynchronous operation.</param>
         /// <returns></returns>
         internal abstract ValueTask<SqlConnector> GetInternalConnection(SqlConnectionX owningConnection, TimeSpan timeout, bool async, CancellationToken cancellationToken);
-    
+
         /// <summary>
         /// Returns a SqlConnector to the data source for recycling or finalization.
         /// </summary>
+        /// <param name="async">Whether this method should be run asynchronously.</param>
         /// <param name="connection">The connection returned to the data source.</param>
-        internal abstract void ReturnInternalConnection(SqlConnector connection)
+        internal abstract ValueTask ReturnInternalConnection(bool async, SqlConnector connection);
+
+        /// <summary>
+        /// Opens a new SqlConnector.
+        /// </summary>
+        /// <param name="owningConnection">The SqlConnectionX object that will exclusively own and use this connector.</param>
+        /// <param name="timeout">The connection timeout for this operation.</param>
+        /// <param name="async">Whether this method should be run asynchronously.</param>
+        /// <param name="cancellationToken">Cancels an outstanding asynchronous operation.</param>
+        /// <returns></returns>
+        internal abstract ValueTask<SqlConnector> OpenNewInternalConnection(SqlConnectionX owningConnection, TimeSpan timeout, bool async, CancellationToken cancellationToken);
     }
 }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/UnpooledDataSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/UnpooledDataSource.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Data.SqlClientX
         /// <inheritdoc/>
         internal override async ValueTask<SqlConnector> OpenNewInternalConnection(SqlConnectionX owningConnection, TimeSpan timeout, bool async, CancellationToken cancellationToken)
         {
-            var connector = new SqlConnector(owningConnection);
+            var connector = new SqlConnector(owningConnection, this);
             await connector.Open(timeout, async, cancellationToken).ConfigureAwait(false);
             return connector;
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/UnpooledDataSource.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/UnpooledDataSource.cs
@@ -38,19 +38,25 @@ namespace Microsoft.Data.SqlClientX
         {
         }
 
-        /// <summary>
-        /// Creates and opens a new SqlConnector.
-        /// </summary>
-        /// <param name="owningConnection">The SqlConnectionX object that will exclusively own and use this connector.</param>
-        /// <param name="timeout">The connection timeout for this operation.</param>
-        /// <param name="async">Whether this method should be run asynchronously.</param>
-        /// <param name="cancellationToken">Cancels an outstanding asynchronous operation.</param>
-        /// <returns></returns>
-        internal override async ValueTask<SqlConnector> GetInternalConnection(SqlConnectionX owningConnection, TimeSpan timeout, bool async, CancellationToken cancellationToken)
+
+        /// <inheritdoc/>
+        internal override ValueTask<SqlConnector> GetInternalConnection(SqlConnectionX owningConnection, TimeSpan timeout, bool async, CancellationToken cancellationToken)
+        {
+            return OpenNewInternalConnection(owningConnection, timeout, async, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        internal override async ValueTask<SqlConnector> OpenNewInternalConnection(SqlConnectionX owningConnection, TimeSpan timeout, bool async, CancellationToken cancellationToken)
         {
             var connector = new SqlConnector(owningConnection);
             await connector.Open(timeout, async, cancellationToken).ConfigureAwait(false);
             return connector;
+        }
+
+        /// <inheritdoc/>
+        internal override async ValueTask ReturnInternalConnection(bool async, SqlConnector connection)
+        {
+            await connection.Close(async).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Adds the skeleton of a concrete, pooling SqlDataSource class.
Introduces a "return" flow so that data sources can received an internal connection for recycling or closing.