### PR TITLE
[3.1.6] | Update SNI version 3.0.2

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <!-- NetFx project dependencies -->
   <PropertyGroup>
-    <MicrosoftDataSqlClientSniVersion>3.0.1</MicrosoftDataSqlClientSniVersion>    
+    <MicrosoftDataSqlClientSniVersion>3.0.2</MicrosoftDataSqlClientSniVersion>    
     <SystemSecurityCryptographyAlgorithmsVersion>4.3.1</SystemSecurityCryptographyAlgorithmsVersion>
     <SystemSecurityCryptographyPrimitivesVersion>4.3.0</SystemSecurityCryptographyPrimitivesVersion>
   </PropertyGroup>
@@ -32,7 +32,7 @@
   <!-- NetCore project dependencies -->
   <PropertyGroup>
     <MicrosoftWin32RegistryVersion>4.7.0</MicrosoftWin32RegistryVersion>
-    <MicrosoftDataSqlClientSNIRuntimeVersion>3.0.1</MicrosoftDataSqlClientSNIRuntimeVersion>
+    <MicrosoftDataSqlClientSNIRuntimeVersion>3.0.2</MicrosoftDataSqlClientSNIRuntimeVersion>
     <SystemConfigurationConfigurationManagerVersion>4.7.0</SystemConfigurationConfigurationManagerVersion>
     <SystemDiagnosticsDiagnosticSourceVersion>4.7.0</SystemDiagnosticsDiagnosticSourceVersion>
     <SystemDiagnosticsPerformanceCounterVersion>4.7.0</SystemDiagnosticsPerformanceCounterVersion>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -28,7 +28,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <tags>sqlclient microsoft.data.sqlclient</tags>
     <dependencies>
       <group targetFramework="net461">
-        <dependency id="Microsoft.Data.SqlClient.SNI" version="[3.0.1]" />
+        <dependency id="Microsoft.Data.SqlClient.SNI" version="[3.0.2]" />
         <dependency id="Azure.Identity" version="1.3.0" />
         <dependency id="System.Text.Encodings.Web" version="4.7.2" />
         <dependency id="Microsoft.Identity.Client" version="4.22.0" />
@@ -37,7 +37,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Configuration.ConfigurationManager" version="4.7.0" exclude="Compile" />
       </group>
       <group targetFramework="netcoreapp2.1">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="[3.0.1]" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="[3.0.2]" exclude="Compile" />
         <dependency id="Microsoft.Win32.Registry" version="4.7.0" exclude="Compile" />
         <dependency id="System.Security.Principal.Windows" version="4.7.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="4.7.0" exclude="Compile" />
@@ -51,7 +51,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="[3.0.1]" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="[3.0.2]" exclude="Compile" />
         <dependency id="Microsoft.Win32.Registry" version="4.7.0" exclude="Compile" />
         <dependency id="System.Security.Principal.Windows" version="4.7.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="4.7.0" exclude="Compile" />
@@ -65,7 +65,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="6.8.0" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="[3.0.1]" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="[3.0.2]" exclude="Compile" />
         <dependency id="Microsoft.Win32.Registry" version="4.7.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" exclude="Compile" />
         <dependency id="System.Memory" version="4.5.4" exclude="Compile" />
@@ -81,7 +81,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Runtime.Loader" version="4.3.0" exclude="Compile" />
       </group>
       <group targetFramework="netstandard2.1">
-        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="[3.0.1]" exclude="Compile" />
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="[3.0.2]" exclude="Compile" />
         <dependency id="Microsoft.Win32.Registry" version="4.7.0" exclude="Compile" />
         <dependency id="System.Buffers" version="4.5.1" exclude="Compile" />
         <dependency id="System.Memory" version="4.5.4" exclude="Compile" />


### PR DESCRIPTION
Included changes in the SNI v3.0.2:

- Fixed multiple AppDomain issue due to registration of duplicate tracelogging provider introducing in issue [1418](https://github.com/dotnet/SqlClient/issues/1418).
- Sanitized the coding style without touching the functionality.
