### PR TITLE
Adding the SqlDbTypeExtensions

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -625,6 +625,9 @@
     <Compile Include="$(CommonSourceRoot)System\Diagnostics\CodeAnalysis.cs">
       <Link>Common\System\Diagnostics\CodeAnalysis.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlDbTypeExtensions.cs">
+      <Link>Microsoft\Data\SqlDbTypeExtensions.cs</Link>
+    </Compile>
 
     <Compile Include="Interop\SNINativeMethodWrapper.Common.cs" />
     <Compile Include="Microsoft\Data\Common\DbConnectionOptions.cs" />

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -646,6 +646,9 @@
     <Compile Include="$(CommonSourceRoot)\Microsoft\Data\ProviderBase\DbReferenceCollection.cs">
       <Link>Microsoft\Data\ProviderBase\DbReferenceCollection.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlDbTypeExtensions.cs">
+      <Link>Microsoft\Data\SqlDbTypeExtensions.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\src\Microsoft\Data\Common\NameValuePermission.cs" />

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlDbTypeExtensions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlDbTypeExtensions.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data;
+
+namespace Microsoft.Data
+{
+    /// <summary>
+    /// Extensions for SqlDbType enum to enable its usage.
+    /// </summary>
+    public static class SqlDbTypeExtensions
+    {
+        /// <summary>
+        /// Represents the JSON Data type in SQL Server.
+        /// </summary>
+#if NET9_0_OR_GREATER
+        public const SqlDbType Json = SqlDbType.Json;
+#else
+        public const SqlDbType Json = (SqlDbType)35;
+#endif
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/SqlClient/issues/2668

As a follow up, when all the JSON types are ready, then we need to make sure that the ref assemblies are updated with the new APIs together. 

The internal implementation of Datatypes in SqlClient will use `SqlDbTypeExtensions.Json`. There are a lot of places in code where this decisions needs to be taken on SqlDbType. This change will allow internal implementation to move forward as well. 

The tracking issue is at https://github.com/dotnet/SqlClient/issues/2670 