### PR TITLE
Fix the prelogin handler inheritance and remove the Error object

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/Handlers/Connection/ConnectionHandlerContext.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/Handlers/Connection/ConnectionHandlerContext.cs
@@ -35,11 +35,6 @@ namespace Microsoft.Data.SqlClientX.Handlers.Connection
         public DataSource DataSource { get; set; }
 
         /// <summary>
-        /// Class used by orchestrator while chaining handlers.
-        /// </summary>
-        public Exception Error { get; set; }
-
-        /// <summary>
         /// The Guid of the Connection.
         /// </summary>
         public Guid ConnectionId { get; internal set; } = Guid.Empty;
@@ -111,7 +106,6 @@ namespace Microsoft.Data.SqlClientX.Handlers.Connection
                 ConnectionStream = this.ConnectionStream, 
                 ConnectionString = this.ConnectionString, 
                 DataSource = this.DataSource, 
-                Error = this.Error, 
                 ConnectionId = this.ConnectionId,
                 SslStream = this.SslStream, 
                 SslOverTdsStream = this.SslOverTdsStream, 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/Handlers/Connection/DataSourceParsingHandler.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/Handlers/Connection/DataSourceParsingHandler.cs
@@ -26,8 +26,7 @@ namespace Microsoft.Data.SqlClientX.Handlers.Connection
                 //TODO: populate other details for the SQLException
                 SqlErrorCollection collection = new SqlErrorCollection();
                 collection.Add(new SqlError(0,0,TdsEnums.FATAL_ERROR_CLASS, null, StringsHelper.GetString("LocalDB_UnobtainableMessage"), null, 0));
-                request.Error = SqlException.CreateException(collection, null);
-                return;
+                throw SqlException.CreateException(collection, null);
             }
             
             // If a localDB Data source is available, we need to use it.
@@ -38,8 +37,7 @@ namespace Microsoft.Data.SqlClientX.Handlers.Connection
                 //TODO: populate other details for the SQLException
                 SqlErrorCollection collection = new SqlErrorCollection();
                 collection.Add(new SqlError(0, 0, TdsEnums.FATAL_ERROR_CLASS, null, StringsHelper.GetString("LocalDB_UnobtainableMessage"), null, 0));
-                request.Error = SqlException.CreateException(collection, null);
-                return;
+                throw SqlException.CreateException(collection, null);
             }
             
             request.DataSource = details;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/Handlers/Connection/PreloginHandler.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/Handlers/Connection/PreloginHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClientX.Handlers.Connection
     /// This handler will send the prelogin based on the features requested in the connection string.
     /// It will consume the prelogin handshake and pass the control to the next handler.
     /// </summary>
-    internal class PreloginHandler : IHandler<ConnectionHandlerContext>
+    internal class PreloginHandler : ContextHandler<ConnectionHandlerContext>
     {
         /// <summary>
         /// The Helper object to perform TLS authentication.
@@ -50,10 +50,7 @@ namespace Microsoft.Data.SqlClientX.Handlers.Connection
         }
 
         /// <inheritdoc />
-        public IHandler<ConnectionHandlerContext> NextHandler { get; set; }
-
-        /// <inheritdoc />
-        public async ValueTask Handle(ConnectionHandlerContext connectionContext, bool isAsync, CancellationToken ct)
+        public override async ValueTask Handle(ConnectionHandlerContext connectionContext, bool isAsync, CancellationToken ct)
         {
             PreloginHandlerContext context = new PreloginHandlerContext(connectionContext);
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/Handlers/Connection/TransportCreationHandler.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/Handlers/Connection/TransportCreationHandler.cs
@@ -34,15 +34,7 @@ namespace Microsoft.Data.SqlClientX.Handlers.Connection
         /// <inheritdoc />
         public override async ValueTask Handle(ConnectionHandlerContext context, bool isAsync, CancellationToken ct)
         {
-            try
-            {
-                context.ConnectionStream = await _streamCreationChain.Handle(context, isAsync, ct).ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                context.Error = e;
-                return;
-            }
+            context.ConnectionStream = await _streamCreationChain.Handle(context, isAsync, ct).ConfigureAwait(false);
 
             // Every physical connection has a Unique ID which is used by the rest 
             // of the connection for tracing on the server side, to correlate with 

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Handlers/LoginChainTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Handlers/LoginChainTest.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClientX.Handlers.Connection;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.NetCore.UnitTests.Handlers
+{
+    /// <summary>
+    ///  Place holder for stitching all the handlers for login and testing them
+    ///  without the orchestrator.
+    /// </summary>
+    public sealed class LoginChainTest
+    {
+
+        /// <summary>
+        ///  Datasource to use for connection test. This may be changed locally to test against a different server.
+        ///  TODO: Migrate to config when we enable CI.
+        /// </summary>
+        private string _dataSource = "tcp:localhost,1446";
+
+        [Fact]
+        public async void TestConnectivity()
+        {
+            DataSourceParsingHandler dspHandler = new();
+            TransportCreationHandler tcHandler = new();
+            PreloginHandler plHandler = new();
+            ConnectionHandlerContext chc = new();
+            SqlConnectionStringBuilder csb = new()
+            {
+                DataSource = _dataSource,
+                Encrypt = SqlConnectionEncryptOption.Mandatory,
+                TrustServerCertificate = true
+            };
+
+            SqlConnectionString scs = new(csb.ConnectionString);
+            chc.ConnectionString = scs;
+            var serverInfo = new ServerInfo(scs);
+            serverInfo.SetDerivedNames(null, serverInfo.UserServerName);
+            chc.ServerInfo = serverInfo;
+            dspHandler.NextHandler = tcHandler;
+            tcHandler.NextHandler = plHandler;
+            await Assert.ThrowsAsync<SocketException>(async () => await dspHandler.Handle(chc, true, default));
+        }
+    }
+}


### PR DESCRIPTION
The changes do the following:

1. Change the base type of Prelogin handler to ContextHandler.
2. Add a test to construct the chain of handlers, so that any base class changes dont break the sub-handler.
3. Removed the error from the context based on the earlier discussions where we will throw exception rather than saving it. 
4. Added test to create a chain of handlers to test this behavior to make sure that the chain works. In this test the prelogin handler is not being tested since there is no server to test with ATM.

I will be sending LoginHandler based on these changes, but these changes make sure that the code before prelogin handler is working OK. 