### PR TITLE
Replace unused out arguments with discards

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
@@ -406,7 +406,7 @@ namespace System.Net
 
         public static object QueryContextAttributes(SSPIInterface secModule, SafeDeleteContext securityContext, Interop.SspiCli.ContextAttribute contextAttribute)
         {
-            return QueryContextAttributes(secModule, securityContext, contextAttribute, out int _);
+            return QueryContextAttributes(secModule, securityContext, contextAttribute, out _);
         }
 
         public static object QueryContextAttributes(SSPIInterface secModule, SafeDeleteContext securityContext, Interop.SspiCli.ContextAttribute contextAttribute, out int errorCode)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
@@ -406,8 +406,7 @@ namespace System.Net
 
         public static object QueryContextAttributes(SSPIInterface secModule, SafeDeleteContext securityContext, Interop.SspiCli.ContextAttribute contextAttribute)
         {
-            int errorCode;
-            return QueryContextAttributes(secModule, securityContext, contextAttribute, out errorCode);
+            return QueryContextAttributes(secModule, securityContext, contextAttribute, out int _);
         }
 
         public static object QueryContextAttributes(SSPIInterface secModule, SafeDeleteContext securityContext, Interop.SspiCli.ContextAttribute contextAttribute, out int errorCode)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
@@ -214,7 +214,6 @@ namespace System.Net.Security
                 NetEventSource.Enter(null, package, intent);
 
             int errorCode = -1;
-            long timeStamp;
 
             outCredential = new SafeFreeCredential_SECURITY();
 
@@ -227,7 +226,7 @@ namespace System.Net.Security
                             null,
                             null,
                             ref outCredential._handle,
-                            out timeStamp);
+                            out long _);
 
 #if TRACE_VERBOSE
             if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"{nameof(Interop.SspiCli.AcquireCredentialsHandleW)} returns 0x{errorCode:x}, handle = {outCredential}");
@@ -248,7 +247,6 @@ namespace System.Net.Security
             out SafeFreeCredentials outCredential)
         {
             int errorCode = -1;
-            long timeStamp;
 
             outCredential = new SafeFreeCredential_SECURITY();
             errorCode = Interop.SspiCli.AcquireCredentialsHandleW(
@@ -260,7 +258,7 @@ namespace System.Net.Security
                             null,
                             null,
                             ref outCredential._handle,
-                            out timeStamp);
+                            out long _);
 
             if (errorCode != 0)
             {
@@ -280,7 +278,6 @@ namespace System.Net.Security
                 NetEventSource.Enter(null, package, intent, authdata);
 
             int errorCode = -1;
-            long timeStamp;
 
 
             // If there is a certificate, wrap it into an array.
@@ -305,7 +302,7 @@ namespace System.Net.Security
                                 null,
                                 null,
                                 ref outCredential._handle,
-                                out timeStamp);
+                                out long _);
             }
             finally
             {
@@ -632,8 +629,6 @@ namespace System.Net.Security
 
                 Interop.SspiCli.CredHandle credentialHandle = inCredentials._handle;
 
-                long timeStamp;
-
                 errorCode = Interop.SspiCli.InitializeSecurityContextW(
                                 ref credentialHandle,
                                 inContextPtr,
@@ -646,7 +641,7 @@ namespace System.Net.Security
                                 ref outContext._handle,
                                 ref outputBuffer,
                                 ref attributes,
-                                out timeStamp);
+                                out long _);
             }
             finally
             {
@@ -919,7 +914,6 @@ namespace System.Net.Security
                 outContext.DangerousAddRef(ref ignore);
 
                 Interop.SspiCli.CredHandle credentialHandle = inCredentials._handle;
-                long timeStamp;
 
                 errorCode = Interop.SspiCli.AcceptSecurityContext(
                                 ref credentialHandle,
@@ -930,7 +924,7 @@ namespace System.Net.Security
                                 ref outContext._handle,
                                 ref outputBuffer,
                                 ref outFlags,
-                                out timeStamp);
+                                out long _);
             }
             finally
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
@@ -226,7 +226,7 @@ namespace System.Net.Security
                             null,
                             null,
                             ref outCredential._handle,
-                            out long _);
+                            out _);
 
 #if TRACE_VERBOSE
             if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"{nameof(Interop.SspiCli.AcquireCredentialsHandleW)} returns 0x{errorCode:x}, handle = {outCredential}");
@@ -258,7 +258,7 @@ namespace System.Net.Security
                             null,
                             null,
                             ref outCredential._handle,
-                            out long _);
+                            out _);
 
             if (errorCode != 0)
             {
@@ -302,7 +302,7 @@ namespace System.Net.Security
                                 null,
                                 null,
                                 ref outCredential._handle,
-                                out long _);
+                                out _);
             }
             finally
             {
@@ -641,7 +641,7 @@ namespace System.Net.Security
                                 ref outContext._handle,
                                 ref outputBuffer,
                                 ref attributes,
-                                out long _);
+                                out _);
             }
             finally
             {
@@ -924,7 +924,7 @@ namespace System.Net.Security
                                 ref outContext._handle,
                                 ref outputBuffer,
                                 ref outFlags,
-                                out long _);
+                                out _);
             }
             finally
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.ProviderBase
         {
             get
             {
-                return (!_connectionIsDoomed && !_cannotBePooled && !_owningObject.TryGetTarget(out DbConnection _));
+                return (!_connectionIsDoomed && !_cannotBePooled && !_owningObject.TryGetTarget(out _));
             }
         }
 
@@ -102,7 +102,7 @@ namespace Microsoft.Data.ProviderBase
                 // of the pool and it's owning object is no longer around to
                 // return it.
 
-                return (_pooledCount < 1) && !_owningObject.TryGetTarget(out DbConnection _);
+                return (_pooledCount < 1) && !_owningObject.TryGetTarget(out _);
             }
         }
 
@@ -409,7 +409,7 @@ namespace Microsoft.Data.ProviderBase
             // IMPORTANT NOTE: You must have taken a lock on the object before
             // you call this method to prevent race conditions with Clear and
             // ReclaimEmancipatedObjects.
-            if (_owningObject.TryGetTarget(out DbConnection _))
+            if (_owningObject.TryGetTarget(out _))
             {
                 throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectHasOwner);        // pooled connection already has an owner!
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Interop/SNINativeMethodWrapper.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Interop/SNINativeMethodWrapper.Windows.cs
@@ -476,14 +476,13 @@ namespace Microsoft.Data.SqlClient
             fixed (byte* pin_serverUserName = &serverUserName[0])
             fixed (byte* pInBuff = inBuff)
             {
-                bool local_fDone;
                 return SNISecGenClientContextWrapper(
                     pConnectionObject,
                     pInBuff,
                     (uint)inBuff.Length,
                     OutBuff,
                     ref sendLength,
-                    out local_fDone,
+                    out bool _,
                     pin_serverUserName,
                     (uint)serverUserName.Length,
                     null,

--- a/src/Microsoft.Data.SqlClient/netcore/src/Interop/SNINativeMethodWrapper.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Interop/SNINativeMethodWrapper.Windows.cs
@@ -482,7 +482,7 @@ namespace Microsoft.Data.SqlClient
                     (uint)inBuff.Length,
                     OutBuff,
                     ref sendLength,
-                    out bool _,
+                    out _,
                     pin_serverUserName,
                     (uint)serverUserName.Length,
                     null,

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Data.ProviderBase
                 }
                 pool.PutObjectFromTransactedPool(this);
             }
-            else if (-1 == _pooledCount && !_owningObject.TryGetTarget(out DbConnection _))
+            else if (-1 == _pooledCount && !_owningObject.TryGetTarget(out _))
             {
                 // When _pooledCount is -1 and the owning object no longer exists,
                 // it indicates a closed (or leaked), non-pooled connection so 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1605,10 +1605,8 @@ namespace Microsoft.Data.SqlClient
                 {
                     try
                     {
-                        bool dataReady;
                         Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                        TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj,
-                            out dataReady);
+                        TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out _);
                         if (result != TdsOperationStatus.Done)
                         {
                             throw SQL.SynchronousCallMayNotPend();
@@ -3680,9 +3678,8 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    bool dataReady;
                     Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                    TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
+                    TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         throw SQL.SynchronousCallMayNotPend();
@@ -5298,9 +5295,8 @@ namespace Microsoft.Data.SqlClient
             {
                 try
                 {
-                    bool dataReady;
                     Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                    TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, ds, null, _stateObj, out dataReady);
+                    TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, ds, null, _stateObj, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         throw SQL.SynchronousCallMayNotPend();

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2165,8 +2165,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void OnInfoMessage(SqlInfoMessageEventArgs imevent)
         {
-            bool notified;
-            OnInfoMessage(imevent, out notified);
+            OnInfoMessage(imevent, out bool _);
         }
 
         internal void OnInfoMessage(SqlInfoMessageEventArgs imevent, out bool notified)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2165,7 +2165,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void OnInfoMessage(SqlInfoMessageEventArgs imevent)
         {
-            OnInfoMessage(imevent, out bool _);
+            OnInfoMessage(imevent, out _);
         }
 
         internal void OnInfoMessage(SqlInfoMessageEventArgs imevent, out bool notified)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -1001,8 +1001,7 @@ namespace Microsoft.Data.SqlClient
 #endif
 
 
-                        bool ignored;
-                        result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out ignored);
+                        result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out bool _);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -3208,8 +3207,7 @@ namespace Microsoft.Data.SqlClient
                         throw ADP.ClosedConnectionError();
                     }
 
-                    bool ignored;
-                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out ignored);
+                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
                     if (result != TdsOperationStatus.Done)
                     {
                         moreResults = false;
@@ -3279,8 +3277,7 @@ namespace Microsoft.Data.SqlClient
                             throw ADP.ClosedConnectionError();
                         }
 
-                        bool ignored;
-                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out ignored);
+                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
                         if (result != TdsOperationStatus.Done)
                         {
                             moreRows = false;
@@ -4116,8 +4113,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (_stateObj._longlen != 0)
                     {
-                        ulong ignored;
-                        result = _stateObj.Parser.TrySkipPlpValue(ulong.MaxValue, _stateObj, out ignored);
+                        result = _stateObj.Parser.TrySkipPlpValue(ulong.MaxValue, _stateObj, out ulong _);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -4212,8 +4208,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 if (TdsEnums.SQLORDER == b)
                 {
-                    bool ignored;
-                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out ignored);
+                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;
@@ -4229,8 +4224,7 @@ namespace Microsoft.Data.SqlClient
                     try
                     {
                         _stateObj._accumulateInfoEvents = true;
-                        bool ignored;
-                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, null, null, _stateObj, out ignored);
+                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, null, null, _stateObj, out bool _);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -4308,9 +4302,9 @@ namespace Microsoft.Data.SqlClient
 
                         // simply rip the order token off the wire
                         if (b == TdsEnums.SQLORDER)
-                        {                     //  same logic as SetAltMetaDataSet
-                            bool ignored;
-                            result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out ignored);
+                        {
+                            //  same logic as SetAltMetaDataSet
+                            result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out bool _);
                             if (result != TdsOperationStatus.Done)
                             {
                                 return result;
@@ -4329,8 +4323,7 @@ namespace Microsoft.Data.SqlClient
                             try
                             {
                                 _stateObj._accumulateInfoEvents = true;
-                                bool ignored;
-                                result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out ignored);
+                                result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out bool _);
                                 if (result != TdsOperationStatus.Done)
                                 {
                                     return result;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -1001,7 +1001,7 @@ namespace Microsoft.Data.SqlClient
 #endif
 
 
-                        result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out bool _);
+                        result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out _);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -3207,7 +3207,7 @@ namespace Microsoft.Data.SqlClient
                         throw ADP.ClosedConnectionError();
                     }
 
-                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
+                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         moreResults = false;
@@ -3277,7 +3277,7 @@ namespace Microsoft.Data.SqlClient
                             throw ADP.ClosedConnectionError();
                         }
 
-                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
+                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _);
                         if (result != TdsOperationStatus.Done)
                         {
                             moreRows = false;
@@ -4113,7 +4113,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (_stateObj._longlen != 0)
                     {
-                        result = _stateObj.Parser.TrySkipPlpValue(ulong.MaxValue, _stateObj, out ulong _);
+                        result = _stateObj.Parser.TrySkipPlpValue(ulong.MaxValue, _stateObj, out _);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -4208,7 +4208,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 if (TdsEnums.SQLORDER == b)
                 {
-                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
+                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;
@@ -4224,7 +4224,7 @@ namespace Microsoft.Data.SqlClient
                     try
                     {
                         _stateObj._accumulateInfoEvents = true;
-                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, null, null, _stateObj, out bool _);
+                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, null, null, _stateObj, out _);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -4304,7 +4304,7 @@ namespace Microsoft.Data.SqlClient
                         if (b == TdsEnums.SQLORDER)
                         {
                             //  same logic as SetAltMetaDataSet
-                            result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out bool _);
+                            result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out _);
                             if (result != TdsOperationStatus.Done)
                             {
                                 return result;
@@ -4323,7 +4323,7 @@ namespace Microsoft.Data.SqlClient
                             try
                             {
                                 _stateObj._accumulateInfoEvents = true;
-                                result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out bool _);
+                                result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out _);
                                 if (result != TdsOperationStatus.Done)
                                 {
                                     return result;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -4141,8 +4141,7 @@ namespace Microsoft.Data.SqlClient
             returnValue = null;
             SqlReturnValue rec = new SqlReturnValue();
             rec.length = length;        // In 2005 this length is -1
-            ushort parameterIndex;
-            TdsOperationStatus result = stateObj.TryReadUInt16(out parameterIndex);
+            TdsOperationStatus result = stateObj.TryReadUInt16(out _);
             if (result != TdsOperationStatus.Done)
             {
                 return result;
@@ -4164,9 +4163,8 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            // read status and ignore
-            byte ignored;
-            result = stateObj.TryReadByte(out ignored);
+            // read status
+            result = stateObj.TryReadByte(out _);
             if (result != TdsOperationStatus.Done)
             {
                 return result;
@@ -4697,8 +4695,7 @@ namespace Microsoft.Data.SqlClient
                             {
                                 if (stateObj._longlen != 0)
                                 {
-                                    ulong ignored;
-                                    if (TrySkipPlpValue(ulong.MaxValue, stateObj, out ignored) != TdsOperationStatus.Done)
+                                    if (TrySkipPlpValue(ulong.MaxValue, stateObj, out _) != TdsOperationStatus.Done)
                                     {
                                         throw SQL.SynchronousCallMayNotPend();
                                     }
@@ -4782,15 +4779,14 @@ namespace Microsoft.Data.SqlClient
             {
                 // internal meta data class
                 _SqlMetaData col = altMetaDataSet[i];
-
-                byte op;
-                result = stateObj.TryReadByte(out op);
+                
+                result = stateObj.TryReadByte(out _);
                 if (result != TdsOperationStatus.Done)
                 {
                     return result;
                 }
-                ushort operand;
-                result = stateObj.TryReadUInt16(out operand);
+                
+                result = stateObj.TryReadUInt16(out _);
                 if (result != TdsOperationStatus.Done)
                 {
                     return result;
@@ -5470,9 +5466,8 @@ namespace Microsoft.Data.SqlClient
             for (int i = 0; i < columns.Length; i++)
             {
                 _SqlMetaData col = columns[i];
-
-                byte ignored;
-                TdsOperationStatus result = stateObj.TryReadByte(out ignored);
+                
+                TdsOperationStatus result = stateObj.TryReadByte(out _);
                 if (result != TdsOperationStatus.Done)
                 {
                     return result;
@@ -5866,8 +5861,7 @@ namespace Microsoft.Data.SqlClient
             TdsOperationStatus result;
             if (md.metaType.IsPlp)
             {
-                ulong ignored;
-                result = TrySkipPlpValue(ulong.MaxValue, stateObj, out ignored);
+                result = TrySkipPlpValue(ulong.MaxValue, stateObj, out _);
                 if (result != TdsOperationStatus.Done)
                 {
                     return result;
@@ -6356,8 +6350,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         // If we are given -1 for length, then we read the entire value,
                         // otherwise only the requested amount, usually first chunk.
-                        int ignored;
-                        result = stateObj.TryReadPlpBytes(ref b, 0, length, out ignored);
+                        result = stateObj.TryReadPlpBytes(ref b, 0, length, out _);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -12782,8 +12775,7 @@ namespace Microsoft.Data.SqlClient
             TdsOperationStatus result;
             if (stateObj._longlenleft == 0)
             {
-                ulong ignored;
-                result = stateObj.TryReadPlpLength(false, out ignored);
+                result = stateObj.TryReadPlpLength(false, out _);
                 if (result != TdsOperationStatus.Done)
                 {
                     totalCharsRead = 0;
@@ -12846,8 +12838,7 @@ namespace Microsoft.Data.SqlClient
                         return result;
                     }
                     stateObj._longlenleft--;
-                    ulong ignored;
-                    result = stateObj.TryReadPlpLength(false, out ignored);
+                    result = stateObj.TryReadPlpLength(false, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;
@@ -12868,9 +12859,9 @@ namespace Microsoft.Data.SqlClient
                     totalCharsRead++;
                 }
                 if (stateObj._longlenleft == 0)
-                { // Read the next chunk or cleanup state if hit the end
-                    ulong ignored;
-                    result = stateObj.TryReadPlpLength(false, out ignored);
+                {
+                    // Read the next chunk or cleanup state if hit the end
+                    result = stateObj.TryReadPlpLength(false, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;
@@ -12977,9 +12968,7 @@ namespace Microsoft.Data.SqlClient
 
             if (stateObj._longlenleft == 0)
             {
-                ulong ignored;
-
-                result = stateObj.TryReadPlpLength(false, out ignored);
+                result = stateObj.TryReadPlpLength(false, out _);
                 if (result != TdsOperationStatus.Done)
                 {
                     return result;
@@ -13005,8 +12994,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (stateObj._longlenleft == 0)
                 {
-                    ulong ignored;
-                    result = stateObj.TryReadPlpLength(false, out ignored);
+                    result = stateObj.TryReadPlpLength(false, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
@@ -1258,9 +1258,8 @@ namespace Microsoft.Data.SqlClient
                                 return;
                             }
 
-                            uint sniError;
                             _parser._asyncWrite = false; // stop async write
-                            SNIWritePacket(attnPacket, out sniError, canAccumulate: false, callerHasConnectionLock: false, asyncClose);
+                            SNIWritePacket(attnPacket, out uint _, canAccumulate: false, callerHasConnectionLock: false, asyncClose);
                             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObject.SendAttention | Info | State Object Id {0}, Sent Attention.", _objectID);
                         }
                         finally

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
@@ -1259,7 +1259,7 @@ namespace Microsoft.Data.SqlClient
                             }
 
                             _parser._asyncWrite = false; // stop async write
-                            SNIWritePacket(attnPacket, out uint _, canAccumulate: false, callerHasConnectionLock: false, asyncClose);
+                            SNIWritePacket(attnPacket, out _, canAccumulate: false, callerHasConnectionLock: false, asyncClose);
                             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObject.SendAttention | Info | State Object Id {0}, Sent Attention.", _objectID);
                         }
                         finally

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
@@ -494,8 +494,8 @@ namespace Microsoft.Data.Common
             {
                 int startPosition = nextStartPosition;
 
-                string keyname, keyvalue; // since parsing restrictions ignores values, it doesn't matter if we use ODBC rules or OLEDB rules
-                nextStartPosition = DbConnectionOptions.GetKeyValuePair(restrictions, startPosition, buffer, false, out keyname, out keyvalue);
+                string keyname; // since parsing restrictions ignores values, it doesn't matter if we use ODBC rules or OLEDB rules
+                nextStartPosition = DbConnectionOptions.GetKeyValuePair(restrictions, startPosition, buffer, false, out keyname, out string _);
                 if (!ADP.IsEmpty(keyname))
                 {
 #if DEBUG

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
@@ -495,7 +495,7 @@ namespace Microsoft.Data.Common
                 int startPosition = nextStartPosition;
 
                 string keyname; // since parsing restrictions ignores values, it doesn't matter if we use ODBC rules or OLEDB rules
-                nextStartPosition = DbConnectionOptions.GetKeyValuePair(restrictions, startPosition, buffer, false, out keyname, out string _);
+                nextStartPosition = DbConnectionOptions.GetKeyValuePair(restrictions, startPosition, buffer, false, out keyname, out _);
                 if (!ADP.IsEmpty(keyname))
                 {
 #if DEBUG

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeMethodWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeMethodWrapper.cs
@@ -1201,8 +1201,7 @@ namespace Microsoft.Data.SqlClient
             if (ret == ERROR_SUCCESS)
             {
                 // added a provider, need to requery for sync over async support
-                bool fSupportsSyncOverAsync;
-                ret = SNIGetInfoWrapper(pConn, QTypes.SNI_QUERY_CONN_SUPPORTS_SYNC_OVER_ASYNC, out fSupportsSyncOverAsync);
+                ret = SNIGetInfoWrapper(pConn, QTypes.SNI_QUERY_CONN_SUPPORTS_SYNC_OVER_ASYNC, out bool _);
                 Debug.Assert(ret == ERROR_SUCCESS, "SNIGetInfo cannot fail with this QType");
             }
 
@@ -1230,8 +1229,7 @@ namespace Microsoft.Data.SqlClient
             if (ret == ERROR_SUCCESS)
             {
                 // added a provider, need to requery for sync over async support
-                bool fSupportsSyncOverAsync;
-                ret = SNIGetInfoWrapper(pConn, QTypes.SNI_QUERY_CONN_SUPPORTS_SYNC_OVER_ASYNC, out fSupportsSyncOverAsync);
+                ret = SNIGetInfoWrapper(pConn, QTypes.SNI_QUERY_CONN_SUPPORTS_SYNC_OVER_ASYNC, out bool _);
                 Debug.Assert(ret == ERROR_SUCCESS, "SNIGetInfo cannot fail with this QType");
             }
 
@@ -1384,13 +1382,12 @@ namespace Microsoft.Data.SqlClient
         {
             fixed (byte* pin_serverUserName = &serverUserName[0])
             {
-                bool local_fDone;
                 return SNISecGenClientContextWrapper(
                     pConnectionObject,
                     inBuff,
                     OutBuff,
                     ref sendLength,
-                    out local_fDone,
+                    out bool _,
                     pin_serverUserName,
                     (uint)serverUserName.Length,
                     null,

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Data.ProviderBase
         {
             get
             {
-                return (!_connectionIsDoomed && !_cannotBePooled && !_owningObject.TryGetTarget(out DbConnection _));
+                return (!_connectionIsDoomed && !_cannotBePooled && !_owningObject.TryGetTarget(out _));
             }
         }
 
@@ -286,7 +286,7 @@ namespace Microsoft.Data.ProviderBase
                 // of the pool and it's owning object is no longer around to
                 // return it.
 
-                return !IsTxRootWaitingForTxEnd && (_pooledCount < 1) && !_owningObject.TryGetTarget(out DbConnection _);
+                return !IsTxRootWaitingForTxEnd && (_pooledCount < 1) && !_owningObject.TryGetTarget(out _);
             }
         }
 
@@ -621,7 +621,7 @@ namespace Microsoft.Data.ProviderBase
                 }
                 pool.PutObjectFromTransactedPool(this);
             }
-            else if (-1 == _pooledCount && !_owningObject.TryGetTarget(out DbConnection _))
+            else if (-1 == _pooledCount && !_owningObject.TryGetTarget(out _))
             {
                 // When _pooledCount is -1 and the owning object no longer exists,
                 // it indicates a closed (or leaked), non-pooled connection so 
@@ -829,7 +829,7 @@ namespace Microsoft.Data.ProviderBase
             // IMPORTANT NOTE: You must have taken a lock on the object before
             // you call this method to prevent race conditions with Clear and
             // ReclaimEmancipatedObjects.
-            if (_owningObject.TryGetTarget(out DbConnection _))
+            if (_owningObject.TryGetTarget(out _))
             {
                 throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectHasOwner);        // pooled connection already has an owner!
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1535,14 +1535,13 @@ namespace Microsoft.Data.SqlClient
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
                     WriteBeginExecuteEvent();
-                    bool usedCache;
                     if (IsProviderRetriable)
                     {
-                        InternalExecuteNonQueryWithRetry(nameof(ExecuteNonQuery), sendToPipe: false, CommandTimeout, out usedCache, asyncWrite: false, inRetry: false);
+                        InternalExecuteNonQueryWithRetry(nameof(ExecuteNonQuery), sendToPipe: false, CommandTimeout, out _, asyncWrite: false, inRetry: false);
                     }
                     else
                     {
-                        InternalExecuteNonQuery(null, nameof(ExecuteNonQuery), sendToPipe: false, CommandTimeout, out usedCache);
+                        InternalExecuteNonQuery(null, nameof(ExecuteNonQuery), sendToPipe: false, CommandTimeout, out _);
                     }
                     success = true;
                     return _rowsAffected;
@@ -1577,8 +1576,7 @@ namespace Microsoft.Data.SqlClient
                 try
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
-                    bool usedCache;
-                    InternalExecuteNonQuery(null, nameof(ExecuteNonQuery), true, CommandTimeout, out usedCache);
+                    InternalExecuteNonQuery(null, nameof(ExecuteNonQuery), true, CommandTimeout, out _);
                 }
                 finally
                 {
@@ -1968,9 +1966,8 @@ namespace Microsoft.Data.SqlClient
                         {
                             try
                             {
-                                bool dataReady;
                                 Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                                TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
+                                TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out _);
                                 if (result != TdsOperationStatus.Done)
                                 {
                                     throw SQL.SynchronousCallMayNotPend();
@@ -4000,9 +3997,8 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    bool dataReady;
                     Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                    TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
+                    TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         throw SQL.SynchronousCallMayNotPend();
@@ -5131,8 +5127,7 @@ namespace Microsoft.Data.SqlClient
         internal SqlDataReader RunExecuteReader(CommandBehavior cmdBehavior, RunBehavior runBehavior, bool returnStream, string method)
         {
             Task unused; // sync execution 
-            bool usedCache;
-            SqlDataReader reader = RunExecuteReader(cmdBehavior, runBehavior, returnStream, method, completion: null, timeout: CommandTimeout, task: out unused, usedCache: out usedCache);
+            SqlDataReader reader = RunExecuteReader(cmdBehavior, runBehavior, returnStream, method, completion: null, timeout: CommandTimeout, task: out unused, out _);
             Debug.Assert(unused == null, "returned task during synchronous execution");
             return reader;
         }
@@ -5615,9 +5610,8 @@ namespace Microsoft.Data.SqlClient
                     {
                         Task executeTask = _stateObj.Parser.TdsExecuteSQLBatch(optionSettings, timeout, this.Notification, _stateObj, sync: true);
                         Debug.Assert(executeTask == null, "Shouldn't get a task when doing sync writes");
-                        bool dataReady;
                         Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                        TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out dataReady);
+                        TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out _);
                         if (result != TdsOperationStatus.Done)
                         {
                             throw SQL.SynchronousCallMayNotPend();
@@ -5822,9 +5816,8 @@ namespace Microsoft.Data.SqlClient
             {
                 try
                 {
-                    bool dataReady;
                     Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                    TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, ds, null, _stateObj, out dataReady);
+                    TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, ds, null, _stateObj, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         throw SQL.SynchronousCallMayNotPend();

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2536,8 +2536,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void OnInfoMessage(SqlInfoMessageEventArgs imevent)
         {
-            bool notified;
-            OnInfoMessage(imevent, out notified);
+            OnInfoMessage(imevent, out bool _);
         }
 
         internal void OnInfoMessage(SqlInfoMessageEventArgs imevent, out bool notified)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2536,7 +2536,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void OnInfoMessage(SqlInfoMessageEventArgs imevent)
         {
-            OnInfoMessage(imevent, out bool _);
+            OnInfoMessage(imevent, out _);
         }
 
         internal void OnInfoMessage(SqlInfoMessageEventArgs imevent, out bool notified)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -1118,8 +1118,7 @@ namespace Microsoft.Data.SqlClient
 #endif
 
 
-                            bool ignored;
-                            result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out ignored);
+                            result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out bool _);
                             if (result != TdsOperationStatus.Done)
                             {
                                 return result;
@@ -3560,8 +3559,7 @@ namespace Microsoft.Data.SqlClient
                         throw ADP.ClosedConnectionError();
                     }
 
-                    bool ignored;
-                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out ignored);
+                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
                     if (result != TdsOperationStatus.Done)
                     {
                         moreResults = false;
@@ -3647,8 +3645,7 @@ namespace Microsoft.Data.SqlClient
                             throw ADP.ClosedConnectionError();
                         }
 
-                        bool ignored;
-                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out ignored);
+                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
                         if (result != TdsOperationStatus.Done)
                         {
                             moreRows = false;
@@ -4659,8 +4656,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (_stateObj._longlen != 0)
                     {
-                        ulong ignored;
-                        result = _stateObj.Parser.TrySkipPlpValue(UInt64.MaxValue, _stateObj, out ignored);
+                        result = _stateObj.Parser.TrySkipPlpValue(UInt64.MaxValue, _stateObj, out ulong _);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -4755,8 +4751,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 if (TdsEnums.SQLORDER == b)
                 {
-                    bool ignored;
-                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out ignored);
+                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;
@@ -4772,8 +4767,7 @@ namespace Microsoft.Data.SqlClient
                     try
                     {
                         _stateObj._accumulateInfoEvents = true;
-                        bool ignored;
-                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, null, null, _stateObj, out ignored);
+                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, null, null, _stateObj, out _);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -4853,12 +4847,12 @@ namespace Microsoft.Data.SqlClient
 
                         // simply rip the order token off the wire
                         if (b == TdsEnums.SQLORDER)
-                        {                     //  same logic as SetAltMetaDataSet
-                                              // Devnote: That's not the right place to process TDS
-                                              // Can this result in Reentrance to Run?
-                                              //
-                            bool ignored;
-                            result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out ignored);
+                        {                     
+                            // same logic as SetAltMetaDataSet
+                            // Devnote: That's not the right place to process TDS
+                            // Can this result in Reentrance to Run?
+
+                            result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out bool _);
                             if (result != TdsOperationStatus.Done)
                             {
                                 return result;
@@ -4877,8 +4871,7 @@ namespace Microsoft.Data.SqlClient
                             try
                             {
                                 _stateObj._accumulateInfoEvents = true;
-                                bool ignored;
-                                result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out ignored);
+                                result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out bool _);
                                 if (result != TdsOperationStatus.Done)
                                 {
                                     return result;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -1118,7 +1118,7 @@ namespace Microsoft.Data.SqlClient
 #endif
 
 
-                            result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out bool _);
+                            result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out _);
                             if (result != TdsOperationStatus.Done)
                             {
                                 return result;
@@ -3559,7 +3559,7 @@ namespace Microsoft.Data.SqlClient
                         throw ADP.ClosedConnectionError();
                     }
 
-                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
+                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         moreResults = false;
@@ -3645,7 +3645,7 @@ namespace Microsoft.Data.SqlClient
                             throw ADP.ClosedConnectionError();
                         }
 
-                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
+                        result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _);
                         if (result != TdsOperationStatus.Done)
                         {
                             moreRows = false;
@@ -4656,7 +4656,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (_stateObj._longlen != 0)
                     {
-                        result = _stateObj.Parser.TrySkipPlpValue(UInt64.MaxValue, _stateObj, out ulong _);
+                        result = _stateObj.Parser.TrySkipPlpValue(UInt64.MaxValue, _stateObj, out _);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -4751,7 +4751,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 if (TdsEnums.SQLORDER == b)
                 {
-                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out bool _);
+                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;
@@ -4852,7 +4852,7 @@ namespace Microsoft.Data.SqlClient
                             // Devnote: That's not the right place to process TDS
                             // Can this result in Reentrance to Run?
 
-                            result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out bool _);
+                            result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out _);
                             if (result != TdsOperationStatus.Done)
                             {
                                 return result;
@@ -4871,7 +4871,7 @@ namespace Microsoft.Data.SqlClient
                             try
                             {
                                 _stateObj._accumulateInfoEvents = true;
-                                result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out bool _);
+                                result = _parser.TryRun(RunBehavior.ReturnImmediately, null, null, null, _stateObj, out _);
                                 if (result != TdsOperationStatus.Done)
                                 {
                                     return result;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -4720,9 +4720,8 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            // read status and ignore
-            byte ignored;
-            result = stateObj.TryReadByte(out ignored);
+            // read status
+            result = stateObj.TryReadByte(out _);
             if (result != TdsOperationStatus.Done)
             {
                 return result;
@@ -5302,8 +5301,7 @@ namespace Microsoft.Data.SqlClient
                                     {
                                         if (stateObj._longlen != 0)
                                         {
-                                            ulong ignored;
-                                            TdsOperationStatus result = TrySkipPlpValue(UInt64.MaxValue, stateObj, out ignored);
+                                            TdsOperationStatus result = TrySkipPlpValue(UInt64.MaxValue, stateObj, out _);
                                             if (result != TdsOperationStatus.Done)
                                             {
                                                 throw SQL.SynchronousCallMayNotPend();
@@ -6309,9 +6307,8 @@ namespace Microsoft.Data.SqlClient
             for (int i = 0; i < columns.Length; i++)
             {
                 _SqlMetaData col = columns[i];
-
-                byte ignored;// colnum, ignore
-                result = stateObj.TryReadByte(out ignored);
+                
+                result = stateObj.TryReadByte(out _);
                 if (result != TdsOperationStatus.Done)
                 {
                     return result;
@@ -6712,8 +6709,7 @@ namespace Microsoft.Data.SqlClient
 
             if (md.metaType.IsPlp)
             {
-                ulong ignored;
-                result = TrySkipPlpValue(UInt64.MaxValue, stateObj, out ignored);
+                result = TrySkipPlpValue(UInt64.MaxValue, stateObj, out _);
                 if (result != TdsOperationStatus.Done)
                 {
                     return result;
@@ -13761,9 +13757,7 @@ namespace Microsoft.Data.SqlClient
 
             if (stateObj._longlenleft == 0)
             {
-                ulong ignored;
-
-                result = stateObj.TryReadPlpLength(false, out ignored);
+                result = stateObj.TryReadPlpLength(false, out _);
                 if (result != TdsOperationStatus.Done)
                 {
                     totalCharsRead = 0;
@@ -13812,8 +13806,7 @@ namespace Microsoft.Data.SqlClient
                         return result;
                     }
                     stateObj._longlenleft--;
-                    ulong ignored;
-                    result = stateObj.TryReadPlpLength(false, out ignored);
+                    result = stateObj.TryReadPlpLength(false, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;
@@ -13835,8 +13828,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 if (stateObj._longlenleft == 0)
                 { // Read the next chunk or cleanup state if hit the end
-                    ulong ignored;
-                    result = stateObj.TryReadPlpLength(false, out ignored);
+                    result = stateObj.TryReadPlpLength(false, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;
@@ -13944,8 +13936,7 @@ namespace Microsoft.Data.SqlClient
 
             if (stateObj._longlenleft == 0)
             {
-                ulong ignored;
-                result = stateObj.TryReadPlpLength(false, out ignored);
+                result = stateObj.TryReadPlpLength(false, out _);
                 if (result != TdsOperationStatus.Done)
                 {
                     return result;
@@ -13971,8 +13962,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (stateObj._longlenleft == 0)
                 {
-                    ulong ignored;
-                    result = stateObj.TryReadPlpLength(false, out ignored);
+                    result = stateObj.TryReadPlpLength(false, out _);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
@@ -1310,7 +1310,7 @@ namespace Microsoft.Data.SqlClient
                             }
 
                             _parser._asyncWrite = false; // stop async write
-                            SNIWritePacket(Handle, attnPacket, out uint _, canAccumulate: false, callerHasConnectionLock: false, asyncClose);
+                            SNIWritePacket(Handle, attnPacket, out _, canAccumulate: false, callerHasConnectionLock: false, asyncClose);
                             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObject.SendAttention | Info | State Object Id {0}, Sent Attention.", _objectID);
                         }
                         finally

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
@@ -1309,9 +1309,8 @@ namespace Microsoft.Data.SqlClient
                                 return;
                             }
 
-                            uint sniError;
                             _parser._asyncWrite = false; // stop async write
-                            SNIWritePacket(Handle, attnPacket, out sniError, canAccumulate: false, callerHasConnectionLock: false, asyncClose);
+                            SNIWritePacket(Handle, attnPacket, out uint _, canAccumulate: false, callerHasConnectionLock: false, asyncClose);
                             SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObject.SendAttention | Info | State Object Id {0}, Sent Attention.", _objectID);
                         }
                         finally

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
@@ -705,8 +705,6 @@ namespace Microsoft.Data.SqlTypes
                 oa.securityQualityOfService = qos;
                 oa.objectName = objectName;
 
-                UnsafeNativeMethods.IO_STATUS_BLOCK ioStatusBlock;
-
                 uint oldMode;
                 uint retval = 0;
 
@@ -717,7 +715,7 @@ namespace Microsoft.Data.SqlTypes
                        "fileAttributes=0x{3}, shareAccess=0x{4}, dwCreateDisposition=0x{5}, createOptions=0x{6}", ObjectID, (int)nDesiredAccess, allocationSize, 0, (int)shareAccess, dwCreateDisposition, dwCreateOptions);
 
                     retval = UnsafeNativeMethods.NtCreateFile(out hFile, nDesiredAccess,
-                        ref oa, out ioStatusBlock, ref allocationSize,
+                        ref oa, out UnsafeNativeMethods.IO_STATUS_BLOCK _, ref allocationSize,
                         0, shareAccess, dwCreateDisposition, dwCreateOptions,
                         eaBuffer, (uint)eaBuffer.Length);
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbReferenceCollection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbReferenceCollection.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.ProviderBase
 
             public void SetNewTarget(int refInfo, object target)
             {
-                Debug.Assert(!TryGetTarget(out object _), "Entry already has a valid target");
+                Debug.Assert(!TryGetTarget(out _), "Entry already has a valid target");
                 Debug.Assert(refInfo != 0, "Bad reference info");
                 Debug.Assert(target != null, "Invalid target");
 
@@ -96,7 +96,7 @@ namespace Microsoft.Data.ProviderBase
                     if (_items[i].RefInfo == 0)
                     {
                         _items[i].SetNewTarget(refInfo, value);
-                        Debug.Assert(_items[i].TryGetTarget(out object _), "missing expected target");
+                        Debug.Assert(_items[i].TryGetTarget(out _), "missing expected target");
                         itemAdded = true;
                         break;
                     }
@@ -115,10 +115,10 @@ namespace Microsoft.Data.ProviderBase
                 {
                     for (int i = 0; i <= _lastItemIndex; ++i)
                     {
-                        if (!_items[i].TryGetTarget(out object _))
+                        if (!_items[i].TryGetTarget(out _))
                         {
                             _items[i].SetNewTarget(refInfo, value);
-                            Debug.Assert(_items[i].TryGetTarget(out object _), "missing expected target");
+                            Debug.Assert(_items[i].TryGetTarget(out _), "missing expected target");
                             itemAdded = true;
                             break;
                         }
@@ -196,7 +196,7 @@ namespace Microsoft.Data.ProviderBase
                                     NotifyItem(message, _items[index].RefInfo, value);
                                     _items[index].RemoveTarget();
                                 }
-                                Debug.Assert(!_items[index].TryGetTarget(out object _), "Unexpected target after notifying");
+                                Debug.Assert(!_items[index].TryGetTarget(out _), "Unexpected target after notifying");
                             }
                             _estimatedCount = 0;
                         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -409,9 +409,8 @@ namespace Microsoft.Data.SqlClient
 
             try
             {
-                SecurityToken validatedToken;
                 JwtSecurityTokenHandler handler = new JwtSecurityTokenHandler();
-                var token = handler.ValidateToken(attestationToken, validationParameters, out validatedToken);
+                var token = handler.ValidateToken(attestationToken, validationParameters, out SecurityToken _);
                 isSignatureValid = true;
             }
             catch (SecurityTokenExpiredException securityException)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 JwtSecurityTokenHandler handler = new JwtSecurityTokenHandler();
-                var token = handler.ValidateToken(attestationToken, validationParameters, out SecurityToken _);
+                var token = handler.ValidateToken(attestationToken, validationParameters, out _);
                 isSignatureValid = true;
             }
             catch (SecurityTokenExpiredException securityException)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SQLFallbackDNSCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SQLFallbackDNSCache.cs
@@ -42,8 +42,7 @@ namespace Microsoft.Data.SqlClient
 
         internal bool DeleteDNSInfo(string FQDN)
         {
-            SQLDNSInfo value;
-            return DNSInfoCache.TryRemove(FQDN, out value);
+            return DNSInfoCache.TryRemove(FQDN, out SQLDNSInfo _);
         }
 
         internal bool GetDNSInfo(string FQDN, out SQLDNSInfo result)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SQLFallbackDNSCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SQLFallbackDNSCache.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Data.SqlClient
 
         internal bool DeleteDNSInfo(string FQDN)
         {
-            return DNSInfoCache.TryRemove(FQDN, out SQLDNSInfo _);
+            return DNSInfoCache.TryRemove(FQDN, out _);
         }
 
         internal bool GetDNSInfo(string FQDN, out SQLDNSInfo result)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Data.SqlClient
                     Debug.Assert(_transactionType == TransactionType.LocalFromTSQL, "invalid state");
                     result = false;
                 }
-                else if (!_parent.TryGetTarget(out SqlTransaction _))
+                else if (!_parent.TryGetTarget(out _))
                 {
                     // We had a parent, but parent was GC'ed.
                     result = true;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -411,7 +411,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal bool HasOwner => _owner.TryGetTarget(out object _);
+        internal bool HasOwner => _owner.TryGetTarget(out _);
 
         internal TdsParser Parser => _parser;
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/Randomizer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/Randomizer.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public State GetCurrentState()
         {
             byte[] binState = new byte[BinaryStateSize];
-            Serialize(binState, out int _);
+            Serialize(binState, out _);
             return new State(GetType(), binState);
         }
 
@@ -186,7 +186,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             if (state._randomizerType != GetType())
                 throw new ArgumentException("Type mismatch!");
 
-            Deserialize(state._binState, out int _);
+            Deserialize(state._binState, out _);
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/Randomizer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/Randomizer.cs
@@ -145,8 +145,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public State GetCurrentState()
         {
             byte[] binState = new byte[BinaryStateSize];
-            int offset;
-            Serialize(binState, out offset);
+            Serialize(binState, out int _);
             return new State(GetType(), binState);
         }
 
@@ -187,8 +186,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             if (state._randomizerType != GetType())
                 throw new ArgumentException("Type mismatch!");
 
-            int offset;
-            Deserialize(state._binState, out offset);
+            Deserialize(state._binState, out int _);
         }
 
         /// <summary>


### PR DESCRIPTION
**Description**: C# 7.0 added support for discards, such that if an out variable is not used after the call to a method that sets it, it can be replaced with `_` to discard to value. There are around 90 instances of this in the codebase, and they are very easy to remove. As far as I can tell this makes no semantic difference to the code, but does clean up the code a bit and bring it up to a more modern standard.

The only real argument I could see against making this quick cleanup change is that it reduces the understanding of what the code aims to do. I feel this change is fairly neutral, but please feel free to disagree as necessary.

**Testing**: Projects still build so it should be good 👍 