### PR TITLE
Fix IP Comparison

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/Handlers/Connection/TransportCreation/IpAddressVersionComparer.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClientX/Handlers/Connection/TransportCreation/IpAddressVersionComparer.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Data.SqlClientX.Handlers.Connection.TransportCreation
                 return 0;
             }
 
-            return x.AddressFamily == _preferredAddressFamily ? 1 : -1;
+            // If the address family is the preferred one, it should come first.
+            return x.AddressFamily == _preferredAddressFamily ? -1 : 1;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Handlers/TransportCreation/IpAddressVersionSorterTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Handlers/TransportCreation/IpAddressVersionSorterTests.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Data.SqlClient.NetCore.UnitTests.Handlers.TransportCreation
             get => new TheoryData<IPAddress, IPAddress, int>
             {
                 { Ipv4, Ipv4, 0 },
-                { Ipv4, Ipv6, 1 },
-                { Ipv6, Ipv4, -1 },
+                { Ipv4, Ipv6, -1 },
+                { Ipv6, Ipv4, 1 },
                 { Ipv6, Ipv6, 0 },
             };
         }
@@ -40,8 +40,8 @@ namespace Microsoft.Data.SqlClient.NetCore.UnitTests.Handlers.TransportCreation
             get => new TheoryData<IPAddress, IPAddress, int>
             {
                 { Ipv4, Ipv4, 0 },
-                { Ipv4, Ipv6, -1 },
-                { Ipv6, Ipv4, 1 },
+                { Ipv4, Ipv6, 1 },
+                { Ipv6, Ipv4, -1 },
                 { Ipv6, Ipv6, 0 },
             };
         }


### PR DESCRIPTION
When comparing IpV6 and IPV4 based on IP preferences, the first IP address that should be used is the one that matches the preference.

This means that the Version Comparer should expect the Matching Address family to be higher in precedence, or lower in sort order.

This change brings in the fix and adjusts the tests to honor this fix.

