### PR TITLE
Code Cleanup | `null == x` to `x == null`

### DIFF
--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/SqlColumnEncryptionAzureKeyVaultProvider.cs
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/SqlColumnEncryptionAzureKeyVaultProvider.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
                 byte[] message = new byte[encryptedColumnEncryptionKey.Length - signatureLength];
                 Buffer.BlockCopy(encryptedColumnEncryptionKey, 0, message, 0, encryptedColumnEncryptionKey.Length - signatureLength);
 
-                if (null == message)
+                if (message == null)
                 {
                     throw ADP.NullHashFound();
                 }

--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Utils.cs
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Utils.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
         internal static void ValidateEncryptionAlgorithm(string encryptionAlgorithm, bool isSystemOp)
         {
             // This validates that the encryption algorithm is RSA_OAEP
-            if (null == encryptionAlgorithm)
+            if (encryptionAlgorithm == null)
             {
                 throw ADP.NullAlgorithm(isSystemOp);
             }
@@ -124,8 +124,9 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
 
         internal static ArgumentException InvalidAKVPath(string masterKeyPath, bool isSystemOp)
         {
-            string errorMessage = null == masterKeyPath ? Strings.NullAkvPath
-                                                        : string.Format(CultureInfo.InvariantCulture, Strings.InvalidAkvPathTemplate, masterKeyPath);
+            string errorMessage = masterKeyPath == null
+                ? Strings.NullAkvPath
+                : string.Format(CultureInfo.InvariantCulture, Strings.InvalidAkvPathTemplate, masterKeyPath);
             if (isSystemOp)
             {
                 return new ArgumentNullException(Constants.AeParamMasterKeyPath, errorMessage);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Data.ProviderBase
             // we are completing an asynchronous open
             Debug.Assert(retry.Task.Status == TaskStatus.RanToCompletion, "retry task must be completed successfully");
             DbConnectionInternal openConnection = retry.Task.Result;
-            if (null == openConnection)
+            if (openConnection == null)
             {
                 connectionFactory.SetInnerConnectionTo(outerConnection, this);
                 throw ADP.InternalConnectionError(ADP.ConnectionError.GetConnectionReturnsNull);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -214,12 +214,12 @@ namespace Microsoft.Data.ProviderBase
                 // new pool entry and add it to our collection.
 
                 DbConnectionOptions connectionOptions = CreateConnectionOptions(key.ConnectionString, userConnectionOptions);
-                if (null == connectionOptions)
+                if (connectionOptions == null)
                 {
                     throw ADP.InternalConnectionError(ADP.ConnectionError.ConnectionOptionsMissing);
                 }
 
-                if (null == userConnectionOptions)
+                if (userConnectionOptions == null)
                 { // we only allow one expansion on the connection string
 
                     userConnectionOptions = connectionOptions;
@@ -236,7 +236,7 @@ namespace Microsoft.Data.ProviderBase
                 }
 
                 // We don't support connection pooling on Win9x
-                if (null == poolOptions)
+                if (poolOptions == null)
                 {
                     if (null != connectionPoolGroup)
                     {
@@ -279,7 +279,7 @@ namespace Microsoft.Data.ProviderBase
                 Debug.Assert(null != connectionPoolGroup, "how did we not create a pool entry?");
                 Debug.Assert(null != userConnectionOptions, "how did we not have user connection options?");
             }
-            else if (null == userConnectionOptions)
+            else if (userConnectionOptions == null)
             {
                 userConnectionOptions = connectionPoolGroup.ConnectionOptions;
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -178,10 +178,10 @@ namespace Microsoft.Data.ProviderBase
 
         internal void AddWeakReference(object value, int tag)
         {
-            if (null == _referenceCollection)
+            if (_referenceCollection == null)
             {
                 _referenceCollection = CreateReferenceCollection();
-                if (null == _referenceCollection)
+                if (_referenceCollection == null)
                 {
                     throw ADP.InternalError(ADP.InternalErrorCode.CreateReferenceCollectionReturnedNull);
                 }
@@ -349,7 +349,7 @@ namespace Microsoft.Data.ProviderBase
                     connectionFactory.SetInnerConnectionTo(outerConnection, this);
                     throw;
                 }
-                if (null == openConnection)
+                if (openConnection == null)
                 {
                     connectionFactory.SetInnerConnectionTo(outerConnection, this);
                     throw ADP.InternalConnectionError(ADP.ConnectionError.GetConnectionReturnsNull);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/Common/DbConnectionOptions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Common
                 // find the replacement path
                 object rootFolderObject = AppDomain.CurrentDomain.GetData("DataDirectory");
                 var rootFolderPath = (rootFolderObject as string);
-                if ((null != rootFolderObject) && (null == rootFolderPath))
+                if ((null != rootFolderObject) && rootFolderPath == null)
                 {
                     throw ADP.InvalidDataDirectory();
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.ProviderBase
                 poolGroup = GetConnectionPoolGroup(owningConnection);
                 // Doing this on the callers thread is important because it looks up the WindowsIdentity from the thread.
                 connectionPool = GetConnectionPool(owningConnection, poolGroup);
-                if (null == connectionPool)
+                if (connectionPool == null)
                 {
                     // If GetConnectionPool returns null, we can be certain that
                     // this connection should not be pooled via DbConnectionPool

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.ProviderBase
             set
             {
                 Transaction currentEnlistedTransaction = _enlistedTransaction;
-                if (((null == currentEnlistedTransaction) && (null != value))
+                if ((currentEnlistedTransaction == null && (null != value))
                     || ((null != currentEnlistedTransaction) && !currentEnlistedTransaction.Equals(value)))
                 {  // WebData 20000024
 
@@ -354,7 +354,7 @@ namespace Microsoft.Data.ProviderBase
 
                 DbConnectionPool pool = Pool;
 
-                if (null == pool)
+                if (pool == null)
                 {
                     throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectWithoutPool);      // pooled connection does not have a pool
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -729,7 +729,7 @@ namespace Microsoft.Data.ProviderBase
             try
             {
                 newObj = _connectionFactory.CreatePooledConnection(this, owningObject, _connectionPoolGroup.ConnectionOptions, _connectionPoolGroup.PoolKey, userOptions);
-                if (null == newObj)
+                if (newObj == null)
                 {
                     throw ADP.InternalError(ADP.InternalErrorCode.CreateObjectReturnedNull);    // CreateObject succeeded, but null object
                 }
@@ -1172,7 +1172,7 @@ namespace Microsoft.Data.ProviderBase
                 obj = GetFromTransactedPool(out transaction);
             }
 
-            if (null == obj)
+            if (obj == null)
             {
                 Interlocked.Increment(ref _waitCount);
 
@@ -1217,7 +1217,7 @@ namespace Microsoft.Data.ProviderBase
                                 }
                                 catch
                                 {
-                                    if (null == obj)
+                                    if (obj == null)
                                     {
                                         Interlocked.Decrement(ref _waitCount);
                                     }
@@ -1233,7 +1233,7 @@ namespace Microsoft.Data.ProviderBase
                                     }
                                 }
 
-                                if (null == obj)
+                                if (obj == null)
                                 {
                                     // If we were not able to create an object, check to see if
                                     // we reached MaxPoolSize.  If so, we will no longer wait on
@@ -1309,7 +1309,7 @@ namespace Microsoft.Data.ProviderBase
                         DestroyObject(obj);
                         obj = null;
                     }
-                } while (null == obj);
+                } while (obj == null);
             }
 
             if (null != obj)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.NetCoreApp.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.NetCoreApp.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.SqlClient
             {
                 // New configuration section "SqlClientAuthenticationProviders" for Microsoft.Data.SqlClient accepted to avoid conflicts with older one.
                 configurationSection = FetchConfigurationSection<SqlClientAuthenticationProviderConfigurationSection>(SqlClientAuthenticationProviderConfigurationSection.Name);
-                if (null == configurationSection)
+                if (configurationSection == null)
                 {
                     // If configuration section is not yet found, try with old Configuration Section name for backwards compatibility
                     configurationSection = FetchConfigurationSection<SqlAuthenticationProviderConfigurationSection>(SqlAuthenticationProviderConfigurationSection.Name);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -540,7 +540,7 @@ namespace Microsoft.Data.SqlClient
 
             isInTransaction = _connection.HasLocalTransaction;
             // Throw if there is a transaction but no flag is set
-            if (isInTransaction && null == _externalTransaction && null == _internalTransaction && (_connection.Parser != null && _connection.Parser.CurrentTransaction != null && _connection.Parser.CurrentTransaction.IsLocal))
+            if (isInTransaction && _externalTransaction == null && _internalTransaction == null && (_connection.Parser != null && _connection.Parser.CurrentTransaction != null && _connection.Parser.CurrentTransaction.IsLocal))
             {
                 throw SQL.BulkLoadExistingTransaction();
             }
@@ -1281,7 +1281,7 @@ namespace Microsoft.Data.SqlClient
 
         private void CreateOrValidateConnection(string method)
         {
-            if (null == _connection)
+            if (_connection == null)
             {
                 throw ADP.ConnectionRequired(method);
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.SqlClient
             // Validate the input parameters
             ValidateNonEmptyKeyPath(masterKeyPath, isSystemOp: true);
 
-            if (null == encryptedColumnEncryptionKey)
+            if (encryptedColumnEncryptionKey == null)
             {
                 throw SQL.NullEncryptedColumnEncryptionKey();
             }
@@ -126,7 +126,7 @@ namespace Microsoft.Data.SqlClient
             // Validate the input parameters
             ValidateNonEmptyKeyPath(masterKeyPath, isSystemOp: false);
 
-            if (null == columnEncryptionKey)
+            if (columnEncryptionKey == null)
             {
                 throw SQL.NullColumnEncryptionKey();
             }
@@ -231,7 +231,7 @@ namespace Microsoft.Data.SqlClient
         private void ValidateEncryptionAlgorithm(string encryptionAlgorithm, bool isSystemOp)
         {
             // This validates that the encryption algorithm is RSA_OAEP
-            if (null == encryptionAlgorithm)
+            if (encryptionAlgorithm == null)
             {
                 throw SQL.NullKeyEncryptionAlgorithm(isSystemOp);
             }
@@ -251,7 +251,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (string.IsNullOrWhiteSpace(masterKeyPath))
             {
-                if (null == masterKeyPath)
+                if (masterKeyPath == null)
                 {
                     throw SQL.NullCngKeyPath(isSystemOp);
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.Windows.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.SqlClient
             // Validate the input parameters
             ValidateNonEmptyCSPKeyPath(masterKeyPath, isSystemOp: true);
 
-            if (null == encryptedColumnEncryptionKey)
+            if (encryptedColumnEncryptionKey == null)
             {
                 throw SQL.NullEncryptedColumnEncryptionKey();
             }
@@ -134,7 +134,7 @@ namespace Microsoft.Data.SqlClient
             // Validate the input parameters
             ValidateNonEmptyCSPKeyPath(masterKeyPath, isSystemOp: false);
 
-            if (null == columnEncryptionKey)
+            if (columnEncryptionKey == null)
             {
                 throw SQL.NullColumnEncryptionKey();
             }
@@ -239,7 +239,7 @@ namespace Microsoft.Data.SqlClient
         private void ValidateEncryptionAlgorithm(string encryptionAlgorithm, bool isSystemOp)
         {
             // This validates that the encryption algorithm is RSA_OAEP
-            if (null == encryptionAlgorithm)
+            if (encryptionAlgorithm == null)
             {
                 throw SQL.NullKeyEncryptionAlgorithm(isSystemOp);
             }
@@ -260,7 +260,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (string.IsNullOrWhiteSpace(masterKeyPath))
             {
-                if (null == masterKeyPath)
+                if (masterKeyPath == null)
                 {
                     throw SQL.NullCspKeyPath(isSystemOp);
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -615,7 +615,7 @@ namespace Microsoft.Data.SqlClient
             get
             {
                 // if the transaction object has been zombied, just return null
-                if ((null != _transaction) && (null == _transaction.Connection))
+                if ((null != _transaction) && _transaction.Connection == null)
                 {
                     _transaction = null;
                 }
@@ -783,7 +783,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (null == _parameters)
+                if (_parameters == null)
                 {
                     // delay the creation of the SqlParameterCollection
                     // until user actually uses the Parameters property
@@ -1028,12 +1028,12 @@ namespace Microsoft.Data.SqlClient
                     // if we have pending data, but it is not a result of this command, then we don't cancel either.  Note that
                     // this model is implementable because we only allow one active command at any one time.  This code
                     // will have to change we allow multiple outstanding batches
-                    if (null == _activeConnection)
+                    if (_activeConnection == null)
                     {
                         return;
                     }
                     SqlInternalConnectionTds connection = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
-                    if (null == connection)
+                    if (connection == null)
                     {  // Fail with out locking
                         return;
                     }
@@ -1050,11 +1050,10 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         TdsParser parser = connection.Parser;
-                        if (null == parser)
+                        if (parser == null)
                         {
                             return;
                         }
-
 
                         if (!_pendingCancel)
                         { // Do nothing if already pending.
@@ -1644,7 +1643,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            Debug.Assert(null == _stateObj, "non-null state object in EndExecuteNonQuery");
+            Debug.Assert(_stateObj == null, "non-null state object in EndExecuteNonQuery");
             return _rowsAffected;
         }
 
@@ -1716,7 +1715,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            Debug.Assert(isAsync || null == _stateObj, "non-null state object in InternalExecuteNonQuery");
+            Debug.Assert(isAsync || _stateObj == null, "non-null state object in InternalExecuteNonQuery");
             return task;
         }
 
@@ -2564,7 +2563,7 @@ namespace Microsoft.Data.SqlClient
             CheckThrowSNIException();
 
             SqlDataReader reader = CompleteAsyncExecuteReader(isInternal);
-            Debug.Assert(null == _stateObj, "non-null state object in InternalEndExecuteReader");
+            Debug.Assert(_stateObj == null, "non-null state object in InternalEndExecuteReader");
             return reader;
         }
 
@@ -3297,7 +3296,7 @@ namespace Microsoft.Data.SqlClient
 
             // Use common parser for SqlClient and OleDb - parse into 4 parts - Server, Catalog, Schema, ProcedureName
             string[] parsedSProc = MultipartIdentifier.ParseMultipartIdentifier(CommandText, "[\"", "]\"", Strings.SQL_SqlCommandCommandText, false);
-            if (null == parsedSProc[3] || string.IsNullOrEmpty(parsedSProc[3]))
+            if (string.IsNullOrEmpty(parsedSProc[3]))
             {
                 throw ADP.NoStoredProcedureExists(CommandText);
             }
@@ -3590,7 +3589,7 @@ namespace Microsoft.Data.SqlClient
             {
                 if (_sqlDep != null)
                 {
-                    if (null == _sqlDep.Options)
+                    if (_sqlDep.Options == null)
                     {
                         // If null, SqlDependency was not created with options, so we need to obtain default options now.
                         // GetDefaultOptions can and will throw under certain conditions.
@@ -3885,10 +3884,10 @@ namespace Microsoft.Data.SqlClient
                     // If we didn't have parameters, we can fall back to regular code path, by simply returning.
                     if (!describeParameterEncryptionNeeded)
                     {
-                        Debug.Assert(null == fetchInputParameterEncryptionInfoTask,
+                        Debug.Assert(fetchInputParameterEncryptionInfoTask == null,
                             "fetchInputParameterEncryptionInfoTask should not be set if describe parameter encryption is not needed.");
 
-                        Debug.Assert(null == describeParameterEncryptionDataReader,
+                        Debug.Assert(describeParameterEncryptionDataReader == null,
                             "SqlDataReader created for describe parameter encryption params when it is not needed.");
 
                         return;
@@ -4013,7 +4012,7 @@ namespace Microsoft.Data.SqlClient
 
                         // Complete executereader.
                         describeParameterEncryptionDataReader = command.CompleteAsyncExecuteReader(forDescribeParameterEncryption: true);
-                        Debug.Assert(null == command._stateObj, "non-null state object in PrepareForTransparentEncryption.");
+                        Debug.Assert(command._stateObj == null, "non-null state object in PrepareForTransparentEncryption.");
 
                         // Read the results of describe parameter encryption.
                         command.ReadDescribeEncryptionParameterResults(describeParameterEncryptionDataReader, describeParameterEncryptionRpcOriginalRpcMap, inRetry);
@@ -4087,7 +4086,7 @@ namespace Microsoft.Data.SqlClient
 
                     // Complete executereader.
                     describeParameterEncryptionDataReader = CompleteAsyncExecuteReader(forDescribeParameterEncryption: true);
-                    Debug.Assert(null == _stateObj, "non-null state object in PrepareForTransparentEncryption.");
+                    Debug.Assert(_stateObj == null, "non-null state object in PrepareForTransparentEncryption.");
 
                     // Read the results of describe parameter encryption.
                     ReadDescribeEncryptionParameterResults(describeParameterEncryptionDataReader,
@@ -5191,7 +5190,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            Debug.Assert(isAsync || null == _stateObj, "non-null state object in RunExecuteReader");
+            Debug.Assert(isAsync || _stateObj == null, "non-null state object in RunExecuteReader");
             return ds;
         }
 
@@ -5409,7 +5408,7 @@ namespace Microsoft.Data.SqlClient
         // throws exception for error case, returns false if the commandText is empty
         private void ValidateCommand(bool isAsync, [CallerMemberName] string method = "")
         {
-            if (null == _activeConnection)
+            if (_activeConnection == null)
             {
                 throw ADP.ConnectionRequired(method);
             }
@@ -5462,7 +5461,7 @@ namespace Microsoft.Data.SqlClient
 
             // throw if the connection is in a transaction but there is no
             // locally assigned transaction object
-            if (_activeConnection.HasLocalTransactionFromAPI && (null == _transaction))
+            if (_activeConnection.HasLocalTransactionFromAPI && _transaction == null)
             {
                 throw ADP.TransactionRequired(method);
             }
@@ -5499,7 +5498,7 @@ namespace Microsoft.Data.SqlClient
 
         private void GetStateObject(TdsParser parser = null)
         {
-            Debug.Assert(null == _stateObj, "StateObject not null on GetStateObject");
+            Debug.Assert(_stateObj == null, "StateObject not null on GetStateObject");
             Debug.Assert(null != _activeConnection, "no active connection?");
 
             if (_pendingCancel)
@@ -5850,7 +5849,7 @@ namespace Microsoft.Data.SqlClient
             SqlParameter thisParam = null;
             bool foundParam = false;
 
-            if (null == paramName)
+            if (paramName == null)
             {
                 // rec.parameter should only be null for a return value from a function
                 for (int i = 0; i < paramCount; i++)
@@ -5979,12 +5978,12 @@ namespace Microsoft.Data.SqlClient
                     // set default value bit
                     if (parameter.Direction != ParameterDirection.Output)
                     {
-                        // remember that null == Convert.IsEmpty, DBNull.Value is a database null!
+                        // remember that Convert.IsEmpty is null, DBNull.Value is a database null!
 
                         // Don't assume a default value exists for parameters in the case when
                         // the user is simply requesting schema.
                         // TVPs use DEFAULT and do not allow NULL, even for schema only.
-                        if (null == parameter.Value && (!inSchema || SqlDbType.Structured == parameter.SqlDbType))
+                        if (parameter.Value == null && (!inSchema || SqlDbType.Structured == parameter.SqlDbType))
                         {
                             options |= TdsEnums.RPC_PARAM_DEFAULT;
                         }
@@ -6440,7 +6439,7 @@ namespace Microsoft.Data.SqlClient
                         if ((null != val) && (DBNull.Value != val))
                         {
                             s = (val as string);
-                            if (null == s)
+                            if (s == null)
                             {
                                 SqlString sval = val is SqlString ? (SqlString)val : SqlString.Null;
                                 if (!sval.IsNull)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -468,7 +468,7 @@ namespace Microsoft.Data.SqlClient
                         // start
                         if (ConnectionState.Open == State)
                         {
-                            if (null == _statistics)
+                            if (_statistics == null)
                             {
                                 _statistics = new SqlStatistics();
                                 _statistics._openTimestamp = ADP.TimerCurrent();
@@ -1883,7 +1883,7 @@ namespace Microsoft.Data.SqlClient
                 s_diagnosticListener.IsEnabled(SqlClientCommandAfter.Name) ||
                 s_diagnosticListener.IsEnabled(SqlClientConnectionOpenAfter.Name))
             {
-                if (null == _statistics)
+                if (_statistics == null)
                 {
                     _statistics = new SqlStatistics();
                 }
@@ -2146,7 +2146,7 @@ namespace Microsoft.Data.SqlClient
         internal SqlInternalConnectionTds GetOpenTdsConnection()
         {
             SqlInternalConnectionTds innerConnection = (InnerConnection as SqlInternalConnectionTds);
-            if (null == innerConnection)
+            if (innerConnection == null)
             {
                 throw ADP.ClosedConnectionError();
             }
@@ -2156,7 +2156,7 @@ namespace Microsoft.Data.SqlClient
         internal SqlInternalConnectionTds GetOpenTdsConnection(string method)
         {
             SqlInternalConnectionTds innerConnection = (InnerConnection as SqlInternalConnectionTds);
-            if (null == innerConnection)
+            if (innerConnection == null)
             {
                 throw ADP.OpenConnectionRequired(method, InnerConnection.State);
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -85,8 +85,7 @@ namespace Microsoft.Data.SqlClient
                 redirectedUserInstance = true;
                 string instanceName;
 
-                if ((null == pool) ||
-                     (null != pool && pool.Count <= 0))
+                if (pool == null || (null != pool && pool.Count <= 0))
                 { // Non-pooled or pooled and no connections in the pool.
                     SqlInternalConnectionTds sseConnection = null;
                     try
@@ -208,7 +207,7 @@ namespace Microsoft.Data.SqlClient
         internal static SqlConnectionString FindSqlConnectionOptions(SqlConnectionPoolKey key)
         {
             SqlConnectionString connectionOptions = (SqlConnectionString)SingletonInstance.FindConnectionOptions(key);
-            if (null == connectionOptions)
+            if (connectionOptions == null)
             {
                 connectionOptions = new SqlConnectionString(key.ConnectionString);
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(DbConnectionClosedConnecting.SingletonInstance == _innerConnection, "not connecting");
             DbConnectionPoolGroup poolGroup = PoolGroup;
             DbConnectionOptions connectionOptions = ((null != poolGroup) ? poolGroup.ConnectionOptions : null);
-            if ((null == connectionOptions) || connectionOptions.IsEmpty)
+            if (connectionOptions == null || connectionOptions.IsEmpty)
             {
                 throw ADP.NoConnectionString();
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -431,7 +431,7 @@ namespace Microsoft.Data.SqlClient
         {
             Debug.Assert(null != stateObj, "null stateobject");
 
-            Debug.Assert(null == _snapshot, "Should not change during execution of asynchronous command");
+            Debug.Assert(_snapshot == null, "Should not change during execution of asynchronous command");
 
             stateObj.Owner = this;
             _stateObj = stateObj;
@@ -1446,7 +1446,7 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
-                if (null == _fieldNameLookup)
+                if (_fieldNameLookup == null)
                 {
                     CheckMetaDataIsReady();
                     _fieldNameLookup = new FieldNameLookup(this, _defaultLCID);
@@ -1480,7 +1480,7 @@ namespace Microsoft.Data.SqlClient
                 try
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
-                    if (null == _metaData || null == _metaData.schemaTable)
+                    if (_metaData == null || _metaData.schemaTable == null)
                     {
                         if (null != this.MetaData)
                         {
@@ -1696,7 +1696,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // if no buffer is passed in, return the number total of bytes, or -1
-                if (null == buffer)
+                if (buffer == null)
                 {
                     if (_metaData[i].metaType.IsPlp)
                     {
@@ -1807,7 +1807,7 @@ namespace Microsoft.Data.SqlClient
             cbytes = data.Length;
 
             // if no buffer is passed in, return the number of characters we have
-            if (null == buffer)
+            if (buffer == null)
             {
                 remaining = cbytes;
                 return TdsOperationStatus.Done;
@@ -2147,8 +2147,10 @@ namespace Microsoft.Data.SqlClient
                 int ndataIndex = (int)dataIndex;
 
                 // if no buffer is passed in, return the number of characters we have
-                if (null == buffer)
+                if (buffer == null)
+                {
                     return cchars;
+                }
 
                 // if dataIndex outside of data range, return 0
                 if (ndataIndex < 0 || ndataIndex >= cchars)
@@ -2252,7 +2254,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             // if no buffer is passed in, return the total number of characters or -1
-            if (null == buffer)
+            if (buffer == null)
             {
                 cch = (long)_parser.PlpBytesTotalLength(_stateObj);
                 return (isUnicode && (cch > 0)) ? cch >> 1 : cch;
@@ -2631,7 +2633,7 @@ namespace Microsoft.Data.SqlClient
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
                 CheckDataIsReady();
-                if (null == values)
+                if (values == null)
                 {
                     throw ADP.ArgumentNull(nameof(values));
                 }
@@ -3045,7 +3047,7 @@ namespace Microsoft.Data.SqlClient
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
 
-                if (null == values)
+                if (values == null)
                 {
                     throw ADP.ArgumentNull(nameof(values));
                 }
@@ -5826,7 +5828,7 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
-                if (null == _metaData || null == _metaData.dbColumnSchema)
+                if (_metaData == null || _metaData.dbColumnSchema == null)
                 {
                     if (null != this.MetaData)
                     {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Data.SqlClient
                 connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Begin, null, _isolationLevel, _internalTransaction, true);
 
                 // Handle case where ExecuteTran didn't produce a new transaction, but also didn't throw.
-                if (null == connection.CurrentTransaction)
+                if (connection.CurrentTransaction == null)
                 {
                     connection.DoomThisConnection();
                     throw ADP.InternalError(ADP.InternalErrorCode.UnknownTransactionFailure);
@@ -485,7 +485,7 @@ namespace Microsoft.Data.SqlClient
         private SqlInternalConnection GetValidConnection()
         {
             SqlInternalConnection connection = _connection;
-            if (null == connection && Transaction.TransactionInformation.Status != TransactionStatus.Aborted)
+            if (connection == null && Transaction.TransactionInformation.Status != TransactionStatus.Aborted)
             {
                 throw ADP.ObjectDisposed(this);
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -641,7 +641,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                return IsTransactionRoot && (!Is2008OrNewer || null == Pool);
+                return IsTransactionRoot && (!Is2008OrNewer || Pool == null);
             }
         }
 
@@ -689,7 +689,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                bool result = (null == FindLiveReader(null)); // can't prepare with a live data reader...
+                bool result = FindLiveReader(null) == null; // can't prepare with a live data reader...
                 return result;
             }
         }
@@ -1004,7 +1004,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            string transactionName = (null == name) ? string.Empty : name;
+            string transactionName = name == null ? string.Empty : name;
 
             ExecuteTransaction2005(transactionRequest, transactionName, iso, internalTransaction, isDelegateControlRequest);
         }
@@ -1591,12 +1591,13 @@ namespace Microsoft.Data.SqlClient
                         continue;
                     }
 
-                    if (null == _parser
-                            || TdsParserState.Closed != _parser.State
-                            || IsDoNotRetryConnectError(sqlex)
-                            || timeout.IsExpired)
-                    {       // no more time to try again
-                        throw;  // Caller will call LoginFailure()
+                    if (_parser == null
+                        || TdsParserState.Closed != _parser.State
+                        || IsDoNotRetryConnectError(sqlex)
+                        || timeout.IsExpired)
+                    {
+                        // no more time to try again
+                        throw; // Caller will call LoginFailure()
                     }
 
                     // Check sleep interval to make sure we won't exceed the timeout
@@ -1710,7 +1711,7 @@ namespace Microsoft.Data.SqlClient
             ServerInfo failoverServerInfo = new ServerInfo(connectionOptions, failoverHost, connectionOptions.FailoverPartnerSPN);
 
             ResolveExtendedServerName(primaryServerInfo, !redirectedUserInstance, connectionOptions);
-            if (null == ServerProvidedFailOverPartner)
+            if (ServerProvidedFailOverPartner == null)
             {
                 ResolveExtendedServerName(failoverServerInfo, !redirectedUserInstance && failoverHost != primaryServerInfo.UserServerName, connectionOptions);
             }
@@ -1844,7 +1845,7 @@ namespace Microsoft.Data.SqlClient
             _activeDirectoryAuthTimeoutRetryHelper.State = ActiveDirectoryAuthenticationTimeoutRetryState.HasLoggedIn;
 
             // if connected to failover host, but said host doesn't have DbMirroring set up, throw an error
-            if (useFailoverHost && null == ServerProvidedFailOverPartner)
+            if (useFailoverHost && ServerProvidedFailOverPartner == null)
             {
                 throw SQL.InvalidPartnerConfiguration(failoverHost, CurrentDatabase);
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -231,16 +231,16 @@ namespace Microsoft.Data.SqlClient
             set
             {
                 Debug.Assert(value == _currentTransaction
-                          || null == _currentTransaction
-                          || null == value
+                          || _currentTransaction == null
+                          || value == null
                           || (null != _currentTransaction && !_currentTransaction.IsLocal), "attempting to change current transaction?");
 
                 // If there is currently a transaction active, we don't want to
                 // change it; this can occur when there is a delegated transaction
                 // and the user attempts to do an API begin transaction; in these
                 // cases, it's safe to ignore the set.
-                if ((null == _currentTransaction && null != value)
-                  || (null != _currentTransaction && null == value))
+                if ((_currentTransaction == null && null != value)
+                    || (null != _currentTransaction && value == null))
                 {
                     _currentTransaction = value;
                 }
@@ -508,7 +508,7 @@ namespace Microsoft.Data.SqlClient
             uint result = _physicalStateObj.SniGetConnectionId(ref _connHandler._clientConnectionId);
             Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionId");
 
-            if (null == _connHandler.pendingSQLDNSObject)
+            if (_connHandler.pendingSQLDNSObject == null)
             {
                 // for DNS Caching phase 1
                 _physicalStateObj.AssignPendingDNSInfo(serverInfo.UserProtocol, FQDNforDNSCache, ref _connHandler.pendingSQLDNSObject);
@@ -581,7 +581,7 @@ namespace Microsoft.Data.SqlClient
                 Debug.Assert(retCode == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionId");
                 SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.Connect|SEC> Sending prelogin handshake");
 
-                if (null == _connHandler.pendingSQLDNSObject)
+                if (_connHandler.pendingSQLDNSObject == null)
                 {
                     // for DNS Caching phase 1
                     _physicalStateObj.AssignPendingDNSInfo(serverInfo.UserProtocol, FQDNforDNSCache, ref _connHandler.pendingSQLDNSObject);
@@ -1183,7 +1183,7 @@ namespace Microsoft.Data.SqlClient
                 _sessionPool.Deactivate();
             }
 
-            Debug.Assert(connectionIsDoomed || null == _pendingTransaction, "pending transaction at disconnect?");
+            Debug.Assert(connectionIsDoomed || _pendingTransaction == null, "pending transaction at disconnect?");
 
             if (!connectionIsDoomed && null != _physicalStateObj)
             {
@@ -1211,7 +1211,7 @@ namespace Microsoft.Data.SqlClient
             if (null != currentTransaction && currentTransaction.HasParentTransaction)
             {
                 currentTransaction.CloseFromConnection();
-                Debug.Assert(null == CurrentTransaction, "rollback didn't clear current transaction?");
+                Debug.Assert(CurrentTransaction == null, "rollback didn't clear current transaction?");
             }
 
             Statistics = null; // must come after CleanWire or we won't count the stuff that happens there...
@@ -1316,7 +1316,7 @@ namespace Microsoft.Data.SqlClient
             if (null != currentTransaction && currentTransaction.HasParentTransaction && currentTransaction.IsOrphaned)
             {
                 currentTransaction.CloseFromConnection();
-                Debug.Assert(null == CurrentTransaction, "rollback didn't clear current transaction?");
+                Debug.Assert(CurrentTransaction == null, "rollback didn't clear current transaction?");
             }
         }
 
@@ -1680,7 +1680,7 @@ namespace Microsoft.Data.SqlClient
         //
         internal byte[] SerializeShort(int v, TdsParserStateObject stateObj)
         {
-            if (null == stateObj._bShortBytes)
+            if (stateObj._bShortBytes == null)
             {
                 stateObj._bShortBytes = new byte[2];
             }
@@ -1739,7 +1739,7 @@ namespace Microsoft.Data.SqlClient
         //
         internal byte[] SerializeInt(int v, TdsParserStateObject stateObj)
         {
-            if (null == stateObj._bIntBytes)
+            if (stateObj._bIntBytes == null)
             {
                 stateObj._bIntBytes = new byte[sizeof(int)];
             }
@@ -1812,7 +1812,7 @@ namespace Microsoft.Data.SqlClient
         internal byte[] SerializeLong(long v, TdsParserStateObject stateObj)
         {
             int current = 0;
-            if (null == stateObj._bLongBytes)
+            if (stateObj._bLongBytes == null)
             {
                 stateObj._bLongBytes = new byte[8];
             }
@@ -2256,7 +2256,7 @@ namespace Microsoft.Data.SqlClient
                                             // the current transaction, then we store the token in it.
                                             // if there isn't a pending transaction, then it's either
                                             // a TSQL transaction or a distributed transaction.
-                                            Debug.Assert(null == _currentTransaction, "non-null current transaction with an ENV Change");
+                                            Debug.Assert(_currentTransaction == null, "non-null current transaction with an ENV Change");
                                             _currentTransaction = _pendingTransaction;
                                             _pendingTransaction = null;
 
@@ -6235,12 +6235,12 @@ namespace Microsoft.Data.SqlClient
                     {
                         System.Text.Encoding encoding = md.baseTI.encoding;
 
-                        if (null == encoding)
+                        if (encoding == null)
                         {
                             encoding = _defaultEncoding;
                         }
 
-                        if (null == encoding)
+                        if (encoding == null)
                         {
                             ThrowUnsupportedCollationEncountered(stateObj);
                         }
@@ -7134,7 +7134,7 @@ namespace Microsoft.Data.SqlClient
         internal Task WriteSqlVariantDataRowValue(object value, TdsParserStateObject stateObj, bool canAccumulate = true)
         {
             // handle null values
-            if ((null == value) || (DBNull.Value == value))
+            if (value == null || (DBNull.Value == value))
             {
                 WriteInt(TdsEnums.FIXEDNULL, stateObj);
                 return null;
@@ -7369,7 +7369,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             Debug.Assert(8 == length, "invalid length in SerializeCurrency");
-            if (null == stateObj._bLongBytes)
+            if (stateObj._bLongBytes == null)
             {
                 stateObj._bLongBytes = new byte[8];
             }
@@ -7543,7 +7543,7 @@ namespace Microsoft.Data.SqlClient
             bits = stateObj._decimalBits; // used alloc'd array if we have one already
             int i;
 
-            if (null == bits)
+            if (bits == null)
             {
                 bits = new int[4];
                 stateObj._decimalBits = bits;
@@ -7601,7 +7601,7 @@ namespace Microsoft.Data.SqlClient
 
         internal byte[] SerializeSqlDecimal(SqlDecimal d, TdsParserStateObject stateObj)
         {
-            if (null == stateObj._bDecimalBytes)
+            if (stateObj._bDecimalBytes == null)
             {
                 stateObj._bDecimalBytes = new byte[17];
             }
@@ -7660,7 +7660,7 @@ namespace Microsoft.Data.SqlClient
         private byte[] SerializeDecimal(decimal value, TdsParserStateObject stateObj)
         {
             int[] decimalBits = Decimal.GetBits(value);
-            if (null == stateObj._bDecimalBytes)
+            if (stateObj._bDecimalBytes == null)
             {
                 stateObj._bDecimalBytes = new byte[17];
             }
@@ -7931,7 +7931,7 @@ namespace Microsoft.Data.SqlClient
             // 7.0 has no support for multiple code pages in data - single code page support only
             if (encoding == null)
             {
-                if (null == _defaultEncoding)
+                if (_defaultEncoding == null)
                 {
                     ThrowUnsupportedCollationEncountered(null);
                 }
@@ -8586,8 +8586,10 @@ namespace Microsoft.Data.SqlClient
                 WriteShort(rec.database.Length, _physicalStateObj);
                 offset += rec.database.Length * 2;
 
-                if (null == s_nicAddress)
+                if (s_nicAddress == null)
+                {
                     s_nicAddress = TdsParserStaticMethods.GetNetworkPhysicalAddressForTdsLoginOnly();
+                }
 
                 _physicalStateObj.WriteByteArray(s_nicAddress, s_nicAddress.Length, 0);
 
@@ -10772,7 +10774,7 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.SQLBIGCHAR:
                 case TdsEnums.SQLBIGVARCHAR:
                 case TdsEnums.SQLTEXT:
-                    if (null == _defaultEncoding)
+                    if (_defaultEncoding == null)
                     {
                         ThrowUnsupportedCollationEncountered(null); // stateObject only when reading
                     }
@@ -10910,7 +10912,7 @@ namespace Microsoft.Data.SqlClient
                         case TdsEnums.SQLBIGCHAR:
                         case TdsEnums.SQLBIGVARCHAR:
                         case TdsEnums.SQLTEXT:
-                            if (null == _defaultEncoding)
+                            if (_defaultEncoding == null)
                             {
                                 ThrowUnsupportedCollationEncountered(null); // stateObject only when reading
                             }
@@ -11076,7 +11078,7 @@ namespace Microsoft.Data.SqlClient
                 string service = notificationRequest.Options;
                 int timeout = notificationRequest.Timeout;
 
-                if (null == callbackId)
+                if (callbackId == null)
                 {
                     throw ADP.ArgumentNull(nameof(callbackId));
                 }
@@ -11085,7 +11087,7 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.ArgumentOutOfRange(nameof(callbackId));
                 }
 
-                if (null == service)
+                if (service == null)
                 {
                     throw ADP.ArgumentNull(nameof(service));
                 }
@@ -12376,7 +12378,7 @@ namespace Microsoft.Data.SqlClient
                         if (0 > dt.days || dt.days > UInt16.MaxValue)
                             throw SQL.SmallDateTimeOverflow(MetaType.ToDateTime(dt.days, dt.time, 4).ToString(CultureInfo.InvariantCulture));
 
-                        if (null == stateObj._bIntBytes)
+                        if (stateObj._bIntBytes == null)
                         {
                             stateObj._bIntBytes = new byte[4];
                         }
@@ -12395,7 +12397,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        if (null == stateObj._bLongBytes)
+                        if (stateObj._bLongBytes == null)
                         {
                             stateObj._bLongBytes = new byte[8];
                         }
@@ -12569,7 +12571,7 @@ namespace Microsoft.Data.SqlClient
                         if (0 > dt.DayTicks || dt.DayTicks > UInt16.MaxValue)
                             throw SQL.SmallDateTimeOverflow(dt.ToString());
 
-                        if (null == stateObj._bIntBytes)
+                        if (stateObj._bIntBytes == null)
                         {
                             stateObj._bIntBytes = new byte[4];
                         }
@@ -12588,7 +12590,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        if (null == stateObj._bLongBytes)
+                        if (stateObj._bLongBytes == null)
                         {
                             stateObj._bLongBytes = new byte[8];
                         }
@@ -12909,7 +12911,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (enc == null)
                 {
-                    if (null == _defaultEncoding)
+                    if (_defaultEncoding == null)
                     {
                         ThrowUnsupportedCollationEncountered(stateObj);
                     }
@@ -13153,38 +13155,38 @@ namespace Microsoft.Data.SqlClient
         {
             return string.Format(/*IFormatProvider*/ null,
                            StateTraceFormatString,
-                           null == _physicalStateObj ? "(null)" : _physicalStateObj.ObjectID.ToString((IFormatProvider)null),
-                           null == _pMarsPhysicalConObj ? "(null)" : _pMarsPhysicalConObj.ObjectID.ToString((IFormatProvider)null),
+                           _physicalStateObj == null ? "(null)" : _physicalStateObj.ObjectID.ToString((IFormatProvider)null),
+                           _pMarsPhysicalConObj == null ? "(null)" : _pMarsPhysicalConObj.ObjectID.ToString((IFormatProvider)null),
                            _state,
                            _server,
                            _fResetConnection ? bool.TrueString : bool.FalseString,
-                           null == _defaultCollation ? "(null)" : _defaultCollation.TraceString(),
+                           _defaultCollation == null ? "(null)" : _defaultCollation.TraceString(),
                            _defaultCodePage,
                            _defaultLCID,
                            TraceObjectClass(_defaultEncoding),
                            _encryptionOption,
-                           null == _currentTransaction ? "(null)" : _currentTransaction.TraceString(),
-                           null == _pendingTransaction ? "(null)" : _pendingTransaction.TraceString(),
+                           _currentTransaction == null ? "(null)" : _currentTransaction.TraceString(),
+                           _pendingTransaction == null ? "(null)" : _pendingTransaction.TraceString(),
                            _retainedTransactionId,
                            _nonTransactedOpenResultCount,
-                           null == _connHandler ? "(null)" : _connHandler.ObjectID.ToString((IFormatProvider)null),
+                           _connHandler == null ? "(null)" : _connHandler.ObjectID.ToString((IFormatProvider)null),
                            _fMARS ? bool.TrueString : bool.FalseString,
-                           null == _sessionPool ? "(null)" : _sessionPool.TraceString(),
+                           _sessionPool == null ? "(null)" : _sessionPool.TraceString(),
                            _is2005 ? bool.TrueString : bool.FalseString,
-                           null == _sniSpnBuffer ? "(null)" : _sniSpnBuffer.Length.ToString((IFormatProvider)null),
+                           _sniSpnBuffer == null ? "(null)" : _sniSpnBuffer.Length.ToString((IFormatProvider)null),
                            _physicalStateObj != null ? "(null)" : _physicalStateObj.ErrorCount.ToString((IFormatProvider)null),
                            _physicalStateObj != null ? "(null)" : _physicalStateObj.WarningCount.ToString((IFormatProvider)null),
                            _physicalStateObj != null ? "(null)" : _physicalStateObj.PreAttentionErrorCount.ToString((IFormatProvider)null),
                            _physicalStateObj != null ? "(null)" : _physicalStateObj.PreAttentionWarningCount.ToString((IFormatProvider)null),
-                           null == _statistics ? bool.TrueString : bool.FalseString,
+                           _statistics == null ? bool.TrueString : bool.FalseString,
                            _statisticsIsInTransaction ? bool.TrueString : bool.FalseString,
                            _fPreserveTransaction ? bool.TrueString : bool.FalseString,
-                           null == _connHandler ? "(null)" : _connHandler.ConnectionOptions.MultiSubnetFailover.ToString((IFormatProvider)null));
+                           _connHandler == null ? "(null)" : _connHandler.ConnectionOptions.MultiSubnetFailover.ToString((IFormatProvider)null));
         }
 
         private string TraceObjectClass(object instance)
         {
-            if (null == instance)
+            if (instance == null)
             {
                 return "(null)";
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                Debug.Assert(null == value, "used only by SqlBulkCopy");
+                Debug.Assert(value == null, "used only by SqlBulkCopy");
                 _metaDataArray[index] = value;
             }
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Common/src/Microsoft/Data/Common/NameValuePermission.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Common/src/Microsoft/Data/Common/NameValuePermission.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Data.Common
                     NameValuePermission kv;
 
                     kv = kvtree.CheckKeyForValue(keychain.Name);
-                    if (null == kv)
+                    if (kv == null)
                     {
                         kv = new NameValuePermission(keychain.Name);
                         kvtree.Add(kv); // add directly into live tree
@@ -82,7 +82,7 @@ namespace Microsoft.Data.Common
                     kvtree = kv;
 
                     kv = kvtree.CheckKeyForValue(keychain.Value);
-                    if (null == kv)
+                    if (kv == null)
                     {
                         DBConnectionString insertValue = ((null != keychain.Next) ? null : entry);
                         kv = new NameValuePermission(keychain.Value, insertValue);
@@ -92,7 +92,7 @@ namespace Microsoft.Data.Common
                             entries.Add(insertValue);
                         }
                     }
-                    else if (null == keychain.Next)
+                    else if (keychain.Next == null)
                     { // shorter chain potential
                         if (null != kv._entry)
                         {
@@ -128,7 +128,7 @@ namespace Microsoft.Data.Common
 
         internal void Intersect(ArrayList entries, NameValuePermission target)
         {
-            if (null == target)
+            if (target == null)
             {
                 _tree = null;
                 _entry = null;
@@ -199,7 +199,7 @@ namespace Microsoft.Data.Common
 
         internal bool CheckValueForKeyPermit(DBConnectionString parsetable)
         {
-            if (null == parsetable)
+            if (parsetable == null)
             {
                 return false;
             }
@@ -219,7 +219,7 @@ namespace Microsoft.Data.Common
                         {
                             string keyword = permitKey._value;
 #if DEBUG
-                            Debug.Assert(null == permitKey._entry, "key member has no restrictions");
+                            Debug.Assert(permitKey._entry == null, "key member has no restrictions");
 #endif
                             if (parsetable.ContainsKey(keyword))
                             {
@@ -252,7 +252,7 @@ namespace Microsoft.Data.Common
                         // else try next keyword
                     }
                 }
-                // partial chain match, either leaf-node by shorter chain or fail mid-chain if (null == _restrictions)
+                // partial chain match, either leaf-node by shorter chain or fail mid-chain if ( _restrictions == null)
             }
 
             DBConnectionString entry = _entry;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/AdapterSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/AdapterSwitches.cs
@@ -15,7 +15,7 @@ namespace System.Data.Common {
         static internal TraceSwitch DataSchema {
             get {
                 TraceSwitch dataSchema = _dataSchema;
-                if (null == dataSchema) {
+                if (dataSchema == null) {
                     _dataSchema = dataSchema = new TraceSwitch("Data.Schema", "Enable tracing for schema actions.");
                 }
                 return dataSchema;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Data.Common
 
         internal bool IsEmpty
         {
-            get { return (null == _keychain); }
+            get { return _keychain == null; }
         }
 
         internal NameValuePair KeyChain
@@ -160,7 +160,7 @@ namespace Microsoft.Data.Common
             get
             {
                 string restrictions = _restrictions;
-                if (null == restrictions)
+                if (restrictions == null)
                 {
                     string[] restrictionValues = _restrictionValues;
                     if ((null != restrictionValues) && (0 < restrictionValues.Length))
@@ -202,7 +202,7 @@ namespace Microsoft.Data.Common
             KeyRestrictionBehavior behavior = _behavior;
             string[] restrictionValues = null;
 
-            if (null == entry)
+            if (entry == null)
             {
                 //Debug.WriteLine("0 entry AllowNothing");
                 behavior = KeyRestrictionBehavior.AllowOnly;
@@ -287,7 +287,7 @@ namespace Microsoft.Data.Common
 
             // verify _hasPassword & _parsetable are in sync between Everett/Whidbey
             Debug.Assert(!_hasPassword || ContainsKey(KEY.Password) || ContainsKey(KEY.Pwd), "OnDeserialized password mismatch this");
-            Debug.Assert(null == entry || !entry._hasPassword || entry.ContainsKey(KEY.Password) || entry.ContainsKey(KEY.Pwd), "OnDeserialized password mismatch entry");
+            Debug.Assert(entry == null || !entry._hasPassword || entry.ContainsKey(KEY.Password) || entry.ContainsKey(KEY.Pwd), "OnDeserialized password mismatch entry");
 
             DBConnectionString value = new DBConnectionString(this, restrictionValues, behavior);
             ValidateCombinedSet(this, value);
@@ -367,7 +367,7 @@ namespace Microsoft.Data.Common
         private bool IsRestrictedKeyword(string key)
         {
             // restricted if not found
-            return ((null == _restrictionValues) || (0 > Array.BinarySearch(_restrictionValues, key, StringComparer.Ordinal)));
+            return (_restrictionValues == null || (0 > Array.BinarySearch(_restrictionValues, key, StringComparer.Ordinal)));
         }
 
         internal bool IsSupersetOf(DBConnectionString entry)
@@ -415,7 +415,7 @@ namespace Microsoft.Data.Common
             {
                 if (0 > Array.BinarySearch(preventusage, allowonly[i], StringComparer.Ordinal))
                 {
-                    if (null == newlist)
+                    if (newlist == null)
                     {
                         newlist = new List<string>();
                     }
@@ -438,7 +438,7 @@ namespace Microsoft.Data.Common
             {
                 if (0 <= Array.BinarySearch(b, a[i], StringComparer.Ordinal))
                 {
-                    if (null == newlist)
+                    if (newlist == null)
                     {
                         newlist = new List<string>();
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DbConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DbConnectionOptions.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Data.Common
             ADP.CheckArgumentNull(builder, nameof(builder));
             ADP.CheckArgumentLength(keyName, nameof(keyName));
 
-            if ((null == keyName) || !s_connectionStringValidKeyRegex.IsMatch(keyName))
+            if (keyName == null || !s_connectionStringValidKeyRegex.IsMatch(keyName))
             {
                 throw ADP.InvalidKeyname(keyName);
             }
@@ -169,12 +169,12 @@ namespace Microsoft.Data.Common
             {
 
                 string rootFolderPath = datadir;
-                if (null == rootFolderPath)
+                if (rootFolderPath == null)
                 {
                     // find the replacement path
                     object rootFolderObject = AppDomain.CurrentDomain.GetData("DataDirectory");
                     rootFolderPath = (rootFolderObject as string);
-                    if ((null != rootFolderObject) && (null == rootFolderPath))
+                    if ((null != rootFolderObject) && rootFolderPath == null)
                     {
                         throw ADP.InvalidDataDirectory();
                     }
@@ -182,7 +182,7 @@ namespace Microsoft.Data.Common
                     {
                         rootFolderPath = AppDomain.CurrentDomain.BaseDirectory;
                     }
-                    if (null == rootFolderPath)
+                    if (rootFolderPath == null)
                     {
                         rootFolderPath = "";
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/GreenMethods.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/GreenMethods.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Common
 
         internal static object MicrosoftDataSqlClientSqlProviderServices_Instance()
         {
-            if (null == MicrosoftDataSqlClientSqlProviderServices_Instance_FieldInfo)
+            if (MicrosoftDataSqlClientSqlProviderServices_Instance_FieldInfo == null)
             {
                 Type t = Type.GetType(MicrosoftDataSqlClientSqlProviderServices_TypeName, false);
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeMethodWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeMethodWrapper.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 Trace.Assert(1 == thelock); // Now that we have the lock, lock should be equal to 1.
 
-                if (null == data)
+                if (data == null)
                 {
                     data = Marshal.AllocHGlobal(passedSize).ToPointer();
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Data.ProviderBase
             // we are completing an asynchronous open
             Debug.Assert(retry.Task.Status == TaskStatus.RanToCompletion, "retry task must be completed successfully");
             DbConnectionInternal openConnection = retry.Task.Result;
-            if (null == openConnection)
+            if (openConnection == null)
             {
                 connectionFactory.SetInnerConnectionTo(outerConnection, this);
                 throw ADP.InternalConnectionError(ADP.ConnectionError.GetConnectionReturnsNull);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Data.ProviderBase
                 poolGroup = GetConnectionPoolGroup(owningConnection);
                 // Doing this on the callers thread is important because it looks up the WindowsIdentity from the thread.
                 connectionPool = GetConnectionPool(owningConnection, poolGroup);
-                if (null == connectionPool)
+                if (connectionPool == null)
                 {
                     // If GetConnectionPool returns null, we can be certain that
                     // this connection should not be pooled via DbConnectionPool
@@ -426,13 +426,13 @@ namespace Microsoft.Data.ProviderBase
                 // new pool entry and add it to our collection.
 
                 DbConnectionOptions connectionOptions = CreateConnectionOptions(key.ConnectionString, userConnectionOptions);
-                if (null == connectionOptions)
+                if (connectionOptions == null)
                 {
                     throw ADP.InternalConnectionError(ADP.ConnectionError.ConnectionOptionsMissing);
                 }
 
                 string expandedConnectionString = key.ConnectionString;
-                if (null == userConnectionOptions)
+                if (userConnectionOptions == null)
                 { // we only allow one expansion on the connection string
 
                     userConnectionOptions = connectionOptions;
@@ -449,7 +449,7 @@ namespace Microsoft.Data.ProviderBase
                 }
 
                 // We don't support connection pooling on Win9x; it lacks too many of the APIs we require.
-                if ((null == poolOptions) && ADP.s_isWindowsNT)
+                if (poolOptions == null && ADP.s_isWindowsNT)
                 {
                     if (null != connectionPoolGroup)
                     {
@@ -492,7 +492,7 @@ namespace Microsoft.Data.ProviderBase
                 Debug.Assert(null != connectionPoolGroup, "how did we not create a pool entry?");
                 Debug.Assert(null != userConnectionOptions, "how did we not have user connection options?");
             }
-            else if (null == userConnectionOptions)
+            else if (userConnectionOptions == null)
             {
                 userConnectionOptions = connectionPoolGroup.ConnectionOptions;
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Data.ProviderBase
             set
             {
                 Transaction currentEnlistedTransaction = _enlistedTransaction;
-                if (((null == currentEnlistedTransaction) && (null != value))
+                if ((currentEnlistedTransaction == null && (null != value))
                     || ((null != currentEnlistedTransaction) && !currentEnlistedTransaction.Equals(value)))
                 {  // WebData 20000024
 
@@ -404,10 +404,10 @@ namespace Microsoft.Data.ProviderBase
 
         internal void AddWeakReference(object value, int tag)
         {
-            if (null == _referenceCollection)
+            if (_referenceCollection == null)
             {
                 _referenceCollection = CreateReferenceCollection();
-                if (null == _referenceCollection)
+                if (_referenceCollection == null)
                 {
                     throw ADP.InternalError(ADP.InternalErrorCode.CreateReferenceCollectionReturnedNull);
                 }
@@ -615,7 +615,7 @@ namespace Microsoft.Data.ProviderBase
 
                 DbConnectionPool pool = Pool;
 
-                if (null == pool)
+                if (pool == null)
                 {
                     throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectWithoutPool);      // pooled connection does not have a pool
                 }
@@ -768,7 +768,7 @@ namespace Microsoft.Data.ProviderBase
                     connectionFactory.SetInnerConnectionTo(outerConnection, this);
                     throw;
                 }
-                if (null == openConnection)
+                if (openConnection == null)
                 {
                     connectionFactory.SetInnerConnectionTo(outerConnection, this);
                     throw ADP.InternalConnectionError(ADP.ConnectionError.GetConnectionReturnsNull);
@@ -790,7 +790,7 @@ namespace Microsoft.Data.ProviderBase
 
             //3 // The following tests are retail assertions of things we can't allow to happen.
             bool isAlive = _owningObject.TryGetTarget(out DbConnection connection);
-            if (null == expectedOwner)
+            if (expectedOwner == null)
             {
                 if (isAlive)
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -850,7 +850,7 @@ namespace Microsoft.Data.ProviderBase
             try
             {
                 newObj = _connectionFactory.CreatePooledConnection(this, owningObject, _connectionPoolGroup.ConnectionOptions, _connectionPoolGroup.PoolKey, userOptions);
-                if (null == newObj)
+                if (newObj == null)
                 {
                     throw ADP.InternalError(ADP.InternalErrorCode.CreateObjectReturnedNull);    // CreateObject succeeded, but null object
                 }
@@ -1347,7 +1347,7 @@ namespace Microsoft.Data.ProviderBase
                 obj = GetFromTransactedPool(out transaction);
             }
 
-            if (null == obj)
+            if (obj == null)
             {
                 Interlocked.Increment(ref _waitCount);
                 uint waitHandleCount = allowCreate ? 3u : 2u;
@@ -1411,7 +1411,7 @@ namespace Microsoft.Data.ProviderBase
                                 }
                                 catch
                                 {
-                                    if (null == obj)
+                                    if (obj == null)
                                     {
                                         Interlocked.Decrement(ref _waitCount);
                                     }
@@ -1427,7 +1427,7 @@ namespace Microsoft.Data.ProviderBase
                                     }
                                 }
 
-                                if (null == obj)
+                                if (obj == null)
                                 {
                                     // If we were not able to create an object, check to see if
                                     // we reached MaxPoolSize.  If so, we will no longer wait on
@@ -1541,7 +1541,7 @@ namespace Microsoft.Data.ProviderBase
                         DestroyObject(obj);
                         obj = null;
                     }
-                } while (null == obj);
+                } while (obj == null);
             }
 
             if (null != obj)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiContextFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiContextFactory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.SqlClient.Server
             {
                 Type smiLinkType = Type.GetType("Microsoft.SqlServer.Server.InProcLink, SqlAccess, PublicKeyToken=89845dcd8080cc91");
 
-                if (null == smiLinkType)
+                if (smiLinkType == null)
                 {
                     Debug.Assert(false, "could not get InProcLink type");
                     throw SQL.ContextUnavailableOutOfProc();    // Must not be a valid version of Sql Server.
@@ -95,7 +95,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             get
             {
-                if (null == _smiLink)
+                if (_smiLink == null)
                 {
                     throw SQL.ContextUnavailableOutOfProc();    // Must not be a valid version of Sql Server, or not be SqlCLR
                 }
@@ -108,7 +108,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             get
             {
-                if (null == _smiLink)
+                if (_smiLink == null)
                 {
                     throw SQL.ContextUnavailableOutOfProc();    // Must not be a valid version of Sql Server, or not be SqlCLR
                 }
@@ -119,7 +119,7 @@ namespace Microsoft.Data.SqlClient.Server
 
         internal SmiContext GetCurrentContext()
         {
-            if (null == _smiLink)
+            if (_smiLink == null)
             {
                 throw SQL.ContextUnavailableOutOfProc();    // Must not be a valid version of Sql Server, or not be SqlCLR
             }
@@ -127,7 +127,7 @@ namespace Microsoft.Data.SqlClient.Server
             object result = _smiLink.GetCurrentContext(_eventSinkForGetCurrentContext);
             _eventSinkForGetCurrentContext.ProcessMessagesAndThrow();
 
-            if (null == result)
+            if (result == null)
             {
                 throw SQL.ContextUnavailableWhileInProc();
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Data.SqlClient
             {
                 // New configuration section "SqlClientAuthenticationProviders" for Microsoft.Data.SqlClient accepted to avoid conflicts with older one.
                 configurationSection = FetchConfigurationSection<SqlClientAuthenticationProviderConfigurationSection>(SqlClientAuthenticationProviderConfigurationSection.Name);
-                if (null == configurationSection)
+                if (configurationSection == null)
                 {
                     // If configuration section is not yet found, try with old Configuration Section name for backwards compatibility
                     configurationSection = FetchConfigurationSection<SqlAuthenticationProviderConfigurationSection>(SqlAuthenticationProviderConfigurationSection.Name);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -572,7 +572,10 @@ namespace Microsoft.Data.SqlClient
             }
 
             // Throw if there is a transaction but no flag is set
-            if (isInTransaction && null == _externalTransaction && null == _internalTransaction && (_connection.Parser != null && _connection.Parser.CurrentTransaction != null && _connection.Parser.CurrentTransaction.IsLocal))
+            if (isInTransaction &&
+                _externalTransaction == null &&
+                _internalTransaction == null &&
+                (_connection.Parser != null && _connection.Parser.CurrentTransaction != null && _connection.Parser.CurrentTransaction.IsLocal))
             {
                 throw SQL.BulkLoadExistingTransaction();
             }
@@ -1319,7 +1322,7 @@ namespace Microsoft.Data.SqlClient
 
         private void CreateOrValidateConnection(string method)
         {
-            if (null == _connection)
+            if (_connection == null)
             {
                 throw ADP.ConnectionRequired(method);
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientPermission.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientPermission.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Data.SqlClient
                 AllowBlankPassword = constr.HasBlankPassword; // MDAC 84563
                 AddPermissionEntry(new DBConnectionString(constr));
             }
-            if ((null == constr) || constr.IsEmpty)
+            if (constr == null || constr.IsEmpty)
             {
                 base.Add("", "", KeyRestrictionBehavior.AllowOnly);
             }
@@ -81,11 +81,11 @@ namespace Microsoft.Data.SqlClient
 
         internal void AddPermissionEntry(DBConnectionString entry)
         {
-            if (null == _keyvaluetree)
+            if (_keyvaluetree == null)
             {
                 _keyvaluetree = new NameValuePermission();
             }
-            if (null == _keyvalues)
+            if (_keyvalues == null)
             {
                 _keyvalues = new ArrayList();
             }
@@ -129,7 +129,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/Intersect/*' />
         override public IPermission Intersect(IPermission target)
         { // used during Deny actions
-            if (null == target)
+            if (target == null)
             {
                 return null;
             }
@@ -175,7 +175,7 @@ namespace Microsoft.Data.SqlClient
         private bool IsEmpty()
         { // MDAC 84804
             ArrayList keyvalues = _keyvalues;
-            bool flag = (!IsUnrestricted() && !AllowBlankPassword && ((null == keyvalues) || (0 == keyvalues.Count)));
+            bool flag = !IsUnrestricted() && !AllowBlankPassword && (keyvalues == null || (0 == keyvalues.Count));
             return flag;
         }
 
@@ -198,7 +198,7 @@ namespace Microsoft.Data.SqlClient
             {
                 if (!IsUnrestricted() &&
                     (!AllowBlankPassword || superset.AllowBlankPassword) &&
-                    ((null == _keyvalues) || (null != superset._keyvaluetree)))
+                    (_keyvalues == null || (null != superset._keyvaluetree)))
                 {
 
                     subset = true;
@@ -221,7 +221,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/Union/*' />
         override public IPermission Union(IPermission target)
         {
-            if (null == target)
+            if (target == null)
             {
                 return this.Copy();
             }
@@ -285,7 +285,7 @@ namespace Microsoft.Data.SqlClient
         override public void FromXml(SecurityElement securityElement)
         {
             // code derived from CodeAccessPermission.ValidateElement
-            if (null == securityElement)
+            if (securityElement == null)
             {
                 throw ADP.ArgumentNull("securityElement");
             }
@@ -375,8 +375,10 @@ namespace Microsoft.Data.SqlClient
                         }
                         tmp = value.Restrictions;
                         tmp = EncodeXmlValue(tmp);
-                        if (null == tmp)
-                        { tmp = ""; }
+                        if (tmp == null)
+                        {
+                            tmp = "";
+                        }
                         valueElement.AddAttribute(XmlStr._KeyRestrictions, tmp);
 
                         tmp = value.Behavior.ToString();

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientWrapperSmiStreamChars.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientWrapperSmiStreamChars.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             get
             {
-                return null == _stream;
+                return _stream == null;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.SqlClient
             // Validate the input parameters
             ValidateNonEmptyKeyPath(masterKeyPath, isSystemOp: true);
 
-            if (null == encryptedColumnEncryptionKey)
+            if (encryptedColumnEncryptionKey == null)
             {
                 throw SQL.NullEncryptedColumnEncryptionKey();
             }
@@ -126,7 +126,7 @@ namespace Microsoft.Data.SqlClient
             // Validate the input parameters
             ValidateNonEmptyKeyPath(masterKeyPath, isSystemOp: false);
 
-            if (null == columnEncryptionKey)
+            if (columnEncryptionKey == null)
             {
                 throw SQL.NullColumnEncryptionKey();
             }
@@ -231,7 +231,7 @@ namespace Microsoft.Data.SqlClient
         private void ValidateEncryptionAlgorithm(string encryptionAlgorithm, bool isSystemOp)
         {
             // This validates that the encryption algorithm is RSA_OAEP
-            if (null == encryptionAlgorithm)
+            if (encryptionAlgorithm == null)
             {
                 throw SQL.NullKeyEncryptionAlgorithm(isSystemOp);
             }
@@ -251,7 +251,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (string.IsNullOrWhiteSpace(masterKeyPath))
             {
-                if (null == masterKeyPath)
+                if (masterKeyPath == null)
                 {
                     throw SQL.NullCngKeyPath(isSystemOp);
                 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient
             // Validate the input parameters
             ValidateNonEmptyCSPKeyPath(masterKeyPath, isSystemOp: true);
 
-            if (null == encryptedColumnEncryptionKey)
+            if (encryptedColumnEncryptionKey == null)
             {
                 throw SQL.NullEncryptedColumnEncryptionKey();
             }
@@ -130,7 +130,7 @@ namespace Microsoft.Data.SqlClient
             // Validate the input parameters
             ValidateNonEmptyCSPKeyPath(masterKeyPath, isSystemOp: false);
 
-            if (null == columnEncryptionKey)
+            if (columnEncryptionKey == null)
             {
                 throw SQL.NullColumnEncryptionKey();
             }
@@ -235,7 +235,7 @@ namespace Microsoft.Data.SqlClient
         private void ValidateEncryptionAlgorithm(string encryptionAlgorithm, bool isSystemOp)
         {
             // This validates that the encryption algorithm is RSA_OAEP
-            if (null == encryptionAlgorithm)
+            if (encryptionAlgorithm == null)
             {
                 throw SQL.NullKeyEncryptionAlgorithm(isSystemOp);
             }
@@ -256,7 +256,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (string.IsNullOrWhiteSpace(masterKeyPath))
             {
-                if (null == masterKeyPath)
+                if (masterKeyPath == null)
                 {
                     throw SQL.NullCspKeyPath(isSystemOp);
                 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -411,7 +411,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (null == _smiEventSink)
+                if (_smiEventSink == null)
                 {
                     _smiEventSink = new CommandEventSink(this);
                 }
@@ -425,7 +425,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (null == _outParamEventSink)
+                if (_outParamEventSink == null)
                 {
                     _outParamEventSink = new SmiEventSink_DeferedProcessing(EventSink);
                 }
@@ -711,7 +711,7 @@ namespace Microsoft.Data.SqlClient
             get
             {
                 // if the transaction object has been zombied, just return null
-                if ((null != _transaction) && (null == _transaction.Connection))
+                if ((null != _transaction) && _transaction.Connection == null)
                 {
                     _transaction = null;
                 }
@@ -895,7 +895,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (null == _parameters)
+                if (_parameters == null)
                 {
                     // delay the creation of the SqlParameterCollection
                     // until user actually uses the Parameters property
@@ -1230,12 +1230,12 @@ namespace Microsoft.Data.SqlClient
                     // if we have pending data, but it is not a result of this command, then we don't cancel either.  Note that
                     // this model is implementable because we only allow one active command at any one time.  This code
                     // will have to change we allow multiple outstanding batches
-                    if (null == _activeConnection)
+                    if (_activeConnection == null)
                     {
                         return;
                     }
                     SqlInternalConnectionTds connection = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
-                    if (null == connection)
+                    if (connection == null)
                     {  // Fail with out locking
                         return;
                     }
@@ -1252,7 +1252,7 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         TdsParser parser = connection.Parser;
-                        if (null == parser)
+                        if (parser == null)
                         {
                             return;
                         }
@@ -2004,7 +2004,7 @@ namespace Microsoft.Data.SqlClient
                         }
                     }
 
-                    Debug.Assert(null == _stateObj, "non-null state object in EndExecuteNonQuery");
+                    Debug.Assert(_stateObj == null, "non-null state object in EndExecuteNonQuery");
                     return _rowsAffected;
                 }
 #if DEBUG
@@ -2119,7 +2119,7 @@ namespace Microsoft.Data.SqlClient
                             }
                         }
                     }
-                    Debug.Assert(async || null == _stateObj, "non-null state object in InternalExecuteNonQuery");
+                    Debug.Assert(async || _stateObj == null, "non-null state object in InternalExecuteNonQuery");
                     return task;
                 }
 #if DEBUG
@@ -3016,7 +3016,7 @@ namespace Microsoft.Data.SqlClient
 #endif //DEBUG
                     bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
                     SqlDataReader reader = CompleteAsyncExecuteReader(isInternal);
-                    Debug.Assert(null == _stateObj, "non-null state object in InternalEndExecuteReader");
+                    Debug.Assert(_stateObj == null, "non-null state object in InternalEndExecuteReader");
                     return reader;
                 }
 #if DEBUG
@@ -3553,7 +3553,7 @@ namespace Microsoft.Data.SqlClient
 
             // Use common parser for SqlClient and OleDb - parse into 4 parts - Server, Catalog, Schema, ProcedureName
             string[] parsedSProc = MultipartIdentifier.ParseMultipartIdentifier(CommandText, "[\"", "]\"", Strings.SQL_SqlCommandCommandText, false);
-            if (null == parsedSProc[3] || ADP.IsEmpty(parsedSProc[3]))
+            if (parsedSProc[3] == null || ADP.IsEmpty(parsedSProc[3]))
             {
                 throw ADP.NoStoredProcedureExists(CommandText);
             }
@@ -3877,7 +3877,7 @@ namespace Microsoft.Data.SqlClient
             {
                 if (_sqlDep != null)
                 {
-                    if (null == _sqlDep.Options)
+                    if (_sqlDep.Options == null)
                     {
                         // If null, SqlDependency was not created with options, so we need to obtain default options now.
                         // GetDefaultOptions can and will throw under certain conditions.
@@ -4265,10 +4265,10 @@ namespace Microsoft.Data.SqlClient
                         // If we didn't have parameters, we can fall back to regular code path, by simply returning.
                         if (!describeParameterEncryptionNeeded)
                         {
-                            Debug.Assert(null == fetchInputParameterEncryptionInfoTask,
+                            Debug.Assert(fetchInputParameterEncryptionInfoTask == null,
                                 "fetchInputParameterEncryptionInfoTask should not be set if describe parameter encryption is not needed.");
 
-                            Debug.Assert(null == describeParameterEncryptionDataReader,
+                            Debug.Assert(describeParameterEncryptionDataReader == null,
                                 "SqlDataReader created for describe parameter encryption params when it is not needed.");
 
                             return;
@@ -4315,7 +4315,7 @@ namespace Microsoft.Data.SqlClient
 
                                         // Complete executereader.
                                         describeParameterEncryptionDataReader = CompleteAsyncExecuteReader(forDescribeParameterEncryption: true);
-                                        Debug.Assert(null == _stateObj, "non-null state object in PrepareForTransparentEncryption.");
+                                        Debug.Assert(_stateObj == null, "non-null state object in PrepareForTransparentEncryption.");
 
                                         // Read the results of describe parameter encryption.
                                         ReadDescribeEncryptionParameterResults(
@@ -4403,7 +4403,7 @@ namespace Microsoft.Data.SqlClient
 
                                             // Complete executereader.
                                             describeParameterEncryptionDataReader = CompleteAsyncExecuteReader(forDescribeParameterEncryption: true);
-                                            Debug.Assert(null == _stateObj, "non-null state object in PrepareForTransparentEncryption.");
+                                            Debug.Assert(_stateObj == null, "non-null state object in PrepareForTransparentEncryption.");
 
                                             // Read the results of describe parameter encryption.
                                             ReadDescribeEncryptionParameterResults(describeParameterEncryptionDataReader, describeParameterEncryptionRpcOriginalRpcMap, inRetry);
@@ -5679,7 +5679,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            Debug.Assert(async || null == _stateObj, "non-null state object in RunExecuteReader");
+            Debug.Assert(async || _stateObj == null, "non-null state object in RunExecuteReader");
             return ds;
         }
 
@@ -5942,7 +5942,7 @@ namespace Microsoft.Data.SqlClient
         // throws exception for error case, returns false if the commandText is empty
         private void ValidateCommand(string method, bool async)
         {
-            if (null == _activeConnection)
+            if (_activeConnection == null)
             {
                 throw ADP.ConnectionRequired(method);
             }
@@ -6035,7 +6035,7 @@ namespace Microsoft.Data.SqlClient
 
             // throw if the connection is in a transaction but there is no
             // locally assigned transaction object
-            if (_activeConnection.HasLocalTransactionFromAPI && (null == _transaction))
+            if (_activeConnection.HasLocalTransactionFromAPI && _transaction == null)
             {
                 throw ADP.TransactionRequired(method);
             }
@@ -6085,7 +6085,7 @@ namespace Microsoft.Data.SqlClient
 
         private void GetStateObject(TdsParser parser = null)
         {
-            Debug.Assert(null == _stateObj, "StateObject not null on GetStateObject");
+            Debug.Assert(_stateObj == null, "StateObject not null on GetStateObject");
             Debug.Assert(null != _activeConnection, "no active connection?");
 
             if (_pendingCancel)
@@ -6533,7 +6533,7 @@ namespace Microsoft.Data.SqlClient
             SqlParameter thisParam = null;
             bool foundParam = false;
 
-            if (null == paramName)
+            if (paramName == null)
             {
                 // rec.parameter should only be null for a return value from a function
                 for (int i = 0; i < paramCount; i++)
@@ -6679,7 +6679,7 @@ namespace Microsoft.Data.SqlClient
                         // MDAC 62117, don't assume a default value exists for parameters in the case when
                         // the user is simply requesting schema
                         // SQLBUVSTS 179488 TVPs use DEFAULT and do not allow NULL, even for schema only.
-                        if (null == parameter.Value && (!inSchema || SqlDbType.Structured == parameter.SqlDbType))
+                        if (parameter.Value == null && (!inSchema || SqlDbType.Structured == parameter.SqlDbType))
                         {
                             options |= TdsEnums.RPC_PARAM_DEFAULT;
                         }
@@ -7146,7 +7146,7 @@ namespace Microsoft.Data.SqlClient
                         if ((null != val) && (DBNull.Value != val))
                         {
                             s = (val as string);
-                            if (null == s)
+                            if (s == null)
                             {
                                 SqlString sval = val is SqlString ? (SqlString)val : SqlString.Null;
                                 if (!sval.IsNull)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -499,7 +499,7 @@ namespace Microsoft.Data.SqlClient
                         // start
                         if (ConnectionState.Open == State)
                         {
-                            if (null == _statistics)
+                            if (_statistics == null)
                             {
                                 _statistics = new SqlStatistics();
                                 _statistics._openTimestamp = ADP.TimerCurrent();
@@ -1124,7 +1124,7 @@ namespace Microsoft.Data.SqlClient
                 // rebooting.  Therefore, don't cache this machine name.
                 SqlConnectionString constr = (SqlConnectionString)ConnectionOptions;
                 string result = ((null != constr) ? constr.WorkstationId : null);
-                if (null == result)
+                if (result == null)
                 {
                     // getting machine name requires Environment.Permission
                     // user must have that permission in order to retrieve this
@@ -1719,7 +1719,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (StatisticsEnabled)
                 {
-                    if (null == _statistics)
+                    if (_statistics == null)
                     {
                         _statistics = new SqlStatistics();
                     }
@@ -1988,7 +1988,7 @@ namespace Microsoft.Data.SqlClient
             {
                 if (StatisticsEnabled)
                 {
-                    if (null == _statistics)
+                    if (_statistics == null)
                     {
                         _statistics = new SqlStatistics();
                     }
@@ -2351,7 +2351,7 @@ namespace Microsoft.Data.SqlClient
             get
             {
                 SqlInternalConnectionTds tdsConnection = (GetOpenConnection() as SqlInternalConnectionTds);
-                if (null == tdsConnection)
+                if (tdsConnection == null)
                 {
                     throw SQL.NotAvailableOnContextConnection();
                 }
@@ -2496,7 +2496,7 @@ namespace Microsoft.Data.SqlClient
         internal SqlInternalConnection GetOpenConnection()
         {
             SqlInternalConnection innerConnection = (InnerConnection as SqlInternalConnection);
-            if (null == innerConnection)
+            if (innerConnection == null)
             {
                 throw ADP.ClosedConnectionError();
             }
@@ -2507,7 +2507,7 @@ namespace Microsoft.Data.SqlClient
         {
             DbConnectionInternal innerConnection = InnerConnection;
             SqlInternalConnection innerSqlConnection = (innerConnection as SqlInternalConnection);
-            if (null == innerSqlConnection)
+            if (innerSqlConnection == null)
             {
                 throw ADP.OpenConnectionRequired(method, innerConnection.State);
             }
@@ -2517,7 +2517,7 @@ namespace Microsoft.Data.SqlClient
         internal SqlInternalConnectionTds GetOpenTdsConnection()
         {
             SqlInternalConnectionTds innerConnection = (InnerConnection as SqlInternalConnectionTds);
-            if (null == innerConnection)
+            if (innerConnection == null)
             {
                 throw ADP.ClosedConnectionError();
             }
@@ -2527,7 +2527,7 @@ namespace Microsoft.Data.SqlClient
         internal SqlInternalConnectionTds GetOpenTdsConnection(string method)
         {
             SqlInternalConnectionTds innerConnection = (InnerConnection as SqlInternalConnectionTds);
-            if (null == innerConnection)
+            if (innerConnection == null)
             {
                 throw ADP.OpenConnectionRequired(method, InnerConnection.State);
             }
@@ -3278,12 +3278,16 @@ namespace Microsoft.Data.SqlClient
             IntPtr pDacl = IntPtr.Zero;
 
             // validate the structure
-            if (null == pszMachineName || null == pszSDIDLLName)
+            if (pszMachineName == null || pszSDIDLLName == null)
+            {
                 return false;
+            }
 
             if (pszMachineName.Length > TdsEnums.SDCI_MAX_MACHINENAME ||
-            pszSDIDLLName.Length > TdsEnums.SDCI_MAX_DLLNAME)
+                pszSDIDLLName.Length > TdsEnums.SDCI_MAX_DLLNAME)
+            {
                 return false;
+            }
 
             // note that these are ansi strings
             Encoding cp = System.Text.Encoding.GetEncoding(TdsEnums.DEFAULT_ENGLISH_CODE_PAGE_VALUE);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -92,8 +92,7 @@ namespace Microsoft.Data.SqlClient
                     redirectedUserInstance = true;
                     string instanceName;
 
-                    if ((null == pool) ||
-                         (null != pool && pool.Count <= 0))
+                    if (pool == null || (null != pool && pool.Count <= 0))
                     { // Non-pooled or pooled and no connections in the pool.
 
                         SqlInternalConnectionTds sseConnection = null;
@@ -229,7 +228,7 @@ namespace Microsoft.Data.SqlClient
         internal static SqlConnectionString FindSqlConnectionOptions(SqlConnectionPoolKey key)
         {
             SqlConnectionString connectionOptions = (SqlConnectionString)SingletonInstance.FindConnectionOptions(key);
-            if (null == connectionOptions)
+            if (connectionOptions == null)
             {
                 connectionOptions = new SqlConnectionString(key.ConnectionString);
             }
@@ -247,7 +246,7 @@ namespace Microsoft.Data.SqlClient
             SqlInternalConnectionSmi result = (SqlInternalConnectionSmi)smiContext.GetContextValue((int)SmiContextFactory.ContextKey.Connection);
 
             // context connections are automatically re-useable if they exist unless they've been doomed.
-            if (null == result || result.IsConnectionDoomed)
+            if (result == null || result.IsConnectionDoomed)
             {
                 if (null != result)
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Data.SqlClient
 
             Microsoft.Data.ProviderBase.DbConnectionPoolGroup poolGroup = PoolGroup;
             DbConnectionOptions connectionOptions = ((null != poolGroup) ? poolGroup.ConnectionOptions : null);
-            if ((null == connectionOptions) || connectionOptions.IsEmpty)
+            if (connectionOptions == null || connectionOptions.IsEmpty)
             {
                 throw ADP.NoConnectionString();
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -485,8 +485,7 @@ namespace Microsoft.Data.SqlClient
         internal void Bind(TdsParserStateObject stateObj)
         {
             Debug.Assert(null != stateObj, "null stateobject");
-
-            Debug.Assert(null == _snapshot, "Should not change during execution of asynchronous command");
+            Debug.Assert(_snapshot == null, "Should not change during execution of asynchronous command");
 
             stateObj.Owner = this;
             _stateObj = stateObj;
@@ -1641,7 +1640,7 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
-                if (null == _fieldNameLookup)
+                if (_fieldNameLookup == null)
                 {
                     CheckMetaDataIsReady();
                     _fieldNameLookup = new FieldNameLookup(this, _defaultLCID);
@@ -1675,7 +1674,7 @@ namespace Microsoft.Data.SqlClient
                 try
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
-                    if (null == _metaData || null == _metaData._schemaTable)
+                    if (_metaData == null || _metaData._schemaTable == null)
                     {
                         if (null != this.MetaData)
                         {
@@ -1904,7 +1903,7 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         // if no buffer is passed in, return the number total of bytes, or -1
-                        if (null == buffer)
+                        if (buffer == null)
                         {
                             if (_metaData[i].metaType.IsPlp)
                             {
@@ -2015,7 +2014,7 @@ namespace Microsoft.Data.SqlClient
                     cbytes = data.Length;
 
                     // if no buffer is passed in, return the number of characters we have
-                    if (null == buffer)
+                    if (buffer == null)
                     {
                         remaining = cbytes;
                         return TdsOperationStatus.Done;
@@ -2438,12 +2437,16 @@ namespace Microsoft.Data.SqlClient
                 int ndataIndex = (int)dataIndex;
 
                 // if no buffer is passed in, return the number of characters we have
-                if (null == buffer)
+                if (buffer == null)
+                {
                     return cchars;
+                }
 
                 // if dataIndex outside of data range, return 0
                 if (ndataIndex < 0 || ndataIndex >= cchars)
+                {
                     return 0;
+                }
 
                 try
                 {
@@ -2558,7 +2561,7 @@ namespace Microsoft.Data.SqlClient
 
                     // if no buffer is passed in, return the total number of characters or -1
                     // TODO: for DBCS encoding it returns number of bytes, not number of chars
-                    if (null == buffer)
+                    if (buffer == null)
                     {
                         cch = (long)_parser.PlpBytesTotalLength(_stateObj);
                         return (isUnicode && (cch > 0)) ? cch >> 1 : cch;
@@ -2985,7 +2988,7 @@ namespace Microsoft.Data.SqlClient
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
                 CheckDataIsReady();
-                if (null == values)
+                if (values == null)
                 {
                     throw ADP.ArgumentNull("values");
                 }
@@ -3391,7 +3394,7 @@ namespace Microsoft.Data.SqlClient
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
 
-                if (null == values)
+                if (values == null)
                 {
                     throw ADP.ArgumentNull("values");
                 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Data.SqlClient
                     connection.ExecuteTransaction(SqlInternalConnection.TransactionRequest.Begin, null, _isolationLevel, _internalTransaction, true);
 
                     // Handle case where ExecuteTran didn't produce a new transaction, but also didn't throw.
-                    if (null == connection.CurrentTransaction)
+                    if (connection.CurrentTransaction == null)
                     {
                         connection.DoomThisConnection();
                         throw ADP.InternalError(ADP.InternalErrorCode.UnknownTransactionFailure);
@@ -546,7 +546,7 @@ namespace Microsoft.Data.SqlClient
         private SqlInternalConnection GetValidConnection()
         {
             SqlInternalConnection connection = _connection;
-            if (null == connection && _atomicTransaction.TransactionInformation.Status != TransactionStatus.Aborted)
+            if (connection == null && _atomicTransaction.TransactionInformation.Status != TransactionStatus.Aborted)
             {
                 throw ADP.ObjectDisposed(this);
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Data.SqlClient
                 //   This works for now only because we can't unenlist from the context transaction
                 Transaction tx = EnlistedTransaction;
 
-                if (null == tx)
+                if (tx == null)
                 {
                     tx = ContextTransaction;
                 }
@@ -282,7 +282,7 @@ namespace Microsoft.Data.SqlClient
                 _currentTransaction = new SqlInternalTransaction(this, TransactionType.Context, null, contextTransactionId);
                 ContextTransaction = contextTransaction;
             }
-            else if (null == currentSystemTransaction)
+            else if (currentSystemTransaction == null)
             {
                 _currentTransaction = null;  // there really isn't a transaction.
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionSmi.AutomaticEnlistment|ADV> {0}, no transaction.", ObjectID);
@@ -535,7 +535,7 @@ namespace Microsoft.Data.SqlClient
             // the current transaction, then we store the token in it.
             // if there isn't a pending transaction, then it's either
             // a TSQL transaction or a distributed transaction.
-            Debug.Assert(null == _currentTransaction, "non-null current transaction with an env change");
+            Debug.Assert(_currentTransaction == null, "non-null current transaction with an env change");
             _currentTransaction = _pendingTransaction;
             _pendingTransaction = null;
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -738,7 +738,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                return IsTransactionRoot && (!Is2008OrNewer || null == Pool);
+                return IsTransactionRoot && (!Is2008OrNewer || Pool == null);
             }
         }
 
@@ -803,7 +803,7 @@ namespace Microsoft.Data.SqlClient
             get
             {
                 // TODO: probably need to use a different method, but that's a different bug
-                bool result = (null == FindLiveReader(null)); // can't prepare with a live data reader...
+                bool result = FindLiveReader(null) == null; // can't prepare with a live data reader...
                 return result;
             }
         }
@@ -1173,7 +1173,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            string transactionName = (null == name) ? String.Empty : name;
+            string transactionName = name == null ? String.Empty : name;
 
             if (!_parser.Is2005OrNewer)
             {
@@ -1914,7 +1914,7 @@ namespace Microsoft.Data.SqlClient
                         continue;
                     }
 
-                    if (null == _parser
+                    if (_parser == null
                         || TdsParserState.Closed != _parser.State
                         || IsDoNotRetryConnectError(sqlex)
                         || timeout.IsExpired)
@@ -2060,7 +2060,7 @@ namespace Microsoft.Data.SqlClient
             ServerInfo failoverServerInfo = new ServerInfo(connectionOptions, failoverHost, connectionOptions.FailoverPartnerSPN);
 
             ResolveExtendedServerName(primaryServerInfo, !redirectedUserInstance, connectionOptions);
-            if (null == ServerProvidedFailOverPartner)
+            if (ServerProvidedFailOverPartner == null)
             {// No point in resolving the failover partner when we're going to override it below
              // Don't resolve aliases if failover == primary // UNDONE: WHY?  Previous code in TdsParser.Connect did this, but the reason is not clear
                 ResolveExtendedServerName(failoverServerInfo, !redirectedUserInstance && failoverHost != primaryServerInfo.UserServerName, connectionOptions);
@@ -2233,7 +2233,7 @@ namespace Microsoft.Data.SqlClient
             _activeDirectoryAuthTimeoutRetryHelper.State = ActiveDirectoryAuthenticationTimeoutRetryState.HasLoggedIn;
 
             // if connected to failover host, but said host doesn't have DbMirroring set up, throw an error
-            if (useFailoverHost && null == ServerProvidedFailOverPartner)
+            if (useFailoverHost && ServerProvidedFailOverPartner == null)
             {
                 throw SQL.InvalidPartnerConfiguration(failoverHost, CurrentDatabase);
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -347,16 +347,16 @@ namespace Microsoft.Data.SqlClient
             set
             {
                 Debug.Assert(value == _currentTransaction
-                          || null == _currentTransaction
-                          || null == value
+                          || _currentTransaction == null
+                          || value == null
                           || (null != _currentTransaction && !_currentTransaction.IsLocal), "attempting to change current transaction?");
 
                 // If there is currently a transaction active, we don't want to
                 // change it; this can occur when there is a delegated transaction
                 // and the user attempts to do an API begin transaction; in these
                 // cases, it's safe to ignore the set.
-                if ((null == _currentTransaction && null != value)
-                  || (null != _currentTransaction && null == value))
+                if ((_currentTransaction == null && null != value) ||
+                    (null != _currentTransaction && value == null))
                 {
                     _currentTransaction = value;
                 }
@@ -1621,7 +1621,7 @@ namespace Microsoft.Data.SqlClient
                 _sessionPool.Deactivate();
             }
 
-            Debug.Assert(connectionIsDoomed || null == _pendingTransaction, "pending transaction at disconnect?");
+            Debug.Assert(connectionIsDoomed || _pendingTransaction == null, "pending transaction at disconnect?");
 
             if (!connectionIsDoomed && null != _physicalStateObj)
             {
@@ -1649,7 +1649,7 @@ namespace Microsoft.Data.SqlClient
             if (null != currentTransaction && currentTransaction.HasParentTransaction)
             {
                 currentTransaction.CloseFromConnection();
-                Debug.Assert(null == CurrentTransaction, "rollback didn't clear current transaction?");
+                Debug.Assert(CurrentTransaction == null, "rollback didn't clear current transaction?");
             }
 
             Statistics = null; // must come after CleanWire or we won't count the stuff that happens there...
@@ -1749,7 +1749,7 @@ namespace Microsoft.Data.SqlClient
             if (null != currentTransaction && currentTransaction.HasParentTransaction && currentTransaction.IsOrphaned)
             {
                 currentTransaction.CloseFromConnection();
-                Debug.Assert(null == CurrentTransaction, "rollback didn't clear current transaction?");
+                Debug.Assert(CurrentTransaction == null, "rollback didn't clear current transaction?");
             }
         }
 
@@ -2087,7 +2087,7 @@ namespace Microsoft.Data.SqlClient
         //
         internal byte[] SerializeShort(int v, TdsParserStateObject stateObj)
         {
-            if (null == stateObj._bShortBytes)
+            if (stateObj._bShortBytes == null)
             {
                 stateObj._bShortBytes = new byte[2];
             }
@@ -2145,7 +2145,7 @@ namespace Microsoft.Data.SqlClient
         //
         internal byte[] SerializeInt(int v, TdsParserStateObject stateObj)
         {
-            if (null == stateObj._bIntBytes)
+            if (stateObj._bIntBytes == null)
             {
                 stateObj._bIntBytes = new byte[4];
             }
@@ -2213,7 +2213,7 @@ namespace Microsoft.Data.SqlClient
         internal byte[] SerializeLong(long v, TdsParserStateObject stateObj)
         {
             int current = 0;
-            if (null == stateObj._bLongBytes)
+            if (stateObj._bLongBytes == null)
             {
                 stateObj._bLongBytes = new byte[8];
             }
@@ -2702,7 +2702,7 @@ namespace Microsoft.Data.SqlClient
                                             // the current transaction, then we store the token in it.
                                             // if there isn't a pending transaction, then it's either
                                             // a TSQL transaction or a distributed transaction.
-                                            Debug.Assert(null == _currentTransaction, "non-null current transaction with an ENV Change");
+                                            Debug.Assert(_currentTransaction == null, "non-null current transaction with an ENV Change");
                                             _currentTransaction = _pendingTransaction;
                                             _pendingTransaction = null;
 
@@ -7065,12 +7065,12 @@ namespace Microsoft.Data.SqlClient
                     {
                         System.Text.Encoding encoding = md.baseTI.encoding;
 
-                        if (null == encoding)
+                        if (encoding == null)
                         {
                             encoding = _defaultEncoding;
                         }
 
-                        if (null == encoding)
+                        if (encoding == null)
                         {
                             ThrowUnsupportedCollationEncountered(stateObj);
                         }
@@ -7971,7 +7971,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(_is2000 == true, "Shouldn't be dealing with sql_variant in pre-SQL2000 server!");
 
             // handle null values
-            if ((null == value) || (DBNull.Value == value))
+            if (value == null || (DBNull.Value == value))
             {
                 WriteInt(TdsEnums.FIXEDNULL, stateObj);
                 return null;
@@ -8206,7 +8206,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             Debug.Assert(8 == length, "invalid length in SerializeCurrency");
-            if (null == stateObj._bLongBytes)
+            if (stateObj._bLongBytes == null)
             {
                 stateObj._bLongBytes = new byte[8];
             }
@@ -8381,8 +8381,10 @@ namespace Microsoft.Data.SqlClient
             bits = stateObj._decimalBits; // used alloc'd array if we have one already
             int i;
 
-            if (null == bits)
+            if (bits == null)
+            {
                 bits = new int[4];
+            }
             else
             {
                 for (i = 0; i < bits.Length; i++)
@@ -8437,7 +8439,7 @@ namespace Microsoft.Data.SqlClient
 
         internal byte[] SerializeSqlDecimal(SqlDecimal d, TdsParserStateObject stateObj)
         {
-            if (null == stateObj._bDecimalBytes)
+            if (stateObj._bDecimalBytes == null)
             {
                 stateObj._bDecimalBytes = new byte[17];
             }
@@ -8487,7 +8489,7 @@ namespace Microsoft.Data.SqlClient
         private byte[] SerializeDecimal(decimal value, TdsParserStateObject stateObj)
         {
             int[] decimalBits = Decimal.GetBits(value);
-            if (null == stateObj._bDecimalBytes)
+            if (stateObj._bDecimalBytes == null)
             {
                 stateObj._bDecimalBytes = new byte[17];
             }
@@ -8747,7 +8749,7 @@ namespace Microsoft.Data.SqlClient
             // 7.0 has no support for multiple code pages in data - single code page support only
             if (encoding == null)
             {
-                if (null == _defaultEncoding)
+                if (_defaultEncoding == null)
                 {
                     ThrowUnsupportedCollationEncountered(null);
                 }
@@ -9428,8 +9430,10 @@ namespace Microsoft.Data.SqlClient
 
                 // UNDONE: NIC address
                 // previously we declared the array and simply sent it over - byte[] of 0's
-                if (null == s_nicAddress)
+                if (s_nicAddress == null)
+                {
                     s_nicAddress = TdsParserStaticMethods.GetNetworkPhysicalAddressForTdsLoginOnly();
+                }
 
                 _physicalStateObj.WriteByteArray(s_nicAddress, s_nicAddress.Length, 0);
 
@@ -11701,7 +11705,7 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.SQLBIGCHAR:
                 case TdsEnums.SQLBIGVARCHAR:
                 case TdsEnums.SQLTEXT:
-                    if (null == _defaultEncoding)
+                    if (_defaultEncoding == null)
                     {
                         ThrowUnsupportedCollationEncountered(null); // stateObject only when reading
                     }
@@ -11839,7 +11843,7 @@ namespace Microsoft.Data.SqlClient
                         case TdsEnums.SQLBIGCHAR:
                         case TdsEnums.SQLBIGVARCHAR:
                         case TdsEnums.SQLTEXT:
-                            if (null == _defaultEncoding)
+                            if (_defaultEncoding == null)
                             {
                                 ThrowUnsupportedCollationEncountered(null); // stateObject only when reading
                             }
@@ -12007,7 +12011,7 @@ namespace Microsoft.Data.SqlClient
                 string service = notificationRequest.Options;
                 int timeout = notificationRequest.Timeout;
 
-                if (null == callbackId)
+                if (callbackId == null)
                 {
                     throw ADP.ArgumentNull("CallbackId");
                 }
@@ -12016,7 +12020,7 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.ArgumentOutOfRange("CallbackId");
                 }
 
-                if (null == service)
+                if (service == null)
                 {
                     throw ADP.ArgumentNull("Service");
                 }
@@ -13366,9 +13370,11 @@ namespace Microsoft.Data.SqlClient
                     if (type.FixedLength == 4)
                     {
                         if (0 > dt.days || dt.days > UInt16.MaxValue)
+                        {
                             throw SQL.SmallDateTimeOverflow(MetaType.ToDateTime(dt.days, dt.time, 4).ToString(CultureInfo.InvariantCulture));
+                        }
 
-                        if (null == stateObj._bIntBytes)
+                        if (stateObj._bIntBytes == null)
                         {
                             stateObj._bIntBytes = new byte[4];
                         }
@@ -13387,7 +13393,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        if (null == stateObj._bLongBytes)
+                        if (stateObj._bLongBytes == null)
                         {
                             stateObj._bLongBytes = new byte[8];
                         }
@@ -13562,7 +13568,7 @@ namespace Microsoft.Data.SqlClient
                         if (0 > dt.DayTicks || dt.DayTicks > UInt16.MaxValue)
                             throw SQL.SmallDateTimeOverflow(dt.ToString());
 
-                        if (null == stateObj._bIntBytes)
+                        if (stateObj._bIntBytes == null)
                         {
                             stateObj._bIntBytes = new byte[4];
                         }
@@ -13581,7 +13587,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     else
                     {
-                        if (null == stateObj._bLongBytes)
+                        if (stateObj._bLongBytes == null)
                         {
                             stateObj._bLongBytes = new byte[8];
                         }
@@ -13874,12 +13880,11 @@ namespace Microsoft.Data.SqlClient
             {
                 Encoding enc = metadata.encoding;
 
-                if (enc == null)
+                if (null == enc)
                 {
-                    if (null == _defaultEncoding)
+                    if (_defaultEncoding == null)
                     {
                         ThrowUnsupportedCollationEncountered(stateObj);
-
                     }
 
                     enc = _defaultEncoding;
@@ -14043,36 +14048,36 @@ namespace Microsoft.Data.SqlClient
         {
             return string.Format(/*IFormatProvider*/ null,
                             StateTraceFormatString,
-                            null == _physicalStateObj ? "(null)" : _physicalStateObj.ObjectID.ToString((IFormatProvider)null),
-                            null == _pMarsPhysicalConObj ? "(null)" : _pMarsPhysicalConObj.ObjectID.ToString((IFormatProvider)null),
+                            _physicalStateObj == null ? "(null)" : _physicalStateObj.ObjectID.ToString((IFormatProvider)null),
+                            _pMarsPhysicalConObj == null ? "(null)" : _pMarsPhysicalConObj.ObjectID.ToString((IFormatProvider)null),
                             _state,
                             _server,
                             _fResetConnection ? bool.TrueString : bool.FalseString,
-                            null == _defaultCollation ? "(null)" : _defaultCollation.TraceString(),
+                            _defaultCollation == null ? "(null)" : _defaultCollation.TraceString(),
                             _defaultCodePage,
                             _defaultLCID,
                             TraceObjectClass(_defaultEncoding),
                             _encryptionOption,
-                            null == _currentTransaction ? "(null)" : _currentTransaction.TraceString(),
-                            null == _pendingTransaction ? "(null)" : _pendingTransaction.TraceString(),
+                            _currentTransaction == null ? "(null)" : _currentTransaction.TraceString(),
+                            _pendingTransaction == null ? "(null)" : _pendingTransaction.TraceString(),
                             _retainedTransactionId,
                             _nonTransactedOpenResultCount,
-                            null == _connHandler ? "(null)" : _connHandler.ObjectID.ToString((IFormatProvider)null),
+                            _connHandler == null ? "(null)" : _connHandler.ObjectID.ToString((IFormatProvider)null),
                             _fMARS ? bool.TrueString : bool.FalseString,
-                            null == _sessionPool ? "(null)" : _sessionPool.TraceString(),
+                            _sessionPool == null ? "(null)" : _sessionPool.TraceString(),
                             _is2000 ? bool.TrueString : bool.FalseString,
                             _is2000SP1 ? bool.TrueString : bool.FalseString,
                             _is2005 ? bool.TrueString : bool.FalseString,
-                            null == _sniSpnBuffer ? "(null)" : _sniSpnBuffer.Length.ToString((IFormatProvider)null),
+                            _sniSpnBuffer == null ? "(null)" : _sniSpnBuffer.Length.ToString((IFormatProvider)null),
                             _physicalStateObj != null ? "(null)" : _physicalStateObj.ErrorCount.ToString((IFormatProvider)null),
                             _physicalStateObj != null ? "(null)" : _physicalStateObj.WarningCount.ToString((IFormatProvider)null),
                             _physicalStateObj != null ? "(null)" : _physicalStateObj.PreAttentionErrorCount.ToString((IFormatProvider)null),
                             _physicalStateObj != null ? "(null)" : _physicalStateObj.PreAttentionWarningCount.ToString((IFormatProvider)null),
-                            null == _statistics ? bool.TrueString : bool.FalseString,
+                            _statistics == null ? bool.TrueString : bool.FalseString,
                             _statisticsIsInTransaction ? bool.TrueString : bool.FalseString,
                             _fPreserveTransaction ? bool.TrueString : bool.FalseString,
-                            null == _connHandler ? "(null)" : _connHandler.ConnectionOptions.MultiSubnetFailover.ToString((IFormatProvider)null),
-                            null == _connHandler ? "(null)" : _connHandler.ConnectionOptions.TransparentNetworkIPResolution.ToString((IFormatProvider)null));
+                            _connHandler == null ? "(null)" : _connHandler.ConnectionOptions.MultiSubnetFailover.ToString((IFormatProvider)null),
+                            _connHandler == null ? "(null)" : _connHandler.ConnectionOptions.TransparentNetworkIPResolution.ToString((IFormatProvider)null));
         }
 
         private string TraceObjectClass(object instance)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -13880,7 +13880,7 @@ namespace Microsoft.Data.SqlClient
             {
                 Encoding enc = metadata.encoding;
 
-                if (null == enc)
+                if (enc == null)
                 {
                     if (_defaultEncoding == null)
                     {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -579,7 +579,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                Debug.Assert(null == value, "used only by SqlBulkCopy");
+                Debug.Assert(value == null, "used only by SqlBulkCopy");
                 _metaDataArray[index] = value;
             }
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
@@ -570,7 +570,7 @@ namespace Microsoft.Data.Common
 
         internal static SqlAuthenticationMethod ConvertToAuthenticationType(string keyword, object value)
         {
-            if (null == value)
+            if (value == null)
             {
                 return DbConnectionStringDefaults.Authentication;
             }
@@ -644,7 +644,7 @@ namespace Microsoft.Data.Common
         /// <returns></returns>
         internal static SqlConnectionColumnEncryptionSetting ConvertToColumnEncryptionSetting(string keyword, object value)
         {
-            if (null == value)
+            if (value == null)
             {
                 return DbConnectionStringDefaults.ColumnEncryptionSetting;
             }
@@ -765,7 +765,7 @@ namespace Microsoft.Data.Common
 
         internal static SqlConnectionAttestationProtocol ConvertToAttestationProtocol(string keyword, object value)
         {
-            if (null == value)
+            if (value == null)
             {
                 return DbConnectionStringDefaults.AttestationProtocol;
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/MultipartIdentifier.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/MultipartIdentifier.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Data.Common
                             if (IsWhitespace(testchar))
                             { // If it is Whitespace 
                                 parsedNames[stringCount] = sb.ToString(); // Set the currently parsed string
-                                if (null == whitespaceSB)
+                                if (whitespaceSB == null)
                                 {
                                     whitespaceSB = new StringBuilder();
                                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/NameValuePair.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/NameValuePair.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Common
             get => _next;
             set
             {
-                if ((null != _next) || (null == value))
+                if ((null != _next) || value == null)
                 {
                     throw ADP.InternalError(ADP.InternalErrorCode.NameValuePairNext);
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Data.ProviderBase
         {
             Debug.Assert(null != connectionOptions, "null connection options");
 #if NETFRAMEWORK
-            Debug.Assert(null == poolGroupOptions || ADP.s_isWindowsNT, "should not have pooling options on Win9x");
+            Debug.Assert(poolGroupOptions == null || ADP.s_isWindowsNT, "should not have pooling options on Win9x");
 #endif
 
             _connectionOptions = connectionOptions;
@@ -224,7 +224,7 @@ namespace Microsoft.Data.ProviderBase
                 }
             }
 
-            if (null == pool)
+            if (pool == null)
             {
                 lock (this)
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Data.ProviderBase
 
             DataColumn collectionNameColumn = metaDataCollectionsTable.Columns[DbMetaDataColumnNames.CollectionName];
 
-            if ((null == collectionNameColumn) || (typeof(string) != collectionNameColumn.DataType))
+            if (collectionNameColumn == null || (typeof(string) != collectionNameColumn.DataType))
             {
                 throw ADP.InvalidXmlMissingColumn(DbMetaDataCollectionNames.MetaDataCollections, DbMetaDataColumnNames.CollectionName);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Data.SqlClient
             {
                 result = await TryAcquireTokenSilent(app, parameters, scopes, cts).ConfigureAwait(false);
 
-                if (null == result)
+                if (result == null)
                 {
                     if (!string.IsNullOrEmpty(parameters.UserId))
                     {
@@ -252,7 +252,7 @@ namespace Microsoft.Data.SqlClient
                     result = await TryAcquireTokenSilent(app, parameters, scopes, cts).ConfigureAwait(false);
                 }
 
-                if (null == result)
+                if (result == null)
                 {
                     result = await app.AcquireTokenByUsernamePassword(scopes, parameters.UserId, parameters.Password)
                        .WithCorrelationId(parameters.ConnectionId)
@@ -288,7 +288,7 @@ namespace Microsoft.Data.SqlClient
                     SqlClientEventSource.Log.TryTraceEvent("AcquireTokenAsync | Acquired access token (interactive) for {0} auth mode. Expiry Time: {1}", parameters.AuthenticationMethod, result?.ExpiresOn);
                 }
 
-                if (null == result)
+                if (result == null)
                 {
                     // If no existing 'account' is found, we request user to sign in interactively.
                     result = await AcquireTokenInteractiveDeviceFlowAsync(app, scopes, parameters.ConnectionId, parameters.UserId, parameters.AuthenticationMethod, cts, _customWebUI, _deviceCodeFlowCallback).ConfigureAwait(false);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ColumnEncryptionKeyInfo.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ColumnEncryptionKeyInfo.cs
@@ -35,14 +35,22 @@ namespace Microsoft.Data.SqlClient
         internal ColumnEncryptionKeyInfo(byte[] decryptedKey, int databaseId, byte[] keyMetadataVersion, int keyid)
         {
 
-            if (null == decryptedKey)
+            if (decryptedKey == null)
+            {
                 throw SQL.NullArgumentInConstructorInternal(_decryptedKeyName, _className);
+            }
             if (0 == decryptedKey.Length)
+            {
                 throw SQL.EmptyArgumentInConstructorInternal(_decryptedKeyName, _className);
-            if (null == keyMetadataVersion)
+            }
+            if (keyMetadataVersion == null)
+            {
                 throw SQL.NullArgumentInConstructorInternal(_keyMetadataVersionName, _className);
+            }
             if (0 == keyMetadataVersion.Length)
+            {
                 throw SQL.EmptyArgumentInConstructorInternal(_keyMetadataVersionName, _className);
+            }
 
             KeyId = keyid;
             DatabaseId = databaseId;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Data.SqlClient.Server
             ExtendedClrTypeCode extendedCode = ExtendedClrTypeCode.Invalid;
 
             // fast-track null, which is valid for all types
-            if (null == value)
+            if (value == null)
             {
                 extendedCode = ExtendedClrTypeCode.Empty;
             }
@@ -343,7 +343,7 @@ namespace Microsoft.Data.SqlClient.Server
                         break;
                     case SqlDbType.Udt:
                         // Validate UDT type if caller gave us a type to validate against
-                        if (null == udtType || value.GetType() == udtType)
+                        if (udtType == null || value.GetType() == udtType)
                         {
                             extendedCode = ExtendedClrTypeCode.Object;
                         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiEventSink_Default.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiEventSink_Default.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
             else
             {
-                Debug.Assert(null == _warnings || 0 != _warnings.Count, "empty warning collection?");// must be something in the collection
+                Debug.Assert(_warnings == null || 0 != _warnings.Count, "empty warning collection?");// must be something in the collection
 
                 if (!ignoreWarnings)
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiEventSink_Default.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiEventSink_Default.netfx.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             get
             {
-                if (null == _errors)
+                if (_errors == null)
                 {
                     _errors = new SqlErrorCollection();
                 }
@@ -32,7 +32,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             get
             {
-                if (null == _warnings)
+                if (_warnings == null)
                 {
                     _warnings = new SqlErrorCollection();
                 }
@@ -98,7 +98,7 @@ namespace Microsoft.Data.SqlClient.Server
         //</summary>
         internal override void BatchCompleted()
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.BatchCompleted);
             }
@@ -107,7 +107,7 @@ namespace Microsoft.Data.SqlClient.Server
 
         internal override void ParametersAvailable(SmiParameterMetaData[] metaData, ITypedGettersV3 paramValues)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.ParametersAvailable);
             }
@@ -116,7 +116,7 @@ namespace Microsoft.Data.SqlClient.Server
 
         internal override void ParameterAvailable(SmiParameterMetaData metaData, SmiTypedGetterSetter paramValue, int ordinal)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.ParameterAvailable);
             }
@@ -126,7 +126,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called when the server database context changes (ENVCHANGE token)
         internal override void DefaultDatabaseChanged(string databaseName)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.DefaultDatabaseChanged);
             }
@@ -136,7 +136,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called for messages and errors (ERROR and INFO tokens)
         internal override void MessagePosted(int number, byte state, byte errorClass, string server, string message, string procedure, int lineNumber)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SmiEventSink_Default.MessagePosted|ADV> {0}, number={1} state={2} errorClass={3} server='{4}' message='{5}' procedure='{6}' linenumber={7}.", 0, number, state, errorClass, server, message, procedure, lineNumber);
                 SqlError error = new SqlError(number, state, errorClass, server, message, procedure, lineNumber);
@@ -159,7 +159,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called for new resultset starting (COLMETADATA token)
         internal override void MetaDataAvailable(SmiQueryMetaData[] metaData, bool nextEventIsRow)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.MetaDataAvailable);
             }
@@ -169,7 +169,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called when a new row arrives (ROW token)
         internal override void RowAvailable(ITypedGetters rowData)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.RowAvailable);
             }
@@ -179,7 +179,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called when a new row arrives (ROW token)
         internal override void RowAvailable(ITypedGettersV3 rowData)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.RowAvailable);
             }
@@ -189,7 +189,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called when any statement completes on server (DONE token)
         internal override void StatementCompleted(int rowsAffected)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.StatementCompleted);
             }
@@ -199,7 +199,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called when a transaction is committed (ENVCHANGE token)
         internal override void TransactionCommitted(long transactionId)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.TransactionCommitted);
             }
@@ -209,7 +209,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called when a transaction is committed (ENVCHANGE token)
         internal override void TransactionDefected(long transactionId)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.TransactionDefected);
             }
@@ -219,7 +219,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called when a transaction is committed (ENVCHANGE token)
         internal override void TransactionEnlisted(long transactionId)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.TransactionEnlisted);
             }
@@ -230,7 +230,7 @@ namespace Microsoft.Data.SqlClient.Server
         // by the provider's batch (ENVCHANGE token)
         internal override void TransactionEnded(long transactionId)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.TransactionEnded);
             }
@@ -240,7 +240,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called when a transaction is rolled back (ENVCHANGE token)
         internal override void TransactionRolledBack(long transactionId)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.TransactionRolledBack);
             }
@@ -250,7 +250,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Called when a transaction is started (ENVCHANGE token)
         internal override void TransactionStarted(long transactionId)
         {
-            if (null == _parent)
+            if (_parent == null)
             {
                 throw SQL.UnexpectedSmiEvent(UnexpectedEventType.TransactionStarted);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
@@ -493,7 +493,7 @@ namespace Microsoft.Data.SqlClient.Server
             get
             {
                 // Fault-in UDT clr types on access if have assembly-qualified name
-                if (null == _clrType && SqlDbType.Udt == _databaseType && _udtAssemblyQualifiedName != null)
+                if (_clrType == null && SqlDbType.Udt == _databaseType && _udtAssemblyQualifiedName != null)
                 {
                     _clrType = Type.GetType(_udtAssemblyQualifiedName, true);
                 }
@@ -507,7 +507,7 @@ namespace Microsoft.Data.SqlClient.Server
             get
             {
                 // Fault-in UDT clr types on access if have assembly-qualified name
-                if (null == _clrType && SqlDbType.Udt == _databaseType && _udtAssemblyQualifiedName != null)
+                if (_clrType == null && SqlDbType.Udt == _databaseType && _udtAssemblyQualifiedName != null)
                 {
                     _clrType = Type.GetType(_udtAssemblyQualifiedName, false);
                 }
@@ -872,7 +872,7 @@ namespace Microsoft.Data.SqlClient.Server
                 extendedProperties
             )
         {
-            Debug.Assert(null == name || MaxNameLength >= name.Length, "Name is too long");
+            Debug.Assert(name == null || MaxNameLength >= name.Length, "Name is too long");
 
             _name = name;
             _typeSpecificNamePart1 = typeSpecificNamePart1;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Data.SqlClient.Server
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/GetSqlValues/*' />
         public virtual int GetSqlValues(object[] values)
         {
-            if (null == values)
+            if (values == null)
             {
                 throw ADP.ArgumentNull(nameof(values));
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
@@ -913,7 +913,7 @@ namespace Microsoft.Data.SqlClient.Server
                 throw SQL.InvalidSqlDbTypeForConstructor(dbType);
             }
 
-            if (null == userDefinedType)
+            if (userDefinedType == null)
             {
                 throw ADP.ArgumentNull(nameof(userDefinedType));
             }
@@ -954,7 +954,7 @@ namespace Microsoft.Data.SqlClient.Server
 
             if (null != database || null != owningSchema)
             {
-                if (null == objectName)
+                if (objectName == null)
                 {
                     throw ADP.ArgumentNull(nameof(objectName));
                 }
@@ -974,7 +974,7 @@ namespace Microsoft.Data.SqlClient.Server
 
         private void AssertNameIsValid(string name)
         {
-            if (null == name)
+            if (name == null)
             {
                 throw ADP.ArgumentNull(nameof(name));
             }
@@ -1078,7 +1078,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
 
             // Handle null values after type check
-            if (null == value)
+            if (value == null)
             {
                 return null;
             }
@@ -1389,7 +1389,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
 
             // Handle null values after type check.
-            if (null == value || value.IsNull)
+            if (value == null || value.IsNull)
             {
                 return value;
             }
@@ -1438,7 +1438,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
 
             // Handle null values after type check.
-            if (null == value || value.IsNull)
+            if (value == null || value.IsNull)
             {
                 return value;
             }
@@ -1487,7 +1487,7 @@ namespace Microsoft.Data.SqlClient.Server
         public object Adjust(object value)
         {
             // Pass null references through
-            if (null == value)
+            if (value == null)
             {
                 return null;
             }
@@ -1961,7 +1961,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
 
             // Handle null values after type check
-            if (null == value)
+            if (value == null)
             {
                 return null;
             }
@@ -2032,7 +2032,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
 
             // Handle null values after type check
-            if (null == value)
+            if (value == null)
             {
                 return null;
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
             ThrowIfITypedGettersIsNull(sink, getters, ordinal);
             object obj = GetValue(sink, getters, ordinal, metaData);
-            if (null == obj)
+            if (obj == null)
             {
                 throw ADP.InvalidCast();
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SignatureVerificationCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SignatureVerificationCache.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (signature == null || signature.Length == 0)
             {
-                if (null == signature)
+                if (signature == null)
                 {
                     throw SQL.NullArgumentInternal(_signatureName, _className, methodName);
                 }
@@ -102,7 +102,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (string.IsNullOrWhiteSpace(stringArgValue))
             {
-                if (null == stringArgValue)
+                if (stringArgValue == null)
                 {
                     throw SQL.NullArgumentInternal(stringArgName, _className, methodName);
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Data.SqlClient
             // Validate the input parameters
             ValidateNonEmptyCertificatePath(masterKeyPath, isSystemOp: true);
 
-            if (null == encryptedColumnEncryptionKey)
+            if (encryptedColumnEncryptionKey == null)
             {
                 throw SQL.NullEncryptedColumnEncryptionKey();
             }
@@ -152,7 +152,7 @@ namespace Microsoft.Data.SqlClient
         {
             // Validate the input parameters
             ValidateNonEmptyCertificatePath(masterKeyPath, isSystemOp: false);
-            if (null == columnEncryptionKey)
+            if (columnEncryptionKey == null)
             {
                 throw SQL.NullColumnEncryptionKey();
             }
@@ -295,7 +295,7 @@ namespace Microsoft.Data.SqlClient
         private void ValidateEncryptionAlgorithm(string encryptionAlgorithm, bool isSystemOp)
         {
             // This validates that the encryption algorithm is RSA_OAEP
-            if (null == encryptionAlgorithm)
+            if (encryptionAlgorithm == null)
             {
                 throw SQL.NullKeyEncryptionAlgorithm(isSystemOp);
             }
@@ -334,7 +334,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (string.IsNullOrWhiteSpace(masterKeyPath))
             {
-                if (null == masterKeyPath)
+                if (masterKeyPath == null)
                 {
                     throw SQL.NullCertificatePath(GetValidCertificateLocations(), isSystemOp);
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Data.SqlClient
 #if NETFRAMEWORK
             SqlConnection.ExecutePermission.Demand();
 #endif
-            if (null == command)
+            if (command == null)
             {
                 throw ADP.ArgumentNull(nameof(command));
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.SqlClient
             get
             {
                 SqlCommand command = _batchCommand;
-                if (null == command)
+                if (command == null)
                 {
                     throw ADP.ObjectDisposed(this);
                 }
@@ -50,7 +50,7 @@ namespace Microsoft.Data.SqlClient
             get
             {
                 List<SqlBatchCommand> commandList = _commandList;
-                if (null == commandList)
+                if (commandList == null)
                 {
                     throw ADP.ObjectDisposed(this);
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionPoolGroupProviderInfo.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionPoolGroupProviderInfo.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Data.SqlClient
             {
                 lock (this)
                 {
-                    if (null == _alias)
+                    if (_alias == null)
                     {
                         _alias = server;
                     }
@@ -105,7 +105,7 @@ namespace Microsoft.Data.SqlClient
             //       in the original connection string.
 
             if (userConnectionOptions.ContainsKey(SqlConnectionString.KEY.FailoverPartner) &&
-                null == userConnectionOptions[SqlConnectionString.KEY.FailoverPartner])
+                userConnectionOptions[SqlConnectionString.KEY.FailoverPartner] == null)
             {
                 keywordToReplace = SqlConnectionString.KEY.Data_Source;
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -782,7 +782,7 @@ namespace Microsoft.Data.SqlClient
             {
                 // so tdsparser.connect can determine if SqlConnection.UserConnectionOptions
                 // needs to enforce local host after datasource alias lookup
-                return (null != _expandedAttachDBFilename) && (null == _localDBInstance);
+                return (null != _expandedAttachDBFilename) && _localDBInstance == null;
             }
         }
 
@@ -831,7 +831,7 @@ namespace Microsoft.Data.SqlClient
         internal static Dictionary<string, string> GetParseSynonyms()
         {
             Dictionary<string, string> synonyms = s_sqlClientSynonyms;
-            if (null == synonyms)
+            if (synonyms == null)
             {
 
                 int count = SqlConnectionStringBuilder.KeywordsCount + SynonymCount;
@@ -936,7 +936,7 @@ namespace Microsoft.Data.SqlClient
             // Note: In Longhorn you'll be able to rename a machine without
             // rebooting.  Therefore, don't cache this machine name.
             string result = WorkstationId;
-            if (null == result)
+            if (result == null)
             {
                 // permission to obtain Environment.MachineName is Asserted
                 // since permission to open the connection has been granted
@@ -1172,7 +1172,7 @@ namespace Microsoft.Data.SqlClient
             const int NetLibCount = 8;
 
             Hashtable hash = s_netlibMapping;
-            if (null == hash)
+            if (hash == null)
             {
                 hash = new Hashtable(NetLibCount)
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
@@ -193,13 +193,13 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.TryTraceEvent("SqlDataAdapter.InitializeBatching | API | Object Id {0}", ObjectID);
             _commandSet = new SqlCommandSet();
             SqlCommand command = SelectCommand;
-            if (null == command)
+            if (command == null)
             {
                 command = InsertCommand;
-                if (null == command)
+                if (command == null)
                 {
                     command = UpdateCommand;
-                    if (null == command)
+                    if (command == null)
                     {
                         command = DeleteCommand;
                     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Data.SqlClient
 
                 bool result = false;
 
-                if (null == temp)
+                if (temp == null)
                 { // If passed value null - false.
                     result = false;
                 }
@@ -115,7 +115,7 @@ namespace Microsoft.Data.SqlClient
 
                 bool result = false;
 
-                if (null == temp)
+                if (temp == null)
                 { // If passed value null - false.
                     result = false;
                 }
@@ -158,7 +158,7 @@ namespace Microsoft.Data.SqlClient
 
                 bool result = false;
 
-                if (null == temp)
+                if (temp == null)
                 { // If passed value null - false.
                     result = false;
                 }
@@ -577,7 +577,7 @@ namespace Microsoft.Data.SqlClient
 #endif
                 if (string.IsNullOrEmpty(connectionString))
                 {
-                    if (null == connectionString)
+                    if (connectionString == null)
                     {
                         throw ADP.ArgumentNull(nameof(connectionString));
                     }
@@ -612,7 +612,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     try
                     {
-                        if (null == s_processDispatcher)
+                        if (s_processDispatcher == null)
                         { // Ensure _processDispatcher reference is present - inside lock.
 #if NETFRAMEWORK
                             ObtainProcessDispatcher();
@@ -730,7 +730,7 @@ namespace Microsoft.Data.SqlClient
 #endif
                 if (string.IsNullOrEmpty(connectionString))
                 {
-                    if (null == connectionString)
+                    if (connectionString == null)
                     {
                         throw ADP.ArgumentNull(nameof(connectionString));
                     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -426,7 +426,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                             }
                         }
 
-                        if (null == trans)
+                        if (trans == null)
                         { // Create a new transaction for next operations.
                             trans = _con.BeginTransaction();
                             com.Transaction = trans;
@@ -1281,7 +1281,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
 
             // Ignore SqlConnectionStringBuilder, since it is present largely for debug purposes.
 
-            if (null == temp)
+            if (temp == null)
             { // If passed value null - false.
                 result = false;
             }
@@ -1363,7 +1363,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
     // Private constructor - only called by public constructor for static initialization.
     private SqlDependencyProcessDispatcher(object dummyVariable)
     {
-        Debug.Assert(null == s_staticInstance, "Real constructor called with static instance already created!");
+        Debug.Assert(s_staticInstance == null, "Real constructor called with static instance already created!");
         long scopeID = SqlClientEventSource.Log.TryNotificationScopeEnterEvent("<sc.SqlDependencyProcessDispatcher|DEP> {0}", ObjectID);
         try
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Data.SqlClient
             long scopeID = SqlClientEventSource.Log.TryNotificationScopeEnterEvent("<sc.SqlDependencyPerAppDomainDispatcher.LookupDependencyEntry|DEP> {0}, Key: '{1}'", ObjectID, id);
             try
             {
-                if (null == id)
+                if (id == null)
                 {
                     throw ADP.ArgumentNull(nameof(id));
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlEnclaveSession.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlEnclaveSession.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlEnclaveSession.xml' path='docs/members[@name="SqlEnclaveSession"]/ctor/*' />
         internal SqlEnclaveSession(byte[] sessionKey, long sessionId)
         {
-            if (null == sessionKey)
+            if (sessionKey == null)
             {
                 throw SQL.NullArgumentInConstructorInternal(_sessionKeyName, _className);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -430,7 +430,7 @@ namespace Microsoft.Data.SqlClient
             // Sys.Tx keeps the connection alive until the transaction is completed.
             Debug.Assert(!IsNonPoolableTransactionRoot, "cannot defect an active delegated transaction!");  // potential race condition, but it's an assert
 
-            if (null == tx)
+            if (tx == null)
             {
                 if (IsEnlistedInTransaction)
                 {
@@ -581,7 +581,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    if (null == _whereAbouts)
+                    if (_whereAbouts == null)
                     {
                         byte[] dtcAddress = GetDTCAddress();
                         _whereAbouts = dtcAddress ?? throw SQL.CannotGetDTCAddress();
@@ -644,7 +644,7 @@ namespace Microsoft.Data.SqlClient
             // In either case, when we're working with a 2005 or newer server
             // we better not have a current transaction at this point.
 
-            Debug.Assert(null == CurrentTransaction, "unenlisted transaction with non-null current transaction?");   // verify it!
+            Debug.Assert(CurrentTransaction == null, "unenlisted transaction with non-null current transaction?");   // verify it!
         }
 
         override public void EnlistTransaction(Transaction transaction)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Data.SqlClient
             set
             {
                 MetaType metatype = _metaType;
-                if ((null == metatype) || (metatype.DbType != value))
+                if (metatype == null || (metatype.DbType != value))
                 {
                     PropertyTypeChanging();
                     _metaType = MetaType.GetMetaTypeFromDbType(value);
@@ -608,7 +608,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     throw SQL.InvalidSqlDbType(value);
                 }
-                if ((null == metatype) || (metatype.SqlDbType != value))
+                if (metatype == null || (metatype.SqlDbType != value))
                 {
                     PropertyTypeChanging();
                     _metaType = MetaType.GetMetaTypeFromSqlDbType(value, value == SqlDbType.Structured);
@@ -741,7 +741,7 @@ namespace Microsoft.Data.SqlClient
                 _coercedValue = null;
                 _valueAsINullable = _value as INullable;
                 SetFlag(SqlParameterFlags.IsSqlParameterSqlType, _valueAsINullable != null);
-                SetFlag(SqlParameterFlags.IsNull, (null == _value) || (_value == DBNull.Value) || (HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && _valueAsINullable.IsNull));
+                SetFlag(SqlParameterFlags.IsNull, _value == null || (_value == DBNull.Value) || (HasFlag(SqlParameterFlags.IsSqlParameterSqlType) && _valueAsINullable.IsNull));
                 _udtLoadError = null;
                 _actualSize = -1;
             }
@@ -897,7 +897,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (null == _coercedValue)
+                if (_coercedValue == null)
                 {
                     GetCoercedValue();
                 }
@@ -1346,7 +1346,7 @@ namespace Microsoft.Data.SqlClient
                             if (hasDefault)
                             {
                                 // May have already created props list in unique key handling
-                                if (null == props)
+                                if (props == null)
                                 {
                                     props = new SmiMetaDataPropertyCollection();
                                 }
@@ -1375,7 +1375,7 @@ namespace Microsoft.Data.SqlClient
                                 }
 
                                 // May have already created props list
-                                if (null == props)
+                                if (props == null)
                                 {
                                     props = new SmiMetaDataPropertyCollection();
                                 }
@@ -1877,7 +1877,7 @@ namespace Microsoft.Data.SqlClient
         private SqlDbType GetMetaSqlDbTypeOnly()
         {
             MetaType metaType = _metaType;
-            if (null == metaType)
+            if (metaType == null)
             { // infer the type from the value
                 metaType = MetaType.GetDefaultMetaType();
             }
@@ -1977,7 +1977,7 @@ namespace Microsoft.Data.SqlClient
                 !ADP.IsDirection(this, ParameterDirection.ReturnValue) &&
                 (!metaType.IsFixed) &&
                 !ShouldSerializeSize() &&
-                ((null == _value) || Convert.IsDBNull(_value)) &&
+                (_value == null || Convert.IsDBNull(_value)) &&
                 (SqlDbType != SqlDbType.Timestamp) &&
                 (SqlDbType != SqlDbType.Udt) &&
                 // BUG: (VSTFDevDiv - 479609): Output parameter with size 0 throws for XML, TEXT, NTEXT, IMAGE.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlReferenceCollection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlReferenceCollection.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (command is null)
             {
-                // if null == command, will find first live datareader
+                // if command is null, will find first live datareader
                 return FindItem(DataReaderTag, s_hasOpenReaderFunc);
             }
             else

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Data.SqlClient
         /// <returns>returns true if both the arrays have the same byte values else returns false</returns>
         internal static bool CompareBytes(byte[] buffer1, byte[] buffer2, int buffer2Index, int lengthToCompare)
         {
-            if (null == buffer1 || null == buffer2)
+            if (buffer1 == null || buffer2 == null)
             {
                 return false;
             }
@@ -140,7 +140,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (TdsEnums.CustomCipherAlgorithmId == cipherAlgorithmId)
             {
-                if (null == cipherAlgorithmName)
+                if (cipherAlgorithmName == null)
                 {
                     throw SQL.NullColumnEncryptionAlgorithm(SqlClientEncryptionAlgorithmFactoryList.GetInstance().GetRegisteredCipherAlgorithmNames());
                 }
@@ -178,7 +178,7 @@ namespace Microsoft.Data.SqlClient
 
             Debug.Assert(md.IsAlgorithmInitialized(), "Encryption Algorithm is not initialized");
             byte[] cipherText = md.CipherAlgorithm.EncryptData(plainText); // this call succeeds or throws.
-            if (null == cipherText || 0 == cipherText.Length)
+            if (cipherText == null || 0 == cipherText.Length)
             {
                 throw SQL.NullCipherText();
             }
@@ -217,7 +217,7 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 byte[] plainText = md.CipherAlgorithm.DecryptData(cipherText); // this call succeeds or throws.
-                if (null == plainText)
+                if (plainText == null)
                 {
                     throw SQL.NullPlainText();
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlStream.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlStream.cs
@@ -76,11 +76,11 @@ namespace Microsoft.Data.SqlClient
             int intCount = 0;
             int cBufferedData = 0;
 
-            if (null == _reader)
+            if (_reader == null)
             {
                 throw ADP.StreamClosed();
             }
-            if (null == buffer)
+            if (buffer == null)
             {
                 throw ADP.ArgumentNull(nameof(buffer));
             }
@@ -305,7 +305,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                if (null == _cachedBytes)
+                if (_cachedBytes == null)
                 {
                     throw ADP.StreamClosed(ADP.ParameterSetPosition);
                 }
@@ -337,12 +337,12 @@ namespace Microsoft.Data.SqlClient
             int cb;
             int intCount = 0;
 
-            if (null == _cachedBytes)
+            if (_cachedBytes == null)
             {
                 throw ADP.StreamClosed();
             }
 
-            if (null == buffer)
+            if (buffer == null)
             {
                 throw ADP.ArgumentNull(nameof(buffer));
             }
@@ -394,7 +394,7 @@ namespace Microsoft.Data.SqlClient
         {
             long pos = 0;
 
-            if (null == _cachedBytes)
+            if (_cachedBytes == null)
             {
                 throw ADP.StreamClosed();
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                return (null == _freeStateObjects);
+                return _freeStateObjects == null;
             }
         }
 
@@ -212,7 +212,7 @@ namespace Microsoft.Data.SqlClient
             return string.Format(/*IFormatProvider*/ null,
                         "(ObjID={0}, free={1}, cached={2}, total={3})",
                         _objectID,
-                        null == _freeStateObjects ? "(null)" : _freeStateObjectCount.ToString((IFormatProvider)null),
+                        _freeStateObjects == null ? "(null)" : _freeStateObjectCount.ToString((IFormatProvider)null),
                         _cachedCount,
                         _cache.Count);
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -1654,7 +1654,7 @@ namespace Microsoft.Data.SqlClient
             TdsParser.ReliabilitySection.Assert("unreliable call to ReadStringWithEncoding");  // you need to setup for a thread abort somewhere before you call this method
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
 
-            if (null == encoding)
+            if (encoding == null)
             {
                 // Need to skip the current column before throwing the error - this ensures that the state shared between this and the data reader is consistent when calling DrainData
                 if (isPlp)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            if (null == nicAddress)
+            if (nicAddress == null)
             {
                 nicAddress = new byte[TdsEnums.MAX_NIC_SIZE];
                 Random random = new Random();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsValueSetter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsValueSetter.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Data.SqlClient
             // ANSI types must convert to byte[] because that's the tool we have.
             if (MetaDataUtilsSmi.IsAnsiType(_metaData.SqlDbType))
             {
-                if (null == _encoder)
+                if (_encoder == null)
                 {
                     _encoder = _stateObj.Parser._defaultEncoding.GetEncoder();
                 }
@@ -452,7 +452,7 @@ namespace Microsoft.Data.SqlClient
                 SmiXetterAccessMap.IsSetterAccessValid(_metaData, SmiXetterTypeCode.XetInt64));
             if (SqlDbType.Variant == _metaData.SqlDbType)
             {
-                if (null == _variantType)
+                if (_variantType == null)
                 {
                     _stateObj.Parser.WriteSqlVariantHeader(10, TdsEnums.SQLINT8, 0, _stateObj);
                     _stateObj.Parser.WriteLong(value, _stateObj);
@@ -735,7 +735,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void SetVariantType(SmiMetaData value)
         {
-            Debug.Assert(null == _variantType, "Variant type can only be set once");
+            Debug.Assert(_variantType == null, "Variant type can only be set once");
             Debug.Assert(value != null &&
                 (value.SqlDbType == SqlDbType.Money ||
                 value.SqlDbType == SqlDbType.NVarChar ||

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static string GetAccessToken()
         {
-            if (null == AADAccessToken && IsAADPasswordConnStrSetup() && IsAADAuthorityURLSetup())
+            if (AADAccessToken == null && IsAADPasswordConnStrSetup() && IsAADAuthorityURLSetup())
             {
                 string username = RetrieveValueFromConnStr(AADPasswordConnectionString, new string[] { "User ID", "UID" });
                 string password = RetrieveValueFromConnStr(AADPasswordConnectionString, new string[] { "Password", "PWD" });
@@ -655,7 +655,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static string GetSystemIdentityAccessToken()
         {
-            if (ManagedIdentitySupported && SupportsSystemAssignedManagedIdentity && null == AADSystemIdentityAccessToken && IsAADPasswordConnStrSetup())
+            if (ManagedIdentitySupported && SupportsSystemAssignedManagedIdentity && AADSystemIdentityAccessToken == null && IsAADPasswordConnStrSetup())
             {
                 AADSystemIdentityAccessToken = AADUtility.GetManagedIdentityToken().GetAwaiter().GetResult();
                 if (AADSystemIdentityAccessToken == null)
@@ -668,7 +668,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static string GetUserIdentityAccessToken()
         {
-            if (ManagedIdentitySupported && null == AADUserIdentityAccessToken && IsAADPasswordConnStrSetup())
+            if (ManagedIdentitySupported && AADUserIdentityAccessToken == null && IsAADPasswordConnStrSetup())
             {
                 // Pass User Assigned Managed Identity Client Id here.
                 AADUserIdentityAccessToken = AADUtility.GetManagedIdentityToken(UserManagedIdentityClientId).GetAwaiter().GetResult();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/MultipleResultsTest/MultipleResultsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/MultipleResultsTest/MultipleResultsTest.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private string AssemblyFilter(StreamWriter writer)
         {
-            if (null == _outputBuilder)
+            if (_outputBuilder == null)
             {
                 _outputBuilder = new StringBuilder();
             }
@@ -279,7 +279,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private void AssemblyFilter(StringBuilder builder)
         {
             string[] filter = _outputFilter;
-            if (null == filter)
+            if (filter == null)
             {
                 filter = new string[5];
                 string tmp = typeof(System.Guid).AssemblyQualifiedName;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AdapterTest/AdapterTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AdapterTest/AdapterTest.cs
@@ -1643,7 +1643,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 return;
             }
-            if (null == value)
+            if (value == null)
             {
                 textBuilder.Append("DEFAULT");
             }
@@ -1847,7 +1847,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                                 if (property.CanRead)
                                 {
                                     ParameterInfo[] parameters = property.GetIndexParameters();
-                                    if ((null == parameters) || (0 == parameters.Length))
+                                    if (parameters == null || (0 == parameters.Length))
                                     {
                                         AppendNewLineIndent(textBuilder, indent + 1);
                                         textBuilder.Append(property.Name);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
@@ -1034,7 +1034,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 object value = row[i];
                 Type t;
-                if ((null == value || DBNull.Value == value))
+                if (value == null || DBNull.Value == value)
                 {
                     if (lastRowTypes[i] == null)
                     {
@@ -1310,7 +1310,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     }
                 }
 
-                if (null == targetTable)
+                if (targetTable == null)
                 {
                     targetTable = CreateNewTable(row, ref valueTypes);
                     if (null != targetTable)
@@ -1345,10 +1345,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private bool IsNull(object value)
         {
-            return null == value ||
-                    DBNull.Value == value ||
-                    (value is INullable nullable &&
-                     nullable.IsNull);
+            return value == null ||
+                   DBNull.Value == value ||
+                   (value is INullable nullable && nullable.IsNull);
         }
 
         private SqlMetaData PermToSqlMetaData(StePermutation perm)
@@ -1417,11 +1416,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private void ReportMismatch(object source, object result, StePermutation perm)
         {
-            if (null == source)
+            if (source == null)
             {
                 source = "(null)";
             }
-            if (null == result)
+            if (result == null)
             {
                 result = "(null)";
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/InvalidAccessFromEvent.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/InvalidAccessFromEvent.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             bool hitException = false;
             try
             {
-                if (null == _tx || null == _tx.Connection)
+                if (_tx == null || _tx.Connection == null)
                 {
                     _tx = _dstConn.BeginTransaction();
                     _dstcmd.Transaction = _tx;


### PR DESCRIPTION
**Description**: This PR is part of a series that aims to remove "yoda conditions" from the codebase. In my opinion, these make the code harder to read due to the natural tendency to read an if condition like "x equals y". In this case "null equals x" is unnatural compared to "x equals null". In most if not all cases, there is no semantic difference between `x == null` and `null == x`, meaning these changes can be safely made without impact to the behavior.

**AI Analysis**: Since this PR is large and boring for people to review, I ran the patch through a large language model to ask it to assess the safety of it. Here's is its analysis:

![image](https://github.com/user-attachments/assets/a3009ff2-84c0-4354-98c6-aec57e6887f2)

**Testing**: The code builds, I will wait for CI to verify it more thoroughly.

_Note, this is only part 1 of several parts_