### PR TITLE
Code Cleanup | Fixing Inconsistent Modifiers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -132,6 +132,9 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
+# Ensure consistent member modifier order
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+
 # Xml project files
 
 # CA1063: Implement IDisposable Correctly

--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/SqlColumnEncryptionAzureKeyVaultProvider.cs
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/SqlColumnEncryptionAzureKeyVaultProvider.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
         /// <summary>
         /// Algorithm version
         /// </summary>
-        private readonly static byte[] s_firstVersion = new byte[] { 0x01 };
+        private static readonly byte[] s_firstVersion = new byte[] { 0x01 };
 
-        private readonly static KeyWrapAlgorithm s_keyWrapAlgorithm = KeyWrapAlgorithm.RsaOaep;
+        private static readonly KeyWrapAlgorithm s_keyWrapAlgorithm = KeyWrapAlgorithm.RsaOaep;
 
         /// <summary>
         /// List of Trusted Endpoints

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.Manual.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.Manual.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Data.SqlClient
     {
         // SqlCommand expects IDisposable methods to be implemented via System.ComponentModel.Component, which it no longer inherits from
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Dispose/*'/>
-        override protected void Dispose(bool disposing) { }
+        protected override void Dispose(bool disposing) { }
     }
     public sealed partial class SqlConnection : System.Data.Common.DbConnection
     {
         // SqlConnection expects IDisposable methods to be implemented via System.ComponentModel.Component, which it no longer inherits from
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/Dispose/*'/>
-        override protected void Dispose(bool disposing) { }
+        protected override void Dispose(bool disposing) { }
     }
     [System.ComponentModel.TypeConverter(typeof(SqlParameterConverter))]
     public sealed partial class SqlParameter

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/CoreLib/Microsoft/Win32/SafeHandles/SafeLibraryHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/CoreLib/Microsoft/Win32/SafeHandles/SafeLibraryHandle.cs
@@ -4,11 +4,11 @@
 
 namespace Microsoft.Win32.SafeHandles
 {
-    sealed internal class SafeLibraryHandle : SafeHandleZeroOrMinusOneIsInvalid
+    internal sealed class SafeLibraryHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         internal SafeLibraryHandle() : base(true) { }
 
-        override protected bool ReleaseHandle()
+        protected override bool ReleaseHandle()
         {
             return Interop.Kernel32.FreeLibrary(handle);
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/NtDll/Interop.NtCreateFile.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/NtDll/Interop.NtCreateFile.cs
@@ -12,7 +12,7 @@ internal partial class Interop
         // https://msdn.microsoft.com/en-us/library/bb432380.aspx
         // https://msdn.microsoft.com/en-us/library/windows/hardware/ff566424.aspx
         [DllImport(Libraries.NtDll, CharSet = CharSet.Unicode, ExactSpelling = true)]
-        private unsafe static extern int NtCreateFile(
+        private static extern unsafe int NtCreateFile(
             out IntPtr FileHandle,
             DesiredAccess DesiredAccess,
             ref OBJECT_ATTRIBUTES ObjectAttributes,
@@ -25,7 +25,7 @@ internal partial class Interop
             void* EaBuffer,
             uint EaLength);
 
-        internal unsafe static (int status, IntPtr handle) CreateFile(
+        internal static unsafe (int status, IntPtr handle) CreateFile(
             ReadOnlySpan<char> path,
             IntPtr rootDirectory,
             CreateDisposition createDisposition,

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/NtDll/Interop.RtlNtStatusToDosError.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/NtDll/Interop.RtlNtStatusToDosError.cs
@@ -11,7 +11,7 @@ internal partial class Interop
     {
         // https://msdn.microsoft.com/en-us/library/windows/desktop/ms680600(v=vs.85).aspx
         [DllImport(Libraries.NtDll, ExactSpelling = true)]
-        public unsafe static extern uint RtlNtStatusToDosError(
+        public static extern unsafe uint RtlNtStatusToDosError(
             int Status);
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/kernel32/Interop.CTL_CODE.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Interop/Windows/kernel32/Interop.CTL_CODE.cs
@@ -13,7 +13,7 @@ internal partial class Interop
         /// <param name="function">Identifies the function to be performed by the driver. Values of less than 0x800 are reserved for Microsoft. Values of 0x800 and higher can be used by vendors.</param>
         /// <param name="method">Indicates how the system will pass data between the caller of DeviceIoControl (or IoBuildDeviceIoControlRequest) and the driver that handles the IRP.</param>
         /// <param name="access">Indicates the type of access that a caller must request when opening the file object that represents the device (see IRP_MJ_CREATE).</param>
-        internal unsafe static uint CTL_CODE(
+        internal static unsafe uint CTL_CODE(
             ushort deviceType,
             ushort function,
             byte method,

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Data.ProviderBase
 {
-    abstract internal partial class DbConnectionClosed : DbConnectionInternal
+    internal abstract partial class DbConnectionClosed : DbConnectionInternal
     {
         // Construct an "empty" connection
         protected DbConnectionClosed(ConnectionState state, bool hidePassword, bool allowSetConnectionString) : base(state, hidePassword, allowSetConnectionString)
@@ -39,7 +39,7 @@ namespace Microsoft.Data.ProviderBase
             => base.TryOpenConnectionInternal(outerConnection, connectionFactory, retry, userOptions);
     }
 
-    abstract internal class DbConnectionBusy : DbConnectionClosed
+    internal abstract class DbConnectionBusy : DbConnectionClosed
     {
         protected DbConnectionBusy(ConnectionState state) : base(state, true, false)
         {
@@ -49,7 +49,7 @@ namespace Microsoft.Data.ProviderBase
             => throw ADP.ConnectionAlreadyOpen(State);
     }
 
-    sealed internal class DbConnectionClosedBusy : DbConnectionBusy
+    internal sealed class DbConnectionClosedBusy : DbConnectionBusy
     {
         // Closed Connection, Currently Busy - changing connection string
         internal static readonly DbConnectionInternal SingletonInstance = new DbConnectionClosedBusy();   // singleton object
@@ -59,7 +59,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    sealed internal class DbConnectionOpenBusy : DbConnectionBusy
+    internal sealed class DbConnectionOpenBusy : DbConnectionBusy
     {
         // Open Connection, Currently Busy - closing connection
         internal static readonly DbConnectionInternal SingletonInstance = new DbConnectionOpenBusy();   // singleton object
@@ -69,7 +69,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    sealed internal class DbConnectionClosedConnecting : DbConnectionBusy
+    internal sealed class DbConnectionClosedConnecting : DbConnectionBusy
     {
         // Closed Connection, Currently Connecting
 
@@ -113,7 +113,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    sealed internal class DbConnectionClosedNeverOpened : DbConnectionClosed
+    internal sealed class DbConnectionClosedNeverOpened : DbConnectionClosed
     {
         // Closed Connection, Has Never Been Opened
 
@@ -124,7 +124,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    sealed internal class DbConnectionClosedPreviouslyOpened : DbConnectionClosed
+    internal sealed class DbConnectionClosedPreviouslyOpened : DbConnectionClosed
     {
         // Closed Connection, Has Previously Been Opened
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Data.ProviderBase
         }
 
 
-        abstract public DbProviderFactory ProviderFactory
+        public abstract DbProviderFactory ProviderFactory
         {
             get;
         }
@@ -130,7 +130,7 @@ namespace Microsoft.Data.ProviderBase
             return newConnection;
         }
 
-        virtual internal DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(DbConnectionOptions connectionOptions)
+        internal virtual DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(DbConnectionOptions connectionOptions)
         {
             return null;
         }
@@ -412,7 +412,7 @@ namespace Microsoft.Data.ProviderBase
             SqlClientEventSource.Log.ExitActiveConnectionPoolGroup();
         }
 
-        virtual protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
+        protected virtual DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
         {
             return CreateConnection(options, poolKey, poolGroupProviderInfo, pool, owningConnection);
         }
@@ -447,29 +447,29 @@ namespace Microsoft.Data.ProviderBase
             throw ADP.NotSupported();
         }
 
-        abstract protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection);
+        protected abstract DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection);
 
-        abstract protected DbConnectionOptions CreateConnectionOptions(string connectionString, DbConnectionOptions previous);
+        protected abstract DbConnectionOptions CreateConnectionOptions(string connectionString, DbConnectionOptions previous);
 
-        abstract protected DbConnectionPoolGroupOptions CreateConnectionPoolGroupOptions(DbConnectionOptions options);
+        protected abstract DbConnectionPoolGroupOptions CreateConnectionPoolGroupOptions(DbConnectionOptions options);
 
-        abstract internal DbConnectionPoolGroup GetConnectionPoolGroup(DbConnection connection);
+        internal abstract DbConnectionPoolGroup GetConnectionPoolGroup(DbConnection connection);
 
-        abstract internal DbConnectionInternal GetInnerConnection(DbConnection connection);
+        internal abstract DbConnectionInternal GetInnerConnection(DbConnection connection);
 
-        abstract protected int GetObjectId(DbConnection conne);
+        protected abstract int GetObjectId(DbConnection conne);
 
-        abstract internal void PermissionDemand(DbConnection outerConnection);
+        internal abstract void PermissionDemand(DbConnection outerConnection);
 
-        abstract internal void SetConnectionPoolGroup(DbConnection outerConnection, DbConnectionPoolGroup poolGroup);
+        internal abstract void SetConnectionPoolGroup(DbConnection outerConnection, DbConnectionPoolGroup poolGroup);
 
-        abstract internal void SetInnerConnectionEvent(DbConnection owningObject, DbConnectionInternal to);
+        internal abstract void SetInnerConnectionEvent(DbConnection owningObject, DbConnectionInternal to);
 
-        abstract internal bool SetInnerConnectionFrom(DbConnection owningObject, DbConnectionInternal to, DbConnectionInternal from);
+        internal abstract bool SetInnerConnectionFrom(DbConnection owningObject, DbConnectionInternal to, DbConnectionInternal from);
 
-        abstract internal void SetInnerConnectionTo(DbConnection owningObject, DbConnectionInternal to);
+        internal abstract void SetInnerConnectionTo(DbConnection owningObject, DbConnectionInternal to);
 
-        virtual internal void Unload()
+        internal virtual void Unload()
         {
             _pruningTimer.Dispose();
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -146,13 +146,13 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        abstract public string ServerVersion
+        public abstract string ServerVersion
         {
             get;
         }
 
         // this should be abstract but until it is added to all the providers virtual will have to do
-        virtual public string ServerVersionNormalized
+        public virtual string ServerVersionNormalized
         {
             get
             {
@@ -189,39 +189,39 @@ namespace Microsoft.Data.ProviderBase
             _referenceCollection.Add(value, tag);
         }
 
-        abstract public DbTransaction BeginTransaction(System.Data.IsolationLevel il);
+        public abstract DbTransaction BeginTransaction(System.Data.IsolationLevel il);
 
-        virtual public void ChangeDatabase(string value)
+        public virtual void ChangeDatabase(string value)
         {
             throw ADP.MethodNotImplemented();
         }
 
-        virtual internal void PrepareForReplaceConnection()
+        internal virtual void PrepareForReplaceConnection()
         {
             // By default, there is no preparation required
         }
 
-        virtual protected void PrepareForCloseConnection()
+        protected virtual void PrepareForCloseConnection()
         {
             // By default, there is no preparation required
         }
 
-        virtual protected bool ObtainAdditionalLocksForClose()
+        protected virtual bool ObtainAdditionalLocksForClose()
         {
             return false; // no additional locks in default implementation
         }
 
-        virtual protected void ReleaseAdditionalLocksForClose(bool lockToken)
+        protected virtual void ReleaseAdditionalLocksForClose(bool lockToken)
         {
             // no additional locks in default implementation
         }
 
-        virtual protected DbReferenceCollection CreateReferenceCollection()
+        protected virtual DbReferenceCollection CreateReferenceCollection()
         {
             throw ADP.InternalError(ADP.InternalErrorCode.AttemptingToConstructReferenceCollectionOnStaticObject);
         }
 
-        abstract protected void Deactivate();
+        protected abstract void Deactivate();
 
         internal void DeactivateConnection()
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -422,7 +422,7 @@ namespace System.Net
             Debug.Assert(IsEnabled || arg == null, $"Should not be formatting FormattableString \"{arg}\" if tracing isn't enabled");
         }
 
-        public static new bool IsEnabled =>
+        public new static bool IsEnabled =>
             Log.IsEnabled();
         //true; // uncomment for debugging only
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        virtual protected bool UnbindOnTransactionCompletion
+        protected virtual bool UnbindOnTransactionCompletion
         {
             get
             {
@@ -180,7 +180,7 @@ namespace Microsoft.Data.ProviderBase
         }
 
         // Is this a connection that must be put in stasis (or is already in stasis) pending the end of it's transaction?
-        virtual protected internal bool IsNonPoolableTransactionRoot
+        protected internal virtual bool IsNonPoolableTransactionRoot
         {
             get
             {
@@ -188,7 +188,7 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        virtual internal bool IsTransactionRoot
+        internal virtual bool IsTransactionRoot
         {
             get
             {
@@ -196,7 +196,7 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        virtual protected bool ReadyToPrepareTransaction
+        protected virtual bool ReadyToPrepareTransaction
         {
             get
             {
@@ -206,7 +206,7 @@ namespace Microsoft.Data.ProviderBase
 
         internal virtual bool IsAccessTokenExpired => false;
 
-        abstract protected void Activate(Transaction transaction);
+        protected abstract void Activate(Transaction transaction);
 
         internal void ActivateConnection(Transaction transaction)
         {
@@ -331,7 +331,7 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        virtual internal void DelegatedTransactionEnded()
+        internal virtual void DelegatedTransactionEnded()
         {
             // Called by System.Transactions when the delegated transaction has
             // completed.  We need to make closed connections that are in stasis
@@ -399,12 +399,12 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        abstract public void EnlistTransaction(Transaction transaction);
+        public abstract void EnlistTransaction(Transaction transaction);
 
         // Cleanup connection's transaction-specific structures (currently used by Delegated transaction).
         //  This is a separate method because cleanup can be triggered in multiple ways for a delegated
         //  transaction.
-        virtual protected void CleanupTransactionOnCompletion(Transaction transaction)
+        protected virtual void CleanupTransactionOnCompletion(Transaction transaction)
         {
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -15,7 +15,7 @@ using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Data.ProviderBase
 {
-    sealed internal partial class DbConnectionPool
+    internal sealed partial class DbConnectionPool
     {
         private enum State
         {
@@ -27,7 +27,7 @@ namespace Microsoft.Data.ProviderBase
         // This class is a way to stash our cloned Tx key for later disposal when it's no longer needed.
         // We can't get at the key in the dictionary without enumerating entries, so we stash an extra
         // copy as part of the value.
-        sealed private class TransactedConnectionList : List<DbConnectionInternal>
+        private sealed class TransactedConnectionList : List<DbConnectionInternal>
         {
             private Transaction _transaction;
             internal TransactedConnectionList(int initialAllocation, Transaction tx) : base(initialAllocation)
@@ -59,7 +59,7 @@ namespace Microsoft.Data.ProviderBase
             public DbConnectionOptions UserOptions { get; private set; }
         }
 
-        sealed private class TransactedConnectionPool
+        private sealed class TransactedConnectionPool
         {
             Dictionary<Transaction, TransactedConnectionList> _transactedCxns;
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPoolIdentity.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPoolIdentity.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.Data.ProviderBase
 {
-    sealed internal partial class DbConnectionPoolIdentity
+    internal sealed partial class DbConnectionPoolIdentity
     {
         public static readonly DbConnectionPoolIdentity NoIdentity = new DbConnectionPoolIdentity(string.Empty, false, true);
 
@@ -27,7 +27,7 @@ namespace Microsoft.Data.ProviderBase
         }
 
 
-        override public bool Equals(object value)
+        public override bool Equals(object value)
         {
             bool result = ((this == NoIdentity) || (this == value));
             if (!result && value != null)
@@ -38,7 +38,7 @@ namespace Microsoft.Data.ProviderBase
             return result;
         }
 
-        override public int GetHashCode()
+        public override int GetHashCode()
         {
             return _hashCode;
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AlwaysEncryptedHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AlwaysEncryptedHelperClasses.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal partial class _SqlMetaDataSet
+    internal sealed partial class _SqlMetaDataSet
     {
         internal readonly SqlTceCipherInfoTable cekTable; // table of "column encryption keys" used for this metadataset
 
@@ -468,7 +468,7 @@ namespace Microsoft.Data.SqlClient
     /// <summary>
     /// Class encapsulating additional information when sending encrypted input parameters.
     /// </summary>
-    sealed internal class SqlColumnEncryptionInputParameterInfo
+    internal sealed class SqlColumnEncryptionInputParameterInfo
     {
         /// <summary>
         /// Metadata of the parameter to write the TYPE_INFO of the unencrypted column data type.

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -477,7 +477,7 @@ namespace Microsoft.Data.SqlClient
         [DefaultValue(null)]
         [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data)]
         [ResDescription(StringsHelper.ResourceNames.DbCommand_Connection)]
-        new public SqlConnection Connection
+        public new SqlConnection Connection
         {
             get
             {
@@ -610,7 +610,7 @@ namespace Microsoft.Data.SqlClient
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [ResDescription(StringsHelper.ResourceNames.DbCommand_Transaction)]
-        new public SqlTransaction Transaction
+        public new SqlTransaction Transaction
         {
             get
             {
@@ -779,7 +779,7 @@ namespace Microsoft.Data.SqlClient
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data)]
         [ResDescription(StringsHelper.ResourceNames.DbCommand_Parameters)]
-        new public SqlParameterCollection Parameters
+        public new SqlParameterCollection Parameters
         {
             get
             {
@@ -1088,7 +1088,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/CreateParameter/*'/>
-        new public SqlParameter CreateParameter()
+        public new SqlParameter CreateParameter()
         {
             return new SqlParameter();
         }
@@ -2052,7 +2052,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReader[@name="default"]/*'/>
-        new public SqlDataReader ExecuteReader()
+        public new SqlDataReader ExecuteReader()
         {
             SqlStatistics statistics = null;
             SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.ExecuteReader | API | Correlation | ObjectID {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
@@ -2068,7 +2068,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReader[@name="CommandBehavior"]/*'/>
-        new public SqlDataReader ExecuteReader(CommandBehavior behavior)
+        public new SqlDataReader ExecuteReader(CommandBehavior behavior)
         {
             // Reset _pendingCancel upon entry into any Execute - used to synchronize state
             // between entry into Execute* API and the thread obtaining the stateObject.
@@ -2680,25 +2680,25 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="default"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync()
+        public new Task<SqlDataReader> ExecuteReaderAsync()
         {
             return ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="CommandBehavior"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
+        public new Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
         {
             return ExecuteReaderAsync(behavior, CancellationToken.None);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="CancellationToken"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
+        public new Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
         {
             return ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="commandBehaviorAndCancellationToken"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+        public new Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
             => IsProviderRetriable ?
                 InternalExecuteReaderWithRetryAsync(behavior, cancellationToken) :
                 InternalExecuteReaderAsync(behavior, cancellationToken);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1151,14 +1151,14 @@ namespace Microsoft.Data.SqlClient
         // PUBLIC METHODS
         //
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/BeginTransaction2/*' />
-        new public SqlTransaction BeginTransaction()
+        public new SqlTransaction BeginTransaction()
         {
             // this is just a delegate. The actual method tracks executiontime
             return BeginTransaction(System.Data.IsolationLevel.Unspecified, null);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/BeginTransactionIso/*' />
-        new public SqlTransaction BeginTransaction(System.Data.IsolationLevel iso)
+        public new SqlTransaction BeginTransaction(System.Data.IsolationLevel iso)
         {
             // this is just a delegate. The actual method tracks executiontime
             return BeginTransaction(iso, null);
@@ -1176,7 +1176,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/BeginDbTransaction/*' />
         [SuppressMessage("Microsoft.Reliability", "CA2004:RemoveCallsToGCKeepAlive")]
-        override protected DbTransaction BeginDbTransaction(System.Data.IsolationLevel isolationLevel)
+        protected override DbTransaction BeginDbTransaction(System.Data.IsolationLevel isolationLevel)
         {
             using (TryEventScope.Create("SqlConnection.BeginDbTransaction | API | Object Id {0}, Isolation Level {1}", ObjectID, (int)isolationLevel))
             {
@@ -1357,7 +1357,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/CreateCommand/*' />
-        new public SqlCommand CreateCommand()
+        public new SqlCommand CreateCommand()
         {
             return new SqlCommand(null, this);
         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -11,7 +11,7 @@ using Microsoft.Data.ProviderBase;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal partial class SqlConnectionFactory : DbConnectionFactory
+    internal sealed partial class SqlConnectionFactory : DbConnectionFactory
     {
 
         private const string _metaDataXml = "MetaDataXml";
@@ -23,7 +23,7 @@ namespace Microsoft.Data.SqlClient
 
         public static readonly SqlConnectionFactory SingletonInstance = new SqlConnectionFactory();
 
-        override public DbProviderFactory ProviderFactory
+        public override DbProviderFactory ProviderFactory
         {
             get
             {
@@ -31,12 +31,12 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection)
+        protected override DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection)
         {
             return CreateConnection(options, poolKey, poolGroupProviderInfo, pool, owningConnection, userOptions: null);
         }
 
-        override protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
+        protected override DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
         {
             SqlConnectionString opt = (SqlConnectionString)options;
             SqlConnectionPoolKey key = (SqlConnectionPoolKey)poolKey;
@@ -142,7 +142,7 @@ namespace Microsoft.Data.SqlClient
             return result;
         }
 
-        override internal DbConnectionPoolProviderInfo CreateConnectionPoolProviderInfo(DbConnectionOptions connectionOptions)
+        internal override DbConnectionPoolProviderInfo CreateConnectionPoolProviderInfo(DbConnectionOptions connectionOptions)
         {
             DbConnectionPoolProviderInfo providerInfo = null;
 
@@ -154,7 +154,7 @@ namespace Microsoft.Data.SqlClient
             return providerInfo;
         }
 
-        override protected DbConnectionPoolGroupOptions CreateConnectionPoolGroupOptions(DbConnectionOptions connectionOptions)
+        protected override DbConnectionPoolGroupOptions CreateConnectionPoolGroupOptions(DbConnectionOptions connectionOptions)
         {
             SqlConnectionString opt = (SqlConnectionString)connectionOptions;
 
@@ -198,7 +198,7 @@ namespace Microsoft.Data.SqlClient
         }
 
 
-        override internal DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(DbConnectionOptions connectionOptions)
+        internal override DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(DbConnectionOptions connectionOptions)
         {
             return new SqlConnectionPoolGroupProviderInfo((SqlConnectionString)connectionOptions);
         }
@@ -219,7 +219,7 @@ namespace Microsoft.Data.SqlClient
         }
 
 
-        override internal DbConnectionPoolGroup GetConnectionPoolGroup(DbConnection connection)
+        internal override DbConnectionPoolGroup GetConnectionPoolGroup(DbConnection connection)
         {
             SqlConnection c = (connection as SqlConnection);
             if (c != null)
@@ -229,7 +229,7 @@ namespace Microsoft.Data.SqlClient
             return null;
         }
 
-        override internal DbConnectionInternal GetInnerConnection(DbConnection connection)
+        internal override DbConnectionInternal GetInnerConnection(DbConnection connection)
         {
             SqlConnection c = (connection as SqlConnection);
             if (c != null)
@@ -239,7 +239,7 @@ namespace Microsoft.Data.SqlClient
             return null;
         }
 
-        override protected int GetObjectId(DbConnection connection)
+        protected override int GetObjectId(DbConnection connection)
         {
             SqlConnection c = (connection as SqlConnection);
             if (c != null)
@@ -249,7 +249,7 @@ namespace Microsoft.Data.SqlClient
             return 0;
         }
 
-        override internal void PermissionDemand(DbConnection outerConnection)
+        internal override void PermissionDemand(DbConnection outerConnection)
         {
             SqlConnection c = (outerConnection as SqlConnection);
             if (c != null)
@@ -258,7 +258,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal void SetConnectionPoolGroup(DbConnection outerConnection, DbConnectionPoolGroup poolGroup)
+        internal override void SetConnectionPoolGroup(DbConnection outerConnection, DbConnectionPoolGroup poolGroup)
         {
             SqlConnection c = (outerConnection as SqlConnection);
             if (c != null)
@@ -267,7 +267,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal void SetInnerConnectionEvent(DbConnection owningObject, DbConnectionInternal to)
+        internal override void SetInnerConnectionEvent(DbConnection owningObject, DbConnectionInternal to)
         {
             SqlConnection c = (owningObject as SqlConnection);
             if (c != null)
@@ -276,7 +276,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool SetInnerConnectionFrom(DbConnection owningObject, DbConnectionInternal to, DbConnectionInternal from)
+        internal override bool SetInnerConnectionFrom(DbConnection owningObject, DbConnectionInternal to, DbConnectionInternal from)
         {
             SqlConnection c = (owningObject as SqlConnection);
             if (c != null)
@@ -286,7 +286,7 @@ namespace Microsoft.Data.SqlClient
             return false;
         }
 
-        override internal void SetInnerConnectionTo(DbConnection owningObject, DbConnectionInternal to)
+        internal override void SetInnerConnectionTo(DbConnection owningObject, DbConnectionInternal to)
         {
             SqlConnection c = (owningObject as SqlConnection);
             if (c != null)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/CreateDbCommand/*' />
-        override protected DbCommand CreateDbCommand()
+        protected override DbCommand CreateDbCommand()
         {
             using (TryEventScope.Create("<prov.DbConnectionHelper.CreateDbCommand|API> {0}", ObjectID))
             {
@@ -164,7 +164,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/Dispose/*' />
-        override protected void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing)
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Data.SqlClient
         public SensitivityClassification SensitivityClassification { get; internal set; }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Depth/*' />
-        override public int Depth
+        public override int Depth
         {
             get
             {
@@ -163,7 +163,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/FieldCount/*' />
         // fields/attributes collection
-        override public int FieldCount
+        public override int FieldCount
         {
             get
             {
@@ -186,7 +186,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/HasRows/*' />
-        override public bool HasRows
+        public override bool HasRows
         {
             get
             {
@@ -204,7 +204,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/IsClosed/*' />
-        override public bool IsClosed
+        public override bool IsClosed
         {
             get
             {
@@ -350,7 +350,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/RecordsAffected/*' />
-        override public int RecordsAffected
+        public override int RecordsAffected
         {
             get
             {
@@ -393,7 +393,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/VisibleFieldCount/*' />
-        override public int VisibleFieldCount
+        public override int VisibleFieldCount
         {
             get
             {
@@ -412,7 +412,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/ItemI/*' />
         // this operator
-        override public object this[int i]
+        public override object this[int i]
         {
             get
             {
@@ -421,7 +421,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/ItemName/*' />
-        override public object this[string name]
+        public override object this[string name]
         {
             get
             {
@@ -1099,7 +1099,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        virtual internal void CloseReaderFromConnection()
+        internal virtual void CloseReaderFromConnection()
         {
             var parser = _parser;
             Debug.Assert(parser == null || parser.State != TdsParserState.OpenNotLoggedIn, "Reader on a connection that is not logged in");
@@ -1168,7 +1168,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDataTypeName/*' />
-        override public string GetDataTypeName(int i)
+        public override string GetDataTypeName(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -1235,7 +1235,7 @@ namespace Microsoft.Data.SqlClient
             return dataTypeName;
         }
 
-        virtual internal SqlBuffer.StorageType GetVariantInternalStorageType(int i)
+        internal virtual SqlBuffer.StorageType GetVariantInternalStorageType(int i)
         {
             Debug.Assert(_data != null, "Attempting to get variant internal storage type");
             Debug.Assert(i < _data.Length, "Reading beyond data length?");
@@ -1244,7 +1244,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetEnumerator/*' />
-        override public IEnumerator GetEnumerator()
+        public override IEnumerator GetEnumerator()
         {
             return new DbEnumerator(this, IsCommandBehavior(CommandBehavior.CloseConnection));
         }
@@ -1255,7 +1255,7 @@ namespace Microsoft.Data.SqlClient
                    Justification = "Annotations for DbDataReader was not shipped in net6.0")]
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
-        override public Type GetFieldType(int i)
+        public override Type GetFieldType(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -1325,7 +1325,7 @@ namespace Microsoft.Data.SqlClient
             return fieldType;
         }
 
-        virtual internal int GetLocaleId(int i)
+        internal virtual int GetLocaleId(int i)
         {
             _SqlMetaData sqlMetaData = MetaData[i];
             int lcid;
@@ -1359,7 +1359,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetName/*' />
-        override public string GetName(int i)
+        public override string GetName(int i)
         {
             CheckMetaDataIsReady(columnIndex: i);
             return _metaData[i].column;
@@ -1369,7 +1369,7 @@ namespace Microsoft.Data.SqlClient
 #if NET8_0_OR_GREATER
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
-        override public Type GetProviderSpecificFieldType(int i)
+        public override Type GetProviderSpecificFieldType(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -1442,7 +1442,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetOrdinal/*' />
         // named field access
-        override public int GetOrdinal(string name)
+        public override int GetOrdinal(string name)
         {
             SqlStatistics statistics = null;
             try
@@ -1462,13 +1462,13 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetProviderSpecificValue/*' />
-        override public object GetProviderSpecificValue(int i)
+        public override object GetProviderSpecificValue(int i)
         {
             return GetSqlValue(i);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetProviderSpecificValues/*' />
-        override public int GetProviderSpecificValues(object[] values)
+        public override int GetProviderSpecificValues(object[] values)
         {
             return GetSqlValues(values);
         }
@@ -1500,14 +1500,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetBoolean/*' />
-        override public bool GetBoolean(int i)
+        public override bool GetBoolean(int i)
         {
             ReadColumn(i);
             return _data[i].Boolean;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetXmlReader/*' />
-        virtual public XmlReader GetXmlReader(int i)
+        public virtual XmlReader GetXmlReader(int i)
         {
             // NOTE: sql_variant can not contain a XML data type: http://msdn.microsoft.com/en-us/library/ms173829.aspx
             // If this ever changes, the following code should be changed to be like GetStream/GetTextReader
@@ -1547,7 +1547,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetStream/*' />
-        override public Stream GetStream(int i)
+        public override Stream GetStream(int i)
         {
             CheckDataIsReady(columnIndex: i);
 
@@ -1595,14 +1595,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetByte/*' />
-        override public byte GetByte(int i)
+        public override byte GetByte(int i)
         {
             ReadColumn(i);
             return _data[i].Byte;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetBytes/*' />
-        override public long GetBytes(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
+        public override long GetBytes(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
         {
             SqlStatistics statistics = null;
             long cbBytes = 0;
@@ -1631,7 +1631,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Used (indirectly) by SqlCommand.CompleteXmlReader
-        virtual internal long GetBytesInternal(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
+        internal virtual long GetBytesInternal(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
         {
             if (_currentTask != null)
             {
@@ -1952,7 +1952,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetTextReader/*' />
-        override public TextReader GetTextReader(int i)
+        public override TextReader GetTextReader(int i)
         {
             CheckDataIsReady(columnIndex: i);
 
@@ -2022,13 +2022,13 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetChar/*' />
-        override public char GetChar(int i)
+        public override char GetChar(int i)
         {
             throw ADP.NotSupported();
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetChars/*' />
-        override public long GetChars(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
+        public override long GetChars(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
         {
             SqlStatistics statistics = null;
 
@@ -2318,7 +2318,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDateTime/*' />
-        override public DateTime GetDateTime(int i)
+        public override DateTime GetDateTime(int i)
         {
             ReadColumn(i);
 
@@ -2340,77 +2340,77 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDecimal/*' />
-        override public decimal GetDecimal(int i)
+        public override decimal GetDecimal(int i)
         {
             ReadColumn(i);
             return _data[i].Decimal;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDouble/*' />
-        override public double GetDouble(int i)
+        public override double GetDouble(int i)
         {
             ReadColumn(i);
             return _data[i].Double;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetFloat/*' />
-        override public float GetFloat(int i)
+        public override float GetFloat(int i)
         {
             ReadColumn(i);
             return _data[i].Single;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetGuid/*' />
-        override public Guid GetGuid(int i)
+        public override Guid GetGuid(int i)
         {
             ReadColumn(i);
             return _data[i].Guid;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetInt16/*' />
-        override public short GetInt16(int i)
+        public override short GetInt16(int i)
         {
             ReadColumn(i);
             return _data[i].Int16;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetInt32/*' />
-        override public int GetInt32(int i)
+        public override int GetInt32(int i)
         {
             ReadColumn(i);
             return _data[i].Int32;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetInt64/*' />
-        override public long GetInt64(int i)
+        public override long GetInt64(int i)
         {
             ReadColumn(i);
             return _data[i].Int64;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlBoolean/*' />
-        virtual public SqlBoolean GetSqlBoolean(int i)
+        public virtual SqlBoolean GetSqlBoolean(int i)
         {
             ReadColumn(i);
             return _data[i].SqlBoolean;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlBinary/*' />
-        virtual public SqlBinary GetSqlBinary(int i)
+        public virtual SqlBinary GetSqlBinary(int i)
         {
             ReadColumn(i, setTimeout: true, allowPartiallyReadColumn: true);
             return _data[i].SqlBinary;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlByte/*' />
-        virtual public SqlByte GetSqlByte(int i)
+        public virtual SqlByte GetSqlByte(int i)
         {
             ReadColumn(i);
             return _data[i].SqlByte;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlBytes/*' />
-        virtual public SqlBytes GetSqlBytes(int i)
+        public virtual SqlBytes GetSqlBytes(int i)
         {
             ReadColumn(i);
             SqlBinary data = _data[i].SqlBinary;
@@ -2418,7 +2418,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlChars/*' />
-        virtual public SqlChars GetSqlChars(int i)
+        public virtual SqlChars GetSqlChars(int i)
         {
             ReadColumn(i);
             SqlString data;
@@ -2435,70 +2435,70 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDateTime/*' />
-        virtual public SqlDateTime GetSqlDateTime(int i)
+        public virtual SqlDateTime GetSqlDateTime(int i)
         {
             ReadColumn(i);
             return _data[i].SqlDateTime;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDecimal/*' />
-        virtual public SqlDecimal GetSqlDecimal(int i)
+        public virtual SqlDecimal GetSqlDecimal(int i)
         {
             ReadColumn(i);
             return _data[i].SqlDecimal;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlGuid/*' />
-        virtual public SqlGuid GetSqlGuid(int i)
+        public virtual SqlGuid GetSqlGuid(int i)
         {
             ReadColumn(i);
             return _data[i].SqlGuid;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDouble/*' />
-        virtual public SqlDouble GetSqlDouble(int i)
+        public virtual SqlDouble GetSqlDouble(int i)
         {
             ReadColumn(i);
             return _data[i].SqlDouble;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlInt16/*' />
-        virtual public SqlInt16 GetSqlInt16(int i)
+        public virtual SqlInt16 GetSqlInt16(int i)
         {
             ReadColumn(i);
             return _data[i].SqlInt16;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlInt32/*' />
-        virtual public SqlInt32 GetSqlInt32(int i)
+        public virtual SqlInt32 GetSqlInt32(int i)
         {
             ReadColumn(i);
             return _data[i].SqlInt32;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlInt64/*' />
-        virtual public SqlInt64 GetSqlInt64(int i)
+        public virtual SqlInt64 GetSqlInt64(int i)
         {
             ReadColumn(i);
             return _data[i].SqlInt64;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlMoney/*' />
-        virtual public SqlMoney GetSqlMoney(int i)
+        public virtual SqlMoney GetSqlMoney(int i)
         {
             ReadColumn(i);
             return _data[i].SqlMoney;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlSingle/*' />
-        virtual public SqlSingle GetSqlSingle(int i)
+        public virtual SqlSingle GetSqlSingle(int i)
         {
             ReadColumn(i);
             return _data[i].SqlSingle;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlString/*' />
-        virtual public SqlString GetSqlString(int i)
+        public virtual SqlString GetSqlString(int i)
         {
             ReadColumn(i);
 
@@ -2511,7 +2511,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlXml/*' />
-        virtual public SqlXml GetSqlXml(int i)
+        public virtual SqlXml GetSqlXml(int i)
         {
             ReadColumn(i);
             SqlXml sx = null;
@@ -2542,7 +2542,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlValue/*' />
-        virtual public object GetSqlValue(int i)
+        public virtual object GetSqlValue(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -2628,7 +2628,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlValues/*' />
-        virtual public int GetSqlValues(object[] values)
+        public virtual int GetSqlValues(object[] values)
         {
             SqlStatistics statistics = null;
             try
@@ -2657,7 +2657,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetString/*' />
-        override public string GetString(int i)
+        public override string GetString(int i)
         {
             ReadColumn(i);
 
@@ -2671,7 +2671,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetFieldValue/*' />
-        override public T GetFieldValue<T>(int i)
+        public override T GetFieldValue<T>(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -2688,7 +2688,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetValue/*' />
-        override public object GetValue(int i)
+        public override object GetValue(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -2705,7 +2705,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetTimeSpan/*' />
-        virtual public TimeSpan GetTimeSpan(int i)
+        public virtual TimeSpan GetTimeSpan(int i)
         {
             ReadColumn(i);
 
@@ -2727,7 +2727,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDateTimeOffset/*' />
-        virtual public DateTimeOffset GetDateTimeOffset(int i)
+        public virtual DateTimeOffset GetDateTimeOffset(int i)
         {
             ReadColumn(i);
 
@@ -3040,7 +3040,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetValues/*' />
-        override public int GetValues(object[] values)
+        public override int GetValues(object[] values)
         {
             SqlStatistics statistics = null;
             bool sequentialAccess = IsCommandBehavior(CommandBehavior.SequentialAccess);
@@ -3320,7 +3320,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/IsDBNull/*' />
-        override public bool IsDBNull(int i)
+        public override bool IsDBNull(int i)
         {
             {
                 CheckHeaderIsReady(columnIndex: i);
@@ -3340,7 +3340,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/NextResult/*' />
-        override public bool NextResult()
+        public override bool NextResult()
         {
             if (_currentTask != null)
             {
@@ -3509,7 +3509,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Read/*' />
         // user must call Read() to position on the first row
-        override public bool Read()
+        public override bool Read()
         {
             if (_currentTask != null)
             {
@@ -5014,7 +5014,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/IsDBNullAsync/*' />
-        override public Task<bool> IsDBNullAsync(int i, CancellationToken cancellationToken)
+        public override Task<bool> IsDBNullAsync(int i, CancellationToken cancellationToken)
         {
             try
             {
@@ -5165,7 +5165,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetFieldValueAsync/*' />
-        override public Task<T> GetFieldValueAsync<T>(int i, CancellationToken cancellationToken)
+        public override Task<T> GetFieldValueAsync<T>(int i, CancellationToken cancellationToken)
         {
             try
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -11,7 +11,7 @@ using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal partial class SqlDelegatedTransaction : IPromotableSinglePhaseNotification
+    internal sealed partial class SqlDelegatedTransaction : IPromotableSinglePhaseNotification
     {
         private static int _objectTypeCount;
         internal int ObjectID { get; } = Interlocked.Increment(ref _objectTypeCount);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -637,7 +637,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal protected override bool IsNonPoolableTransactionRoot
+        protected internal override bool IsNonPoolableTransactionRoot
         {
             get
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -546,7 +546,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlMetaDataXmlSchemaCollection
+    internal sealed class SqlMetaDataXmlSchemaCollection
     {
         internal string Database;
         internal string OwningSchema;
@@ -563,7 +563,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlMetaDataUdt
+    internal sealed class SqlMetaDataUdt
     {
 #if NET6_0_OR_GREATER
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlFileStream.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlTypes/SqlFileStream.Windows.cs
@@ -429,7 +429,7 @@ namespace Microsoft.Data.SqlTypes
 #endregion
 
         [Conditional("DEBUG")]
-        static private void AssertPathFormat(string path)
+        private static void AssertPathFormat(string path)
         {
             Debug.Assert(path != null);
             Debug.Assert(path == path.Trim());
@@ -437,7 +437,7 @@ namespace Microsoft.Data.SqlTypes
             Debug.Assert(path.StartsWith(@"\\", StringComparison.OrdinalIgnoreCase));
         }
 
-        static private string GetFullPathInternal(string path)
+        private static string GetFullPathInternal(string path)
         {
             //-----------------------------------------------------------------
             // precondition validation should be validated by callers of this method
@@ -688,7 +688,7 @@ namespace Microsoft.Data.SqlTypes
         // This method exists to ensure that the requested path name is unique so that SMB/DNS is prevented
         // from collapsing a file open request to a file handle opened previously. In the SQL FILESTREAM case,
         // this would likely be a file open in another transaction, so this mechanism ensures isolation.
-        static private string InitializeNtPath(string path)
+        private static string InitializeNtPath(string path)
         {
             // Ensure we have validated and normalized the path before
             AssertPathFormat(path);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Common/src/Microsoft/Data/Common/NameValuePermission.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Common/src/Microsoft/Data/Common/NameValuePermission.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Data.Common
     using System.Diagnostics;
 
     [Serializable] // MDAC 83147
-    sealed internal class NameValuePermission : IComparable
+    internal sealed class NameValuePermission : IComparable
     {
         // reused as both key and value nodes
         // key nodes link to value nodes
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Common
 
         private NameValuePermission[] _tree; // with branches
 
-        static internal readonly NameValuePermission Default = null;// = new NameValuePermission(String.Empty, new string[] { "File Name" }, KeyRestrictionBehavior.AllowOnly);
+        internal static readonly NameValuePermission Default = null;// = new NameValuePermission(String.Empty, new string[] { "File Name" }, KeyRestrictionBehavior.AllowOnly);
 
         internal NameValuePermission()
         { // root node
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Common
             return StringComparer.Ordinal.Compare(_value, ((NameValuePermission)a)._value);
         }
 
-        static internal void AddEntry(NameValuePermission kvtree, ArrayList entries, DBConnectionString entry)
+        internal static void AddEntry(NameValuePermission kvtree, ArrayList entries, DBConnectionString entry)
         {
             Debug.Assert(entry != null, "null DBConnectionString");
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/AdapterSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/AdapterSwitches.cs
@@ -10,9 +10,9 @@ namespace System.Data.Common {
 
     internal static class AdapterSwitches {
 
-        static private TraceSwitch _dataSchema;
+        private static TraceSwitch _dataSchema;
 
-        static internal TraceSwitch DataSchema {
+        internal static TraceSwitch DataSchema {
             get {
                 TraceSwitch dataSchema = _dataSchema;
                 if (dataSchema == null) {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
@@ -27,27 +27,27 @@ namespace Microsoft.Data.Common
         };
 
         // this class is serializable with Everett, so ugly field names can't be changed
-        readonly private string _encryptedUsersConnectionString;
+        private readonly string _encryptedUsersConnectionString;
 
         // hash of unique keys to values
-        readonly private Dictionary<string, string> _parsetable;
+        private readonly Dictionary<string, string> _parsetable;
 
         // a linked list of key/value and their length in _encryptedUsersConnectionString
-        readonly private NameValuePair _keychain;
+        private readonly NameValuePair _keychain;
 
         // track the existence of "password" or "pwd" in the connection string
         // not used for anything anymore but must keep it set correct for V1.1 serialization
-        readonly private bool _hasPassword;
+        private readonly bool _hasPassword;
 
-        readonly private string[] _restrictionValues;
-        readonly private string _restrictions;
+        private readonly string[] _restrictionValues;
+        private readonly string _restrictions;
 
-        readonly private KeyRestrictionBehavior _behavior;
+        private readonly KeyRestrictionBehavior _behavior;
 
 #pragma warning disable 169
         // this field is no longer used, hence the warning was disabled
         // however, it can not be removed or it will break serialization with V1.1
-        readonly private string _encryptedActualConnectionString;
+        private readonly string _encryptedActualConnectionString;
 #pragma warning restore 169
 
         internal DBConnectionString(string value, string restrictions, KeyRestrictionBehavior behavior, Dictionary<string, string> synonyms, bool useOdbcRules)
@@ -408,7 +408,7 @@ namespace Microsoft.Data.Common
             return true;
         }
 
-        static private string[] NewRestrictionAllowOnly(string[] allowonly, string[] preventusage)
+        private static string[] NewRestrictionAllowOnly(string[] allowonly, string[] preventusage)
         {
             List<string> newlist = null;
             for (int i = 0; i < allowonly.Length; ++i)
@@ -431,7 +431,7 @@ namespace Microsoft.Data.Common
             return restrictionValues;
         }
 
-        static private string[] NewRestrictionIntersect(string[] a, string[] b)
+        private static string[] NewRestrictionIntersect(string[] a, string[] b)
         {
             List<string> newlist = null;
             for (int i = 0; i < a.Length; ++i)
@@ -454,7 +454,7 @@ namespace Microsoft.Data.Common
             return restrictionValues;
         }
 
-        static private string[] NoDuplicateUnion(string[] a, string[] b)
+        private static string[] NoDuplicateUnion(string[] a, string[] b)
         {
 #if DEBUG
             Debug.Assert(a != null && 0 < a.Length, "empty a");
@@ -513,7 +513,7 @@ namespace Microsoft.Data.Common
 
         }
 
-        static internal string[] RemoveDuplicates(string[] restrictions)
+        internal static string[] RemoveDuplicates(string[] restrictions)
         {
             int count = restrictions.Length;
             if (0 < count)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/NativeMethods.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/NativeMethods.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Common
 
         [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         [ResourceExposure(ResourceScope.Machine)]
-        static internal extern IntPtr MapViewOfFile(IntPtr hFileMappingObject, int dwDesiredAccess, int dwFileOffsetHigh, int dwFileOffsetLow, IntPtr dwNumberOfBytesToMap);
+        internal static extern IntPtr MapViewOfFile(IntPtr hFileMappingObject, int dwDesiredAccess, int dwFileOffsetHigh, int dwFileOffsetLow, IntPtr dwNumberOfBytesToMap);
 
         // OpenFileMappingA contains a security venerability, in the unicode->ansi conversion 
         // Its possible to spoof the directory and construct ../ sequences,  See FxCop Warning
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Common
         [DllImport(ExternDll.Kernel32, CharSet = System.Runtime.InteropServices.CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         //        [DllImport(ExternDll.Kernel32, CharSet=System.Runtime.InteropServices.CharSet.Ansi)]
         [ResourceExposure(ResourceScope.Machine)]
-        static internal extern IntPtr OpenFileMappingA(int dwDesiredAccess, bool bInheritHandle, [MarshalAs(UnmanagedType.LPStr)] string lpName);
+        internal static extern IntPtr OpenFileMappingA(int dwDesiredAccess, bool bInheritHandle, [MarshalAs(UnmanagedType.LPStr)] string lpName);
 
         // CreateFileMappingA contains a security venerability, in the unicode->ansi conversion 
         // Its possible to spoof the directory and construct ../ sequences,  See FxCop Warning
@@ -56,19 +56,19 @@ namespace Microsoft.Data.Common
         [DllImport(ExternDll.Kernel32, CharSet = System.Runtime.InteropServices.CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         //        [DllImport(ExternDll.Kernel32, CharSet=System.Runtime.InteropServices.CharSet.Ansi)]
         [ResourceExposure(ResourceScope.Machine)]
-        static internal extern IntPtr CreateFileMappingA(IntPtr hFile, IntPtr pAttr, int flProtect, int dwMaximumSizeHigh, int dwMaximumSizeLow, [MarshalAs(UnmanagedType.LPStr)] string lpName);
+        internal static extern IntPtr CreateFileMappingA(IntPtr hFile, IntPtr pAttr, int flProtect, int dwMaximumSizeHigh, int dwMaximumSizeLow, [MarshalAs(UnmanagedType.LPStr)] string lpName);
 
         [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         [ResourceExposure(ResourceScope.Machine)]
-        static internal extern bool UnmapViewOfFile(IntPtr lpBaseAddress);
+        internal static extern bool UnmapViewOfFile(IntPtr lpBaseAddress);
 
         [DllImport(ExternDll.Kernel32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]
         [ResourceExposure(ResourceScope.Machine)]
-        static internal extern bool CloseHandle(IntPtr handle);
+        internal static extern bool CloseHandle(IntPtr handle);
 
         [DllImport(ExternDll.Advapi32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern bool AllocateAndInitializeSid(
+        internal static extern bool AllocateAndInitializeSid(
             IntPtr pIdentifierAuthority, // authority
             byte nSubAuthorityCount,                        // count of subauthorities
             int dwSubAuthority0,                          // subauthority 0
@@ -84,19 +84,19 @@ namespace Microsoft.Data.Common
 
         [DllImport(ExternDll.Advapi32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern int GetLengthSid(
+        internal static extern int GetLengthSid(
             IntPtr pSid);   // SID to query
 
         [DllImport(ExternDll.Advapi32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern bool InitializeAcl(
+        internal static extern bool InitializeAcl(
             IntPtr pAcl,            // ACL
             int nAclLength,     // size of ACL
             int dwAclRevision);  // revision level of ACL
 
         [DllImport(ExternDll.Advapi32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern bool AddAccessDeniedAce(
+        internal static extern bool AddAccessDeniedAce(
             IntPtr pAcl,            // access control list
             int dwAceRevision,  // ACL revision level
             int AccessMask,     // access mask
@@ -104,7 +104,7 @@ namespace Microsoft.Data.Common
 
         [DllImport(ExternDll.Advapi32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern bool AddAccessAllowedAce(
+        internal static extern bool AddAccessAllowedAce(
             IntPtr pAcl,            // access control list
             int dwAceRevision,  // ACL revision level
             uint AccessMask,     // access mask
@@ -112,12 +112,12 @@ namespace Microsoft.Data.Common
 
         [DllImport(ExternDll.Advapi32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern bool InitializeSecurityDescriptor(
+        internal static extern bool InitializeSecurityDescriptor(
             IntPtr pSecurityDescriptor, // SD
             int dwRevision);                         // revision level
         [DllImport(ExternDll.Advapi32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern bool SetSecurityDescriptorDacl(
+        internal static extern bool SetSecurityDescriptorDacl(
             IntPtr pSecurityDescriptor, // SD
             bool bDaclPresent,                        // DACL presence
             IntPtr pDacl,                               // DACL
@@ -125,7 +125,7 @@ namespace Microsoft.Data.Common
 
         [DllImport(ExternDll.Advapi32, ExactSpelling = true, CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern IntPtr FreeSid(
+        internal static extern IntPtr FreeSid(
             IntPtr pSid);   // SID to free
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/SafeNativeMethods.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/SafeNativeMethods.cs
@@ -20,21 +20,21 @@ namespace Microsoft.Data.Common
         [DllImport(ExternDll.Ole32, SetLastError = false)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern IntPtr CoTaskMemAlloc(IntPtr cb);
+        internal static extern IntPtr CoTaskMemAlloc(IntPtr cb);
 
         [DllImport(ExternDll.Ole32, SetLastError = false)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern void CoTaskMemFree(IntPtr handle);
+        internal static extern void CoTaskMemFree(IntPtr handle);
 
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Unicode, PreserveSig = true)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern int GetUserDefaultLCID();
+        internal static extern int GetUserDefaultLCID();
 
         [DllImport(ExternDll.Kernel32, PreserveSig = true)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern void ZeroMemory(IntPtr dest, IntPtr length);
+        internal static extern void ZeroMemory(IntPtr dest, IntPtr length);
 
         // <WARNING>
         // Using the int versions of the Increment() and Decrement() methods is correct.
@@ -46,7 +46,7 @@ namespace Microsoft.Data.Common
         // a workaround for this issue to meet the M1 exit criteria.  We need to revisit this in M2.
 
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-        static internal unsafe IntPtr InterlockedExchangePointer(
+        internal static unsafe IntPtr InterlockedExchangePointer(
                 IntPtr lpAddress,
                 IntPtr lpValue)
         {
@@ -66,31 +66,31 @@ namespace Microsoft.Data.Common
         // http://msdn.microsoft.com/library/default.asp?url=/library/en-us/sysinfo/base/getcomputernameex.asp
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "GetComputerNameExW", SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern int GetComputerNameEx(int nameType, StringBuilder nameBuffer, ref int bufferSize);
+        internal static extern int GetComputerNameEx(int nameType, StringBuilder nameBuffer, ref int bufferSize);
 
         [DllImport(ExternDll.Kernel32, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
         [ResourceExposure(ResourceScope.Process)]
-        static internal extern int GetCurrentProcessId();
+        internal static extern int GetCurrentProcessId();
 
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Auto, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         //        [DllImport(ExternDll.Kernel32, CharSet=CharSet.Auto)]
         [ResourceExposure(ResourceScope.Process)]
-        static internal extern IntPtr GetModuleHandle([MarshalAs(UnmanagedType.LPTStr), In] string moduleName/*lpctstr*/);
+        internal static extern IntPtr GetModuleHandle([MarshalAs(UnmanagedType.LPTStr), In] string moduleName/*lpctstr*/);
 
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true, SetLastError = true)]
         //        [DllImport(ExternDll.Kernel32, CharSet=CharSet.Ansi)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern IntPtr GetProcAddress(IntPtr HModule, [MarshalAs(UnmanagedType.LPStr), In] string funcName/*lpcstr*/);
+        internal static extern IntPtr GetProcAddress(IntPtr HModule, [MarshalAs(UnmanagedType.LPStr), In] string funcName/*lpcstr*/);
 
         [DllImport(ExternDll.Kernel32, SetLastError = true)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern IntPtr LocalAlloc(int flags, IntPtr countOfBytes);
+        internal static extern IntPtr LocalAlloc(int flags, IntPtr countOfBytes);
 
         [DllImport(ExternDll.Kernel32, SetLastError = true)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern IntPtr LocalFree(IntPtr handle);
+        internal static extern IntPtr LocalFree(IntPtr handle);
 
         [DllImport(ExternDll.Oleaut32, CharSet = CharSet.Unicode)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
@@ -106,34 +106,34 @@ namespace Microsoft.Data.Common
         [DllImport(ExternDll.Oleaut32, CharSet = CharSet.Unicode, PreserveSig = false)]
         // TLS values are preserved between threads, need to check that we use this API to clear the error state only.
         [ResourceExposure(ResourceScope.Process)]
-        static private extern void SetErrorInfo(Int32 dwReserved, IntPtr pIErrorInfo);
+        private static extern void SetErrorInfo(Int32 dwReserved, IntPtr pIErrorInfo);
 
         [DllImport(ExternDll.Kernel32, SetLastError = true)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         [ResourceExposure(ResourceScope.Machine)]
-        static internal extern int ReleaseSemaphore(IntPtr handle, int releaseCount, IntPtr previousCount);
+        internal static extern int ReleaseSemaphore(IntPtr handle, int releaseCount, IntPtr previousCount);
 
         [DllImport(ExternDll.Kernel32, SetLastError = true)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern int WaitForMultipleObjectsEx(uint nCount, IntPtr lpHandles, bool bWaitAll, uint dwMilliseconds, bool bAlertable);
+        internal static extern int WaitForMultipleObjectsEx(uint nCount, IntPtr lpHandles, bool bWaitAll, uint dwMilliseconds, bool bAlertable);
 
         [DllImport(ExternDll.Kernel32/*, SetLastError=true*/)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern int WaitForSingleObjectEx(IntPtr lpHandles, uint dwMilliseconds, bool bAlertable);
+        internal static extern int WaitForSingleObjectEx(IntPtr lpHandles, uint dwMilliseconds, bool bAlertable);
 
         [DllImport(ExternDll.Ole32, PreserveSig = false)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern void PropVariantClear(IntPtr pObject);
+        internal static extern void PropVariantClear(IntPtr pObject);
 
         [DllImport(ExternDll.Oleaut32, PreserveSig = false)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern void VariantClear(IntPtr pObject);
+        internal static extern void VariantClear(IntPtr pObject);
 
-        sealed internal class Wrapper
+        internal sealed class Wrapper
         {
 
             private Wrapper() { }
@@ -141,7 +141,7 @@ namespace Microsoft.Data.Common
             // SxS: clearing error information is considered safe
             [ResourceExposure(ResourceScope.None)]
             [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-            static internal void ClearErrorInfo()
+            internal static void ClearErrorInfo()
             { // MDAC 68199
                 SafeNativeMethods.SetErrorInfo(0, ADP.s_ptrZero);
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/UnsafeNativeMethods.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/UnsafeNativeMethods.cs
@@ -104,21 +104,21 @@ namespace Microsoft.Data.Common
 
         [DllImport(ExternDll.Advapi32, CharSet = CharSet.Unicode)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern uint GetEffectiveRightsFromAclW(byte[] pAcl, ref Trustee pTrustee, out uint pAccessMask);
+        internal static extern uint GetEffectiveRightsFromAclW(byte[] pAcl, ref Trustee pTrustee, out uint pAccessMask);
 
         [DllImport(ExternDll.Advapi32, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        static internal extern bool CheckTokenMembership(IntPtr tokenHandle, byte[] sidToCheck, out bool isMember);
+        internal static extern bool CheckTokenMembership(IntPtr tokenHandle, byte[] sidToCheck, out bool isMember);
 
         [DllImport(ExternDll.Advapi32, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        static internal extern bool ConvertSidToStringSidW(IntPtr sid, out IntPtr stringSid);
+        internal static extern bool ConvertSidToStringSidW(IntPtr sid, out IntPtr stringSid);
 
         [DllImport(ExternDll.Advapi32, EntryPoint = "CreateWellKnownSid", SetLastError = true, CharSet = CharSet.Unicode)]
         [ResourceExposure(ResourceScope.None)]
-        static internal extern int CreateWellKnownSid(
+        internal static extern int CreateWellKnownSid(
             int sidType,
             byte[] domainSid,
             [Out] byte[] resultSid,
@@ -127,7 +127,7 @@ namespace Microsoft.Data.Common
         [DllImport(ExternDll.Advapi32, SetLastError = true)]
         [ResourceExposure(ResourceScope.None)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        static internal extern bool GetTokenInformation(IntPtr tokenHandle, uint token_class, IntPtr tokenStruct, uint tokenInformationLength, ref uint tokenString);
+        internal static extern bool GetTokenInformation(IntPtr tokenHandle, uint token_class, IntPtr tokenStruct, uint tokenInformationLength, ref uint tokenString);
 
         [DllImport(ExternDll.Kernel32, CharSet = CharSet.Unicode)]
         [ResourceExposure(ResourceScope.None)]

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeMethodWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeMethodWrapper.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Data.SqlClient
 
         [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        internal unsafe static byte[] GetData()
+        internal static unsafe byte[] GetData()
         {
             int size;
             IntPtr ptr = (IntPtr)(SqlDependencyProcessDispatcherStorage.NativeGetData(out size));
@@ -93,7 +93,7 @@ namespace Microsoft.Data.SqlClient
 
         [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        internal unsafe static void SetData(Byte[] data)
+        internal static unsafe void SetData(Byte[] data)
         {
             //cli::pin_ptr<System::Byte> pin_dispatcher = &data[0];
             fixed (byte* pin_dispatcher = &data[0])
@@ -102,7 +102,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        unsafe internal class SqlDependencyProcessDispatcherStorage
+        internal unsafe class SqlDependencyProcessDispatcherStorage
         {
 
             static void* data;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbBuffer.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Data.ProviderBase
             return *(Single*)&value;
         }
 
-        override protected bool ReleaseHandle()
+        protected override bool ReleaseHandle()
         {
             // NOTE: The SafeHandle class guarantees this will be called exactly once.
             IntPtr ptr = base.handle;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Data.ProviderBase
     using Microsoft.Data.Common;
     using System.Transactions;
 
-    abstract internal class DbConnectionClosed : DbConnectionInternal
+    internal abstract class DbConnectionClosed : DbConnectionInternal
     {
         // Construct an "empty" connection
         protected DbConnectionClosed(ConnectionState state, bool hidePassword, bool allowSetConnectionString) : base(state, hidePassword, allowSetConnectionString)
         {
         }
 
-        override public string ServerVersion
+        public override string ServerVersion
         {
             get
             {
@@ -26,17 +26,17 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        override protected void Activate(Transaction transaction)
+        protected override void Activate(Transaction transaction)
         {
             throw ADP.ClosedConnectionError();
         }
 
-        override public DbTransaction BeginTransaction(System.Data.IsolationLevel il)
+        public override DbTransaction BeginTransaction(System.Data.IsolationLevel il)
         {
             throw ADP.ClosedConnectionError();
         }
 
-        override public void ChangeDatabase(string database)
+        public override void ChangeDatabase(string database)
         {
             throw ADP.ClosedConnectionError();
         }
@@ -46,17 +46,17 @@ namespace Microsoft.Data.ProviderBase
             // not much to do here...
         }
 
-        override protected void Deactivate()
+        protected override void Deactivate()
         {
             throw ADP.ClosedConnectionError();
         }
 
-        override public void EnlistTransaction(Transaction transaction)
+        public override void EnlistTransaction(Transaction transaction)
         {
             throw ADP.ClosedConnectionError();
         }
 
-        override protected internal DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
+        protected internal override DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
         {
             throw ADP.ClosedConnectionError();
         }
@@ -72,7 +72,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    abstract internal class DbConnectionBusy : DbConnectionClosed
+    internal abstract class DbConnectionBusy : DbConnectionClosed
     {
 
         protected DbConnectionBusy(ConnectionState state) : base(state, true, false)
@@ -85,7 +85,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    sealed internal class DbConnectionClosedBusy : DbConnectionBusy
+    internal sealed class DbConnectionClosedBusy : DbConnectionBusy
     {
         // Closed Connection, Currently Busy - changing connection string
         internal static readonly DbConnectionInternal SingletonInstance = new DbConnectionClosedBusy();   // singleton object
@@ -95,7 +95,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    sealed internal class DbConnectionOpenBusy : DbConnectionBusy
+    internal sealed class DbConnectionOpenBusy : DbConnectionBusy
     {
         // Open Connection, Currently Busy - closing connection
         internal static readonly DbConnectionInternal SingletonInstance = new DbConnectionOpenBusy();   // singleton object
@@ -105,7 +105,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    sealed internal class DbConnectionClosedConnecting : DbConnectionBusy
+    internal sealed class DbConnectionClosedConnecting : DbConnectionBusy
     {
         // Closed Connection, Currently Connecting
 
@@ -152,7 +152,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    sealed internal class DbConnectionClosedNeverOpened : DbConnectionClosed
+    internal sealed class DbConnectionClosedNeverOpened : DbConnectionClosed
     {
         // Closed Connection, Has Never Been Opened
 
@@ -163,7 +163,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    sealed internal class DbConnectionClosedPreviouslyOpened : DbConnectionClosed
+    internal sealed class DbConnectionClosedPreviouslyOpened : DbConnectionClosed
     {
         // Closed Connection, Has Previously Been Opened
         internal static readonly DbConnectionInternal SingletonInstance = new DbConnectionClosedPreviouslyOpened();   // singleton object

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Data.ProviderBase
             get { return _performanceCounters; }
         }
 
-        abstract public DbProviderFactory ProviderFactory
+        public abstract DbProviderFactory ProviderFactory
         {
             get;
         }
@@ -113,7 +113,7 @@ namespace Microsoft.Data.ProviderBase
             return null;
         }
 
-        virtual protected DbMetaDataFactory CreateMetaDataFactory(DbConnectionInternal internalConnection, out bool cacheMetaDataFactory)
+        protected virtual DbMetaDataFactory CreateMetaDataFactory(DbConnectionInternal internalConnection, out bool cacheMetaDataFactory)
         {
             // providers that support GetSchema must override this with a method that creates a meta data
             // factory appropriate for them.
@@ -156,7 +156,7 @@ namespace Microsoft.Data.ProviderBase
             return newConnection;
         }
 
-        virtual internal DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(DbConnectionOptions connectionOptions)
+        internal virtual DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(DbConnectionOptions connectionOptions)
         {
             return null;
         }
@@ -644,31 +644,31 @@ namespace Microsoft.Data.ProviderBase
             PerformanceCounters.NumberOfInactiveConnectionPoolGroups.Increment();
         }
 
-        virtual protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
+        protected virtual DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
         {
             return CreateConnection(options, poolKey, poolGroupProviderInfo, pool, owningConnection);
         }
 
-        abstract protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection);
+        protected abstract DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection);
 
-        abstract protected DbConnectionOptions CreateConnectionOptions(string connectionString, DbConnectionOptions previous);
+        protected abstract DbConnectionOptions CreateConnectionOptions(string connectionString, DbConnectionOptions previous);
 
-        abstract protected DbConnectionPoolGroupOptions CreateConnectionPoolGroupOptions(DbConnectionOptions options);
+        protected abstract DbConnectionPoolGroupOptions CreateConnectionPoolGroupOptions(DbConnectionOptions options);
 
-        abstract internal DbConnectionPoolGroup GetConnectionPoolGroup(DbConnection connection);
+        internal abstract DbConnectionPoolGroup GetConnectionPoolGroup(DbConnection connection);
 
-        abstract internal DbConnectionInternal GetInnerConnection(DbConnection connection);
+        internal abstract DbConnectionInternal GetInnerConnection(DbConnection connection);
 
-        abstract protected int GetObjectId(DbConnection connection);
+        protected abstract int GetObjectId(DbConnection connection);
 
-        abstract internal void PermissionDemand(DbConnection outerConnection);
+        internal abstract void PermissionDemand(DbConnection outerConnection);
 
-        abstract internal void SetConnectionPoolGroup(DbConnection outerConnection, DbConnectionPoolGroup poolGroup);
+        internal abstract void SetConnectionPoolGroup(DbConnection outerConnection, DbConnectionPoolGroup poolGroup);
 
-        abstract internal void SetInnerConnectionEvent(DbConnection owningObject, DbConnectionInternal to);
+        internal abstract void SetInnerConnectionEvent(DbConnection owningObject, DbConnectionInternal to);
 
-        abstract internal bool SetInnerConnectionFrom(DbConnection owningObject, DbConnectionInternal to, DbConnectionInternal from);
+        internal abstract bool SetInnerConnectionFrom(DbConnection owningObject, DbConnectionInternal to, DbConnectionInternal from);
 
-        abstract internal void SetInnerConnectionTo(DbConnection owningObject, DbConnectionInternal to);
+        internal abstract void SetInnerConnectionTo(DbConnection owningObject, DbConnectionInternal to);
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Data.ProviderBase
         /// <value>
         /// True if the enlisted transaction can be unbound on transaction completion; otherwise false.
         /// </value>
-        virtual protected bool UnbindOnTransactionCompletion
+        protected virtual bool UnbindOnTransactionCompletion
         {
             get
             {
@@ -235,7 +235,7 @@ namespace Microsoft.Data.ProviderBase
         }
 
         // Is this a connection that must be put in stasis (or is already in stasis) pending the end of it's transaction?
-        virtual protected internal bool IsNonPoolableTransactionRoot
+        protected internal virtual bool IsNonPoolableTransactionRoot
         {
             get
             {
@@ -243,7 +243,7 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        virtual internal bool IsTransactionRoot
+        internal virtual bool IsTransactionRoot
         {
             get
             {
@@ -337,7 +337,7 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        virtual protected bool ReadyToPrepareTransaction
+        protected virtual bool ReadyToPrepareTransaction
         {
             get
             {
@@ -353,13 +353,13 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        abstract public string ServerVersion
+        public abstract string ServerVersion
         {
             get;
         }
 
         // this should be abstract but until it is added to all the providers virtual will have to do RickFe
-        virtual public string ServerVersionNormalized
+        public virtual string ServerVersionNormalized
         {
             get
             {
@@ -385,7 +385,7 @@ namespace Microsoft.Data.ProviderBase
 
         internal virtual bool IsAccessTokenExpired => false;
 
-        abstract protected void Activate(Transaction transaction);
+        protected abstract void Activate(Transaction transaction);
 
         internal void ActivateConnection(Transaction transaction)
         {
@@ -415,9 +415,9 @@ namespace Microsoft.Data.ProviderBase
             _referenceCollection.Add(value, tag);
         }
 
-        abstract public DbTransaction BeginTransaction(System.Data.IsolationLevel il);
+        public abstract DbTransaction BeginTransaction(System.Data.IsolationLevel il);
 
-        virtual public void ChangeDatabase(string value)
+        public virtual void ChangeDatabase(string value)
         {
             throw ADP.MethodNotImplemented("ChangeDatabase");
         }
@@ -536,32 +536,32 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        virtual internal void PrepareForReplaceConnection()
+        internal virtual void PrepareForReplaceConnection()
         {
             // By default, there is no preparation required
         }
 
-        virtual protected void PrepareForCloseConnection()
+        protected virtual void PrepareForCloseConnection()
         {
             // By default, there is no preparation required
         }
 
-        virtual protected object ObtainAdditionalLocksForClose()
+        protected virtual object ObtainAdditionalLocksForClose()
         {
             return null; // no additional locks in default implementation
         }
 
-        virtual protected void ReleaseAdditionalLocksForClose(object lockToken)
+        protected virtual void ReleaseAdditionalLocksForClose(object lockToken)
         {
             // no additional locks in default implementation
         }
 
-        virtual protected DbReferenceCollection CreateReferenceCollection()
+        protected virtual DbReferenceCollection CreateReferenceCollection()
         {
             throw ADP.InternalError(ADP.InternalErrorCode.AttemptingToConstructReferenceCollectionOnStaticObject);
         }
 
-        abstract protected void Deactivate();
+        protected abstract void Deactivate();
 
         internal void DeactivateConnection()
         {
@@ -592,7 +592,7 @@ namespace Microsoft.Data.ProviderBase
             Deactivate();
         }
 
-        virtual internal void DelegatedTransactionEnded()
+        internal virtual void DelegatedTransactionEnded()
         {
             // Called by System.Transactions when the delegated transaction has
             // completed.  We need to make closed connections that are in stasis
@@ -681,9 +681,9 @@ namespace Microsoft.Data.ProviderBase
             _connectionIsDoomed = false;
         }
 
-        abstract public void EnlistTransaction(Transaction transaction);
+        public abstract void EnlistTransaction(Transaction transaction);
 
-        virtual protected internal DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
+        protected internal virtual DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
         {
             Debug.Assert(outerConnection != null, "outerConnection may not be null.");
 
@@ -865,7 +865,7 @@ namespace Microsoft.Data.ProviderBase
         // Cleanup connection's transaction-specific structures (currently used by Delegated transaction).
         //  This is a separate method because cleanup can be triggered in multiple ways for a delegated
         //  transaction.
-        virtual protected void CleanupTransactionOnCompletion(Transaction transaction)
+        protected virtual void CleanupTransactionOnCompletion(Transaction transaction)
         {
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.ProviderBase
     using Microsoft.Data.SqlClient;
     using System.Transactions;
 
-    sealed internal class DbConnectionPool
+    internal sealed class DbConnectionPool
     {
         private enum State
         {
@@ -33,7 +33,7 @@ namespace Microsoft.Data.ProviderBase
         // This class is a way to stash our cloned Tx key for later disposal when it's no longer needed.
         // We can't get at the key in the dictionary without enumerating entries, so we stash an extra
         // copy as part of the value.
-        sealed private class TransactedConnectionList : List<DbConnectionInternal>
+        private sealed class TransactedConnectionList : List<DbConnectionInternal>
         {
             private Transaction _transaction;
             internal TransactedConnectionList(int initialAllocation, Transaction tx) : base(initialAllocation)
@@ -65,7 +65,7 @@ namespace Microsoft.Data.ProviderBase
             public DbConnectionOptions UserOptions { get; private set; }
         }
 
-        sealed private class TransactedConnectionPool
+        private sealed class TransactedConnectionPool
         {
 
             Dictionary<Transaction, TransactedConnectionList> _transactedCxns;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPoolCounters.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPoolCounters.cs
@@ -18,78 +18,78 @@ namespace Microsoft.Data.ProviderBase
         private static class CreationData
         {
 
-            static internal readonly CounterCreationData HardConnectsPerSecond = new CounterCreationData(
+            internal static readonly CounterCreationData HardConnectsPerSecond = new CounterCreationData(
                                                                         "HardConnectsPerSecond",
                                                                         "The number of actual connections per second that are being made to servers",
                                                                         PerformanceCounterType.RateOfCountsPerSecond32);
 
-            static internal readonly CounterCreationData HardDisconnectsPerSecond = new CounterCreationData(
+            internal static readonly CounterCreationData HardDisconnectsPerSecond = new CounterCreationData(
                                                                         "HardDisconnectsPerSecond",
                                                                         "The number of actual disconnects per second that are being made to servers",
                                                                         PerformanceCounterType.RateOfCountsPerSecond32);
 
-            static internal readonly CounterCreationData SoftConnectsPerSecond = new CounterCreationData(
+            internal static readonly CounterCreationData SoftConnectsPerSecond = new CounterCreationData(
                                                                         "SoftConnectsPerSecond",
                                                                         "The number of connections we get from the pool per second",
                                                                         PerformanceCounterType.RateOfCountsPerSecond32);
 
-            static internal readonly CounterCreationData SoftDisconnectsPerSecond = new CounterCreationData(
+            internal static readonly CounterCreationData SoftDisconnectsPerSecond = new CounterCreationData(
                                                                         "SoftDisconnectsPerSecond",
                                                                         "The number of connections we return to the pool per second",
                                                                         PerformanceCounterType.RateOfCountsPerSecond32);
 
-            static internal readonly CounterCreationData NumberOfNonPooledConnections = new CounterCreationData(
+            internal static readonly CounterCreationData NumberOfNonPooledConnections = new CounterCreationData(
                                                                         "NumberOfNonPooledConnections",
                                                                         "The number of connections that are not using connection pooling",
                                                                         PerformanceCounterType.NumberOfItems32);
 
-            static internal readonly CounterCreationData NumberOfPooledConnections = new CounterCreationData(
+            internal static readonly CounterCreationData NumberOfPooledConnections = new CounterCreationData(
                                                                         "NumberOfPooledConnections",
                                                                         "The number of connections that are managed by the connection pooler",
                                                                         PerformanceCounterType.NumberOfItems32);
 
-            static internal readonly CounterCreationData NumberOfActiveConnectionPoolGroups = new CounterCreationData(
+            internal static readonly CounterCreationData NumberOfActiveConnectionPoolGroups = new CounterCreationData(
                                                                         "NumberOfActiveConnectionPoolGroups",
                                                                         "The number of unique connection strings",
                                                                         PerformanceCounterType.NumberOfItems32);
 
-            static internal readonly CounterCreationData NumberOfInactiveConnectionPoolGroups = new CounterCreationData(
+            internal static readonly CounterCreationData NumberOfInactiveConnectionPoolGroups = new CounterCreationData(
                                                                         "NumberOfInactiveConnectionPoolGroups",
                                                                         "The number of unique connection strings waiting for pruning",
                                                                         PerformanceCounterType.NumberOfItems32);
 
-            static internal readonly CounterCreationData NumberOfActiveConnectionPools = new CounterCreationData(
+            internal static readonly CounterCreationData NumberOfActiveConnectionPools = new CounterCreationData(
                                                                         "NumberOfActiveConnectionPools",
                                                                         "The number of connection pools",
                                                                         PerformanceCounterType.NumberOfItems32);
 
-            static internal readonly CounterCreationData NumberOfInactiveConnectionPools = new CounterCreationData(
+            internal static readonly CounterCreationData NumberOfInactiveConnectionPools = new CounterCreationData(
                                                                         "NumberOfInactiveConnectionPools",
                                                                         "The number of connection pools",
                                                                         PerformanceCounterType.NumberOfItems32);
 
-            static internal readonly CounterCreationData NumberOfActiveConnections = new CounterCreationData(
+            internal static readonly CounterCreationData NumberOfActiveConnections = new CounterCreationData(
                                                                         "NumberOfActiveConnections",
                                                                         "The number of connections currently in-use",
                                                                         PerformanceCounterType.NumberOfItems32);
 
-            static internal readonly CounterCreationData NumberOfFreeConnections = new CounterCreationData(
+            internal static readonly CounterCreationData NumberOfFreeConnections = new CounterCreationData(
                                                                         "NumberOfFreeConnections",
                                                                         "The number of connections currently available for use",
                                                                         PerformanceCounterType.NumberOfItems32);
 
-            static internal readonly CounterCreationData NumberOfStasisConnections = new CounterCreationData(
+            internal static readonly CounterCreationData NumberOfStasisConnections = new CounterCreationData(
                                                                         "NumberOfStasisConnections",
                                                                         "The number of connections currently waiting to be made ready for use",
                                                                         PerformanceCounterType.NumberOfItems32);
 
-            static internal readonly CounterCreationData NumberOfReclaimedConnections = new CounterCreationData(
+            internal static readonly CounterCreationData NumberOfReclaimedConnections = new CounterCreationData(
                                                                         "NumberOfReclaimedConnections",
                                                                         "The number of connections we reclaim from GC'd external connections",
                                                                         PerformanceCounterType.NumberOfItems32);
         };
 
-        sealed internal class Counter
+        internal sealed class Counter
         {
             private PerformanceCounter _instance;
 
@@ -343,7 +343,7 @@ namespace Microsoft.Data.ProviderBase
         }
     }
 
-    sealed internal class DbConnectionPoolCountersNoCounters : DbConnectionPoolCounters
+    internal sealed class DbConnectionPoolCountersNoCounters : DbConnectionPoolCounters
     {
 
         public static readonly DbConnectionPoolCountersNoCounters SingletonInstance = new DbConnectionPoolCountersNoCounters();

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPoolIdentity.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPoolIdentity.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.ProviderBase
     using Microsoft.Data.Common;
 
     [Serializable] // Serializable so SqlDependencyProcessDispatcher can marshall cross domain to SqlDependency.
-    sealed internal class DbConnectionPoolIdentity
+    internal sealed class DbConnectionPoolIdentity
     {
         private const int E_NotImpersonationToken = unchecked((int)0x8007051D);
         private const int Win32_CheckTokenMembership = 1;
@@ -23,9 +23,9 @@ namespace Microsoft.Data.ProviderBase
         private const int Win32_ConvertSidToStringSidW = 4;
         private const int Win32_CreateWellKnownSid = 5;
 
-        static public readonly DbConnectionPoolIdentity NoIdentity = new DbConnectionPoolIdentity(String.Empty, false, true);
-        static private readonly byte[] NetworkSid = (ADP.s_isWindowsNT ? CreateWellKnownSid(WellKnownSidType.NetworkSid) : null);
-        static private DbConnectionPoolIdentity _lastIdentity = null;
+        public static readonly DbConnectionPoolIdentity NoIdentity = new DbConnectionPoolIdentity(String.Empty, false, true);
+        private static readonly byte[] NetworkSid = (ADP.s_isWindowsNT ? CreateWellKnownSid(WellKnownSidType.NetworkSid) : null);
+        private static DbConnectionPoolIdentity _lastIdentity = null;
 
         private readonly string _sidString;
         private readonly bool _isRestricted;
@@ -50,7 +50,7 @@ namespace Microsoft.Data.ProviderBase
             get { return _isNetwork; }
         }
 
-        static private byte[] CreateWellKnownSid(WellKnownSidType sidType)
+        private static byte[] CreateWellKnownSid(WellKnownSidType sidType)
         {
             // Passing an array as big as it can ever be is a small price to pay for
             // not having to P/Invoke twice (once to get the buffer, once to get the data)
@@ -67,7 +67,7 @@ namespace Microsoft.Data.ProviderBase
             return resultSid;
         }
 
-        override public bool Equals(object value)
+        public override bool Equals(object value)
         {
             bool result = ((this == NoIdentity) || (this == value));
             if (!result && value != null)
@@ -79,20 +79,20 @@ namespace Microsoft.Data.ProviderBase
         }
 
         [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.ControlPrincipal)]
-        static internal WindowsIdentity GetCurrentWindowsIdentity()
+        internal static WindowsIdentity GetCurrentWindowsIdentity()
         {
             return WindowsIdentity.GetCurrent();
         }
 
         [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
-        static private IntPtr GetWindowsIdentityToken(WindowsIdentity identity)
+        private static IntPtr GetWindowsIdentityToken(WindowsIdentity identity)
         {
             return identity.Token;
         }
 
         [ResourceExposure(ResourceScope.None)] // SxS: this method does not create named objects
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        static internal DbConnectionPoolIdentity GetCurrent()
+        internal static DbConnectionPoolIdentity GetCurrent()
         {
 
             // DEVNOTE: GetTokenInfo and EqualSID do not work on 9x.  WindowsIdentity does not
@@ -219,12 +219,12 @@ namespace Microsoft.Data.ProviderBase
             return current;
         }
 
-        override public int GetHashCode()
+        public override int GetHashCode()
         {
             return _hashCode;
         }
 
-        static private void IntegratedSecurityError(int caller)
+        private static void IntegratedSecurityError(int caller)
         {
             // passing 1,2,3,4,5 instead of true/false so that with a debugger
             // we could determine more easily which Win32 method call failed

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/RelationshipConverter.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/RelationshipConverter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data
     using System.ComponentModel;
     using System.ComponentModel.Design.Serialization;
 
-    sealed internal class RelationshipConverter : ExpandableObjectConverter
+    internal sealed class RelationshipConverter : ExpandableObjectConverter
     {
 
         // converter classes should have public ctor

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Sql/SqlGenericUtil.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Sql/SqlGenericUtil.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Sql
     using Microsoft.Data;
     using Microsoft.Data.Common;
 
-    sealed internal class SqlGenericUtil
+    internal sealed class SqlGenericUtil
     {
 
         private SqlGenericUtil() { /* prevent utility class from being instantiated*/ }
@@ -21,11 +21,11 @@ namespace Microsoft.Data.Sql
         // Sql.Definition
         //
 
-        static internal Exception NullCommandText()
+        internal static Exception NullCommandText()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.Sql_NullCommandText));
         }
-        static internal Exception MismatchedMetaDataDirectionArrayLengths()
+        internal static Exception MismatchedMetaDataDirectionArrayLengths()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.Sql_MismatchedMetaDataDirectionArrayLengths));
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiContextFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/Server/SmiContextFactory.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 namespace Microsoft.Data.SqlClient.Server
 {
 
-    sealed internal class SmiContextFactory
+    internal sealed class SmiContextFactory
     {
         public static readonly SmiContextFactory Instance = new SmiContextFactory();
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientPermission.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientPermission.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/Copy/*' />
-        override public IPermission Copy()
+        public override IPermission Copy()
         {
             return new SqlClientPermission(this);
         }
@@ -127,7 +127,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/Intersect/*' />
-        override public IPermission Intersect(IPermission target)
+        public override IPermission Intersect(IPermission target)
         { // used during Deny actions
             if (target == null)
             {
@@ -180,7 +180,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/IsSubsetOf/*' />
-        override public bool IsSubsetOf(IPermission target)
+        public override bool IsSubsetOf(IPermission target)
         {
             if (null == target)
             {
@@ -219,7 +219,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/Union/*' />
-        override public IPermission Union(IPermission target)
+        public override IPermission Union(IPermission target)
         {
             if (target == null)
             {
@@ -282,7 +282,7 @@ namespace Microsoft.Data.SqlClient
         //     <add ConnectionString="provider=x;data source=y;" KeyRestrictions="address=;server=" KeyRestrictionBehavior=PreventUsage/>
         // </IPermission>
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/FromXml/*' />
-        override public void FromXml(SecurityElement securityElement)
+        public override void FromXml(SecurityElement securityElement)
         {
             // code derived from CodeAccessPermission.ValidateElement
             if (securityElement == null)
@@ -345,7 +345,7 @@ namespace Microsoft.Data.SqlClient
         //     <add ConnectionString="provider=x;data source=y;" KeyRestrictions="address=;server=" KeyRestrictionBehavior=PreventUsage/>
         // </IPermission>
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/ToXml/*' />
-        override public SecurityElement ToXml()
+        public override SecurityElement ToXml()
         {
             Type type = this.GetType();
             SecurityElement root = new SecurityElement(XmlStr._IPermission);
@@ -424,7 +424,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermissionAttribute.xml' path='docs/members[@name="SqlClientPermissionAttribute"]/CreatePermission/*' />
-        override public IPermission CreatePermission()
+        public override IPermission CreatePermission()
         {
             return new SqlClientPermission(this);
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Data.SqlClient
         //
         //  Smi execution-specific stuff
         //
-        sealed private class CommandEventSink : SmiEventSink_Default
+        private sealed class CommandEventSink : SmiEventSink_Default
         {
             private SqlCommand _command;
 
@@ -499,7 +499,7 @@ namespace Microsoft.Data.SqlClient
         ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
         ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_Connection),
         ]
-        new public SqlConnection Connection
+        public new SqlConnection Connection
         {
             get
             {
@@ -706,7 +706,7 @@ namespace Microsoft.Data.SqlClient
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
         ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_Transaction),
         ]
-        new public SqlTransaction Transaction
+        public new SqlTransaction Transaction
         {
             get
             {
@@ -891,7 +891,7 @@ namespace Microsoft.Data.SqlClient
         ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
         ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_Parameters),
         ]
-        new public SqlParameterCollection Parameters
+        public new SqlParameterCollection Parameters
         {
             get
             {
@@ -1330,7 +1330,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/CreateParameter/*'/>
-        new public SqlParameter CreateParameter()
+        public new SqlParameter CreateParameter()
         {
             return new SqlParameter();
         }
@@ -2490,7 +2490,7 @@ namespace Microsoft.Data.SqlClient
             => RetryLogicProvider.Execute(this, () => ExecuteReader(behavior, method));
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReader[@name="default"]/*'/>
-        new public SqlDataReader ExecuteReader()
+        public new SqlDataReader ExecuteReader()
         {
             SqlStatistics statistics = null;
             using (TryEventScope.Create("<sc.SqlCommand.ExecuteReader|API> {0}", ObjectID))
@@ -2511,7 +2511,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReader[@name="CommandBehavior"]/*'/>
-        new public SqlDataReader ExecuteReader(CommandBehavior behavior)
+        public new SqlDataReader ExecuteReader(CommandBehavior behavior)
         {
             using (TryEventScope.Create("<sc.SqlCommand.ExecuteReader|API> {0}, behavior={1}", ObjectID, (int)behavior))
             {
@@ -3130,25 +3130,25 @@ namespace Microsoft.Data.SqlClient
             => RetryLogicProvider.ExecuteAsync(this, () => InternalExecuteReaderAsync(behavior, cancellationToken), cancellationToken);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="default"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync()
+        public new Task<SqlDataReader> ExecuteReaderAsync()
             => IsProviderRetriable ?
                 InternalExecuteReaderWithRetryAsync(CommandBehavior.Default, CancellationToken.None) :
                 InternalExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="CommandBehavior"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
+        public new Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
             => IsProviderRetriable ?
                 InternalExecuteReaderWithRetryAsync(behavior, CancellationToken.None) :
                 InternalExecuteReaderAsync(behavior, CancellationToken.None);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="CancellationToken"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
+        public new Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
             => IsProviderRetriable ?
                 InternalExecuteReaderWithRetryAsync(CommandBehavior.Default, cancellationToken) :
                 InternalExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="commandBehaviorAndCancellationToken"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+        public new Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
             => IsProviderRetriable ?
                 InternalExecuteReaderWithRetryAsync(behavior, cancellationToken) :
                 InternalExecuteReaderAsync(behavior, cancellationToken);
@@ -3914,7 +3914,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         [System.Security.Permissions.SecurityPermission(SecurityAction.Assert, Infrastructure = true)]
-        static internal string SqlNotificationContext()
+        internal static string SqlNotificationContext()
         {
             SqlConnection.VerifyExecutePermission();
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.SqlClient
 
         internal bool _suppressStateChangeForReconnection = false; // Do not use for anything else ! Value will be overwritten by CR process
 
-        static private readonly object EventInfoMessage = new object();
+        private static readonly object EventInfoMessage = new object();
 
         // System column encryption key store providers are added by default
         private static Dictionary<string, SqlColumnEncryptionKeyStoreProvider> s_systemColumnEncryptionKeyStoreProviders
@@ -84,7 +84,7 @@ namespace Microsoft.Data.SqlClient
         /// Key to the dictionary is a SQL Server Name
         /// IList contains a list of trusted key paths.
         /// </summary>
-        static private readonly ConcurrentDictionary<string, IList<string>> _ColumnEncryptionTrustedMasterKeyPaths
+        private static readonly ConcurrentDictionary<string, IList<string>> _ColumnEncryptionTrustedMasterKeyPaths
             = new(concurrencyLevel: 4 * Environment.ProcessorCount /* default value in ConcurrentDictionary*/,
                                                             capacity: 1,
                                                             comparer: StringComparer.OrdinalIgnoreCase);
@@ -100,7 +100,7 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// Defines whether query metadata caching is enabled.
         /// </summary>
-        static private bool _ColumnEncryptionQueryMetadataCacheEnabled = true;
+        private static bool _ColumnEncryptionQueryMetadataCacheEnabled = true;
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ColumnEncryptionQueryMetadataCacheEnabled/*' />
         [
@@ -108,7 +108,7 @@ namespace Microsoft.Data.SqlClient
         ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
         ResDescriptionAttribute(StringsHelper.ResourceNames.TCE_SqlConnection_ColumnEncryptionQueryMetadataCacheEnabled),
         ]
-        static public bool ColumnEncryptionQueryMetadataCacheEnabled
+        public static bool ColumnEncryptionQueryMetadataCacheEnabled
         {
             get
             {
@@ -123,7 +123,7 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// Defines whether query metadata caching is enabled.
         /// </summary>
-        static private TimeSpan _ColumnEncryptionKeyCacheTtl = TimeSpan.FromHours(2);
+        private static TimeSpan _ColumnEncryptionKeyCacheTtl = TimeSpan.FromHours(2);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ColumnEncryptionKeyCacheTtl/*' />
         [
@@ -131,14 +131,14 @@ namespace Microsoft.Data.SqlClient
         ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
         ResDescriptionAttribute(StringsHelper.ResourceNames.TCE_SqlConnection_ColumnEncryptionKeyCacheTtl),
         ]
-        static public TimeSpan ColumnEncryptionKeyCacheTtl
+        public static TimeSpan ColumnEncryptionKeyCacheTtl
         {
             get => _ColumnEncryptionKeyCacheTtl;
             set => _ColumnEncryptionKeyCacheTtl = value;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/RegisterColumnEncryptionKeyStoreProviders/*' />
-        static public void RegisterColumnEncryptionKeyStoreProviders(IDictionary<string, SqlColumnEncryptionKeyStoreProvider> customProviders)
+        public static void RegisterColumnEncryptionKeyStoreProviders(IDictionary<string, SqlColumnEncryptionKeyStoreProvider> customProviders)
         {
             ValidateCustomProviders(customProviders);
 
@@ -706,7 +706,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/DbProviderFactory/*' />
-        override protected DbProviderFactory DbProviderFactory
+        protected override DbProviderFactory DbProviderFactory
         {
             get
             {
@@ -804,7 +804,7 @@ namespace Microsoft.Data.SqlClient
         ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
         ResDescriptionAttribute(StringsHelper.ResourceNames.SqlConnection_ConnectionString),
         ]
-        override public string ConnectionString
+        public override string ConnectionString
         {
             get
             {
@@ -874,7 +874,7 @@ namespace Microsoft.Data.SqlClient
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
         ResDescriptionAttribute(StringsHelper.ResourceNames.SqlConnection_ConnectionTimeout),
         ]
-        override public int ConnectionTimeout
+        public override int ConnectionTimeout
         {
             get
             {
@@ -888,7 +888,7 @@ namespace Microsoft.Data.SqlClient
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
         ResDescriptionAttribute(StringsHelper.ResourceNames.SqlConnection_Database),
         ]
-        override public string Database
+        public override string Database
         {
             // if the connection is open, we need to ask the inner connection what it's
             // current catalog is because it may have gotten changed, otherwise we can
@@ -965,7 +965,7 @@ namespace Microsoft.Data.SqlClient
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
         ResDescriptionAttribute(StringsHelper.ResourceNames.SqlConnection_DataSource),
         ]
-        override public string DataSource
+        public override string DataSource
         {
             get
             {
@@ -1056,7 +1056,7 @@ namespace Microsoft.Data.SqlClient
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
         ResDescriptionAttribute(StringsHelper.ResourceNames.SqlConnection_ServerVersion),
         ]
-        override public string ServerVersion
+        public override string ServerVersion
         {
             get
             {
@@ -1082,7 +1082,7 @@ namespace Microsoft.Data.SqlClient
         DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
         ResDescriptionAttribute(StringsHelper.ResourceNames.DbConnection_State),
         ]
-        override public ConnectionState State
+        public override ConnectionState State
         {
             get
             {
@@ -1386,14 +1386,14 @@ namespace Microsoft.Data.SqlClient
         // PUBLIC METHODS
         //
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/BeginTransaction2/*' />
-        new public SqlTransaction BeginTransaction()
+        public new SqlTransaction BeginTransaction()
         {
             // this is just a delegate. The actual method tracks executiontime
             return BeginTransaction(IsolationLevel.Unspecified, null);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/BeginTransactionIso/*' />
-        new public SqlTransaction BeginTransaction(IsolationLevel iso)
+        public new SqlTransaction BeginTransaction(IsolationLevel iso)
         {
             // this is just a delegate. The actual method tracks executiontime
             return BeginTransaction(iso, null);
@@ -1412,7 +1412,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/BeginDbTransaction/*' />
         // suppress this message - we cannot use SafeHandle here. Also, see notes in the code (VSTFDEVDIV# 560355)
         [SuppressMessage("Microsoft.Reliability", "CA2004:RemoveCallsToGCKeepAlive")]
-        override protected DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
         {
             using (TryEventScope.Create("<prov.SqlConnection.BeginDbTransaction|API> {0}, isolationLevel={1}", ObjectID, (int)isolationLevel))
             {
@@ -1468,7 +1468,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ChangeDatabase/*' />
-        override public void ChangeDatabase(string database)
+        public override void ChangeDatabase(string database)
         {
             SqlStatistics statistics = null;
             RepairInnerConnection();
@@ -1522,14 +1522,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ClearAllPools/*' />
-        static public void ClearAllPools()
+        public static void ClearAllPools()
         {
             (new SqlClientPermission(PermissionState.Unrestricted)).Demand();
             SqlConnectionFactory.SingletonInstance.ClearAllPools();
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ClearPool/*' />
-        static public void ClearPool(SqlConnection connection)
+        public static void ClearPool(SqlConnection connection)
         {
             ADP.CheckArgumentNull(connection, "connection");
 
@@ -1564,7 +1564,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/Close/*' />
-        override public void Close()
+        public override void Close()
         {
             using (TryEventScope.Create("<sc.SqlConnection.Close|API> {0}", ObjectID))
             {
@@ -1660,7 +1660,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/CreateCommand/*' />
-        new public SqlCommand CreateCommand()
+        public new SqlCommand CreateCommand()
         {
             return new SqlCommand(null, this);
         }
@@ -1702,7 +1702,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/Open/*' />
-        override public void Open()
+        public override void Open()
         {
             Open(SqlConnectionOverrides.None);
         }
@@ -2392,7 +2392,7 @@ namespace Microsoft.Data.SqlClient
         // Surround name in brackets and then escape any end bracket to protect against SQL Injection.
         // NOTE: if the user escapes it themselves it will not work, but this was the case in V1 as well
         // as native OleDb and Odbc.
-        static internal string FixupDatabaseTransactionName(string name)
+        internal static string FixupDatabaseTransactionName(string name)
         {
             if (!ADP.IsEmpty(name))
             {
@@ -2930,7 +2930,7 @@ namespace Microsoft.Data.SqlClient
 
 
         // updates our context with any changes made to the memory-mapped data by an external process
-        static private void RefreshMemoryMappedData(SqlDebugContext sdc)
+        private static void RefreshMemoryMappedData(SqlDebugContext sdc)
         {
             Debug.Assert(ADP.s_ptrZero != sdc.pMemMap, "SQL Debug: invalid null value for pMemMap!");
             // copy memory mapped file contents into managed types

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -15,7 +15,7 @@ using Microsoft.Data.SqlClient.Server;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlConnectionFactory : DbConnectionFactory
+    internal sealed class SqlConnectionFactory : DbConnectionFactory
     {
         private SqlConnectionFactory() : base(SqlPerformanceCounters.SingletonInstance)
         {
@@ -24,7 +24,7 @@ namespace Microsoft.Data.SqlClient
         public static readonly SqlConnectionFactory SingletonInstance = new SqlConnectionFactory();
         private const string _metaDataXml = "MetaDataXml";
 
-        override public DbProviderFactory ProviderFactory
+        public override DbProviderFactory ProviderFactory
         {
             get
             {
@@ -32,12 +32,12 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection)
+        protected override DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection)
         {
             return CreateConnection(options, poolKey, poolGroupProviderInfo, pool, owningConnection, userOptions: null);
         }
 
-        override protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
+        protected override DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, DbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
         {
             SqlConnectionString opt = (SqlConnectionString)options;
             SqlConnectionPoolKey key = (SqlConnectionPoolKey)poolKey;
@@ -153,7 +153,7 @@ namespace Microsoft.Data.SqlClient
             return result;
         }
 
-        override internal DbConnectionPoolProviderInfo CreateConnectionPoolProviderInfo(DbConnectionOptions connectionOptions)
+        internal override DbConnectionPoolProviderInfo CreateConnectionPoolProviderInfo(DbConnectionOptions connectionOptions)
         {
             DbConnectionPoolProviderInfo providerInfo = null;
 
@@ -165,7 +165,7 @@ namespace Microsoft.Data.SqlClient
             return providerInfo;
         }
 
-        override protected DbConnectionPoolGroupOptions CreateConnectionPoolGroupOptions(DbConnectionOptions connectionOptions)
+        protected override DbConnectionPoolGroupOptions CreateConnectionPoolGroupOptions(DbConnectionOptions connectionOptions)
         {
             SqlConnectionString opt = (SqlConnectionString)connectionOptions;
 
@@ -205,7 +205,7 @@ namespace Microsoft.Data.SqlClient
             return poolingOptions;
         }
 
-        override protected DbMetaDataFactory CreateMetaDataFactory(DbConnectionInternal internalConnection, out bool cacheMetaDataFactory)
+        protected override DbMetaDataFactory CreateMetaDataFactory(DbConnectionInternal internalConnection, out bool cacheMetaDataFactory)
         {
             Debug.Assert(internalConnection != null, "internalConnection may not be null.");
 
@@ -219,7 +219,7 @@ namespace Microsoft.Data.SqlClient
                                           internalConnection.ServerVersion); //internalConnection.ServerVersionNormalized);
         }
 
-        override internal DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(DbConnectionOptions connectionOptions)
+        internal override DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(DbConnectionOptions connectionOptions)
         {
             return new SqlConnectionPoolGroupProviderInfo((SqlConnectionString)connectionOptions);
         }
@@ -262,7 +262,7 @@ namespace Microsoft.Data.SqlClient
             return result;
         }
 
-        override internal DbConnectionPoolGroup GetConnectionPoolGroup(DbConnection connection)
+        internal override DbConnectionPoolGroup GetConnectionPoolGroup(DbConnection connection)
         {
             SqlConnection c = (connection as SqlConnection);
             if (c != null)
@@ -272,7 +272,7 @@ namespace Microsoft.Data.SqlClient
             return null;
         }
 
-        override internal DbConnectionInternal GetInnerConnection(DbConnection connection)
+        internal override DbConnectionInternal GetInnerConnection(DbConnection connection)
         {
             SqlConnection c = (connection as SqlConnection);
             if (c != null)
@@ -282,7 +282,7 @@ namespace Microsoft.Data.SqlClient
             return null;
         }
 
-        override protected int GetObjectId(DbConnection connection)
+        protected override int GetObjectId(DbConnection connection)
         {
             SqlConnection c = (connection as SqlConnection);
             if (c != null)
@@ -292,7 +292,7 @@ namespace Microsoft.Data.SqlClient
             return 0;
         }
 
-        override internal void PermissionDemand(DbConnection outerConnection)
+        internal override void PermissionDemand(DbConnection outerConnection)
         {
             SqlConnection c = (outerConnection as SqlConnection);
             if (c != null)
@@ -301,7 +301,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal void SetConnectionPoolGroup(DbConnection outerConnection, DbConnectionPoolGroup poolGroup)
+        internal override void SetConnectionPoolGroup(DbConnection outerConnection, DbConnectionPoolGroup poolGroup)
         {
             SqlConnection c = (outerConnection as SqlConnection);
             if (c != null)
@@ -310,7 +310,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal void SetInnerConnectionEvent(DbConnection owningObject, DbConnectionInternal to)
+        internal override void SetInnerConnectionEvent(DbConnection owningObject, DbConnectionInternal to)
         {
             SqlConnection c = (owningObject as SqlConnection);
             if (c != null)
@@ -319,7 +319,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool SetInnerConnectionFrom(DbConnection owningObject, DbConnectionInternal to, DbConnectionInternal from)
+        internal override bool SetInnerConnectionFrom(DbConnection owningObject, DbConnectionInternal to, DbConnectionInternal from)
         {
             SqlConnection c = (owningObject as SqlConnection);
             if (c != null)
@@ -329,7 +329,7 @@ namespace Microsoft.Data.SqlClient
             return false;
         }
 
-        override internal void SetInnerConnectionTo(DbConnection owningObject, DbConnectionInternal to)
+        internal override void SetInnerConnectionTo(DbConnection owningObject, DbConnectionInternal to)
         {
             SqlConnection c = (owningObject as SqlConnection);
             if (c != null)
@@ -341,7 +341,7 @@ namespace Microsoft.Data.SqlClient
     }
 
     [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name = "FullTrust")]
-    sealed internal class SqlPerformanceCounters : DbConnectionPoolCounters
+    internal sealed class SqlPerformanceCounters : DbConnectionPoolCounters
     {
         private const string CategoryName = ".NET Data Provider for SqlServer";
         private const string CategoryHelp = "Counters for Microsoft.Data.SqlClient";

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/CreateDbCommand/*' />
-        override protected DbCommand CreateDbCommand()
+        protected override DbCommand CreateDbCommand()
         {
             using (TryEventScope.Create("<prov.DbConnectionHelper.CreateDbCommand|API> {0}", ObjectID))
             {
@@ -216,7 +216,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/Dispose/*' />
-        override protected void Dispose(bool disposing)
+        protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
@@ -262,7 +262,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/EnlistTransaction/*' />
-        override public void EnlistTransaction(Transaction transaction)
+        public override void EnlistTransaction(Transaction transaction)
         {
             SqlConnection.ExecutePermission.Demand();
             SqlClientEventSource.Log.TryTraceEvent("<prov.DbConnectionHelper.EnlistTransaction|RES|TRAN> {0}, Connection enlisting in a transaction.", ObjectID);
@@ -312,19 +312,19 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/GetSchema2/*' />
-        override public DataTable GetSchema()
+        public override DataTable GetSchema()
         {
             return this.GetSchema(DbMetaDataCollectionNames.MetaDataCollections, null);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/GetSchemaCollectionName/*' />
-        override public DataTable GetSchema(string collectionName)
+        public override DataTable GetSchema(string collectionName)
         {
             return this.GetSchema(collectionName, null);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/GetSchemaCollectionNameRestrictionValues/*' />
-        override public DataTable GetSchema(string collectionName, string[] restrictionValues)
+        public override DataTable GetSchema(string collectionName, string[] restrictionValues)
         {
             // NOTE: This is virtual because not all providers may choose to support
             //       returning schema data

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Data.SqlClient
         public SensitivityClassification SensitivityClassification { get; internal set; }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Depth/*' />
-        override public int Depth
+        public override int Depth
         {
             get
             {
@@ -171,7 +171,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/FieldCount/*' />
         // fields/attributes collection
-        override public int FieldCount
+        public override int FieldCount
         {
             get
             {
@@ -194,7 +194,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/HasRows/*' />
-        override public bool HasRows
+        public override bool HasRows
         {
             get
             {
@@ -212,7 +212,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/IsClosed/*' />
-        override public bool IsClosed
+        public override bool IsClosed
         {
             get
             {
@@ -406,7 +406,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/RecordsAffected/*' />
-        override public int RecordsAffected
+        public override int RecordsAffected
         {
             get
             {
@@ -448,7 +448,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/VisibleFieldCount/*' />
-        override public int VisibleFieldCount
+        public override int VisibleFieldCount
         {
             get
             {
@@ -467,7 +467,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/ItemI/*' />
         // this operator
-        override public object this[int i]
+        public override object this[int i]
         {
             get
             {
@@ -476,7 +476,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/ItemName/*' />
-        override public object this[string name]
+        public override object this[string name]
         {
             get
             {
@@ -959,7 +959,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Close/*' />
-        override public void Close()
+        public override void Close()
         {
             SqlStatistics statistics = null;
             using (TryEventScope.Create("<sc.SqlDataReader.Close|API> {0}", ObjectID))
@@ -1298,7 +1298,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        virtual internal void CloseReaderFromConnection()
+        internal virtual void CloseReaderFromConnection()
         {
             var parser = _parser;
             Debug.Assert(parser == null || parser.State != TdsParserState.OpenNotLoggedIn, "Reader on a connection that is not logged in");
@@ -1368,7 +1368,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDataTypeName/*' />
-        override public string GetDataTypeName(int i)
+        public override string GetDataTypeName(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -1436,7 +1436,7 @@ namespace Microsoft.Data.SqlClient
             return dataTypeName;
         }
 
-        virtual internal SqlBuffer.StorageType GetVariantInternalStorageType(int i)
+        internal virtual SqlBuffer.StorageType GetVariantInternalStorageType(int i)
         {
             Debug.Assert(_data != null, "Attempting to get variant internal storage type");
             Debug.Assert(i < _data.Length, "Reading beyond data length?");
@@ -1445,13 +1445,13 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetEnumerator/*' />
-        override public IEnumerator GetEnumerator()
+        public override IEnumerator GetEnumerator()
         {
             return new DbEnumerator(this, IsCommandBehavior(CommandBehavior.CloseConnection));
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetFieldType/*' />
-        override public Type GetFieldType(int i)
+        public override Type GetFieldType(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -1521,7 +1521,7 @@ namespace Microsoft.Data.SqlClient
             return fieldType;
         }
 
-        virtual internal int GetLocaleId(int i)
+        internal virtual int GetLocaleId(int i)
         {
             _SqlMetaData sqlMetaData = MetaData[i];
             int lcid;
@@ -1554,7 +1554,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetName/*' />
-        override public string GetName(int i)
+        public override string GetName(int i)
         {
             CheckMetaDataIsReady(columnIndex: i);
 
@@ -1563,7 +1563,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetProviderSpecificFieldType/*' />
-        override public Type GetProviderSpecificFieldType(int i)
+        public override Type GetProviderSpecificFieldType(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -1636,7 +1636,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetOrdinal/*' />
         // named field access
-        override public int GetOrdinal(string name)
+        public override int GetOrdinal(string name)
         {
             SqlStatistics statistics = null;
             try
@@ -1656,19 +1656,19 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetProviderSpecificValue/*' />
-        override public object GetProviderSpecificValue(int i)
+        public override object GetProviderSpecificValue(int i)
         {
             return GetSqlValue(i);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetProviderSpecificValues/*' />
-        override public int GetProviderSpecificValues(object[] values)
+        public override int GetProviderSpecificValues(object[] values)
         {
             return GetSqlValues(values);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSchemaTable/*' />
-        override public DataTable GetSchemaTable()
+        public override DataTable GetSchemaTable()
         {
             SqlStatistics statistics = null;
             using (TryEventScope.Create("<sc.SqlDataReader.GetSchemaTable|API> {0}", ObjectID))
@@ -1694,14 +1694,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetBoolean/*' />
-        override public bool GetBoolean(int i)
+        public override bool GetBoolean(int i)
         {
             ReadColumn(i);
             return _data[i].Boolean;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetXmlReader/*' />
-        virtual public XmlReader GetXmlReader(int i)
+        public virtual XmlReader GetXmlReader(int i)
         {
             // NOTE: sql_variant can not contain a XML data type: http://msdn.microsoft.com/en-us/library/ms173829.aspx
             // If this ever changes, the following code should be changed to be like GetStream\GetTextReader
@@ -1741,7 +1741,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetStream/*' />
-        override public Stream GetStream(int i)
+        public override Stream GetStream(int i)
         {
             CheckDataIsReady(columnIndex: i, methodName: "GetStream");
 
@@ -1789,14 +1789,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetByte/*' />
-        override public byte GetByte(int i)
+        public override byte GetByte(int i)
         {
             ReadColumn(i);
             return _data[i].Byte;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetBytes/*' />
-        override public long GetBytes(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
+        public override long GetBytes(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
         {
             SqlStatistics statistics = null;
             long cbBytes = 0;
@@ -1825,7 +1825,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Used (indirectly) by SqlCommand.CompleteXmlReader
-        virtual internal long GetBytesInternal(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
+        internal virtual long GetBytesInternal(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
         {
             if (_currentTask != null)
             {
@@ -2240,7 +2240,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetTextReader/*' />
-        override public TextReader GetTextReader(int i)
+        public override TextReader GetTextReader(int i)
         {
             CheckDataIsReady(columnIndex: i, methodName: "GetTextReader");
 
@@ -2311,13 +2311,13 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetChar/*' />
         [EditorBrowsableAttribute(EditorBrowsableState.Never)] // MDAC 69508
-        override public char GetChar(int i)
+        public override char GetChar(int i)
         {
             throw ADP.NotSupported();
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetChars/*' />
-        override public long GetChars(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
+        public override long GetChars(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
         {
             SqlStatistics statistics = null;
 
@@ -2670,7 +2670,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDateTime/*' />
-        override public DateTime GetDateTime(int i)
+        public override DateTime GetDateTime(int i)
         {
             ReadColumn(i);
 
@@ -2692,77 +2692,77 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDecimal/*' />
-        override public Decimal GetDecimal(int i)
+        public override Decimal GetDecimal(int i)
         {
             ReadColumn(i);
             return _data[i].Decimal;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDouble/*' />
-        override public double GetDouble(int i)
+        public override double GetDouble(int i)
         {
             ReadColumn(i);
             return _data[i].Double;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetFloat/*' />
-        override public float GetFloat(int i)
+        public override float GetFloat(int i)
         {
             ReadColumn(i);
             return _data[i].Single;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetGuid/*' />
-        override public Guid GetGuid(int i)
+        public override Guid GetGuid(int i)
         {
             ReadColumn(i);
             return _data[i].Guid;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetInt16/*' />
-        override public Int16 GetInt16(int i)
+        public override Int16 GetInt16(int i)
         {
             ReadColumn(i);
             return _data[i].Int16;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetInt32/*' />
-        override public Int32 GetInt32(int i)
+        public override Int32 GetInt32(int i)
         {
             ReadColumn(i);
             return _data[i].Int32;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetInt64/*' />
-        override public Int64 GetInt64(int i)
+        public override Int64 GetInt64(int i)
         {
             ReadColumn(i);
             return _data[i].Int64;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlBoolean/*' />
-        virtual public SqlBoolean GetSqlBoolean(int i)
+        public virtual SqlBoolean GetSqlBoolean(int i)
         {
             ReadColumn(i);
             return _data[i].SqlBoolean;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlBinary/*' />
-        virtual public SqlBinary GetSqlBinary(int i)
+        public virtual SqlBinary GetSqlBinary(int i)
         {
             ReadColumn(i, setTimeout: true, allowPartiallyReadColumn: true);
             return _data[i].SqlBinary;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlByte/*' />
-        virtual public SqlByte GetSqlByte(int i)
+        public virtual SqlByte GetSqlByte(int i)
         {
             ReadColumn(i);
             return _data[i].SqlByte;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlBytes/*' />
-        virtual public SqlBytes GetSqlBytes(int i)
+        public virtual SqlBytes GetSqlBytes(int i)
         {
             ReadColumn(i);
             SqlBinary data = _data[i].SqlBinary;
@@ -2770,7 +2770,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlChars/*' />
-        virtual public SqlChars GetSqlChars(int i)
+        public virtual SqlChars GetSqlChars(int i)
         {
             ReadColumn(i);
             SqlString data;
@@ -2787,63 +2787,63 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDateTime/*' />
-        virtual public SqlDateTime GetSqlDateTime(int i)
+        public virtual SqlDateTime GetSqlDateTime(int i)
         {
             ReadColumn(i);
             return _data[i].SqlDateTime;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDecimal/*' />
-        virtual public SqlDecimal GetSqlDecimal(int i)
+        public virtual SqlDecimal GetSqlDecimal(int i)
         {
             ReadColumn(i);
             return _data[i].SqlDecimal;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlGuid/*' />
-        virtual public SqlGuid GetSqlGuid(int i)
+        public virtual SqlGuid GetSqlGuid(int i)
         {
             ReadColumn(i);
             return _data[i].SqlGuid;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDouble/*' />
-        virtual public SqlDouble GetSqlDouble(int i)
+        public virtual SqlDouble GetSqlDouble(int i)
         {
             ReadColumn(i);
             return _data[i].SqlDouble;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlInt16/*' />
-        virtual public SqlInt16 GetSqlInt16(int i)
+        public virtual SqlInt16 GetSqlInt16(int i)
         {
             ReadColumn(i);
             return _data[i].SqlInt16;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlInt32/*' />
-        virtual public SqlInt32 GetSqlInt32(int i)
+        public virtual SqlInt32 GetSqlInt32(int i)
         {
             ReadColumn(i);
             return _data[i].SqlInt32;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlInt64/*' />
-        virtual public SqlInt64 GetSqlInt64(int i)
+        public virtual SqlInt64 GetSqlInt64(int i)
         {
             ReadColumn(i);
             return _data[i].SqlInt64;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlMoney/*' />
-        virtual public SqlMoney GetSqlMoney(int i)
+        public virtual SqlMoney GetSqlMoney(int i)
         {
             ReadColumn(i);
             return _data[i].SqlMoney;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlSingle/*' />
-        virtual public SqlSingle GetSqlSingle(int i)
+        public virtual SqlSingle GetSqlSingle(int i)
         {
             ReadColumn(i);
             return _data[i].SqlSingle;
@@ -2851,7 +2851,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlString/*' />
         // UNDONE: need non-unicode SqlString support
-        virtual public SqlString GetSqlString(int i)
+        public virtual SqlString GetSqlString(int i)
         {
             ReadColumn(i);
 
@@ -2864,7 +2864,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlXml/*' />
-        virtual public SqlXml GetSqlXml(int i)
+        public virtual SqlXml GetSqlXml(int i)
         {
             ReadColumn(i);
             SqlXml sx = null;
@@ -2895,7 +2895,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlValue/*' />
-        virtual public object GetSqlValue(int i)
+        public virtual object GetSqlValue(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -2983,7 +2983,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlValues/*' />
-        virtual public int GetSqlValues(object[] values)
+        public virtual int GetSqlValues(object[] values)
         {
             SqlStatistics statistics = null;
             try
@@ -3012,7 +3012,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetString/*' />
-        override public string GetString(int i)
+        public override string GetString(int i)
         {
             ReadColumn(i);
 
@@ -3026,7 +3026,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetFieldValue/*' />
-        override public T GetFieldValue<T>(int i)
+        public override T GetFieldValue<T>(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -3043,7 +3043,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetValue/*' />
-        override public object GetValue(int i)
+        public override object GetValue(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -3060,7 +3060,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetTimeSpan/*' />
-        virtual public TimeSpan GetTimeSpan(int i)
+        public virtual TimeSpan GetTimeSpan(int i)
         {
             ReadColumn(i);
 
@@ -3082,7 +3082,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDateTimeOffset/*' />
-        virtual public DateTimeOffset GetDateTimeOffset(int i)
+        public virtual DateTimeOffset GetDateTimeOffset(int i)
         {
             ReadColumn(i);
 
@@ -3387,7 +3387,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetValues/*' />
-        override public int GetValues(object[] values)
+        public override int GetValues(object[] values)
         {
             SqlStatistics statistics = null;
             bool sequentialAccess = IsCommandBehavior(CommandBehavior.SequentialAccess);
@@ -3689,7 +3689,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/IsDBNull/*' />
-        override public bool IsDBNull(int i)
+        public override bool IsDBNull(int i)
         {
             if ((IsCommandBehavior(CommandBehavior.SequentialAccess)) && ((_sharedState._nextColumnHeaderToRead > i + 1) || (_lastColumnWithDataChunkRead > i)))
             {
@@ -3720,7 +3720,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/NextResult/*' />
-        override public bool NextResult()
+        public override bool NextResult()
         {
             if (_currentTask != null)
             {
@@ -3937,7 +3937,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Read/*' />
         // user must call Read() to position on the first row
-        override public bool Read()
+        public override bool Read()
         {
             if (_currentTask != null)
             {
@@ -5555,7 +5555,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/IsDBNullAsync/*' />
-        override public Task<bool> IsDBNullAsync(int i, CancellationToken cancellationToken)
+        public override Task<bool> IsDBNullAsync(int i, CancellationToken cancellationToken)
         {
 
             try
@@ -5696,7 +5696,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetFieldValueAsync/*' />
-        override public Task<T> GetFieldValueAsync<T>(int i, CancellationToken cancellationToken)
+        public override Task<T> GetFieldValueAsync<T>(int i, CancellationToken cancellationToken)
         {
             try
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReaderSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReaderSmi.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override public Type GetProviderSpecificFieldType(int ordinal)
+        public override Type GetProviderSpecificFieldType(int ordinal)
         {
             EnsureCanGetMetaData();
 
@@ -166,7 +166,7 @@ namespace Microsoft.Data.SqlClient
             return ADP.CreatedTaskWithException<T>(ADP.ExceptionWithStackTrace(SQL.NotAvailableOnContextConnection()));
         }
 
-        override internal SqlBuffer.StorageType GetVariantInternalStorageType(int ordinal)
+        internal override SqlBuffer.StorageType GetVariantInternalStorageType(int ordinal)
         {
             Debug.Assert(_currentColumnValuesV3 != null, "Attempting to get variant internal storage type without calling GetValue first");
             if (IsDBNull(ordinal))
@@ -1060,7 +1060,7 @@ namespace Microsoft.Data.SqlClient
 
         //  Assumes that if there were any results, the first chunk of them are in the data stream
         //      (up to the first actual row or the end of the resultsets).
-        unsafe internal SqlDataReaderSmi(
+        internal unsafe SqlDataReaderSmi(
                 SmiEventStream eventStream,        // the event stream that receives the events from the execution engine
                 SqlCommand parent,             // command that owns reader
                 CommandBehavior behavior,           // behavior specified for this execution

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -13,7 +13,7 @@ using System.Transactions;
 namespace Microsoft.Data.SqlClient
 {
 
-    sealed internal class SqlDelegatedTransaction : IPromotableSinglePhaseNotification
+    internal sealed class SqlDelegatedTransaction : IPromotableSinglePhaseNotification
     {
         private static int _objectTypeCount;
         private readonly int _objectID = Interlocked.Increment(ref _objectTypeCount);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
@@ -12,7 +12,7 @@ using System.Transactions;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlInternalConnectionSmi : SqlInternalConnection
+    internal sealed class SqlInternalConnectionSmi : SqlInternalConnection
     {
 
         private SmiContext _smiContext;
@@ -23,12 +23,12 @@ namespace Microsoft.Data.SqlClient
         private SqlInternalTransaction _pendingTransaction; // transaction awaiting event signalling that it is active
         private SqlInternalTransaction _currentTransaction; // currently active non-context transaction.
 
-        sealed private class EventSink : SmiEventSink_Default
+        private sealed class EventSink : SmiEventSink_Default
         {
 
             SqlInternalConnectionSmi _connection;
 
-            override internal string ServerVersion
+            internal override string ServerVersion
             {
                 get
                 {
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            override protected void DispatchMessages(bool ignoreNonFatalMessages)
+            protected override void DispatchMessages(bool ignoreNonFatalMessages)
             {
                 // Override this on the Connection event sink, since we can deal
                 // with info messages here.
@@ -146,7 +146,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal SqlInternalTransaction CurrentTransaction
+        internal override SqlInternalTransaction CurrentTransaction
         {
             get
             {
@@ -154,7 +154,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool IsLockedForBulkCopy
+        internal override bool IsLockedForBulkCopy
         {
             get
             {
@@ -162,7 +162,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool Is2000
+        internal override bool Is2000
         {
             get
             {
@@ -170,7 +170,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool Is2005OrNewer
+        internal override bool Is2005OrNewer
         {
             get
             {
@@ -178,7 +178,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool Is2008OrNewer
+        internal override bool Is2008OrNewer
         {
             get
             {
@@ -186,7 +186,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal SqlInternalTransaction PendingTransaction
+        internal override SqlInternalTransaction PendingTransaction
         {
             get
             {
@@ -194,7 +194,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override public string ServerVersion
+        public override string ServerVersion
         {
             get
             {
@@ -246,7 +246,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected void Activate(Transaction transaction)
+        protected override void Activate(Transaction transaction)
         {
             Debug.Assert(false, "Activating an internal SMI connection?"); // we should never be activating, because that would indicate we're being pooled.
         }
@@ -298,13 +298,13 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected void ChangeDatabaseInternal(string database)
+        protected override void ChangeDatabaseInternal(string database)
         {
             _smiConnection.SetCurrentDatabase(database, _smiEventSink);
             _smiEventSink.ProcessMessagesAndThrow();
         }
 
-        override protected void InternalDeactivate()
+        protected override void InternalDeactivate()
         {
             SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionSmi.Deactivate|ADV> {0}, Deactivating.", ObjectID);
 
@@ -332,14 +332,14 @@ namespace Microsoft.Data.SqlClient
             _isInUse = 0;  // don't need compare-exchange.
         }
 
-        override internal void DelegatedTransactionEnded()
+        internal override void DelegatedTransactionEnded()
         {
             base.DelegatedTransactionEnded();
             SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionSmi.DelegatedTransactionEnded|ADV> {0}, cleaning up after Delegated Transaction Completion", ObjectID);
             _currentTransaction = null;           // clean up our current transaction too
         }
 
-        override internal void DisconnectTransaction(SqlInternalTransaction internalTransaction)
+        internal override void DisconnectTransaction(SqlInternalTransaction internalTransaction)
         {
             SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionSmi.DisconnectTransaction|ADV> {0}, Disconnecting Transaction {1}.", ObjectID, internalTransaction.ObjectID);
 
@@ -352,13 +352,13 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override public void Dispose()
+        public override void Dispose()
         {
             _smiContext.OutOfScope -= new EventHandler(OnOutOfScope);
             base.Dispose();
         }
 
-        override internal void ExecuteTransaction(
+        internal override void ExecuteTransaction(
                     TransactionRequest transactionRequest,
                     string transactionName,
                     System.Data.IsolationLevel iso,
@@ -422,7 +422,7 @@ namespace Microsoft.Data.SqlClient
             _smiEventSink.ProcessMessagesAndThrow();
         }
 
-        override protected byte[] GetDTCAddress()
+        protected override byte[] GetDTCAddress()
         {
             byte[] whereAbouts = _smiConnection.GetDTCAddress(_smiEventSink);     // might want to store this on the SmiLink because it doesn't change, but we want to be compatible with TDS which doesn't have a link yet.
 
@@ -486,7 +486,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected void PropagateTransactionCookie(byte[] transactionCookie)
+        protected override void PropagateTransactionCookie(byte[] transactionCookie)
         {
 
             if (transactionCookie != null)
@@ -562,7 +562,7 @@ namespace Microsoft.Data.SqlClient
             _currentTransaction.Activate(); // SQLBUDT #376531 -- ensure this is activated to prevent asserts later.
         }
 
-        override internal void ValidateConnectionForExecute(SqlCommand command)
+        internal override void ValidateConnectionForExecute(SqlCommand command)
         {
             SqlDataReader reader = FindLiveReader(null);
             if (reader != null)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlInternalConnectionTds : SqlInternalConnection, IDisposable
+    internal sealed class SqlInternalConnectionTds : SqlInternalConnection, IDisposable
     {
         // https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/retry-after#simple-retry-for-errors-with-http-error-codes-500-600
         internal const int MsalHttpRetryStatusCode = 429;
@@ -685,7 +685,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal SqlInternalTransaction CurrentTransaction
+        internal override SqlInternalTransaction CurrentTransaction
         {
             get
             {
@@ -693,7 +693,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal SqlInternalTransaction AvailableInternalTransaction
+        internal override SqlInternalTransaction AvailableInternalTransaction
         {
             get
             {
@@ -702,7 +702,7 @@ namespace Microsoft.Data.SqlClient
         }
 
 
-        override internal SqlInternalTransaction PendingTransaction
+        internal override SqlInternalTransaction PendingTransaction
         {
             get
             {
@@ -726,7 +726,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool IsLockedForBulkCopy
+        internal override bool IsLockedForBulkCopy
         {
             get
             {
@@ -734,7 +734,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected internal bool IsNonPoolableTransactionRoot
+        protected internal override bool IsNonPoolableTransactionRoot
         {
             get
             {
@@ -742,7 +742,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool Is2000
+        internal override bool Is2000
         {
             get
             {
@@ -750,7 +750,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool Is2005OrNewer
+        internal override bool Is2005OrNewer
         {
             get
             {
@@ -758,7 +758,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool Is2008OrNewer
+        internal override bool Is2008OrNewer
         {
             get
             {
@@ -798,7 +798,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected bool ReadyToPrepareTransaction
+        protected override bool ReadyToPrepareTransaction
         {
             get
             {
@@ -808,7 +808,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override public string ServerVersion
+        public override string ServerVersion
         {
             get
             {
@@ -851,7 +851,7 @@ namespace Microsoft.Data.SqlClient
         // GENERAL METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
         [SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")] // copied from Triaged.cs
-        override protected void ChangeDatabaseInternal(string database)
+        protected override void ChangeDatabaseInternal(string database)
         {
             // MDAC 73598 - add brackets around database
             database = SqlConnection.FixupDatabaseTransactionName(database);
@@ -860,7 +860,7 @@ namespace Microsoft.Data.SqlClient
             _parser.Run(RunBehavior.UntilDone, null, null, null, _parser._physicalStateObj);
         }
 
-        override public void Dispose()
+        public override void Dispose()
         {
             SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionTds.Dispose|ADV> {0} disposing", ObjectID);
             try
@@ -883,7 +883,7 @@ namespace Microsoft.Data.SqlClient
             base.Dispose();
         }
 
-        override internal void ValidateConnectionForExecute(SqlCommand command)
+        internal override void ValidateConnectionForExecute(SqlCommand command)
         {
             TdsParser parser = _parser;
             if ((parser == null) || (parser.State == TdsParserState.Broken) || (parser.State == TdsParserState.Closed))
@@ -1012,7 +1012,7 @@ namespace Microsoft.Data.SqlClient
         // POOLING METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        override protected void Activate(Transaction transaction)
+        protected override void Activate(Transaction transaction)
         {
             FailoverPermissionDemand(); // Demand for unspecified failover pooled connections
 
@@ -1037,7 +1037,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected void InternalDeactivate()
+        protected override void InternalDeactivate()
         {
             // When we're deactivated, the user must have called End on all
             // the async commands, or we don't know that we're in a state that
@@ -1136,7 +1136,7 @@ namespace Microsoft.Data.SqlClient
         // LOCAL TRANSACTION METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        override internal void DisconnectTransaction(SqlInternalTransaction internalTransaction)
+        internal override void DisconnectTransaction(SqlInternalTransaction internalTransaction)
         {
             TdsParser parser = Parser;
 
@@ -1151,7 +1151,7 @@ namespace Microsoft.Data.SqlClient
             ExecuteTransaction(transactionRequest, name, iso, null, false);
         }
 
-        override internal void ExecuteTransaction(TransactionRequest transactionRequest, string name, System.Data.IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest)
+        internal override void ExecuteTransaction(TransactionRequest transactionRequest, string name, System.Data.IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest)
         {
             if (IsConnectionDoomed)
             {  // doomed means we can't do anything else...
@@ -1427,20 +1427,20 @@ namespace Microsoft.Data.SqlClient
         // DISTRIBUTED TRANSACTION METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        override internal void DelegatedTransactionEnded()
+        internal override void DelegatedTransactionEnded()
         {
             // TODO: I don't like the way that this works, but I don't want to rototill the entire pooler to avoid this call.
             base.DelegatedTransactionEnded();
         }
 
-        override protected byte[] GetDTCAddress()
+        protected override byte[] GetDTCAddress()
         {
             byte[] dtcAddress = _parser.GetDTCAddress(ConnectionOptions.ConnectTimeout, _parser.GetSession(this));
             Debug.Assert(dtcAddress != null, "null dtcAddress?");
             return dtcAddress;
         }
 
-        override protected void PropagateTransactionCookie(byte[] cookie)
+        protected override void PropagateTransactionCookie(byte[] cookie)
         {
             _parser.PropagateDistributedTransaction(cookie, ConnectionOptions.ConnectTimeout, _parser._physicalStateObj);
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlSequentialStreamSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlSequentialStreamSmi.cs
@@ -8,7 +8,7 @@ using Microsoft.Data.SqlClient.Server;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlSequentialStreamSmi : System.IO.Stream
+    internal sealed class SqlSequentialStreamSmi : System.IO.Stream
     {
         private SmiEventSink_Default _sink;
         private ITypedGettersV3 _getters;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlSequentialTextReaderSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlSequentialTextReaderSmi.cs
@@ -9,7 +9,7 @@ using Microsoft.Data.SqlClient.Server;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlSequentialTextReaderSmi : System.IO.TextReader
+    internal sealed class SqlSequentialTextReaderSmi : System.IO.TextReader
     {
         private SmiEventSink_Default _sink;
         private ITypedGettersV3 _getters;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.SqlClient
 {
     // The TdsParser Object controls reading/writing to the netlib, parsing the tds,
     // and surfacing objects to the user.
-    sealed internal partial class TdsParser
+    internal sealed partial class TdsParser
     {
         private static int _objectTypeCount; // EventSource Counter
         private readonly SqlClientLogger _logger = new SqlClientLogger();
@@ -8410,7 +8410,7 @@ namespace Microsoft.Data.SqlClient
             return TdsOperationStatus.Done;
         }
 
-        static internal SqlDecimal AdjustSqlDecimalScale(SqlDecimal d, int newScale)
+        internal static SqlDecimal AdjustSqlDecimalScale(SqlDecimal d, int newScale)
         {
             if (d.Scale != newScale)
             {
@@ -8421,7 +8421,7 @@ namespace Microsoft.Data.SqlClient
             return d;
         }
 
-        static internal decimal AdjustDecimalScale(decimal value, int newScale)
+        internal static decimal AdjustDecimalScale(decimal value, int newScale)
         {
             int oldScale = (Decimal.GetBits(value)[3] & 0x00ff0000) >> 0x10;
 
@@ -8669,12 +8669,12 @@ namespace Microsoft.Data.SqlClient
         }
 
 
-        private unsafe static void CopyCharsToBytes(char[] source, int sourceOffset, byte[] dest, int destOffset, int charLength)
+        private static unsafe void CopyCharsToBytes(char[] source, int sourceOffset, byte[] dest, int destOffset, int charLength)
         {
             Buffer.BlockCopy(source, sourceOffset, dest, destOffset, charLength * ADP.CharSize);
         }
 
-        private unsafe static void CopyStringToBytes(string source, int sourceOffset, byte[] dest, int destOffset, int charLength)
+        private static unsafe void CopyStringToBytes(string source, int sourceOffset, byte[] dest, int destOffset, int charLength)
         {
             Encoding.Unicode.GetBytes(source, sourceOffset, charLength, dest, destOffset);
         }
@@ -8933,7 +8933,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(!stateObj._attentionSent, "Invalid attentionSent state at end of ProcessAttention");
         }
 
-        static private int StateValueLength(int dataLen)
+        private static int StateValueLength(int dataLen)
         {
             return dataLen < 0xFF ? (dataLen + 1) : (dataLen + 5);
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -312,7 +312,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlLogin
+    internal sealed class SqlLogin
     {
         internal SqlAuthenticationMethod authentication = SqlAuthenticationMethod.NotSpecified;               // Authentication type
         internal int timeout;                                                       // login timeout
@@ -334,7 +334,7 @@ namespace Microsoft.Data.SqlClient
         internal SecureString newSecurePassword;                                    // new password in SecureString for resetting pasword
     }
 
-    sealed internal class SqlLoginAck
+    internal sealed class SqlLoginAck
     {
         internal string programName;
         internal byte majorVersion;
@@ -344,7 +344,7 @@ namespace Microsoft.Data.SqlClient
         internal UInt32 tdsVersion;
     }
 
-    sealed internal class SqlFedAuthInfo
+    internal sealed class SqlFedAuthInfo
     {
         internal string spn;
         internal string stsurl;
@@ -354,14 +354,14 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlFedAuthToken
+    internal sealed class SqlFedAuthToken
     {
         internal UInt32 dataLen;
         internal byte[] accessToken;
         internal long expirationFileTime;
     }
 
-    sealed internal class _SqlMetaData : SqlMetaDataPriv, ICloneable
+    internal sealed class _SqlMetaData : SqlMetaDataPriv, ICloneable
     {
         [Flags]
         private enum _SqlMetadataFlags : int
@@ -511,7 +511,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class _SqlMetaDataSet 
+    internal sealed class _SqlMetaDataSet 
     {
         internal ushort id;             // for altrow-columns only
         internal DataTable _schemaTable;
@@ -635,7 +635,7 @@ namespace Microsoft.Data.SqlClient
     }
 
 
-    sealed internal class _SqlMetaDataSetCollection : ICloneable
+    internal sealed class _SqlMetaDataSetCollection : ICloneable
     {
         private readonly List<_SqlMetaDataSet> altMetaDataSetArray;
         internal _SqlMetaDataSet metaDataSet;
@@ -986,7 +986,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlMetaDataXmlSchemaCollection
+    internal sealed class SqlMetaDataXmlSchemaCollection
     {
         internal string Database;
         internal string OwningSchema;
@@ -1003,7 +1003,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlMetaDataUdt
+    internal sealed class SqlMetaDataUdt
     {
         internal Type Type;
         internal string DatabaseName;
@@ -1027,7 +1027,7 @@ namespace Microsoft.Data.SqlClient
     /// <summary>
     /// Class encapsulating additional information when sending encrypted input parameters.
     /// </summary>
-    sealed internal class SqlColumnEncryptionInputParameterInfo
+    internal sealed class SqlColumnEncryptionInputParameterInfo
     {
         /// <summary>
         /// Metadata of the parameter to write the TYPE_INFO of the unencrypted column data type.
@@ -1155,7 +1155,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class _SqlRPC
+    internal sealed class _SqlRPC
     {
         internal string rpcName;
         internal ushort ProcID;       // Used instead of name
@@ -1215,7 +1215,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlReturnValue : SqlMetaDataPriv
+    internal sealed class SqlReturnValue : SqlMetaDataPriv
     {
 
         internal ushort parmIndex;      //2005 or later only

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
@@ -17,7 +17,7 @@ using Microsoft.Data.SqlClient;
 namespace Microsoft.Data.SqlTypes
 {
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml' path='docs/members[@name="SqlFileStream"]/SqlFileStream/*' />
-    sealed public class SqlFileStream : System.IO.Stream
+    public sealed class SqlFileStream : System.IO.Stream
     {
         // NOTE: if we ever unseal this class, be sure to specify the Name, SafeFileHandle, and 
         //   TransactionContext accessors as virtual methods. Doing so now on a sealed class
@@ -439,7 +439,7 @@ namespace Microsoft.Data.SqlTypes
 
         #endregion
 
-        static private readonly char[] InvalidPathChars = Path.GetInvalidPathChars();
+        private static readonly char[] InvalidPathChars = Path.GetInvalidPathChars();
 
         // path length limitations:
         // 1. path length storage (in bytes) in UNICODE_STRING is limited to UInt16.MaxValue bytes = Int16.MaxValue chars
@@ -449,7 +449,7 @@ namespace Microsoft.Data.SqlTypes
         private const int MaxWin32PathLength = Int16.MaxValue - 1;
 
         [ConditionalAttribute("DEBUG")]
-        static private void AssertPathFormat(string path)
+        private static void AssertPathFormat(string path)
         {
             Debug.Assert(path != null);
             Debug.Assert(path == path.Trim());
@@ -467,7 +467,7 @@ namespace Microsoft.Data.SqlTypes
         // To overcome the above limitations we decided to use GetFullPathName function from kernel32.dll
         [ResourceExposure(ResourceScope.Machine)]
         [ResourceConsumption(ResourceScope.Machine)]
-        static private string GetFullPathInternal(string path)
+        private static string GetFullPathInternal(string path)
         {
             //-----------------------------------------------------------------
             // precondition validation
@@ -522,7 +522,7 @@ namespace Microsoft.Data.SqlTypes
             return path;
         }
 
-        static private void DemandAccessPermission
+        private static void DemandAccessPermission
             (
                 string path,
                 System.IO.FileAccess access
@@ -844,7 +844,7 @@ namespace Microsoft.Data.SqlTypes
         // This method exists to ensure that the requested path name is unique so that SMB/DNS is prevented
         //   from collapsing a file open request to a file handle opened previously. In the SQL FILESTREAM case,
         //   this would likely be a file open in another transaction, so this mechanism ensures isolation.
-        static private string InitializeNtPath(string path)
+        private static string InitializeNtPath(string path)
         {
             // ensure we have validated and normalized the path before
             AssertPathFormat(path);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlTypes/SqlTypeWorkarounds.netfx.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Data.SqlTypes
         {
             // Returns null if .ctor(TValue, TIgnored) cannot be found.
             // Caller should have fallback logic in place in case the API doesn't exist.
-            internal unsafe static Func<TValue, TInstance> CreateFactory<TInstance, TValue, TIgnored>() where TInstance : struct
+            internal static unsafe Func<TValue, TInstance> CreateFactory<TInstance, TValue, TIgnored>() where TInstance : struct
             {
                 try
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Data.Common
         }
         #endregion
 
-        static private void TraceException(string trace, Exception e)
+        private static void TraceException(string trace, Exception e)
         {
             Debug.Assert(e != null, "TraceException: null Exception");
             if (e is not null)
@@ -897,7 +897,7 @@ namespace Microsoft.Data.Common
 #region Stream
         internal static Exception StreamClosed([CallerMemberName] string method = "") => InvalidOperation(StringsHelper.GetString(Strings.ADP_StreamClosed, method));
 
-        static internal Exception InvalidSeekOrigin(string parameterName) => ArgumentOutOfRange(StringsHelper.GetString(Strings.ADP_InvalidSeekOrigin), parameterName);
+        internal static Exception InvalidSeekOrigin(string parameterName) => ArgumentOutOfRange(StringsHelper.GetString(Strings.ADP_InvalidSeekOrigin), parameterName);
 
         internal static IOException ErrorReadingFromStream(Exception internalException) => IO(StringsHelper.GetString(Strings.SqlMisc_StreamErrorMessage), internalException);
 #endregion
@@ -1029,7 +1029,7 @@ namespace Microsoft.Data.Common
 
 #region IDbCommand
         // IDbCommand.CommandType
-        static internal ArgumentOutOfRangeException InvalidCommandType(CommandType value)
+        internal static ArgumentOutOfRangeException InvalidCommandType(CommandType value)
         {
 #if DEBUG
             switch (value)
@@ -1293,16 +1293,16 @@ namespace Microsoft.Data.Common
         internal static InvalidOperationException InvalidMixedUsageOfAccessTokenAndIntegratedSecurity()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndIntegratedSecurity));
 
-        static internal InvalidOperationException InvalidMixedUsageOfAccessTokenAndUserIDPassword()
+        internal static InvalidOperationException InvalidMixedUsageOfAccessTokenAndUserIDPassword()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndUserIDPassword));
 
-        static internal InvalidOperationException InvalidMixedUsageOfAccessTokenAndAuthentication()
+        internal static InvalidOperationException InvalidMixedUsageOfAccessTokenAndAuthentication()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndAuthentication));
 
-        static internal Exception InvalidMixedUsageOfCredentialAndAccessToken()
+        internal static Exception InvalidMixedUsageOfCredentialAndAccessToken()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfCredentialAndAccessToken));
 
-        static internal Exception InvalidMixedUsageOfAccessTokenAndTokenCallback()
+        internal static Exception InvalidMixedUsageOfAccessTokenAndTokenCallback()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndTokenCallback));
 
         internal static Exception InvalidMixedUsageOfAccessTokenCallbackAndAuthentication()

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
@@ -860,7 +860,7 @@ namespace Microsoft.Data.Common
         /// <summary>
         /// IP Address Preference.
         /// </summary>
-        private readonly static Dictionary<string, SqlConnectionIPAddressPreference> s_preferenceNames = new(StringComparer.InvariantCultureIgnoreCase);
+        private static readonly Dictionary<string, SqlConnectionIPAddressPreference> s_preferenceNames = new(StringComparer.InvariantCultureIgnoreCase);
 
         static DbConnectionStringBuilderUtil()
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/NameValuePair.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/NameValuePair.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Data.Common
     [Serializable]
     internal sealed class NameValuePair
     {
-        readonly private string _name;
-        readonly private string _value;
+        private readonly string _name;
+        private readonly string _value;
         [OptionalField(VersionAdded = 2)]
-        readonly private int _length;
+        private readonly int _length;
         private NameValuePair _next;
 
         internal NameValuePair(string name, string value, int length)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolAuthenticationContext.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolAuthenticationContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.ProviderBase
     /// Represents the context of an authentication attempt when using the new active directory based authentication mechanisms.
     /// All data members, except_isUpdateInProgressCounter, should be immutable.
     /// </summary>
-    sealed internal class DbConnectionPoolAuthenticationContext
+    internal sealed class DbConnectionPoolAuthenticationContext
     {
         /// <summary>
         /// The value expected in _isUpdateInProgress if a thread has taken a lock on this context,

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolAuthenticationContextKey.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolAuthenticationContextKey.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.ProviderBase
     /// Represents the key of dbConnectionPoolAuthenticationContext.
     /// All data members should be immutable and so, hashCode is pre-computed.
     /// </summary>
-    sealed internal class DbConnectionPoolAuthenticationContextKey
+    internal sealed class DbConnectionPoolAuthenticationContextKey
     {
         /// <summary>
         /// Security Token Service Authority.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.ProviderBase
     // and once no pools remain, change state from Active->Idle->Disabled
     // Once Disabled, factory can remove its reference to the pool entry
 
-    sealed internal class DbConnectionPoolGroup
+    internal sealed class DbConnectionPoolGroup
     {
         private readonly DbConnectionOptions _connectionOptions;
         private readonly DbConnectionPoolKey _poolKey;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbReferenceCollection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbReferenceCollection.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Data.ProviderBase
             _lastItemIndex = 0;
         }
 
-        abstract public void Add(object value, int refInfo);
+        public abstract void Add(object value, int refInfo);
 
         protected void AddItem(object value, int refInfo)
         {
@@ -220,9 +220,9 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        abstract protected void NotifyItem(int message, int refInfo, object value);
+        protected abstract void NotifyItem(int message, int refInfo, object value);
 
-        abstract public void Remove(object value);
+        public abstract void Remove(object value);
 
         protected void RemoveItem(object value)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumerator.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumerator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Sql
         public static SqlDataSourceEnumerator Instance => s_singletonInstance.Value;
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.Sql/SqlDataSourceEnumerator.xml' path='docs/members[@name="SqlDataSourceEnumerator"]/GetDataSources/*' />
-        override public DataTable GetDataSources() => GetDataSourcesInternal();
+        public override DataTable GetDataSources() => GetDataSourcesInternal();
 
         private partial DataTable GetDataSourcesInternal();
     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.SqlClient
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConfigurableRetryFactory.xml' path='docs/members[@name="SqlConfigurableRetryFactory"]/SqlConfigurableRetryFactory/*' />
     public sealed class SqlConfigurableRetryFactory
     {
-        private readonly static object s_syncObject = new();
+        private static readonly object s_syncObject = new();
         /// Default known transient error numbers.
         private static readonly HashSet<int> s_defaultTransientErrors
             = new HashSet<int>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NativeSSPIContextProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NativeSSPIContextProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.SqlClient
         private static bool s_fSSPILoaded;
 
         // variable to hold max SSPI data size, keep for token from server
-        private volatile static uint s_maxSSPILength;
+        private static volatile uint s_maxSSPILength;
 
         internal override uint MaxSSPILength => s_maxSSPILength;
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
@@ -988,7 +988,7 @@ namespace Microsoft.Data.SqlClient.Server
 
 #if NETFRAMEWORK
 
-        static internal bool IsValidForSmiVersion(SmiExtendedMetaData md, ulong smiVersion)
+        internal static bool IsValidForSmiVersion(SmiExtendedMetaData md, ulong smiVersion)
         {
             if (SmiContextFactory.LatestVersion == smiVersion)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
@@ -701,7 +701,7 @@ namespace Microsoft.Data.SqlClient.Server
 
         internal string TraceString() => TraceString(0);
 
-        virtual internal string TraceString(int indent)
+        internal virtual string TraceString(int indent)
         {
             string indentStr = new string(' ', indent);
             string fields = string.Empty;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCachedBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCachedBuffer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Data.SqlClient
             return new SqlCachedStream(this);
         }
 
-        override public string ToString()
+        public override string ToString()
         {
             if (IsNull)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEncryptionAlgorithmFactoryList.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEncryptionAlgorithmFactoryList.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.SqlClient
     /// <summary>
     /// <para> Implements a global directory of all the encryption algorithms registered with client.</para>
     /// </summary>
-    sealed internal class SqlClientEncryptionAlgorithmFactoryList
+    internal sealed class SqlClientEncryptionAlgorithmFactoryList
     {
         private readonly ConcurrentDictionary<string, SqlClientEncryptionAlgorithmFactory> _encryptionAlgoFactoryList;
         private static readonly SqlClientEncryptionAlgorithmFactoryList _singletonInstance = new SqlClientEncryptionAlgorithmFactoryList();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -1167,7 +1167,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        static internal Hashtable NetlibMapping()
+        internal static Hashtable NetlibMapping()
         {
             const int NetLibCount = 8;
 
@@ -1190,7 +1190,7 @@ namespace Microsoft.Data.SqlClient
             }
             return hash;
         }
-        static internal bool ValidProtocol(string protocol)
+        internal static bool ValidProtocol(string protocol)
         {
             return protocol switch
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Data.SqlClient
         [DefaultValue(null)]
         [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Update)]
         [ResDescriptionAttribute(StringsHelper.ResourceNames.DbDataAdapter_DeleteCommand)]
-        new public SqlCommand DeleteCommand
+        public new SqlCommand DeleteCommand
         {
             get { return _deleteCommand; }
             set { _deleteCommand = value; }
@@ -84,7 +84,7 @@ namespace Microsoft.Data.SqlClient
         [DefaultValue(null)]
         [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Update)]
         [ResDescriptionAttribute(StringsHelper.ResourceNames.DbDataAdapter_InsertCommand)]
-        new public SqlCommand InsertCommand
+        public new SqlCommand InsertCommand
         {
             get { return _insertCommand; }
             set { _insertCommand = value; }
@@ -101,7 +101,7 @@ namespace Microsoft.Data.SqlClient
         [DefaultValue(null)]
         [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Fill)]
         [ResDescriptionAttribute(StringsHelper.ResourceNames.DbDataAdapter_SelectCommand)]
-        new public SqlCommand SelectCommand
+        public new SqlCommand SelectCommand
         {
             get { return _selectCommand; }
             set { _selectCommand = value; }
@@ -118,7 +118,7 @@ namespace Microsoft.Data.SqlClient
         [DefaultValue(null)]
         [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Update)]
         [ResDescriptionAttribute(StringsHelper.ResourceNames.DbDataAdapter_UpdateCommand)]
-        new public SqlCommand UpdateCommand
+        public new SqlCommand UpdateCommand
         {
             get { return _updateCommand; }
             set { _updateCommand = value; }
@@ -284,7 +284,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataAdapter.xml' path='docs/members[@name="SqlDataAdapter"]/OnRowUpdated/*' />
-        override protected void OnRowUpdated(RowUpdatedEventArgs value)
+        protected override void OnRowUpdated(RowUpdatedEventArgs value)
         {
             SqlRowUpdatedEventHandler handler = (SqlRowUpdatedEventHandler)Events[s_eventRowUpdated];
             if (handler != null && value is SqlRowUpdatedEventArgs args)
@@ -295,7 +295,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataAdapter.xml' path='docs/members[@name="SqlDataAdapter"]/OnRowUpdating/*' />
-        override protected void OnRowUpdating(RowUpdatingEventArgs value)
+        protected override void OnRowUpdating(RowUpdatingEventArgs value)
         {
             SqlRowUpdatingEventHandler handler = (SqlRowUpdatingEventHandler)Events[s_eventRowUpdating];
             if (handler != null && value is SqlRowUpdatingEventArgs args)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Data.SqlClient
         public byte State => Errors.Count > 0 ? Errors[0].State : default;
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/Source/*' />
-        override public string Source => TdsEnums.SQL_PROVIDER_NAME;
+        public override string Source => TdsEnums.SQL_PROVIDER_NAME;
 
 
 #if NET6_0_OR_GREATER

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInfoMessageEvent.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInfoMessageEvent.cs
@@ -29,6 +29,6 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlInfoMessageEventArgs.xml' path='docs/members[@name="SqlInfoMessageEventArgs"]/ToString/*' />
         // MDAC 68482
-        override public string ToString() => Message;
+        public override string ToString() => Message;
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        abstract internal SqlInternalTransaction CurrentTransaction
+        internal abstract SqlInternalTransaction CurrentTransaction
         {
             get;
         }
@@ -91,7 +91,7 @@ namespace Microsoft.Data.SqlClient
         //  Get the internal transaction that should be hooked to a new outer transaction
         //  during a BeginTransaction API call.  In some cases (i.e. connection is going to
         //  be reset), CurrentTransaction should not be hooked up this way.
-        virtual internal SqlInternalTransaction AvailableInternalTransaction
+        internal virtual SqlInternalTransaction AvailableInternalTransaction
         {
             get
             {
@@ -99,12 +99,12 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        abstract internal SqlInternalTransaction PendingTransaction
+        internal abstract SqlInternalTransaction PendingTransaction
         {
             get;
         }
 
-        override protected internal bool IsNonPoolableTransactionRoot
+        protected internal override bool IsNonPoolableTransactionRoot
         {
             get
             {
@@ -112,7 +112,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool IsTransactionRoot
+        internal override bool IsTransactionRoot
         {
             get
             {
@@ -150,12 +150,12 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        abstract internal bool IsLockedForBulkCopy
+        internal abstract bool IsLockedForBulkCopy
         {
             get;
         }
 
-        abstract internal bool Is2008OrNewer
+        internal abstract bool Is2008OrNewer
         {
             get;
         }
@@ -199,12 +199,12 @@ namespace Microsoft.Data.SqlClient
 #if NETFRAMEWORK
         private bool _isAzureSQLConnection = false; // If connected to Azure SQL
 
-        abstract internal bool Is2000
+        internal abstract bool Is2000
         {
             get;
         }
 
-        abstract internal bool Is2005OrNewer
+        internal abstract bool Is2005OrNewer
         {
             get;
         }
@@ -222,12 +222,12 @@ namespace Microsoft.Data.SqlClient
         }
 #endif
 
-        override public DbTransaction BeginTransaction(System.Data.IsolationLevel iso)
+        public override DbTransaction BeginTransaction(System.Data.IsolationLevel iso)
         {
             return BeginSqlTransaction(iso, null, false);
         }
 
-        virtual internal SqlTransaction BeginSqlTransaction(System.Data.IsolationLevel iso, string transactionName, bool shouldReconnect)
+        internal virtual SqlTransaction BeginSqlTransaction(System.Data.IsolationLevel iso, string transactionName, bool shouldReconnect)
         {
             SqlStatistics statistics = null;
 #if NETFRAMEWORK
@@ -305,7 +305,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override public void ChangeDatabase(string database)
+        public override void ChangeDatabase(string database)
         {
             if (string.IsNullOrEmpty(database))
             {
@@ -317,9 +317,9 @@ namespace Microsoft.Data.SqlClient
             ChangeDatabaseInternal(database);  // do the real work...
         }
 
-        abstract protected void ChangeDatabaseInternal(string database);
+        protected abstract void ChangeDatabaseInternal(string database);
 
-        override protected void CleanupTransactionOnCompletion(Transaction transaction)
+        protected override void CleanupTransactionOnCompletion(Transaction transaction)
         {
             // Note: unlocked, potentially multi-threaded code, so pull delegate to local to
             //  ensure it doesn't change between test and call.
@@ -330,12 +330,12 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected DbReferenceCollection CreateReferenceCollection()
+        protected override DbReferenceCollection CreateReferenceCollection()
         {
             return new SqlReferenceCollection();
         }
 
-        override protected void Deactivate()
+        protected override void Deactivate()
         {
 #if NETFRAMEWORK
             TdsParser bestEffortCleanupTarget = null;
@@ -411,9 +411,9 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        abstract internal void DisconnectTransaction(SqlInternalTransaction internalTransaction);
+        internal abstract void DisconnectTransaction(SqlInternalTransaction internalTransaction);
 
-        override public void Dispose()
+        public override void Dispose()
         {
             _whereAbouts = null;
             base.Dispose();
@@ -647,7 +647,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(CurrentTransaction == null, "unenlisted transaction with non-null current transaction?");   // verify it!
         }
 
-        override public void EnlistTransaction(Transaction transaction)
+        public override void EnlistTransaction(Transaction transaction)
         {
 #if NETFRAMEWORK
             SqlConnection.VerifyExecutePermission();
@@ -729,7 +729,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        abstract internal void ExecuteTransaction(TransactionRequest transactionRequest, string name, System.Data.IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest);
+        internal abstract void ExecuteTransaction(TransactionRequest transactionRequest, string name, System.Data.IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest);
 
         internal SqlDataReader FindLiveReader(SqlCommand command)
         {
@@ -742,9 +742,9 @@ namespace Microsoft.Data.SqlClient
             return reader;
         }
 
-        abstract protected byte[] GetDTCAddress();
+        protected abstract byte[] GetDTCAddress();
 
-        static private byte[] GetTransactionCookie(Transaction transaction, byte[] whereAbouts)
+        private static byte[] GetTransactionCookie(Transaction transaction, byte[] whereAbouts)
         {
             byte[] transactionCookie = null;
             if (transaction != null)
@@ -754,7 +754,7 @@ namespace Microsoft.Data.SqlClient
             return transactionCookie;
         }
 
-        virtual protected void InternalDeactivate()
+        protected virtual void InternalDeactivate()
         {
         }
 
@@ -780,12 +780,12 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        abstract protected void PropagateTransactionCookie(byte[] transactionCookie);
+        protected abstract void PropagateTransactionCookie(byte[] transactionCookie);
 
-        abstract internal void ValidateConnectionForExecute(SqlCommand command);
+        internal abstract void ValidateConnectionForExecute(SqlCommand command);
 
 #if NETFRAMEWORK
-        static internal TdsParser GetBestEffortCleanupTarget(SqlConnection connection)
+        internal static TdsParser GetBestEffortCleanupTarget(SqlConnection connection)
         {
             if (connection != null)
             {
@@ -800,7 +800,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-        static internal void BestEffortCleanup(TdsParser target)
+        internal static void BestEffortCleanup(TdsParser target)
         {
             if (target != null)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.SqlClient
         Context = 5,     // only valid in proc.
     }
 
-    sealed internal class SqlInternalTransaction
+    internal sealed class SqlInternalTransaction
     {
         internal const long NullTransactionId = 0;
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.SqlClient
     /// <summary>
     /// <para> Implements a cache of query parameter metadata that is used to avoid the extra roundtrip to the server for every execution of the same query.</para>
     /// </summary>
-    sealed internal class SqlQueryMetadataCache
+    internal sealed class SqlQueryMetadataCache
     {
         const int CacheSize = 2000; // Cache size in number of entries.
         const int CacheTrimThreshold = 300; // Threshold above the cache size when we start trimming.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlReferenceCollection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlReferenceCollection.cs
@@ -9,7 +9,7 @@ using Microsoft.Data.ProviderBase;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlReferenceCollection : DbReferenceCollection
+    internal sealed class SqlReferenceCollection : DbReferenceCollection
     {
         private sealed class FindLiveReaderContext
         {
@@ -30,7 +30,7 @@ namespace Microsoft.Data.SqlClient
         internal const int CommandTag = 2;
         internal const int BulkCopyTag = 3;
 
-        private readonly static Func<SqlDataReader, bool> s_hasOpenReaderFunc = HasOpenReaderPredicate;
+        private static readonly Func<SqlDataReader, bool> s_hasOpenReaderFunc = HasOpenReaderPredicate;
         private static FindLiveReaderContext s_cachedFindLiveReaderContext;
 
         public override void Add(object value, int tag)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlRowUpdatedEvent.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlRowUpdatedEvent.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlRowUpdatedEventArgs.xml' path='docs/members[@name="SqlRowUpdatedEventArgs"]/Command/*' />
-        new public SqlCommand Command
+        public new SqlCommand Command
         {
             get
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlRowUpdatingEvent.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlRowUpdatingEvent.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlRowUpdatingEventArgs.xml' path='docs/members[@name="SqlRowUpdatingEventArgs"]/Command/*' />
-        new public SqlCommand Command
+        public new SqlCommand Command
         {
             get { return (base.Command as SqlCommand); }
             set { base.Command = value; }
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlRowUpdatingEventArgs.xml' path='docs/members[@name="SqlRowUpdatingEventArgs"]/BaseCommand/*' />
-        override protected IDbCommand BaseCommand
+        protected override IDbCommand BaseCommand
         {
             get { return base.BaseCommand; }
             set { base.BaseCommand = (value as SqlCommand); }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialStream.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialStream.cs
@@ -10,7 +10,7 @@ using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlSequentialStream : System.IO.Stream
+    internal sealed class SqlSequentialStream : System.IO.Stream
     {
         private SqlDataReader _reader;  // The SqlDataReader that we are reading data from
         private readonly int _columnIndex;       // The index of out column in the table

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
@@ -13,7 +13,7 @@ using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlSequentialTextReader : System.IO.TextReader
+    internal sealed class SqlSequentialTextReader : System.IO.TextReader
     {
         private SqlDataReader _reader;  // The SqlDataReader that we are reading data from
         private readonly int _columnIndex;       // The index of out column in the table
@@ -478,7 +478,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlUnicodeEncoding : UnicodeEncoding
+    internal sealed class SqlUnicodeEncoding : UnicodeEncoding
     {
         private static readonly SqlUnicodeEncoding s_singletonEncoding = new();
 
@@ -501,7 +501,7 @@ namespace Microsoft.Data.SqlClient
             get { return s_singletonEncoding; }
         }
 
-        sealed private class SqlUnicodeDecoder : Decoder
+        private sealed class SqlUnicodeDecoder : Decoder
         {
             public override int GetCharCount(byte[] bytes, int index, int count)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlStream.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlStream.cs
@@ -13,7 +13,7 @@ using Microsoft.Data.SqlTypes;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlStream : Stream
+    internal sealed class SqlStream : Stream
     {
         private SqlDataReader _reader; // reader we will stream off
         private readonly int _columnOrdinal;
@@ -267,7 +267,7 @@ namespace Microsoft.Data.SqlClient
     // case. This causes double buffering and is a perf hit, but this is not the high perf way for accessing this type of data.
     // In the case of sequential access, we do not have to do any buffering since the XmlTextReader we return can become 
     // invalid as soon as we move off the current column.
-    sealed internal class SqlCachedStream : Stream
+    internal sealed class SqlCachedStream : Stream
     {
         private int _currentPosition;   // Position within the current array byte
         private int _currentArrayIndex; // Index into the _cachedBytes List
@@ -468,7 +468,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlStreamingXml
+    internal sealed class SqlStreamingXml
     {
         private readonly int _columnOrdinal;
         private SqlDataReader _reader;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.SqlClient
     /// <summary>
     /// <para> Implements a cache of Symmetric Keys (once they are decrypted).Useful for rapidly decrypting multiple data values.</para>
     /// </summary>
-    sealed internal class SqlSymmetricKeyCache
+    internal sealed class SqlSymmetricKeyCache
     {
         private readonly MemoryCache _cache;
         private static readonly SqlSymmetricKeyCache _singletonInstance = new SqlSymmetricKeyCache();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -484,7 +484,7 @@ namespace Microsoft.Data.SqlClient
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_CannotGetDTCAddress));
         }
 
-        static internal Exception InvalidOptionLength(string key)
+        internal static Exception InvalidOptionLength(string key)
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_InvalidOptionLength, key));
         }
@@ -504,20 +504,20 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_InvalidSSPIPacketSize));
         }
-        static internal Exception NullEmptyTransactionName()
+        internal static Exception NullEmptyTransactionName()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_NullEmptyTransactionName));
         }
 
-        static internal Exception UserInstanceFailoverNotCompatible()
+        internal static Exception UserInstanceFailoverNotCompatible()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_UserInstanceFailoverNotCompatible));
         }
-        static internal Exception CredentialsNotProvided(SqlAuthenticationMethod auth)
+        internal static Exception CredentialsNotProvided(SqlAuthenticationMethod auth)
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_CredentialsNotProvided, DbConnectionStringBuilderUtil.AuthenticationTypeToString(auth)));
         }
-        static internal Exception InvalidCertAuth()
+        internal static Exception InvalidCertAuth()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_Certificate));
         }
@@ -1063,7 +1063,7 @@ namespace Microsoft.Data.SqlClient
         //
         // SQL.SqlDelegatedTransaction
         //
-        static internal Exception CannotCompleteDelegatedTransactionWithOpenResults(SqlInternalConnectionTds internalConnection, bool marsOn)
+        internal static Exception CannotCompleteDelegatedTransactionWithOpenResults(SqlInternalConnectionTds internalConnection, bool marsOn)
         {
             SqlErrorCollection errors = new SqlErrorCollection();
             errors.Add(new SqlError(TdsEnums.TIMEOUT_EXPIRED, (byte)0x00, TdsEnums.MIN_ERROR_CLASS, null, (StringsHelper.GetString(Strings.ADP_OpenReaderExists, marsOn ? ADP.Command : ADP.Connection)), "", 0, TdsEnums.SNI_WAIT_TIMEOUT));
@@ -1082,7 +1082,7 @@ namespace Microsoft.Data.SqlClient
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SqlNotify_SqlDepCannotBeCreatedInProc));
         }
 
-        static internal Exception SqlNotificationException(SqlNotificationEventArgs notify)
+        internal static Exception SqlNotificationException(SqlNotificationEventArgs notify)
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQLNotify_ErrorFormat, notify.Type, notify.Info, notify.Source));
         }
@@ -1579,7 +1579,7 @@ namespace Microsoft.Data.SqlClient
         }
         // SQLBU 402363: Exception to prevent Parameter.Size data corruption case from working.
         //  This should be temporary until changing to correct behavior can be safely implemented.
-        static internal Exception ParameterSizeRestrictionFailure(int index)
+        internal static Exception ParameterSizeRestrictionFailure(int index)
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.OleDb_CommandParameterError, index.ToString(CultureInfo.InvariantCulture), "SqlParameter.Size"));
         }
@@ -1955,7 +1955,7 @@ namespace Microsoft.Data.SqlClient
             return ADP.ArgumentNull(StringsHelper.GetString(Strings.TCE_NullPlainText));
         }
 
-        static internal Exception VeryLargeCiphertext(long cipherTextLength, long maxCipherTextSize, long plainTextLength)
+        internal static Exception VeryLargeCiphertext(long cipherTextLength, long maxCipherTextSize, long plainTextLength)
         {
             return ADP.Argument(StringsHelper.GetString(Strings.TCE_VeryLargeCiphertext, cipherTextLength, maxCipherTextSize, plainTextLength));
         }
@@ -2411,56 +2411,56 @@ namespace Microsoft.Data.SqlClient
         // Merged Provider
         //
 
-        static internal Exception ContextAllowsLimitedKeywords()
+        internal static Exception ContextAllowsLimitedKeywords()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ContextAllowsLimitedKeywords));
         }
-        static internal Exception ContextAllowsOnlyTypeSystem2005()
+        internal static Exception ContextAllowsOnlyTypeSystem2005()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ContextAllowsOnlyTypeSystem2005));
         }
-        static internal Exception ContextConnectionIsInUse()
+        internal static Exception ContextConnectionIsInUse()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ContextConnectionIsInUse));
         }
-        static internal Exception ContextUnavailableOutOfProc()
+        internal static Exception ContextUnavailableOutOfProc()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ContextUnavailableOutOfProc));
         }
-        static internal Exception ContextUnavailableWhileInProc()
+        internal static Exception ContextUnavailableWhileInProc()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ContextUnavailableWhileInProc));
         }
-        static internal Exception NestedTransactionScopesNotSupported()
+        internal static Exception NestedTransactionScopesNotSupported()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_NestedTransactionScopesNotSupported));
         }
-        static internal Exception NotAvailableOnContextConnection()
+        internal static Exception NotAvailableOnContextConnection()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_NotAvailableOnContextConnection));
         }
-        static internal Exception NotificationsNotAvailableOnContextConnection()
+        internal static Exception NotificationsNotAvailableOnContextConnection()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_NotificationsNotAvailableOnContextConnection));
         }
 
-        static internal Exception UserInstanceNotAvailableInProc()
+        internal static Exception UserInstanceNotAvailableInProc()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_UserInstanceNotAvailableInProc));
         }
-        static internal Exception ArgumentLengthMismatch(string arg1, string arg2)
+        internal static Exception ArgumentLengthMismatch(string arg1, string arg2)
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_ArgumentLengthMismatch, arg1, arg2));
         }
-        static internal Exception InvalidSqlDbTypeOneAllowedType(SqlDbType invalidType, string method, SqlDbType allowedType)
+        internal static Exception InvalidSqlDbTypeOneAllowedType(SqlDbType invalidType, string method, SqlDbType allowedType)
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_InvalidSqlDbTypeWithOneAllowedType, invalidType, method, allowedType));
         }
-        static internal Exception SqlPipeErrorRequiresSendEnd()
+        internal static Exception SqlPipeErrorRequiresSendEnd()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_PipeErrorRequiresSendEnd));
         }
-        static internal Exception TooManyValues(string arg)
+        internal static Exception TooManyValues(string arg)
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_TooManyValues), arg);
         }
@@ -2513,11 +2513,11 @@ namespace Microsoft.Data.SqlClient
             return new InternalException(StringsHelper.GetString(Strings.SQL_SocketDidNotThrow, nameof(SocketException), nameof(SocketError.WouldBlock)));
         }
 #else
-        static internal Exception SnapshotNotSupported(System.Data.IsolationLevel level)
+        internal static Exception SnapshotNotSupported(System.Data.IsolationLevel level)
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_SnapshotNotSupported, typeof(System.Data.IsolationLevel), level.ToString()));
         }
-        static internal Exception UnexpectedSmiEvent(Microsoft.Data.SqlClient.Server.SmiEventSink_Default.UnexpectedEventType eventType)
+        internal static Exception UnexpectedSmiEvent(Microsoft.Data.SqlClient.Server.SmiEventSink_Default.UnexpectedEventType eventType)
         {
             Debug.Assert(false, "UnexpectedSmiEvent: " + eventType.ToString());    // Assert here, because these exceptions will most likely be eaten by the server.
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_UnexpectedSmiEvent, (int)eventType));
@@ -2526,7 +2526,7 @@ namespace Microsoft.Data.SqlClient
 
     }
 
-    sealed internal class SQLMessage
+    internal sealed class SQLMessage
     {
         private SQLMessage() { /* prevent utility class from being instantiated*/ }
 
@@ -2772,7 +2772,7 @@ namespace Microsoft.Data.SqlClient
     }
 
 #if NETFRAMEWORK
-    sealed internal class InOutOfProcHelper
+    internal sealed class InOutOfProcHelper
     {
         private static readonly InOutOfProcHelper SingletonInstance = new InOutOfProcHelper();
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.Windows.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Data.SqlClient
 
         public override bool IsInvalid => (IntPtr.Zero == base.handle);
 
-        override protected bool ReleaseHandle()
+        protected override bool ReleaseHandle()
         {
             if (base.handle != IntPtr.Zero)
             {
@@ -213,7 +213,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected bool ReleaseHandle()
+        protected override bool ReleaseHandle()
         {
             // NOTE: The SafeHandle class guarantees this will be called exactly once.
             IntPtr ptr = base.handle;
@@ -256,7 +256,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected bool ReleaseHandle()
+        protected override bool ReleaseHandle()
         {
             // NOTE: The SafeHandle class guarantees this will be called exactly once.
             IntPtr ptr = base.handle;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient
     using RuntimeHelpers = System.Runtime.CompilerServices.RuntimeHelpers;
 #endif
 
-    sealed internal class LastIOTimer
+    internal sealed class LastIOTimer
     {
         internal long _value;
     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.SqlClient
         // SxS: this method accesses registry to resolve the alias.
         [ResourceExposure(ResourceScope.None)]
         [ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)]
-        static internal void AliasRegistryLookup(ref string host, ref string protocol)
+        internal static void AliasRegistryLookup(ref string host, ref string protocol)
         {
             if (!ADP.IsEmpty(host))
             {
@@ -158,7 +158,7 @@ namespace Microsoft.Data.SqlClient
 
         [ResourceExposure(ResourceScope.None)] // SxS: we use MAC address for TDS login only
         [ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)]
-        static internal byte[] GetNetworkPhysicalAddressForTdsLoginOnly()
+        internal static byte[] GetNetworkPhysicalAddressForTdsLoginOnly()
         {
             if (s_nicAddress != null)
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ExceptionsGenericError.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ExceptionsGenericError.cs
@@ -108,8 +108,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
     public sealed class ExceptionGenericErrorFixture : IDisposable
     {
-        static public string encryptedTableName;
-        static public string encryptedProcedureName;
+        public static string encryptedTableName;
+        public static string encryptedProcedureName;
 
         public ExceptionGenericErrorFixture()
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             public int? id { get; set; }
         }
 
-        static internal void AddCommandParameters(SqlCommand command, IEnumerable parameters)
+        internal static void AddCommandParameters(SqlCommand command, IEnumerable parameters)
         {
             if (parameters == null)
                 return;
@@ -1535,72 +1535,72 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             _currentRow = -1;
         }
 
-        override public int Depth
+        public override int Depth
         {
             get { return 0; }
         }
 
-        override public int FieldCount
+        public override int FieldCount
         {
             get { return _sourceData[_currentRow].FieldCount; }
         }
 
-        override public bool HasRows
+        public override bool HasRows
         {
             get { return _sourceData.Count > 0; }
         }
 
-        override public bool IsClosed
+        public override bool IsClosed
         {
             get { return false; }
         }
 
-        override public int RecordsAffected
+        public override int RecordsAffected
         {
             get { return 0; }
         }
 
-        override public object this[int ordinal]
+        public override object this[int ordinal]
         {
             get { return GetValue(ordinal); }
         }
 
-        override public object this[string name]
+        public override object this[string name]
         {
             get { return GetValue(GetOrdinal(name)); }
         }
 
-        override public void Close()
+        public override void Close()
         {
             _currentRow = _sourceData.Count;
         }
 
-        override public string GetDataTypeName(int ordinal)
+        public override string GetDataTypeName(int ordinal)
         {
             return _sourceData[_currentRow].GetDataTypeName(ordinal);
         }
 
-        override public IEnumerator GetEnumerator()
+        public override IEnumerator GetEnumerator()
         {
             return _sourceData.GetEnumerator();
         }
 
-        override public Type GetFieldType(int ordinal)
+        public override Type GetFieldType(int ordinal)
         {
             return _sourceData[_currentRow].GetFieldType(ordinal);
         }
 
-        override public string GetName(int ordinal)
+        public override string GetName(int ordinal)
         {
             return _sourceData[_currentRow].GetName(ordinal);
         }
 
-        override public int GetOrdinal(string name)
+        public override int GetOrdinal(string name)
         {
             return _sourceData[_currentRow].GetOrdinal(name);
         }
 
-        override public DataTable GetSchemaTable()
+        public override DataTable GetSchemaTable()
         {
             SqlDataRecord rec = _sourceData[0];
 
@@ -1662,37 +1662,37 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return schemaTable;
         }
 
-        override public bool GetBoolean(int ordinal)
+        public override bool GetBoolean(int ordinal)
         {
             return _sourceData[_currentRow].GetBoolean(ordinal);
         }
 
-        override public byte GetByte(int ordinal)
+        public override byte GetByte(int ordinal)
         {
             return _sourceData[_currentRow].GetByte(ordinal);
         }
 
-        override public long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
+        public override long GetBytes(int ordinal, long dataOffset, byte[] buffer, int bufferOffset, int length)
         {
             return _sourceData[_currentRow].GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
         }
 
-        override public char GetChar(int ordinal)
+        public override char GetChar(int ordinal)
         {
             return _sourceData[_currentRow].GetChar(ordinal);
         }
 
-        override public long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
+        public override long GetChars(int ordinal, long dataOffset, char[] buffer, int bufferOffset, int length)
         {
             return _sourceData[_currentRow].GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
         }
 
-        override public DateTime GetDateTime(int ordinal)
+        public override DateTime GetDateTime(int ordinal)
         {
             return _sourceData[_currentRow].GetDateTime(ordinal);
         }
 
-        override public decimal GetDecimal(int ordinal)
+        public override decimal GetDecimal(int ordinal)
         {
             // DataRecord may have illegal values for Decimal...
             decimal result;
@@ -1707,63 +1707,63 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return result;
         }
 
-        override public double GetDouble(int ordinal)
+        public override double GetDouble(int ordinal)
         {
             return _sourceData[_currentRow].GetDouble(ordinal);
         }
 
-        override public float GetFloat(int ordinal)
+        public override float GetFloat(int ordinal)
         {
             return _sourceData[_currentRow].GetFloat(ordinal);
         }
 
-        override public Guid GetGuid(int ordinal)
+        public override Guid GetGuid(int ordinal)
         {
             return _sourceData[_currentRow].GetGuid(ordinal);
         }
 
-        override public short GetInt16(int ordinal)
+        public override short GetInt16(int ordinal)
         {
             return _sourceData[_currentRow].GetInt16(ordinal);
         }
 
-        override public int GetInt32(int ordinal)
+        public override int GetInt32(int ordinal)
         {
             return _sourceData[_currentRow].GetInt32(ordinal);
         }
 
-        override public long GetInt64(int ordinal)
+        public override long GetInt64(int ordinal)
         {
             return _sourceData[_currentRow].GetInt64(ordinal);
         }
 
-        override public string GetString(int ordinal)
+        public override string GetString(int ordinal)
         {
             return _sourceData[_currentRow].GetString(ordinal);
         }
 
-        override public object GetValue(int ordinal)
+        public override object GetValue(int ordinal)
         {
             return _sourceData[_currentRow].GetValue(ordinal);
         }
 
-        override public int GetValues(object[] values)
+        public override int GetValues(object[] values)
         {
             return _sourceData[_currentRow].GetValues(values);
         }
 
-        override public bool IsDBNull(int ordinal)
+        public override bool IsDBNull(int ordinal)
         {
             return _sourceData[_currentRow].IsDBNull(ordinal);
         }
 
-        override public bool NextResult()
+        public override bool NextResult()
         {
             Close();
             return false;
         }
 
-        override public bool Read()
+        public override bool Read()
         {
             _currentRow++;
 


### PR DESCRIPTION
**Description**: One thing that lights up my IDE a lot is inconsistent ordering of modifiers for methods, properties, etc. This PR does a quick sweep of the codebase (automated) and reorders the modifiers to be consistent with C# standards.

**AI Analysis**: 
![image](https://github.com/user-attachments/assets/1d638a7a-7fa4-4761-8b69-aeb69136ef63)

**Testing**: Well ... if it builds and passes the CI tests, I think it's good to go.