### PR TITLE
Code Cleanup | `123 == x` => `x == 123` etc

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Data.ProviderBase
             // distributed transactions that need it.
             lock (_poolsToRelease)
             {
-                if (0 != _poolsToRelease.Count)
+                if (_poolsToRelease.Count != 0)
                 {
                     DbConnectionPool[] poolsToRelease = _poolsToRelease.ToArray();
                     foreach (DbConnectionPool pool in poolsToRelease)
@@ -307,7 +307,7 @@ namespace Microsoft.Data.ProviderBase
                         {
                             pool.Clear();
 
-                            if (0 == pool.Count)
+                            if (pool.Count == 0)
                             {
                                 _poolsToRelease.Remove(pool);
                                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}, ReleasePool={1}", ObjectID, pool.ObjectID);
@@ -323,7 +323,7 @@ namespace Microsoft.Data.ProviderBase
             // empty, it's because there are active pools that need it.
             lock (_poolGroupsToRelease)
             {
-                if (0 != _poolGroupsToRelease.Count)
+                if (_poolGroupsToRelease.Count != 0)
                 {
                     DbConnectionPoolGroup[] poolGroupsToRelease = _poolGroupsToRelease.ToArray();
                     foreach (DbConnectionPoolGroup poolGroup in poolGroupsToRelease)
@@ -332,7 +332,7 @@ namespace Microsoft.Data.ProviderBase
                         {
                             int poolsLeft = poolGroup.Clear(); // may add entries to _poolsToRelease
 
-                            if (0 == poolsLeft)
+                            if (poolsLeft == 0)
                             {
                                 _poolGroupsToRelease.Remove(poolGroup);
                                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}, ReleasePoolGroup={1}", ObjectID, poolGroup.ObjectID);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.ProviderBase
 
         private DbConnectionPool _connectionPool;           // the pooler that the connection came from (Pooled connections only)
         private DbReferenceCollection _referenceCollection;      // collection of objects that we need to notify in some way when we're being deactivated
-        private int _pooledCount;              // [usage must be thread safe] the number of times this object has been pushed into the pool less the number of times it's been popped (0 != inPool)
+        private int _pooledCount;              // [usage must be thread safe] the number of times this object has been pushed into the pool less the number of times it's been popped (inPool != 0)
 
         private bool _connectionIsDoomed;       // true when the connection should no longer be used.
         private bool _cannotBePooled;           // true when the connection should no longer be pooled.
@@ -382,7 +382,7 @@ namespace Microsoft.Data.ProviderBase
             {
                 throw ADP.InternalError(ADP.InternalErrorCode.UnpooledObjectHasWrongOwner); // unpooled object has incorrect owner
             }
-            if (0 != _pooledCount)
+            if (_pooledCount != 0)
             {
                 throw ADP.InternalError(ADP.InternalErrorCode.PushingObjectSecondTime);         // pushing object onto stack a second time
             }
@@ -420,12 +420,12 @@ namespace Microsoft.Data.ProviderBase
             //3 // The following tests are retail assertions of things we can't allow to happen.
             if (Pool != null)
             {
-                if (0 != _pooledCount)
+                if (_pooledCount != 0)
                 {
                     throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectInPoolMoreThanOnce);  // popping object off stack with multiple pooledCount
                 }
             }
-            else if (-1 != _pooledCount)
+            else if (_pooledCount != -1)
             {
                 throw ADP.InternalError(ADP.InternalErrorCode.NonPooledObjectUsedMoreThanOnce); // popping object off stack with multiple pooledCount
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Data.ProviderBase
 
 #if DEBUG
             int activateCount = Interlocked.Increment(ref _activateCount);
-            Debug.Assert(1 == activateCount, "activated multiple times?");
+            Debug.Assert(activateCount == 1, "activated multiple times?");
 #endif // DEBUG
 
             Activate(transaction);
@@ -342,7 +342,7 @@ namespace Microsoft.Data.ProviderBase
             // ReclaimEmancipatedObjects.
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DelegatedTransactionEnded|RES|CPOOL> {0}, Delegated Transaction Completed.", ObjectID);
 
-            if (1 == _pooledCount)
+            if (_pooledCount == 1)
             {
                 // When _pooledCount is 1, it indicates a closed, pooled,
                 // connection so it is ready to put back into the pool for
@@ -360,7 +360,7 @@ namespace Microsoft.Data.ProviderBase
                 }
                 pool.PutObjectFromTransactedPool(this);
             }
-            else if (-1 == _pooledCount && !_owningObject.TryGetTarget(out _))
+            else if (_pooledCount == -1 && !_owningObject.TryGetTarget(out _))
             {
                 // When _pooledCount is -1 and the owning object no longer exists,
                 // it indicates a closed (or leaked), non-pooled connection so 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Data.ProviderBase
                     lock (connections)
                     {
                         int i = connections.Count - 1;
-                        if (0 <= i)
+                        if (i >= 0)
                         {
                             transactedObject = connections[i];
                             connections.RemoveAt(i);
@@ -159,7 +159,7 @@ namespace Microsoft.Data.ProviderBase
                         // synchronize multi-threaded access with GetTransactedObject
                         lock (connections)
                         {
-                            Debug.Assert(0 > connections.IndexOf(transactedObject), "adding to pool a second time?");
+                            Debug.Assert(connections.IndexOf(transactedObject) < 0, "adding to pool a second time?");
                             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Pushing.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                             connections.Add(transactedObject);
                         }
@@ -194,7 +194,7 @@ namespace Microsoft.Data.ProviderBase
                                 // synchronize multi-threaded access with GetTransactedObject
                                 lock (connections)
                                 {
-                                    Debug.Assert(0 > connections.IndexOf(transactedObject), "adding to pool a second time?");
+                                    Debug.Assert(connections.IndexOf(transactedObject) < 0, "adding to pool a second time?");
                                     SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.PutTransactedObject|RES|CPOOL> {0}, Transaction {1}, Connection {2}, Pushing.", ObjectID, transaction.GetHashCode(), transactedObject.ObjectID);
                                     connections.Add(transactedObject);
                                 }
@@ -268,7 +268,7 @@ namespace Microsoft.Data.ProviderBase
 
                             // Once we've completed all the ended notifications, we can
                             // safely remove the list from the transacted pool.
-                            if (0 >= connections.Count)
+                            if (connections.Count <= 0)
                             {
                                 SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionPool.TransactedConnectionPool.TransactionEnded|RES|CPOOL> {0}, Transaction {1}, Removing List from transacted pool.", ObjectID, transaction.GetHashCode());
                                 _transactedCxns.Remove(transaction);
@@ -292,7 +292,7 @@ namespace Microsoft.Data.ProviderBase
 
                 // If (and only if) we found the connection in the list of
                 // connections, we'll put it back...
-                if (0 <= entry)
+                if (entry >= 0)
                 {
                     SqlClientEventSource.Log.ExitFreeConnection();
                     Pool.PutObjectFromTransactedPool(transactedObject);
@@ -816,7 +816,7 @@ namespace Microsoft.Data.ProviderBase
 
                 Debug.Assert(timerIsNotDisposed, "ErrorCallback timer has been disposed");
 
-                if (30000 < _errorWait)
+                if (_errorWait > 30000)
                 {
                     _errorWait = 60000;
                 }
@@ -1239,12 +1239,12 @@ namespace Microsoft.Data.ProviderBase
                                     // we reached MaxPoolSize.  If so, we will no longer wait on
                                     // the CreationHandle, but instead wait for a free object or
                                     // the timeout.
-                                    if (Count >= MaxPoolSize && 0 != MaxPoolSize)
+                                    if (Count >= MaxPoolSize && MaxPoolSize != 0)
                                     {
                                         if (!ReclaimEmancipatedObjects())
                                         {
                                             // modify handle array not to wait on creation mutex anymore
-                                            Debug.Assert(2 == CREATION_HANDLE, "creation handle changed value");
+                                            Debug.Assert(CREATION_HANDLE == 2, "creation handle changed value");
                                             allowCreate = false;
                                         }
                                     }
@@ -1753,7 +1753,7 @@ namespace Microsoft.Data.ProviderBase
             }
             else
             {
-                if ((oldConnection != null) || (Count < MaxPoolSize) || (0 == MaxPoolSize))
+                if ((oldConnection != null) || (Count < MaxPoolSize) || MaxPoolSize == 0)
                 {
                     // If we have an odd number of total objects, reclaim any dead objects.
                     // If we did not find any objects to reclaim, create a new one.

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AlwaysEncryptedHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/AlwaysEncryptedHelperClasses.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Data.SqlClient
             };
             _columnEncryptionKeyValues.Add(encryptionKey);
 
-            if (0 == _databaseId)
+            if (_databaseId == 0)
             {
                 _databaseId = databaseId;
                 _cekId = cekId;
@@ -202,7 +202,7 @@ namespace Microsoft.Data.SqlClient
 
         internal SqlTceCipherInfoTable(int tabSize)
         {
-            Debug.Assert(0 < tabSize, "Invalid Table Size");
+            Debug.Assert(tabSize > 0, "Invalid Table Size");
             keyList = new SqlTceCipherInfoEntry[tabSize];
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -525,7 +525,7 @@ namespace Microsoft.Data.SqlClient
 
             StringBuilder updateBulkCommandText = new StringBuilder();
 
-            if (0 == internalResults[CollationResultId].Count)
+            if (internalResults[CollationResultId].Count == 0)
             {
                 throw SQL.BulkLoadNoCollation();
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.NullEncryptedColumnEncryptionKey();
             }
 
-            if (0 == encryptedColumnEncryptionKey.Length)
+            if (encryptedColumnEncryptionKey.Length == 0)
             {
                 throw SQL.EmptyEncryptedColumnEncryptionKey();
             }
@@ -130,7 +130,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.NullColumnEncryptionKey();
             }
-            else if (0 == columnEncryptionKey.Length)
+            else if (columnEncryptionKey.Length == 0)
             {
                 throw SQL.EmptyColumnEncryptionKey();
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.Windows.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.NullEncryptedColumnEncryptionKey();
             }
 
-            if (0 == encryptedColumnEncryptionKey.Length)
+            if (encryptedColumnEncryptionKey.Length == 0)
             {
                 throw SQL.EmptyEncryptedColumnEncryptionKey();
             }
@@ -138,7 +138,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.NullColumnEncryptionKey();
             }
-            else if (0 == columnEncryptionKey.Length)
+            else if (columnEncryptionKey.Length == 0)
             {
                 throw SQL.EmptyColumnEncryptionKey();
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Data.SqlClient
             {    // never pool context connections.
                 int connectionTimeout = opt.ConnectTimeout;
 
-                if ((0 < connectionTimeout) && (connectionTimeout < int.MaxValue / 1000))
+                if (connectionTimeout > 0 && connectionTimeout < int.MaxValue / 1000)
                 {
                     connectionTimeout *= 1000;
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Data.SqlClient
         internal long ColumnDataBytesRemaining()
         {
             // If there are an unknown (-1) number of bytes left for a PLP, read its size
-            if (-1 == _sharedState._columnDataBytesRemaining)
+            if (_sharedState._columnDataBytesRemaining == -1)
             {
                 _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
             }
@@ -270,7 +270,7 @@ namespace Microsoft.Data.SqlClient
             SmiExtendedMetaData[] metaDataReturn = null;
             _SqlMetaDataSet metaData = this.MetaData;
 
-            if (metaData != null && 0 < metaData.Length)
+            if (metaData != null && metaData.Length > 0)
             {
                 metaDataReturn = new SmiExtendedMetaData[metaData.VisibleColumnCount];
                 int returnIndex = 0;
@@ -568,15 +568,15 @@ namespace Microsoft.Data.SqlClient
                             schemaRow[size] = TdsEnums.WHIDBEY_DATE_LENGTH;
                             break;
                         case SqlDbType.Time:
-                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (0 <= col.scale && col.scale <= 7), "Invalid scale for Time column: " + col.scale);
+                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (col.scale >= 0 && col.scale <= 7), "Invalid scale for Time column: " + col.scale);
                             schemaRow[size] = TdsEnums.WHIDBEY_TIME_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
                             break;
                         case SqlDbType.DateTime2:
-                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (0 <= col.scale && col.scale <= 7), "Invalid scale for DateTime2 column: " + col.scale);
+                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (col.scale >= 0 && col.scale <= 7), "Invalid scale for DateTime2 column: " + col.scale);
                             schemaRow[size] = TdsEnums.WHIDBEY_DATETIME2_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
                             break;
                         case SqlDbType.DateTimeOffset:
-                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (0 <= col.scale && col.scale <= 7), "Invalid scale for DateTimeOffset column: " + col.scale);
+                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (col.scale >= 0 && col.scale <= 7), "Invalid scale for DateTimeOffset column: " + col.scale);
                             schemaRow[size] = TdsEnums.WHIDBEY_DATETIMEOFFSET_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
                             break;
                     }
@@ -781,13 +781,13 @@ namespace Microsoft.Data.SqlClient
             // iib. user called read and fetched a subset of the column data
 
             // Wipe out any Streams or TextReaders
-            if (-1 != _lastColumnWithDataChunkRead)
+            if (_lastColumnWithDataChunkRead != -1)
             {
                 CloseActiveSequentialStreamAndTextReader();
             }
 
             // i. user called read but didn't fetch anything
-            if (0 == _sharedState._nextColumnHeaderToRead)
+            if (_sharedState._nextColumnHeaderToRead == 0)
             {
                 result = _stateObj.Parser.TrySkipRow(_metaData, _stateObj);
                 if (result != TdsOperationStatus.Done)
@@ -1681,7 +1681,7 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // If there are an unknown (-1) number of bytes left for a PLP, read its size
-                if ((-1 == _sharedState._columnDataBytesRemaining) && (_metaData[i].metaType.IsPlp))
+                if (_sharedState._columnDataBytesRemaining == -1 && (_metaData[i].metaType.IsPlp))
                 {
                     ulong left;
                     result = _parser.TryPlpBytesLeft(_stateObj, out left);
@@ -1692,7 +1692,7 @@ namespace Microsoft.Data.SqlClient
                     _sharedState._columnDataBytesRemaining = (long)left;
                 }
 
-                if (0 == _sharedState._columnDataBytesRemaining)
+                if (_sharedState._columnDataBytesRemaining == 0)
                 {
                     return TdsOperationStatus.Done; // We've read this column to the end
                 }
@@ -2244,12 +2244,12 @@ namespace Microsoft.Data.SqlClient
             bool isUnicode = _metaData[i].metaType.IsNCharType;
 
             // If there are an unknown (-1) number of bytes left for a PLP, read its size
-            if (-1 == _sharedState._columnDataBytesRemaining)
+            if (_sharedState._columnDataBytesRemaining == -1)
             {
                 _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
             }
 
-            if (0 == _sharedState._columnDataBytesRemaining)
+            if (_sharedState._columnDataBytesRemaining == 0)
             {
                 _stateObj._plpdecoder = null;
                 return 0; // We've read this column to the end
@@ -3850,7 +3850,7 @@ namespace Microsoft.Data.SqlClient
             bool isSequentialAccess = IsCommandBehavior(CommandBehavior.SequentialAccess);
             if (isSequentialAccess)
             {
-                if (0 < _sharedState._nextColumnDataToRead)
+                if (_sharedState._nextColumnDataToRead > 0)
                 {
                     _data[_sharedState._nextColumnDataToRead - 1].Clear();
                 }
@@ -4069,12 +4069,12 @@ namespace Microsoft.Data.SqlClient
                     byte typeAndMask = (byte)(_metaData[currentColumn].tdsType & TdsEnums.SQLLenMask);
                     if ((typeAndMask == TdsEnums.SQLVarLen) || (typeAndMask == TdsEnums.SQLVarCnt))
                     {
-                        if (0 != (_metaData[currentColumn].tdsType & 0x80))
+                        if ((_metaData[currentColumn].tdsType & 0x80) != 0)
                         {
                             // UInt16 represents size
                             maxHeaderSize = 2;
                         }
-                        else if (0 == (_metaData[currentColumn].tdsType & 0x0c))
+                        else if ((_metaData[currentColumn].tdsType & 0x0c) == 0)
                         {
                             // UInt32 represents size
                             maxHeaderSize = 4;
@@ -4130,7 +4130,7 @@ namespace Microsoft.Data.SqlClient
                         localSXml.Close();
                     }
                 }
-                else if (0 < _sharedState._columnDataBytesRemaining)
+                else if (_sharedState._columnDataBytesRemaining > 0)
                 {
                     result = _stateObj.TrySkipLongBytes(_sharedState._columnDataBytesRemaining);
                     if (result != TdsOperationStatus.Done)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -901,7 +901,7 @@ namespace Microsoft.Data.SqlClient
             // the async commands, or we don't know that we're in a state that
             // we can recover from.  We doom the connection in this case, to
             // prevent odd cases when we go to the wire.
-            if (0 != _asyncCommandCount)
+            if (_asyncCommandCount != 0)
             {
                 DoomThisConnection();
             }
@@ -1814,7 +1814,7 @@ namespace Microsoft.Data.SqlClient
                         throw;
                     }
 
-                    if (1 == attemptNumber % 2)
+                    if (attemptNumber % 2 == 1)
                     {
                         // Check sleep interval to make sure we won't exceed the original timeout
                         //  Do this in the catch block so we can re-throw the current exception
@@ -1829,7 +1829,7 @@ namespace Microsoft.Data.SqlClient
 
                 // After trying to connect to both servers fails, sleep for a bit to prevent clogging
                 //  the network with requests, then update sleep interval for next iteration (max 1 second interval)
-                if (1 == attemptNumber % 2)
+                if (attemptNumber % 2 == 1)
                 {
                     SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}, sleeping {1}[milisec]", ObjectID, sleepInterval);
                     Thread.Sleep(sleepInterval);
@@ -2650,7 +2650,7 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         IsGlobalTransaction = true;
-                        if (1 == data[0])
+                        if (data[0] == 1)
                         {
                             IsGlobalTransactionsEnabledForServer = true;
                         }
@@ -2721,7 +2721,7 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         byte supportedTceVersion = data[0];
-                        if (0 == supportedTceVersion || supportedTceVersion > TdsEnums.MAX_SUPPORTED_TCE_VERSION)
+                        if (supportedTceVersion == 0 || supportedTceVersion > TdsEnums.MAX_SUPPORTED_TCE_VERSION)
                         {
                             SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for TCE", ObjectID);
                             throw SQL.ParsingErrorValue(ParsingErrorState.TceInvalidVersion, supportedTceVersion);
@@ -2760,7 +2760,7 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         byte supportedDataClassificationVersion = data[0];
-                        if ((0 == supportedDataClassificationVersion) || (supportedDataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_MAX_SUPPORTED))
+                        if (supportedDataClassificationVersion == 0 || (supportedDataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_MAX_SUPPORTED))
                         {
                             SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for DATACLASSIFICATION", ObjectID);
                             throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, supportedDataClassificationVersion);
@@ -2786,7 +2786,7 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
 
-                        if (1 == data[0])
+                        if (data[0] == 1)
                         {
                             IsSQLDNSCachingSupported = true;
                             _cleanSQLDNSCaching = false;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1521,12 +1521,12 @@ namespace Microsoft.Data.SqlClient
                     // strip provider info from SNI
                     //
                     int iColon = errorMessage.IndexOf(':');
-                    Debug.Assert(0 <= iColon, "':' character missing in sni errorMessage");
+                    Debug.Assert(iColon >= 0, "':' character missing in sni errorMessage");
                     SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > ':' character missing in sni errorMessage. Error Message index of ':' = {0}", iColon);
                     Debug.Assert(errorMessage.Length > iColon + 1 && errorMessage[iColon + 1] == ' ', "Expecting a space after the ':' character");
                     SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Expecting a space after the ':' character. Error Message Length = {0}", errorMessage.Length);
                     // extract the message excluding the colon and trailing cr/lf chars
-                    if (0 <= iColon)
+                    if (iColon >= 0)
                     {
                         int len = errorMessage.Length;
                         len -= Environment.NewLine.Length; // exclude newline sequence
@@ -1686,7 +1686,7 @@ namespace Microsoft.Data.SqlClient
             }
             else
             {
-                Debug.Assert(2 == stateObj._bShortBytes.Length);
+                Debug.Assert(stateObj._bShortBytes.Length == 2);
             }
 
             byte[] bytes = stateObj._bShortBytes;
@@ -1818,7 +1818,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             byte[] bytes = stateObj._bLongBytes;
-            Debug.Assert(8 == bytes.Length, "Cached buffer has wrong size");
+            Debug.Assert(bytes.Length == 8, "Cached buffer has wrong size");
 
             bytes[current++] = (byte)(v & 0xff);
             bytes[current++] = (byte)((v >> 8) & 0xff);
@@ -2957,7 +2957,7 @@ namespace Microsoft.Data.SqlClient
                             return result;
                         }
                         env._oldLength = byteLength;
-                        Debug.Assert(0 == env._oldLength, "old length should be zero");
+                        Debug.Assert(env._oldLength == 0, "old length should be zero");
 
                         // env.length includes 1 byte for type token
                         env._length = 5 + env._newLength;
@@ -4576,10 +4576,10 @@ namespace Microsoft.Data.SqlClient
         {
             int codePage = 0;
 
-            if (0 != collation._sortId)
+            if (collation._sortId != 0)
             {
                 codePage = TdsEnums.CODE_PAGE_FROM_SORT_ID[collation._sortId];
-                Debug.Assert(0 != codePage, "GetCodePage accessed codepage array and produced 0!, sortID =" + ((Byte)(collation._sortId)).ToString((IFormatProvider)null));
+                Debug.Assert(codePage != 0, "GetCodePage accessed codepage array and produced 0!, sortID =" + ((Byte)(collation._sortId)).ToString((IFormatProvider)null));
             }
             else
             {
@@ -4678,7 +4678,7 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.SynchronousCallMayNotPend();
                         }
                     }
-                    if (0 == sharedState._nextColumnHeaderToRead)
+                    if (sharedState._nextColumnHeaderToRead == 0)
                     {
                         // i. user called read but didn't fetch anything
                         if (stateObj.Parser.TrySkipRow(stateObj._cleanupMetaData, stateObj) != TdsOperationStatus.Done)
@@ -4702,7 +4702,7 @@ namespace Microsoft.Data.SqlClient
                                 }
                             }
 
-                            else if (0 < sharedState._columnDataBytesRemaining)
+                            else if (sharedState._columnDataBytesRemaining > 0)
                             {
                                 if (stateObj.TrySkipLongBytes(sharedState._columnDataBytesRemaining) != TdsOperationStatus.Done)
                                 {
@@ -4956,7 +4956,7 @@ namespace Microsoft.Data.SqlClient
                 return result;
             }
 
-            if (0 != tableSize)
+            if (tableSize != 0)
             {
                 SqlTceCipherInfoTable tempTable = new SqlTceCipherInfoTable(tableSize);
 
@@ -5149,7 +5149,7 @@ namespace Microsoft.Data.SqlClient
                     return result;
                 }
 
-                Debug.Assert(0 <= col.scale && col.scale <= 7);
+                Debug.Assert(col.scale >= 0 && col.scale <= 7);
 
                 // calculate actual column length here
                 // TODO: variable-length calculation needs to be encapsulated better
@@ -5562,7 +5562,7 @@ namespace Microsoft.Data.SqlClient
                     return result;
                 }
 
-                if (0 != textPtrLen)
+                if (textPtrLen != 0)
                 {
                     // read past text pointer
                     result = stateObj.TrySkipBytes(textPtrLen);
@@ -5878,7 +5878,7 @@ namespace Microsoft.Data.SqlClient
                     return result;
                 }
 
-                if (0 != textPtrLen)
+                if (textPtrLen != 0)
                 {
                     result = stateObj.TrySkipBytes(textPtrLen + TdsEnums.TEXT_TIME_STAMP_LEN);
                     if (result != TdsOperationStatus.Done)
@@ -6211,7 +6211,7 @@ namespace Microsoft.Data.SqlClient
                     // Check the sign from the first byte.
                     int index = 0;
                     byteValue = unencryptedBytes[index++];
-                    bool fPositive = (1 == byteValue);
+                    bool fPositive = (byteValue == 1);
 
                     // Now read the 4 next integers which contain the actual value.
                     length = checked((int)length - 1);
@@ -6483,17 +6483,17 @@ namespace Microsoft.Data.SqlClient
                     break;
 
                 case TdsEnums.SQLTIME:
-                    Debug.Assert(3 <= length && length <= 5, "invalid length for time type!");
+                    Debug.Assert(length >= 3 && length <= 5, "invalid length for time type!");
                     value.SetToTime(dateTimeData, scale, scale);
                     break;
 
                 case TdsEnums.SQLDATETIME2:
-                    Debug.Assert(6 <= length && length <= 8, "invalid length for datetime2 type!");
+                    Debug.Assert(length >= 6 && length <= 8, "invalid length for datetime2 type!");
                     value.SetToDateTime2(dateTimeData, scale, scale);
                     break;
 
                 case TdsEnums.SQLDATETIMEOFFSET:
-                    Debug.Assert(8 <= length && length <= 10, "invalid length for datetimeoffset type!");
+                    Debug.Assert(length >= 8 && length <= 10, "invalid length for datetimeoffset type!");
                     value.SetToDateTimeOffset(dateTimeData, scale, scale);
                     break;
 
@@ -6976,7 +6976,7 @@ namespace Microsoft.Data.SqlClient
             MetaType mt = MetaType.GetMetaTypeFromValue(value);
 
             // Special case data type correction for SqlMoney inside a SqlVariant.
-            if ((TdsEnums.SQLNUMERICN == mt.TDSType) && (8 == length))
+            if ((TdsEnums.SQLNUMERICN == mt.TDSType) && length == 8)
             {
                 // The caller will coerce all SqlTypes to native CLR types, which means SqlMoney will
                 // coerce to decimal/SQLNUMERICN (via SqlMoney.Value call).  In the case where the original
@@ -7319,7 +7319,7 @@ namespace Microsoft.Data.SqlClient
             int[] bits = decimal.GetBits(value.Value);
 
             // this decimal should be scaled by 10000 (regardless of what the incoming decimal was scaled by)
-            bool isNeg = (0 != (bits[3] & unchecked((int)0x80000000)));
+            bool isNeg = (bits[3] & unchecked((int)0x80000000)) != 0;
             long l = ((long)(uint)bits[1]) << 0x20 | (uint)bits[0];
 
             if (isNeg)
@@ -7350,7 +7350,7 @@ namespace Microsoft.Data.SqlClient
             int[] bits = Decimal.GetBits(m.Value);
 
             // this decimal should be scaled by 10000 (regardless of what the incoming decimal was scaled by)
-            bool isNeg = (0 != (bits[3] & unchecked((int)0x80000000)));
+            bool isNeg = (bits[3] & unchecked((int)0x80000000)) != 0;
             long l = ((long)(uint)bits[1]) << 0x20 | (uint)bits[0];
 
             if (isNeg)
@@ -7368,7 +7368,7 @@ namespace Microsoft.Data.SqlClient
                 length = 8;
             }
 
-            Debug.Assert(8 == length, "invalid length in SerializeCurrency");
+            Debug.Assert(length == 8, "invalid length in SerializeCurrency");
             if (stateObj._bLongBytes == null)
             {
                 stateObj._bLongBytes = new byte[8];
@@ -7393,7 +7393,7 @@ namespace Microsoft.Data.SqlClient
             int[] bits = decimal.GetBits(m.Value);
 
             // this decimal should be scaled by 10000 (regardless of what the incoming decimal was scaled by)
-            bool isNeg = (0 != (bits[3] & unchecked((int)0x80000000)));
+            bool isNeg = (bits[3] & unchecked((int)0x80000000)) != 0;
             long l = ((long)(uint)bits[1]) << 0x20 | (uint)bits[0];
 
             if (isNeg)
@@ -7430,7 +7430,7 @@ namespace Microsoft.Data.SqlClient
 
         private byte[] SerializeTime(TimeSpan value, byte scale, int length)
         {
-            if (0 > value.Ticks || value.Ticks >= TimeSpan.TicksPerDay)
+            if (value.Ticks < 0 || value.Ticks >= TimeSpan.TicksPerDay)
             {
                 throw SQL.TimeOverflow(value.ToString());
             }
@@ -7446,7 +7446,7 @@ namespace Microsoft.Data.SqlClient
 
         private void WriteTime(TimeSpan value, byte scale, int length, TdsParserStateObject stateObj)
         {
-            if (0 > value.Ticks || value.Ticks >= TimeSpan.TicksPerDay)
+            if (value.Ticks < 0 || value.Ticks >= TimeSpan.TicksPerDay)
             {
                 throw SQL.TimeOverflow(value.ToString());
             }
@@ -7521,7 +7521,7 @@ namespace Microsoft.Data.SqlClient
             {
                 return result;
             }
-            bool fPositive = (1 == byteValue);
+            bool fPositive = (byteValue == 1);
 
             length = checked((int)length - 1);
 
@@ -7688,7 +7688,7 @@ namespace Microsoft.Data.SqlClient
             */
 
             // write the sign (note that COM and SQL are opposite)
-            if (0x80000000 == (decimalBits[3] & 0x80000000))
+            if ((decimalBits[3] & 0x80000000) == 0x80000000)
                 bytes[current++] = 0;
             else
                 bytes[current++] = 1;
@@ -7733,7 +7733,7 @@ namespace Microsoft.Data.SqlClient
             */
 
             // write the sign (note that COM and SQL are opposite)
-            if (0x80000000 == (stateObj._decimalBits[3] & 0x80000000))
+            if ((stateObj._decimalBits[3] & 0x80000000) == 0x80000000)
                 stateObj.WriteByte(0);
             else
                 stateObj.WriteByte(1);
@@ -8034,7 +8034,7 @@ namespace Microsoft.Data.SqlClient
                     return TdsOperationStatus.Done;
                 case TdsEnums.SQLVarLen:
                 case TdsEnums.SQLVarCnt:
-                    if (0 != (token & 0x80))
+                    if ((token & 0x80) != 0)
                     {
                         ushort value;
                         result = stateObj.TryReadUInt16(out value);
@@ -8046,7 +8046,7 @@ namespace Microsoft.Data.SqlClient
                         tokenLength = value;
                         return TdsOperationStatus.Done;
                     }
-                    else if (0 == (token & 0x0c))
+                    else if ((token & 0x0c) == 0)
                     {
                         return stateObj.TryReadInt32(out tokenLength);
                     }
@@ -9339,7 +9339,7 @@ namespace Microsoft.Data.SqlClient
 
                             if (mt.Is2008Type)
                             {
-                                WriteSmiParameter(param, i, 0 != (options & TdsEnums.RPC_PARAM_DEFAULT), stateObj, enableOptimizedParameterBinding, isAdvancedTraceOn);
+                                WriteSmiParameter(param, i, (options & TdsEnums.RPC_PARAM_DEFAULT) != 0, stateObj, enableOptimizedParameterBinding, isAdvancedTraceOn);
                                 continue;
                             }
 
@@ -9557,7 +9557,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            bool isParameterEncrypted = 0 != (options & TdsEnums.RPC_PARAM_ENCRYPTED);
+            bool isParameterEncrypted = (options & TdsEnums.RPC_PARAM_ENCRYPTED) != 0;
 
             // Additional information we need to send over wire to the server when writing encrypted parameters.
             SqlColumnEncryptionInputParameterInfo encryptedParameterInfoToWrite = null;
@@ -9816,7 +9816,7 @@ namespace Microsoft.Data.SqlClient
             // scale and precision are only relevant for numeric and decimal types
             if (mt.SqlDbType == SqlDbType.Decimal)
             {
-                if (0 == precision)
+                if (precision == 0)
                 {
                     stateObj.WriteByte(TdsEnums.DEFAULT_NUMERIC_PRECISION);
                 }
@@ -9890,7 +9890,7 @@ namespace Microsoft.Data.SqlClient
                 stateObj.WriteByte(outCollation._sortId);
             }
 
-            if (0 == codePageByteSize)
+            if (codePageByteSize == 0)
                 WriteParameterVarLen(mt, actualSize, isNull, stateObj, isDataFeed);
             else
                 WriteParameterVarLen(mt, codePageByteSize, isNull, stateObj, isDataFeed);
@@ -10175,7 +10175,7 @@ namespace Microsoft.Data.SqlClient
                 case SqlDbType.Decimal:
                     stateObj.WriteByte(TdsEnums.SQLNUMERICN);
                     stateObj.WriteByte(checked((byte)MetaType.MetaDecimal.FixedLength));   // SmiMetaData's length and actual wire format's length are different
-                    stateObj.WriteByte(0 == metaData.Precision ? (byte)1 : metaData.Precision);
+                    stateObj.WriteByte(metaData.Precision == 0 ? (byte)1 : metaData.Precision);
                     stateObj.WriteByte(metaData.Scale);
                     break;
                 case SqlDbType.Float:
@@ -10333,7 +10333,7 @@ namespace Microsoft.Data.SqlClient
             WriteIdentifier(metaData.TypeSpecificNamePart3, stateObj);
 
             // TVP_COLMETADATA
-            if (0 == metaData.FieldMetaData.Count)
+            if (metaData.FieldMetaData.Count == 0)
             {
                 WriteUnsignedShort((ushort)TdsEnums.TVP_NOMETADATA_TOKEN, stateObj);
             }
@@ -10432,14 +10432,14 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // Remember this column if any flags were set
-                if (0 != flags)
+                if (flags != 0)
                 {
                     columnList.Add(new TdsOrderUnique(checked((short)(i + 1)), flags));
                 }
             }
 
             // Write flagged columns to wire...
-            if (0 < columnList.Count)
+            if (columnList.Count > 0)
             {
                 stateObj.WriteByte(TdsEnums.TVP_ORDER_UNIQUE_TOKEN);
                 WriteShort(columnList.Count, stateObj);
@@ -10510,7 +10510,7 @@ namespace Microsoft.Data.SqlClient
                 WriteInt(cekTable[i].CekVersion, stateObj);
 
                 // Write 8 bytes of key MD Version
-                Debug.Assert(8 == cekTable[i].CekMdVersion.Length);
+                Debug.Assert(cekTable[i].CekMdVersion.Length == 8);
                 stateObj.WriteByteArray(cekTable[i].CekMdVersion, 8, 0);
 
                 // We don't really need to send the keys
@@ -11091,7 +11091,7 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.ArgumentOutOfRange(nameof(service));
                 }
 
-                if (-1 > timeout)
+                if (timeout < -1)
                 {
                     throw ADP.ArgumentOutOfRange(nameof(timeout));
                 }
@@ -11134,7 +11134,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(ushort.MaxValue >= callbackId.Length, "CallbackId length is out of range");
             Debug.Assert(service != null, "Service is null");
             Debug.Assert(ushort.MaxValue >= service.Length, "Service length is out of range");
-            Debug.Assert(-1 <= timeout, "Timeout");
+            Debug.Assert(timeout >= -1, "Timeout");
 
             SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.TdsParser.WriteQueryNotificationHeader|DEP> NotificationRequest: userData: '{0}', options: '{1}', timeout: '{2}'", notificationRequest.UserData, notificationRequest.Options, notificationRequest.Timeout);
             WriteShort(TdsEnums.HEADERTYPE_QNOTIFICATION, stateObj);      // Query notifications Type
@@ -11190,7 +11190,7 @@ namespace Microsoft.Data.SqlClient
             // Write Mars header data
             WriteMarsHeaderData(stateObj, CurrentTransaction);
 
-            if (0 != notificationHeaderSize)
+            if (notificationHeaderSize != 0)
             {
                 // Write Notification header length
                 WriteInt(notificationHeaderSize, stateObj);
@@ -11238,12 +11238,18 @@ namespace Microsoft.Data.SqlClient
 
                     case TdsEnums.SQLVarLen:
                     case TdsEnums.SQLVarCnt:
-                        if (0 != (token & 0x80))
+                        if ((token & 0x80) != 0)
+                        {
                             tokenLength = 2;
-                        else if (0 == (token & 0x0c))
+                        }
+                        else if ((token & 0x0c) == 0)
+                        {
                             tokenLength = 4;
+                        }
                         else
+                        {
                             tokenLength = 1;
+                        }
 
                         break;
 
@@ -11494,8 +11500,10 @@ namespace Microsoft.Data.SqlClient
 
                     if (type.FixedLength == 4)
                     {
-                        if (0 > dt.DayTicks || dt.DayTicks > ushort.MaxValue)
+                        if (dt.DayTicks < 0 || dt.DayTicks > ushort.MaxValue)
+                        {
                             throw SQL.SmallDateTimeOverflow(dt.ToString());
+                        }
 
                         WriteShort(dt.DayTicks, stateObj);
                         WriteShort(dt.TimeTicks / SqlDateTime.SQLTicksPerMinute, stateObj);
@@ -12160,8 +12168,10 @@ namespace Microsoft.Data.SqlClient
 
                     if (type.FixedLength == 4)
                     {
-                        if (0 > dt.days || dt.days > ushort.MaxValue)
+                        if (dt.days < 0 || dt.days > ushort.MaxValue)
+                        {
                             throw SQL.SmallDateTimeOverflow(MetaType.ToDateTime(dt.days, dt.time, 4).ToString(CultureInfo.InvariantCulture));
+                        }
 
                         WriteShort(dt.days, stateObj);
                         WriteShort(dt.time, stateObj);
@@ -12370,8 +12380,10 @@ namespace Microsoft.Data.SqlClient
 
                     if (type.FixedLength == 4)
                     {
-                        if (0 > dt.days || dt.days > UInt16.MaxValue)
+                        if (dt.days < 0 || dt.days > UInt16.MaxValue)
+                        {
                             throw SQL.SmallDateTimeOverflow(MetaType.ToDateTime(dt.days, dt.time, 4).ToString(CultureInfo.InvariantCulture));
+                        }
 
                         if (stateObj._bIntBytes == null)
                         {
@@ -12563,8 +12575,10 @@ namespace Microsoft.Data.SqlClient
 
                     if (type.FixedLength == 4)
                     {
-                        if (0 > dt.DayTicks || dt.DayTicks > UInt16.MaxValue)
+                        if (dt.DayTicks < 0 || dt.DayTicks > UInt16.MaxValue)
+                        {
                             throw SQL.SmallDateTimeOverflow(dt.ToString());
+                        }
 
                         if (stateObj._bIntBytes == null)
                         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Data.SqlClient
 
         protected override void FreeGcHandle(int remaining, bool release)
         {
-            if ((0 == remaining || release) && _gcHandle.IsAllocated)
+            if ((remaining == 0 || release) && _gcHandle.IsAllocated)
             {
                 _gcHandle.Free();
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Common/src/Microsoft/Data/Common/NameValuePermission.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Common/src/Microsoft/Data/Common/NameValuePermission.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Data.Common
                             --count;
                         }
                     }
-                    if (0 == count)
+                    if (count == 0)
                     {
                         _tree = null;
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DBConnectionString.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Data.Common
                 if (restrictions == null)
                 {
                     string[] restrictionValues = _restrictionValues;
-                    if (restrictionValues != null && (0 < restrictionValues.Length))
+                    if (restrictionValues != null && restrictionValues.Length > 0)
                     {
                         StringBuilder builder = new StringBuilder();
                         for (int i = 0; i < restrictionValues.Length; ++i)
@@ -367,7 +367,7 @@ namespace Microsoft.Data.Common
         private bool IsRestrictedKeyword(string key)
         {
             // restricted if not found
-            return (_restrictionValues == null || (0 > Array.BinarySearch(_restrictionValues, key, StringComparer.Ordinal)));
+            return _restrictionValues == null || Array.BinarySearch(_restrictionValues, key, StringComparer.Ordinal) < 0;
         }
 
         internal bool IsSupersetOf(DBConnectionString entry)
@@ -413,7 +413,7 @@ namespace Microsoft.Data.Common
             List<string> newlist = null;
             for (int i = 0; i < allowonly.Length; ++i)
             {
-                if (0 > Array.BinarySearch(preventusage, allowonly[i], StringComparer.Ordinal))
+                if (Array.BinarySearch(preventusage, allowonly[i], StringComparer.Ordinal) < 0)
                 {
                     if (newlist == null)
                     {
@@ -436,7 +436,7 @@ namespace Microsoft.Data.Common
             List<string> newlist = null;
             for (int i = 0; i < a.Length; ++i)
             {
-                if (0 <= Array.BinarySearch(b, a[i], StringComparer.Ordinal))
+                if (Array.BinarySearch(b, a[i], StringComparer.Ordinal) >= 0)
                 {
                     if (newlist == null)
                     {
@@ -457,8 +457,8 @@ namespace Microsoft.Data.Common
         static private string[] NoDuplicateUnion(string[] a, string[] b)
         {
 #if DEBUG
-            Debug.Assert(a != null && 0 < a.Length, "empty a");
-            Debug.Assert(b != null && 0 < b.Length, "empty b");
+            Debug.Assert(a != null && a.Length > 0, "empty a");
+            Debug.Assert(b != null && b.Length > 0, "empty b");
             Verify(a);
             Verify(b);
 #endif
@@ -469,7 +469,7 @@ namespace Microsoft.Data.Common
             }
             for (int i = 0; i < b.Length; ++i)
             { // find duplicates
-                if (0 > Array.BinarySearch(a, b[i], StringComparer.Ordinal))
+                if (Array.BinarySearch(a, b[i], StringComparer.Ordinal) < 0)
                 {
                     newlist.Add(b[i]);
                 }
@@ -516,20 +516,20 @@ namespace Microsoft.Data.Common
         static internal string[] RemoveDuplicates(string[] restrictions)
         {
             int count = restrictions.Length;
-            if (0 < count)
+            if (count > 0)
             {
                 Array.Sort(restrictions, StringComparer.Ordinal);
 
                 for (int i = 1; i < restrictions.Length; ++i)
                 {
                     string prev = restrictions[i - 1];
-                    if ((0 == prev.Length) || (prev == restrictions[i]))
+                    if (prev.Length == 0 || (prev == restrictions[i]))
                     {
                         restrictions[i - 1] = null;
                         count--;
                     }
                 }
-                if (0 == restrictions[restrictions.Length - 1].Length)
+                if (restrictions[restrictions.Length - 1].Length == 0)
                 {
                     restrictions[restrictions.Length - 1] = null;
                     count--;
@@ -561,7 +561,7 @@ namespace Microsoft.Data.Common
                 {
                     Debug.Assert(!ADP.IsEmpty(restrictionValues[i - 1]), "empty restriction");
                     Debug.Assert(!ADP.IsEmpty(restrictionValues[i]), "empty restriction");
-                    Debug.Assert(0 >= StringComparer.Ordinal.Compare(restrictionValues[i - 1], restrictionValues[i]));
+                    Debug.Assert(StringComparer.Ordinal.Compare(restrictionValues[i - 1], restrictionValues[i]) <= 0);
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DbConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Common/DbConnectionOptions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Data.Common
                 throw ADP.InvalidValue(keyName);
             }
 
-            if ((0 < builder.Length) && (';' != builder[builder.Length - 1]))
+            if (builder.Length > 0 && builder[builder.Length - 1] != ';')
             {
                 builder.Append(";");
             }
@@ -116,8 +116,8 @@ namespace Microsoft.Data.Common
             { // else <keyword>=;
                 if (useOdbcRules)
                 {
-                    if ((0 < keyValue.Length) &&
-                        (('{' == keyValue[0]) || (0 <= keyValue.IndexOf(';')) || (0 == string.Compare(DbConnectionStringKeywords.Driver, keyName, StringComparison.OrdinalIgnoreCase))) &&
+                    if (keyValue.Length > 0 &&
+                        (keyValue[0] == '{' || keyValue.IndexOf(';') >= 0 || string.Compare(DbConnectionStringKeywords.Driver, keyName, StringComparison.OrdinalIgnoreCase) == 0) &&
                         !s_connectionStringQuoteOdbcValueRegex.IsMatch(keyValue))
                     {
                         // always quote Driver value (required for ODBC Version 2.65 and earlier)
@@ -134,7 +134,7 @@ namespace Microsoft.Data.Common
                     // <value> -> <value>
                     builder.Append(keyValue);
                 }
-                else if ((-1 != keyValue.IndexOf('\"')) && (-1 == keyValue.IndexOf('\'')))
+                else if (keyValue.IndexOf('\"') != -1 && keyValue.IndexOf('\'') == -1)
                 {
                     // <val"ue> -> <'val"ue'>
                     builder.Append('\'');
@@ -192,7 +192,7 @@ namespace Microsoft.Data.Common
 
                 // We don't know if rootFolderpath ends with '\', and we don't know if the given name starts with onw
                 int fileNamePosition = DataDirectory.Length;    // filename starts right after the '|datadirectory|' keyword
-                bool rootFolderEndsWith = (0 < rootFolderPath.Length) && rootFolderPath[rootFolderPath.Length - 1] == '\\';
+                bool rootFolderEndsWith = rootFolderPath.Length > 0 && rootFolderPath[rootFolderPath.Length - 1] == '\\';
                 bool fileNameStartsWith = (fileNamePosition < value.Length) && value[fileNamePosition] == '\\';
 
                 // replace |datadirectory| with root folder path

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeMethodWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/Interop/SNINativeMethodWrapper.cs
@@ -120,11 +120,11 @@ namespace Microsoft.Data.SqlClient
             {
                 bool success = false;
 
-                while (0 != Interlocked.CompareExchange(ref thelock, 1, 0))
+                while (Interlocked.CompareExchange(ref thelock, 1, 0) != 0)
                 { // Spin until we have the lock.
                     Thread.Sleep(50); // Sleep with short-timeout to prevent starvation.
                 }
-                Trace.Assert(1 == thelock); // Now that we have the lock, lock should be equal to 1.
+                Trace.Assert(thelock == 1); // Now that we have the lock, lock should be equal to 1.
 
                 if (data == null)
                 {
@@ -134,13 +134,13 @@ namespace Microsoft.Data.SqlClient
 
                     System.Buffer.MemoryCopy(passedData, data, passedSize, passedSize);
 
-                    Trace.Assert(0 == size); // Size should still be zero at this point.
+                    Trace.Assert(size == 0); // Size should still be zero at this point.
                     size = passedSize;
                     success = true;
                 }
 
                 int result = Interlocked.CompareExchange(ref thelock, 0, 1);
-                Trace.Assert(1 == result); // The release of the lock should have been successful.  
+                Trace.Assert(result == 1); // The release of the lock should have been successful.
 
                 return success;
             }
@@ -978,13 +978,13 @@ namespace Microsoft.Data.SqlClient
 
                 ret = SNIGetInfoWrapper(pConnectionObject, QTypes.SNI_QUERY_CONN_SSL_SECCTXTHANDLE, ref secHandlePtr);
                 //ERROR_SUCCESS
-                if (0 == ret)
+                if (ret == 0)
                 {
                     // Cast an unmanaged block to pSecHandle;
                     pSecHandle = Marshal.PtrToStructure<CredHandle>(secHandlePtr);
 
                     // SEC_E_OK
-                    if (0 == (ret = QueryContextAttributes(ref pSecHandle, ContextAttribute.SECPKG_ATTR_REMOTE_CERT_CONTEXT, pCertContext.Handle)))
+                    if ((ret = QueryContextAttributes(ref pSecHandle, ContextAttribute.SECPKG_ATTR_REMOTE_CERT_CONTEXT, pCertContext.Handle)) == 0)
                     {
                         certificate = new X509Certificate2(pCertContext.Handle);
                     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbBuffer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.ProviderBase
 
         private DbBuffer(int initialSize, bool zeroBuffer) : base(IntPtr.Zero, true)
         {
-            if (0 < initialSize)
+            if (initialSize > 0)
             {
                 int flags = ((zeroBuffer) ? LMEM_ZEROINIT : LMEM_FIXED);
 
@@ -71,7 +71,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             Validate(offset, 2);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
 
             string value = null;
             bool mustRelease = false;
@@ -100,7 +100,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             Validate(offset, 2 * length);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
 
             string value = null;
             bool mustRelease = false;
@@ -126,7 +126,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             ValidateCheck(offset, 1);
-            Debug.Assert(0 == offset % 4, "invalid alignment");
+            Debug.Assert(offset % 4 == 0, "invalid alignment");
 
             byte value;
             bool mustRelease = false;
@@ -158,7 +158,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             Validate(offset, length);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
             Debug.Assert(destination != null, "null destination");
             Debug.Assert(startIndex + length <= destination.Length, "destination too small");
 
@@ -191,7 +191,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             Validate(offset, 2 * length);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
             Debug.Assert(destination != null, "null destination");
             Debug.Assert(startIndex + length <= destination.Length, "destination too small");
 
@@ -224,7 +224,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             ValidateCheck(offset, 2);
-            Debug.Assert(0 == offset % 2, "invalid alignment");
+            Debug.Assert(offset % 2 == 0, "invalid alignment");
 
             short value;
             bool mustRelease = false;
@@ -250,7 +250,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             Validate(offset, 2 * length);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
             Debug.Assert(destination != null, "null destination");
             Debug.Assert(startIndex + length <= destination.Length, "destination too small");
 
@@ -276,7 +276,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             ValidateCheck(offset, 4);
-            Debug.Assert(0 == offset % 4, "invalid alignment");
+            Debug.Assert(offset % 4 == 0, "invalid alignment");
 
             int value;
             bool mustRelease = false;
@@ -302,7 +302,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             Validate(offset, 4 * length);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
             Debug.Assert(destination != null, "null destination");
             Debug.Assert(startIndex + length <= destination.Length, "destination too small");
 
@@ -328,7 +328,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             ValidateCheck(offset, 8);
-            Debug.Assert(0 == offset % IntPtr.Size, "invalid alignment");
+            Debug.Assert(offset % IntPtr.Size == 0, "invalid alignment");
 
             long value;
             bool mustRelease = false;
@@ -354,7 +354,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             ValidateCheck(offset, IntPtr.Size);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
 
             IntPtr value;
             bool mustRelease = false;
@@ -399,7 +399,7 @@ namespace Microsoft.Data.ProviderBase
             Debug.Assert(structure != null, "null structure");
             offset += BaseOffset;
             ValidateCheck(offset, Marshal.SizeOf(structure.GetType()));
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
 
             bool mustRelease = false;
             RuntimeHelpers.PrepareConstrainedRegions();
@@ -423,7 +423,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             ValidateCheck(offset, 1);
-            Debug.Assert(0 == offset % 4, "invalid alignment");
+            Debug.Assert(offset % 4 == 0, "invalid alignment");
 
             bool mustRelease = false;
             RuntimeHelpers.PrepareConstrainedRegions();
@@ -447,7 +447,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             Validate(offset, length);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
             Debug.Assert(source != null, "null source");
             Debug.Assert(startIndex + length <= source.Length, "source too small");
 
@@ -473,7 +473,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             Validate(offset, 2 * length);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
             Debug.Assert(source != null, "null source");
             Debug.Assert(startIndex + length <= source.Length, "source too small");
 
@@ -504,7 +504,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             ValidateCheck(offset, 2);
-            Debug.Assert(0 == offset % 2, "invalid alignment");
+            Debug.Assert(offset % 2 == 0, "invalid alignment");
 
             bool mustRelease = false;
             RuntimeHelpers.PrepareConstrainedRegions();
@@ -528,7 +528,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             Validate(offset, 2 * length);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
             Debug.Assert(source != null, "null source");
             Debug.Assert(startIndex + length <= source.Length, "source too small");
 
@@ -554,7 +554,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             ValidateCheck(offset, 4);
-            Debug.Assert(0 == offset % 4, "invalid alignment");
+            Debug.Assert(offset % 4 == 0, "invalid alignment");
 
             bool mustRelease = false;
             RuntimeHelpers.PrepareConstrainedRegions();
@@ -578,7 +578,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             Validate(offset, 4 * length);
-            Debug.Assert(0 == offset % ADP.s_ptrSize, "invalid alignment");
+            Debug.Assert(offset % ADP.s_ptrSize == 0, "invalid alignment");
             Debug.Assert(source != null, "null source");
             Debug.Assert(startIndex + length <= source.Length, "source too small");
 
@@ -604,7 +604,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             ValidateCheck(offset, 8);
-            Debug.Assert(0 == offset % IntPtr.Size, "invalid alignment");
+            Debug.Assert(offset % IntPtr.Size == 0, "invalid alignment");
 
             bool mustRelease = false;
             RuntimeHelpers.PrepareConstrainedRegions();
@@ -628,7 +628,7 @@ namespace Microsoft.Data.ProviderBase
         {
             offset += BaseOffset;
             ValidateCheck(offset, IntPtr.Size);
-            Debug.Assert(0 == offset % IntPtr.Size, "invalid alignment");
+            Debug.Assert(offset % IntPtr.Size == 0, "invalid alignment");
 
             bool mustRelease = false;
             RuntimeHelpers.PrepareConstrainedRegions();
@@ -760,14 +760,14 @@ namespace Microsoft.Data.ProviderBase
 
             int[] buffer = new int[4];
             buffer[3] = ((int)bits[2]) << 16; // scale
-            if (0 == bits[3])
+            if (bits[3] == 0)
             {
                 buffer[3] |= unchecked((int)0x80000000); //sign
             }
             buffer[0] = BitConverter.ToInt32(bits, 4);     // low
             buffer[1] = BitConverter.ToInt32(bits, 8);     // mid
             buffer[2] = BitConverter.ToInt32(bits, 12);     // high
-            if (0 != BitConverter.ToInt32(bits, 16))
+            if (BitConverter.ToInt32(bits, 16) != 0)
             {
                 throw ADP.NumericToDecimalOverflow();
             }
@@ -781,7 +781,7 @@ namespace Microsoft.Data.ProviderBase
 
             buffer[1] = precision;
             Buffer.BlockCopy(tmp, 14, buffer, 2, 2); // copy sign and scale
-            buffer[3] = (Byte)((0 == buffer[3]) ? 1 : 0); // flip sign for native
+            buffer[3] = (Byte)(buffer[3] == 0 ? 1 : 0); // flip sign for native
             Buffer.BlockCopy(tmp, 0, buffer, 4, 12);
             buffer[16] = 0;
             buffer[17] = 0;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -532,7 +532,7 @@ namespace Microsoft.Data.ProviderBase
             // distributed transactions that need it.
             lock (_poolsToRelease)
             {
-                if (0 != _poolsToRelease.Count)
+                if (_poolsToRelease.Count != 0)
                 {
                     DbConnectionPool[] poolsToRelease = _poolsToRelease.ToArray();
                     foreach (DbConnectionPool pool in poolsToRelease)
@@ -541,7 +541,7 @@ namespace Microsoft.Data.ProviderBase
                         {
                             pool.Clear();
 
-                            if (0 == pool.Count)
+                            if (pool.Count == 0)
                             {
                                 _poolsToRelease.Remove(pool);
                                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}, ReleasePool={1}", ObjectID, pool.ObjectID);
@@ -557,7 +557,7 @@ namespace Microsoft.Data.ProviderBase
             // empty, it's because there are active pools that need it.
             lock (_poolGroupsToRelease)
             {
-                if (0 != _poolGroupsToRelease.Count)
+                if (_poolGroupsToRelease.Count != 0)
                 {
                     DbConnectionPoolGroup[] poolGroupsToRelease = _poolGroupsToRelease.ToArray();
                     foreach (DbConnectionPoolGroup poolGroup in poolGroupsToRelease)
@@ -566,7 +566,7 @@ namespace Microsoft.Data.ProviderBase
                         {
                             int poolsLeft = poolGroup.Clear(); // may add entries to _poolsToRelease
 
-                            if (0 == poolsLeft)
+                            if (poolsLeft == 0)
                             {
                                 _poolGroupsToRelease.Remove(poolGroup);
                                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<prov.DbConnectionFactory.PruneConnectionPoolGroups|RES|INFO|CPOOL> {0}, ReleasePoolGroup={1}", ObjectID, poolGroup.ObjectID);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPoolIdentity.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/ProviderBase/DbConnectionPoolIdentity.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Data.ProviderBase
 
             // NOTE - We copied this code from System.Security.Principal.Win32.CreateWellKnownSid...
 
-            if (0 == UnsafeNativeMethods.CreateWellKnownSid((int)sidType, null, resultSid, ref length))
+            if (UnsafeNativeMethods.CreateWellKnownSid((int)sidType, null, resultSid, ref length) == 0)
             {
                 IntegratedSecurityError(Win32_CreateWellKnownSid);
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -549,7 +549,7 @@ namespace Microsoft.Data.SqlClient
 
             StringBuilder updateBulkCommandText = new StringBuilder();
 
-            if (_connection.Is2000 && 0 == internalResults[CollationResultId].Count)
+            if (_connection.Is2000 && internalResults[CollationResultId].Count == 0)
             {
                 throw SQL.BulkLoadNoCollation();
             }
@@ -568,7 +568,7 @@ namespace Microsoft.Data.SqlClient
             }
             else
             {
-                isInTransaction = (bool)(0 < (SqlInt32)(internalResults[TranCountResultId][TranCountRowId][TranCountValueId]));
+                isInTransaction = (bool)((SqlInt32)internalResults[TranCountResultId][TranCountRowId][TranCountValueId] > 0);
             }
 
             // Throw if there is a transaction but no flag is set

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientPermission.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientPermission.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Data.SqlClient
         private bool IsEmpty()
         { // MDAC 84804
             ArrayList keyvalues = _keyvalues;
-            bool flag = !IsUnrestricted() && !AllowBlankPassword && (keyvalues == null || (0 == keyvalues.Count));
+            bool flag = !IsUnrestricted() && !AllowBlankPassword && (keyvalues == null || keyvalues.Count == 0);
             return flag;
         }
 
@@ -252,7 +252,7 @@ namespace Microsoft.Data.SqlClient
 
         private string DecodeXmlValue(string value)
         {
-            if (value != null && (0 < value.Length))
+            if (value != null && value.Length > 0)
             {
                 value = value.Replace("&quot;", "\"");
                 value = value.Replace("&apos;", "\'");
@@ -265,7 +265,7 @@ namespace Microsoft.Data.SqlClient
 
         private string EncodeXmlValue(string value)
         {
-            if (value != null && (0 < value.Length))
+            if (value != null && value.Length > 0)
             {
                 value = value.Replace('\0', ' '); // assumption that '\0' will only be at end of string
                 value = value.Trim();

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.NullEncryptedColumnEncryptionKey();
             }
 
-            if (0 == encryptedColumnEncryptionKey.Length)
+            if (encryptedColumnEncryptionKey.Length == 0)
             {
                 throw SQL.EmptyEncryptedColumnEncryptionKey();
             }
@@ -130,7 +130,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.NullColumnEncryptionKey();
             }
-            else if (0 == columnEncryptionKey.Length)
+            else if (columnEncryptionKey.Length == 0)
             {
                 throw SQL.EmptyColumnEncryptionKey();
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.NullEncryptedColumnEncryptionKey();
             }
 
-            if (0 == encryptedColumnEncryptionKey.Length)
+            if (encryptedColumnEncryptionKey.Length == 0)
             {
                 throw SQL.EmptyEncryptedColumnEncryptionKey();
             }
@@ -134,7 +134,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.NullColumnEncryptionKey();
             }
-            else if (0 == columnEncryptionKey.Length)
+            else if (columnEncryptionKey.Length == 0)
             {
                 throw SQL.EmptyColumnEncryptionKey();
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -175,10 +175,14 @@ namespace Microsoft.Data.SqlClient
             {    // never pool context connections.
                 int connectionTimeout = opt.ConnectTimeout;
 
-                if ((0 < connectionTimeout) && (connectionTimeout < Int32.MaxValue / 1000))
+                if (connectionTimeout > 0 && connectionTimeout < Int32.MaxValue / 1000)
+                {
                     connectionTimeout *= 1000;
+                }
                 else if (connectionTimeout >= Int32.MaxValue / 1000)
+                {
                     connectionTimeout = Int32.MaxValue;
+                }
 
                 if (opt.Authentication == SqlAuthenticationMethod.ActiveDirectoryInteractive)
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Data.SqlClient
         internal long ColumnDataBytesRemaining()
         {
             // If there are an unknown (-1) number of bytes left for a PLP, read its size
-            if (-1 == _sharedState._columnDataBytesRemaining)
+            if (_sharedState._columnDataBytesRemaining == -1)
             {
                 _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
             }
@@ -327,7 +327,7 @@ namespace Microsoft.Data.SqlClient
             SmiExtendedMetaData[] metaDataReturn = null;
             _SqlMetaDataSet metaData = this.MetaData;
 
-            if (metaData != null && 0 < metaData.Length)
+            if (metaData != null && metaData.Length > 0)
             {
                 metaDataReturn = new SmiExtendedMetaData[metaData.VisibleColumnCount];
                 int returnIndex = 0;
@@ -621,15 +621,15 @@ namespace Microsoft.Data.SqlClient
                             schemaRow[Size] = TdsEnums.WHIDBEY_DATE_LENGTH;
                             break;
                         case SqlDbType.Time:
-                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (0 <= col.scale && col.scale <= 7), "Invalid scale for Time column: " + col.scale);
+                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (col.scale >= 0 && col.scale <= 7), "Invalid scale for Time column: " + col.scale);
                             schemaRow[Size] = TdsEnums.WHIDBEY_TIME_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
                             break;
                         case SqlDbType.DateTime2:
-                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (0 <= col.scale && col.scale <= 7), "Invalid scale for DateTime2 column: " + col.scale);
+                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (col.scale >= 0 && col.scale <= 7), "Invalid scale for DateTime2 column: " + col.scale);
                             schemaRow[Size] = TdsEnums.WHIDBEY_DATETIME2_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
                             break;
                         case SqlDbType.DateTimeOffset:
-                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (0 <= col.scale && col.scale <= 7), "Invalid scale for DateTimeOffset column: " + col.scale);
+                            Debug.Assert(TdsEnums.UNKNOWN_PRECISION_SCALE == col.scale || (col.scale >= 0 && col.scale <= 7), "Invalid scale for DateTimeOffset column: " + col.scale);
                             schemaRow[Size] = TdsEnums.WHIDBEY_DATETIMEOFFSET_LENGTH[TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale ? col.scale : col.metaType.Scale];
                             break;
                     }
@@ -832,13 +832,13 @@ namespace Microsoft.Data.SqlClient
             // iib. user called read and fetched a subset of the column data
 
             // Wipe out any Streams or TextReaders
-            if (-1 != _lastColumnWithDataChunkRead)
+            if (_lastColumnWithDataChunkRead != -1)
             {
                 CloseActiveSequentialStreamAndTextReader();
             }
 
             // i. user called read but didn't fetch anything
-            if (0 == _sharedState._nextColumnHeaderToRead)
+            if (_sharedState._nextColumnHeaderToRead == 0)
             {
                 result = _stateObj.Parser.TrySkipRow(_metaData, _stateObj);
                 if (result != TdsOperationStatus.Done)
@@ -1888,7 +1888,7 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         // If there are an unknown (-1) number of bytes left for a PLP, read its size
-                        if ((-1 == _sharedState._columnDataBytesRemaining) && (_metaData[i].metaType.IsPlp))
+                        if (_sharedState._columnDataBytesRemaining == -1 && (_metaData[i].metaType.IsPlp))
                         {
                             ulong left;
                             result = _parser.TryPlpBytesLeft(_stateObj, out left);
@@ -1899,7 +1899,7 @@ namespace Microsoft.Data.SqlClient
                             _sharedState._columnDataBytesRemaining = (long)left;
                         }
 
-                        if (0 == _sharedState._columnDataBytesRemaining)
+                        if (_sharedState._columnDataBytesRemaining == 0)
                         {
                             return TdsOperationStatus.Done; // We've read this column to the end
                         }
@@ -2550,12 +2550,12 @@ namespace Microsoft.Data.SqlClient
                     bool isUnicode = _metaData[i].metaType.IsNCharType;
 
                     // If there are an unknown (-1) number of bytes left for a PLP, read its size
-                    if (-1 == _sharedState._columnDataBytesRemaining)
+                    if (_sharedState._columnDataBytesRemaining == -1)
                     {
                         _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
                     }
 
-                    if (0 == _sharedState._columnDataBytesRemaining)
+                    if (_sharedState._columnDataBytesRemaining == 0)
                     {
                         _stateObj._plpdecoder = null;
                         return 0; // We've read this column to the end
@@ -4384,7 +4384,7 @@ namespace Microsoft.Data.SqlClient
             bool isSequentialAccess = IsCommandBehavior(CommandBehavior.SequentialAccess);
             if (isSequentialAccess)
             {
-                if (0 < _sharedState._nextColumnDataToRead)
+                if (_sharedState._nextColumnDataToRead > 0)
                 {
                     _data[_sharedState._nextColumnDataToRead - 1].Clear();
                 }
@@ -4613,12 +4613,12 @@ namespace Microsoft.Data.SqlClient
                     byte typeAndMask = (byte)(_metaData[currentColumn].tdsType & TdsEnums.SQLLenMask);
                     if ((typeAndMask == TdsEnums.SQLVarLen) || (typeAndMask == TdsEnums.SQLVarCnt))
                     {
-                        if (0 != (_metaData[currentColumn].tdsType & 0x80))
+                        if ((_metaData[currentColumn].tdsType & 0x80) != 0)
                         {
                             // UInt16 represents size
                             maxHeaderSize = 2;
                         }
-                        else if (0 == (_metaData[currentColumn].tdsType & 0x0c))
+                        else if ((_metaData[currentColumn].tdsType & 0x0c) == 0)
                         {
                             // UInt32 represents size
                             maxHeaderSize = 4;
@@ -4674,7 +4674,7 @@ namespace Microsoft.Data.SqlClient
                         localSXml.Close();
                     }
                 }
-                else if (0 < _sharedState._columnDataBytesRemaining)
+                else if (_sharedState._columnDataBytesRemaining > 0)
                 {
                     result = _stateObj.TrySkipLongBytes(_sharedState._columnDataBytesRemaining);
                     if (result != TdsOperationStatus.Done)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Data.SqlClient
         internal void Activate()
         {
             int wasInUse = System.Threading.Interlocked.Exchange(ref _isInUse, 1);
-            if (0 != wasInUse)
+            if (wasInUse != 0)
             {
                 throw SQL.ContextConnectionIsInUse();
             }
@@ -448,7 +448,7 @@ namespace Microsoft.Data.SqlClient
             {
                 transactionId = CurrentTransaction != null ? CurrentTransaction.TransactionId : 0;
                 transaction = null;
-                if (0 != transactionId)
+                if (transactionId != 0)
                 {
                     transaction = InternalEnlistedTransaction;
                 }
@@ -469,7 +469,7 @@ namespace Microsoft.Data.SqlClient
 
             try
             {
-                if (owningObject != null && 1 == _isInUse)
+                if (owningObject != null && _isInUse == 1)
                 {
                     // SQLBU 369953
                     //  for various reasons, the owning object may no longer be connection to this
@@ -529,7 +529,7 @@ namespace Microsoft.Data.SqlClient
             {
 #if DEBUG
                 // Check null for case where Begin and Rollback obtained in the same message.
-                if (0 != _currentTransaction.TransactionId)
+                if (_currentTransaction.TransactionId != 0)
                 {
                     Debug.Assert(_currentTransaction.TransactionId == transactionId, "transaction id's are not equal!");
                 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1043,7 +1043,7 @@ namespace Microsoft.Data.SqlClient
             // the async commands, or we don't know that we're in a state that
             // we can recover from.  We doom the connection in this case, to
             // prevent odd cases when we go to the wire.
-            if (0 != _asyncCommandCount)
+            if (_asyncCommandCount != 0)
             {
                 DoomThisConnection();
             }
@@ -2200,7 +2200,7 @@ namespace Microsoft.Data.SqlClient
                         throw;
                     }
 
-                    if (1 == attemptNumber % 2)
+                    if (attemptNumber % 2 == 1)
                     {
                         // Check sleep interval to make sure we won't exceed the original timeout
                         //  Do this in the catch block so we can re-throw the current exception
@@ -2217,7 +2217,7 @@ namespace Microsoft.Data.SqlClient
 
                 // After trying to connect to both servers fails, sleep for a bit to prevent clogging
                 //  the network with requests, then update sleep interval for next iteration (max 1 second interval)
-                if (1 == attemptNumber % 2)
+                if (attemptNumber % 2 == 1)
                 {
                     SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover|ADV> {0}, sleeping {1}[milisec]", ObjectID, sleepInterval);
                     Thread.Sleep(sleepInterval);
@@ -3107,7 +3107,7 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         byte supportedTceVersion = data[0];
-                        if (0 == supportedTceVersion || supportedTceVersion > TdsEnums.MAX_SUPPORTED_TCE_VERSION)
+                        if (supportedTceVersion == 0 || supportedTceVersion > TdsEnums.MAX_SUPPORTED_TCE_VERSION)
                         {
                             SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for TCE", ObjectID);
                             throw SQL.ParsingErrorValue(ParsingErrorState.TceInvalidVersion, supportedTceVersion);
@@ -3138,7 +3138,7 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         IsGlobalTransaction = true;
-                        if (1 == data[0])
+                        if (data[0] == 1)
                         {
                             IsGlobalTransactionsEnabledForServer = true;
                         }
@@ -3175,7 +3175,7 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
                         byte supportedDataClassificationVersion = data[0];
-                        if ((0 == supportedDataClassificationVersion) || (supportedDataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_MAX_SUPPORTED))
+                        if (supportedDataClassificationVersion == 0 || (supportedDataClassificationVersion > TdsEnums.DATA_CLASSIFICATION_VERSION_MAX_SUPPORTED))
                         {
                             SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Invalid version number for DATACLASSIFICATION", ObjectID);
                             throw SQL.ParsingErrorValue(ParsingErrorState.DataClassificationInvalidVersion, supportedDataClassificationVersion);
@@ -3213,7 +3213,7 @@ namespace Microsoft.Data.SqlClient
                             throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
                         }
 
-                        if (1 == data[0])
+                        if (data[0] == 1)
                         {
                             IsSQLDNSCachingSupported = true;
                             _cleanSQLDNSCaching = false;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1943,11 +1943,11 @@ namespace Microsoft.Data.SqlClient
                 // strip provider info from SNI
                 //
                 int iColon = errorMessage.IndexOf(':');
-                Debug.Assert(0 <= iColon, "':' character missing in sni errorMessage");
+                Debug.Assert(iColon >= 0, "':' character missing in sni errorMessage");
                 Debug.Assert(errorMessage.Length > iColon + 1 && errorMessage[iColon + 1] == ' ', "Expecting a space after the ':' character");
 
                 // extract the message excluding the colon and trailing cr/lf chars
-                if (0 <= iColon)
+                if (iColon >= 0)
                 {
                     int len = errorMessage.Length;
                     len -= 2;    // exclude "\r\n" sequence
@@ -2093,7 +2093,7 @@ namespace Microsoft.Data.SqlClient
             }
             else
             {
-                Debug.Assert(2 == stateObj._bShortBytes.Length);
+                Debug.Assert(stateObj._bShortBytes.Length == 2);
             }
 
             byte[] bytes = stateObj._bShortBytes;
@@ -2151,7 +2151,7 @@ namespace Microsoft.Data.SqlClient
             }
             else
             {
-                Debug.Assert(4 == stateObj._bIntBytes.Length);
+                Debug.Assert(stateObj._bIntBytes.Length == 4);
             }
 
             int current = 0;
@@ -2219,7 +2219,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             byte[] bytes = stateObj._bLongBytes;
-            Debug.Assert(8 == bytes.Length, "Cached buffer has wrong size");
+            Debug.Assert(bytes.Length == 8, "Cached buffer has wrong size");
 
             bytes[current++] = (byte)(v & 0xff);
             bytes[current++] = (byte)((v >> 8) & 0xff);
@@ -3419,7 +3419,7 @@ namespace Microsoft.Data.SqlClient
                             return result;
                         }
                         env._oldLength = byteLength;
-                        Debug.Assert(0 == env._oldLength, "old length should be zero");
+                        Debug.Assert(env._oldLength == 0, "old length should be zero");
 
                         // env.length includes 1 byte for type token
                         env._length = 5 + env._newLength;
@@ -5158,10 +5158,10 @@ namespace Microsoft.Data.SqlClient
         {
             int codePage = 0;
 
-            if (0 != collation._sortId)
+            if (collation._sortId != 0)
             {
                 codePage = TdsEnums.CODE_PAGE_FROM_SORT_ID[collation._sortId];
-                Debug.Assert(0 != codePage, "GetCodePage accessed codepage array and produced 0!, sortID =" + ((Byte)(collation._sortId)).ToString((IFormatProvider)null));
+                Debug.Assert(codePage != 0, "GetCodePage accessed codepage array and produced 0!, sortID =" + ((Byte)(collation._sortId)).ToString((IFormatProvider)null));
             }
             else
             {
@@ -5283,7 +5283,7 @@ namespace Microsoft.Data.SqlClient
                                     throw SQL.SynchronousCallMayNotPend();
                                 }
                             }
-                            if (0 == sharedState._nextColumnHeaderToRead)
+                            if (sharedState._nextColumnHeaderToRead == 0)
                             {
                                 // i. user called read but didn't fetch anything
                                 TdsOperationStatus result = stateObj.Parser.TrySkipRow(stateObj._cleanupMetaData, stateObj);
@@ -5309,7 +5309,7 @@ namespace Microsoft.Data.SqlClient
                                         }
                                     }
 
-                                    else if (0 < sharedState._columnDataBytesRemaining)
+                                    else if (sharedState._columnDataBytesRemaining > 0)
                                     {
                                         TdsOperationStatus result = stateObj.TrySkipLongBytes(sharedState._columnDataBytesRemaining);
                                         if (result != TdsOperationStatus.Done)
@@ -5645,7 +5645,7 @@ namespace Microsoft.Data.SqlClient
                 return result;
             }
 
-            if (0 != tableSize)
+            if (tableSize != 0)
             {
                 SqlTceCipherInfoTable tempTable = new SqlTceCipherInfoTable(tableSize);
 
@@ -5849,7 +5849,7 @@ namespace Microsoft.Data.SqlClient
                     return result;
                 }
 
-                Debug.Assert(0 <= col.scale && col.scale <= 7);
+                Debug.Assert(col.scale >= 0 && col.scale <= 7);
 
                 // calculate actual column length here
                 // TODO: variable-length calculation needs to be encapsulated better
@@ -6402,7 +6402,7 @@ namespace Microsoft.Data.SqlClient
                     length = 0;
                     return result;
                 }
-                if (0 != textPtrLen)
+                if (textPtrLen != 0)
                 {
                     // read past text pointer
                     result = stateObj.TrySkipBytes(textPtrLen);
@@ -6727,7 +6727,7 @@ namespace Microsoft.Data.SqlClient
                     return result;
                 }
 
-                if (0 != textPtrLen)
+                if (textPtrLen != 0)
                 {
                     result = stateObj.TrySkipBytes(textPtrLen + TdsEnums.TEXT_TIME_STAMP_LEN);
                     if (result != TdsOperationStatus.Done)
@@ -7042,7 +7042,7 @@ namespace Microsoft.Data.SqlClient
                     // Check the sign from the first byte.
                     int index = 0;
                     byteValue = unencryptedBytes[index++];
-                    bool fPositive = (1 == byteValue);
+                    bool fPositive = byteValue == 1;
 
                     // Now read the 4 next integers which contain the actual value.
                     length = checked((int)length - 1);
@@ -7314,17 +7314,17 @@ namespace Microsoft.Data.SqlClient
                     break;
 
                 case TdsEnums.SQLTIME:
-                    Debug.Assert(3 <= length && length <= 5, "invalid length for time type!");
+                    Debug.Assert(length >= 3 && length <= 5, "invalid length for time type!");
                     value.SetToTime(dateTimeData, scale, scale);
                     break;
 
                 case TdsEnums.SQLDATETIME2:
-                    Debug.Assert(6 <= length && length <= 8, "invalid length for datetime2 type!");
+                    Debug.Assert(length >= 6 && length <= 8, "invalid length for datetime2 type!");
                     value.SetToDateTime2(dateTimeData, scale, scale);
                     break;
 
                 case TdsEnums.SQLDATETIMEOFFSET:
-                    Debug.Assert(8 <= length && length <= 10, "invalid length for datetimeoffset type!");
+                    Debug.Assert(length >= 8 && length <= 10, "invalid length for datetimeoffset type!");
                     value.SetToDateTimeOffset(dateTimeData, scale, scale);
                     break;
 
@@ -7812,7 +7812,7 @@ namespace Microsoft.Data.SqlClient
             MetaType mt = MetaType.GetMetaTypeFromValue(value);
 
             // Special case data type correction for SqlMoney inside a SqlVariant.
-            if ((TdsEnums.SQLNUMERICN == mt.TDSType) && (8 == length))
+            if ((TdsEnums.SQLNUMERICN == mt.TDSType) && length == 8)
             {
                 // The caller will coerce all SqlTypes to native CLR types, which means SqlMoney will
                 // coerce to decimal/SQLNUMERICN (via SqlMoney.Value call).  In the case where the original
@@ -8156,7 +8156,7 @@ namespace Microsoft.Data.SqlClient
             int[] bits = Decimal.GetBits(value.Value);
 
             // this decimal should be scaled by 10000 (regardless of what the incoming decimal was scaled by)
-            bool isNeg = (0 != (bits[3] & unchecked((int)0x80000000)));
+            bool isNeg = (bits[3] & unchecked((int)0x80000000)) != 0;
             long l = ((long)(uint)bits[1]) << 0x20 | (uint)bits[0];
 
             if (isNeg)
@@ -8187,7 +8187,7 @@ namespace Microsoft.Data.SqlClient
             int[] bits = Decimal.GetBits(m.Value);
 
             // this decimal should be scaled by 10000 (regardless of what the incoming decimal was scaled by)
-            bool isNeg = (0 != (bits[3] & unchecked((int)0x80000000)));
+            bool isNeg = (bits[3] & unchecked((int)0x80000000)) != 0;
             long l = ((long)(uint)bits[1]) << 0x20 | (uint)bits[0];
 
             if (isNeg)
@@ -8205,7 +8205,7 @@ namespace Microsoft.Data.SqlClient
                 length = 8;
             }
 
-            Debug.Assert(8 == length, "invalid length in SerializeCurrency");
+            Debug.Assert(length == 8, "invalid length in SerializeCurrency");
             if (stateObj._bLongBytes == null)
             {
                 stateObj._bLongBytes = new byte[8];
@@ -8230,7 +8230,7 @@ namespace Microsoft.Data.SqlClient
             int[] bits = Decimal.GetBits(m.Value);
 
             // this decimal should be scaled by 10000 (regardless of what the incoming decimal was scaled by)
-            bool isNeg = (0 != (bits[3] & unchecked((int)0x80000000)));
+            bool isNeg = (bits[3] & unchecked((int)0x80000000)) != 0;
             long l = ((long)(uint)bits[1]) << 0x20 | (uint)bits[0];
 
             if (isNeg)
@@ -8267,7 +8267,7 @@ namespace Microsoft.Data.SqlClient
 
         private byte[] SerializeTime(TimeSpan value, byte scale, int length)
         {
-            if (0 > value.Ticks || value.Ticks >= TimeSpan.TicksPerDay)
+            if (value.Ticks < 0 || value.Ticks >= TimeSpan.TicksPerDay)
             {
                 throw SQL.TimeOverflow(value.ToString());
             }
@@ -8283,7 +8283,7 @@ namespace Microsoft.Data.SqlClient
 
         private void WriteTime(TimeSpan value, byte scale, int length, TdsParserStateObject stateObj)
         {
-            if (0 > value.Ticks || value.Ticks >= TimeSpan.TicksPerDay)
+            if (value.Ticks < 0 || value.Ticks >= TimeSpan.TicksPerDay)
             {
                 throw SQL.TimeOverflow(value.ToString());
             }
@@ -8359,7 +8359,7 @@ namespace Microsoft.Data.SqlClient
             {
                 return result;
             }
-            bool fPositive = (1 == byteValue);
+            bool fPositive = byteValue == 1;
 
             length = checked((int)length - 1);
 
@@ -8517,10 +8517,14 @@ namespace Microsoft.Data.SqlClient
             */
 
             // write the sign (note that COM and SQL are opposite)
-            if (0x80000000 == (decimalBits[3] & 0x80000000))
+            if ((decimalBits[3] & 0x80000000) == 0x80000000)
+            {
                 bytes[current++] = 0;
+            }
             else
+            {
                 bytes[current++] = 1;
+            }
 
             byte[] bytesPart = SerializeInt(decimalBits[0], stateObj);
             Buffer.BlockCopy(bytesPart, 0, bytes, current, 4);
@@ -8562,10 +8566,14 @@ namespace Microsoft.Data.SqlClient
             */
 
             // write the sign (note that COM and SQL are opposite)
-            if (0x80000000 == (stateObj._decimalBits[3] & 0x80000000))
+            if ((stateObj._decimalBits[3] & 0x80000000) == 0x80000000)
+            {
                 stateObj.WriteByte(0);
+            }
             else
+            {
                 stateObj.WriteByte(1);
+            }
 
             WriteInt(stateObj._decimalBits[0], stateObj);
             WriteInt(stateObj._decimalBits[1], stateObj);
@@ -8852,7 +8860,7 @@ namespace Microsoft.Data.SqlClient
                     return TdsOperationStatus.Done;
                 case TdsEnums.SQLVarLen:
                 case TdsEnums.SQLVarCnt:
-                    if (0 != (token & 0x80))
+                    if ((token & 0x80) != 0)
                     {
                         ushort value;
                         result = stateObj.TryReadUInt16(out value);
@@ -8864,7 +8872,7 @@ namespace Microsoft.Data.SqlClient
                         tokenLength = value;
                         return TdsOperationStatus.Done;
                     }
-                    else if (0 == (token & 0x0c))
+                    else if ((token & 0x0c) == 0)
                     {
                         // UNDONE: This should be uint
                         return stateObj.TryReadInt32(out tokenLength);
@@ -10215,7 +10223,7 @@ namespace Microsoft.Data.SqlClient
 
                             if (mt.Is2008Type)
                             {
-                                WriteSmiParameter(param, i, 0 != (options & TdsEnums.RPC_PARAM_DEFAULT), stateObj, enableOptimizedParameterBinding, isAdvancedTraceOn);
+                                WriteSmiParameter(param, i, (options & TdsEnums.RPC_PARAM_DEFAULT) != 0, stateObj, enableOptimizedParameterBinding, isAdvancedTraceOn);
                                 continue;
                             }
 
@@ -10313,7 +10321,7 @@ namespace Microsoft.Data.SqlClient
                                 }
                             }
 
-                            bool isParameterEncrypted = 0 != (options & TdsEnums.RPC_PARAM_ENCRYPTED);
+                            bool isParameterEncrypted = (options & TdsEnums.RPC_PARAM_ENCRYPTED) != 0;
 
                             // Additional information we need to send over wire to the server when writing encrypted parameters.
                             SqlColumnEncryptionInputParameterInfo encryptedParameterInfoToWrite = null;
@@ -10572,15 +10580,21 @@ namespace Microsoft.Data.SqlClient
                             // scale and precision are only relevant for numeric and decimal types
                             if (mt.SqlDbType == SqlDbType.Decimal)
                             {
-                                if (0 == precision)
+                                if (precision == 0)
                                 {
                                     if (_is2000)
+                                    {
                                         stateObj.WriteByte(TdsEnums.DEFAULT_NUMERIC_PRECISION);
+                                    }
                                     else
+                                    {
                                         stateObj.WriteByte(TdsEnums.SQL70_DEFAULT_NUMERIC_PRECISION);
+                                    }
                                 }
                                 else
+                                {
                                     stateObj.WriteByte(precision);
+                                }
 
                                 stateObj.WriteByte(scale);
                             }
@@ -10647,10 +10661,14 @@ namespace Microsoft.Data.SqlClient
                                 stateObj.WriteByte(outCollation._sortId);
                             }
 
-                            if (0 == codePageByteSize)
+                            if (codePageByteSize == 0)
+                            {
                                 WriteParameterVarLen(mt, actualSize, isNull, stateObj, isDataFeed);
+                            }
                             else
+                            {
                                 WriteParameterVarLen(mt, codePageByteSize, isNull, stateObj, isDataFeed);
+                            }
 
                             Task writeParamTask = null;
                             // write the value now
@@ -11093,7 +11111,7 @@ namespace Microsoft.Data.SqlClient
                 case SqlDbType.Decimal:
                     stateObj.WriteByte(TdsEnums.SQLNUMERICN);
                     stateObj.WriteByte(checked((byte)MetaType.MetaDecimal.FixedLength));   // SmiMetaData's length and actual wire format's length are different
-                    stateObj.WriteByte(0 == metaData.Precision ? (byte)1 : metaData.Precision);
+                    stateObj.WriteByte(metaData.Precision == 0 ? (byte)1 : metaData.Precision);
                     stateObj.WriteByte(metaData.Scale);
                     break;
                 case SqlDbType.Float:
@@ -11251,7 +11269,7 @@ namespace Microsoft.Data.SqlClient
             WriteIdentifier(metaData.TypeSpecificNamePart3, stateObj);
 
             // TVP_COLMETADATA
-            if (0 == metaData.FieldMetaData.Count)
+            if (metaData.FieldMetaData.Count == 0)
             {
                 WriteUnsignedShort((ushort)TdsEnums.TVP_NOMETADATA_TOKEN, stateObj);
             }
@@ -11352,14 +11370,14 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // Remember this column if any flags were set
-                if (0 != flags)
+                if (flags != 0)
                 {
                     columnList.Add(new TdsOrderUnique(checked((short)(i + 1)), flags));
                 }
             }
 
             // Write flagged columns to wire...
-            if (0 < columnList.Count)
+            if (columnList.Count > 0)
             {
                 stateObj.WriteByte(TdsEnums.TVP_ORDER_UNIQUE_TOKEN);
                 WriteShort(columnList.Count, stateObj);
@@ -11430,7 +11448,7 @@ namespace Microsoft.Data.SqlClient
                 WriteInt(cekTable[i].CekVersion, stateObj);
 
                 // Write 8 bytes of key MD Version
-                Debug.Assert(8 == cekTable[i].CekMdVersion.Length);
+                Debug.Assert(cekTable[i].CekMdVersion.Length == 8);
                 stateObj.WriteByteArray(cekTable[i].CekMdVersion, 8, 0);
 
                 // We don't really need to send the keys
@@ -12024,7 +12042,7 @@ namespace Microsoft.Data.SqlClient
                     throw ADP.ArgumentOutOfRange("Service");
                 }
 
-                if (-1 > timeout)
+                if (timeout < -1)
                 {
                     throw ADP.ArgumentOutOfRange("Timeout");
                 }
@@ -12067,7 +12085,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(UInt16.MaxValue >= callbackId.Length, "CallbackId length is out of range");
             Debug.Assert(service != null, "Service is null");
             Debug.Assert(UInt16.MaxValue >= service.Length, "Service length is out of range");
-            Debug.Assert(-1 <= timeout, "Timeout");
+            Debug.Assert(timeout >= -1, "Timeout");
 
 
             SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.TdsParser.WriteQueryNotificationHeader|DEP> NotificationRequest: userData: '{0}', options: '{1}', timeout: '{2}'", notificationRequest.UserData, notificationRequest.Options, notificationRequest.Timeout);
@@ -12135,7 +12153,7 @@ namespace Microsoft.Data.SqlClient
             // Write Mars header data
             WriteMarsHeaderData(stateObj, CurrentTransaction);
 
-            if (0 != notificationHeaderSize)
+            if (notificationHeaderSize != 0)
             {
                 // Write Notification header length
                 WriteInt(notificationHeaderSize, stateObj);
@@ -12193,14 +12211,19 @@ namespace Microsoft.Data.SqlClient
 
                     case TdsEnums.SQLVarLen:
                     case TdsEnums.SQLVarCnt:
-                        if (0 != (token & 0x80))
+                        if ((token & 0x80) != 0)
+                        {
                             tokenLength = 2;
-                        else if (0 == (token & 0x0c))
-
+                        }
+                        else if ((token & 0x0c) == 0)
+                        {
                             // UNDONE: This should be uint
                             tokenLength = 4;
+                        }
                         else
+                        {
                             tokenLength = 1;
+                        }
 
                         break;
 
@@ -12446,8 +12469,10 @@ namespace Microsoft.Data.SqlClient
 
                     if (type.FixedLength == 4)
                     {
-                        if (0 > dt.DayTicks || dt.DayTicks > UInt16.MaxValue)
+                        if (dt.DayTicks < 0 || dt.DayTicks > UInt16.MaxValue)
+                        {
                             throw SQL.SmallDateTimeOverflow(dt.ToString());
+                        }
 
                         WriteShort(dt.DayTicks, stateObj);
                         WriteShort(dt.TimeTicks / SqlDateTime.SQLTicksPerMinute, stateObj);
@@ -13154,8 +13179,10 @@ namespace Microsoft.Data.SqlClient
 
                     if (type.FixedLength == 4)
                     {
-                        if (0 > dt.days || dt.days > UInt16.MaxValue)
+                        if (dt.days < 0 || dt.days > UInt16.MaxValue)
+                        {
                             throw SQL.SmallDateTimeOverflow(MetaType.ToDateTime(dt.days, dt.time, 4).ToString(CultureInfo.InvariantCulture));
+                        }
 
                         WriteShort(dt.days, stateObj);
                         WriteShort(dt.time, stateObj);
@@ -13364,7 +13391,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (type.FixedLength == 4)
                     {
-                        if (0 > dt.days || dt.days > UInt16.MaxValue)
+                        if (dt.days < 0 || dt.days > UInt16.MaxValue)
                         {
                             throw SQL.SmallDateTimeOverflow(MetaType.ToDateTime(dt.days, dt.time, 4).ToString(CultureInfo.InvariantCulture));
                         }
@@ -13560,8 +13587,10 @@ namespace Microsoft.Data.SqlClient
 
                     if (type.FixedLength == 4)
                     {
-                        if (0 > dt.DayTicks || dt.DayTicks > UInt16.MaxValue)
+                        if (dt.DayTicks < 0 || dt.DayTicks > UInt16.MaxValue)
+                        {
                             throw SQL.SmallDateTimeOverflow(dt.ToString());
+                        }
 
                         if (stateObj._bIntBytes == null)
                         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Data.SqlClient
             encryptionKey.algorithmName = algorithmName;
             _columnEncryptionKeyValues.Add(encryptionKey);
 
-            if (0 == _databaseId)
+            if (_databaseId == 0)
             {
                 _databaseId = databaseId;
                 _cekId = cekId;
@@ -271,7 +271,7 @@ namespace Microsoft.Data.SqlClient
 
         internal SqlTceCipherInfoTable(int tabSize)
         {
-            Debug.Assert(0 < tabSize, "Invalid Table Size");
+            Debug.Assert(tabSize > 0, "Invalid Table Size");
             keyList = new SqlTceCipherInfoEntry[tabSize];
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Data.Common
 
         internal static ArgumentOutOfRangeException InvalidCommandBehavior(CommandBehavior value)
         {
-            Debug.Assert((0 > (int)value) || ((int)value > 0x3F), "valid CommandType " + value.ToString());
+            Debug.Assert((int)value < 0 || ((int)value > 0x3F), "valid CommandType " + value.ToString());
 
             return InvalidEnumerationValue(typeof(CommandBehavior), (int)value);
         }
@@ -577,11 +577,11 @@ namespace Microsoft.Data.Common
             // should be added, even if the name part is null/empty, to maintain proper location of the parts.
             for (int i = 0; i < strings.Length; i++)
             {
-                if (0 < bld.Length)
+                if (bld.Length > 0)
                 {
                     bld.Append('.');
                 }
-                if (strings[i] is not null && 0 != strings[i].Length)
+                if (strings[i] is not null && strings[i].Length != 0)
                 {
                     bld.Append(BuildQuotedString("[", "]", strings[i]));
                 }
@@ -1006,7 +1006,7 @@ namespace Microsoft.Data.Common
             => IndexOutOfRange(StringsHelper.GetString(Strings.SQL_InvalidDataLength, length.ToString(CultureInfo.InvariantCulture)));
 
         internal static bool CompareInsensitiveInvariant(string strvalue, string strconst)
-            => 0 == CultureInfo.InvariantCulture.CompareInfo.Compare(strvalue, strconst, CompareOptions.IgnoreCase);
+            => CultureInfo.InvariantCulture.CompareInfo.Compare(strvalue, strconst, CompareOptions.IgnoreCase) == 0;
 
         internal static int DstCompare(string strA, string strB) // this is null safe
             => CultureInfo.CurrentCulture.CompareInfo.Compare(strA, strB, ADP.DefaultCompareOptions);
@@ -1342,7 +1342,7 @@ namespace Microsoft.Data.Common
         internal static void CheckArgumentLength(string value, string parameterName)
         {
             CheckArgumentNull(value, parameterName);
-            if (0 == value.Length)
+            if (value.Length == 0)
             {
                 throw Argument(StringsHelper.GetString(Strings.ADP_EmptyString, parameterName)); // MDAC 94859
             }
@@ -1500,7 +1500,7 @@ namespace Microsoft.Data.Common
                                 // query for the required length
                                 // VSTFDEVDIV 479551 - ensure that GetComputerNameEx does not fail with unexpected values and that the length is positive
                 int getComputerNameExError = 0;
-                if (0 == SafeNativeMethods.GetComputerNameEx(ComputerNameDnsFullyQualified, null, ref length))
+                if (SafeNativeMethods.GetComputerNameEx(ComputerNameDnsFullyQualified, null, ref length) == 0)
                 {
                     getComputerNameExError = Marshal.GetLastWin32Error();
                 }
@@ -1511,7 +1511,7 @@ namespace Microsoft.Data.Common
 
                 StringBuilder buffer = new(length);
                 length = buffer.Capacity;
-                if (0 == SafeNativeMethods.GetComputerNameEx(ComputerNameDnsFullyQualified, buffer, ref length))
+                if (SafeNativeMethods.GetComputerNameEx(ComputerNameDnsFullyQualified, buffer, ref length) == 0)
                 {
                     throw ADP.ComputerNameEx(Marshal.GetLastWin32Error());
                 }
@@ -1530,11 +1530,11 @@ namespace Microsoft.Data.Common
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         internal static IntPtr IntPtrOffset(IntPtr pbase, int offset)
         {
-            if (4 == ADP.s_ptrSize)
+            if (ADP.s_ptrSize == 4)
             {
                 return (IntPtr)checked(pbase.ToInt32() + offset);
             }
-            Debug.Assert(8 == ADP.s_ptrSize, "8 != IntPtr.Size"); // MDAC 73747
+            Debug.Assert(ADP.s_ptrSize == 8, "8 != IntPtr.Size"); // MDAC 73747
             return (IntPtr)checked(pbase.ToInt64() + offset);
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionOptions.Common.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Data.Common
             _usersConnectionString = connectionString != null ? connectionString : "";
 
             // first pass on parsing, initial syntax check
-            if (0 < _usersConnectionString.Length)
+            if (_usersConnectionString.Length > 0)
             {
                 _keyChain = ParseInternal(_parsetable, _usersConnectionString, true, synonyms, false);
                 _hasPasswordKeyword = (_parsetable.ContainsKey(KEY.Password) || _parsetable.ContainsKey(SYNONYM.Pwd));
@@ -240,7 +240,7 @@ namespace Microsoft.Data.Common
         }
 
         private static bool CompareInsensitiveInvariant(string strvalue, string strconst)
-            => (0 == StringComparer.OrdinalIgnoreCase.Compare(strvalue, strconst));
+            => StringComparer.OrdinalIgnoreCase.Compare(strvalue, strconst) == 0;
 
         [System.Diagnostics.Conditional("DEBUG")]
         private static void DebugTraceKeyValuePair(string keyname, string keyvalue, Dictionary<string, string> synonyms)
@@ -269,7 +269,7 @@ namespace Microsoft.Data.Common
         private static string GetKeyName(StringBuilder buffer)
         {
             int count = buffer.Length;
-            while ((0 < count) && char.IsWhiteSpace(buffer[count - 1]))
+            while (count > 0 && char.IsWhiteSpace(buffer[count - 1]))
             {
                 count--; // trailing whitespace
             }
@@ -286,7 +286,7 @@ namespace Microsoft.Data.Common
                 {
                     index++; // leading whitespace
                 }
-                while ((0 < count) && char.IsWhiteSpace(buffer[count - 1]))
+                while (count > 0 && char.IsWhiteSpace(buffer[count - 1]))
                 {
                     count--; // trailing whitespace
                 }
@@ -522,9 +522,9 @@ namespace Microsoft.Data.Common
             {
 #if DEBUG
                 bool compValue = s_connectionStringValidValueRegex.IsMatch(keyvalue);
-                Debug.Assert((-1 == keyvalue.IndexOf('\u0000')) == compValue, "IsValueValid mismatch with regex");
+                Debug.Assert((keyvalue.IndexOf('\u0000') == -1) == compValue, "IsValueValid mismatch with regex");
 #endif
-                return (-1 == keyvalue.IndexOf('\u0000'));
+                return keyvalue.IndexOf('\u0000') == -1;
             }
             return true;
         }
@@ -535,9 +535,9 @@ namespace Microsoft.Data.Common
             {
 #if DEBUG
                 bool compValue = s_connectionStringValidKeyRegex.IsMatch(keyname);
-                Debug.Assert(((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && (-1 == keyname.IndexOf('\u0000'))) == compValue, "IsValueValid mismatch with regex");
+                Debug.Assert((keyname.Length > 0 && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && (-1 == keyname.IndexOf('\u0000'))) == compValue, "IsValueValid mismatch with regex");
 #endif
-                return ((0 < keyname.Length) && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && (-1 == keyname.IndexOf('\u0000')));
+                return keyname.Length > 0 && (';' != keyname[0]) && !char.IsWhiteSpace(keyname[0]) && keyname.IndexOf('\u0000') == -1;
             }
             return false;
         }
@@ -565,7 +565,7 @@ namespace Microsoft.Data.Common
                 {
                     string keyname = (firstKey ? keypair.Value : keypair.Value.Replace("==", "=")).ToLower(CultureInfo.InvariantCulture);
                     string keyvalue = keyvalues[indexValue++].Value;
-                    if (0 < keyvalue.Length)
+                    if (keyvalue.Length > 0)
                     {
                         if (!firstKey)
                         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/MultipartIdentifier.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/MultipartIdentifier.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Common
                 throw ADP.InvalidMultipartNameToManyParts(property, name, limit);
             }
 
-            if (-1 != leftQuote.IndexOf(separator) || -1 != rightQuote.IndexOf(separator) || leftQuote.Length != rightQuote.Length)
+            if (leftQuote.IndexOf(separator) != -1 || rightQuote.IndexOf(separator) != -1 || leftQuote.Length != rightQuote.Length)
             {
                 throw ADP.InvalidMultipartNameIncorrectUsageOfQuotes(property, name);
             }
@@ -99,7 +99,7 @@ namespace Microsoft.Data.Common
                                 IncrementStringCount(name, parsedNames, ref stringCount, property);
                             }
                             else
-                            if (-1 != (quoteIndex = leftQuote.IndexOf(testchar)))
+                            if ((quoteIndex = leftQuote.IndexOf(testchar)) != -1)
                             { // If we are a left quote                                                                                                                          
                                 rightQuoteChar = rightQuote[quoteIndex]; // record the corresponding right quote for the left quote
                                 sb.Length = 0;
@@ -110,7 +110,7 @@ namespace Microsoft.Data.Common
                                 state = MPIState.MPI_ParseQuote;
                             }
                             else
-                            if (-1 != rightQuote.IndexOf(testchar))
+                            if (rightQuote.IndexOf(testchar) != -1)
                             { // If we shouldn't see a right quote
                                 throw ADP.InvalidMultipartNameIncorrectUsageOfQuotes(property, name);
                             }
@@ -132,12 +132,12 @@ namespace Microsoft.Data.Common
                                 state = MPIState.MPI_Value;
                             }
                             else // Quotes are not valid inside a non-quoted name
-                            if (-1 != rightQuote.IndexOf(testchar))
+                            if (rightQuote.IndexOf(testchar) != -1)
                             {
                                 throw ADP.InvalidMultipartNameIncorrectUsageOfQuotes(property, name);
                             }
                             else
-                            if (-1 != leftQuote.IndexOf(testchar))
+                            if (leftQuote.IndexOf(testchar) != -1)
                             {
                                 throw ADP.InvalidMultipartNameIncorrectUsageOfQuotes(property, name);
                             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/NameValuePair.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/NameValuePair.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Common
         {
             get
             {
-                Debug.Assert(0 < _length, "NameValuePair zero Length usage");
+                Debug.Assert(_length > 0, "NameValuePair zero Length usage");
                 return _length;
             }
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Data.ProviderBase
                             // Empty pool during pruning indicates zero or low activity, but
                             //  an error state indicates the pool needs to stay around to
                             //  throttle new connection attempts.
-                            if ((!pool.ErrorOccurred) && (0 == pool.Count))
+                            if ((!pool.ErrorOccurred) && pool.Count == 0)
                             {
                                 // Order is important here.  First we remove the pool
                                 // from the collection of pools so no one will try
@@ -292,7 +292,7 @@ namespace Microsoft.Data.ProviderBase
 
                 // must be pruning thread to change state and no connections
                 // otherwise pruning thread risks making entry disabled soon after user calls ClearPool
-                if (0 == _poolCollection.Count)
+                if (_poolCollection.Count == 0)
                 {
                     if (PoolGroupStateActive == _state)
                     {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolOptions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.ProviderBase
             _maxPoolSize = maxPoolSize;
             _creationTimeout = creationTimeout;
 
-            if (0 != loadBalanceTimeout)
+            if (loadBalanceTimeout != 0)
             {
                 _loadBalanceTimeout = new TimeSpan(0, 0, loadBalanceTimeout);
                 _useLoadBalancing = true;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbMetaDataFactory.cs
@@ -531,7 +531,7 @@ namespace Microsoft.Data.ProviderBase
                 {
                     if (version != DBNull.Value)
                     {
-                        if (0 > string.Compare(_normalizedServerVersion, (string)version, StringComparison.OrdinalIgnoreCase))
+                        if (string.Compare(_normalizedServerVersion, (string)version, StringComparison.OrdinalIgnoreCase) < 0)
                         {
                             result = false;
                         }
@@ -550,7 +550,7 @@ namespace Microsoft.Data.ProviderBase
                     {
                         if (version != DBNull.Value)
                         {
-                            if (0 < string.Compare(_normalizedServerVersion, (string)version, StringComparison.OrdinalIgnoreCase))
+                            if (string.Compare(_normalizedServerVersion, (string)version, StringComparison.OrdinalIgnoreCase) > 0)
                             {
                                 result = false;
                             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbReferenceCollection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbReferenceCollection.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Data.ProviderBase
 
         protected void AddItem(object value, int refInfo)
         {
-            Debug.Assert(value != null && 0 != refInfo, "AddItem with null value or 0 reference info");
+            Debug.Assert(value != null && refInfo != 0, "AddItem with null value or 0 reference info");
             bool itemAdded = false;
 
             lock (_itemLock)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/FieldNameLookup.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/FieldNameLookup.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Data.ProviderBase
             // walk the field names from the end to the beginning so that if a name exists
             // multiple times the first (from beginning to end) index of it is stored
             // in the hash table
-            for (int index = length - 1; 0 <= index; --index)
+            for (int index = length - 1; index >= 0; --index)
             {
                 string fieldName = _fieldNames[index];
                 lookup[fieldName] = index;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/TimeoutTimer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/TimeoutTimer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Data.ProviderBase
         {
             //--------------------
             // Preconditions
-            Debug.Assert(0 <= milliseconds);
+            Debug.Assert(milliseconds >= 0);
 
             //--------------------
             // Method body
@@ -78,7 +78,7 @@ namespace Microsoft.Data.ProviderBase
         {
             //--------------------
             // Preconditions
-            Debug.Assert(0 <= seconds || InfiniteTimeout == seconds);  // no need to support negative seconds at present
+            Debug.Assert(seconds >= 0 || InfiniteTimeout == seconds);  // no need to support negative seconds at present
 
             //--------------------
             // Method body
@@ -167,7 +167,7 @@ namespace Microsoft.Data.ProviderBase
                 else
                 {
                     milliseconds = ADP.TimerRemainingMilliseconds(_timerExpire);
-                    if (0 > milliseconds)
+                    if (milliseconds < 0)
                     {
                         milliseconds = 0;
                     }
@@ -175,7 +175,7 @@ namespace Microsoft.Data.ProviderBase
 
                 //--------------------
                 // Postconditions
-                Debug.Assert(0 <= milliseconds); // This property guarantees no negative return values
+                Debug.Assert(milliseconds >= 0); // This property guarantees no negative return values
 
                 return milliseconds;
             }
@@ -196,7 +196,7 @@ namespace Microsoft.Data.ProviderBase
                 else
                 {
                     long longMilliseconds = ADP.TimerRemainingMilliseconds(_timerExpire);
-                    if (0 > longMilliseconds)
+                    if (longMilliseconds < 0)
                     {
                         milliseconds = 0;
                     }
@@ -212,7 +212,7 @@ namespace Microsoft.Data.ProviderBase
 
                 //--------------------
                 // Postconditions
-                Debug.Assert(0 <= milliseconds);
+                Debug.Assert(milliseconds >= 0);
 
                 return milliseconds;
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlNotificationRequest.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlNotificationRequest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Sql
             }
             set
             {
-                if (0 > value)
+                if (value < 0)
                 {
                     throw ADP.ArgumentOutOfRange(string.Empty, nameof(Timeout));
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ColumnEncryptionKeyInfo.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ColumnEncryptionKeyInfo.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.NullArgumentInConstructorInternal(_decryptedKeyName, _className);
             }
-            if (0 == decryptedKey.Length)
+            if (decryptedKey.Length == 0)
             {
                 throw SQL.EmptyArgumentInConstructorInternal(_decryptedKeyName, _className);
             }
@@ -47,7 +47,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.NullArgumentInConstructorInternal(_keyMetadataVersionName, _className);
             }
-            if (0 == keyMetadataVersion.Length)
+            if (keyMetadataVersion.Length == 0)
             {
                 throw SQL.EmptyArgumentInConstructorInternal(_keyMetadataVersionName, _className);
             }
@@ -109,14 +109,22 @@ namespace Microsoft.Data.SqlClient
         internal int SerializeToBuffer(byte[] bytePackage, int startOffset)
         {
 
-            if (null == bytePackage)
+            if (bytePackage == null)
+            {
                 throw SQL.NullArgumentInternal(_bytePackageName, _className, _serializeToBufferMethodName);
-            if (0 == bytePackage.Length)
+            }
+            if (bytePackage.Length == 0)
+            {
                 throw SQL.EmptyArgumentInternal(_bytePackageName, _className, _serializeToBufferMethodName);
+            }
             if (!(startOffset < bytePackage.Length))
+            {
                 throw SQL.OffsetOutOfBounds(_startOffsetName, _className, _serializeToBufferMethodName);
-            if ((bytePackage.Length - startOffset) < GetLengthForSerialization())
+            }
+            if (bytePackage.Length - startOffset < GetLengthForSerialization())
+            {
                 throw SQL.InsufficientBuffer(_bytePackageName, _className, _serializeToBufferMethodName);
+            }
 
             Buffer.BlockCopy(DatabaseIdBytes, 0, bytePackage, startOffset, DatabaseIdBytes.Length);
             startOffset += DatabaseIdBytes.Length;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NativeSSPIContextProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NativeSSPIContextProvider.cs
@@ -35,8 +35,10 @@ namespace Microsoft.Data.SqlClient
                         // use local for ref param to defer setting s_maxSSPILength until we know the call succeeded.
                         uint maxLength = 0;
 
-                        if (0 != SNINativeMethodWrapper.SNISecInitPackage(ref maxLength))
+                        if (SNINativeMethodWrapper.SNISecInitPackage(ref maxLength) != 0)
+                        {
                             SSPIError(SQLMessage.SSPIInitializeError(), TdsEnums.INIT_SSPI_PACKAGE);
+                        }
 
                         s_maxSSPILength = maxLength;
                         s_fSSPILoaded = true;
@@ -58,7 +60,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(_physicalStateObj.SessionHandle.Type == SessionHandle.NativeHandleType);
             SNIHandle handle = _physicalStateObj.SessionHandle.NativeHandle;
 #endif
-            if (0 != SNINativeMethodWrapper.SNISecGenClientContext(handle, receivedBuff.Span, sendBuff, ref sendLength, _sniSpnBuffer[0]))
+            if (SNINativeMethodWrapper.SNISecGenClientContext(handle, receivedBuff.Span, sendBuff, ref sendLength, _sniSpnBuffer[0]) != 0)
             {
                 throw new InvalidOperationException(SQLMessage.SSPIGenerateError());
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
@@ -496,16 +496,16 @@ namespace Microsoft.Data.SqlClient.Server
                 {
                     string[] names = SqlParameter.ParseTypeName(typeName, true /* isUdtTypeName */);
 
-                    if (1 == names.Length)
+                    if (names.Length == 1)
                     {
                         typeSpecificNamePart3 = names[0];
                     }
-                    else if (2 == names.Length)
+                    else if (names.Length == 2)
                     {
                         typeSpecificNamePart2 = names[0];
                         typeSpecificNamePart3 = names[1];
                     }
-                    else if (3 == names.Length)
+                    else if (names.Length == 3)
                     {
                         typeSpecificNamePart1 = names[0];
                         typeSpecificNamePart2 = names[1];
@@ -603,7 +603,7 @@ namespace Microsoft.Data.SqlClient.Server
                 {
                     throw SQL.InvalidTableDerivedPrecisionForTvp(column.ColumnName, precision);
                 }
-                else if (0 == precision)
+                else if (precision == 0)
                 {
                     precision = 1;
                 }
@@ -645,7 +645,7 @@ namespace Microsoft.Data.SqlClient.Server
                 {
                     throw SQL.InvalidTableDerivedPrecisionForTvp(column.ColumnName, precision);
                 }
-                else if (0 == precision)
+                else if (precision == 0)
                 {
                     precision = 1;
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiEventSink_Default.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiEventSink_Default.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Data.SqlClient.Server
 
             if (_errors != null)
             {
-                Debug.Assert(0 != _errors.Count, "empty error collection?"); // must be something in the collection
+                Debug.Assert(_errors.Count != 0, "empty error collection?"); // must be something in the collection
 #if NETFRAMEWORK
                 if (ignoreNonFatalMessages)
                 {
@@ -118,7 +118,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
             else
             {
-                Debug.Assert(_warnings == null || 0 != _warnings.Count, "empty warning collection?");// must be something in the collection
+                Debug.Assert(_warnings == null || _warnings.Count != 0, "empty warning collection?");// must be something in the collection
 
                 if (!ignoreWarnings)
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiGettersStream.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiGettersStream.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             Debug.Assert(sink != null);
             Debug.Assert(getters != null);
-            Debug.Assert(0 <= ordinal);
+            Debug.Assert(ordinal >= 0);
             Debug.Assert(metaData != null);
 
             _sink = sink;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
@@ -352,7 +352,7 @@ namespace Microsoft.Data.SqlClient.Server
                 case SqlDbType.Udt:
                     // For SqlParameter, both userDefinedType and udtAssemblyQualifiedName can be NULL,
                     // so we are checking only maxLength if it will be used (i.e. userDefinedType is NULL)
-                    Debug.Assert((userDefinedType != null) || (0 <= maxLength || UnlimitedMaxLengthIndicator == maxLength),
+                    Debug.Assert((userDefinedType != null) || (maxLength >= 0 || UnlimitedMaxLengthIndicator == maxLength),
                              $"SmiMetaData.ctor: Udt name={udtAssemblyQualifiedName}, maxLength={maxLength}");
                     // Type not validated until matched to a server.  Could be null if extended metadata supplies three-part name!
                     _clrType = userDefinedType;
@@ -445,22 +445,22 @@ namespace Microsoft.Data.SqlClient.Server
                 case SqlDbType.DateTimeOffset:
                     break;
                 case SqlDbType.Binary:
-                    result = 0 < maxLength && MaxBinaryLength >= maxLength;
+                    result = maxLength > 0 && MaxBinaryLength >= maxLength;
                     break;
                 case SqlDbType.VarBinary:
-                    result = UnlimitedMaxLengthIndicator == maxLength || (0 < maxLength && MaxBinaryLength >= maxLength);
+                    result = UnlimitedMaxLengthIndicator == maxLength || (maxLength > 0 && MaxBinaryLength >= maxLength);
                     break;
                 case SqlDbType.Char:
-                    result = 0 < maxLength && MaxANSICharacters >= maxLength;
+                    result = maxLength > 0 && MaxANSICharacters >= maxLength;
                     break;
                 case SqlDbType.NChar:
-                    result = 0 < maxLength && MaxUnicodeCharacters >= maxLength;
+                    result = maxLength > 0 && MaxUnicodeCharacters >= maxLength;
                     break;
                 case SqlDbType.NVarChar:
-                    result = UnlimitedMaxLengthIndicator == maxLength || (0 < maxLength && MaxUnicodeCharacters >= maxLength);
+                    result = UnlimitedMaxLengthIndicator == maxLength || (maxLength > 0 && MaxUnicodeCharacters >= maxLength);
                     break;
                 case SqlDbType.VarChar:
-                    result = UnlimitedMaxLengthIndicator == maxLength || (0 < maxLength && MaxANSICharacters >= maxLength);
+                    result = UnlimitedMaxLengthIndicator == maxLength || (maxLength > 0 && MaxANSICharacters >= maxLength);
                     break;
                 default:
                     Debug.Fail("How in the world did we get here? :" + dbType);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaDataProperty.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaDataProperty.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Data.SqlClient.Server
         [Conditional("DEBUG")]
         internal void CheckCount(int countToMatch)
         {
-            Debug.Assert(0 == _columns.Count || countToMatch == _columns.Count,
+            Debug.Assert(_columns.Count == 0 || countToMatch == _columns.Count,
                     "SmiDefaultFieldsProperty.CheckCount: DefaultFieldsProperty size (" + _columns.Count +
                     ") not equal to checked size (" + countToMatch + ")");
         }
@@ -181,7 +181,7 @@ namespace Microsoft.Data.SqlClient.Server
         [Conditional("DEBUG")]
         internal void CheckCount(int countToMatch)
         {
-            Debug.Assert(0 == _columns.Count || countToMatch == _columns.Count,
+            Debug.Assert(_columns.Count == 0 || countToMatch == _columns.Count,
                     "SmiDefaultFieldsProperty.CheckCount: DefaultFieldsProperty size (" + _columns.Count +
                     ") not equal to checked size (" + countToMatch + ")");
         }
@@ -243,7 +243,7 @@ namespace Microsoft.Data.SqlClient.Server
         [Conditional("DEBUG")]
         internal void CheckCount(int countToMatch)
         {
-            Debug.Assert(0 == _defaults.Count || countToMatch == _defaults.Count,
+            Debug.Assert(_defaults.Count == 0 || countToMatch == _defaults.Count,
                     "SmiDefaultFieldsProperty.CheckCount: DefaultFieldsProperty size (" + _defaults.Count +
                     ") not equal to checked size (" + countToMatch + ")");
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiSettersStream.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiSettersStream.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             Debug.Assert(sink != null);
             Debug.Assert(setters != null);
-            Debug.Assert(0 <= ordinal);
+            Debug.Assert(ordinal >= 0);
             Debug.Assert(metaData != null);
 
             _sink = sink;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
@@ -413,7 +413,7 @@ namespace Microsoft.Data.SqlClient.Server
 
         internal void ThrowIfInvalidOrdinal(int ordinal)
         {
-            if (0 > ordinal || FieldCount <= ordinal)
+            if (ordinal < 0 || ordinal >= FieldCount)
             {
                 throw ADP.IndexOutOfRange(ordinal);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
@@ -1982,12 +1982,12 @@ namespace Microsoft.Data.SqlClient.Server
         {
             if (SqlDbType.Char == SqlDbType || SqlDbType.NChar == SqlDbType)
             {
-                if (1 != MaxLength)
+                if (MaxLength != 1)
                 {
                     ThrowInvalidType();
                 }
             }
-            else if ((1 > MaxLength) ||  // char must have max length of at least 1
+            else if (MaxLength < 1 ||  // char must have max length of at least 1
                     (SqlDbType.VarChar != SqlDbType && SqlDbType.NVarChar != SqlDbType &&
                     SqlDbType.Text != SqlDbType && SqlDbType.NText != SqlDbType)
                     )

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlRecordBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlRecordBuffer.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
             set
             {
-                if (0 == value)
+                if (value == 0)
                 {
                     _value._int64 = value;
                     _object = Array.Empty<byte>();
@@ -393,7 +393,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
             set
             {
-                if (0 == value)
+                if (value == 0)
                 {
                     _value._int64 = value;
                     _object = Array.Empty<char>();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
@@ -2827,7 +2827,7 @@ namespace Microsoft.Data.SqlClient.Server
                 length = Math.Min(length, TdsEnums.TYPE_SIZE_LIMIT);
             }
 
-            Debug.Assert(0 > maxLength || 0 > actualLength || maxLength >= actualLength, "Actual = " + actualLength + ", max = " + maxLength + ", sqldbtype=" + dbType);
+            Debug.Assert(maxLength < 0 || actualLength < 0 || maxLength >= actualLength, "Actual = " + actualLength + ", max = " + maxLength + ", sqldbtype=" + dbType);
 
             if (actualLength >= 0)
             {
@@ -3941,7 +3941,7 @@ namespace Microsoft.Data.SqlClient.Server
 
             byte[] copyBuffer = new byte[chunkSize];
             int bytesRead;
-            while (0 != (bytesRead = source.Read(copyBuffer, 0, chunkSize)))
+            while ((bytesRead = source.Read(copyBuffer, 0, chunkSize)) != 0)
             {
                 dest.Write(copyBuffer, 0, bytesRead);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.netfx.cs
@@ -492,7 +492,7 @@ namespace Microsoft.Data.SqlClient.Server
 
             byte[] copyBuffer = new byte[chunkSize];
             int bytesRead;
-            while (0 != (bytesRead = source.Read(copyBuffer, 0, chunkSize)))
+            while ((bytesRead = source.Read(copyBuffer, 0, chunkSize)) != 0)
             {
                 dest.Write(copyBuffer, 0, bytesRead);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SignatureVerificationCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SignatureVerificationCache.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Data.SqlClient
         {
             // If the size of the cache exceeds the threshold, set that we are in trimming and trim the cache accordingly.
             long currentCacheSize = _cache.Count;
-            if ((currentCacheSize > _cacheSize + _cacheTrimThreshold) && (0 == Interlocked.CompareExchange(ref _inTrim, 1, 0)))
+            if (currentCacheSize > _cacheSize + _cacheTrimThreshold && Interlocked.CompareExchange(ref _inTrim, 1, 0) == 0)
             {
                 try
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAeadAes256CbcHmac256Algorithm.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAeadAes256CbcHmac256Algorithm.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Data.SqlClient
             _version[0] = algorithmVersion;
 
             Debug.Assert(encryptionKey != null, "Null encryption key detected in AeadAes256CbcHmac256 algorithm");
-            Debug.Assert(0x01 == algorithmVersion, "Unknown algorithm version passed to AeadAes256CbcHmac256");
+            Debug.Assert(algorithmVersion == 0x01, "Unknown algorithm version passed to AeadAes256CbcHmac256");
 
             // Validate encryption type for this algorithm
             // This algorithm can only provide randomized or deterministic encryption types.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBuffer.cs
@@ -1339,9 +1339,9 @@ namespace Microsoft.Data.SqlClient
         private static void FillInTimeInfo(ref TimeInfo timeInfo, ReadOnlySpan<byte> timeBytes, byte scale, byte denormalizedScale)
         {
             int length = timeBytes.Length;
-            Debug.Assert(3 <= length && length <= 5, "invalid data length for timeInfo: " + length);
-            Debug.Assert(0 <= scale && scale <= 7, "invalid scale: " + scale);
-            Debug.Assert(0 <= denormalizedScale && denormalizedScale <= 7, "invalid denormalized scale: " + denormalizedScale);
+            Debug.Assert(length >= 3 && length <= 5, "invalid data length for timeInfo: " + length);
+            Debug.Assert(scale >= 0 && scale <= 7, "invalid scale: " + scale);
+            Debug.Assert(denormalizedScale >= 0 && denormalizedScale <= 7, "invalid denormalized scale: " + denormalizedScale);
 
             long tickUnits = timeBytes[0] + ((long)timeBytes[1] << 8) + ((long)timeBytes[2] << 16);
             if (length > 3)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCollation.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCollation.cs
@@ -45,16 +45,26 @@ namespace Microsoft.Data.SqlClient
             get
             {
                 SqlCompareOptions options = SqlCompareOptions.None;
-                if (0 != (_info & IgnoreCase))
+                if ((_info & IgnoreCase) != 0)
+                {
                     options |= SqlCompareOptions.IgnoreCase;
-                if (0 != (_info & IgnoreNonSpace))
+                }
+                if ((_info & IgnoreNonSpace) != 0)
+                {
                     options |= SqlCompareOptions.IgnoreNonSpace;
-                if (0 != (_info & IgnoreWidth))
+                }
+                if ((_info & IgnoreWidth) != 0)
+                {
                     options |= SqlCompareOptions.IgnoreWidth;
-                if (0 != (_info & IgnoreKanaType))
+                }
+                if ((_info & IgnoreKanaType) != 0)
+                {
                     options |= SqlCompareOptions.IgnoreKanaType;
-                if (0 != (_info & BinarySort))
+                }
+                if ((_info & BinarySort) != 0)
+                {
                     options |= SqlCompareOptions.BinarySort;
+                }
                 return options;
             }
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.NullEncryptedColumnEncryptionKey();
             }
-            else if (0 == encryptedColumnEncryptionKey.Length)
+            else if (encryptedColumnEncryptionKey.Length == 0)
             {
                 throw SQL.EmptyEncryptedColumnEncryptionKey();
             }
@@ -156,7 +156,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.NullColumnEncryptionKey();
             }
-            else if (0 == columnEncryptionKey.Length)
+            else if (columnEncryptionKey.Length == 0)
             {
                 throw SQL.EmptyColumnEncryptionKey();
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandSet.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Data.SqlClient
             SqlParameterCollection parameters = null;
 
             SqlParameterCollection collection = command.Parameters;
-            if (0 < collection.Count)
+            if (collection.Count > 0)
             {
                 parameters = new SqlParameterCollection();
 
@@ -164,7 +164,7 @@ namespace Microsoft.Data.SqlClient
                             int offset = p.Offset;
                             int size = p.Size;
                             int countOfChars = charValues.Length - offset;
-                            if ((0 != size) && (size < countOfChars))
+                            if (size != 0 && (size < countOfChars))
                             {
                                 countOfChars = size;
                             }
@@ -192,7 +192,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static void BuildStoredProcedureName(StringBuilder builder, string part)
         {
-            if (part != null && (0 < part.Length))
+            if (part != null && part.Length > 0)
             {
                 if ('[' == part[0])
                 {
@@ -204,7 +204,7 @@ namespace Microsoft.Data.SqlClient
                             count++;
                         }
                     }
-                    if (1 == (count % 2))
+                    if (count % 2 == 1)
                     {
                         builder.Append(part);
                         return;
@@ -288,7 +288,7 @@ namespace Microsoft.Data.SqlClient
 
         private void ValidateCommandBehavior(string method, CommandBehavior behavior)
         {
-            if (0 != (behavior & ~(CommandBehavior.SequentialAccess | CommandBehavior.CloseConnection)))
+            if ((behavior & ~(CommandBehavior.SequentialAccess | CommandBehavior.CloseConnection)) != 0)
             {
                 ADP.ValidateCommandBehavior(behavior);
                 throw ADP.NotSupportedCommandBehavior(behavior & ~(CommandBehavior.SequentialAccess | CommandBehavior.CloseConnection), method);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -489,7 +489,7 @@ namespace Microsoft.Data.SqlClient
 #endif // NETFRAMEWORK
             if (_expandedAttachDBFilename != null)
             {
-                if (0 <= _expandedAttachDBFilename.IndexOf('|'))
+                if (_expandedAttachDBFilename.IndexOf('|') >= 0)
                 {
                     throw ADP.InvalidConnectionOptionValue(KEY.AttachDBFilename);
                 }
@@ -506,7 +506,7 @@ namespace Microsoft.Data.SqlClient
                     VerifyLocalHostAndFixup(ref host, true, false /*don't fix-up*/);
                 }
             }
-            else if (0 <= _attachDBFileName.IndexOf('|'))
+            else if (_attachDBFileName.IndexOf('|') >= 0)
             {
                 throw ADP.InvalidConnectionOptionValue(KEY.AttachDBFilename);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -674,7 +674,7 @@ namespace Microsoft.Data.SqlClient
                     SqlConnectionStringBuilder constr = (context.Instance as SqlConnectionStringBuilder);
                     if (constr is not null)
                     {
-                        if ((0 < constr.DataSource.Length) && (constr.IntegratedSecurity || (0 < constr.UserID.Length)))
+                        if (constr.DataSource.Length > 0 && (constr.IntegratedSecurity || constr.UserID.Length > 0))
                         {
                             flag = true;
                         }
@@ -800,7 +800,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         string server = rows[i][serverName] as string;
                         string instance = rows[i][instanceName] as string;
-                        if ((instance is null) || (0 == instance.Length) || ("MSSQLSERVER" == instance))
+                        if ((instance is null) || instance.Length == 0 || ("MSSQLSERVER" == instance))
                         {
                             serverNames[i] = server;
                         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Data.SqlClient
             }
             set
             {
-                if (0 > value)
+                if (value < 0)
                 {
                     throw ADP.ArgumentOutOfRange(nameof(UpdateBatchSize));
                 }
@@ -166,7 +166,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataAdapter.xml' path='docs/members[@name="SqlDataAdapter"]/ExecuteBatch/*' />
         protected override int ExecuteBatch()
         {
-            Debug.Assert(_commandSet != null && (0 < _commandSet.CommandCount), "no commands");
+            Debug.Assert(_commandSet != null && _commandSet.CommandCount > 0, "no commands");
             SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlDataAdapter.ExecuteBatch | Info | Correlation | Object Id {0}, Activity Id {1}, Command Count {2}", ObjectID, ActivityCorrelator.Current, _commandSet.CommandCount);
             return _commandSet.ExecuteNonQuery();
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Data.SqlClient
                         lock (_eventHandlerLock)
                         {
                             int index = _eventList.IndexOf(pair);
-                            if (0 <= index)
+                            if (index >= 0)
                             {
                                 _eventList.RemoveAt(index);
                             }
@@ -968,7 +968,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (!s_serverUserHash.ContainsKey(server))
                     {
-                        if (0 == s_serverUserHash.Count)
+                        if (s_serverUserHash.Count == 0)
                         {
                             // Special error for no calls to start.
                             SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.GetDefaultComposedOptions|DEP|ERR> ERROR - no start calls have been made, about to throw.");
@@ -1071,7 +1071,7 @@ namespace Microsoft.Data.SqlClient
                 lock (_serverList)
                 {
                     int index = _serverList.BinarySearch(server, StringComparer.OrdinalIgnoreCase);
-                    if (0 > index)
+                    if (index < 0)
                     { // If less than 0, item was not found in list.
                         SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.AddToServerList|DEP> Server not present in hashtable, adding server: '{0}'.", server);
                         index = ~index; // BinarySearch returns the 2's compliment of where the item should be inserted to preserver a sorted list after insertion.
@@ -1179,7 +1179,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.StartTimer|DEP> We've timed out, executing logic.");
                     int seconds = SQL.SqlDependencyServerTimeout;
-                    if (0 != _timeout)
+                    if (_timeout != 0)
                     {
                         seconds = _timeout;
                     }
@@ -1246,8 +1246,8 @@ namespace Microsoft.Data.SqlClient
                                 // We should never be able to enter this state, since if we've fired our event list is cleared
                                 // and the event method will immediately fire if a new event is added.  So, we should never have
                                 // an event to fire in the event list once we've fired.
-                                Debug.Assert(0 == _eventList.Count, "How can we have an event at this point?");
-                                if (0 == _eventList.Count)
+                                Debug.Assert(_eventList.Count == 0, "How can we have an event at this point?");
+                                if (_eventList.Count == 0)
                                 {
                                     // Keep logic just in case.
                                     SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.AddCommandInternal|DEP|ERR> ERROR - firing events, though it is unexpected we have events at this point.");

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -268,7 +268,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                         }
 
                         // Stop will remove key when decremented to 0 for this AppDomain, which should now be the case.
-                        Debug.Assert(0 == value, "We did not reach 0 at end of loop in AppDomainUnload!");
+                        Debug.Assert(value == 0, "We did not reach 0 at end of loop in AppDomainUnload!");
                         Debug.Assert(!_appDomainKeyHash.ContainsKey(appDomainKey), "Key not removed after AppDomainUnload!");
 
                         if (_appDomainKeyHash.ContainsKey(appDomainKey))
@@ -860,7 +860,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                                 Debug.Fail("Unexpected AppDomainKey count in Stop()");
                             }
 
-                            if (1 == value)
+                            if (value == 1)
                             { // Remove from dictionary if pre-decrement count was one.
                                 _appDomainKeyHash.Remove(appDomainKey);
                                 appDomainStop = true;
@@ -877,7 +877,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 Debug.Assert(_startCount > 0, "About to decrement _startCount less than 0!");
                 int result = Interlocked.Decrement(ref _startCount);
 
-                if (0 == result)
+                if (result == 0)
                 {
                     // If we've reached refCount 0, destroy.
                     // Lock to ensure Cancel() complete prior to other thread calling TearDown.
@@ -946,7 +946,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlConnectionContainer.Stop|DEP> _startCount not 0 after decrement.  _startCount: '{0}'.", _startCount);
                 }
 
-                Debug.Assert(0 <= _startCount, "Invalid start count state");
+                Debug.Assert(_startCount >= 0, "Invalid start count state");
 
                 return _stopped;
             }
@@ -1093,7 +1093,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                 xmlReader.Read();
                 if ((XmlNodeType.Element == xmlReader.NodeType) &&
                      (RootNode == xmlReader.LocalName) &&
-                     (3 <= xmlReader.AttributeCount))
+                     xmlReader.AttributeCount >= 3)
                 {
                     // Loop until we've processed all the attributes.
                     while ((MessageAttributes.All != messageAttributes) && (xmlReader.MoveToNextAttribute()))
@@ -1189,7 +1189,7 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                     }
 
                     // Verify state after Read().
-                    if ((XmlNodeType.Element != xmlReader.NodeType) || (0 != string.Compare(xmlReader.LocalName, MessageNode, StringComparison.OrdinalIgnoreCase)))
+                    if ((XmlNodeType.Element != xmlReader.NodeType) || string.Compare(xmlReader.LocalName, MessageNode, StringComparison.OrdinalIgnoreCase) != 0)
                     {
                         SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependencyProcessDispatcher.ProcessMessage|DEP|ERR> unexpected Read failure on xml or unexpected structure of xml.");
                         return null;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Data.SqlClient
                         _dependencyIdToDependencyHash.Remove(id);
 
                         // if there are no more dependencies then we can dispose the timer.
-                        if (0 == _dependencyIdToDependencyHash.Count)
+                        if (_dependencyIdToDependencyHash.Count == 0)
                         {
                             _timeoutTimer.Change(Timeout.Infinite, Timeout.Infinite);
                             _sqlDependencyTimeOutTimerStarted = false;
@@ -545,7 +545,7 @@ namespace Microsoft.Data.SqlClient
                 // the lock.
                 lock (SingletonInstance._instanceLock)
                 {
-                    if (0 == SingletonInstance._dependencyIdToDependencyHash.Count)
+                    if (SingletonInstance._dependencyIdToDependencyHash.Count == 0)
                     {
                         SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependencyPerAppDomainDispatcher.TimeoutTimerCallback|DEP> No dependencies, exiting.");
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlEnclaveSession.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlEnclaveSession.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.NullArgumentInConstructorInternal(_sessionKeyName, _className);
             }
-            if (0 == sessionKey.Length)
+            if (sessionKey.Length == 0)
             {
                 throw SQL.EmptyArgumentInConstructorInternal(_sessionKeyName, _className);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlEnums.cs
@@ -779,13 +779,15 @@ namespace Microsoft.Data.SqlClient
             switch (tdsType)
             {
                 case TdsEnums.SQLMONEYN:
-                    return ((4 == length) ? s_metaSmallMoney : s_metaMoney);
+                    return length == 4 ? s_metaSmallMoney : s_metaMoney;
                 case TdsEnums.SQLDATETIMN:
-                    return ((4 == length) ? s_metaSmallDateTime : s_metaDateTime);
+                    return length == 4 ? s_metaSmallDateTime : s_metaDateTime;
                 case TdsEnums.SQLINTN:
-                    return ((4 <= length) ? ((4 == length) ? s_metaInt : s_metaBigInt) : ((2 == length) ? s_metaSmallInt : s_metaTinyInt));
+                    return length >= 4
+                        ? length == 4 ? s_metaInt : s_metaBigInt
+                        : length == 2 ? s_metaSmallInt : s_metaTinyInt;
                 case TdsEnums.SQLFLTN:
-                    return ((4 == length) ? s_metaReal : s_metaFloat);
+                    return length == 4 ? s_metaReal : s_metaFloat;
                 case TdsEnums.SQLTEXT:
                     return MetaText;
                 case TdsEnums.SQLVARBINARY:

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInfoMessageEvent.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInfoMessageEvent.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.SqlClient
         public SqlErrorCollection Errors => _exception.Errors;
 
         // MDAC 65548
-        private bool ShouldSerializeErrors() => _exception != null && (0 < _exception.Errors.Count);
+        private bool ShouldSerializeErrors() => _exception != null && _exception.Errors.Count > 0;
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlInfoMessageEventArgs.xml' path='docs/members[@name="SqlInfoMessageEventArgs"]/Message/*' />
         public string Message => _exception.Message;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlMetadataFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlMetadataFactory.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Data.SqlClient
                 "on assemblies.assembly_id = types.assembly_id ";
 
             // pre 9.0/2005 servers do not have UDTs
-            if (0 > string.Compare(ServerVersion, ServerVersionNormalized90, StringComparison.OrdinalIgnoreCase))
+            if (string.Compare(ServerVersion, ServerVersionNormalized90, StringComparison.OrdinalIgnoreCase) < 0)
             {
                 return;
             }
@@ -190,7 +190,7 @@ namespace Microsoft.Data.SqlClient
 
             // TODO: update this check once the server upgrades major version number!!!
             // pre 9.0/2005 servers do not have Table types
-            if (0 > string.Compare(ServerVersion, ServerVersionNormalized10, StringComparison.OrdinalIgnoreCase))
+            if (string.Compare(ServerVersion, ServerVersionNormalized10, StringComparison.OrdinalIgnoreCase) < 0)
             {
                 return;
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameter.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Data.SqlClient
                         ctorValues = new object[] { p.ParameterName, p.Value };
                         break;
                     default:
-                        if (0 == (32 & flags))
+                        if ((32 & flags) == 0)
                         { // v1.0 everything
                             ctorParams = new Type[] {
                                                     typeof(string), typeof(SqlDbType), typeof(int), typeof(ParameterDirection),
@@ -962,7 +962,7 @@ namespace Microsoft.Data.SqlClient
             {
                 byte precision = _precision;
                 SqlDbType dbtype = GetMetaSqlDbTypeOnly();
-                if ((0 == precision) && (SqlDbType.Decimal == dbtype))
+                if (precision == 0 && (SqlDbType.Decimal == dbtype))
                 {
                     precision = ValuePrecision(SqlValue);
                 }
@@ -1051,7 +1051,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal bool SizeInferred => 0 == _size;
+        internal bool SizeInferred => _size == 0;
 
         internal INullable ValueAsINullable => _valueAsINullable;
 
@@ -1215,7 +1215,7 @@ namespace Microsoft.Data.SqlClient
 
                 // set up primary key as unique key list
                 //  do this prior to general metadata loop to favor the primary key
-                if (dt.PrimaryKey != null && 0 < dt.PrimaryKey.Length)
+                if (dt.PrimaryKey != null && dt.PrimaryKey.Length > 0)
                 {
                     foreach (DataColumn col in dt.PrimaryKey)
                     {
@@ -1282,7 +1282,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         firstRecord = enumerator.Current;
                         int fieldCount = firstRecord.FieldCount;
-                        if (0 < fieldCount)
+                        if (fieldCount > 0)
                         {
                             // It's valid!  Grab those fields.
                             bool[] keyCols = new bool[fieldCount];
@@ -1354,7 +1354,7 @@ namespace Microsoft.Data.SqlClient
                                 props[SmiPropertySelector.DefaultFields] = new SmiDefaultFieldsProperty(new List<bool>(defaultFields));
                             }
 
-                            if (0 < sortCount)
+                            if (sortCount > 0)
                             {
                                 // validate monotonically increasing sort order.
                                 //  Since we already checked for duplicates, we just need

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameterCollection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlParameterCollection.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Data.SqlClient
         private void RemoveIndex(int index)
         {
             List<SqlParameter> items = InnerList;
-            Debug.Assert((items != null) && (0 <= index) && (index < Count), "RemoveIndex, invalid");
+            Debug.Assert((items != null) && index >= 0 && (index < Count), "RemoveIndex, invalid");
             SqlParameter item = items[index];
             items.RemoveAt(index);
             item.ResetParent();
@@ -347,7 +347,7 @@ namespace Microsoft.Data.SqlClient
         private void Replace(int index, object newValue)
         {
             List<SqlParameter> items = InnerList;
-            Debug.Assert((items != null) && (0 <= index) && (index < Count), "Replace Index invalid");
+            Debug.Assert((items != null) && index >= 0 && (index < Count), "Replace Index invalid");
             ValidateType(newValue);
             Validate(index, newValue);
             SqlParameter item = items[index];
@@ -384,7 +384,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     name = ADP.Parameter + index.ToString(CultureInfo.CurrentCulture);
                     index++;
-                } while (-1 != IndexOf(name));
+                } while (IndexOf(name) != -1);
                 ((SqlParameter)value).ParameterName = name;
             }
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Data.SqlClient
 
             // If the size of the cache exceeds the threshold, set that we are in trimming and trim the cache accordingly.
             long currentCacheSize = _cache.Count;
-            if ((currentCacheSize > CacheSize + CacheTrimThreshold) && (0 == Interlocked.CompareExchange(ref _inTrim, 1, 0)))
+            if ((currentCacheSize > CacheSize + CacheTrimThreshold) && (Interlocked.CompareExchange(ref _inTrim, 1, 0) == 0))
             {
                 try
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlReferenceCollection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlReferenceCollection.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Data.SqlClient
 
         protected override void NotifyItem(int message, int tag, object value)
         {
-            Debug.Assert(0 == message, "unexpected message?");
+            Debug.Assert(message == 0, "unexpected message?");
             Debug.Assert(DataReaderTag == tag || CommandTag == tag || BulkCopyTag == tag, "unexpected tag?");
 
             if (tag == DataReaderTag)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Data.SqlClient
 
             Debug.Assert(md.IsAlgorithmInitialized(), "Encryption Algorithm is not initialized");
             byte[] cipherText = md.CipherAlgorithm.EncryptData(plainText); // this call succeeds or throws.
-            if (cipherText == null || 0 == cipherText.Length)
+            if (cipherText == null || cipherText.Length == 0)
             {
                 throw SQL.NullCipherText();
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlStream.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlStream.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Data.SqlClient
                 while (count > 0)
                 {
                     // if no bytes were read, get the next row
-                    if (_advanceReader && (0 == _bytesCol))
+                    if (_advanceReader && _bytesCol == 0)
                     {
                         gotData = false;
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -1683,7 +1683,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception NullCertificatePath(string[] validLocations, bool isSystemOp)
         {
-            Debug.Assert(2 == validLocations.Length);
+            Debug.Assert(validLocations.Length == 2);
             if (isSystemOp)
             {
                 return ADP.ArgumentNull(TdsEnums.TCE_PARAM_MASTERKEY_PATH, StringsHelper.GetString(Strings.TCE_NullCertificatePathSysErr, validLocations[0], validLocations[1], @"/"));
@@ -1720,7 +1720,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception InvalidCertificatePath(string actualCertificatePath, string[] validLocations, bool isSystemOp)
         {
-            Debug.Assert(2 == validLocations.Length);
+            Debug.Assert(validLocations.Length == 2);
             if (isSystemOp)
             {
                 return ADP.Argument(StringsHelper.GetString(Strings.TCE_InvalidCertificatePathSysErr, actualCertificatePath, validLocations[0], validLocations[1], @"/"), TdsEnums.TCE_PARAM_MASTERKEY_PATH);
@@ -1843,7 +1843,7 @@ namespace Microsoft.Data.SqlClient
         {
 
 #if NETFRAMEWORK
-            Debug.Assert(2 == validLocations.Length);
+            Debug.Assert(validLocations.Length == 2);
 #endif
             if (isSystemOp)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParameterSetter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParameterSetter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Data.SqlClient
         //  This method called for both get and set.
         internal override SmiTypedGetterSetter GetTypedGetterSetter(SmiEventSink sink, int ordinal)
         {
-            Debug.Assert(0 == ordinal, "TdsParameterSetter only supports 0 for ordinal.  Actual = " + ordinal);
+            Debug.Assert(ordinal == 0, "TdsParameterSetter only supports 0 for ordinal.  Actual = " + ordinal);
             return _target;
         }
 
@@ -57,8 +57,7 @@ namespace Microsoft.Data.SqlClient
         //  valid for all types
         public override void SetDBNull(SmiEventSink sink, int ordinal)
         {
-            Debug.Assert(0 == ordinal, "TdsParameterSetter only supports 0 for ordinal.  Actual = " + ordinal);
-
+            Debug.Assert(ordinal == 0, "TdsParameterSetter only supports 0 for ordinal.  Actual = " + ordinal);
             _target.EndElements(sink);
         }
         #endregion

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.Windows.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Data.SqlClient
             base.handle = IntPtr.Zero;
             if (IntPtr.Zero != ptr)
             {
-                if (0 != SNINativeMethodWrapper.SNIClose(ptr))
+                if (SNINativeMethodWrapper.SNIClose(ptr) != 0)
                 {
                     return false;   // SNIClose should never fail.
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -387,10 +387,10 @@ namespace Microsoft.Data.SqlClient
             get
             {
                 bool isAlive = _owner.TryGetTarget(out object target);
-                Debug.Assert((0 == _activateCount && !isAlive) // in pool
-                             || (1 == _activateCount && isAlive && target != null)
-                             || (1 == _activateCount && !isAlive), "Unknown state on TdsParserStateObject.IsOrphaned!");
-                return (0 != _activateCount && !isAlive);
+                Debug.Assert((_activateCount == 0 && !isAlive) // in pool
+                             || (_activateCount == 1 && isAlive && target != null)
+                             || (_activateCount == 1 && !isAlive), "Unknown state on TdsParserStateObject.IsOrphaned!");
+                return _activateCount != 0 && !isAlive;
             }
         }
 
@@ -434,7 +434,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                Debug.Assert(0 == _timeoutMilliseconds || 0 == _timeoutTime, "_timeoutTime hasn't been reset");
+                Debug.Assert(_timeoutMilliseconds == 0 || _timeoutTime == 0, "_timeoutTime hasn't been reset");
                 return TdsParserStaticMethods.TimeoutHasExpired(_timeoutTime);
             }
         }
@@ -443,7 +443,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (0 != _timeoutMilliseconds)
+                if (_timeoutMilliseconds != 0)
                 {
                     _timeoutTime = TdsParserStaticMethods.GetTimeout(_timeoutMilliseconds);
                     _timeoutMilliseconds = 0;
@@ -460,7 +460,7 @@ namespace Microsoft.Data.SqlClient
         internal int GetTimeoutRemaining()
         {
             int remaining;
-            if (0 != _timeoutMilliseconds)
+            if (_timeoutMilliseconds != 0)
             {
                 remaining = (int)Math.Min((long)int.MaxValue, _timeoutMilliseconds);
                 _timeoutTime = TdsParserStaticMethods.GetTimeout(_timeoutMilliseconds);
@@ -883,7 +883,7 @@ namespace Microsoft.Data.SqlClient
         {
             lock (this)
             {
-                if (_cancelled && 1 == _outputPacketNumber)
+                if (_cancelled && _outputPacketNumber == 1)
                 {
                     ResetBuffer();
                     _cancelled = false;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.SqlClient
                     int index = aliasLookup.IndexOf(',');
 
                     // If we found the key, but there was no "," in the string, it is a bad Alias so return.
-                    if (-1 != index)
+                    if (index != -1)
                     {
                         string parsedProtocol = aliasLookup.Substring(0, index).ToLower(CultureInfo.InvariantCulture);
 
@@ -64,7 +64,7 @@ namespace Microsoft.Data.SqlClient
                             if ("dbnetlib" == parsedProtocol)
                             {
                                 index = parsedAliasName.IndexOf(':');
-                                if (-1 != index && index + 1 < parsedAliasName.Length)
+                                if (index != -1 && index + 1 < parsedAliasName.Length)
                                 {
                                     parsedProtocol = parsedAliasName.Substring(0, index);
                                     if (SqlConnectionString.ValidProtocol(parsedProtocol))
@@ -266,7 +266,7 @@ namespace Microsoft.Data.SqlClient
         {
             bool result = false;
 
-            if (0 != timeoutTime && long.MaxValue != timeoutTime)
+            if (timeoutTime != 0 && long.MaxValue != timeoutTime)
             {
                 result = ADP.TimerHasExpired(timeoutTime);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsRecordBufferSetter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsRecordBufferSetter.cs
@@ -241,10 +241,10 @@ namespace Microsoft.Data.SqlClient
         private void CheckWritingToColumn(int ordinal)
         {
 #if DEBUG
-            Debug.Assert(0 <= ordinal, "TdsRecordBufferSetter.CheckWritingToColumn: Targeting invalid column: " + ordinal);
+            Debug.Assert(ordinal >= 0, "TdsRecordBufferSetter.CheckWritingToColumn: Targeting invalid column: " + ordinal);
             SkipPossibleDefaultedColumns(ordinal);
 
-            Debug.Assert(0 <= _currentField && _metaData.FieldMetaData.Count > _currentField, "_currentField out of range for setting a column:" + _currentField);
+            Debug.Assert(_currentField >= 0 && _metaData.FieldMetaData.Count > _currentField, "_currentField out of range for setting a column:" + _currentField);
             Debug.Assert(ordinal == _currentField, "Setter called out of order.  Should be " + _currentField + ", but was " + ordinal);
             // Must not write to field with a DefaultFieldsProperty set to true
             Debug.Assert(!((SmiDefaultFieldsProperty)_metaData.ExtendedProperties[SmiPropertySelector.DefaultFields])[ordinal],

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsValueSetter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsValueSetter.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Data.SqlClient
             {
                 // Non-plp data must be sent in one chunk for now.
 #if DEBUG
-                Debug.Assert(0 == _currentOffset, "SetBytes doesn't yet support chunking for non-plp data: " + _currentOffset);
+                Debug.Assert(_currentOffset == 0, "SetBytes doesn't yet support chunking for non-plp data: " + _currentOffset);
 
 #endif
                 Debug.Assert(!MetaType.GetMetaTypeFromSqlDbType(_metaData.SqlDbType, _metaData.IsMultiValued).IsLong,
@@ -206,7 +206,7 @@ namespace Microsoft.Data.SqlClient
                 SmiXetterAccessMap.IsSetterAccessValid(_metaData, SmiXetterTypeCode.XetBytes));
             CheckSettingOffset(length);
 
-            if (0 == length)
+            if (length == 0)
             {
                 if (_isPlp)
                 {
@@ -280,7 +280,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // Non-plp data must be sent in one chunk for now.
 #if DEBUG
-                    Debug.Assert(0 == _currentOffset, "SetChars doesn't yet support chunking for non-plp data: " + _currentOffset);
+                    Debug.Assert(_currentOffset == 0, "SetChars doesn't yet support chunking for non-plp data: " + _currentOffset);
 #endif
 
                     if (SqlDbType.Variant == _metaData.SqlDbType)
@@ -308,7 +308,7 @@ namespace Microsoft.Data.SqlClient
                 SmiXetterAccessMap.IsSetterAccessValid(_metaData, SmiXetterTypeCode.XetChars));
             CheckSettingOffset(length);
 
-            if (0 == length)
+            if (length == 0)
             {
                 if (_isPlp)
                 {
@@ -570,7 +570,7 @@ namespace Microsoft.Data.SqlClient
                 if (SqlDbType.SmallDateTime == _metaData.SqlDbType)
                 {
                     TdsDateTime dt = MetaType.FromDateTime(value, (byte)_metaData.MaxLength);
-                    Debug.Assert(0 <= dt.days && dt.days <= ushort.MaxValue, "Invalid DateTime '" + value + "' for SmallDateTime");
+                    Debug.Assert(dt.days >= 0 && dt.days <= ushort.MaxValue, "Invalid DateTime '" + value + "' for SmallDateTime");
 
                     _stateObj.Parser.WriteShort(dt.days, _stateObj);
                     _stateObj.Parser.WriteShort(dt.time, _stateObj);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -682,8 +682,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                             }
 
                             Assert.True(rowsAffected == numberOfRows, "no: of rows returned by EndExecuteReader is unexpected.");
-                            Assert.True(3 == sqlDataReader.VisibleFieldCount);
-                            Assert.True(3 == sqlDataReader.FieldCount);
+                            Assert.True(sqlDataReader.VisibleFieldCount == 3);
+                            Assert.True(sqlDataReader.FieldCount == 3);
                         }
                     }
                 }
@@ -827,8 +827,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                                 }
                             }
 
-                            Assert.True(3 == sqlDataReader.VisibleFieldCount, "value returned by sqlDataReader.VisibleFieldCount is unexpected.");
-                            Assert.True(3 == sqlDataReader.FieldCount, "value returned by sqlDataReader.FieldCount is unexpected.");
+                            Assert.True(sqlDataReader.VisibleFieldCount == 3, "value returned by sqlDataReader.VisibleFieldCount is unexpected.");
+                            Assert.True(sqlDataReader.FieldCount == 3, "value returned by sqlDataReader.FieldCount is unexpected.");
                         }
                     }
 
@@ -1329,8 +1329,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                             Assert.True(isDbNullTask.Result == false, @"IsDBNullAsync unexpectedly returned false.");
                         }
 
-                        Assert.True(3 == sqlDataReader.VisibleFieldCount, "value returned by sqlDataReader.VisibleFieldCount is unexpected.");
-                        Assert.True(3 == sqlDataReader.FieldCount, "value returned by sqlDataReader.FieldCount is unexpected.");
+                        Assert.True(sqlDataReader.VisibleFieldCount == 3, "value returned by sqlDataReader.VisibleFieldCount is unexpected.");
+                        Assert.True(sqlDataReader.FieldCount == 3, "value returned by sqlDataReader.FieldCount is unexpected.");
                     }
                 }
 
@@ -2873,8 +2873,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                         Assert.True(sqlDataReader.GetString(2) == (string)testAsyncCallBackStateObject.Values[2], "LastName value read from the table was incorrect.");
                     }
 
-                    Assert.True(3 == sqlDataReader.VisibleFieldCount, "value returned by sqlDataReader.VisibleFieldCount is unexpected.");
-                    Assert.True(3 == sqlDataReader.FieldCount, "value returned by sqlDataReader.FieldCount is unexpected.");
+                    Assert.True(sqlDataReader.VisibleFieldCount == 3, "value returned by sqlDataReader.VisibleFieldCount is unexpected.");
+                    Assert.True(sqlDataReader.FieldCount == 3, "value returned by sqlDataReader.FieldCount is unexpected.");
                 }
 
                 // Based on the command behavior, verify the appropriate outcome.
@@ -3087,8 +3087,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                     Assert.True(sqlDataReader.GetString(2) == (string)values[2], "LastName value read from the table was incorrect.");
                 }
 
-                Assert.True(3 == sqlDataReader.VisibleFieldCount, "value returned by sqlDataReader.VisibleFieldCount is unexpected.");
-                Assert.True(3 == sqlDataReader.FieldCount, "value returned by sqlDataReader.FieldCount is unexpected.");
+                Assert.True(sqlDataReader.VisibleFieldCount == 3, "value returned by sqlDataReader.VisibleFieldCount is unexpected.");
+                Assert.True(sqlDataReader.FieldCount == 3, "value returned by sqlDataReader.FieldCount is unexpected.");
             }
 
             VerifySqlCommandStateAfterCompletionOrCancel(sqlCommand);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ConversionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ConversionTests.cs
@@ -1055,7 +1055,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                         count--;
                     }
 
-                    millisecond = (0 == strBuilder.Length) ? 0 : rand.Next(0, Int32.Parse(strBuilder.ToString()));
+                    millisecond = strBuilder.Length == 0 ? 0 : rand.Next(0, Int32.Parse(strBuilder.ToString()));
 
                     if (SqlDbType.DateTime2 == columnInfo.ColumnType)
                     {
@@ -1073,7 +1073,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
                     count = columnInfo.Scale;
 
-                    if (0 == count)
+                    if (count == 0)
                     {
                         strBuilder.Append(@"hh\:mm\:ss");
                     }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/SqlBulkCopyTruncation.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/SqlBulkCopyTruncation.cs
@@ -390,7 +390,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                             while (reader.Read())
                             {
                                 byte[] columnValue = (byte[])reader[0];
-                                Assert.True(3000 == columnValue.Length, "Unexpected array length!");
+                                Assert.True(columnValue.Length == 3000, "Unexpected array length!");
 
                                 foreach (byte b in columnValue)
                                 {
@@ -459,7 +459,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                             while (reader.Read())
                             {
                                 byte[] columnValue = (byte[])reader[0];
-                                Assert.True(3000 == columnValue.Length, "Unexpected length for varbinary TabSmallBinaryMaxTarget!");
+                                Assert.True(columnValue.Length == 3000, "Unexpected length for varbinary TabSmallBinaryMaxTarget!");
                                 foreach (byte b in columnValue)
                                 {
                                     Assert.True(0xee == b, "unexpected element read!");

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/SqlNullValues.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/SqlNullValues.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                         // Again expect int
                         Assert.True(value1 is System.Data.SqlTypes.SqlInt32, "Unexpected type");
                         Assert.True(value2 is System.Data.SqlTypes.SqlInt32, "Unexpected type");
-                        Assert.True(10 == ((System.Data.SqlTypes.SqlInt32)value2).Value, "Unexpected Value");
+                        Assert.True(((System.Data.SqlTypes.SqlInt32)value2).Value == 10, "Unexpected Value");
                         if (SqlCommandColumnEncryptionSetting.ResultSetOnly == commandSetting)
                         {
                             // For ResultSetOnly we don't expect to see plaintext for return values
@@ -138,7 +138,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                             // Expect int
                             Assert.True(value1 is System.Data.SqlTypes.SqlInt32, "Unexpected type");
                             Assert.True(value2 is System.Data.SqlTypes.SqlInt32, "Unexpected type");
-                            Assert.True(10 == ((System.Data.SqlTypes.SqlInt32)value2).Value, "Unexpected Value");
+                            Assert.True(((System.Data.SqlTypes.SqlInt32)value2).Value == 10, "Unexpected Value");
                             Assert.True(param.Value is System.Data.SqlTypes.SqlInt32, "Unexpected Return value");
                         }
                         else

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AdapterTest/AdapterTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AdapterTest/AdapterTest.cs
@@ -519,19 +519,19 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                                 DataTestUtility.AssertEqualsWithDescription(_c_guid_val, (Guid)param.Value, "FAILED: " + procName + ", UniqueIdentifier parameter");
                                 break;
                             case SqlDbType.DateTime:
-                                Assert.True(0 == DateTime.Compare((DateTime)param.Value, _c_datetime_val), "FAILED: " + procName + ", DateTime parameter");
+                                Assert.True(DateTime.Compare((DateTime)param.Value, _c_datetime_val) == 0, "FAILED: " + procName + ", DateTime parameter");
                                 break;
                             case SqlDbType.SmallDateTime:
-                                Assert.True(0 == DateTime.Compare((DateTime)param.Value, _c_smalldatetime_val), "FAILED: " + procName + ", SmallDateTime parameter");
+                                Assert.True(DateTime.Compare((DateTime)param.Value, _c_smalldatetime_val) == 0, "FAILED: " + procName + ", SmallDateTime parameter");
                                 break;
                             case SqlDbType.Money:
                                 Assert.True(
-                                    0 == decimal.Compare((decimal)param.Value, _c_money_val),
+                                    decimal.Compare((decimal)param.Value, _c_money_val) == 0,
                                     string.Format("FAILED: " + procName + ", Money parameter. Expected: {0}. Actual: {1}.", _c_money_val, (decimal)param.Value));
                                 break;
                             case SqlDbType.SmallMoney:
                                 Assert.True(
-                                    0 == decimal.Compare((decimal)param.Value, _c_smallmoney_val),
+                                    decimal.Compare((decimal)param.Value, _c_smallmoney_val) == 0,
                                     string.Format("FAILED: " + procName + ", SmallMoney parameter. Expected: {0}. Actual: {1}.", _c_smallmoney_val, (decimal)param.Value));
                                 break;
                             default:
@@ -599,7 +599,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     // check our ouput and return value params
                     Assert.True(VerifyOutputParams(cmd.Parameters), "FAILED: InputOutput parameter test with returned rows and bound return value!");
 
-                    Assert.True(1 == dataSet.Tables[0].Rows.Count, "FAILED:  Expected 1 row to be loaded in the dataSet!");
+                    Assert.True(dataSet.Tables[0].Rows.Count == 1, "FAILED:  Expected 1 row to be loaded in the dataSet!");
 
                     DataRow row = dataSet.Tables[0].Rows[0];
                     Assert.True((int)row["ShipperId"] == 2, "FAILED:  ShipperId column should be 2, not " + DBConvertToString(row["ShipperId"]));
@@ -631,10 +631,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     // verify the ouptut parameter
                     Assert.True(
                         ((int)cmd.Parameters[1].Value == 2000) &&
-                        (0 == string.Compare(cmd.Parameters[2].Value.ToString(), "Success!", false, CultureInfo.InvariantCulture)),
+                        string.Compare(cmd.Parameters[2].Value.ToString(), "Success!", false, CultureInfo.InvariantCulture) == 0,
                         "FAILED:  unbound return value case, output param is not correct!");
 
-                    Assert.True(1 == dataSet.Tables[0].Rows.Count, "FAILED:  Expected 1 row to be loaded in the dataSet!");
+                    Assert.True(dataSet.Tables[0].Rows.Count == 1, "FAILED:  Expected 1 row to be loaded in the dataSet!");
 
                     row = dataSet.Tables[0].Rows[0];
                     Assert.True((int)row["ShipperId"] == 1, "FAILED:  ShipperId column should be 1, not " + DBConvertToString(row["ShipperId"]));
@@ -1626,7 +1626,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             return
                 (int)sqlParameters[1].Value == 2000 &&
-                (0 == string.Compare((string)sqlParameters[2].Value, "Success!", false, CultureInfo.InvariantCulture)) &&
+                string.Compare((string)sqlParameters[2].Value, "Success!", false, CultureInfo.InvariantCulture) == 0 &&
                 (int)sqlParameters[3].Value == 42;
         }
 
@@ -1639,7 +1639,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private void WriteObject(StringBuilder textBuilder, object value, CultureInfo cultureInfo, Hashtable used, int indent, int recursionLimit)
         {
-            if (0 > --recursionLimit)
+            if (--recursionLimit < 0)
             {
                 return;
             }
@@ -1741,7 +1741,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     textBuilder.Append(valuetype.Name);
                     Array array = (Array)value;
 
-                    if (1 < array.Rank)
+                    if (array.Rank > 1)
                     {
                         textBuilder.Append("{");
                     }
@@ -1763,7 +1763,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         AppendNewLineIndent(textBuilder, indent);
                         textBuilder.Append("}");
                     }
-                    if (1 < array.Rank)
+                    if (array.Rank > 1)
                     {
                         textBuilder.Append('}');
                     }
@@ -1814,7 +1814,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         PropertyInfo[] properties = valuetype.GetProperties(BindingFlags.Instance | BindingFlags.Public);
 
                         bool hasinfo = false;
-                        if (fields != null && (0 < fields.Length))
+                        if (fields != null && fields.Length > 0)
                         {
                             textBuilder.Append(fullName);
                             fullName = null;
@@ -1832,7 +1832,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             }
                             hasinfo = true;
                         }
-                        if (properties != null && (0 < properties.Length))
+                        if (properties != null && properties.Length > 0)
                         {
                             if (fullName != null)
                             {
@@ -1847,7 +1847,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                                 if (property.CanRead)
                                 {
                                     ParameterInfo[] parameters = property.GetIndexParameters();
-                                    if (parameters == null || (0 == parameters.Length))
+                                    if (parameters == null || parameters.Length == 0)
                                     {
                                         AppendNewLineIndent(textBuilder, indent + 1);
                                         textBuilder.Append(property.Name);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static void ClearAllPoolsTest(string connectionString)
         {
             SqlConnection.ClearAllPools();
-            Assert.True(0 == ConnectionPoolWrapper.AllConnectionPools().Length, "Pools exist after clearing all pools");
+            Assert.True(ConnectionPoolWrapper.AllConnectionPools().Length == 0, "Pools exist after clearing all pools");
 
             using (SqlConnection connection = new SqlConnection(connectionString))
             {
@@ -135,7 +135,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 DataTestUtility.AssertEqualsWithDescription(1, pool.ConnectionCount, "Saved pool has incorrect number of connections");
 
                 SqlConnection.ClearAllPools();
-                Assert.True(0 == ConnectionPoolWrapper.AllConnectionPools().Length, "Pools exist after clearing all pools");
+                Assert.True(ConnectionPoolWrapper.AllConnectionPools().Length == 0, "Pools exist after clearing all pools");
                 DataTestUtility.AssertEqualsWithDescription(0, pool.ConnectionCount, "Saved pool has incorrect number of connections.");
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderStreamsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderStreamsTest.cs
@@ -613,7 +613,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 int index = 1;
                 xmlWriter.WriteStartElement("root");
-                while (buffer.Length / 2 < (packetSize * forcedPacketCount))
+                while (buffer.Length / 2 < packetSize * forcedPacketCount)
                 {
                     xmlWriter.WriteStartElement("block");
                     {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/StePermutationSet.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/StePermutationSet.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     }
                 }
 
-                if (0 < _position.Length)
+                if (_position.Length > 0)
                 {
                     _logicalPosition = LogicalPosition.BeforeElements;
                 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SteTypeBoundaries.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SteTypeBoundaries.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 {
                     result[i] = 0;
                 }
-                else if (3 == cycleStep)
+                else if (cycleStep == 3)
                 {
                     result[i] = (byte)cycleCount;
                 }
@@ -419,7 +419,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 // set up rowcount column
                 _rowCountColumn = new StePermutation();
-                if (0 <= _metaDataKeysOfInterest.IndexOf(SteAttributeKey.SqlDbType))
+                if (_metaDataKeysOfInterest.IndexOf(SteAttributeKey.SqlDbType) >= 0)
                 {
                     _rowCountColumn.Add(SteAttributeKey.SqlDbType, SqlDbType.Int);
                 }
@@ -519,7 +519,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     }
                 }
 
-                if (0 < _fieldEnumerators.Count)
+                if (_fieldEnumerators.Count > 0)
                 {
                     _logicalPosition = LogicalPosition.BeforeElements;
                     _completed = new bool[_fieldEnumerators.Count];
@@ -599,33 +599,33 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             private StePermutation CreateTopLevelPermutation(IList<StePermutation> fields)
             {
                 StePermutation perm = new();
-                if (0 <= _metaDataKeysOfInterest.IndexOf(SteAttributeKey.SqlDbType))
+                if (_metaDataKeysOfInterest.IndexOf(SteAttributeKey.SqlDbType) >= 0)
                 {
                     perm.Add(SteAttributeKey.SqlDbType, SqlDbType.Structured);
                 }
 
-                if (0 <= _metaDataKeysOfInterest.IndexOf(SteAttributeKey.MultiValued))
+                if (_metaDataKeysOfInterest.IndexOf(SteAttributeKey.MultiValued) >= 0)
                 {
                     perm.Add(SteAttributeKey.MultiValued, _isMultiValued);
                 }
 
-                if (0 <= _metaDataKeysOfInterest.IndexOf(SteAttributeKey.MaxLength))
+                if (_metaDataKeysOfInterest.IndexOf(SteAttributeKey.MaxLength) >= 0)
                 {
                     perm.Add(SteAttributeKey.MaxLength, -1);
                 }
 
-                if (0 <= _metaDataKeysOfInterest.IndexOf(SteAttributeKey.TypeName))
+                if (_metaDataKeysOfInterest.IndexOf(SteAttributeKey.TypeName) >= 0)
                 {
                     perm.Add(SteAttributeKey.TypeName, _typeNameBase + _typeNumber);
                     _typeNumber++;
                 }
 
-                if (0 <= _metaDataKeysOfInterest.IndexOf(SteAttributeKey.Fields))
+                if (_metaDataKeysOfInterest.IndexOf(SteAttributeKey.Fields) >= 0)
                 {
                     perm.Add(SteAttributeKey.Fields, fields);
                 }
 
-                if (0 <= _metaDataKeysOfInterest.IndexOf(SteAttributeKey.Value))
+                if (_metaDataKeysOfInterest.IndexOf(SteAttributeKey.Value) >= 0)
                 {
                     if (!UseSeparateValueList)
                     {
@@ -686,30 +686,30 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 {
                     foreach (SteAttributeKey columnKey in column.DefaultKeys)
                     {
-                        if (0 > result.IndexOf(columnKey))
+                        if (result.IndexOf(columnKey) < 0)
                         {
                             result.Add(columnKey);
                         }
                     }
                 }
 
-                if (0 > result.IndexOf(SteAttributeKey.SqlDbType))
+                if (result.IndexOf(SteAttributeKey.SqlDbType) < 0)
                 {
                     result.Add(SteAttributeKey.SqlDbType);
                 }
-                if (0 > result.IndexOf(SteAttributeKey.Value))
+                if (result.IndexOf(SteAttributeKey.Value) < 0)
                 {
                     result.Add(SteAttributeKey.Value);
                 }
-                if (0 > result.IndexOf(SteAttributeKey.MaxLength))
+                if (result.IndexOf(SteAttributeKey.MaxLength) < 0)
                 {
                     result.Add(SteAttributeKey.MaxLength);
                 }
-                if (0 > result.IndexOf(SteAttributeKey.TypeName))
+                if (result.IndexOf(SteAttributeKey.TypeName) < 0)
                 {
                     result.Add(SteAttributeKey.TypeName);
                 }
-                if (0 > result.IndexOf(SteAttributeKey.Fields))
+                if (result.IndexOf(SteAttributeKey.Fields) < 0)
                 {
                     result.Add(SteAttributeKey.Fields);
                 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
@@ -1290,7 +1290,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             foreach (object[] row in values)
             {
                 DataTable targetTable = null;
-                if (0 < dtList.Count)
+                if (dtList.Count > 0)
                 {
                     // shortcut for matching last table (most common scenario)
                     if (DoesRowMatchMetadata(row, dtList[dtList.Count - 1]))

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
@@ -264,7 +264,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             int readerRand = rand.NextIntInclusive(0, maxValueInclusive: 256);
             CommandBehavior readerBehavior = CommandBehavior.Default;
             if (readerRand % 10 == 0)
+            {
                 readerBehavior = CommandBehavior.SequentialAccess;
+            }
             try
             {
                 using (SqlDataReader reader = cmd.ExecuteReader(readerBehavior))

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/Bug903514.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/Bug903514.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             column.ColumnName = "col2";
             table.Columns.Add(column);
 
-            if (0 == timeout)
+            if (timeout == 0)
             {
                 for (int i = 0; i < 100; i++)
                 {
@@ -86,7 +86,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     }
                     catch (Exception e)
                     {
-                        Assert.True(e.Message.Contains("Timeout Expired") && 0 != timeout, "Unexpected exception: " + e);
+                        Assert.True(e.Message.Contains("Timeout Expired") && timeout != 0, "Unexpected exception: " + e);
                     }
                 }
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReader.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReader.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             }
                             Helpers.VerifyResults(dstConn, dstTable, 3, 5);
 
-                            Assert.True(0 < (long)stats["BytesReceived"], "BytesReceived is non-positive.");
-                            Assert.True(0 < (long)stats["BytesSent"], "BytesSent is non-positive.");
+                            Assert.True((long)stats["BytesReceived"] > 0, "BytesReceived is non-positive.");
+                            Assert.True((long)stats["BytesSent"] > 0, "BytesSent is non-positive.");
                             Assert.True((long)stats["ConnectionTime"] >= (long)stats["ExecutionTime"], "Connection Time is less than Execution Time.");
                             Assert.True((long)stats["ExecutionTime"] >= (long)stats["NetworkServerTime"], "Execution Time is less than Network Server Time.");
                             DataTestUtility.AssertEqualsWithDescription((long)0, (long)stats["UnpreparedExecs"], "Non-zero UnpreparedExecs value: " + (long)stats["UnpreparedExecs"]);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlNotificationTest/SqlNotificationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlNotificationTest/SqlNotificationTest.cs
@@ -334,7 +334,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 {
                     cmd.CommandText = stmt;
                     int tmp = cmd.ExecuteNonQuery();
-                    count = ((0 <= tmp) ? ((0 <= count) ? count + tmp : tmp) : count);
+                    count = tmp >= 0
+                        ? count >= 0 ? count + tmp : tmp
+                        : count;
                 }
             }
             return count;

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/DBFramework/TablePatterns.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/DBFramework/TablePatterns.cs
@@ -74,7 +74,9 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         internal static Table TableX25Columns(int count, DataTypes dt, string tableNamePrefix)
         {
             if (count % 25 != 0)
+            {
                 throw new System.ArgumentException($"Count {count} not a multiple of 25.");
+            }
 
             Table t = Table.Build(tableNamePrefix);
             int sets = count / 25, i = 0;


### PR DESCRIPTION
**Description**: In the latest in my series of code cleanup PRs to remove Yoda conditions, this PR flips conditions where `0 == x` to `x == 0`. This is also applied for >, >=, <, <=, and !=.

**AI Analysis**:
![image](https://github.com/user-attachments/assets/e27f9ede-f330-4b1b-8bd6-4027f1628b1a)

**Testing**: Again, if it builds and passes CI, I think it's safe.