### PR TITLE
Fix | Fix the issue with Socke.Connect in managed SNI

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
@@ -292,20 +292,14 @@ namespace Microsoft.Data.SqlClient.SNI
 
         internal static IPAddress[] GetDnsIpAddresses(string serverName, TimeoutTimer timeout)
         {
-            using (TrySNIEventScope.Create(nameof(SNICommon)))
+            IPAddress[] ipAddresses = GetDnsIpAddresses(serverName);
+
+            // We cannot timeout accurately in sync code above, so throe TimeoutException if we've now exceeded the timeout.
+            if (timeout.IsExpired)
             {
-                int remainingTimeout = timeout.MillisecondsRemainingInt;
-                SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNICommon), EventType.INFO,
-                                                          "Getting DNS host entries for serverName {0} within {1} milliseconds.",
-                                                          args0: serverName,
-                                                          args1: remainingTimeout);
-                using CancellationTokenSource cts = new CancellationTokenSource(remainingTimeout);
-                // using this overload to support netstandard
-                Task<IPAddress[]> task = Dns.GetHostAddressesAsync(serverName);
-                task.ConfigureAwait(false);
-                task.Wait(cts.Token);
-                return task.Result;
+                throw new TimeoutException();
             }
+            return ipAddresses;
         }
 
         internal static IPAddress[] GetDnsIpAddresses(string serverName)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNICommon.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Data.SqlClient.SNI
         {
             IPAddress[] ipAddresses = GetDnsIpAddresses(serverName);
 
-            // We cannot timeout accurately in sync code above, so throe TimeoutException if we've now exceeded the timeout.
+            // We cannot timeout accurately in sync code above, so throw TimeoutException if we've now exceeded the timeout.
             if (timeout.IsExpired)
             {
                 throw new TimeoutException();

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -426,33 +426,16 @@ namespace Microsoft.Data.SqlClient.SNI
                     bool isConnected;
                     try // catching SocketException with SocketErrorCode == WouldBlock to run Socket.Select
                     {
-                        if (isInfiniteTimeout)
+                        socket.Connect(ipAddress, port);
+                        if (!isInfiniteTimeout)
                         {
-                            socket.Connect(ipAddress, port);
-                        }
-                        else
-                        {
-                            if (timeout.IsExpired)
-                            {
-                                return null;
-                            }
-                            // Socket.Connect does not support infinite timeouts, so we use Task to simulate it
-                            Task socketConnectTask = new Task(() => socket.Connect(ipAddress, port));
-                            socketConnectTask.ConfigureAwait(false);
-                            socketConnectTask.Start();
-                            int remainingTimeout = timeout.MillisecondsRemainingInt;
-                            if (!socketConnectTask.Wait(remainingTimeout))
-                            {
-                                throw ADP.TimeoutException($"The socket couldn't connect during the expected {remainingTimeout} remaining time.");
-                            }
                             throw SQL.SocketDidNotThrow();
                         }
 
                         isConnected = true;
                     }
-                    catch (AggregateException aggregateException) when (!isInfiniteTimeout
-                                                                        && aggregateException.InnerException is SocketException socketException
-                                                                        && socketException.SocketErrorCode == SocketError.WouldBlock)
+                    catch (SocketException socketException) when (!isInfiniteTimeout && 
+                                                                  socketException.SocketErrorCode == SocketError.WouldBlock)
                     {
                         // https://github.com/dotnet/SqlClient/issues/826#issuecomment-736224118
                         // Socket.Select is used because it supports timeouts, while Socket.Connect does not
@@ -509,11 +492,11 @@ namespace Microsoft.Data.SqlClient.SNI
                         return socket;
                     }
                 }
-                catch (AggregateException aggregateException) when (aggregateException.InnerException is SocketException socketException)
+                catch (SocketException e)
                 {
-                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNITCPHandle), EventType.ERR, "THIS EXCEPTION IS BEING SWALLOWED: {0}", args0: socketException?.Message);
+                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNITCPHandle), EventType.ERR, "THIS EXCEPTION IS BEING SWALLOWED: {0}", args0: e?.Message);
                     SqlClientEventSource.Log.TryAdvancedTraceEvent(
-                        $"{nameof(SNITCPHandle)}.{nameof(Connect)}{EventType.ERR}THIS EXCEPTION IS BEING SWALLOWED: {socketException}");
+                        $"{nameof(SNITCPHandle)}.{nameof(Connect)}{EventType.ERR}THIS EXCEPTION IS BEING SWALLOWED: {e}");
                 }
                 finally
                 {


### PR DESCRIPTION
Fixes issue #2378 

PR #2098 improved the handling of timeouts, but there were a couple of asynchronous tasks in a synchronous flow that were intended to respect these timeouts. The change in `SNITCPHandle.Connect` introduced a regression. It seems that the entire asynchronous task is unnecessary. The socket is already set to non-blocking mode, so `Socket.Connect` will not block, and we are subsequently looping with `socket.Select` to check if the connection is established within the timeout period.

If the fix is approved and merged it will need to be backported to 5.2 servicing branch.