### PR TITLE
Fixed incorrect string format at event tracing when OutOfMemory exception thrown

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Data.SqlClient
             // will end the reliable try...
             if (e is OutOfMemoryException)
             {
-                SqlClientEventSource.Log.TryTraceEvent("<prov.DbConnectionHelper.Abort|RES|INFO|CPOOL> {0}, Aborting operation due to asynchronous exception: {'OutOfMemory'}", ObjectID);
+                SqlClientEventSource.Log.TryTraceEvent("<prov.DbConnectionHelper.Abort|RES|INFO|CPOOL> {0}, Aborting operation due to asynchronous exception: OutOfMemory", ObjectID);
             }
             else
             {


### PR DESCRIPTION
Due to incorrect string TryTraceEvent throws StringFormatException. I've remove redundant braces.  