### PR TITLE
CertificateTests are broken

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionTestWithSSLCert/CertificateTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionTestWithSSLCert/CertificateTest.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private static bool IsNotAzureServer() => DataTestUtility.IsNotAzureServer();
         private static bool UseManagedSNIOnWindows() => DataTestUtility.UseManagedSNIOnWindows;
 
+        [ActiveIssue("31754")]
         [ConditionalFact(nameof(AreConnStringsSetup), nameof(IsNotAzureServer), nameof(IsLocalHost))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void OpenningConnectionWithGoodCertificateTest()
@@ -121,6 +122,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         // Provided hostname in certificate are:
         // localhost, FQDN, Loopback IPv4: 127.0.0.1, IPv6: ::1
+        [ActiveIssue("31754")]
         [ConditionalFact(nameof(AreConnStringsSetup), nameof(IsNotAzureServer), nameof(IsLocalHost))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void OpeningConnectionWitHNICTest()
@@ -164,7 +166,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ActiveIssue("26934")]
+        [ActiveIssue("31754")]
         [ConditionalFact(nameof(AreConnStringsSetup), nameof(UseManagedSNIOnWindows), nameof(IsNotAzureServer), nameof(IsLocalHost))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void RemoteCertificateNameMismatchErrorTest()


### PR DESCRIPTION
OpeningConnectionWitHNICTest and OpenningConnectionWithGoodCertificateTest are both broken and fail if the TCPConnectionString doesn't include TrustServerCertificate=true. The tests are supposed to install a self-signed certificate to the localhost SQL Server instance and add it to the root cert store so that it is trusted by the system. But it doesn't work and needs to be fixed.

RemoteCertificateNameMismatchErrorTest was already flagged as an active issue (26934), but I can't find that issue number anywhere, so updating that number to include in the new issue I filed internally.