### PR TITLE
[5.2.2] | Fix ArgumentNullException on SqlDataRecord.GetValue when using Udt data type 

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
@@ -500,11 +500,7 @@ namespace Microsoft.Data.SqlClient.Server
                                             source.Scale,
                                             source.LocaleId,
                                             source.CompareOptions,
-#if NETFRAMEWORK
                                             source.Type,
-#else
-                                            null,
-#endif
                                             source.Name,
                                             typeSpecificNamePart1,
                                             typeSpecificNamePart2,

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -94,6 +94,8 @@
     <PackageReference Condition="$(ReferenceType.Contains('NetStandard'))" Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourceVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <Reference Condition="'$(TargetGroup)'=='netfx'" Include="System.Transactions" />
+    <PackageReference Condition="'$(TargetGroup)'=='netfx'" Include="Microsoft.SqlServer.Types" Version="$(MicrosoftSqlServerTypesVersion)" />
+    <PackageReference Condition="'$(TargetGroup)'=='netcoreapp'" Include="Microsoft.SqlServer.Types" Version="$(MicrosoftSqlServerTypesVersionNet)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <PackageReference Include="System.Data.Odbc" Version="$(SystemDataOdbcVersion)" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlDataRecordTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlDataRecordTest.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlTypes;
 using Microsoft.Data.SqlClient.Server;
+using Microsoft.SqlServer.Types;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.Tests
@@ -319,6 +320,19 @@ namespace Microsoft.Data.SqlClient.Tests
         }
 
         [Theory]
+        [ClassData(typeof(GetUdtTypeTestData))]
+        public void GetUdt_ReturnsValue(Type udtType, object value, string serverTypeName)
+        {
+            SqlMetaData[] metadata = new SqlMetaData[] { new SqlMetaData(nameof(udtType.Name), SqlDbType.Udt, udtType, serverTypeName) };
+
+            SqlDataRecord record = new SqlDataRecord(metadata);
+
+            record.SetValue(0, value);
+
+            Assert.Equal(value.ToString(), record.GetValue(0).ToString());
+        }
+
+        [Theory]
         [ClassData(typeof(GetXXXBadTypeTestData))]
         public void GetXXX_ThrowsIfBadType(Func<SqlDataRecord, object> getXXX)
         {
@@ -342,8 +356,8 @@ namespace Microsoft.Data.SqlClient.Tests
             };
             SqlDataRecord record = new SqlDataRecord(metaData);
             record.SetValue(0, value);
+            Assert.Equal(value, record.GetValue(0));
             Assert.Equal(value, getXXX(record));
-
         }
     }
 
@@ -369,6 +383,21 @@ namespace Microsoft.Data.SqlClient.Tests
         }
     }
 
+    public class GetUdtTypeTestData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { typeof(SqlGeography), SqlGeography.Point(43, -81, 4326), "Geography" };
+            yield return new object[] { typeof(SqlGeometry), SqlGeometry.Point(43, -81, 4326), "Geometry" };
+            yield return new object[] { typeof(SqlHierarchyId), SqlHierarchyId.Parse("/"), "HierarchyId" };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
     public class GetXXXCheckValueTestData : IEnumerable<object[]>
     {
         public IEnumerator<object[]> GetEnumerator()
@@ -383,6 +412,10 @@ namespace Microsoft.Data.SqlClient.Tests
             yield return new object[] { SqlDbType.DateTime, DateTime.Now, new Func<SqlDataRecord, object>(r => r.GetDateTime(0)) };
             yield return new object[] { SqlDbType.DateTimeOffset, new DateTimeOffset(DateTime.Now), new Func<SqlDataRecord, object>(r => r.GetDateTimeOffset(0)) };
             yield return new object[] { SqlDbType.Time, TimeSpan.FromHours(1), new Func<SqlDataRecord, object>(r => r.GetTimeSpan(0)) };
+            yield return new object[] { SqlDbType.Date, DateTime.Now.Date, new Func<SqlDataRecord, object>(r => r.GetDateTime(0)) };
+            yield return new object[] { SqlDbType.Bit, bool.Parse(bool.TrueString), new Func<SqlDataRecord, object>(r => r.GetBoolean(0)) };
+            yield return new object[] { SqlDbType.SmallDateTime, DateTime.Now, new Func<SqlDataRecord, object>(r => r.GetDateTime(0)) };
+            yield return new object[] { SqlDbType.TinyInt, (byte)1, new Func<SqlDataRecord, object>(r => r.GetByte(0)) };
         }
 
         IEnumerator IEnumerable.GetEnumerator()


### PR DESCRIPTION
Backports: https://github.com/dotnet/SqlClient/pull/2448