### PR TITLE
Inital part of #1108

### DIFF
--- a/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
@@ -64,6 +64,15 @@ jobs:
     parameters:
       NugetPackageVersion: $(NugetPackageVersion)
       configuration: $(Configuration)
+      nuspecPath: 'tools/specs/Microsoft.Data.SqlClient.Azure.nuspec'
+      OutputDirectory: $(packagePath)
+      generateSymbolsPackage: false
+      displayName: 'Generate NuGet package M.D.SqlClient.Azure'
+
+  - template: ../steps/generate-nuget-package-step.yml@self
+    parameters:
+      NugetPackageVersion: $(NugetPackageVersion)
+      configuration: $(Configuration)
       nuspecPath: 'tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec'
       OutputDirectory: $(packagePath)
       generateSymbolsPackage: false

--- a/tools/specs/Microsoft.Data.SqlClient.Azure.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.Azure.nuspec
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata minClientVersion="2.12">
+    <id>Microsoft.Data.SqlClient.Azure</id>
+    <version>$version$</version>
+    <title>Microsoft.Data.SqlClient.Azure</title>
+    <authors>Microsoft</authors>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://aka.ms/sqlclientproject</projectUrl>
+    <icon>dotnet.png</icon>
+    <readme>README.md</readme>
+    <repository type="git" url="https://github.com/dotnet/sqlclient" commit="$COMMITID$"/>
+    <description>The current data provider for Azure SQL databases and SQL Server. This has replaced System.Data.SqlClient. These classes provide access to SQL and encapsulate database-specific protocols, including tabular data stream (TDS).
+
+Commonly Used Types:
+Microsoft.Data.SqlClient.SqlConnection
+Microsoft.Data.SqlClient.SqlException
+Microsoft.Data.SqlClient.SqlParameter
+Microsoft.Data.SqlClient.SqlDataReader
+Microsoft.Data.SqlClient.SqlCommand
+Microsoft.Data.SqlClient.SqlTransaction
+Microsoft.Data.SqlClient.SqlParameterCollection
+Microsoft.Data.SqlClient.SqlClientFactory
+
+When using NuGet 3.x this package requires at least version 3.4.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?linkid=2090501</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <tags>sqlclient microsoft.data.sqlclient azure</tags>
+    <dependencies>
+      <dependency id="Microsoft.Data.SqlClient" version="[$version$]" />
+    </dependencies>
+  </metadata>
+
+  <files>
+    <file src="..\icons\dotnet.png" target="" />
+    <file src="..\..\README.md" target="" />
+  </files>
+
+</package>


### PR DESCRIPTION
Adds a new M.D.S.Azure package, that Azure SQL Database users can be guide to use going forward.

This package will in the future enable removal of Azure.Identity from the MDS package

Based on the proposal here: https://github.com/dotnet/SqlClient/issues/1108#issuecomment-2310793660

@edwardneal FYI

@DavoudEshtehari Unsure about the signing pipeline - might not be needed yet with this meta package?