### PR TITLE
Fix SqlDataReader.IsDBNull() for json

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -5825,6 +5825,10 @@ namespace Microsoft.Data.SqlClient
                     }
                     break;
 
+                case SqlDbTypeExtensions.Json:
+                    nullVal.SetToNullOfType(SqlBuffer.StorageType.Json);
+                    break;
+
                 default:
                     Debug.Fail("unknown null sqlType!" + md.type.ToString());
                     break;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6670,6 +6670,10 @@ namespace Microsoft.Data.SqlClient
                     }
                     break;
 
+                case SqlDbTypeExtensions.Json:
+                    nullVal.SetToNullOfType(SqlBuffer.StorageType.Json);
+                    break;
+
                 default:
                     Debug.Fail("unknown null sqlType!" + md.type.ToString());
                     break;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -61,6 +61,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        private void ValidateNullJson(SqlDataReader reader)
+        {
+            while (reader.Read())
+            {
+                bool IsNull = reader.IsDBNull(0);
+                _output.WriteLine(IsNull ? "null" : "not null");
+                Assert.True(IsNull);
+            }
+        }
+
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public void TestJsonWrite()
         {       
@@ -283,6 +293,41 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         await ValidateRowsAsync(reader2);
                         reader2.Close();
                     }
+                }
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
+        public void TestNullJson()
+        {
+            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
+
+            string tableCreate = "CREATE TABLE " + tableName + " (Data json)";
+            string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
+            string tableRead = "SELECT * FROM " + tableName;
+
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            {
+                connection.Open();
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    //Create Table
+                    command.CommandText = tableCreate;
+                    command.ExecuteNonQuery();
+
+                    //Insert Null value
+                    command.CommandText = tableInsert;
+                    var parameter = new SqlParameter("@jsonData", SqlDbTypeExtensions.Json);
+                    parameter.Value = DBNull.Value;
+                    command.Parameters.Add(parameter);
+                    command.ExecuteNonQuery();
+
+                    //Query the table
+                    command.CommandText = tableRead;
+                    var reader = command.ExecuteReader();
+
+                    ValidateNullJson(reader);
+                    reader.Close();
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -306,30 +306,28 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string tableRead = "SELECT * FROM " + tableName;
 
-            using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
-            {
-                connection.Open();
-                using (SqlCommand command = connection.CreateCommand())
-                {
-                    //Create Table
-                    command.CommandText = tableCreate;
-                    command.ExecuteNonQuery();
+            using SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString);
+            connection.Open();
+            using SqlCommand command = connection.CreateCommand();
 
-                    //Insert Null value
-                    command.CommandText = tableInsert;
-                    var parameter = new SqlParameter("@jsonData", SqlDbTypeExtensions.Json);
-                    parameter.Value = DBNull.Value;
-                    command.Parameters.Add(parameter);
-                    command.ExecuteNonQuery();
+            //Create Table
+            command.CommandText = tableCreate;
+            command.ExecuteNonQuery();
 
-                    //Query the table
-                    command.CommandText = tableRead;
-                    var reader = command.ExecuteReader();
+            //Insert Null value
+            command.CommandText = tableInsert;
+            var parameter = new SqlParameter("@jsonData", SqlDbTypeExtensions.Json);
+            parameter.Value = DBNull.Value;
+            command.Parameters.Add(parameter);
+            command.ExecuteNonQuery();
 
-                    ValidateNullJson(reader);
-                    reader.Close();
-                }
-            }
+            //Query the table
+            command.CommandText = tableRead;
+            var reader = command.ExecuteReader();
+            ValidateNullJson(reader);
+
+            reader.Close();
+            DataTestUtility.DropTable(connection, tableName);
         }
     }
 }


### PR DESCRIPTION
This PR aims to fix `SqlDataReader.IsDBNull()` API for json data type.
Currently, it returns false for a null json column. Adding the case for json type returns expected output.