### PR TITLE
Prevent connections to SQL 7.0 & 2000

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -4315,25 +4315,6 @@ namespace Microsoft.Data.SqlClient
             // information provided by S. Ashwin
             switch (majorMinor)
             {
-                case TdsEnums.SQL70OR2000_MAJOR << 24 | TdsEnums.DEFAULT_MINOR:    // 7.0 & 2000 RTM
-                    // note that 7.0 and 2000 can only be distinguished by the increment
-                    switch (increment)
-                    {
-                        case TdsEnums.SQL2000_INCREMENT:
-                            _is2000 = true;
-                            break;
-                        case TdsEnums.SQL70_INCREMENT:
-                            // no flag will be set
-                            break;
-                        default:
-                            throw SQL.InvalidTDSVersion();
-                    }
-                    break;
-                case TdsEnums.SQL2000SP1_MAJOR << 24 | TdsEnums.SQL2000SP1_MINOR: // 2000 SP1
-                    if (increment != TdsEnums.SQL2000SP1_INCREMENT)
-                    { throw SQL.InvalidTDSVersion(); }
-                    _is2000SP1 = true;
-                    break;
                 case TdsEnums.SQL2005_MAJOR << 24 | TdsEnums.SQL2005_RTM_MINOR:     // 2005
                     if (increment != TdsEnums.SQL2005_INCREMENT)
                     { throw SQL.InvalidTDSVersion(); }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/TestTdsServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/TestTdsServer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Engine = engine;
         }
 
-        public static TestTdsServer StartServerWithQueryEngine(QueryEngine engine, bool enableFedAuth = false, bool enableLog = false, int connectionTimeout = DefaultConnectionTimeout, bool excludeEncryption = false, [CallerMemberName] string methodName = "")
+        public static TestTdsServer StartServerWithQueryEngine(QueryEngine engine, bool enableFedAuth = false, bool enableLog = false, int connectionTimeout = DefaultConnectionTimeout, bool excludeEncryption = false, Version serverVersion = null, [CallerMemberName] string methodName = "")
         {
             TDSServerArguments args = new TDSServerArguments()
             {
@@ -39,6 +39,10 @@ namespace Microsoft.Data.SqlClient.Tests
             if (excludeEncryption)
             {
                 args.Encryption = SqlServer.TDS.PreLogin.TDSPreLoginTokenEncryptionType.None;
+            }
+            if (serverVersion != null)
+            {
+                args.ServerVersion = serverVersion;
             }
 
             TestTdsServer server = engine == null ? new TestTdsServer(args) : new TestTdsServer(engine, args);
@@ -57,9 +61,9 @@ namespace Microsoft.Data.SqlClient.Tests
             return server;
         }
 
-        public static TestTdsServer StartTestServer(bool enableFedAuth = false, bool enableLog = false, int connectionTimeout = DefaultConnectionTimeout, bool excludeEncryption = false, [CallerMemberName] string methodName = "")
+        public static TestTdsServer StartTestServer(bool enableFedAuth = false, bool enableLog = false, int connectionTimeout = DefaultConnectionTimeout, bool excludeEncryption = false, Version serverVersion = null, [CallerMemberName] string methodName = "")
         {
-            return StartServerWithQueryEngine(null, enableFedAuth, enableLog, connectionTimeout, excludeEncryption, methodName);
+            return StartServerWithQueryEngine(null, enableFedAuth, enableLog, connectionTimeout, excludeEncryption, serverVersion, methodName);
         }
 
         public void Dispose() => _endpoint?.Stop();

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDSVersion.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDSVersion.cs
@@ -12,6 +12,16 @@ namespace Microsoft.SqlServer.TDS
     public static class TDSVersion
     {
         /// <summary>
+        /// 7.0 (Sphinx) TDS version
+        /// </summary>
+        public static Version SqlServer7_0 = new Version(7, 0, 0, 0);
+
+        /// <summary>
+        /// 2000 (Shiloh) TDS version
+        /// </summary>
+        public static Version SqlServer2000 = new Version(7, 1, 0, 1);
+
+        /// <summary>
         /// 2005 (Yukon) TDS version
         /// </summary>
         public static Version SqlServer2005 = new Version(7, 2, 9, 2);
@@ -46,6 +56,14 @@ namespace Microsoft.SqlServer.TDS
             {
                 return SqlServer2005;
             }
+            else if (buildVersion.Major == 8)
+            {
+                return SqlServer2000;
+            }
+            else if (buildVersion.Major == 7)
+            {
+                return SqlServer7_0;
+            }
             else
             {
                 // Not supported TDS version
@@ -79,7 +97,7 @@ namespace Microsoft.SqlServer.TDS
         /// </summary>
         public static bool IsSupported(Version tdsVersion)
         {
-            return tdsVersion >= SqlServer2005 && tdsVersion <= SqlServer2012;
+            return tdsVersion >= SqlServer7_0 && tdsVersion <= SqlServer2012;
         }
     }
 }


### PR DESCRIPTION
This prevents connections from the .NET Framework build of Microsoft.Data.SqlClient to SQL Server 7.0 and SQL Server 2000 (RTM & SP1.) Doing so aligns the .NET Framework build with the .NET Core build on all OSes: the library will no longer be able to connect to any version of SQL Server prior to 2005.

I've also included a test to verify failed/successful connections to different simulated server versions.

There's a bit of SQL Server 2000-specific code in the .NET Framework project, and this hasn't been removed yet. Since this could be considered a breaking change, I'm aiming simply to implement the functional block for the v6 release, ready for the then-redundant paths to be removed later.