### PR TITLE
Fix | Improve async pattern in TCPHandle for ParallelConnect for MultiSubnetFailover scenarios

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -17,7 +17,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Common;
 using Microsoft.Data.ProviderBase;
-using Microsoft.Identity.Client;
 
 namespace Microsoft.Data.SqlClient.SNI
 {


### PR DESCRIPTION
This PR tries to address below:

1.  the fire-and-forget scenario in ParallelConnectHelper, as `async Task void` should be avoided in non-event-handler methods. We never see any exception that is thrown from here.
2. Additionally, it removes `if (!(connectTask.Wait(isInfiniteTimeOut ? -1 : timeout.MillisecondsRemainingInt)))`, which blocks the asynchronous pattern and may lead to deadlocks.

This might be a potential fix for issue #2400 

Any suggestion to make this better is appreciated.