### PR TITLE
XML Documentation Fixes - Batch 8

### DIFF
--- a/doc/snippets/Microsoft.Data.Sql/SqlDataSourceEnumerator.xml
+++ b/doc/snippets/Microsoft.Data.Sql/SqlDataSourceEnumerator.xml
@@ -1,65 +1,187 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SqlDataSourceEnumerator">
+﻿<docs>
+  <members name="SqlDataSourceEnumerator">
     <SqlDataSourceEnumerator>
-    <summary>Provides a mechanism for enumerating all available instances of SQL Server within the local network.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-SQL Server makes it possible for applications to determine the existence of its instances within the current network. The <xref:Microsoft.Data.Sql.SqlDataSourceEnumerator> class exposes this information to the application developer, providing a <xref:System.Data.DataTable> containing information about all the available servers. This returned table contains a list of server instances that matches the list provided when a user attempts to create a new connection, and on the `Connection Properties` dialog box, expands the drop-down list containing all the available servers.  
-
- ]]></format>
-    </remarks>
-    <related type="Article" href="/dotnet/framework/data/adonet/sql/enumerating-instances-of-sql-server">Enumerating Instances of SQL Server</related>
-  </SqlDataSourceEnumerator>
-   <GetDataSources>
-        <summary>Retrieves a <see cref="T:System.Data.DataTable" /> containing information about all visible SQL Server instances.</summary>
-        <returns>A <see cref="T:System.Data.DataTable" /> containing information about the visible SQL Server instances.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-The table returned by this method contains the following columns, all of which contain strings:  
-
-|Column|Description|  
-|------------|-----------------|  
-|**ServerName**|Name of the server.|  
-|**InstanceName**|Name of the server instance. Blank if the server is running as the default instance.|  
-|**IsClustered**|Indicates whether the server is part of a cluster.|  
-|**Version**|Version of the server:<br /><br />10.0.xx for SQL Server 2008<br />10.50.x for SQL Server 2008 R2<br />11.0.xx for SQL Server 2012<br />12.0.xx for SQL Server 2014<br />13.0.xx for SQL Server 2016<br />14.0.xx for SQL Server 2017|  
-  
-> [!NOTE]
-> Due to the nature of the mechanism used by <xref:Microsoft.Data.Sql.SqlDataSourceEnumerator> to locate data sources on a network, the method will not always return a complete list of the available servers, and the list might not be the same on every call. If you plan to use this function to let users select a server from a list, make sure that you always also supply an option to type in a name that is not in the list, in case the server enumeration does not return all the available servers. In addition, this method may take a significant amount of time to execute, so be careful about calling it when performance is critical.  
-
-## Examples  
- The following console application retrieves information about all the visible SQL Server instances and displays the information in the console window.  
-  
-[!code-csharp[SqlDataSourceEnumerator.Example#1](~/../sqlclient/doc/samples/SqlDataSourceEnumeratorExample.cs#1)]
-  
- ]]></format>
-        </remarks>
-        <related type="Article" href="/dotnet/framework/data/adonet/sql/enumerating-instances-of-sql-server">Enumerating Instances of SQL Server</related>
-      </GetDataSources>
+      <summary>
+        Provides a mechanism for enumerating all available instances of SQL Server within the local network.
+      </summary>
+      <remarks>
+        SQL Server makes it possible for applications to determine the existence of its instances within the current network. The <see cref="T:Microsoft.Data.Sql.SqlDataSourceEnumerator" /> class exposes this information to the application developer, providing a <see cref="T:System.Data.DataTable" /> containing information about all the available servers. This returned table contains a list of server instances that matches the list provided when a user attempts to create a new connection, and on the <c>Connection Properties</c> dialog box, expands the drop-down list containing all the available servers.
+      </remarks>
+      <seealso href="/dotnet/framework/data/adonet/sql/enumerating-instances-of-sql-server">
+        Enumerating Instances of SQL Server
+      </seealso>
+    </SqlDataSourceEnumerator>
+    <GetDataSources>
+      <summary>
+        Retrieves a <see cref="T:System.Data.DataTable" /> containing information about all visible SQL Server instances.
+      </summary>
+      <returns>
+        A <see cref="T:System.Data.DataTable" /> containing information about the visible SQL Server instances.
+      </returns>
+      <remarks>
+        <para>
+          The table returned by this method contains the following columns, all of which contain strings:
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>Column</term>
+              <description>Description</description>
+            </listheader>
+            <item>
+              <term><b>ServerName</b></term>
+              <description>Name of the server.</description>
+            </item>
+            <item>
+              <term><b>InstanceName</b></term>
+              <description>Name of the server instance. Blank if the server is running as the default instance.</description>
+            </item>
+            <item>
+              <term><b>IsClustered</b></term>
+              <description>Indicates whether the server is part of a cluster.</description>
+            </item>
+            <item>
+              <term><b>Version</b></term>
+              <description>
+                Version of the server:
+                <list type="bullet">
+                  <item>10.0.xx for SQL Server 2008</item>
+                  <item>10.50.x for SQL Server 2008 R2</item>
+                  <item>11.0.xx for SQL Server 2012 </item>
+                  <item>12.0.xx for SQL Server 2014</item>
+                  <item>13.0.xx for SQL Server 2016</item>
+                  <item>14.0.xx for SQL Server 2017</item>
+                </list>
+              </description>
+            </item>
+          </list>
+          <note type="note">
+            Due to the nature of the mechanism used by <see cref="T:Microsoft.Data.Sql.SqlDataSourceEnumerator" /> to locate data sources on a network, the method will not always return a complete list of the available servers, and the list might not be the same on every call. If you plan to use this function to let users select a server from a list, make sure that you always also supply an option to type in a name that is not in the list, in case the server enumeration does not return all the available servers. In addition, this method may take a significant amount of time to execute, so be careful about calling it when performance is critical.
+          </note>
+        </para>
+      </remarks>
+      <example>
+        <para>
+          The following console application retrieves information about all the visible SQL Server instances and displays the information in the console window.
+        </para>
+        <!-- SqlDataSourceEnumeratorExample -->
+        <code language="c#">
+          using System;
+          using Microsoft.Data.Sql;  
+            
+          class Program  
+          {  
+            static void Main()  
+            {  
+              // Retrieve the enumerator instance and then the data.  
+              SqlDataSourceEnumerator instance = SqlDataSourceEnumerator.Instance;  
+              System.Data.DataTable table = instance.GetDataSources();  
+            
+              // Display the contents of the table.  
+              DisplayData(table);  
+            
+              Console.WriteLine("Press any key to continue.");  
+              Console.ReadKey();  
+            }  
+            
+            private static void DisplayData(System.Data.DataTable table)  
+            {  
+              foreach (System.Data.DataRow row in table.Rows)  
+              {
+                foreach (System.Data.DataColumn col in table.Columns)  
+                {
+                  Console.WriteLine("{0} = {1}", col.ColumnName, row[col]);  
+                }  
+                Console.WriteLine("============================");  
+              }  
+            }  
+          } 
+        </code>
+      </example>
+      <seealso href="/dotnet/framework/data/adonet/sql/enumerating-instances-of-sql-server">
+        Enumerating Instances of SQL Server
+      </seealso>
+    </GetDataSources>
     <Instance>
-        <summary>Gets an instance of the <see cref="T:Microsoft.Data.Sql.SqlDataSourceEnumerator"/>, which can be used to retrieve information about available SQL Server instances.</summary>
-        <value>An instance of the <see cref="T:Microsoft.Data.Sql.SqlDataSourceEnumerator"/> used to retrieve information about available SQL Server instances.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-The <xref:Microsoft.Data.Sql.SqlDataSourceEnumerator> class does not provide a constructor. Use the <xref:Microsoft.Data.Sql.SqlDataSourceEnumerator.Instance%2A> property to retrieve an instance of the class instead.  
-
-[!code-csharp[SqlDataSourceEnumeratorExample#1](~/../sqlclient/doc/samples/SqlDataSourceEnumeratorExample.cs#1)]
-
-## Examples  
-The following console application displays a list of all the available SQL Server 2005 instances within the local network. This code uses the <xref:System.Data.DataTable.Select%2A> method to filter the rows in the table returned by the <xref:Microsoft.Data.Sql.SqlDataSourceEnumerator.GetDataSources%2A> method.  
- [!code-csharp[SqlDataSourceEnumeratorVersionExample#1](~/../sqlclient/doc/samples/SqlDataSourceEnumeratorVersionExample.cs#1)]
-
- ]]></format>
-        </remarks>
-        <related type="Article" href="/dotnet/framework/data/adonet/sql/enumerating-instances-of-sql-server">Enumerating Instances of SQL Server</related>
-    
+      <summary>
+        Gets an instance of the <see cref="T:Microsoft.Data.Sql.SqlDataSourceEnumerator" /> , which can be used to retrieve information about available SQL Server instances.
+      </summary>
+      <value>
+        An instance of the <see cref="T:Microsoft.Data.Sql.SqlDataSourceEnumerator" /> used to retrieve information about available SQL Server instances.
+      </value>
+      <remarks>
+        <para>
+          The <see cref="T:Microsoft.Data.Sql.SqlDataSourceEnumerator" /> class does not provide a constructor. Use the <see cref="P:Microsoft.Data.Sql.SqlDataSourceEnumerator.Instance" /> property to retrieve an instance of the class instead.
+        </para>
+        <!-- SqlDataSourceEnumeratorExample -->
+        <code language="c#">
+          using System;
+          using Microsoft.Data.Sql;  
+            
+          class Program  
+          {  
+            static void Main()  
+            {  
+              // Retrieve the enumerator instance and then the data.  
+              SqlDataSourceEnumerator instance =  
+                SqlDataSourceEnumerator.Instance;  
+              System.Data.DataTable table = instance.GetDataSources();  
+            
+              // Display the contents of the table.  
+              DisplayData(table);  
+            
+              Console.WriteLine("Press any key to continue.");  
+              Console.ReadKey();  
+            }  
+            
+            private static void DisplayData(System.Data.DataTable table)  
+            {  
+              foreach (System.Data.DataRow row in table.Rows)  
+              {  
+                foreach (System.Data.DataColumn col in table.Columns)  
+                {  
+                  Console.WriteLine("{0} = {1}", col.ColumnName, row[col]);  
+                }  
+                Console.WriteLine("============================");  
+              }  
+            }  
+          } 
+        </code>
+      </remarks>
+      <example>
+        <para>
+          The following console application displays a list of all the available SQL Server 2005 instances within the local network. This code uses the <see cref="M:System.Data.DataTable.Select" /> method to filter the rows in the table returned by the <see cref="M:Microsoft.Data.Sql.SqlDataSourceEnumerator.GetDataSources" /> method.
+        </para>
+        <!-- SqlDataSourceEnumeratorVersionExample -->
+        <code language="c#">
+          using System;
+          using Microsoft.Data.Sql;  
+            
+          class Program  
+          {  
+            static void Main()  
+            {  
+              // Retrieve the enumerator instance, and  
+              // then retrieve the data sources.  
+              SqlDataSourceEnumerator instance = SqlDataSourceEnumerator.Instance;  
+              System.Data.DataTable table = instance.GetDataSources();  
+            
+              // Filter the sources to just show SQL Server 2012 instances.  
+              System.Data.DataRow[] rows = table.Select("Version LIKE '11%'");  
+              foreach (System.Data.DataRow row in rows)  
+              {  
+                Console.WriteLine(row["ServerName"]);  
+              }
+              
+              Console.WriteLine("Press any key to continue.");  
+              Console.ReadKey();  
+            }  
+          } 
+        </code>
+      </example>
+      <seealso href="/dotnet/framework/data/adonet/sql/enumerating-instances-of-sql-server">
+        Enumerating Instances of SQL Server
+      </seealso>
     </Instance>
-    </members>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.Sql/SqlNotificationRequest.xml
+++ b/doc/snippets/Microsoft.Data.Sql/SqlNotificationRequest.xml
@@ -42,7 +42,7 @@
         The value of the <paramref name="options" /> parameter is <see langword="null" />.
       </exception>
       <exception cref="T:System.ArgumentOutOfRangeException">
-        The <paramref name="options" /> or <paramref name="userData" /> parameter is longer than <see cref="P:System.Uint16.MaxValue" /> or the value in the <paramref name="timeout" /> parameter is less than zero.
+        The <paramref name="options" /> or <paramref name="userData" /> parameter is longer than <see cref="F:System.UInt16.MaxValue" /> or the value in the <paramref name="timeout" /> parameter is less than zero.
       </exception>
       <seealso href="/sql/connect/ado-net/sql/query-notifications-sql-server">
         Using Query Notifications
@@ -76,7 +76,7 @@
         The value is <see langword="null" />.
       </exception>
       <exception cref="T:System.ArgumentException">
-        The value is longer than <see cref="P:System.Uint16.MaxValue" />.
+        The value is longer than <see cref="F:System.UInt16.MaxValue" />.
       </exception>
       <seealso href="/sql/connect/ado-net/sql/query-notifications-sql-server">
         Using Query Notifications
@@ -110,7 +110,7 @@
         This value is not used by the notifications infrastructure. Instead, it is a mechanism that allows an application to associate notifications with application state. The value specified in the <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.UserData" /> property is included in the SQL Server 2005 queue message.
       </remarks>
       <exception cref="T:System.ArgumentException">
-        The value is longer than <see cref="P:System.Uint16.MaxValue" />.
+        The value is longer than <see cref="F:System.UInt16.MaxValue" />.
       </exception>
       <seealso href="/sql/connect/ado-net/sql/query-notifications-sql-server">
         Using Query Notifications

--- a/doc/snippets/Microsoft.Data.Sql/SqlNotificationRequest.xml
+++ b/doc/snippets/Microsoft.Data.Sql/SqlNotificationRequest.xml
@@ -1,98 +1,120 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SqlNotificationRequest">
-        <SqlNotificationRequest>
-            <summary>Represents a request for notification for a given command.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-This class provides low-level access to the query notification services exposed by SQL Server 2005. For most applications the <xref:Microsoft.Data.SqlClient.SqlDependency> class provides a simpler way of using query notifications. However, if you need fine control over when notifications occur, or you need to customize the message data returned as part of a notification, the <xref:Microsoft.Data.Sql.SqlNotificationRequest> class is the one to use.  
-
-]]></format>
-            </remarks>
-            <related type="Article" href="/sql/connect/ado-net/sql/query-notifications-sql-server">Using Query Notifications</related>
-        </SqlNotificationRequest>
-        <ctor1>
-            <summary>Creates a new instance of the <see cref="T:Microsoft.Data.Sql.SqlNotificationRequest" /> class with default values.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-If the parameterless constructor is used to create a <xref:Microsoft.Data.Sql.SqlNotificationRequest> object, that instance must have its <xref:Microsoft.Data.Sql.SqlNotificationRequest.UserData%2A> and <xref:Microsoft.Data.Sql.SqlNotificationRequest.Options%2A> properties initialized before assigning the object to a <xref:Microsoft.Data.SqlClient.SqlCommand> object's <xref:Microsoft.Data.SqlClient.SqlCommand.Notification%2A> property. The default values used by the constructor are NULL (`Nothing` in Visual Basic) for the <xref:Microsoft.Data.Sql.SqlNotificationRequest.UserData%2A>, an empty string for the <xref:Microsoft.Data.Sql.SqlNotificationRequest.Options%2A>, and zero for the <xref:Microsoft.Data.Sql.SqlNotificationRequest.Timeout%2A>.  
-
-]]></format>
-            </remarks>
-            <related type="Article" href="/sql/connect/ado-net/sql/query-notifications-sql-server">Using Query Notifications</related>
-        </ctor1>
-        <ctor2>
-            <param name="userData">A string that contains an application-specific identifier for this notification. It is not used by the notifications infrastructure, but it allows you to associate notifications with the application state. The value indicated in this parameter is included in the Service Broker queue message.</param>
-            <param name="options">A string that contains the Service Broker service name where notification messages are posted, and it must include a database name or a Service Broker instance GUID that restricts the scope of the service name lookup to a particular database. For more information about the format of the <paramref name="options" /> parameter, see <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.Options" />.</param>
-            <param name="timeout">The time, in seconds, to wait for a notification message.</param>
-            <summary>Creates a new instance of the <see cref="T:Microsoft.Data.Sql.SqlNotificationRequest" /> class with a user-defined string that identifies a particular notification request, the name of a predefined SQL Server 2005 Service Broker service name, and the time-out period, measured in seconds.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-This constructor allows you to initialize a new <xref:Microsoft.Data.Sql.SqlNotificationRequest> instance, providing your own identifier, the SQL Server 2005 Service Broker service name, and a time-out value.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">The value of the <paramref name="options" /> parameter is NULL.</exception>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="options" /> or <paramref name="userData" /> parameter is longer than <see langword="uint16.MaxValue" /> or the value in the <paramref name="timeout" /> parameter is less than zero.</exception>
-            <related type="Article" href="/sql/connect/ado-net/sql/query-notifications-sql-server">Using Query Notifications</related>
-        </ctor2>
-        <Options>
-            <summary>Gets or sets the SQL Server Service Broker service name where notification messages are posted.</summary>
-            <value>
-            <see langword="string" /> that contains the SQL Server 2005 Service Broker service name where notification messages are posted and the database or service broker instance GUID to scope the server name lookup.</value>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-    
-## Remarks  
-The value of the <xref:Microsoft.Data.Sql.SqlNotificationRequest.Options%2A> property has the following format:  
-
-`service=<service-name>{;(local database=<database>|broker instance=<broker instance>)}`  
-
-For example, if you use the service "myservice" in the database "AdventureWorks" the format is:  
-
-`service=myservice;local database=AdventureWorks`  
-
-The SQL Server Service Broker service must be previously configured on the server. In addition, a Service Broker service and queue must be defined and security access granted as needed. See the SQL Server 2005 documentation for more information.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">The value is NULL.</exception>
-            <exception cref="T:System.ArgumentException">The value is longer than <see langword="uint16.MaxValue" />.</exception>
-            <related type="Article" href="/sql/connect/ado-net/sql/query-notifications-sql-server">Using Query Notifications</related>
-        </Options>
-        <Timeout>
-            <summary>Gets or sets a value that specifies how long SQL Server waits for a change to occur before the operation times out.</summary>
-            <value>A signed integer value that specifies, in seconds, how long SQL Server waits for a change to occur before the operation times out.</value>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-After the time-out period expires, the notification is sent even if no change takes place. The <xref:Microsoft.Data.Sql.SqlNotificationRequest.Timeout%2A> property defaults to the value set on the server.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The value is less than zero.</exception>
-            <related type="Article" href="/sql/connect/ado-net/sql/query-notifications-sql-server">Using Query Notifications</related>
-        </Timeout>
-        <UserData>    
-            <summary>Gets or sets an application-specific identifier for this notification.</summary>
-            <value>A <see langword="string" /> value of the application-specific identifier for this notification.</value>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-    
-## Remarks  
-This value is not used by the notifications infrastructure. Instead, it is a mechanism that allows an application to associate notifications with application state. The value specified in the <xref:Microsoft.Data.Sql.SqlNotificationRequest.UserData%2A> property is included in the SQL Server 2005 queue message.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentException">The value is longer than <see langword="uint16.MaxValue" />.</exception>
-            <related type="Article" href="/sql/connect/ado-net/sql/query-notifications-sql-server">Using Query Notifications</related>
-        </UserData>
-    </members>
+﻿<docs>
+  <members name="SqlNotificationRequest">
+    <SqlNotificationRequest>
+      <summary>
+        Represents a request for notification for a given command.
+      </summary>
+      <remarks>
+        This class provides low-level access to the query notification services exposed by SQL Server 2005. For most applications the <see cref="T:Microsoft.Data.SqlClient.SqlDependency" /> class provides a simpler way of using query notifications. However, if you need fine control over when notifications occur, or you need to customize the message data returned as part of a notification, the <see cref="T:Microsoft.Data.Sql.SqlNotificationRequest" /> class is the one to use.
+      </remarks>
+      <seealso href="/sql/connect/ado-net/sql/query-notifications-sql-server">
+        Using Query Notifications
+      </seealso>
+    </SqlNotificationRequest>
+    <ctor1>
+      <summary>
+        Creates a new instance of the <see cref="T:Microsoft.Data.Sql.SqlNotificationRequest" /> class with default values.
+      </summary>
+      <remarks>
+        If the parameterless constructor is used to create a <see cref="T:Microsoft.Data.Sql.SqlNotificationRequest" /> object, that instance must have its <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.UserData" /> and <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.Options" /> properties initialized before assigning the object to a <see cref="T:Microsoft.Data.SqlClient.SqlCommand" /> object's <see cref="P:Microsoft.Data.SqlClient.SqlCommand.Notification" /> property. The default values used by the constructor are <see langword="null" /> (<c>Nothing</c> in Visual Basic) for the <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.UserData" />, an empty string for the <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.Options" />, and zero for the <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.Timeout" />.
+      </remarks>
+      <seealso href="/sql/connect/ado-net/sql/query-notifications-sql-server">
+        Using Query Notifications
+      </seealso>
+    </ctor1>
+    <ctor2>
+      <param name="userData">
+        A string that contains an application-specific identifier for this notification. It is not used by the notifications infrastructure, but it allows you to associate notifications with the application state. The value indicated in this parameter is included in the Service Broker queue message.
+      </param>
+      <param name="options">
+        A string that contains the Service Broker service name where notification messages are posted, and it must include a database name or a Service Broker instance GUID that restricts the scope of the service name lookup to a particular database. For more information about the format of the <paramref name="options" /> parameter, see <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.Options" />.
+      </param>
+      <param name="timeout">
+        The time, in seconds, to wait for a notification message.
+      </param>
+      <summary>
+        Creates a new instance of the <see cref="T:Microsoft.Data.Sql.SqlNotificationRequest" /> class with a user-defined string that identifies a particular notification request, the name of a predefined SQL Server 2005 Service Broker service name, and the time-out period, measured in seconds.
+      </summary>
+      <remarks>
+        This constructor allows you to initialize a new <see cref="T:Microsoft.Data.Sql.SqlNotificationRequest" /> instance, providing your own identifier, the SQL Server 2005 Service Broker service name, and a time-out value.
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        The value of the <paramref name="options" /> parameter is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="options" /> or <paramref name="userData" /> parameter is longer than <see cref="P:System.Uint16.MaxValue" /> or the value in the <paramref name="timeout" /> parameter is less than zero.
+      </exception>
+      <seealso href="/sql/connect/ado-net/sql/query-notifications-sql-server">
+        Using Query Notifications
+      </seealso>
+    </ctor2>
+    <Options>
+      <summary>
+        Gets or sets the SQL Server Service Broker service name where notification messages are posted.
+      </summary>
+      <value>
+        <see cref="T:System.String" /> that contains the SQL Server 2005 Service Broker service name where notification messages are posted and the database or service broker instance GUID to scope the server name lookup.
+      </value>
+      <remarks>
+        <para>
+          The value of the <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.Options" /> property has the following format:
+        </para>
+        <code>
+          service=&lt;service-name&gt;{;(local database=&lt;database&gt;|broker instance=&lt;broker instance&gt;)}
+        </code>
+        <para>
+          For example, if you use the service "myservice" in the database "AdventureWorks" the format is:
+        </para>
+        <code>
+          service=myservice;local database=AdventureWorks
+        </code>
+        <para>
+          The SQL Server Service Broker service must be previously configured on the server. In addition, a Service Broker service and queue must be defined and security access granted as needed. See the SQL Server 2005 documentation for more information.
+        </para>
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        The value is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.ArgumentException">
+        The value is longer than <see cref="P:System.Uint16.MaxValue" />.
+      </exception>
+      <seealso href="/sql/connect/ado-net/sql/query-notifications-sql-server">
+        Using Query Notifications
+      </seealso>
+    </Options>
+    <Timeout>
+      <summary>
+        Gets or sets a value that specifies how long SQL Server waits for a change to occur before the operation times out.
+      </summary>
+      <value>
+        A signed integer value that specifies, in seconds, how long SQL Server waits for a change to occur before the operation times out.
+      </value>
+      <remarks>
+        After the time-out period expires, the notification is sent even if no change takes place. The <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.Timeout" /> property defaults to the value set on the server.
+      </remarks>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The value is less than zero.
+      </exception>
+      <seealso href="/sql/connect/ado-net/sql/query-notifications-sql-server">
+        Using Query Notifications
+      </seealso>
+    </Timeout>
+    <UserData>
+      <summary>
+        Gets or sets an application-specific identifier for this notification.
+      </summary>
+      <value>
+        A <see cref="T:System.String" /> value of the application-specific identifier for this notification.
+      </value>
+      <remarks>
+        This value is not used by the notifications infrastructure. Instead, it is a mechanism that allows an application to associate notifications with application state. The value specified in the <see cref="P:Microsoft.Data.Sql.SqlNotificationRequest.UserData" /> property is included in the SQL Server 2005 queue message.
+      </remarks>
+      <exception cref="T:System.ArgumentException">
+        The value is longer than <see cref="P:System.Uint16.MaxValue" />.
+      </exception>
+      <seealso href="/sql/connect/ado-net/sql/query-notifications-sql-server">
+        Using Query Notifications
+      </seealso>
+    </UserData>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/ColumnSensitivity.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/ColumnSensitivity.xml
@@ -1,16 +1,25 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="ColumnSensitivity">
-        <ColumnSensitivity>
-            <summary>Represents the Data Classification Sensitivity Information for columns as configured in Database.</summary>
-        </ColumnSensitivity>
-        <ctor>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity" /> class.</summary>
-            <param name="sensitivityProperties">List of sensitivity properties.</param>
-        </ctor>
-        <GetSensitivityProperties>
-            <summary>Returns the list of sensitivity properties as received from Server for this 'ColumnSensitivity' information</summary>
-            <value>List of sensitivity properties.</value>
-        </GetSensitivityProperties>
-    </members>
+﻿<docs>
+  <members name="ColumnSensitivity">
+    <ColumnSensitivity>
+      <summary>
+        Represents the Data Classification Sensitivity Information for columns as configured in Database.
+      </summary>
+    </ColumnSensitivity>
+    <ctor>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity" /> class.
+      </summary>
+      <param name="sensitivityProperties">
+        List of sensitivity properties.
+      </param>
+    </ctor>
+    <GetSensitivityProperties>
+      <summary>
+        Returns the list of sensitivity properties as received from Server for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.ColumnSensitivity" /> information.
+      </summary>
+      <value>
+        List of sensitivity properties.
+      </value>
+    </GetSensitivityProperties>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/InformationType.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/InformationType.xml
@@ -1,21 +1,36 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="InformationType">
-        <InformationType>
-            <summary>Represents the Data Classification Information Types as received from SQL Server for the active 'SqlDataReader'</summary>
-        </InformationType>
-        <ctor>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.InformationType" /> class.</summary>
-          <param name="name">Name of Information Type.</param>
-          <param name="id">ID of Information Type.</param>
-        </ctor>
-        <Id>
-            <summary>Gets the ID for this 'InformationType' object</summary>
-            <value>ID of Information Type.</value>
-        </Id>
-        <Name>
-            <summary>Gets the name for this 'InformationType' object</summary>
-            <value>Name of Information Type.</value>
-        </Name>
-    </members>
+﻿<docs>
+  <members name="InformationType">
+    <InformationType>
+      <summary>
+        Represents the Data Classification Information Types as received from SQL Server for the active <see cref="T:Microsoft.Data.SqlClient.DataClassification.InformationType" />
+      </summary>
+    </InformationType>
+    <ctor>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.InformationType" /> class.
+      </summary>
+      <param name="name">
+        Name of Information Type.
+      </param>
+      <param name="id">
+        ID of Information Type.
+      </param>
+    </ctor>
+    <Id>
+      <summary>
+        Gets the ID for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.InformationType" /> object
+      </summary>
+      <value>
+        ID of Information Type.
+      </value>
+    </Id>
+    <Name>
+      <summary>
+        Gets the name for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.InformationType" /> object
+      </summary>
+      <value>
+        Name of Information Type.
+      </value>
+    </Name>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/Label.xml
@@ -1,21 +1,36 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="Label">
-        <Label>
-            <summary>Represents the Data Classification Labels as received from SQL Server for the active 'SqlDataReader'</summary>
-        </Label>
-        <ctor>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.Label" /> class.</summary>
-            <param name="name">Name of label.</param>
-            <param name="id">ID of label.</param>
-        </ctor>
-        <Id>
-            <summary>Gets the ID for this 'Label' object</summary>
-            <value>ID of label.</value>
-        </Id>
-        <Name>
-            <summary>Gets the name for this 'Label' object</summary>
-            <value>Name of label.</value>
-        </Name>
-    </members>
+﻿<docs>
+  <members name="Label">
+    <Label>
+      <summary>
+        Represents the Data Classification Labels as received from SQL Server for the active <see cref="T:Microsoft.Data.SqlClient.DataClassification.InformationType" />
+      </summary>
+    </Label>
+    <ctor>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.Label" /> class.
+      </summary>
+      <param name="name">
+        Name of label.
+      </param>
+      <param name="id">
+        ID of label.
+      </param>
+    </ctor>
+    <Id>
+      <summary>
+        Gets the ID for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.Label" /> object
+      </summary>
+      <value>
+        ID of label.
+      </value>
+    </Id>
+    <Name>
+      <summary>
+        Gets the name for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.Label" /> object
+      </summary>
+      <value>
+        Name of label.
+      </value>
+    </Name>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml
@@ -31,7 +31,7 @@
     </Labels>
     <SensitivityRank>
       <summary>
-        Returns the relative sensitivity rank for the query associated with the active 'SqlDataReader'.
+        Returns the relative sensitivity rank for the query associated with the active <see cref="T:Microsoft.Data.SqlClient.SqlDataReader" />.
       </summary>
       <value>
         Relative sensitivity ranking for this query.

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityClassification.xml
@@ -1,49 +1,93 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SensitivityClassification">
-        <SensitivityClassification>
-            <summary>Provides the functionlity to retrieve Sensitivity Classification data as received from SQL Server for the active 'SqlDataReader'</summary>
-        </SensitivityClassification>
-        <ColumnSensitivities>
-            <summary>Returns the column sensitivity for this 'SensitivityClassification' Object</summary>
-            <value>List of column sensitivities.</value>
-        </ColumnSensitivities>
-        <InformationTypes>
-            <summary>Returns the information types collection for this 'SensitivityClassification' Object</summary>
-            <value>List of information types.</value>
-        </InformationTypes>
-        <Labels>
-            <summary>Returns the labels collection for this 'SensitivityClassification' Object</summary>
-            <value>List of labels.</value>
-        </Labels>
-        <SensitivityRank>
-          <summary>Returns the relative sensitivity rank for the query associated with the active 'SqlDataReader'.</summary>
-          <value>Relative sensitivity ranking for this query.</value>
-          <remarks>
-            <format type="text/markdown">
-              <![CDATA[
-
-## Remarks
-A relative sensitivity ranking of the query. Available values are as below:
-
-| Sensitivity Rank | Description |
-| --- | --- |
-| -1 | Not Defined (default) |
-| 0 | None |
-| 10 | Low |
-| 20 | Medium |
-| 30 | High |
-| 40 | Critical |
-]]>
-            </format>
-          </remarks>
-        </SensitivityRank>
-        <ctor>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityClassification" /> class.</summary>
-            <param name="labels">List of labels.</param>
-            <param name="informationTypes">List of information types.</param>
-            <param name="columnSensitivity">List of column sensitivities.</param>
-            <param name="sensitivityRank">Relative sensitivity rank for the query associated with the active 'SqlDataReader'.</param>
-        </ctor>
-    </members>
+﻿<docs>
+  <members name="SensitivityClassification">
+    <SensitivityClassification>
+      <summary>
+        Provides the functionality to retrieve Sensitivity Classification data as received from SQL Server for the active <see cref="T:Microsoft.Data.SqlClient.SqlDataReader" />.
+      </summary>
+    </SensitivityClassification>
+    <ColumnSensitivities>
+      <summary>
+        Returns the column sensitivity for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityClassification" /> Object
+      </summary>
+      <value>
+        List of column sensitivities.
+      </value>
+    </ColumnSensitivities>
+    <InformationTypes>
+      <summary>
+        Returns the information types collection for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityClassification" /> Object
+      </summary>
+      <value>
+        List of information types.
+      </value>
+    </InformationTypes>
+    <Labels>
+      <summary>
+        Returns the labels collection for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityClassification" /> Object
+      </summary>
+      <value>
+        List of labels.
+      </value>
+    </Labels>
+    <SensitivityRank>
+      <summary>
+        Returns the relative sensitivity rank for the query associated with the active 'SqlDataReader'.
+      </summary>
+      <value>
+        Relative sensitivity ranking for this query.
+      </value>
+      <remarks>
+        <para>
+          A relative sensitivity ranking of the query. Available values are as below:
+        </para>
+        <list type="table">
+          <listheader>
+            <term>Sensitivity Rank</term>
+            <description>Description</description>
+          </listheader>
+          <item>
+            <term>-1</term>
+            <description>Not Defined (default)</description>
+          </item>
+          <item>
+            <term>0</term>
+            <description>None</description>
+          </item>
+          <item>
+            <term>10</term>
+            <description>Low</description>
+          </item>
+          <item>
+            <term>20</term>
+            <description>Medium</description>
+          </item>
+          <item>
+            <term>30</term>
+            <description>High</description>
+          </item>
+          <item>
+            <term>40</term>
+            <description>Critical</description>
+          </item>
+        </list>
+      </remarks>
+    </SensitivityRank>
+    <ctor>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityClassification" /> class.
+      </summary>
+      <param name="labels">
+        List of labels.
+      </param>
+      <param name="informationTypes">
+        List of information types.
+      </param>
+      <param name="columnSensitivity">
+        List of column sensitivities.
+      </param>
+      <param name="sensitivityRank">
+        Relative sensitivity rank for the query associated with the active <see cref="T:Microsoft.Data.SqlClient.SqlDataReader" />.
+      </param>
+    </ctor>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityProperty.xml
@@ -1,44 +1,82 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SensitivityProperty">
-        <SensitivityProperty>
-            <summary>Represents the Data Classification Sensitivity Information for columns as configured in Database.</summary>
-        </SensitivityProperty>
-        <ctor>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" /> class.</summary>
-          <param name="label">Label for this SensitivityProperty.</param>
-          <param name="informationType">Information type for this SensitivityProperty.</param>
-          <param name="sensitivityRank">Sensitivity rank for this SensitivityProperty.</param>
-        </ctor>
-        <InformationType>
-            <summary>Returns the information type for this 'SensitivityProperty' Object</summary>
-            <value>Information type for this SensitivityProperty.</value>
-        </InformationType>
-        <Label>
-            <summary>Returns the label for this 'SensitivityProperty' Object</summary>
-            <value>Label for this SensitivityProperty.</value>
-        </Label>
-        <SensitivityRank>
-          <summary>Returns the sensitivity rank for this 'SensitivityProperty' Object</summary>
-          <value>Sensitivity rank for this SensitivityProperty.</value>
-          <remarks>
-            <format type="text/markdown">
-              <![CDATA[
-
-## Remarks
-A relative sensitivity ranking of a column that is part of percolumn data. Available values are as below:
-
-| Sensitivity Rank | Description |
-| --- | --- |
-| -1 | Not Defined (default) |
-| 0 | None |
-| 10 | Low |
-| 20 | Medium |
-| 30 | High |
-| 40 | Critical |
-]]>
-            </format>
-          </remarks>
-        </SensitivityRank>
-    </members>
+﻿<docs>
+  <members name="SensitivityProperty">
+    <SensitivityProperty>
+      <summary>
+        Represents the Data Classification Sensitivity Information for columns as configured in Database.
+      </summary>
+    </SensitivityProperty>
+    <ctor>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" /> class.
+      </summary>
+      <param name="label">
+        Label for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" />.
+      </param>
+      <param name="informationType">
+        Information type for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" />.
+      </param>
+      <param name="sensitivityRank">
+        Sensitivity rank for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" />.
+      </param>
+    </ctor>
+    <InformationType>
+      <summary>
+        Returns the information type for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" /> Object
+      </summary>
+      <value>
+        Information type for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" />.
+      </value>
+    </InformationType>
+    <Label>
+      <summary>
+        Returns the label for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" /> Object
+      </summary>
+      <value>
+        Label for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" />.
+      </value>
+    </Label>
+    <SensitivityRank>
+      <summary>
+        Returns the sensitivity rank for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" /> Object
+      </summary>
+      <value>
+        Sensitivity rank for this <see cref="T:Microsoft.Data.SqlClient.DataClassification.SensitivityProperty" />.
+      </value>
+      <remarks>
+        <para>
+          A relative sensitivity ranking of a column that is part of per column data. Available values are as below:
+        </para>
+        <list type="table">
+          <listheader>
+            <term>Sensitivity Rank</term>
+            <description>Description</description>
+          </listheader>
+          <item>
+            <term>-1</term>
+            <description>Not Defined (default)</description>
+          </item>
+          <item>
+            <term>0</term>
+            <description>None</description>
+          </item>
+          <item>
+            <term>10</term>
+            <description>Low</description>
+          </item>
+          <item>
+            <term>20</term>
+            <description>Medium</description>
+          </item>
+          <item>
+            <term>30</term>
+            <description>High</description>
+          </item>
+          <item>
+            <term>40</term>
+            <description>Critical</description>
+          </item>
+        </list>
+      </remarks>
+    </SensitivityRank>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml
@@ -1,17 +1,32 @@
-﻿<?xml version="1.0"?>
-<docs>
+﻿<docs>
   <members name="SensitivityRank">
     <SensitivityRank>
       <summary>
-        A relative ranking of the sensitivity of a query or of a column that is part of percolumn data.
-        It is an identifier based on a predefined set of values which define sensitivity rank. Used by other services like Advanced Threat Protection to detect anomalies based on their rank.
+        <para>
+          A relative ranking of the sensitivity of a query or of a column that is part of per column data.
+        </para>
+        <para>
+          It is an identifier based on a predefined set of values which define sensitivity rank. Used by other services like Advanced Threat Protection to detect anomalies based on their rank.
+        </para>
       </summary>
     </SensitivityRank>
-    <NotDefined>No sensitivity rank defined.</NotDefined>
-    <None>Corresponds to rank value of 0.</None>
-    <Low>Corresponds to rank value of 10.</Low>
-    <Medium>Corresponds to rank value 20.</Medium>
-    <High>Corresponds to rank value 30.</High>
-    <Critical>Corresponds to rank value 40.</Critical>
+    <NotDefined>
+      No sensitivity rank defined.
+    </NotDefined>
+    <None>
+      Corresponds to rank value of 0.
+    </None>
+    <Low>
+      Corresponds to rank value of 10.
+    </Low>
+    <Medium>
+      Corresponds to rank value 20.
+    </Medium>
+    <High>
+      Corresponds to rank value 30.
+    </High>
+    <Critical>
+      Corresponds to rank value 40.
+    </Critical>
   </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.DataClassification/SensitivityRank.xml
@@ -11,22 +11,22 @@
       </summary>
     </SensitivityRank>
     <NotDefined>
-      No sensitivity rank defined.
+      <summary>No sensitivity rank defined.</summary>
     </NotDefined>
     <None>
-      Corresponds to rank value of 0.
+      <summary>Corresponds to rank value of 0.</summary>
     </None>
     <Low>
-      Corresponds to rank value of 10.
+      <summary>Corresponds to rank value of 10.</summary>
     </Low>
     <Medium>
-      Corresponds to rank value 20.
+      <summary>Corresponds to rank value 20.</summary>
     </Medium>
     <High>
-      Corresponds to rank value 30.
+      <summary>Corresponds to rank value 30.</summary>
     </High>
     <Critical>
-      Corresponds to rank value 40.
+      <summary>Corresponds to rank value 40.</summary>
     </Critical>
   </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
@@ -1,789 +1,1508 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SqlDataRecord">
-        <SqlDataRecord>
-            <summary>Represents a single row of data and its metadata.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This class is used together with <xref:Microsoft.SqlServer.Server.SqlPipe> to send result sets to the client from managed code stored-procedures.  
-  
- When writing common language runtime (CLR) applications, you should re-use existing `SqlDataRecord` objects instead of creating new ones every time. Creating many new `SqlDataRecord` objects could severely deplete memory and adversely affect performance.  
-  
-   
-  
-## Examples  
- The following example shows how to create several <xref:Microsoft.Data.SqlClient.Server.SqlMetaData> objects, which describe the column metadata of a record, and creating a <xref:Microsoft.Data.SqlClient.Server.SqlDataRecord>.  The column values of the <xref:Microsoft.Data.SqlClient.Server.SqlDataRecord> are set and the <xref:Microsoft.Data.SqlClient.Server.SqlDataRecord> is sent to the calling program by using the <xref:Microsoft.SqlServer.Server.SqlContext> class.  
-  
- [!code-csharp[SqlDataRecord Samples#1](~/../sqlclient/doc/samples/SqlDataRecord.cs#1)]
-  
- ]]></format>
-            </remarks>
-        </SqlDataRecord>
-        <ctor>
-            <param name="metaData">An array of <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects that describe each column in the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" />.</param>
-            <summary>Inititializes a new <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance with the schema based on the array of <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects passed as an argument.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Examples  
- The following example shows how to create a new <xref:Microsoft.Data.SqlClient.Server.SqlDataRecord> object from two  <xref:Microsoft.Data.SqlClient.Server.SqlMetaData> objects, which indicate the column name and data type.  
-  
- [!code-csharp[SqlDataRecord Samples#2](~/../sqlclient/doc/samples/SqlDataRecord.cs#2)]
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">The <paramref name="metaData" /> is <see langword="null" />.</exception>
-        </ctor>
-        <FieldCount>
-            <summary>Gets the number of columns in the data row. This property is read-only.</summary>
-            <value>The number of columns in the data row as an integer.</value>
-            <remarks>To be added.</remarks>
-        </FieldCount>
-        <GetBoolean>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Boolean" />.</summary>
-            <returns>The column value as a <see cref="T:System.Boolean" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetBoolean>
-        <GetByte>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Byte" />.</summary>
-            <returns>The column value as a <see cref="T:System.Byte" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetByte>
-        <GetBytes>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="fieldOffset">The offset into the field value to start retrieving bytes.</param>
-            <param name="buffer">The target buffer to which to copy bytes.</param>
-            <param name="bufferOffset">The offset into the buffer to which to start copying bytes.</param>
-            <param name="length">The number of bytes to copy to the buffer.</param>
-            <summary>Gets the value for the column specified by the ordinal as an array of <see cref="T:System.Byte" /> objects.</summary>
-            <returns>The number of bytes copied.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method enables you to obtain a binary value either in a single call or in chunks. Getting the value in chunks is useful for large values or values of unknown size.  
-  
- To obtain the value in several chunks, allocate a byte array of the chunk-size and call <xref:Microsoft.Data.SqlClient.Server.SqlDataRecord.GetBytes%2A> repeatedly, adjusting the `fieldOffset` parameter accordingly in each call.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetBytes>
-        <GetChar>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Char" />.</summary>
-            <returns>The column value as a <see cref="T:System.Char" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetChar>
-        <GetChars>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="fieldOffset">The offset into the field value to start retrieving characters.</param>
-            <param name="buffer">The target buffer to copy chars to.</param>
-            <param name="bufferOffset">The offset into the buffer to start copying chars to.</param>
-            <param name="length">The number of chars to copy to the buffer.</param>
-            <summary>Gets the value for the column specified by the ordinal as an array of <see cref="T:System.Char" /> objects.</summary>
-            <returns>The number of characters copied.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method enables you to obtain a character value either in a single call or in chunks. Getting the value in chunks is useful for large values or values of unknown size.  
-  
- To obtain the value in several chunks, allocate a char array of the chunk-size and call <xref:Microsoft.Data.SqlClient.Server.SqlDataRecord.GetChars%2A> repeatedly adjusting the `fieldOffset` parameter accordingly in each call.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetChars>
-        <GetData>
-            <param name="ordinal">To be added.</param>
-            <summary>To be added.</summary>
-            <returns>To be added.</returns>
-            <remarks>To be added.</remarks>
-        </GetData>
-        <GetDataTypeName>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Returns the name of the data type for the column specified by the ordinal argument.</summary>
-            <returns>A <see cref="T:System.String" /> that contains the data type of the column.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method returns the type name as known in the SQL Server type-system. For user-defined types (UDTs), it returns the three-part name that was used to register the type with SQL Server.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetDataTypeName>
-        <GetDateTime>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.DateTime" />.</summary>
-            <returns>The column value as a <see cref="T:System.DateTime" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetDateTime>
-        <GetDateTimeOffset>
-            <param name="ordinal">The zero-based column ordinal.</param>
-            <summary>Returns the specified column's data as a <see cref="T:System.DateTimeOffset" />.</summary>
-            <returns>The value of the specified column as a <see cref="T:System.DateTimeOffset" />.</returns>
-            <remarks>To be added.</remarks>
-        </GetDateTimeOffset>
-        <GetDecimal>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Decimal" />.</summary>
-            <returns>The column value as a <see cref="T:System.Decimal" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetDecimal>
-        <GetDouble>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Double" />.</summary>
-            <returns>The column value as a <see cref="T:System.Double" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetDouble>
-        <GetFieldType>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Returns a <see cref="T:System.Type" /> object representing the common language runtime (CLR) type that maps to the SQL Server type of the column specified by the <paramref name="ordinal" /> argument.</summary>
-            <returns>The column type as a <see cref="T:System.Type" /> object.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.TypeLoadException">The column is of a user-defined type that is not available to the calling application domain.</exception>
-            <exception cref="T:System.IO.FileNotFoundException">The column is of a user-defined type that is not available to the calling application domain.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetFieldType>
-        <GetFloat>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see langword="float" />.</summary>
-            <returns>The column value as a <see langword="float" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetFloat>
-        <GetGuid>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Guid" />.</summary>
-            <returns>The column value as a <see cref="T:System.Guid" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetGuid>
-        <GetInt16>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Int16" />.</summary>
-            <returns>The column value as a <see cref="T:System.Int16" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetInt16>
-        <GetInt32>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Int32" />.</summary>
-            <returns>The column value as a <see cref="T:System.Int32" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetInt32>
-        <GetInt64>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Int64" />.</summary>
-            <returns>The column value as a <see cref="T:System.Int64" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.Data.SqlTypes.SqlNullValueException">The column specified by <paramref name="ordinal" /> is null.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetInt64>
-        <GetName>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Returns the name of the column specified by the ordinal argument.</summary>
-            <returns>A <see cref="T:System.String" /> containing the column name.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetName>
-        <GetOrdinal>
-            <param name="name">The name of the column to look up.</param>
-            <summary>Returns the column ordinal specified by the column name.</summary>
-            <returns>The zero-based ordinal of the column as an integer.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentNullException">
-            <paramref name="name" /> is <see langword="null" />.</exception>
-            <exception cref="T:System.IndexOutOfRangeException">The column name could not be found.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetOrdinal>
-        <GetSqlBinary>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlBinary>
-        <GetSqlBoolean>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlBoolean" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlBoolean" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlBoolean>
-        <GetSqlByte>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlByte" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlByte" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlByte>
-        <GetSqlBytes>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlBytes" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlBytes" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlBytes>
-        <GetSqlChars>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlChars" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlChars" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlChars>
-        <GetSqlDateTime>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlDateTime" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlDateTime" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlDateTime>
-        <GetSqlDecimal>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlDecimal>
-        <GetSqlDouble>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlDouble" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlDouble" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlDouble>
-        <GetSqlFieldType>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Returns a <see cref="T:System.Type" /> object that represents the type (as a SQL Server type, defined in <see cref="N:System.Data.SqlTypes" />) that maps to the SQL Server type of the column.</summary>
-            <returns>The column type as a <see cref="T:System.Type" /> object.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.TypeLoadException">The column is of a user-defined type that is not available to the calling application domain.</exception>
-            <exception cref="T:System.IO.FileNotFoundException">The column is of a user-defined type that is not available to the calling application domain.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlFieldType>
-        <GetSqlGuid>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlGuid" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlGuid" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlGuid>
-        <GetSqlInt16>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlInt16>
-        <GetSqlInt32>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlInt32>
-        <GetSqlInt64>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>   
-        </GetSqlInt64>
-        <GetSqlMetaData>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Returns a <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> object, describing the metadata of the column specified by the column ordinal.</summary>
-            <returns>The column metadata as a <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> object.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlMetaData>
-        <GetSqlMoney>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlMoney>
-        <GetSqlSingle>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlSingle>
-        <GetSqlString>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlString" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlString" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlString>
-        <GetSqlValue>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Returns the data value stored in the column, expressed as a SQL Server type, specified by the column ordinal.</summary>
-            <returns>The value of the column, expressed as a SQL Server type, as a <see cref="T:System.Object" />.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- For null values, a SQL Server type instance is returned where the <xref:System.Data.SqlTypes.INullable.IsNull%2A> property is true.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-            <altmember cref="N:System.Data.SqlTypes" />
-        </GetSqlValue>
-        <GetSqlValues>
-            <param name="values">The array into which to copy the values column values.</param>
-            <summary>Returns the values for all the columns in the record, expressed as SQL Server types, in an array.</summary>
-            <returns>An <see cref="T:System.Int32" /> that indicates the number of columns copied.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The SQL Server type values of the column are copied into the `values` array that is passed as a parameter. For null values, a Sql type instance is returned where the <xref:System.Data.SqlTypes.INullable.IsNull%2A> property is true.  
-  
- The length of the `values` array does not need to match the number of columns in the record. If the array length is greater than the number of columns, all of the column values are copied into the array; if it is less, only the array length number of column values are copied into the array, starting at the column value with ordinal 0.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">
-            <paramref name="values" /> is <see langword="null" />.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-            <altmember cref="N:System.Data.SqlTypes" />
-        </GetSqlValues>
-        <GetSqlXml>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlXml" />.</summary>
-            <returns>The column value as a <see cref="T:System.Data.SqlTypes.SqlXml" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetSqlXml>
-        <GetString>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the value for the column specified by the ordinal as a <see cref="T:System.String" />.</summary>
-            <returns>The column value as a <see cref="T:System.String" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetString>
-        <GetTimeSpan>
-            <param name="ordinal">The zero-based column ordinal.</param>
-            <summary>Returns the specified column's data as a <see cref="T:System.TimeSpan" />.</summary>
-            <returns>The value of the specified column as a <see cref="T:System.TimeSpan" />.</returns>
-            <remarks>To be added.</remarks>
-        </GetTimeSpan>
-        <GetValue>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Returns the common language runtime (CLR) type value for the column specified by the ordinal argument.</summary>
-            <returns>The CLR type value of the column specified by the ordinal.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- For columns with null value, <xref:System.DBNull.Value> is returned.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetValue>
-        <GetValues>
-            <param name="values">The array into which to copy the values column values.</param>
-            <summary>Returns the values for all the columns in the record, expressed as common language runtime (CLR) types, in an array.</summary>
-            <returns>An <see cref="T:System.Int32" /> that indicates the number of columns copied.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The CLR type values of the column are copied into the `values` array that is passed as a parameter. For columns with null value, <xref:System.DBNull.Value> is returned.  
-  
- The length of the `values` array does not need to match the number of columns in the record. If the array length is greater than the number of columns, all of the column values are copied into the array; if it is less, only the array length number of column values is copied into the array, starting at the column value with ordinal 0.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">
-            <paramref name="values" /> is <see langword="null" />.</exception>
-            <exception cref="T:System.InvalidCastException">There is a type mismatch.</exception>
-        </GetValues>
-        <IsDBNull>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Returns true if the column specified by the column ordinal parameter is null.</summary>
-            <returns>
-            <see langword="true" /> if the column is null; <see langword="false" /> otherwise.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </IsDBNull>
-        <Item>
-            <summary>Gets the common language runtime (CLR) type value for the column.</summary>
-        </Item>
-        <ItemOrdinal>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Gets the common language runtime (CLR) type value for the column specified by the column <paramref name="ordinal" /> argument.</summary>
-            <value>The CLR type value of the column specified by the <paramref name="ordinal" />.</value>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- For columns with null value, <xref:System.DBNull.Value> is returned.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.IndexOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </ItemOrdinal>
-        <ItemName>
-            <param name="name">The name of the column.</param>
-            <summary>Gets the common language runtime (CLR) type value for the column specified by the column <paramref name="name" /> argument.</summary>
-            <value>The CLR type value of the column specified by the <paramref name="name" />.</value>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- For columns with null value, <xref:System.DBNull.Value> is returned.  
-  
- ]]></format>
-            </remarks>
-        </ItemName>
-        <SetBoolean>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Boolean" /> value.</summary>
-            <remarks>To be added.</remarks>
-        </SetBoolean>
-        <SetByte>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Byte" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetByte>
-        <SetBytes>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="fieldOffset">The offset into the field value to start copying bytes.</param>
-            <param name="buffer">The target buffer from which to copy bytes.</param>
-            <param name="bufferOffset">The offset into the buffer from which to start copying bytes.</param>
-            <param name="length">The number of bytes to copy from the buffer.</param>
-            <summary>Sets the data stored in the column to the specified array of <see cref="T:System.Byte" /> values.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetBytes>
-        <SetChar><param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Char" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetChar>
-        <SetChars>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="fieldOffset">The offset into the field value to start copying characters.</param>
-            <param name="buffer">The target buffer from which to copy chars.</param>
-            <param name="bufferOffset">The offset into the buffer from which to start copying chars.</param>
-            <param name="length">The number of chars to copy from the buffer.</param>
-            <summary>Sets the data stored in the column to the specified array of <see cref="T:System.Char" /> values.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetChars>
-        <SetDateTime>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.DateTime" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetDateTime>
-        <SetDateTimeOffset>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the value of the column specified to the <see cref="T:System.DateTimeOffset" /> value.</summary>
-            <remarks>To be added.</remarks>
-        </SetDateTimeOffset>
-        <SetDBNull>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Sets the value in the specified column to <see cref="T:System.DBNull" />.</summary>
-            <remarks>To be added.</remarks>
-        </SetDBNull>
-        <SetDecimal>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Decimal" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetDecimal>
-        <SetDouble>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Double" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetDouble>
-        <SetFloat>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see langword="float" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetFloat>
-        <SetGuid>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Guid" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetGuid>
-        <SetInt16>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Int16" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetInt16>
-        <SetInt32>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Int32" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetInt32>
-        <SetInt64>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Int64" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetInt64>
-        <SetSqlBinary>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlBinary" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlBinary>
-        <SetSqlBoolean>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlBoolean" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlBoolean>
-        <SetSqlByte>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlByte" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlByte>
-        <SetSqlBytes>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlBytes" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlBytes>
-        <SetSqlChars>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlChars" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlChars>
-        <SetSqlDateTime>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlDateTime" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlDateTime>
-        <SetSqlDecimal>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlDecimal" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlDecimal>
-        <SetSqlDouble>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlDouble" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlDouble>
-        <SetSqlGuid>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlGuid" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlGuid>
-        <SetSqlInt16>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlInt16" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlInt16>
-        <SetSqlInt32>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlInt32" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlInt32>
-        <SetSqlInt64>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlInt64" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlInt64>
-        <SetSqlMoney>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlMoney" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlMoney>
-        <SetSqlSingle>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlSingle" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlSingle>
-        <SetSqlString>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlString" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlString>
-        <SetSqlXml>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlXml" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetSqlXml>
-        <SetString>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the data stored in the column to the specified <see cref="T:System.String" /> value.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetString>
-        <SetTimeSpan>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value of the column.</param>
-            <summary>Sets the value of the column specified to the <see cref="T:System.TimeSpan" />.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> passed in is a negative number.</exception>
-            <exception cref="T:System.ArgumentException">The <see cref="T:System.TimeSpan" /> value passed in is greater than 24 hours in length.</exception>
-        </SetTimeSpan>
-        <SetValue>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <param name="value">The new value for the specified column.</param>
-            <summary>Sets a new value, expressed as a common language runtime (CLR) type, for the column specified by the column ordinal.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- `value` is a SQL type boxed as a <xref:System.Object> instance.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </SetValue>
-        <SetValues>
-            <param name="values">The array of new values, expressed as CLR types boxed as <see cref="T:System.Object" /> references, for the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance.</param>
-            <summary>Sets new values for all of the columns in the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" />. These values are expressed as common language runtime (CLR) types.</summary>
-            <returns>The number of column values set as an integer.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The length of values must match the number of columns in the <xref:Microsoft.Data.SqlClient.Server.SqlDataRecord> instance.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">
-            <paramref name="values" /> is <see langword="null" />.</exception>
-            <exception cref="T:System.ArgumentException">The size of values does not match the number of columns in the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance.</exception>
-        </SetValues>
-        <System.Data.IDataRecord.GetData>
-            <param name="ordinal">The zero-based ordinal of the column.</param>
-            <summary>Not supported in this release.</summary>
-            <returns>
-            <see cref="T:System.Data.IDataReader" />  
-    
-    Always throws an exception.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This method is not supported in this release, and throws <xref:System.NotSupportedException> if called.  
-  
- ]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentOutOfRangeException">The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).</exception>
-        </System.Data.IDataRecord.GetData>
-    </members>
+﻿<docs>
+  <members name="SqlDataRecord">
+    <SqlDataRecord>
+      <summary>
+        Represents a single row of data and its metadata.
+      </summary>
+      <remarks>
+        <para>
+          This class is used together with <see cref="T:Microsoft.SqlServer.Server.SqlPipe" /> to send result sets to the client from managed code stored-procedures.
+        </para>
+        <para>
+          When writing common language runtime (CLR) applications, you should re-use existing <b>SqlDataRecord</b> objects instead of creating new ones every time. Creating many new <b>SqlDataRecord</b> objects could severely deplete memory and adversely affect performance.
+        </para>
+      </remarks>
+      <example>
+        <para>
+          The following example shows how to create several <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects, which describe the column metadata of a record, and creating a <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" />. The column values of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> are set and the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> is sent to the calling program by using the <see cref="T:Microsoft.SqlServer.Server.SqlContext" /> class.
+        </para>
+        <!-- SqlDataRecord #1 -->
+        <code language="c#">
+          using Microsoft.Data.SqlClient.Server;
+          
+          [Microsoft.Data.SqlClient.Server.SqlProcedure]
+          public static void CreateNewRecord()
+          {
+          
+             // Variables.
+             SqlDataRecord record;    
+                
+             // Create a new record with the column metadata. The constructor is 
+             // able to accept a variable number of parameters. 
+             record = new SqlDataRecord(new SqlMetaData[] { new SqlMetaData("Column1", SqlDbType.NVarChar, 12), 
+                                                            new SqlMetaData("Column2", SqlDbType.Int), 
+                                                            new SqlMetaData("Column3", SqlDbType.DateTime) });
+          
+             // Set the record fields.
+             record.SetString(0, "Hello World!");
+             record.SetInt32(1, 42);
+             record.SetDateTime(2, DateTime.Now);
+          
+             // Send the record to the calling program.
+             SqlContext.Pipe.Send(record);
+          }
+        </code>
+      </example>
+    </SqlDataRecord>
+    <ctor>
+      <param name="metaData">
+        An array of <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects that describe each column in the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" />.
+      </param>
+      <summary>
+        Initializes a new <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance with the schema based on the array of <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects passed as an argument.
+      </summary>
+      <example>
+        <para>
+          The following example shows how to create a new <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> object from two <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects, which indicate the column name and data type.
+        </para>
+        <!-- SqlDataRecord #2 -->
+        <code language="c#">
+          using Microsoft.Data.SqlClient.Server;
+          
+          // Variables.
+          SqlMetaData column1Info;
+          SqlMetaData column2Info;
+          SqlDataRecord record;
+          
+          // Create the column metadata.
+          column1Info = new SqlMetaData("Column1", SqlDbType.NVarChar, 12);
+          column2Info = new SqlMetaData("Column2", SqlDbType.Int);
+          
+          // Create a new record with the column metadata.      
+          record = new SqlDataRecord(new SqlMetaData[] { column1Info, column2Info });
+
+          
+          // Set the record fields.
+          record.SetString(0, "Hello World!");
+          record.SetInt32(1, 42);
+          
+          // Send the record to the calling program.
+          SqlContext.Pipe.Send(record);
+        </code>
+      </example>
+      <exception cref="T:System.ArgumentNullException">
+        The <paramref name="metaData" /> is <see langword="null" />.
+      </exception>
+    </ctor>
+    <FieldCount>
+      <summary>
+        Gets the number of columns in the data row. This property is read-only.
+      </summary>
+      <value>
+        The number of columns in the data row as an integer.
+      </value>
+    </FieldCount>
+    <GetBoolean>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Boolean" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Boolean" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is null.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetBoolean>
+    <GetByte>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Byte" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Byte" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is null.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetByte>
+    <GetBytes>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="fieldOffset">
+        The offset into the field value to start retrieving bytes.
+      </param>
+      <param name="buffer">
+        The target buffer to which to copy bytes.
+      </param>
+      <param name="bufferOffset">
+        The offset into the buffer to which to start copying bytes.
+      </param>
+      <param name="length">
+        The number of bytes to copy to the buffer.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as an array of <see cref="T:System.Byte" /> objects.
+      </summary>
+      <returns>
+        The number of bytes copied.
+      </returns>
+      <remarks>
+        <para>
+          This method enables you to obtain a binary value either in a single call or in chunks. Getting the value in chunks is useful for large values or values of unknown size.
+        </para>
+        <para>
+          To obtain the value in several chunks, allocate a byte array of the chunk-size and call <see cref="M:Microsoft.Data.SqlClient.Server.SqlDataRecord.GetBytes" /> repeatedly, adjusting the <paramref name="fieldOffset" /> parameter accordingly in each call.
+        </para>
+      </remarks>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetBytes>
+    <GetChar>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Char" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Char" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetChar>
+    <GetChars>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="fieldOffset">
+        The offset into the field value to start retrieving characters.
+      </param>
+      <param name="buffer">
+        The target buffer to copy chars to.
+      </param>
+      <param name="bufferOffset">
+        The offset into the buffer to start copying chars to.
+      </param>
+      <param name="length">
+        The number of chars to copy to the buffer.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as an array of <see cref="T:System.Char" /> objects.
+      </summary>
+      <returns>
+        The number of characters copied.
+      </returns>
+      <remarks>
+        <para>
+          This method enables you to obtain a character value either in a single call or in chunks. Getting the value in chunks is useful for large values or values of unknown size.
+        </para>
+        <para>
+          To obtain the value in several chunks, allocate a char array of the chunk-size and call <see cref="M:Microsoft.Data.SqlClient.Server.SqlDataRecord.GetChars" /> repeatedly adjusting the<c>fieldOffset</c>parameter accordingly in each call.
+        </para>
+      </remarks>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is null.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetChars>
+    <GetData>
+      <param name="ordinal">
+        To be added.
+      </param>
+      <summary>
+        To be added.
+      </summary>
+      <returns>
+        To be added.
+      </returns>
+      <remarks>
+        To be added.
+      </remarks>
+    </GetData>
+    <GetDataTypeName>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Returns the name of the data type for the column specified by the ordinal argument.
+      </summary>
+      <returns>
+        A <see cref="T:System.String" /> that contains the data type of the column.
+      </returns>
+      <remarks>
+        This method returns the type name as known in the SQL Server type-system. For user-defined types (UDTs), it returns the three-part name that was used to register the type with SQL Server.
+      </remarks>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetDataTypeName>
+    <GetDateTime>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.DateTime" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.DateTime" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetDateTime>
+    <GetDateTimeOffset>
+      <param name="ordinal">
+        The zero-based column ordinal.
+      </param>
+      <summary>
+        Returns the specified column's data as a <see cref="T:System.DateTimeOffset" />.
+      </summary>
+      <returns>
+        The value of the specified column as a <see cref="T:System.DateTimeOffset" />.
+      </returns>
+    </GetDateTimeOffset>
+    <GetDecimal>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Decimal" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Decimal" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetDecimal>
+    <GetDouble>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Double" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Double" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetDouble>
+    <GetFieldType>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Returns a <see cref="T:System.Type" /> object representing the common language runtime (CLR) type that maps to the SQL Server type of the column specified by the <paramref name="ordinal" /> argument.
+      </summary>
+      <returns>
+        The column type as a <see cref="T:System.Type" /> object.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.TypeLoadException">
+        The column is of a user-defined type that is not available to the calling application domain.
+      </exception>
+      <exception cref="T:System.IO.FileNotFoundException">
+        The column is of a user-defined type that is not available to the calling application domain.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetFieldType>
+    <GetFloat>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Single" />.
+      </summary>
+      <returns>
+        The column value as a <see langword="T:System.Single" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is <see langword="null"/>.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetFloat>
+    <GetGuid>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Guid" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Guid" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetGuid>
+    <GetInt16>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Int16" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Int16" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetInt16>
+    <GetInt32>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Int32" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Int32" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetInt32>
+    <GetInt64>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Int64" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Int64" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.Data.SqlTypes.SqlNullValueException">
+        The column specified by <paramref name="ordinal" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetInt64>
+    <GetName>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Returns the name of the column specified by the ordinal argument.
+      </summary>
+      <returns>
+        A <see cref="T:System.String" /> containing the column name.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetName>
+    <GetOrdinal>
+      <param name="name">
+        The name of the column to look up.
+      </param>
+      <summary>
+        Returns the column ordinal specified by the column name.
+      </summary>
+      <returns>
+        The zero-based ordinal of the column as an integer.
+      </returns>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="name" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The column name could not be found.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetOrdinal>
+    <GetSqlBinary>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlBinary>
+    <GetSqlBoolean>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlBoolean" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlBoolean" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlBoolean>
+    <GetSqlByte>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlByte" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlByte" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlByte>
+    <GetSqlBytes>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlBytes" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlBytes" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlBytes>
+    <GetSqlChars>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlChars" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlChars" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlChars>
+    <GetSqlDateTime>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlDateTime" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlDateTime" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlDateTime>
+    <GetSqlDecimal>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlDecimal>
+    <GetSqlDouble>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlDouble" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlDouble" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlDouble>
+    <GetSqlFieldType>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Returns a <see cref="T:System.Type" /> object that represents the type (as a SQL Server type, defined in <see cref="N:System.Data.SqlTypes" />) that maps to the SQL Server type of the column.
+      </summary>
+      <returns>
+        The column type as a <see cref="T:System.Type" /> object.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.TypeLoadException">
+        The column is of a user-defined type that is not available to the calling application domain.
+      </exception>
+      <exception cref="T:System.IO.FileNotFoundException">
+        The column is of a user-defined type that is not available to the calling application domain.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlFieldType>
+    <GetSqlGuid>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlGuid" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlGuid" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlGuid>
+    <GetSqlInt16>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlInt16>
+    <GetSqlInt32>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlInt32>
+    <GetSqlInt64>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlInt64>
+    <GetSqlMetaData>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Returns a <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> object, describing the metadata of the column specified by the column ordinal.
+      </summary>
+      <returns>
+        The column metadata as a <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> object.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlMetaData>
+    <GetSqlMoney>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlMoney>
+    <GetSqlSingle>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlSingle>
+    <GetSqlString>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlString" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlString" />.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlString>
+    <GetSqlValue>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Returns the data value stored in the column, expressed as a SQL Server type, specified by the column ordinal.
+      </summary>
+      <returns>
+        The value of the column, expressed as a SQL Server type, as a <see cref="T:System.Object" />.
+      </returns>
+      <remarks>
+        For null values, a SQL Server type instance is returned where the <see cref="P:System.Data.SqlTypes.INullable.IsNull" /> property is true.
+      </remarks>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+      <seealso cref="N:System.Data.SqlTypes" />
+    </GetSqlValue>
+    <GetSqlValues>
+      <param name="values">
+        The array into which to copy the values column values.
+      </param>
+      <summary>
+        Returns the values for all the columns in the record, expressed as SQL Server types, in an array.
+      </summary>
+      <returns>
+        An <see cref="T:System.Int32" /> that indicates the number of columns copied.
+      </returns>
+      <remarks>
+        <para>
+          The SQL Server type values of the column are copied into the <paramref name="values" /> array that is passed as a parameter. For null values, a Sql type instance is returned where the <see cref="P:System.Data.SqlTypes.INullable.IsNull" /> property is true.
+        </para>
+        <para>
+          The length of the <paramref name="value" /> array does not need to match the number of columns in the record. If the array length is greater than the number of columns, all the column values are copied into the array; if it is less, only the array length number of column values are copied into the array, starting at the column value with ordinal 0.
+        </para>
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="values" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+      <seealso cref="N:System.Data.SqlTypes" />
+    </GetSqlValues>
+    <GetSqlXml>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.Data.SqlTypes.SqlXml" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.Data.SqlTypes.SqlXml" />.
+      </returns>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetSqlXml>
+    <GetString>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the value for the column specified by the ordinal as a <see cref="T:System.String" />.
+      </summary>
+      <returns>
+        The column value as a <see cref="T:System.String" />.
+      </returns>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetString>
+    <GetTimeSpan>
+      <param name="ordinal">
+        The zero-based column ordinal.
+      </param>
+      <summary>
+        Returns the specified column's data as a <see cref="T:System.TimeSpan" />.
+      </summary>
+      <returns>
+        The value of the specified column as a <see cref="T:System.TimeSpan" />.
+      </returns>
+    </GetTimeSpan>
+    <GetValue>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Returns the common language runtime (CLR) type value for the column specified by the ordinal argument.
+      </summary>
+      <returns>
+        The CLR type value of the column specified by the ordinal.
+      </returns>
+      <remarks>
+        For columns with null value, <see cref="P:System.DBNull.Value" /> is returned.
+      </remarks>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetValue>
+    <GetValues>
+      <param name="values">
+        The array into which to copy the values column values.
+      </param>
+      <summary>
+        Returns the values for all the columns in the record, expressed as common language runtime (CLR) types, in an array.
+      </summary>
+      <returns>
+        An <see cref="T:System.Int32" /> that indicates the number of columns copied.
+      </returns>
+      <remarks>
+        <para>
+          The CLR type values of the column are copied into the <paramref name="values" /> array that is passed as a parameter. For columns with null value, <see cref="P:System.DBNull.Value" /> is returned.
+        </para>
+        <para>
+          The length of the <paramref name="values" /> array does not need to match the number of columns in the record. If the array length is greater than the number of columns, all the column values are copied into the array; if it is less, only the array length number of column values is copied into the array, starting at the column value with ordinal 0.
+        </para>
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="values" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.InvalidCastException">
+        There is a type mismatch.
+      </exception>
+    </GetValues>
+    <IsDBNull>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Returns <see langword="true" /> if the column specified by the column ordinal parameter is null.
+      </summary>
+      <returns>
+        <see langword="true" /> if the column is null; <see langword="false" /> otherwise.
+      </returns>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </IsDBNull>
+    <Item>
+      <summary>
+        Gets the common language runtime (CLR) type value for the column.
+      </summary>
+    </Item>
+    <ItemOrdinal>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Gets the common language runtime (CLR) type value for the column specified by the column <paramref name="ordinal" /> argument.
+      </summary>
+      <value>
+        The CLR type value of the column specified by the <paramref name="ordinal" />.
+      </value>
+      <remarks>
+        For columns with null value, <see cref="P:System.DBNull.Value" /> is returned.
+      </remarks>
+      <exception cref="T:System.IndexOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </ItemOrdinal>
+    <ItemName>
+      <param name="name">
+        The name of the column.
+      </param>
+      <summary>
+        Gets the common language runtime (CLR) type value for the column specified by the column <paramref name="name" /> argument.
+      </summary>
+      <value>
+        The CLR type value of the column specified by the <paramref name="name" />.
+      </value>
+      <remarks>
+        For columns with null value, <see cref="P:System.DBNull.Value" /> is returned.
+      </remarks>
+    </ItemName>
+    <SetBoolean>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Boolean" /> value.
+      </summary>
+    </SetBoolean>
+    <SetByte>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Byte" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetByte>
+    <SetBytes>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="fieldOffset">
+        The offset into the field value to start copying bytes.
+      </param>
+      <param name="buffer">
+        The target buffer from which to copy bytes.
+      </param>
+      <param name="bufferOffset">
+        The offset into the buffer from which to start copying bytes.
+      </param>
+      <param name="length">
+        The number of bytes to copy from the buffer.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified array of <see cref="T:System.Byte" /> values.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetBytes>
+    <SetChar>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Char" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetChar>
+    <SetChars>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="fieldOffset">
+        The offset into the field value to start copying characters.
+      </param>
+      <param name="buffer">
+        The target buffer from which to copy chars.
+      </param>
+      <param name="bufferOffset">
+        The offset into the buffer from which to start copying chars.
+      </param>
+      <param name="length">
+        The number of chars to copy from the buffer.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified array of <see cref="T:System.Char" /> values.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetChars>
+    <SetDateTime>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.DateTime" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetDateTime>
+    <SetDateTimeOffset>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the value of the column specified to the <see cref="T:System.DateTimeOffset" /> value.
+      </summary>
+    </SetDateTimeOffset>
+    <SetDBNull>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Sets the value in the specified column to <see cref="T:System.DBNull" />.
+      </summary>
+    </SetDBNull>
+    <SetDecimal>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Decimal" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetDecimal>
+    <SetDouble>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Double" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetDouble>
+    <SetFloat>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Single" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetFloat>
+    <SetGuid>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Guid" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetGuid>
+    <SetInt16>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Int16" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetInt16>
+    <SetInt32>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Int32" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetInt32>
+    <SetInt64>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Int64" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetInt64>
+    <SetSqlBinary>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlBinary" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlBinary>
+    <SetSqlBoolean>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlBoolean" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlBoolean>
+    <SetSqlByte>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlByte" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlByte>
+    <SetSqlBytes>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlBytes" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlBytes>
+    <SetSqlChars>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlChars" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlChars>
+    <SetSqlDateTime>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlDateTime" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlDateTime>
+    <SetSqlDecimal>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlDecimal" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlDecimal>
+    <SetSqlDouble>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlDouble" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlDouble>
+    <SetSqlGuid>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlGuid" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlGuid>
+    <SetSqlInt16>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlInt16" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlInt16>
+    <SetSqlInt32>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlInt32" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlInt32>
+    <SetSqlInt64>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlInt64" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlInt64>
+    <SetSqlMoney>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlMoney" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlMoney>
+    <SetSqlSingle>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlSingle" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlSingle>
+    <SetSqlString>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlString" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlString>
+    <SetSqlXml>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.Data.SqlTypes.SqlXml" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetSqlXml>
+    <SetString>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the data stored in the column to the specified <see cref="T:System.String" /> value.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetString>
+    <SetTimeSpan>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value of the column.
+      </param>
+      <summary>
+        Sets the value of the column specified to the <see cref="T:System.TimeSpan" />.
+      </summary>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> passed in is a negative number.
+      </exception>
+      <exception cref="T:System.ArgumentException">
+        The <see cref="T:System.TimeSpan" /> value passed in is greater than 24 hours in length.
+      </exception>
+    </SetTimeSpan>
+    <SetValue>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <param name="value">
+        The new value for the specified column.
+      </param>
+      <summary>
+        Sets a new value, expressed as a common language runtime (CLR) type, for the column specified by the column ordinal.
+      </summary>
+      <remarks>
+        <paramref name="value" /> is a SQL type boxed as a <see cref="T:System.Object" /> instance.
+      </remarks>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </SetValue>
+    <SetValues>
+      <param name="values">
+        The array of new values, expressed as CLR types boxed as <see cref="T:System.Object" /> references, for the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance.
+      </param>
+      <summary>
+        Sets new values for all the columns in the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" />. These values are expressed as common language runtime (CLR) types.
+      </summary>
+      <returns>
+        The number of column values set as an integer.
+      </returns>
+      <remarks>
+        The length of values must match the number of columns in the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance.
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="values" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.ArgumentException">
+        The size of values does not match the number of columns in the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance.
+      </exception>
+    </SetValues>
+    <System.Data.IDataRecord.GetData>
+      <param name="ordinal">
+        The zero-based ordinal of the column.
+      </param>
+      <summary>
+        Not supported in this release.
+      </summary>
+      <returns>
+        <see cref="T:System.Data.IDataReader" /> Always throws an exception.
+      </returns>
+      <remarks>
+        This method is not supported in this release, and throws <see cref="T:System.NotSupportedException" /> if called.
+      </remarks>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
+      </exception>
+    </System.Data.IDataRecord.GetData>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
@@ -159,7 +159,7 @@
           This method enables you to obtain a binary value either in a single call or in chunks. Getting the value in chunks is useful for large values or values of unknown size.
         </para>
         <para>
-          To obtain the value in several chunks, allocate a byte array of the chunk-size and call <see cref="M:Microsoft.Data.SqlClient.Server.SqlDataRecord.GetBytes" /> repeatedly, adjusting the <paramref name="fieldOffset" /> parameter accordingly in each call.
+          To obtain the value in several chunks, allocate a byte array of the chunk-size and call <b>GetBytes</b> repeatedly, adjusting the <paramref name="fieldOffset" /> parameter accordingly in each call.
         </para>
       </remarks>
       <exception cref="T:System.IndexOutOfRangeException">
@@ -219,7 +219,7 @@
           This method enables you to obtain a character value either in a single call or in chunks. Getting the value in chunks is useful for large values or values of unknown size.
         </para>
         <para>
-          To obtain the value in several chunks, allocate a char array of the chunk-size and call <see cref="M:Microsoft.Data.SqlClient.Server.SqlDataRecord.GetChars" /> repeatedly adjusting the<c>fieldOffset</c>parameter accordingly in each call.
+          To obtain the value in several chunks, allocate a char array of the chunk-size and call <b>GetChars</b> repeatedly adjusting the <paramref name="fieldOffset" /> parameter accordingly in each call.
         </para>
       </remarks>
       <exception cref="T:System.IndexOutOfRangeException">
@@ -368,7 +368,7 @@
         Gets the value for the column specified by the ordinal as a <see cref="T:System.Single" />.
       </summary>
       <returns>
-        The column value as a <see langword="T:System.Single" />.
+        The column value as a <see cref="T:System.Single" />.
       </returns>
       <exception cref="T:System.IndexOutOfRangeException">
         The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
@@ -895,7 +895,7 @@
         The CLR type value of the column specified by the ordinal.
       </returns>
       <remarks>
-        For columns with null value, <see cref="P:System.DBNull.Value" /> is returned.
+        For columns with null value, <see cref="F:System.DBNull.Value" /> is returned.
       </remarks>
       <exception cref="T:System.IndexOutOfRangeException">
         The <paramref name="ordinal" /> is less than 0 or greater than the number of columns (that is, <see cref="P:Microsoft.Data.SqlClient.Server.SqlDataRecord.FieldCount" />).
@@ -916,7 +916,7 @@
       </returns>
       <remarks>
         <para>
-          The CLR type values of the column are copied into the <paramref name="values" /> array that is passed as a parameter. For columns with null value, <see cref="P:System.DBNull.Value" /> is returned.
+          The CLR type values of the column are copied into the <paramref name="values" /> array that is passed as a parameter. For columns with null value, <see cref="F:System.DBNull.Value" /> is returned.
         </para>
         <para>
           The length of the <paramref name="values" /> array does not need to match the number of columns in the record. If the array length is greater than the number of columns, all the column values are copied into the array; if it is less, only the array length number of column values is copied into the array, starting at the column value with ordinal 0.

--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml
@@ -60,7 +60,7 @@
       </summary>
       <remarks>
         <para>
-          Only the following are allowed to be passed to this constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.Bit" />, <see cref="F:System.Data.SqlDbType.BigInt" />, <see cref="F:System.Data.SqlDbType.DateTime" />, <see cref="F:System.Data.SqlDbType.Decimal" />, <see cref="F:System.Data.SqlDbType.Float" />, <see cref="F:System.Data.SqlDbType.Int" />, <see cref="F:System.Data.SqlDbType.Money" />, <see cref="F:System.Data.SqlDbType.Numeric" />, <see cref="F:System.Data.SqlDbType.SmallDateTime" />, <see cref="F:System.Data.SqlDbType.SmallInt" />, <see cref="F:System.Data.SqlDbType.SmallMoney" />, <see cref="F:System.Data.SqlDbType.Timestamp" />, <see cref="F:System.Data.SqlDbType.TinyInt" />, <see cref="F:System.Data.SqlDbType.UniqueIdentifier" />, <see cref="F:System.Data.SqlDbType.Xml" />.
+          Only the following are allowed to be passed to this constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.Bit" />, <see cref="F:System.Data.SqlDbType.BigInt" />, <see cref="F:System.Data.SqlDbType.DateTime" />, <see cref="F:System.Data.SqlDbType.Decimal" />, <see cref="F:System.Data.SqlDbType.Float" />, <see cref="F:System.Data.SqlDbType.Int" />, <see cref="F:System.Data.SqlDbType.Money" />, <c>Numeric</c>, <see cref="F:System.Data.SqlDbType.SmallDateTime" />, <see cref="F:System.Data.SqlDbType.SmallInt" />, <see cref="F:System.Data.SqlDbType.SmallMoney" />, <see cref="F:System.Data.SqlDbType.Timestamp" />, <see cref="F:System.Data.SqlDbType.TinyInt" />, <see cref="F:System.Data.SqlDbType.UniqueIdentifier" />, <see cref="F:System.Data.SqlDbType.Xml" />.
         </para>
         <para>
           The following are the default values assigned to <paramref name="dtType" />, depending on the <see cref="T:System.Data.SqlDbType" /> (the <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema" />, and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Type" /> properties are set to <see langword="null" />):
@@ -76,7 +76,7 @@
               <description>Compare options</description>
             </listheader>
             <item>
-              <term>see cref="F:System.Data.SqlDbType.Bit" /></term>
+              <term><see cref="F:System.Data.SqlDbType.Bit" /></term>
               <description>1</description>
               <description>1</description>
               <description>0</description>
@@ -132,7 +132,7 @@
               <description>None</description>
             </item>
             <item>
-              <term><see cref="F:System.Data.SqlDbType.Numeric" /></term>
+              <term><c>Numeric</c></term>
               <description>9</description>
               <description>18</description>
               <description>0</description>
@@ -535,7 +535,7 @@
         The <paramref name="name" /> is <see langword="null" />.
       </exception>
       <exception cref="T:System.ArgumentException">
-        A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />.
+        A <see cref="T:System.Data.SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />.
       </exception>
     </ctorNameDbTypeMaxLengthLocaleCompareOptions>
     <ctorNameDbTypeDatabaseOwningSchemaObjectName>
@@ -709,7 +709,7 @@
       </summary>
       <remarks>
         <para>
-          Only the following are allowed to be passed to the constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.BigInt" />, <see cref="F:System.Data.SqlDbType.Bit" />, <see cref="F:System.Data.DateTime" />, <see cref="F:System.Data.SqlDbType.Decimal" />, <see cref="F:System.Data.SqlDbType.Float" />, <see cref="F:System.Data.SqlDbType.Image" />, <see cref="F:System.Data.SqlDbType.Int" />, <see cref="F:System.Data.SqlDbType.Money" />, <see cref="F:System.Data.SqlDbType.NText" />, <see cref="F:System.Data.SqlDbType.Numeric" />, <see cref="F:System.Data.SqlDbType.Real" />, <see cref="F:System.Data.SqlDbType.SmallDateTime" />, <see cref="F:System.Data.SqlDbType.SmallInt" />, <see cref="F:System.Data.SqlDbType.SmallMoney" />, <see cref="F:System.Data.SqlDbType.Text" />, <see cref="F:System.Data.SqlDbType.TimeStamp" />, <see cref="F:System.Data.SqlDbType.TinyInt" />, <see cref="F:System.Data.SqlDbType.Udt" />, <see cref="F:System.Data.SqlDbType.UniqueIdentifier" />, <see cref="F:System.Data.SqlDbType.Variant" />, <see cref="F:System.Data.SqlDbType.Xml" />.
+          Only the following are allowed to be passed to the constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.BigInt" />, <see cref="F:System.Data.SqlDbType.Bit" />, <see cref="F:System.Data.SqlDbType.DateTime" />, <see cref="F:System.Data.SqlDbType.Decimal" />, <see cref="F:System.Data.SqlDbType.Float" />, <see cref="F:System.Data.SqlDbType.Image" />, <see cref="F:System.Data.SqlDbType.Int" />, <see cref="F:System.Data.SqlDbType.Money" />, <see cref="F:System.Data.SqlDbType.NText" />, <c>Numeric</c>, <see cref="F:System.Data.SqlDbType.Real" />, <see cref="F:System.Data.SqlDbType.SmallDateTime" />, <see cref="F:System.Data.SqlDbType.SmallInt" />, <see cref="F:System.Data.SqlDbType.SmallMoney" />, <see cref="F:System.Data.SqlDbType.Text" />, <see cref="F:System.Data.SqlDbType.Timestamp" />, <see cref="F:System.Data.SqlDbType.TinyInt" />, <see cref="F:System.Data.SqlDbType.Udt" />, <see cref="F:System.Data.SqlDbType.UniqueIdentifier" />, <see cref="F:System.Data.SqlDbType.Variant" />, <see cref="F:System.Data.SqlDbType.Xml" />.
         </para>
         <para>
           The following are the default values assigned to <paramref name="dbType" />, depending on the <see cref="T:System.Data.SqlDbType" /> (the <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema" />, and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Type" /> properties are set to <see langword="null" />):
@@ -733,7 +733,7 @@
               <description>None</description>
             </item>
             <item>
-              <term><see cref="F:System.Data.Bit" /></term>
+              <term><see cref="F:System.Data.SqlDbType.Bit" /></term>
               <description>1</description>
               <description>1</description>
               <description>0</description>
@@ -741,7 +741,7 @@
               <description>None</description>
             </item>
             <item>
-              <term><see cref="F:System.Data.DateTime" /></term>
+              <term><see cref="F:System.Data.SqlDbType.DateTime" /></term>
               <description>8</description>
               <description>23</description>
               <description>3</description>
@@ -845,7 +845,7 @@
               <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
             </item>
             <item>
-              <term><see cref="F:System.Data.SqlDbType.TimeStamp" /></term>
+              <term><see cref="F:System.Data.SqlDbType.Timestamp" /></term>
               <description>8</description>
               <description>0</description>
               <description>0</description>
@@ -899,7 +899,7 @@
         The <paramref name="name" /> is <see langword="null" />.
       </exception>
       <exception cref="T:System.ArgumentException">
-        A <see langword="SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="userDefinedType" /> points to a type that does not have <see cref="T:Microsoft.Data.SqlClient.Server.SqlUserDefinedTypeAttribute" /> declared.
+        A <see langword="SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="userDefinedType" /> points to a type that does not have <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute" /> declared.
       </exception>
     </ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedType>
     <ctorNameDbTypeUserDefinedTypeServerTypeNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
@@ -1495,7 +1495,7 @@
         Indicates if the column in the table-valued parameter is unique.
       </summary>
       <value>
-        A <see langword="Boolean" /> value.
+        A <see cref="T:System.Boolean" /> value.
       </value>
       <remarks>
         <para>
@@ -1518,7 +1518,7 @@
       </value>
       <remarks>
         <para>
-          The default value is the current locale of the current thread for string-valued SqlDbTypes, and 0 for <see cref="T:System.Data.SqlDbTypes" />s that do not support collation.
+          The default value is the current locale of the current thread for string-valued <see cref="T:System.Data.SqlDbType" />s, and 0 for <see cref="T:System.Data.SqlDbType" />s that do not support collation.
         </para>
         <para>
           Returns 0 if the collation of the underlying column type is not defined.
@@ -1548,7 +1548,7 @@
           The potential maximum length for values of the specified column. Returns 0 for types other than fixed and varying length character and binary types. For variable size columns or parameters declared with the <c>Max</c> constructor parameter, it returns -1.
         </para>
         <para>
-          For <see cref="F:System.Data.DbType.Row" /> this returns the number of columns in the row metadata instance.
+          For <c>Row</c> this returns the number of columns in the row metadata instance.
         </para>
         <para>
           The default value is 0.
@@ -1663,7 +1663,7 @@
         Reports whether this column should use the default server value.
       </summary>
       <value>
-        A <see langword="Boolean" /> value.
+        A <see cref="T:System.Boolean" /> value.
       </value>
       <remarks>
         <para>

--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml
@@ -1,896 +1,1726 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SqlMetaData">
-        <SqlMetaData>
-            <summary>Specifies and retrieves metadata information from parameters and columns of <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> objects. This class cannot be inherited.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Examples  
-The following example shows the creation of several <xref:Microsoft.Data.SqlClient.Server.SqlMetaData> objects, which describe the column metadata of a record, and the creation of a <xref:Microsoft.Data.SqlClient.Server.SqlDataRecord>. The column values of the <xref:Microsoft.Data.SqlClient.Server.SqlDataRecord> are set and the <xref:Microsoft.Data.SqlClient.Server.SqlDataRecord> is sent to the calling program using the <xref:Microsoft.SqlServer.Server.SqlContext> class.  
-
-[!code-csharp[SqlMetaData Samples#1](~/../sqlclient/doc/samples/SqlMetaData.cs#1)]
-
-]]></format>
-            </remarks>
-        </SqlMetaData>
-        <ctor>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class.</summary>
-        </ctor>
-        <ctorNameDbType>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name and type.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-Only the following are allowed to be passed to the constructor as `dbType`: `Bit`, `BigInt`, `DateTime`, `Decimal`, `Float`, `Int`, `Money`, `Numeric`, `SmallDateTime`, `SmallInt`, `SmallMoney`, `TimeStamp`, `TinyInt`, `UniqueIdentifier`, `Xml`.  
-
-The following are the default values assigned to `dbType`, depending on the `SqlDbType` (the <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema%2A>, and <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.Type%2A> properties are set to `null`):  
-
-|SqlDbType|Maximum length|Precision|Scale|Locale|Compare options|  
-|---------------|--------------------|---------------|-----------|------------|---------------------|  
-|`Bit`|1|1|0|0|None|  
-|`BigInt`|8|19|0|0|None|  
-|`DateTime`|8|23|3|0|None|  
-|`Decimal`|9|18|0|0|None|  
-|`Float`|8|53|0|0|None|  
-|`Int`|4|10|0|0|None|  
-|`Money`|8|19|4|0|None|  
-|`Numeric`|9|18|0|0|None|  
-|`SmallDateTime`|4|16|0|0|None|  
-|`SmallInt`|2|5|0|0|None|  
-|`SmallMoney`|4|10|4|0|None|  
-|`TimeStamp`|8|0|0|0|None|  
-|`TinyInt`|1|3|0|0|None|  
-|`UniqueIdentifier`|16|0|0|0|None|  
-|`Xml`|Max (-1)|0|0|0|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-
-## Examples  
-The following example creates a new <xref:Microsoft.Data.SqlClient.Server.SqlMetaData> object by specifying the column name and a column data type of <xref:System.Data.SqlDbType>.`Int`.  
-
-[!code-csharp[SqlMetaData Samples#3](~/../sqlclient/doc/samples/SqlMetaData.cs#3)]
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">The <paramref name="name" /> is <see langword="null" />.</exception>
-            <exception cref="T:System.ArgumentException">A <see langword="SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />.</exception>
-        </ctorNameDbType>
-        <ctorNameDbTypeMaxLength>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="maxLength">The maximum length of the specified type.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, and maximum length.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Only the following are allowed to be passed to the constructor as `dbType`: `Binary`, `Char`, `Image`, `NChar`, `Ntext`, `NVarChar`, `Text`, `VarBinary`, `VarChar`.  
-
-Only a `maxLength` specification of <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.Max%2A>, or -1 is allowed for a `dbType` of `Text`, `NText`, or `Image`.  
-
-For a `dbType` of `Varchar`, `Nvarchar`, or `VarBinary`, a length specification of <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.Max%2A>, or -1, declares the metadata as varchar(max), nvarchar(max), or nvarbinary(max), respectively.  
-
-The following are the default values assigned to `dbType`, depending on the `SqlDbType` (the <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema%2A>, and <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.Type%2A> properties are set to `null`):  
-
-|SqlDbType|Precision|Scale|Locale|Compare options|  
-|---------------|---------------|-----------|------------|---------------------|  
-|Binary|0|0|0|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-|Char|0|0|\<thread>|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-|Image|0|0|0|None|  
-|NChar|0|0|\<thread>|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-|NText|0|0|\<thread>|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-|NVarChar|0|0|\<thread>|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-|Text|0|0|\<thread>|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-|VarBinary|0|0||IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-|VarChar|0|0|\<thread>|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-
-
-## Examples  
-The following example creates a new <xref:Microsoft.Data.SqlClient.Server.SqlMetaData> object by specifying the column name, a column data type of <xref:System.Data.SqlDbType>`.NVarChar`, and a maximum length of 12 characters.  
-
-[!code-csharp[SqlMetaData Samples#2](~/../sqlclient/doc/samples/SqlMetaData.cs#2)]
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">The <paramref name="name" /> is <see langword="null" />.</exception>
-            <exception cref="T:System.ArgumentException">A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />.</exception>
-        </ctorNameDbTypeMaxLength>
-        <ctorNameDbTypeUserDefinedType>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="userDefinedType">A <see cref="T:System.Type" /> instance that points to the UDT.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, and user-defined type (UDT).</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Only the following `SqlDbType` is allowed to be passed to the constructor as `dbType`: `UDT`.  
-
-The following are the default values assigned to `dbType`, depending on the `SqlDbType` (the <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema%2A>, and <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.Type%2A> properties are set to `null`):  
-
-|SqlDbType|Maximum length|Precision|Scale|Locale|Compare options|  
-|---------------|--------------------|---------------|-----------|------------|---------------------|  
-|UDT|\<Max length of the type> or -1|0|0|0|None|  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">The <paramref name="name" /> is <see langword="null" />.</exception>
-            <exception cref="T:System.ArgumentException">A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="userDefinedType" /> points to a type that does not have <see cref="T:Microsoft.Data.SqlClient.Server.SqlUserDefinedTypeAttribute" /> declared.</exception>
-        </ctorNameDbTypeUserDefinedType>
-        <ctorNameDbTypePrecisionScale>
-            <param name="name">The name of the parameter or column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="precision">The precision of the parameter or column.</param>
-            <param name="scale">The scale of the parameter or column.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, precision, and scale.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Only the following `SqlDbType` is allowed to be passed to the constructor as `dbType`: `Decimal`.  
-
-The following are the default values assigned to `dbType`, depending on the `SqlDbType` (the <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema%2A>, and <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.Type%2A> properties are set to `null`):  
-
-|SqlDbType|Maximum length|Precision|Scale|Locale|Compare options|  
-|---------------|--------------------|---------------|-----------|------------|---------------------|  
-|Decimal|9|18|0|0|None|  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">The <paramref name="name" /> is <see langword="null" />.</exception>
-            <exception cref="T:System.ArgumentException">A <see langword="SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="scale" /> was greater than <paramref name="precision" />.</exception>
-        </ctorNameDbTypePrecisionScale>
-        <ctorNameDbTypeUserDefinedTypeServerTypeName>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="userDefinedType">A <see cref="T:System.Type" /> instance that points to the UDT.</param>
-            <param name="serverTypeName">The SQL Server type name for <paramref name="userDefinedType" />.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, user-defined type (UDT), and SQLServer type.</summary>
-        </ctorNameDbTypeUserDefinedTypeServerTypeName>
-        <ctorNameDbTypeMaxLengthLocaleCompareOptions>
-            <param name="name">The name of the parameter or column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="maxLength">The maximum length of the specified type.</param>
-            <param name="locale">The locale ID of the parameter or column.</param>
-            <param name="compareOptions">The comparison rules of the parameter or column.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, maximum length, locale, and compare options.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Only the following are allowed to be passed to the constructor as `dbType`: `Char`, `NChar`, `Ntext`, `NVarChar`, `Text`, `VarChar`.  
-
-Only a `maxLength` specification of <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.Max%2A>, or -1, is allowed for a `dbType` of `Text` or `NText`.  
-
-For a `dbType` of `Varchar` or `Nvarchar`, a length specification of <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.Max%2A>, or -1, declares the metadata as varchar(max) and nvarchar(max), respectively.  
-
-The following are the default values assigned to `dbType`, depending on the `SqlDbType` (the <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema%2A>, and <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.Type%2A> properties are set to `null`):  
-
-|SqlDbType|Precision|Scale|  
-|---------------|---------------|-----------|  
-|`Char`|0|0|  
-|`NChar`|0|0|  
-|`NText`|0|0|  
-|`NVarChar`|0|0|  
-|`Text`|0|0|  
-|`VarChar`|0|0|  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">The <paramref name="name" /> is <see langword="null" />.</exception>
-            <exception cref="T:System.ArgumentException">A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />.</exception>
-        </ctorNameDbTypeMaxLengthLocaleCompareOptions>
-        <ctorNameDbTypeDatabaseOwningSchemaObjectName>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="database">The database name of the XML schema collection of a typed XML instance.</param>
-            <param name="owningSchema">The relational schema name of the XML schema collection of a typed XML instance.</param>
-            <param name="objectName">The name of the XML schema collection of a typed XML instance.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, database name, owning schema, and object name.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Only the following `SqlDbType` is allowed to be passed to the constructor as `dbType`: `Xml`.  
-
-The following are the default values assigned to `dbType`, depending on the `SqlDbType`:  
-
-|SqlDbType|Maximum length|Precision|Scale|Locale|Compare options|  
-|---------------|--------------------|---------------|-----------|------------|---------------------|  
-|`Xml`|Max (-1)|0|0|0|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">The <paramref name="name" /> is <see langword="null" />, or <paramref name="objectName" /> is <see langword="null" /> when <paramref name="database" /> and <paramref name="owningSchema" /> are non-<see langword="null" />.</exception>
-            <exception cref="T:System.ArgumentException">A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />.</exception>
-        </ctorNameDbTypeDatabaseOwningSchemaObjectName>
-        <ctorNameDbTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
-            <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
-            <param name="columnSortOrder">Specifies the sort order for a column.</param>
-            <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, and default server. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-For more information, see [Table-Valued Parameters](/sql/connect/ado-net/sql/table-valued-parameters).  
-
-]]></format>
-            </remarks>
-        </ctorNameDbTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-        <ctorNameDbTypeMaxLengthUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="maxLength">The maximum length of the specified type.</param>
-            <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
-            <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
-            <param name="columnSortOrder">Specifies the sort order for a column.</param>
-            <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, maximum length, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-For more information, see [Table-Valued Parameters](/sql/connect/ado-net/sql/table-valued-parameters).  
-
-]]></format>
-            </remarks>
-        </ctorNameDbTypeMaxLengthUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-        <ctorNameDbTypePrecisionScaleUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="precision">The precision of the parameter or column.</param>
-            <param name="scale">The scale of the parameter or column.</param>
-            <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
-            <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
-            <param name="columnSortOrder">Specifies the sort order for a column.</param>
-            <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, precision, scale, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-For more information, see [Table-Valued Parameters](/sql/connect/ado-net/sql/table-valued-parameters).  
-
-]]></format>
-            </remarks>
-        </ctorNameDbTypePrecisionScaleUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-        <ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedType>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="maxLength">The maximum length of the specified type.</param>
-            <param name="precision">The precision of the parameter or column.</param>
-            <param name="scale">The scale of the parameter or column.</param>
-            <param name="locale">The locale ID of the parameter or column.</param>
-            <param name="compareOptions">The comparison rules of the parameter or column.</param>
-            <param name="userDefinedType">A <see cref="T:System.Type" /> instance that points to the UDT.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, maximum length, precision, scale, locale ID, compare options, and user-defined type (UDT).</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Only the following are allowed to be passed to the constructor as `dbType`: `BigInt`, `Bit`, `BitInt`, `DateTime`, `Decimal`, `Float`, `Image`, `Int`, `Money`, `Ntext`, `Numeric`, `Real`, `SmallDateTime`, `SmallInt`, `SmallMoney`, `Text`, `TimeStamp`, `TinyInt`, `UniqueIdentifier`, `Variant`, `Xml`.  
-
-The following are the default values assigned to `dbType`, depending on the `SqlDbType` (the <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName%2A>, <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema%2A>, and <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.Type%2A> properties are set to `null`):  
-
-|SqlDbType|Maximum length|Precision|Scale|Locale|Compare options|  
-|---------------|--------------------|---------------|-----------|------------|---------------------|  
-|`BigInt`|8|19|0|0|None|  
-|`Bit`|1|1|0|0|None|  
-|`DateTime`|8|23|3|0|None|  
-|`Decimal`|9|18|0|0|None|  
-|`Float`|8|53|0|0|None|  
-|`Image`|Max (-1)|0|0|0|None|  
-|`Int`|4|10|0|0|None|  
-|`Money`|8|19|4|0|None|  
-|`Ntext`|Max (-1)|0|0|\<thread>|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-|`Real`|4|24|0|0|None|  
-|`Row`|\<number of columns>|0|0|0|None|  
-|`SmallDateTime`|4|16|0|0|None|  
-|`SmallInt`|2|5|0|0|None|  
-|`SmallMoney`|4|10|4|0|None|  
-|`Text`|Max (-1)|0|0|\<thread>|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-|`TimeStamp`|8|0|0|0|None|  
-|`TinyInt`|1|3|0|0|None|  
-|`UniqueIdentifier`|16|0|0|0|None|  
-|`UDT`|\<Max length of the type> or -1|0|0|0|None|  
-|`Variant`|8016|0|0|0|None|  
-|`Xml`|Max (-1)|0|0|0|IgnoreCase, IgnoreKanaType, IgnoreWidth|  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">The <paramref name="name" /> is <see langword="null" />.</exception>
-            <exception cref="T:System.ArgumentException">A <see langword="SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="userDefinedType" /> points to a type that does not have <see cref="T:Microsoft.Data.SqlClient.Server.SqlUserDefinedTypeAttribute" /> declared.</exception>
-        </ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedType>
-        <ctorNameDbTypeUserDefinedTypeServerTypeNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="userDefinedType">A <see cref="T:System.Type" /> instance that points to the UDT.</param>
-            <param name="serverTypeName">The SQL Server type name for <paramref name="userDefinedType" />.</param>
-            <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
-            <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
-            <param name="columnSortOrder">Specifies the sort order for a column.</param>
-            <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, user-defined type, SQL Server type, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-For more information, see [Table-Valued Parameters](/sql/connect/ado-net/sql/table-valued-parameters).  
-
-]]></format>
-            </remarks>
-        </ctorNameDbTypeUserDefinedTypeServerTypeNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-        <ctorNameDbTypeMaxLengthLocaleCompareOptionsUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="maxLength">The maximum length of the specified type.</param>
-            <param name="locale">The locale ID of the parameter or column.</param>
-            <param name="compareOptions">The comparison rules of the parameter or column.</param>
-            <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
-            <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
-            <param name="columnSortOrder">Specifies the sort order for a column.</param>
-            <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, maximum length, locale, compare options, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-For more information, see [Table-Valued Parameters](/sql/connect/ado-net/sql/table-valued-parameters).  
-
-]]></format>
-            </remarks>
-        </ctorNameDbTypeMaxLengthLocaleCompareOptionsUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-        <ctorNameDbTypeDatabaseOwningSchemaObjectNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="database">The database name of the XML schema collection of a typed XML instance.</param>
-            <param name="owningSchema">The relational schema name of the XML schema collection of a typed XML instance.</param>
-            <param name="objectName">The name of the XML schema collection of a typed XML instance.</param>
-            <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
-            <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
-            <param name="columnSortOrder">Specifies the sort order for a column.</param>
-            <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, database name, owning schema, object name, and default server. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-For more information, see [Table-Valued Parameters](/sql/connect/ado-net/sql/table-valued-parameters).  
-
-]]></format>
-            </remarks>
-        </ctorNameDbTypeDatabaseOwningSchemaObjectNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-        <ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-            <param name="name">The name of the column.</param>
-            <param name="dbType">The SQL Server type of the parameter or column.</param>
-            <param name="maxLength">The maximum length of the specified type.</param>
-            <param name="precision">The precision of the parameter or column.</param>
-            <param name="scale">The scale of the parameter or column.</param>
-            <param name="localeId">The locale ID of the parameter or column.</param>
-            <param name="compareOptions">The comparison rules of the parameter or column.</param>
-            <param name="userDefinedType">A <see cref="T:System.Type" /> instance that points to the UDT.</param>
-            <param name="useServerDefault">Specifies whether this column should use the default server value.</param>
-            <param name="isUniqueKey">Specifies if the column in the table-valued parameter is unique.</param>
-            <param name="columnSortOrder">Specifies the sort order for a column.</param>
-            <param name="sortOrdinal">Specifies the ordinal of the sort column.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, maximum length, precision, scale, locale ID, compare options, and user-defined type (UDT). This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-For more information, see [Table-Valued Parameters](/sql/connect/ado-net/sql/table-valued-parameters).  
-
-]]></format>
-            </remarks>
-        </ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
-        <Adjust>
-            <summary>Validates the specified value against the metadata, and adjusts the value if necessary.</summary>
-        </Adjust>
-        <AdjustValue1>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Boolean" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Boolean" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue1>
-        <AdjustValue2>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Byte" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Byte" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue2>
-        <AdjustValue3>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified array of <see cref="T:System.Byte" /> values against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as an array of <see cref="T:System.Byte" /> values.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue3>
-        <AdjustValue4>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Char" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Char" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue4>
-        <AdjustValue5>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified array of <see cref="T:System.Char" /> values against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as an array <see cref="T:System.Char" /> values.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue5>
-        <AdjustValue6>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlBinary" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue6>
-        <AdjustValue7>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlBoolean" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlBoolean" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue7>
-        <AdjustValue8>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlByte" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlByte" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue8>
-        <AdjustValue9>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlBytes" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlBytes" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue9>
-        <AdjustValue10>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlChars" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlChars" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue10>
-        <AdjustValue11>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlDateTime" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlDateTime" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue11>
-        <AdjustValue12>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlDecimal" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue12>
-        <AdjustValue13>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlDouble" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlDouble" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue13>
-        <AdjustValue14>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlGuid" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlGuid" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue14>
-        <AdjustValue15>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlInt16" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue15>
-        <AdjustValue16>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlInt32" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue16>
-        <AdjustValue17>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlInt64" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue17>
-        <AdjustValue18>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlMoney" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue18>
-        <AdjustValue19>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlSingle" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue19>
-        <AdjustValue20>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlString" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlString" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue20>
-        <AdjustValue21>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Data.SqlTypes.SqlXml" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlXml" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue21>
-        <AdjustValue22>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.DateTime" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.DateTime" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue22>
-        <AdjustValue23>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.DateTimeOffset" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as an array of <see cref="T:System.DateTimeOffset" /> values.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue23>
-        <AdjustValue24>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Decimal" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Decimal" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue24>
-        <AdjustValue25>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Double" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Double" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue25>
-        <AdjustValue26>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Guid" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Guid" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue26>
-        <AdjustValue27>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Int16" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Int16" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue27>
-        <AdjustValue28>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Int32" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Int32" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue28>
-        <AdjustValue29>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Int64" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Int64" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue29>
-        <AdjustValue30>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Object" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Object" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue30>
-        <AdjustValue31>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.Single" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.Single" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue31>
-        <AdjustValue32>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.String" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as a <see cref="T:System.String" />.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue32>
-        <AdjustValue33>
-            <param name="value">The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Validates the specified <see cref="T:System.TimeSpan" /> value against the metadata, and adjusts the value if necessary.</summary>
-            <returns>The adjusted value as an array of <see cref="T:System.TimeSpan" /> values.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">
-            <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
-        </AdjustValue33>
-        <CompareOptions>
-            <summary>Gets the comparison rules used for the column or parameter.</summary>
-            <value>The comparison rules used for the column or parameter as a <see cref="T:System.Data.SqlTypes.SqlCompareOptions" />.</value>
-            <remarks>To be added.</remarks>
-        </CompareOptions>
-        <DbType>
-            <summary>Gets the data type of the column or parameter.</summary>
-            <value>The data type of the column or parameter as a <see cref="T:System.Data.DbType" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-    
-## Remarks  
-The default type is <xref:System.Data.DbType>.`String`.  
-
-]]></format>
-            </remarks>
-        </DbType>
-        <InferFromValue>
-            <param name="value">The object used from which the metadata is inferred.</param>
-            <param name="name">The name assigned to the returned <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</param>
-            <summary>Infers the metadata from the specified object and returns it as a <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</summary>
-            <returns>The inferred metadata as a <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentNullException">The <paramref name="value" /> is <see langword="null" />.</exception>
-        </InferFromValue>
-        <IsUniqueKey>
-            <summary>Indicates if the column in the table-valued parameter is unique.</summary>
-            <value>A <see langword="Boolean" /> value.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-    
-## Remarks  
-The default is `FALSE`.  
-
-This property can only be set in one of the <xref:Microsoft.Data.SqlClient.Server.SqlMetaData> constructors.  
-
-For more information, see [Table-Valued Parameters](/sql/connect/ado-net/sql/table-valued-parameters).  
-
-]]></format>
-            </remarks>
-        </IsUniqueKey>
-        <LocaleId>
-            <summary>Gets the locale ID of the column or parameter.</summary>
-            <value>The locale ID of the column or parameter as a <see cref="T:System.Int64" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default value is the current locale of the current thread for string-valued SqlDbTypes, and 0 for SqlDbTypes that do not support collation.  
-
-Returns 0 if the collation of the underlying column type is not defined.  
-
-]]></format>
-            </remarks>
-        </LocaleId>
-        <Max>
-            <summary>Gets the length of <see langword="text" />, <see langword="ntext" />, and <see langword="image" /> data types.</summary>
-            <value>The length of <see langword="text" />, <see langword="ntext" />, and <see langword="image" /> data types.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default value is -1.  
-
-]]></format>
-            </remarks>
-        </Max>
-        <MaxLength>
-            <summary>Gets the maximum length of the column or parameter.</summary>
-            <value>The maximum length of the column or parameter as a <see cref="T:System.Int64" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-                    
-## Remarks  
-The potential maximum length for values of the specified column. Returns 0 for types other than fixed and varying length character and binary types. For variable size columns or parameters declared with the `Max` constructor parameter, it returns -1.  
-
-For <xref:System.Data.DbType>.`Row` this returns the number of columns in the row metadata instance.  
-
-The default value is 0.  
-
-]]></format>
-            </remarks>
-        </MaxLength>
-        <Name>
-            <summary>Gets the name of the column or parameter.</summary>
-            <value>The name of the column or parameter as a <see cref="T:System.String" />.</value>
-            <remarks>To be added.</remarks>
-        </Name>
-        <Precision>
-            <summary>Gets the precision of the column or parameter.</summary>
-            <value>The precision of the column or parameter as a <see cref="T:System.Byte" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Returns 0 if the precision of the underlying column type is not defined.  
-
-]]></format>
-            </remarks>
-        </Precision>
-        <Scale>
-            <summary>Gets the scale of the column or parameter.</summary>
-            <value>The scale of the column or parameter.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Returns 0 if the scale of the underlying column type is not defined.  
-
-]]></format>
-            </remarks>
-        </Scale>
-        <SortOrder>
-            <summary>Returns the sort order for a column.</summary>
-            <value>A <see cref="T:Microsoft.Data.SqlClient.SortOrder" /> object.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-This property can only be set in one of the <xref:Microsoft.Data.SqlClient.Server.SqlMetaData> constructors.  
-
-For more information, see [Table-Valued Parameters](/sql/connect/ado-net/sql/table-valued-parameters).  
-
-]]></format>
-            </remarks>
-        </SortOrder>
-        <SortOrdinal>
-            <summary>Returns the ordinal of the sort column.</summary>
-            <value>The ordinal of the sort column.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default is 1.  
-
-This property can only be set in one of the <xref:Microsoft.Data.SqlClient.Server.SqlMetaData> constructors.  
-
-For more information, see [Table-Valued Parameters](/sql/connect/ado-net/sql/table-valued-parameters).  
-
-]]></format>
-            </remarks>
-        </SortOrdinal>
-        <SqlDbType>
-            <summary>Gets the data type of the column or parameter.</summary>
-            <value>The data type of the column or parameter as a <see cref="T:System.Data.DbType" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default value is `NVarChar`.  
-
-]]></format>
-            </remarks>
-        </SqlDbType>
-        <Type>
-            <summary>Gets the common language runtime (CLR) type of a user-defined type (UDT).</summary>
-            <value>The CLR type name of a user-defined type as a <see cref="T:System.Type" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default value is `null`.  
-
-Returns `null` if <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.SqlDbType%2A> is not a UDT type. `Null` may also returned for valid UDT result sets where the assembly is not available to the application.  
-
-]]></format>
-            </remarks>
-        </Type>
-        <TypeName>
-            <summary>Gets the three-part name of the user-defined type (UDT) or the SQL Server type represented by the instance.</summary>
-            <value>The name of the UDT or SQL Server type as a <see cref="T:System.String" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default value is `null`.  
-
-]]></format>
-            </remarks>
-        </TypeName>
-        <UseServerDefault>
-            <summary>Reports whether this column should use the default server value.</summary>
-            <value>A <see langword="Boolean" /> value.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default is `FALSE`.  
-
-This property can only be set in one of the <xref:Microsoft.Data.SqlClient.Server.SqlMetaData> constructors.  
-
-]]></format>
-            </remarks>
-        </UseServerDefault>
-        <XmlSchemaCollectionDatabase>
-            <summary>Gets the name of the database where the schema collection for this XML instance is located.</summary>
-            <value>The name of the database where the schema collection for this XML instance is located as a <see cref="T:System.String" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default value is `null`.  
-
-This property may be `null` if the collection is defined within the current database. It is also `null` if there is no schema collection, in which case <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName%2A> and <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema%2A> are also null.  
-
-]]></format>
-            </remarks>
-        </XmlSchemaCollectionDatabase>
-        <XmlSchemaCollectionName>
-            <summary>Gets the name of the schema collection for this XML instance.</summary>
-            <value>The name of the schema collection for this XML instance as a <see cref="T:System.String" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default value is `null`.  
-
-This value is `null` if there is no associated schema collection. If the value is `null`, then <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase%2A> and <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema%2A> are also `null`.  
-
-]]></format>
-            </remarks>
-        </XmlSchemaCollectionName>
-        <XmlSchemaCollectionOwningSchema>
-            <summary>Gets the owning relational schema where the schema collection for this XML instance is located.</summary>
-            <value>The owning relational schema where the schema collection for this XML instance is located as a <see cref="T:System.String" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-                    
-## Remarks  
-The default value is `null`.  
-
-This value may be `null` if the collection is defined within the current database and default schema. It is also null if there is no schema collection, in which case <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase%2A> and <xref:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName%2A> are also `null`.  
-
-]]></format>
-            </remarks>
-        </XmlSchemaCollectionOwningSchema>
-    </members>
+﻿<docs>
+  <members name="SqlMetaData">
+    <SqlMetaData>
+      <summary>
+        Specifies and retrieves metadata information from parameters and columns of <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> objects. This class cannot be inherited.
+      </summary>
+      <example>
+        <para>
+          The following example shows the creation of several <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects, which describe the column metadata of a record, and the creation of a <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" />. The column values of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> are set and the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> is sent to the calling program using the <see cref="T:Microsoft.SqlServer.Server.SqlContext" /> class.
+        </para>
+        <!-- SqlMetaData #1 -->
+        <code language="c#">
+          using Microsoft.Data.SqlClient.Server;
+      
+          [Microsoft.Data.SqlClient.Server.SqlProcedure]
+          public static void CreateNewRecord()
+          {
+              // Variables.
+              SqlMetaData column1Info;
+              SqlMetaData column2Info;
+              SqlMetaData column3Info;
+              SqlDataRecord record;
+      
+              // Create the column metadata.
+              column1Info = new SqlMetaData("Column1", SqlDbType.NVarChar, 12);
+              column2Info = new SqlMetaData("Column2", SqlDbType.Int);
+              column3Info = new SqlMetaData("Column3", SqlDbType.DateTime);
+      
+              // Create a new record with the column metadata.      
+              record = new SqlDataRecord(new SqlMetaData[] { 
+                column1Info,
+                column2Info,
+                column3Info });
+      
+              // Set the record fields.
+              record.SetString(0, "Hello World!");
+              record.SetInt32(1, 42);
+              record.SetDateTime(2, DateTime.Now);
+      
+              // Send the record to the calling program.
+              SqlContext.Pipe.Send(record);
+          }
+        </code>
+      </example>
+    </SqlMetaData>
+    <ctor>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class.
+      </summary>
+    </ctor>
+    <ctorNameDbType>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name and type.
+      </summary>
+      <remarks>
+        <para>
+          Only the following are allowed to be passed to this constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.Bit" />, <see cref="F:System.Data.SqlDbType.BigInt" />, <see cref="F:System.Data.SqlDbType.DateTime" />, <see cref="F:System.Data.SqlDbType.Decimal" />, <see cref="F:System.Data.SqlDbType.Float" />, <see cref="F:System.Data.SqlDbType.Int" />, <see cref="F:System.Data.SqlDbType.Money" />, <see cref="F:System.Data.SqlDbType.Numeric" />, <see cref="F:System.Data.SqlDbType.SmallDateTime" />, <see cref="F:System.Data.SqlDbType.SmallInt" />, <see cref="F:System.Data.SqlDbType.SmallMoney" />, <see cref="F:System.Data.SqlDbType.Timestamp" />, <see cref="F:System.Data.SqlDbType.TinyInt" />, <see cref="F:System.Data.SqlDbType.UniqueIdentifier" />, <see cref="F:System.Data.SqlDbType.Xml" />.
+        </para>
+        <para>
+          The following are the default values assigned to <paramref name="dtType" />, depending on the <see cref="T:System.Data.SqlDbType" /> (the <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema" />, and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Type" /> properties are set to <see langword="null" />):
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>SqlDbType</term>
+              <description>Maximum length</description>
+              <description>Precision</description>
+              <description>Scale</description>
+              <description>Locale</description>
+              <description>Compare options</description>
+            </listheader>
+            <item>
+              <term>see cref="F:System.Data.SqlDbType.Bit" /></term>
+              <description>1</description>
+              <description>1</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.BigInt" /></term>
+              <description>8</description>
+              <description>19</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.DateTime" /></term>
+              <description>8</description>
+              <description>23</description>
+              <description>3</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Decimal" /></term>
+              <description>9</description>
+              <description>18</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Float" /></term>
+              <description>8</description>
+              <description>53</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Int" /></term>
+              <description>4</description>
+              <description>10</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Money" /></term>
+              <description>8</description>
+              <description>19</description>
+              <description>4</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Numeric" /></term>
+              <description>9</description>
+              <description>18</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.SmallDateTime" /></term>
+              <description>4</description>
+              <description>16</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.SmallInt" /></term>
+              <description>2</description>
+              <description>5</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.SmallMoney" /></term>
+              <description>4</description>
+              <description>10</description>
+              <description>4</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Timestamp" /></term>
+              <description>8</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.TinyInt" /></term>
+              <description>1</description>
+              <description>3</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.UniqueIdentifier" /></term>
+              <description>16</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Xml" /></term>
+              <description>Max (-1)</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+          </list>
+        </para>
+      </remarks>
+      <example>
+        <para>
+          The following example creates a new <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> object by specifying the column name and a column data type of <see cref="F:System.Data.SqlDbType.Int" />
+        </para>
+        <!-- SqlMetadata #3 -->
+        <code language="c#">
+          using Microsoft.Data.SqlClient.Server;
+      
+          public static void CreateSqlMetaData2()
+          {
+              SqlMetaData columnInfo;
+              columnInfo = new SqlMetaData("Column2", SqlDbType.Int);
+          }
+        </code>
+      </example>
+      <exception cref="T:System.ArgumentNullException">
+        The <paramref name="name" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.ArgumentException">
+        A <see langword="SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />.
+      </exception>
+    </ctorNameDbType>
+    <ctorNameDbTypeMaxLength>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="maxLength">
+        The maximum length of the specified type.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, and maximum length.
+      </summary>
+      <remarks>
+        <para>
+          Only the following are allowed to be passed to the constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.Binary" />, <see cref="F:System.Data.SqlDbType.Char" />, <see cref="F:System.Data.SqlDbType.Image" />, <see cref="F:System.Data.SqlDbType.NChar" />, <see cref="F:System.Data.SqlDbType.NText" />, <see cref="F:System.Data.SqlDbType.NVarChar" />, <see cref="F:System.Data.SqlDbType.Text" />, <see cref="F:System.Data.SqlDbType.VarBinary" />, <see cref="F:System.Data.SqlDbType.VarChar" />.
+        </para>
+        <para>
+          Only a <paramref name="maxLength" /> specification of <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Max" />, or -1 is allowed for a <paramref name="dbType" /> of <see cref="F:System.Data.SqlDbType.Text" />, <see cref="F:System.Data.SqlDbType.NText" />, or <see cref="F:System.Data.SqlDbType.Image" />.
+        </para>
+        <para>
+          For a <paramref name="dbType" /> of <see cref="F:System.Data.SqlDbType.VarChar" />, <see cref="F:System.Data.SqlDbType.NVarChar" />, or <see cref="F:System.Data.SqlDbType.VarBinary" />, a length specification of <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Max" />, or -1, declares the metadata as <c>VARCHAR(MAX)</c>, <c>NVARCHAR(MAX)</c>, or <c>NVARBINARY(MAX)</c>, respectively.
+        </para>
+        <para>
+          The following are the default values assigned to <paramref name="dbType" />, depending on the <see cref="T:System.Data.SqlDbType" /> (the <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema" />, and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Type" /> properties are set to <see langword="null" />):
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>SqlDbType</term>
+              <description>Precision</description>
+              <description>Scale</description>
+              <description>Locale</description>
+              <description>Compare options</description>
+            </listheader>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Binary" /></term>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Char" /></term>
+              <description>0</description>
+              <description>0</description>
+              <description>&lt;thread&gt;</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Image" /></term>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.NChar" /></term>
+              <description>0</description>
+              <description>0</description>
+              <description>&lt;thread&gt;</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.NText" /></term>
+              <description>0</description>
+              <description>0</description>
+              <description>&lt;thread&gt;</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.NVarChar" /></term>
+              <description>0</description>
+              <description>0</description>
+              <description>&lt;thread&gt;</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Text" /></term>
+              <description>0</description>
+              <description>0</description>
+              <description>&lt;thread&gt;</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.VarBinary" /></term>
+              <description>0</description>
+              <description>0</description>
+              <description/>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.VarChar" /></term>
+              <description>0</description>
+              <description>0</description>
+              <description>&lt;thread&gt;</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+          </list>
+        </para>
+      </remarks>
+      <example>
+        <para>
+          The following example creates a new <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> object by specifying the column name, a column data type of <see cref="F:System.Data.SqlDbType.NVarChar" />, and a maximum length of 12 characters.
+        </para>
+        <!-- SqlMetaData #2 -->
+        <code language="c#">
+          using Microsoft.Data.SqlClient.Server;
+      
+          public static void CreateSqlMetaData1()
+          {
+              SqlMetaData columnInfo;
+              columnInfo = new SqlMetaData("Column1", SqlDbType.NVarChar, 12);
+          }
+        </code>
+      </example>
+      <exception cref="T:System.ArgumentNullException">
+        The <paramref name="name" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.ArgumentException">
+        A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />.
+      </exception>
+    </ctorNameDbTypeMaxLength>
+    <ctorNameDbTypeUserDefinedType>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="userDefinedType">
+        A <see cref="T:System.Type" /> instance that points to the UDT.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, and user-defined type (UDT).
+      </summary>
+      <remarks>
+        <para>
+          Only the following <see cref="T:System.Data.SqlDbType" /> is allowed to be passed to the constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.Udt" />.
+        </para>
+        <para>
+          The following are the default values assigned to <paramref name="dbType" />, depending on the <see cref="T:System.Data.SqlDbType" /> (the <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema" />, and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Type" /> properties are set to <see langword="null" />):
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>SqlDbType</term>
+              <description>Maximum length</description>
+              <description>Precision</description>
+              <description>Scale</description>
+              <description>Locale</description>
+              <description>Compare options</description>
+            </listheader>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Udt" /></term>
+              <description>&lt;Max length of the type&gt; or -1</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+          </list>
+        </para>
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        The <paramref name="name" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.ArgumentException">
+        A <see cref="T:System.Data.SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="userDefinedType" /> points to a type that does not have <see cref="T:Microsoft.Data.SqlClient.Server.SqlUserDefinedTypeAttribute" /> declared.
+      </exception>
+    </ctorNameDbTypeUserDefinedType>
+    <ctorNameDbTypePrecisionScale>
+      <param name="name">
+        The name of the parameter or column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="precision">
+        The precision of the parameter or column.
+      </param>
+      <param name="scale">
+        The scale of the parameter or column.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, precision, and scale.
+      </summary>
+      <remarks>
+        <para>
+          Only the following <see cref="T:System.Data.SqlDbType" /> is allowed to be passed to the constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.Decimal" />.
+        </para>
+        <para>
+          The following are the default values assigned to <paramref name="dbType" />, depending on the <see cref="T:System.Data.SqlDbType" /> (the <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema" />, and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Type" /> properties are set to <see langword="null" />):
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>SqlDbType</term>
+              <description>Maximum length</description>
+              <description>Precision</description>
+              <description>Scale</description>
+              <description>Locale</description>
+              <description>Compare options</description>
+            </listheader>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Decimal" /></term>
+              <description>9</description>
+              <description>18</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+          </list>
+        </para>
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        The <paramref name="name" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.ArgumentException">
+        A <see cref="T:System.Data.SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="scale" /> was greater than <paramref name="precision" />.
+      </exception>
+    </ctorNameDbTypePrecisionScale>
+    <ctorNameDbTypeUserDefinedTypeServerTypeName>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="userDefinedType">
+        A <see cref="T:System.Type" /> instance that points to the UDT.
+      </param>
+      <param name="serverTypeName">
+        The SQL Server type name for <paramref name="userDefinedType" />.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, user-defined type (UDT), and SQLServer type.
+      </summary>
+    </ctorNameDbTypeUserDefinedTypeServerTypeName>
+    <ctorNameDbTypeMaxLengthLocaleCompareOptions>
+      <param name="name">
+        The name of the parameter or column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="maxLength">
+        The maximum length of the specified type.
+      </param>
+      <param name="locale">
+        The locale ID of the parameter or column.
+      </param>
+      <param name="compareOptions">
+        The comparison rules of the parameter or column.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, maximum length, locale, and compare options.
+      </summary>
+      <remarks>
+        <para>
+          Only the following are allowed to be passed to the constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.Char" />, <see cref="F:System.Data.SqlDbType.NChar" />, <see cref="F:System.Data.SqlDbType.NText" />, <see cref="F:System.Data.SqlDbType.NVarChar" />, <see cref="F:System.Data.SqlDbType.Text" />, <see cref="F:System.Data.SqlDbType.VarChar" />.
+        </para>
+        <para>
+          Only a <see langword="maxLength" /> specification of <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Max" />, or -1, is allowed for a <paramref name="dbType" /> of <see cref="F:System.Data.SqlDbType.Text" /> or <see cref="F:System.Data.SqlDbType.NText" />.
+        </para>
+        <para>
+          For a <paramref name="dbType" /> of <see cref="F:System.Data.SqlDbType.VarChar" /> or <see cref="F:System.Data.SqlDbType.NVarChar" />, a length specification of <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Max" />, or -1, declares the metadata as VARCHAR(MAX) and NVARCHAR(MAX), respectively.
+        </para>
+        <para>
+          The following are the default values assigned to <paramref name="dbType" />, depending on the <see cref="T:System.Data.SqlDbType" /> (the <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema" />, and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Type" /> properties are set to <see langword="null" />):
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>SqlDbType</term>
+              <description>Precision</description>
+              <description>Scale</description>
+            </listheader>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Char" /></term>
+              <description>0</description>
+              <description>0</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.NChar" /></term>
+              <description>0</description>
+              <description>0</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.NText" /></term>
+              <description>0</description>
+              <description>0</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.NVarChar" /></term>
+              <description>0</description>
+              <description>0</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Text" /></term>
+              <description>0</description>
+              <description>0</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.VarChar" /></term>
+              <description>0</description>
+              <description>0</description>
+            </item>
+          </list>
+        </para>
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        The <paramref name="name" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.ArgumentException">
+        A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />.
+      </exception>
+    </ctorNameDbTypeMaxLengthLocaleCompareOptions>
+    <ctorNameDbTypeDatabaseOwningSchemaObjectName>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="database">
+        The database name of the XML schema collection of a typed XML instance.
+      </param>
+      <param name="owningSchema">
+        The relational schema name of the XML schema collection of a typed XML instance.
+      </param>
+      <param name="objectName">
+        The name of the XML schema collection of a typed XML instance.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, database name, owning schema, and object name.
+      </summary>
+      <remarks>
+        <para>
+          Only the following <see cref="T:System.Data.SqlDbType" /> is allowed to be passed to the constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.Xml" />.
+        </para>
+        <para>
+          The following are the default values assigned to <paramref name="dbType" />, depending on the <see cref="T:System.Data.SqlDbType" />:
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>SqlDbType</term>
+              <description>Maximum length</description>
+              <description>Precision</description>
+              <description>Scale</description>
+              <description>Locale</description>
+              <description>Compare options</description>
+            </listheader>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Xml" /></term>
+              <description>Max (-1)</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+          </list>
+        </para>
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        The <paramref name="name" /> is <see langword="null" />, or <paramref name="objectName" /> is <see langword="null" /> when <paramref name="database" /> and <paramref name="owningSchema" /> are non- <see langword="null" />.
+      </exception>
+      <exception cref="T:System.ArgumentException">
+        A SqlDbType that is not allowed was passed to the constructor as <paramref name="dbType" />.
+      </exception>
+    </ctorNameDbTypeDatabaseOwningSchemaObjectName>
+    <ctorNameDbTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="useServerDefault">
+        Specifies whether this column should use the default server value.
+      </param>
+      <param name="isUniqueKey">
+        Specifies if the column in the table-valued parameter is unique.
+      </param>
+      <param name="columnSortOrder">
+        Specifies the sort order for a column.
+      </param>
+      <param name="sortOrdinal">
+        Specifies the ordinal of the sort column.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, and default server. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.
+      </summary>
+      <remarks>
+        For more information, see <see href="/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+      </remarks>
+    </ctorNameDbTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+    <ctorNameDbTypeMaxLengthUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="maxLength">
+        The maximum length of the specified type.
+      </param>
+      <param name="useServerDefault">
+        Specifies whether this column should use the default server value.
+      </param>
+      <param name="isUniqueKey">
+        Specifies if the column in the table-valued parameter is unique.
+      </param>
+      <param name="columnSortOrder">
+        Specifies the sort order for a column.
+      </param>
+      <param name="sortOrdinal">
+        Specifies the ordinal of the sort column.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, maximum length, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.
+      </summary>
+      <remarks>
+        For more information, see <see href="/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+      </remarks>
+    </ctorNameDbTypeMaxLengthUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+    <ctorNameDbTypePrecisionScaleUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="precision">
+        The precision of the parameter or column.
+      </param>
+      <param name="scale">
+        The scale of the parameter or column.
+      </param>
+      <param name="useServerDefault">
+        Specifies whether this column should use the default server value.
+      </param>
+      <param name="isUniqueKey">
+        Specifies if the column in the table-valued parameter is unique.
+      </param>
+      <param name="columnSortOrder">
+        Specifies the sort order for a column.
+      </param>
+      <param name="sortOrdinal">
+        Specifies the ordinal of the sort column.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, precision, scale, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.
+      </summary>
+      <remarks>
+        For more information, see <see href="/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+      </remarks>
+    </ctorNameDbTypePrecisionScaleUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+    <ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedType>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="maxLength">
+        The maximum length of the specified type.
+      </param>
+      <param name="precision">
+        The precision of the parameter or column.
+      </param>
+      <param name="scale">
+        The scale of the parameter or column.
+      </param>
+      <param name="locale">
+        The locale ID of the parameter or column.
+      </param>
+      <param name="compareOptions">
+        The comparison rules of the parameter or column.
+      </param>
+      <param name="userDefinedType">
+        A <see cref="T:System.Type" /> instance that points to the UDT.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, maximum length, precision, scale, locale ID, compare options, and user-defined type (UDT).
+      </summary>
+      <remarks>
+        <para>
+          Only the following are allowed to be passed to the constructor as <paramref name="dbType" />: <see cref="F:System.Data.SqlDbType.BigInt" />, <see cref="F:System.Data.SqlDbType.Bit" />, <see cref="F:System.Data.DateTime" />, <see cref="F:System.Data.SqlDbType.Decimal" />, <see cref="F:System.Data.SqlDbType.Float" />, <see cref="F:System.Data.SqlDbType.Image" />, <see cref="F:System.Data.SqlDbType.Int" />, <see cref="F:System.Data.SqlDbType.Money" />, <see cref="F:System.Data.SqlDbType.NText" />, <see cref="F:System.Data.SqlDbType.Numeric" />, <see cref="F:System.Data.SqlDbType.Real" />, <see cref="F:System.Data.SqlDbType.SmallDateTime" />, <see cref="F:System.Data.SqlDbType.SmallInt" />, <see cref="F:System.Data.SqlDbType.SmallMoney" />, <see cref="F:System.Data.SqlDbType.Text" />, <see cref="F:System.Data.SqlDbType.TimeStamp" />, <see cref="F:System.Data.SqlDbType.TinyInt" />, <see cref="F:System.Data.SqlDbType.Udt" />, <see cref="F:System.Data.SqlDbType.UniqueIdentifier" />, <see cref="F:System.Data.SqlDbType.Variant" />, <see cref="F:System.Data.SqlDbType.Xml" />.
+        </para>
+        <para>
+          The following are the default values assigned to <paramref name="dbType" />, depending on the <see cref="T:System.Data.SqlDbType" /> (the <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName" />, <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema" />, and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.Type" /> properties are set to <see langword="null" />):
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>SqlDbType</term>
+              <description>Maximum length</description>
+              <description>Precision</description>
+              <description>Scale</description>
+              <description>Locale</description>
+              <description>Compare options</description>
+            </listheader>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.BigInt" /></term>
+              <description>8</description>
+              <description>19</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.Bit" /></term>
+              <description>1</description>
+              <description>1</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.DateTime" /></term>
+              <description>8</description>
+              <description>23</description>
+              <description>3</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Decimal" /></term>
+              <description>9</description>
+              <description>18</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Float" /></term>
+              <description>8</description>
+              <description>53</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Image" /></term>
+              <description>Max (-1)</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Int" /></term>
+              <description>4</description>
+              <description>10</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Money" /></term>
+              <description>8</description>
+              <description>19</description>
+              <description>4</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.NText" /></term>
+              <description>Max (-1)</description>
+              <description>0</description>
+              <description>0</description>
+              <description>&lt;thread&gt;</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Real" /></term>
+              <description>4</description>
+              <description>24</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><c>Row</c></term>
+              <description>&lt;number of columns&gt;</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.SmallDateTime" /></term>
+              <description>4</description>
+              <description>16</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.SmallInt" /></term>
+              <description>2</description>
+              <description>5</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.SmallMoney" /></term>
+              <description>4</description>
+              <description>10</description>
+              <description>4</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Text" /></term>
+              <description>Max (-1)</description>
+              <description>0</description>
+              <description>0</description>
+              <description>&lt;thread&gt;</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.TimeStamp" /></term>
+              <description>8</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.TinyInt" /></term>
+              <description>1</description>
+              <description>3</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.UniqueIdentifier" /></term>
+              <description>16</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Udt" /></term>
+              <description>&lt;Max length of the type&gt; or -1</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Variant" /></term>
+              <description>8016</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>None</description>
+            </item>
+            <item>
+              <term><see cref="F:System.Data.SqlDbType.Xml" /></term>
+              <description>Max (-1)</description>
+              <description>0</description>
+              <description>0</description>
+              <description>0</description>
+              <description>IgnoreCase, IgnoreKanaType, IgnoreWidth</description>
+            </item>
+          </list>
+        </para>
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        The <paramref name="name" /> is <see langword="null" />.
+      </exception>
+      <exception cref="T:System.ArgumentException">
+        A <see langword="SqlDbType" /> that is not allowed was passed to the constructor as <paramref name="dbType" />, or <paramref name="userDefinedType" /> points to a type that does not have <see cref="T:Microsoft.Data.SqlClient.Server.SqlUserDefinedTypeAttribute" /> declared.
+      </exception>
+    </ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedType>
+    <ctorNameDbTypeUserDefinedTypeServerTypeNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="userDefinedType">
+        A <see cref="T:System.Type" /> instance that points to the UDT.
+      </param>
+      <param name="serverTypeName">
+        The SQL Server type name for <paramref name="userDefinedType" />.
+      </param>
+      <param name="useServerDefault">
+        Specifies whether this column should use the default server value.
+      </param>
+      <param name="isUniqueKey">
+        Specifies if the column in the table-valued parameter is unique.
+      </param>
+      <param name="columnSortOrder">
+        Specifies the sort order for a column.
+      </param>
+      <param name="sortOrdinal">
+        Specifies the ordinal of the sort column.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, user-defined type, SQL Server type, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.
+      </summary>
+      <remarks>
+        For more information, see <see href="/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+      </remarks>
+    </ctorNameDbTypeUserDefinedTypeServerTypeNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+    <ctorNameDbTypeMaxLengthLocaleCompareOptionsUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="maxLength">
+        The maximum length of the specified type.
+      </param>
+      <param name="locale">
+        The locale ID of the parameter or column.
+      </param>
+      <param name="compareOptions">
+        The comparison rules of the parameter or column.
+      </param>
+      <param name="useServerDefault">
+        Specifies whether this column should use the default server value.
+      </param>
+      <param name="isUniqueKey">
+        Specifies if the column in the table-valued parameter is unique.
+      </param>
+      <param name="columnSortOrder">
+        Specifies the sort order for a column.
+      </param>
+      <param name="sortOrdinal">
+        Specifies the ordinal of the sort column.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, maximum length, locale, compare options, and server default. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.
+      </summary>
+      <remarks>
+        For more information, see <see href="/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+      </remarks>
+    </ctorNameDbTypeMaxLengthLocaleCompareOptionsUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+    <ctorNameDbTypeDatabaseOwningSchemaObjectNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="database">
+        The database name of the XML schema collection of a typed XML instance.
+      </param>
+      <param name="owningSchema">
+        The relational schema name of the XML schema collection of a typed XML instance.
+      </param>
+      <param name="objectName">
+        The name of the XML schema collection of a typed XML instance.
+      </param>
+      <param name="useServerDefault">
+        Specifies whether this column should use the default server value.
+      </param>
+      <param name="isUniqueKey">
+        Specifies if the column in the table-valued parameter is unique.
+      </param>
+      <param name="columnSortOrder">
+        Specifies the sort order for a column.
+      </param>
+      <param name="sortOrdinal">
+        Specifies the ordinal of the sort column.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, database name, owning schema, object name, and default server. This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.
+      </summary>
+      <remarks>
+        For more information, see <see href="/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+      </remarks>
+    </ctorNameDbTypeDatabaseOwningSchemaObjectNameUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+    <ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+      <param name="name">
+        The name of the column.
+      </param>
+      <param name="dbType">
+        The SQL Server type of the parameter or column.
+      </param>
+      <param name="maxLength">
+        The maximum length of the specified type.
+      </param>
+      <param name="precision">
+        The precision of the parameter or column.
+      </param>
+      <param name="scale">
+        The scale of the parameter or column.
+      </param>
+      <param name="localeId">
+        The locale ID of the parameter or column.
+      </param>
+      <param name="compareOptions">
+        The comparison rules of the parameter or column.
+      </param>
+      <param name="userDefinedType">
+        A <see cref="T:System.Type" /> instance that points to the UDT.
+      </param>
+      <param name="useServerDefault">
+        Specifies whether this column should use the default server value.
+      </param>
+      <param name="isUniqueKey">
+        Specifies if the column in the table-valued parameter is unique.
+      </param>
+      <param name="columnSortOrder">
+        Specifies the sort order for a column.
+      </param>
+      <param name="sortOrdinal">
+        Specifies the ordinal of the sort column.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, type, maximum length, precision, scale, locale ID, compare options, and user-defined type (UDT). This form of the constructor supports table-valued parameters by allowing you to specify if the column is unique in the table-valued parameter, the sort order for the column, and the ordinal of the sort column.
+      </summary>
+      <remarks>
+        For more information, see <see href="/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+      </remarks>
+    </ctorNameDbTypeMaxLengthPrecisionScaleLocaleCompareOptionsUserDefinedTypeUseServerDefaultIsUniqueKeyColumnSortOrderSortOrdinal>
+    <Adjust>
+      <summary>
+        Validates the specified value against the metadata, and adjusts the value if necessary.
+      </summary>
+    </Adjust>
+    <AdjustValue1>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Boolean" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Boolean" />.
+      </returns>
+      <exception cref="T:System.ArgumentException">
+        <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.
+      </exception>
+    </AdjustValue1>
+    <AdjustValue2>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Byte" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Byte" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue2>
+    <AdjustValue3>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified array of <see cref="T:System.Byte" /> values against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as an array of <see cref="T:System.Byte" /> values.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue3>
+    <AdjustValue4>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Char" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Char" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue4>
+    <AdjustValue5>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified array of <see cref="T:System.Char" /> values against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as an array <see cref="T:System.Char" /> values.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue5>
+    <AdjustValue6>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlBinary" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlBinary" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue6>
+    <AdjustValue7>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlBoolean" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlBoolean" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue7>
+    <AdjustValue8>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlByte" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlByte" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue8>
+    <AdjustValue9>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlBytes" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlBytes" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue9>
+    <AdjustValue10>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlChars" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlChars" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue10>
+    <AdjustValue11>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlDateTime" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlDateTime" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue11>
+    <AdjustValue12>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlDecimal" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlDecimal" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue12>
+    <AdjustValue13>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlDouble" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlDouble" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue13>
+    <AdjustValue14>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlGuid" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlGuid" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue14>
+    <AdjustValue15>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlInt16" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlInt16" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue15>
+    <AdjustValue16>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlInt32" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlInt32" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue16>
+    <AdjustValue17>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlInt64" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlInt64" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue17>
+    <AdjustValue18>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlMoney" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlMoney" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue18>
+    <AdjustValue19>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlSingle" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlSingle" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue19>
+    <AdjustValue20>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlString" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlString" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue20>
+    <AdjustValue21>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Data.SqlTypes.SqlXml" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Data.SqlTypes.SqlXml" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue21>
+    <AdjustValue22>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.DateTime" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.DateTime" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue22>
+    <AdjustValue23>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.DateTimeOffset" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as an array of <see cref="T:System.DateTimeOffset" /> values.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue23>
+    <AdjustValue24>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Decimal" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Decimal" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue24>
+    <AdjustValue25>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Double" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Double" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue25>
+    <AdjustValue26>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Guid" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Guid" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue26>
+    <AdjustValue27>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Int16" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Int16" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue27>
+    <AdjustValue28>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Int32" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Int32" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue28>
+    <AdjustValue29>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Int64" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Int64" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue29>
+    <AdjustValue30>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Object" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Object" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue30>
+    <AdjustValue31>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.Single" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.Single" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue31>
+    <AdjustValue32>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.String" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as a <see cref="T:System.String" />.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue32>
+    <AdjustValue33>
+      <param name="value">
+        The value to validate against the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Validates the specified <see cref="T:System.TimeSpan" /> value against the metadata, and adjusts the value if necessary.
+      </summary>
+      <returns>
+        The adjusted value as an array of <see cref="T:System.TimeSpan" /> values.
+      </returns>
+      <exception cref="T:System.ArgumentException"> <paramref name="value" /> does not match the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> type, or <paramref name="value" /> could not be adjusted.</exception>
+    </AdjustValue33>
+    <CompareOptions>
+      <summary>
+        Gets the comparison rules used for the column or parameter.
+      </summary>
+      <value>
+        The comparison rules used for the column or parameter as a <see cref="T:System.Data.SqlTypes.SqlCompareOptions" />.
+      </value>
+      <remarks>
+        To be added.
+      </remarks>
+    </CompareOptions>
+    <DbType>
+      <summary>
+        Gets the data type of the column or parameter.
+      </summary>
+      <value>
+        The data type of the column or parameter as a <see cref="T:System.Data.DbType" />.
+      </value>
+      <remarks>
+        The default type is <see cref="F:System.Data.DbType.String" />.
+      </remarks>
+    </DbType>
+    <InferFromValue>
+      <param name="value">
+        The object used from which the metadata is inferred.
+      </param>
+      <param name="name">
+        The name assigned to the returned <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </param>
+      <summary>
+        Infers the metadata from the specified object and returns it as a <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </summary>
+      <returns>
+        The inferred metadata as a <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instance.
+      </returns>
+      <exception cref="T:System.ArgumentNullException">
+        The <paramref name="value" /> is <see langword="null" />.
+      </exception>
+    </InferFromValue>
+    <IsUniqueKey>
+      <summary>
+        Indicates if the column in the table-valued parameter is unique.
+      </summary>
+      <value>
+        A <see langword="Boolean" /> value.
+      </value>
+      <remarks>
+        <para>
+          The default is <see langword="false" />.
+        </para>
+        <para>
+          This property can only be set in one of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> constructors.
+        </para>
+        <para>
+          For more information, see <see href="/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+        </para>
+      </remarks>
+    </IsUniqueKey>
+    <LocaleId>
+      <summary>
+        Gets the locale ID of the column or parameter.
+      </summary>
+      <value>
+        The locale ID of the column or parameter as a <see cref="T:System.Int64" />.
+      </value>
+      <remarks>
+        <para>
+          The default value is the current locale of the current thread for string-valued SqlDbTypes, and 0 for <see cref="T:System.Data.SqlDbTypes" />s that do not support collation.
+        </para>
+        <para>
+          Returns 0 if the collation of the underlying column type is not defined.
+        </para>
+      </remarks>
+    </LocaleId>
+    <Max>
+      <summary>
+        Gets the length of TEXT, NTEXT, and IMAGE data types.
+      </summary>
+      <value>
+        The length of TEXT, NTEXT, and IMAGE data types.
+      </value>
+      <remarks>
+        The default value is -1.
+      </remarks>
+    </Max>
+    <MaxLength>
+      <summary>
+        Gets the maximum length of the column or parameter.
+      </summary>
+      <value>
+        The maximum length of the column or parameter as a <see cref="T:System.Int64" />.
+      </value>
+      <remarks>
+        <para>
+          The potential maximum length for values of the specified column. Returns 0 for types other than fixed and varying length character and binary types. For variable size columns or parameters declared with the <c>Max</c> constructor parameter, it returns -1.
+        </para>
+        <para>
+          For <see cref="F:System.Data.DbType.Row" /> this returns the number of columns in the row metadata instance.
+        </para>
+        <para>
+          The default value is 0.
+        </para>
+      </remarks>
+    </MaxLength>
+    <Name>
+      <summary>
+        Gets the name of the column or parameter.
+      </summary>
+      <value>
+        The name of the column or parameter as a <see cref="T:System.String" />.
+      </value>
+    </Name>
+    <Precision>
+      <summary>
+        Gets the precision of the column or parameter.
+      </summary>
+      <value>
+        The precision of the column or parameter as a <see cref="T:System.Byte" />.
+      </value>
+      <remarks>
+        Returns 0 if the precision of the underlying column type is not defined.
+      </remarks>
+    </Precision>
+    <Scale>
+      <summary>
+        Gets the scale of the column or parameter.
+      </summary>
+      <value>
+        The scale of the column or parameter.
+      </value>
+      <remarks>
+        Returns 0 if the scale of the underlying column type is not defined.
+      </remarks>
+    </Scale>
+    <SortOrder>
+      <summary>
+        Returns the sort order for a column.
+      </summary>
+      <value>
+        A <see cref="T:Microsoft.Data.SqlClient.SortOrder" /> object.
+      </value>
+      <remarks>
+        <para>
+          This property can only be set in one of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> constructors.
+        </para>
+        <para>
+          For more information, see <see href="/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+        </para>
+      </remarks>
+    </SortOrder>
+    <SortOrdinal>
+      <summary>
+        Returns the ordinal of the sort column.
+      </summary>
+      <value>
+        The ordinal of the sort column.
+      </value>
+      <remarks>
+        <para>
+          The default is 1.
+        </para>
+        <para>
+          This property can only be set in one of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> constructors.
+        </para>
+        <para>
+          For more information, see <see href="/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+        </para>
+      </remarks>
+    </SortOrdinal>
+    <SqlDbType>
+      <summary>
+        Gets the data type of the column or parameter.
+      </summary>
+      <value>
+        The data type of the column or parameter as a <see cref="T:System.Data.DbType" />.
+      </value>
+      <remarks>
+        The default value is <see cref="F:System.Data.SqlDbType.NVarChar" />.
+      </remarks>
+    </SqlDbType>
+    <Type>
+      <summary>
+        Gets the common language runtime (CLR) type of user-defined type (UDT).
+      </summary>
+      <value>
+        The CLR type name of a user-defined type as a <see cref="T:System.Type" />.
+      </value>
+      <remarks>
+        <para>
+          The default value is <see langword="null" />.   
+        </para>
+        <para>
+          Returns <see langword="null" /> if <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.SqlDbType" /> is not a UDT type. <see langword="null" /> may also returned for valid UDT result sets where the assembly is not available to the application.
+        </para>
+      </remarks>
+    </Type>
+    <TypeName>
+      <summary>
+        Gets the three-part name of the user-defined type (UDT) or the SQL Server type represented by the instance.
+      </summary>
+      <value>
+        The name of the UDT or SQL Server type as a <see cref="T:System.String" />.
+      </value>
+      <remarks>
+        The default value is <see langword="null" />.
+      </remarks>
+    </TypeName>
+    <UseServerDefault>
+      <summary>
+        Reports whether this column should use the default server value.
+      </summary>
+      <value>
+        A <see langword="Boolean" /> value.
+      </value>
+      <remarks>
+        <para>
+          The default is <see langword="false" />.
+        </para>
+        <para>
+          This property can only be set in one of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> constructors.
+        </para>
+      </remarks>
+    </UseServerDefault>
+    <XmlSchemaCollectionDatabase>
+      <summary>
+        Gets the name of the database where the schema collection for this XML instance is located.
+      </summary>
+      <value>
+        The name of the database where the schema collection for this XML instance is located as a <see cref="T:System.String" />.
+      </value>
+      <remarks>
+        <para>
+          The default value is <see langword="null" />.
+        </para>
+        <para>
+          This property may be <see langword="null" /> if the collection is defined within the current database. It is also <see langword="null" /> if there is no schema collection, in which case <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName" /> and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema" /> are also <see langword="null" />.
+        </para>
+      </remarks>
+    </XmlSchemaCollectionDatabase>
+    <XmlSchemaCollectionName>
+      <summary>
+        Gets the name of the schema collection for this XML instance.
+      </summary>
+      <value>
+        The name of the schema collection for this XML instance as a <see cref="T:System.String" />.
+      </value>
+      <remarks>
+        <para>
+          The default value is <see langword="null" />.
+        </para>
+        <para>
+          This value is <see langword="null" /> if there is no associated schema collection. If the value is <see langword="null" />, then <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase" /> and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionOwningSchema" /> are also <see langword="null" />.
+        </para>
+      </remarks>
+    </XmlSchemaCollectionName>
+    <XmlSchemaCollectionOwningSchema>
+      <summary>
+        Gets the owning relational schema where the schema collection for this XML instance is located.
+      </summary>
+      <value>
+        The owning relational schema where the schema collection for this XML instance is located as a <see cref="T:System.String" />.
+      </value>
+      <remarks>
+        <para>
+          The default value is <see langword="null" />.
+        </para>
+        <para>
+          This value may be <see langword="null" /> if the collection is defined within the current database and default schema. It is also null if there is no schema collection, in which case <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionDatabase" /> and <see cref="P:Microsoft.Data.SqlClient.Server.SqlMetaData.XmlSchemaCollectionName" /> are also <see langword="null" />.
+        </para>
+      </remarks>
+    </XmlSchemaCollectionOwningSchema>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlClient.Server/TriggerAction.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/TriggerAction.xml
@@ -1,244 +1,389 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="TriggerAction">
-        <TriggerAction>
-            <summary>The <see cref="T:Microsoft.Data.SqlClient.Server.TriggerAction" /> enumeration is used by the <see cref="T:Microsoft.SqlServer.Server.SqlTriggerContext" /> class to indicate what action fired the trigger.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The <xref:Microsoft.Data.SqlClient.Server.TriggerAction> enumeration is used by the <xref:Microsoft.SqlServer.Server.SqlTriggerContext> class to indicate what action fired the trigger.
-  
- ]]></format>
-            </remarks>
-        </TriggerAction>
-        <AlterAppRole>
-            <summary>An ALTER APPLICATION ROLE Transact-SQL statement was executed.</summary>
-        </AlterAppRole>
-        <AlterAssembly>
-            <summary>An ALTER ASSEMBLY Transact-SQL statement was executed.</summary>
-        </AlterAssembly>
-        <AlterBinding>
-            <summary>An ALTER_REMOTE_SERVICE_BINDING event type was specified when an event notification was created on the database or server instance.</summary>
-        </AlterBinding>
-        <AlterFunction>
-            <summary>An ALTER FUNCTION Transact-SQL statement was executed.</summary>
-        </AlterFunction>
-        <AlterIndex>
-            <summary>An ALTER INDEX Transact-SQL statement was executed.</summary>
-        </AlterIndex>
-        <AlterLogin>
-            <summary>An ALTER LOGIN Transact-SQL statement was executed.</summary>
-        </AlterLogin>
-        <AlterPartitionFunction>
-            <summary>An ALTER PARTITION FUNCTION Transact-SQL statement was executed.</summary>
-        </AlterPartitionFunction>
-        <AlterPartitionScheme>
-            <summary>An ALTER PARTITION SCHEME Transact-SQL statement was executed.</summary>
-        </AlterPartitionScheme>
-        <AlterProcedure>
-            <summary>An ALTER PROCEDURE Transact-SQL statement was executed.</summary>
-        </AlterProcedure>
-        <AlterQueue>
-            <summary>An ALTER QUEUE Transact-SQL statement was executed.</summary>
-        </AlterQueue>
-        <AlterRole>
-            <summary>An ALTER ROLE Transact-SQL statement was executed.</summary>
-        </AlterRole>
-        <AlterRoute>
-            <summary>An ALTER ROUTE Transact-SQL statement was executed.</summary>
-        </AlterRoute>
-        <AlterSchema>
-            <summary>An ALTER SCHEMA Transact-SQL statement was executed.</summary>
-        </AlterSchema>
-        <AlterService>
-            <summary>An ALTER SERVICE Transact-SQL statement was executed.</summary>
-        </AlterService>
-        <AlterTable>
-            <summary>An ALTER TABLE Transact-SQL statement was executed.</summary>
-        </AlterTable>
-        <AlterTrigger>
-            <summary>An ALTER TRIGGER Transact-SQL statement was executed.</summary>
-        </AlterTrigger>
-        <AlterUser>
-            <summary>An ALTER USER Transact-SQL statement was executed.</summary>
-        </AlterUser>
-        <AlterView>
-            <summary>An ALTER VIEW Transact-SQL statement was executed.</summary>
-        </AlterView>
-        <CreateAppRole>
-            <summary>A CREATE APPLICATION ROLE Transact-SQL statement was executed.</summary>
-        </CreateAppRole>
-        <CreateAssembly>
-            <summary>A CREATE ASSEMBLY Transact-SQL statement was executed.</summary>
-        </CreateAssembly>
-        <CreateBinding>
-            <summary>A CREATE_REMOTE_SERVICE_BINDING event type was specified when an event notification was created on the database or server instance.</summary>
-        </CreateBinding>
-        <CreateContract>
-            <summary>A CREATE CONTRACT Transact-SQL statement was executed.</summary>
-        </CreateContract>
-        <CreateEventNotification>
-            <summary>A CREATE EVENT NOTIFICATION Transact-SQL statement was executed.</summary>
-        </CreateEventNotification>
-        <CreateFunction>
-            <summary>A CREATE FUNCTION Transact-SQL statement was executed.</summary>
-        </CreateFunction>
-        <CreateIndex>
-            <summary>A CREATE INDEX Transact-SQL statement was executed.</summary>
-        </CreateIndex>
-        <CreateLogin>
-            <summary>A CREATE LOGIN Transact-SQL statement was executed.</summary>
-        </CreateLogin>
-        <CreateMsgType>
-            <summary>A CREATE MESSAGE TYPE Transact-SQL statement was executed.</summary>
-        </CreateMsgType>
-        <CreatePartitionFunction>
-            <summary>A CREATE PARTITION FUNCTION Transact-SQL statement was executed.</summary>
-        </CreatePartitionFunction>
-        <CreatePartitionScheme>
-            <summary>A CREATE PARTITION SCHEME Transact-SQL statement was executed.</summary>
-        </CreatePartitionScheme>
-        <CreateProcedure>
-            <summary>A CREATE PROCEDURE Transact-SQL statement was executed.</summary>
-        </CreateProcedure>
-        <CreateQueue>
-            <summary>A CREATE QUEUE Transact-SQL statement was executed.</summary>
-        </CreateQueue>
-        <CreateRole>
-            <summary>A CREATE ROLE Transact-SQL statement was executed.</summary>
-        </CreateRole>
-        <CreateRoute>
-            <summary>A CREATE ROUTE Transact-SQL statement was executed.</summary>
-        </CreateRoute>
-        <CreateSchema>
-            <summary>A CREATE SCHEMA Transact-SQL statement was executed.</summary>
-        </CreateSchema>
-        <CreateSecurityExpression>
-            <summary>Not available.</summary>
-        </CreateSecurityExpression>
-        <CreateService>
-            <summary>A CREATE SERVICE Transact-SQL statement was executed.</summary>
-        </CreateService>
-        <CreateSynonym>
-            <summary>A CREATE SYNONYM Transact-SQL statement was executed.</summary>
-        </CreateSynonym>
-        <CreateTable>
-            <summary>A CREATE TABLE Transact-SQL statement was executed.</summary>
-        </CreateTable>
-        <CreateTrigger>
-            <summary>A CREATE TRIGGER Transact-SQL statement was executed.</summary>
-        </CreateTrigger>
-        <CreateType>
-            <summary>A CREATE TYPE Transact-SQL statement was executed.</summary>
-        </CreateType>
-        <CreateUser>
-            <summary>A CREATE USER Transact-SQL statement was executed.</summary>
-        </CreateUser>
-        <CreateView>
-            <summary>A CREATE VIEW Transact-SQL statement was executed.</summary>
-        </CreateView>
-        <Delete>
-            <summary>A DELETE Transact-SQL statement was executed.</summary>
-        </Delete>
-        <DenyObject>
-            <summary>A DENY Object Permissions Transact-SQL statement was executed.</summary>
-        </DenyObject>
-        <DenyStatement>
-            <summary>A DENY Transact-SQL statement was executed.</summary>
-        </DenyStatement>
-        <DropAppRole>
-            <summary>A DROP APPLICATION ROLE Transact-SQL statement was executed.</summary>
-        </DropAppRole>
-        <DropAssembly>
-            <summary>A DROP ASSEMBLY Transact-SQL statement was executed.</summary>
-        </DropAssembly>
-        <DropBinding>
-            <summary>A DROP_REMOTE_SERVICE_BINDING event type was specified when an event notification was created on the database or server instance.</summary>
-        </DropBinding>
-        <DropContract>
-            <summary>A DROP CONTRACT Transact-SQL statement was executed.</summary>
-        </DropContract>
-        <DropEventNotification>
-            <summary>A DROP EVENT NOTIFICATION Transact-SQL statement was executed.</summary>
-        </DropEventNotification>
-        <DropFunction>
-            <summary>A DROP FUNCTION Transact-SQL statement was executed.</summary>
-        </DropFunction>
-        <DropIndex>
-            <summary>A DROP INDEX Transact-SQL statement was executed.</summary>
-        </DropIndex>
-        <DropLogin>
-            <summary>A DROP LOGIN Transact-SQL statement was executed.</summary>
-        </DropLogin>
-        <DropMsgType>
-            <summary>A DROP MESSAGE TYPE Transact-SQL statement was executed.</summary>
-        </DropMsgType>
-        <DropPartitionFunction>
-            <summary>A DROP PARTITION FUNCTION Transact-SQL statement was executed.</summary>
-        </DropPartitionFunction>
-        <DropPartitionScheme>
-            <summary>A DROP PARTITION SCHEME Transact-SQL statement was executed.</summary>
-        </DropPartitionScheme>
-        <DropProcedure>
-            <summary>A DROP PROCEDURE Transact-SQL statement was executed.</summary>
-        </DropProcedure>
-        <DropQueue>
-            <summary>A DROP QUEUE Transact-SQL statement was executed.</summary>
-        </DropQueue>
-        <DropRole>
-            <summary>A DROP ROLE Transact-SQL statement was executed.</summary>
-        </DropRole>
-        <DropRoute>
-            <summary>A DROP ROUTE Transact-SQL statement was executed.</summary>
-        </DropRoute>
-        <DropSchema>
-            <summary>A DROP SCHEMA Transact-SQL statement was executed.</summary>
-        </DropSchema>
-        <DropSecurityExpression>
-            <summary>Not available.</summary>
-        </DropSecurityExpression>
-        <DropService>
-            <summary>A DROP SERVICE Transact-SQL statement was executed.</summary>
-        </DropService>
-        <DropSynonym>
-            <summary>A DROP SYNONYM Transact-SQL statement was executed.</summary>
-        </DropSynonym>
-        <DropTable>
-            <summary>A DROP TABLE Transact-SQL statement was executed.</summary>
-        </DropTable>
-        <DropTrigger>
-            <summary>A DROP TRIGGER Transact-SQL statement was executed.</summary>
-        </DropTrigger>
-        <DropType>
-            <summary>A DROP TYPE Transact-SQL statement was executed.</summary>
-        </DropType>
-        <DropUser>
-            <summary>A DROP USER Transact-SQL statement was executed.</summary>
-        </DropUser>
-        <DropView>
-            <summary>A DROP VIEW Transact-SQL statement was executed.</summary>
-        </DropView>
-        <GrantObject>
-            <summary>A GRANT OBJECT Transact-SQL statement was executed.</summary>
-        </GrantObject>
-        <GrantStatement>
-            <summary>A GRANT Transact-SQL statement was executed.</summary>
-        </GrantStatement>
-        <Insert>
-            <summary>An INSERT Transact-SQL statement was executed.</summary>
-        </Insert>
-        <Invalid>
-            <summary>An invalid trigger action, one that is not exposed to the user, occurred.</summary>
-        </Invalid>
-        <RevokeObject>
-            <summary>A REVOKE OBJECT Transact-SQL statement was executed.</summary>
-        </RevokeObject>
-        <RevokeStatement>
-            <summary>A REVOKE Transact-SQL statement was executed.</summary>
-        </RevokeStatement>
-        <Update>
-            <summary>An UPDATE Transact-SQL statement was executed.</summary>
-        </Update>
-    </members>
+﻿<docs>
+  <members name="TriggerAction">
+    <TriggerAction>
+      <summary>
+        The <see cref="T:Microsoft.Data.SqlClient.Server.TriggerAction" /> enumeration is used by the <see cref="T:Microsoft.SqlServer.Server.SqlTriggerContext" /> class to indicate what action fired the trigger.
+      </summary>
+    </TriggerAction>
+    <AlterAppRole>
+      <summary>
+        An ALTER APPLICATION ROLE Transact-SQL statement was executed.
+      </summary>
+    </AlterAppRole>
+    <AlterAssembly>
+      <summary>
+        An ALTER ASSEMBLY Transact-SQL statement was executed.
+      </summary>
+    </AlterAssembly>
+    <AlterBinding>
+      <summary>
+        An ALTER_REMOTE_SERVICE_BINDING event type was specified when an event notification was created on the database or server instance.
+      </summary>
+    </AlterBinding>
+    <AlterFunction>
+      <summary>
+        An ALTER FUNCTION Transact-SQL statement was executed.
+      </summary>
+    </AlterFunction>
+    <AlterIndex>
+      <summary>
+        An ALTER INDEX Transact-SQL statement was executed.
+      </summary>
+    </AlterIndex>
+    <AlterLogin>
+      <summary>
+        An ALTER LOGIN Transact-SQL statement was executed.
+      </summary>
+    </AlterLogin>
+    <AlterPartitionFunction>
+      <summary>
+        An ALTER PARTITION FUNCTION Transact-SQL statement was executed.
+      </summary>
+    </AlterPartitionFunction>
+    <AlterPartitionScheme>
+      <summary>
+        An ALTER PARTITION SCHEME Transact-SQL statement was executed.
+      </summary>
+    </AlterPartitionScheme>
+    <AlterProcedure>
+      <summary>
+        An ALTER PROCEDURE Transact-SQL statement was executed.
+      </summary>
+    </AlterProcedure>
+    <AlterQueue>
+      <summary>
+        An ALTER QUEUE Transact-SQL statement was executed.
+      </summary>
+    </AlterQueue>
+    <AlterRole>
+      <summary>
+        An ALTER ROLE Transact-SQL statement was executed.
+      </summary>
+    </AlterRole>
+    <AlterRoute>
+      <summary>
+        An ALTER ROUTE Transact-SQL statement was executed.
+      </summary>
+    </AlterRoute>
+    <AlterSchema>
+      <summary>
+        An ALTER SCHEMA Transact-SQL statement was executed.
+      </summary>
+    </AlterSchema>
+    <AlterService>
+      <summary>
+        An ALTER SERVICE Transact-SQL statement was executed.
+      </summary>
+    </AlterService>
+    <AlterTable>
+      <summary>
+        An ALTER TABLE Transact-SQL statement was executed.
+      </summary>
+    </AlterTable>
+    <AlterTrigger>
+      <summary>
+        An ALTER TRIGGER Transact-SQL statement was executed.
+      </summary>
+    </AlterTrigger>
+    <AlterUser>
+      <summary>
+        An ALTER USER Transact-SQL statement was executed.
+      </summary>
+    </AlterUser>
+    <AlterView>
+      <summary>
+        An ALTER VIEW Transact-SQL statement was executed.
+      </summary>
+    </AlterView>
+    <CreateAppRole>
+      <summary>
+        A CREATE APPLICATION ROLE Transact-SQL statement was executed.
+      </summary>
+    </CreateAppRole>
+    <CreateAssembly>
+      <summary>
+        A CREATE ASSEMBLY Transact-SQL statement was executed.
+      </summary>
+    </CreateAssembly>
+    <CreateBinding>
+      <summary>
+        A CREATE_REMOTE_SERVICE_BINDING event type was specified when an event notification was created on the database or server instance.
+      </summary>
+    </CreateBinding>
+    <CreateContract>
+      <summary>
+        A CREATE CONTRACT Transact-SQL statement was executed.
+      </summary>
+    </CreateContract>
+    <CreateEventNotification>
+      <summary>
+        A CREATE EVENT NOTIFICATION Transact-SQL statement was executed.
+      </summary>
+    </CreateEventNotification>
+    <CreateFunction>
+      <summary>
+        A CREATE FUNCTION Transact-SQL statement was executed.
+      </summary>
+    </CreateFunction>
+    <CreateIndex>
+      <summary>
+        A CREATE INDEX Transact-SQL statement was executed.
+      </summary>
+    </CreateIndex>
+    <CreateLogin>
+      <summary>
+        A CREATE LOGIN Transact-SQL statement was executed.
+      </summary>
+    </CreateLogin>
+    <CreateMsgType>
+      <summary>
+        A CREATE MESSAGE TYPE Transact-SQL statement was executed.
+      </summary>
+    </CreateMsgType>
+    <CreatePartitionFunction>
+      <summary>
+        A CREATE PARTITION FUNCTION Transact-SQL statement was executed.
+      </summary>
+    </CreatePartitionFunction>
+    <CreatePartitionScheme>
+      <summary>
+        A CREATE PARTITION SCHEME Transact-SQL statement was executed.
+      </summary>
+    </CreatePartitionScheme>
+    <CreateProcedure>
+      <summary>
+        A CREATE PROCEDURE Transact-SQL statement was executed.
+      </summary>
+    </CreateProcedure>
+    <CreateQueue>
+      <summary>
+        A CREATE QUEUE Transact-SQL statement was executed.
+      </summary>
+    </CreateQueue>
+    <CreateRole>
+      <summary>
+        A CREATE ROLE Transact-SQL statement was executed.
+      </summary>
+    </CreateRole>
+    <CreateRoute>
+      <summary>
+        A CREATE ROUTE Transact-SQL statement was executed.
+      </summary>
+    </CreateRoute>
+    <CreateSchema>
+      <summary>
+        A CREATE SCHEMA Transact-SQL statement was executed.
+      </summary>
+    </CreateSchema>
+    <CreateSecurityExpression>
+      <summary>
+        Not available.
+      </summary>
+    </CreateSecurityExpression>
+    <CreateService>
+      <summary>
+        A CREATE SERVICE Transact-SQL statement was executed.
+      </summary>
+    </CreateService>
+    <CreateSynonym>
+      <summary>
+        A CREATE SYNONYM Transact-SQL statement was executed.
+      </summary>
+    </CreateSynonym>
+    <CreateTable>
+      <summary>
+        A CREATE TABLE Transact-SQL statement was executed.
+      </summary>
+    </CreateTable>
+    <CreateTrigger>
+      <summary>
+        A CREATE TRIGGER Transact-SQL statement was executed.
+      </summary>
+    </CreateTrigger>
+    <CreateType>
+      <summary>
+        A CREATE TYPE Transact-SQL statement was executed.
+      </summary>
+    </CreateType>
+    <CreateUser>
+      <summary>
+        A CREATE USER Transact-SQL statement was executed.
+      </summary>
+    </CreateUser>
+    <CreateView>
+      <summary>
+        A CREATE VIEW Transact-SQL statement was executed.
+      </summary>
+    </CreateView>
+    <Delete>
+      <summary>
+        A DELETE Transact-SQL statement was executed.
+      </summary>
+    </Delete>
+    <DenyObject>
+      <summary>
+        A DENY Object Permissions Transact-SQL statement was executed.
+      </summary>
+    </DenyObject>
+    <DenyStatement>
+      <summary>
+        A DENY Transact-SQL statement was executed.
+      </summary>
+    </DenyStatement>
+    <DropAppRole>
+      <summary>
+        A DROP APPLICATION ROLE Transact-SQL statement was executed.
+      </summary>
+    </DropAppRole>
+    <DropAssembly>
+      <summary>
+        A DROP ASSEMBLY Transact-SQL statement was executed.
+      </summary>
+    </DropAssembly>
+    <DropBinding>
+      <summary>
+        A DROP_REMOTE_SERVICE_BINDING event type was specified when an event notification was created on the database or server instance.
+      </summary>
+    </DropBinding>
+    <DropContract>
+      <summary>
+        A DROP CONTRACT Transact-SQL statement was executed.
+      </summary>
+    </DropContract>
+    <DropEventNotification>
+      <summary>
+        A DROP EVENT NOTIFICATION Transact-SQL statement was executed.
+      </summary>
+    </DropEventNotification>
+    <DropFunction>
+      <summary>
+        A DROP FUNCTION Transact-SQL statement was executed.
+      </summary>
+    </DropFunction>
+    <DropIndex>
+      <summary>
+        A DROP INDEX Transact-SQL statement was executed.
+      </summary>
+    </DropIndex>
+    <DropLogin>
+      <summary>
+        A DROP LOGIN Transact-SQL statement was executed.
+      </summary>
+    </DropLogin>
+    <DropMsgType>
+      <summary>
+        A DROP MESSAGE TYPE Transact-SQL statement was executed.
+      </summary>
+    </DropMsgType>
+    <DropPartitionFunction>
+      <summary>
+        A DROP PARTITION FUNCTION Transact-SQL statement was executed.
+      </summary>
+    </DropPartitionFunction>
+    <DropPartitionScheme>
+      <summary>
+        A DROP PARTITION SCHEME Transact-SQL statement was executed.
+      </summary>
+    </DropPartitionScheme>
+    <DropProcedure>
+      <summary>
+        A DROP PROCEDURE Transact-SQL statement was executed.
+      </summary>
+    </DropProcedure>
+    <DropQueue>
+      <summary>
+        A DROP QUEUE Transact-SQL statement was executed.
+      </summary>
+    </DropQueue>
+    <DropRole>
+      <summary>
+        A DROP ROLE Transact-SQL statement was executed.
+      </summary>
+    </DropRole>
+    <DropRoute>
+      <summary>
+        A DROP ROUTE Transact-SQL statement was executed.
+      </summary>
+    </DropRoute>
+    <DropSchema>
+      <summary>
+        A DROP SCHEMA Transact-SQL statement was executed.
+      </summary>
+    </DropSchema>
+    <DropSecurityExpression>
+      <summary>
+        Not available.
+      </summary>
+    </DropSecurityExpression>
+    <DropService>
+      <summary>
+        A DROP SERVICE Transact-SQL statement was executed.
+      </summary>
+    </DropService>
+    <DropSynonym>
+      <summary>
+        A DROP SYNONYM Transact-SQL statement was executed.
+      </summary>
+    </DropSynonym>
+    <DropTable>
+      <summary>
+        A DROP TABLE Transact-SQL statement was executed.
+      </summary>
+    </DropTable>
+    <DropTrigger>
+      <summary>
+        A DROP TRIGGER Transact-SQL statement was executed.
+      </summary>
+    </DropTrigger>
+    <DropType>
+      <summary>
+        A DROP TYPE Transact-SQL statement was executed.
+      </summary>
+    </DropType>
+    <DropUser>
+      <summary>
+        A DROP USER Transact-SQL statement was executed.
+      </summary>
+    </DropUser>
+    <DropView>
+      <summary>
+        A DROP VIEW Transact-SQL statement was executed.
+      </summary>
+    </DropView>
+    <GrantObject>
+      <summary>
+        A GRANT OBJECT Transact-SQL statement was executed.
+      </summary>
+    </GrantObject>
+    <GrantStatement>
+      <summary>
+        A GRANT Transact-SQL statement was executed.
+      </summary>
+    </GrantStatement>
+    <Insert>
+      <summary>
+        An INSERT Transact-SQL statement was executed.
+      </summary>
+    </Insert>
+    <Invalid>
+      <summary>
+        An invalid trigger action, one that is not exposed to the user, occurred.
+      </summary>
+    </Invalid>
+    <RevokeObject>
+      <summary>
+        A REVOKE OBJECT Transact-SQL statement was executed.
+      </summary>
+    </RevokeObject>
+    <RevokeStatement>
+      <summary>
+        A REVOKE Transact-SQL statement was executed.
+      </summary>
+    </RevokeStatement>
+    <Update>
+      <summary>
+        An UPDATE Transact-SQL statement was executed.
+      </summary>
+    </Update>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml
+++ b/doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml
@@ -46,13 +46,13 @@
           The access mode to use when opening the file. Supported <see cref="T:System.IO.FileAccess" /> enumeration values are <see cref="F:System.IO.FileAccess.Read" />, <see cref="F:System.IO.FileAccess.Write" />, and <see cref="F:System.IO.FileAccess.ReadWrite" />.
         </para>
         <para>
-          When using <see langword="FileAccess.Read" />, the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object can be used to read all the existing data.
+          When using <see cref="F:System.IO.FileAccess.Read" />, the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object can be used to read all the existing data.
         </para>
         <para>
-          When using <see langword="FileAccess.Write" />, <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> points to a zero byte file. Existing data will be overwritten when the object is closed and the transaction is committed.
+          When using <see cref="F:System.IO.FileAccess.Write" />, <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> points to a zero byte file. Existing data will be overwritten when the object is closed and the transaction is committed.
         </para>
         <para>
-          When using <see langword="FileAccess.ReadWrite" />, the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> points to a file which has all the existing data in it. The handle is positioned at the beginning of the file. You can use one of the <see cref="M:System.IO.Stream.Seek" /> methods to move the handle position within the file to write or append new data.
+          When using <see cref="F:System.IO.FileAccess.ReadWrite" />, the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> points to a file which has all the existing data in it. The handle is positioned at the beginning of the file. You can use one of the <see cref="M:System.IO.Stream.Seek" /> methods to move the handle position within the file to write or append new data.
         </para>         
       </param>
       <summary>
@@ -310,9 +310,9 @@
       <value>
         <see langword="true" /> if the current stream supports writing; otherwise, <see langword="false" />.
       </value>
-      <related href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
         FILESTREAM Data in SQL Server 2008 (ADO.NET)
-      </related>
+      </seealso>
     </CanWrite>
     <dtor>
       <summary>
@@ -341,7 +341,7 @@
         The number of bytes read from the stream, between zero (0) and the number of bytes you requested. Streams return zero (0) only at the end of the stream, otherwise, they should block until at least one byte is available.
       </returns>
       <exception cref="T:System.ArgumentException">
-        The <see cref="T:System.IAsyncResult" /> object did not come from the corresponding <see cref="M:Microsoft.Data.SqlTypes.SqlFileStream.BeginRead" /> method.
+        The <see cref="T:System.IAsyncResult" /> object did not come from the corresponding <see cref="M:Microsoft.Data.SqlTypes.SqlFileStream.BeginRead(System.Byte[],System.Int32,System.Int32,System.AsyncCallback,System.Object)" /> method.
       </exception>
       <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
         FILESTREAM Data in SQL Server 2008 (ADO.NET)
@@ -355,7 +355,7 @@
         Ends an asynchronous write operation.
       </summary>
       <exception cref="T:System.ArgumentException">
-        The <see cref="T:System.IAsyncResult" /> object did not come from the corresponding <see cref="M:Microsoft.Data.SqlTypes.SqlFileStream.BeginRead" /> method.
+        The <see cref="T:System.IAsyncResult" /> object did not come from the corresponding <see cref="M:Microsoft.Data.SqlTypes.SqlFileStream.BeginRead(System.Byte[],System.Int32,System.Int32,System.AsyncCallback,System.Object)" /> method.
       </exception>
       <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
         FILESTREAM Data in SQL Server 2008 (ADO.NET)
@@ -500,7 +500,7 @@
         Gets or sets the transaction context for this <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object.
       </summary>
       <value>
-        The <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream.TransactionContext" /> array that was passed to the constructor for this <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object.
+        The <b>TransactionContext</b> array that was passed to the constructor for this <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object.
       </value>
       <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
         FILESTREAM Data in SQL Server 2008 (ADO.NET)

--- a/doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml
+++ b/doc/snippets/Microsoft.Data.SqlTypes/SqlFileStream.xml
@@ -1,346 +1,561 @@
-<docs>
-    <members name="SqlFileStream">
-        <SqlFileStream>
-            <summary>Exposes SQL Server data that is stored with the FILESTREAM column attribute as a sequence of bytes.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The <xref:Microsoft.Data.SqlTypes.SqlFileStream> class is used to work with `varbinary(max)` data stored with the FILESTREAM attribute in a SQL Server 2008 database. You must install the .NET Framework 3.5 SP1 (or later) to use <xref:Microsoft.Data.SqlTypes.SqlFileStream> to work with FILESTREAM data.  
-
-Specifying the FILESTREAM attribute on a `varbinary(max)` column causes SQL Server to store the data in the local NTFS file system instead of in the database file. Transact-SQL statements provide data manipulation capabilities within the server, and Win32 file system interfaces provide streaming access to the data.  
-
-> [!NOTE]
->  Individual files stored in a FILESTREAM column cannot be opened directly from the NTFS file system. Streaming FILESTREAM data works only in the context of a SQL Server transaction.  
-
-The <xref:Microsoft.Data.SqlTypes.SqlFileStream> class is derived from the <xref:System.IO.Stream> class, which represents an abstraction of a sequence of bytes from some arbitrary data source such as a file or a block of memory. You can read from a FILESTREAM by transferring data from a stream into a data structure such as an array of bytes. You can write to a FILESTREAM by transferring the data from a data structure into a stream. You can also seek within the stream, which allows you to query and modify data at the current position within the stream.  
-
-For conceptual documentation and code examples, see [FILESTREAM Data](/sql/connect/ado-net/sql/filestream-data).  
-
-For documentation about setting up and configuring FILESTREAM data on SQL Server,  see [Designing and Implementing FILESTREAM Storage](https://go.microsoft.com/fwlink/?LinkId=121499) in SQL Server 2008 Books Online.  
-
-]]></format>
-            </remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-            <related type="Article" href="https://msdn.microsoft.com/library/fafdc31a-f435-4cd3-883f-1dfadd971277">SQL Server Data Type Mappings (ADO.NET)</related>
-            <related type="Article" href="https://msdn.microsoft.com/library/e00827b3-7511-4b2d-91d7-851ca86cc6b5">SQL Server Binary and Large-Value Data (ADO.NET)</related>
-        </SqlFileStream>
-        <ctor1>
-            <param name="path">The logical path to the file. The path can be retrieved by using the Transact-SQL Pathname function on the underlying FILESTREAM column in the table.</param>
-            <param name="transactionContext">The transaction context for the <see langword="SqlFileStream" /> object. Applications should return the byte array returned by calling the GET_FILESTREAM_TRANSACTION_CONTEXT method.</param>
-            <param name="access">The access mode to use when opening the file. Supported <see cref="T:System.IO.FileAccess" /> enumeration values are <see cref="F:System.IO.FileAccess.Read" />, <see cref="F:System.IO.FileAccess.Write" />, and <see cref="F:System.IO.FileAccess.ReadWrite" />.  
-            
-When using <see langword="FileAccess.Read" />, the <see langword="SqlFileStream" /> object can be used to read all of the existing data.  
-    
-When using <see langword="FileAccess.Write" />, <see langword="SqlFileStream" /> points to a zero byte file. Existing data will be overwritten when the object is closed and the transaction is committed.  
-    
-When using <see langword="FileAccess.ReadWrite" />, the <see langword="SqlFileStream" /> points to a file which has all the existing data in it. The handle is positioned at the beginning of the file. You can use one of the <see langword="System.IO" /><see langword="Seek" /> methods to move the handle position within the file to write or append new data.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> class.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The following table lists the code access security (CAS) permissions that all callers in the stack must have to use the `SqlFileStream` constructors.  
-
-|File access|Permission|  
-|-----------------|----------------|  
-|Read|<xref:System.Security.Permissions.FileIOPermissionAccess.Read>|  
-|Write|<xref:System.Security.Permissions.FileIOPermissionAccess.Write>|  
-|ReadWrite|<xref:System.Security.Permissions.FileIOPermissionAccess.Read> and <xref:System.Security.Permissions.FileIOPermissionAccess.Write>|  
-
-For more information about CAS, see [Code Access Security and ADO.NET](/dotnet/framework/data/adonet/code-access-security).  
-
-If an exception is thrown, any open transactions should be rolled back. Otherwise, data loss can occur.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">
-            <paramref name="path" /> is a null reference, or <paramref name="transactionContext" /> is null.</exception>
-            <exception cref="T:System.ArgumentOutOfRangeException">
-            <paramref name="path" /> is an empty string (""), contains only white space, or contains one or more invalid characters.  
-            <paramref name="path" /> begins with "\\\\.\\", for example "\\\\.\PHYSICALDRIVE0 ".  
-                The handle returned by the call to NTCreateFile is not of type FILE_TYPE_DISK.  
-            <paramref name="path" /> contains an unsupported value.</exception>
-            <exception cref="T:System.IO.FileNotFoundException">The file cannot be found.</exception>
-            <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
-            <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
-            <exception cref="T:System.IO.DirectoryNotFoundException">The specified <paramref name="path" /> is invalid, such as being on an unmapped drive.</exception>
-            <exception cref="T:System.UnauthorizedAccessException">The access requested is not permitted by the operating system for the specified path. This occurs when Write or ReadWrite access is specified, and the file or directory is set for read-only access.</exception>
-            <exception cref="T:System.InvalidOperationException">NtCreateFile fails with error code set to ERROR_SHARING_VIOLATION.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </ctor1>
-        <ctor2>
-            <param name="path">The logical path to the file. The path can be retrieved by using the Transact-SQL Pathname function on the underlying FILESTREAM column in the table.</param>
-            <param name="transactionContext">The transaction context for the <see langword="SqlFileStream" /> object. When set to null, an implicit transaction will be used for the <see langword="SqlFileStream" /> object. Applications should return the byte array returned by calling the GET_FILESTREAM_TRANSACTION_CONTEXT method.</param>
-            <param name="access">The access mode to use when opening the file. Supported <see cref="T:System.IO.FileAccess" /> enumeration values are <see cref="F:System.IO.FileAccess.Read" />, <see cref="F:System.IO.FileAccess.Write" />, and <see cref="F:System.IO.FileAccess.ReadWrite" />.
-
-When using <see langword="FileAccess.Read" />, the <see langword="SqlFileStream" /> object can be used to read all of the existing data.
-
-When using <see langword="FileAccess.Write" />, <see langword="SqlFileStream" /> points to a zero byte file. Existing data will be overwritten when the object is closed and the transaction is committed.
-
-When using <see langword="FileAccess.ReadWrite" />, the <see langword="SqlFileStream" /> points to a file which has all the existing data in it. The handle is positioned at the beginning of the file. You can use one of the <see langword="System.IO" /><see langword="Seek" /> methods to move the handle position within the file to write or append new data.</param>
-            <param name="options">Specifies the option to use while opening the file. Supported <see cref="T:System.IO.FileOptions" /> values are <see cref="F:System.IO.FileOptions.Asynchronous" />, <see cref="F:System.IO.FileOptions.WriteThrough" />, <see cref="F:System.IO.FileOptions.SequentialScan" />, and <see cref="F:System.IO.FileOptions.RandomAccess" />.</param>
-            <param name="allocationSize">The allocation size to use while creating a file. If set to 0, the default value is used.</param>
-            <summary>Initializes a new instance of the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> class.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The following table lists the code access security (CAS) permissions that all callers in the stack must have to use the `SqlFileStream` constructors.  
-
-|File access|Permission|  
-|-----------------|----------------|  
-|Read|<xref:System.Security.Permissions.FileIOPermissionAccess.Read>|  
-|Write|<xref:System.Security.Permissions.FileIOPermissionAccess.Write>|  
-|ReadWrite|<xref:System.Security.Permissions.FileIOPermissionAccess.Read> and <xref:System.Security.Permissions.FileIOPermissionAccess.Write>|  
-
-For more information about CAS, see [Code Access Security and ADO.NET](/dotnet/framework/data/adonet/code-access-security).  
-
-If an exception is thrown, any open transactions should be rolled back. Otherwise, data loss can occur.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.ArgumentNullException">
-            <paramref name="path" /> is a null reference, or <paramref name="transactionContext" /> is null.</exception>
-            <exception cref="T:System.ArgumentOutOfRangeException">
-<paramref name="path" /> is an empty string (""), contains only white space, or contains one or more invalid characters.
-
-<paramref name="path" /> begins with "\\\\.\\", for example "\\\\.\PHYSICALDRIVE0 "
-    
-The handle returned by call to NTCreateFile is not of type FILE_TYPE_DISK.  
-    
-<paramref name="options" /> contains an unsupported value.</exception>
-            <exception cref="T:System.IO.FileNotFoundException">The file cannot be found.</exception>
-            <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
-            <exception cref="T:System.Security.SecurityException">The caller does not have the required permission.</exception>
-            <exception cref="T:System.IO.DirectoryNotFoundException">The specified <paramref name="path" /> is invalid, such as being on an unmapped drive.</exception>
-            <exception cref="T:System.UnauthorizedAccessException">The access requested is not permitted by the operating system for the specified path. This occurs when Write or ReadWrite access is specified, and the file or directory is set for read-only access.</exception>
-            <exception cref="T:System.InvalidOperationException">NtCreateFile fails with error code set to ERROR_SHARING_VIOLATION.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </ctor2>
-        <BeginRead>
-            <param name="buffer">The buffer to read the data into.</param>
-            <param name="offset">The byte offset in <paramref name="buffer" /> at which to begin writing data read from the stream.</param>
-            <param name="count">The maximum number of bytes to read.</param>
-            <param name="callback">An optional asynchronous callback, to be called when the read is complete.</param>
-            <param name="state">A user-provided object that distinguishes this particular asynchronous read request from other requests</param>
-            <summary>Begins an asynchronous read operation.</summary>
-            <returns>An <see cref="T:System.IAsyncResult" /> that represents the asynchronous read, which could still be pending.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-    
-## Remarks  
-Use the <xref:Microsoft.Data.SqlTypes.SqlFileStream.CanRead%2A> property to determine whether the current instance supports reading.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.NotSupportedException">Reading data is not supported on the stream.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </BeginRead>
-        <BeginWrite>
-            <param name="buffer">The buffer to write data from.</param>
-            <param name="offset">The byte offset in <paramref name="buffer" /> from which to begin writing.</param>
-            <param name="count">The maximum number of bytes to write.</param>
-            <param name="callback">An optional asynchronous callback, to be called when the write is complete.</param>
-            <param name="state">A user-provided object that distinguishes this particular asynchronous write request from other requests.</param>
-            <summary>Begins an asynchronous write operation.</summary>
-            <returns>An <see cref="T:System.IAsyncResult" /> that represents the asynchronous write, which could still be pending.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Use the <xref:Microsoft.Data.SqlTypes.SqlFileStream.CanWrite%2A> property to determine whether the current instance supports writing.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.NotSupportedException">Writing data is not supported on the stream.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </BeginWrite>
-        <CanRead>
-            <summary>Gets a value indicating whether the current stream supports reading.</summary>
-            <value>
-            <see langword="true" /> if the current stream supports reading; otherwise, <see langword="false" />.</value>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </CanRead>
-        <CanSeek>
-            <summary>Gets a value indicating whether the current stream supports seeking.</summary>
-            <value>
-            <see langword="true" /> if the current stream supports seeking; otherwise, <see langword="false" />.</value>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </CanSeek>
-        <CanTimeout>
-            <summary>Gets a value indicating whether the current stream can time out.</summary>
-            <value>
-            <see langword="true" /> if the current stream can time out; otherwise, <see langword="false" />.</value>
-            <remarks>To be added.</remarks>
-        </CanTimeout>
-        <CanWrite>
-            <summary>Gets a value indicating whether the current stream supports writing.</summary>
-            <value>
-            <see langword="true" /> if the current stream supports writing; otherwise, <see langword="false" />.</value>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </CanWrite>
-        <dtor>
-            <summary>Destructor of the SqlFileStream class object.</summary>
-            <remarks>To be added.</remarks>
-        </dtor>
-        <Dispose>
-            <param name="disposing"><see langword="true" /> to release managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.</param>
-            <summary>Releases the unmanaged resources used and optionally releases the managed resources.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-This method calls <xref:Stream.Dispose%2A>.
-
-]]></format>
-            </remarks>
-        </Dispose>
-        <EndRead>
-            <param name="asyncResult">The reference to the pending asynchronous request to finish.</param>
-            <summary>Waits for the pending asynchronous read to complete.</summary>
-            <returns>The number of bytes read from the stream, between zero (0) and the number of bytes you requested. Streams return zero (0) only at the end of the stream, otherwise, they should block until at least one byte is available.</returns>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">The <see cref="T:System.IAsyncResult" /> object did not come from the corresponding <see langword="BeginRead" /> method.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </EndRead>
-        <EndWrite>
-            <param name="asyncResult">A reference to the outstanding asynchronous I/O request.</param>
-            <summary>Ends an asynchronous write operation.</summary>
-            <remarks>To be added.</remarks>
-            <exception cref="T:System.ArgumentException">The <see cref="T:System.IAsyncResult" /> object did not come from the corresponding <see langword="BeginWrite" /> method.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </EndWrite>
-        <Finalize>
-            <summary>Ensures that resources are freed and other cleanup operations are performed when the garbage collector reclaims the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" />.</summary>
-            <remarks>To be added.</remarks>
-        </Finalize>
-        <Flush>
-            <summary>Clears all buffers for this stream and causes any buffered data to be written to the underlying device.</summary>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </Flush>
-        <Length>
-            <summary>Gets a value indicating the length of the current stream in bytes.</summary>
-            <value>An <see cref="T:System.Int64" /> indicating the length of the current stream in bytes.</value>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </Length>
-        <Name>
-            <summary>Gets the logical path of the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> passed to the constructor.</summary>
-            <value>A string value indicating the name of the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" />.</value>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </Name>
-        <Position>
-            <summary>Gets or sets the position within the current stream.</summary>
-            <value>The current position within the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" />.</value>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </Position>
-        <Read>
-            <param name="buffer">An array of bytes. When this method returns, the buffer contains the specified byte array with the values between offset and (offset + count - 1) replaced by the bytes read from the current source.</param>
-            <param name="offset">The zero-based byte offset in buffer at which to begin storing the data read from the current stream.</param>
-            <param name="count">The maximum number of bytes to be read from the current stream.</param>
-            <summary>Reads a sequence of bytes from the current stream and advances the position within the stream by the number of bytes read.</summary>
-            <returns>The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Use the <xref:Microsoft.Data.SqlTypes.SqlFileStream.CanRead%2A> property to determine whether the current instance supports writing.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.NotSupportedException">The object does not support reading of data.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </Read>
-        <ReadByte>
-            <summary>Reads a byte from the stream and advances the position within the stream by one byte, or returns -1 if at the end of the stream.</summary>
-            <returns>The unsigned byte cast to an <see cref="T:System.Int32" />, or -1 if at the end of the stream.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Use the <xref:Microsoft.Data.SqlTypes.SqlFileStream.CanRead%2A> property to determine whether the current instance supports reading.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.NotSupportedException">The object does not support reading of data.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </ReadByte>
-        <ReadTimeout>
-            <summary>Gets or sets a value, in milliseconds, that determines how long the stream will attempt to read before timing out.</summary>
-            <value>A value, in milliseconds, that determines how long the stream will attempt to read before timing out.</value>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </ReadTimeout>
-        <Seek>
-            <param name="offset">A byte offset relative to the <paramref name="origin" /> parameter</param>
-            <param name="origin">A value of type <see cref="T:System.IO.SeekOrigin" /> indicating the reference point used to obtain the new position</param>
-            <summary>Sets the position within the current stream.</summary>
-            <returns>The new position within the current stream.</returns>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </Seek>
-        <SetLength>
-            <param name="value">The desired length of the current stream in bytes.</param>
-            <summary>Sets the length of the current stream.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Use the <xref:Microsoft.Data.SqlTypes.SqlFileStream.CanRead%2A> property to determine whether the current instance supports reading.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.NotSupportedException">The object does not support reading of data.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </SetLength>
-        <TransactionContext>
-            <summary>Gets or sets the transaction context for this <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object.</summary>
-            <value>The <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream.TransactionContext" /> array that was passed to the constructor for this <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object.</value>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </TransactionContext>
-        <Write>
-            <param name="buffer">An array of bytes. This method copies <paramref name="count" /> bytes from <paramref name="buffer" /> to the current stream.</param>
-            <param name="offset">The zero-based byte offset in <paramref name="buffer" /> at which to begin copying bytes to the current stream.</param>
-            <param name="count">The number of bytes to be written to the current stream.</param>
-            <summary>Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Use the <xref:Microsoft.Data.SqlTypes.SqlFileStream.CanWrite%2A> property to determine whether the current instance supports writing.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.NotSupportedException">The object does not support writing of data.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </Write>
-        <WriteByte>
-            <param name="value">The byte to write to the stream.</param>
-            <summary>Writes a byte to the current position in the stream and advances the position within the stream by one byte.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Use the <xref:Microsoft.Data.SqlTypes.SqlFileStream.CanWrite%2A> property to determine whether the current instance supports writing.  
-
-]]></format>
-            </remarks>
-            <exception cref="T:System.NotSupportedException">The object does not support writing of data.</exception>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </WriteByte>
-        <WriteTimeout>
-            <summary>Gets or sets a value, in milliseconds, that determines how long the stream will attempt to write before timing out.</summary>
-            <value>A value, in milliseconds, that determines how long the stream will attempt to write before timing out.</value>
-            <remarks>To be added.</remarks>
-            <related type="Article" href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">FILESTREAM Data in SQL Server 2008 (ADO.NET)</related>
-        </WriteTimeout>
-    </members>
+﻿<docs>
+  <members name="SqlFileStream">
+    <SqlFileStream>
+      <summary>
+        Exposes SQL Server data that is stored with the FILESTREAM column attribute as a sequence of bytes.
+      </summary>
+      <remarks>
+        <para>
+          The <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> class is used to work with VARBINARY(MAX) data stored with the FILESTREAM attribute in a SQL Server 2008 database. You must install the .NET Framework 3.5 SP1 (or later) to use <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> to work with FILESTREAM data.
+        </para>
+        <para>
+          Specifying the FILESTREAM attribute on a VARBINARY(MAX) column causes SQL Server to store the data in the local NTFS file system instead of in the database file. Transact-SQL statements provide data manipulation capabilities within the server, and Win32 file system interfaces provide streaming access to the data.
+        </para>
+        <note type="note">
+          Individual files stored in a FILESTREAM column cannot be opened directly from the NTFS file system. Streaming FILESTREAM data works only in the context of a SQL Server transaction.
+        </note>
+        <para>
+          The <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> class is derived from the <see cref="T:System.IO.Stream" /> class, which represents an abstraction of a sequence of bytes from some arbitrary data source such as a file or a block of memory. You can read from a FILESTREAM by transferring data from a stream into a data structure such as an array of bytes. You can write to a FILESTREAM by transferring the data from a data structure into a stream. You can also seek within the stream, which allows you to query and modify data at the current position within the stream.
+        </para>
+        <para>
+          For conceptual documentation and code examples, see <see href="/sql/connect/ado-net/sql/filestream-data">FILESTREAM Data</see>.
+        </para>
+        <para>
+          For documentation about setting up and configuring FILESTREAM data on SQL Server, see <see href="https://go.microsoft.com/fwlink/?LinkId=121499">Designing and Implementing FILESTREAM Storage</see> in SQL Server 2008 Books Online.
+        </para>
+      </remarks>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+      <seealso href="https://msdn.microsoft.com/library/fafdc31a-f435-4cd3-883f-1dfadd971277">
+        SQL Server Data Type Mappings (ADO.NET)
+      </seealso>
+      <seealso href="https://msdn.microsoft.com/library/e00827b3-7511-4b2d-91d7-851ca86cc6b5">
+        SQL Server Binary and Large-Value Data (ADO.NET)
+      </seealso>
+    </SqlFileStream>
+    <ctor1>
+      <param name="path">
+        The logical path to the file. The path can be retrieved by using the Transact-SQL Pathname function on the underlying FILESTREAM column in the table.
+      </param>
+      <param name="transactionContext">
+        The transaction context for the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object. Applications should return the byte array returned by calling the GET_FILESTREAM_TRANSACTION_CONTEXT method.
+      </param>
+      <param name="access">
+        <para>
+          The access mode to use when opening the file. Supported <see cref="T:System.IO.FileAccess" /> enumeration values are <see cref="F:System.IO.FileAccess.Read" />, <see cref="F:System.IO.FileAccess.Write" />, and <see cref="F:System.IO.FileAccess.ReadWrite" />.
+        </para>
+        <para>
+          When using <see langword="FileAccess.Read" />, the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object can be used to read all the existing data.
+        </para>
+        <para>
+          When using <see langword="FileAccess.Write" />, <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> points to a zero byte file. Existing data will be overwritten when the object is closed and the transaction is committed.
+        </para>
+        <para>
+          When using <see langword="FileAccess.ReadWrite" />, the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> points to a file which has all the existing data in it. The handle is positioned at the beginning of the file. You can use one of the <see cref="M:System.IO.Stream.Seek" /> methods to move the handle position within the file to write or append new data.
+        </para>         
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> class.
+      </summary>
+      <remarks>
+        <para>
+          The following table lists the code access security (CAS) permissions that all callers in the stack must have to use the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> constructors.
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>File access</term>
+              <description>Permission</description>
+            </listheader>
+            <item>
+              <term>Read</term>
+              <description><see cref="F:System.Security.Permissions.FileIOPermissionAccess.Read" /></description>
+            </item>
+            <item>
+              <term>Write</term>
+              <description><see cref="F:System.Security.Permissions.FileIOPermissionAccess.Write" /></description>
+            </item>
+            <item>
+              <term>ReadWrite</term>
+              <description>
+                <see cref="F:System.Security.Permissions.FileIOPermissionAccess.Read" /> and <see cref="F:System.Security.Permissions.FileIOPermissionAccess.Write" />
+              </description>
+            </item>
+          </list>
+        </para>
+        <para>
+          For more information about CAS, see <see href="/dotnet/framework/data/adonet/code-access-security">Code Access Security and ADO.NET</see>.
+        </para>
+        <para>
+          If an exception is thrown, any open transactions should be rolled back. Otherwise, data loss can occur.
+        </para>
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="path" /> is a null reference, or <paramref name="transactionContext" /> is null.
+      </exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <para>
+          <paramref name="path" /> is an empty string (""), contains only white space, or contains one or more invalid characters. <paramref name="path" /> begins with "\\\\.\\", for example "\\\\.\PHYSICALDRIVE0 ".
+        </para>
+        <para>
+          The handle returned by the call to NTCreateFile is not of type FILE_TYPE_DISK. <paramref name="path" /> contains an unsupported value.
+        </para>
+      </exception>
+      <exception cref="T:System.IO.FileNotFoundException">
+        The file cannot be found.
+      </exception>
+      <exception cref="T:System.IO.IOException">
+        An I/O error occurred.
+      </exception>
+      <exception cref="T:System.Security.SecurityException">
+        The caller does not have the required permission.
+      </exception>
+      <exception cref="T:System.IO.DirectoryNotFoundException">
+        The specified <paramref name="path" /> is invalid, such as being on an unmapped drive.
+      </exception>
+      <exception cref="T:System.UnauthorizedAccessException">
+        The access requested is not permitted by the operating system for the specified path. This occurs when Write or ReadWrite access is specified, and the file or directory is set for read-only access.
+      </exception>
+      <exception cref="T:System.InvalidOperationException">
+        NtCreateFile fails with error code set to ERROR_SHARING_VIOLATION.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </ctor1>
+    <ctor2>
+      <param name="path">
+        The logical path to the file. The path can be retrieved by using the Transact-SQL Pathname function on the underlying FILESTREAM column in the table.
+      </param>
+      <param name="transactionContext">
+        The transaction context for the <see langword="SqlFileStream" /> object. When set to null, an implicit transaction will be used for the <see langword="SqlFileStream" /> object. Applications should return the byte array returned by calling the GET_FILESTREAM_TRANSACTION_CONTEXT method.
+      </param>
+      <param name="access">
+        The access mode to use when opening the file. Supported <see cref="T:System.IO.FileAccess" /> enumeration values are <see cref="F:System.IO.FileAccess.Read" />, <see cref="F:System.IO.FileAccess.Write" />, and <see cref="F:System.IO.FileAccess.ReadWrite" />. When using <see langword="FileAccess.Read" />, the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object can be used to read all the existing data.  When using <see langword="FileAccess.Write" />, <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> points to a zero byte file. Existing data will be overwritten when the object is closed and the transaction is committed.  When using <see langword="FileAccess.ReadWrite" />, the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> points to a file which has all the existing data in it. The handle is positioned at the beginning of the file. You can use one of the <see cref="M:System.IO.Stream.Seek" /> methods to move the handle position within the file to write or append new data.
+      </param>
+      <param name="options">
+        Specifies the option to use while opening the file. Supported <see cref="T:System.IO.FileOptions" /> values are <see cref="F:System.IO.FileOptions.Asynchronous" />, <see cref="F:System.IO.FileOptions.WriteThrough" />, <see cref="F:System.IO.FileOptions.SequentialScan" />, and <see cref="F:System.IO.FileOptions.RandomAccess" />.
+      </param>
+      <param name="allocationSize">
+        The allocation size to use while creating a file. If set to 0, the default value is used.
+      </param>
+      <summary>
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> class.
+      </summary>
+      <remarks>
+        <para>
+          The following table lists the code access security (CAS) permissions that all callers in the stack must have to use the <c>SqlFileStream</c> constructors.
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>File access</term>
+              <description>Permission</description>
+            </listheader>
+            <item>
+              <term>Read</term>
+              <description><see cref="F:System.Security.Permissions.FileIOPermissionAccess.Read" /></description>
+            </item>
+            <item>
+              <term>Write</term>
+              <description><see cref="F:System.Security.Permissions.FileIOPermissionAccess.Write" /></description>
+            </item>
+            <item>
+              <term>ReadWrite</term>
+              <description>
+                <see cref="F:System.Security.Permissions.FileIOPermissionAccess.Read" /> and <see cref="F:System.Security.Permissions.FileIOPermissionAccess.Write" />
+              </description>
+            </item>
+          </list>
+        </para>
+        <para>
+          For more information about CAS, see <see href="/dotnet/framework/data/adonet/code-access-security">Code Access Security and ADO.NET</see>.
+        </para>
+        <para>
+          If an exception is thrown, any open transactions should be rolled back. Otherwise, data loss can occur.
+        </para>
+      </remarks>
+      <exception cref="T:System.ArgumentNullException">
+        <paramref name="path" /> is a null reference, or <paramref name="transactionContext" /> is null.
+      </exception>
+      <exception cref="T:System.ArgumentOutOfRangeException">
+        <para>
+          <paramref name="path" /> is an empty string (""), contains only white space, or contains one or more invalid characters. <paramref name="path" /> begins with "\\\\.\\", for example "\\\\.\PHYSICALDRIVE0 "
+        </para>
+        <para>
+          The handle returned by call to NTCreateFile is not of type FILE_TYPE_DISK. <paramref name="options" /> contains an unsupported value.
+        </para>
+     </exception>
+      <exception cref="T:System.IO.FileNotFoundException">
+        The file cannot be found.
+      </exception>
+      <exception cref="T:System.IO.IOException">
+        An I/O error occurred.
+      </exception>
+      <exception cref="T:System.Security.SecurityException">
+        The caller does not have the required permission.
+      </exception>
+      <exception cref="T:System.IO.DirectoryNotFoundException">
+        The specified <paramref name="path" /> is invalid, such as being on an unmapped drive.
+      </exception>
+      <exception cref="T:System.UnauthorizedAccessException">
+        The access requested is not permitted by the operating system for the specified path. This occurs when Write or ReadWrite access is specified, and the file or directory is set for read-only access.
+      </exception>
+      <exception cref="T:System.InvalidOperationException">
+        NtCreateFile fails with error code set to ERROR_SHARING_VIOLATION.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </ctor2>
+    <BeginRead>
+      <param name="buffer">
+        The buffer to read the data into.
+      </param>
+      <param name="offset">
+        The byte offset in <paramref name="buffer" /> at which to begin writing data read from the stream.
+      </param>
+      <param name="count">
+        The maximum number of bytes to read.
+      </param>
+      <param name="callback">
+        An optional asynchronous callback, to be called when the read is complete.
+      </param>
+      <param name="state">
+        A user-provided object that distinguishes this particular asynchronous read request from other requests
+      </param>
+      <summary>
+        Begins an asynchronous read operation.
+      </summary>
+      <returns>
+        An <see cref="T:System.IAsyncResult" /> that represents the asynchronous read, which could still be pending.
+      </returns>
+      <remarks>
+        Use the <see cref="P:Microsoft.Data.SqlTypes.SqlFileStream.CanRead" /> property to determine whether the current instance supports reading.
+      </remarks>
+      <exception cref="T:System.NotSupportedException">
+        Reading data is not supported on the stream.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </BeginRead>
+    <BeginWrite>
+      <param name="buffer">
+        The buffer to write data from.
+      </param>
+      <param name="offset">
+        The byte offset in <paramref name="buffer" /> from which to begin writing.
+      </param>
+      <param name="count">
+        The maximum number of bytes to write.
+      </param>
+      <param name="callback">
+        An optional asynchronous callback, to be called when the write is complete.
+      </param>
+      <param name="state">
+        A user-provided object that distinguishes this particular asynchronous write request from other requests.
+      </param>
+      <summary>
+        Begins an asynchronous write operation.
+      </summary>
+      <returns>
+        An <see cref="T:System.IAsyncResult" /> that represents the asynchronous write, which could still be pending.
+      </returns>
+      <remarks>
+        Use the <see cref="P:Microsoft.Data.SqlTypes.SqlFileStream.CanWrite" /> property to determine whether the current instance supports writing.
+      </remarks>
+      <exception cref="T:System.NotSupportedException">
+        Writing data is not supported on the stream.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </BeginWrite>
+    <CanRead>
+      <summary>
+        Gets a value indicating whether the current stream supports reading.
+      </summary>
+      <value>
+        <see langword="true" /> if the current stream supports reading; otherwise, <see langword="false" />.
+      </value>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </CanRead>
+    <CanSeek>
+      <summary>
+        Gets a value indicating whether the current stream supports seeking.
+      </summary>
+      <value>
+        <see langword="true" /> if the current stream supports seeking; otherwise, <see langword="false" />.
+      </value>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </CanSeek>
+    <CanTimeout>
+      <summary>
+        Gets a value indicating whether the current stream can time out.
+      </summary>
+      <value>
+        <see langword="true" /> if the current stream can time out; otherwise, <see langword="false" />.
+      </value>
+    </CanTimeout>
+    <CanWrite>
+      <summary>
+        Gets a value indicating whether the current stream supports writing.
+      </summary>
+      <value>
+        <see langword="true" /> if the current stream supports writing; otherwise, <see langword="false" />.
+      </value>
+      <related href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </related>
+    </CanWrite>
+    <dtor>
+      <summary>
+        Destructor of the SqlFileStream class object.
+      </summary>
+    </dtor>
+    <Dispose>
+      <param name="disposing">
+        <see langword="true" /> to release managed and unmanaged resources; <see langword="false" /> to release only unmanaged resources.
+      </param>
+      <summary>
+        Releases the unmanaged resources used and optionally releases the managed resources.
+      </summary>
+      <remarks>
+        This method calls <see cref="M:System.IO.Stream.Dispose" />.
+      </remarks>
+    </Dispose>
+    <EndRead>
+      <param name="asyncResult">
+        The reference to the pending asynchronous request to finish.
+      </param>
+      <summary>
+        Waits for the pending asynchronous read to complete.
+      </summary>
+      <returns>
+        The number of bytes read from the stream, between zero (0) and the number of bytes you requested. Streams return zero (0) only at the end of the stream, otherwise, they should block until at least one byte is available.
+      </returns>
+      <exception cref="T:System.ArgumentException">
+        The <see cref="T:System.IAsyncResult" /> object did not come from the corresponding <see cref="M:Microsoft.Data.SqlTypes.SqlFileStream.BeginRead" /> method.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </EndRead>
+    <EndWrite>
+      <param name="asyncResult">
+        A reference to the outstanding asynchronous I/O request.
+      </param>
+      <summary>
+        Ends an asynchronous write operation.
+      </summary>
+      <exception cref="T:System.ArgumentException">
+        The <see cref="T:System.IAsyncResult" /> object did not come from the corresponding <see cref="M:Microsoft.Data.SqlTypes.SqlFileStream.BeginRead" /> method.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </EndWrite>
+    <Finalize>
+      <summary>
+        Ensures that resources are freed and other cleanup operations are performed when the garbage collector reclaims the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" />.
+      </summary>
+    </Finalize>
+    <Flush>
+      <summary>
+        Clears all buffers for this stream and causes any buffered data to be written to the underlying device.
+      </summary>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </Flush>
+    <Length>
+      <summary>
+        Gets a value indicating the length of the current stream in bytes.
+      </summary>
+      <value>
+        An <see cref="T:System.Int64" /> indicating the length of the current stream in bytes.
+      </value>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </Length>
+    <Name>
+      <summary>
+        Gets the logical path of the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> passed to the constructor.
+      </summary>
+      <value>
+        A string value indicating the name of the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" />.
+      </value>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </Name>
+    <Position>
+      <summary>
+        Gets or sets the position within the current stream.
+      </summary>
+      <value>
+        The current position within the <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" />.
+      </value>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </Position>
+    <Read>
+      <param name="buffer">
+        An array of bytes. When this method returns, the buffer contains the specified byte array with the values between offset and (offset + count - 1) replaced by the bytes read from the current source.
+      </param>
+      <param name="offset">
+        The zero-based byte offset in buffer at which to begin storing the data read from the current stream.
+      </param>
+      <param name="count">
+        The maximum number of bytes to be read from the current stream.
+      </param>
+      <summary>
+        Reads a sequence of bytes from the current stream and advances the position within the stream by the number of bytes read.
+      </summary>
+      <returns>
+        The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.
+      </returns>
+      <remarks>
+        Use the <see cref="P:Microsoft.Data.SqlTypes.SqlFileStream.CanRead" /> property to determine whether the current instance supports writing.
+      </remarks>
+      <exception cref="T:System.NotSupportedException">
+        The object does not support reading of data.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </Read>
+    <ReadByte>
+      <summary>
+        Reads a byte from the stream and advances the position within the stream by one byte, or returns -1 if at the end of the stream.
+      </summary>
+      <returns>
+        The unsigned byte cast to an <see cref="T:System.Int32" />, or -1 if at the end of the stream.
+      </returns>
+      <remarks>
+        Use the <see cref="P:Microsoft.Data.SqlTypes.SqlFileStream.CanRead" /> property to determine whether the current instance supports reading.
+      </remarks>
+      <exception cref="T:System.NotSupportedException">
+        The object does not support reading of data.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </ReadByte>
+    <ReadTimeout>
+      <summary>
+        Gets or sets a value, in milliseconds, that determines how long the stream will attempt to read before timing out.
+      </summary>
+      <value>
+        A value, in milliseconds, that determines how long the stream will attempt to read before timing out.
+      </value>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </ReadTimeout>
+    <Seek>
+      <param name="offset">
+        A byte offset relative to the <paramref name="origin" /> parameter
+      </param>
+      <param name="origin">
+        A value of type <see cref="T:System.IO.SeekOrigin" /> indicating the reference point used to obtain the new position
+      </param>
+      <summary>
+        Sets the position within the current stream.
+      </summary>
+      <returns>
+        The new position within the current stream.
+      </returns>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </Seek>
+    <SetLength>
+      <param name="value">
+        The desired length of the current stream in bytes.
+      </param>
+      <summary>
+        Sets the length of the current stream.
+      </summary>
+      <remarks>
+        Use the <see cref="P:Microsoft.Data.SqlTypes.SqlFileStream.CanRead" /> property to determine whether the current instance supports reading.
+      </remarks>
+      <exception cref="T:System.NotSupportedException">
+        The object does not support reading of data.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </SetLength>
+    <TransactionContext>
+      <summary>
+        Gets or sets the transaction context for this <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object.
+      </summary>
+      <value>
+        The <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream.TransactionContext" /> array that was passed to the constructor for this <see cref="T:Microsoft.Data.SqlTypes.SqlFileStream" /> object.
+      </value>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </TransactionContext>
+    <Write>
+      <param name="buffer">
+        An array of bytes. This method copies <paramref name="count" /> bytes from <paramref name="buffer" /> to the current stream.
+      </param>
+      <param name="offset">
+        The zero-based byte offset in <paramref name="buffer" /> at which to begin copying bytes to the current stream.
+      </param>
+      <param name="count">
+        The number of bytes to be written to the current stream.
+      </param>
+      <summary>
+        Writes a sequence of bytes to the current stream and advances the current position within this stream by the number of bytes written.
+      </summary>
+      <remarks>
+        Use the <see cref="P:Microsoft.Data.SqlTypes.SqlFileStream.CanWrite" /> property to determine whether the current instance supports writing.
+      </remarks>
+      <exception cref="T:System.NotSupportedException">
+        The object does not support writing of data.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </Write>
+    <WriteByte>
+      <param name="value">
+        The byte to write to the stream.
+      </param>
+      <summary>
+        Writes a byte to the current position in the stream and advances the position within the stream by one byte.
+      </summary>
+      <remarks>
+        Use the <see cref="P:Microsoft.Data.SqlTypes.SqlFileStream.CanWrite" /> property to determine whether the current instance supports writing.
+      </remarks>
+      <exception cref="T:System.NotSupportedException">
+        The object does not support writing of data.
+      </exception>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </WriteByte>
+    <WriteTimeout>
+      <summary>
+        Gets or sets a value, in milliseconds, that determines how long the stream will attempt to write before timing out.
+      </summary>
+      <value>
+        A value, in milliseconds, that determines how long the stream will attempt to write before timing out.
+      </value>
+      <seealso href="https://msdn.microsoft.com/library/bd8b845c-0f09-4295-b466-97ef106eefa8">
+        FILESTREAM Data in SQL Server 2008 (ADO.NET)
+      </seealso>
+    </WriteTimeout>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.Data/OperationAbortedException.xml
+++ b/doc/snippets/Microsoft.Data/OperationAbortedException.xml
@@ -1,17 +1,12 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="OperationAbortedException">
-        <OperationAbortedException>
-            <summary>This exception is thrown when an ongoing operation is aborted by the user.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-This exception indicates that an operation has been aborted by the consumer of an API. 
-For example, if the event handler of the <xref:Microsoft.Data.SqlClient.SqlBulkCopy.SqlRowsCopied> event sets the **Abort** property to `true` in the <xref:Microsoft.Data.SqlClient.SqlRowsCopiedEventArgs> object passed to the handler, the <xref:Microsoft.Data.SqlClient.SqlBulkCopy.WriteToServer%2A> method stops sending rows to the server and throws an <xref:Microsoft.Data.OperationAbortedException>.  
-
-]]></format>
-            </remarks>
-        </OperationAbortedException>
-    </members>
+﻿<docs>
+  <members name="OperationAbortedException">
+    <OperationAbortedException>
+      <summary>
+        This exception is thrown when an ongoing operation is aborted by the user.
+      </summary>
+      <remarks>
+        This exception indicates that an operation has been aborted by the consumer of an API.  For example, if the event handler of the <see cref="E:Microsoft.Data.SqlClient.SqlBulkCopy.SqlRowsCopied" /> event sets the <see cref="P:Microsoft.Data.SqlClient.SqlRowsCopiedEventArgs.Abort" />  property to <see langword="true" /> in the <see cref="T:Microsoft.Data.SqlClient.SqlRowsCopiedEventArgs" /> object passed to the handler, the <see cref="M:Microsoft.Data.SqlClient.SqlBulkCopy.WriteToServer(System.Data.DataTable)" /> method stops sending rows to the server and throws an <see cref="T:Microsoft.Data.OperationAbortedException" /> .
+      </remarks>
+    </OperationAbortedException>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.SqlServer.Server/DataAccessKind.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/DataAccessKind.xml
@@ -1,26 +1,30 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="DataAccessKind">
-        <DataAccessKind>
-            <summary>Describes the type of access to user data for a user-defined method or function.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Describes the type of access to user data for a user-defined method or function.  
-
-This enumeration is used in <xref:Microsoft.SqlServer.Server.SqlMethodAttribute> and <xref:Microsoft.SqlServer.Server.SqlFunctionAttribute> to indicate whether the method or function uses ADO.NET to connect back to the database using the "context connection."  
-
-Note that methods and functions are not allowed to make changes to the database, so the options for this enumeration are `None` (meaning no data-access performed by the method or function) and `Read` (meaning that the method or function perform read-only data-access operations, such as executing SELECT statements).  
-
- ]]></format>
-            </remarks>
-        </DataAccessKind>
-        <None>
-            <summary>The method or function does not access user data.</summary>
-        </None>
-        <Read>
-            <summary>The method or function reads user data.</summary>
-        </Read>
-    </members>
+﻿<docs>
+  <members name="DataAccessKind">
+    <DataAccessKind>
+      <summary>
+        Describes the type of access to user data for a user-defined method or function.
+      </summary>
+      <remarks>
+        <para>
+          Describes the type of access to user data for a user-defined method or function.
+        </para>
+        <para>
+          This enumeration is used in <see cref="T:Microsoft.SqlServer.Server.SqlMethodAttribute" /> and <see cref="T:Microsoft.SqlServer.Server.SqlFunctionAttribute" /> to indicate whether the method or function uses ADO.NET to connect back to the database using the "context connection."
+        </para>
+        <para>
+          Note that methods and functions are not allowed to make changes to the database, so the options for this enumeration are <see cref="F:Microsoft.SqlServer.Server.DataAccessKind.None" /> (meaning no data-access performed by the method or function) and <see cref="F:Microsoft.SqlServer.Server.DataAccessKind.Read" /> (meaning that the method or function perform read-only data-access operations, such as executing SELECT statements).
+        </para>
+      </remarks>
+    </DataAccessKind>
+    <None>
+      <summary>
+        The method or function does not access user data.
+      </summary>
+    </None>
+    <Read>
+      <summary>
+        The method or function reads user data.
+      </summary>
+    </Read>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.SqlServer.Server/Format.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/Format.xml
@@ -1,56 +1,313 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="Format">
-        <Format>
-            <summary>Used by <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute" /> and <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute" /> to indicate the serialization format of a user-defined type (UDT) or aggregate.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-
-## Remarks 
-
-This enumeration is used by <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute> and <xref:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute> to indicate the serialization format of a user-defined type (UDT) or aggregate. Use of the `Native` and `UserDefined` enumeration members has special requirements.   
-
-- `Format.Native`
-   The requirements for the `Format.Native` format are:  
-
-   - The <xref:System.Runtime.InteropServices.StructLayoutAttribute> with a <xref:System.Runtime.InteropServices.StructLayoutAttribute.Value> property value of <xref:System.Runtime.InteropServices.LayoutKind.Sequential?displayProperty=nameWithType> must be applied to the aggregate or UDT if it is defined in a class and not a structure. This controls the physical layout of the data fields and is used to force the members to be laid out sequentially in the order they appear. SQL Server uses this attribute to determine the field order for UDTs with multiple fields.
-
-   - The type must contain at least one member (serialized values cannot be zero bytes in size).  
-
-   - All the fields of the aggregate must be *blittable*; that is, they must have a common representation in both managed and unmanaged memory and not require special handling by the interop marshaler.  
-
-   - All the fields of the UDT should be of one of the following types that can be serialized: `bool`, `byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`, <xref:System.Data.SqlTypes.SqlByte>, <xref:System.Data.SqlTypes.SqlInt16>, <xref:System.Data.SqlTypes.SqlInt32>, <xref:System.Data.SqlTypes.SqlInt64>, <xref:System.Data.SqlTypes.SqlDateTime>, <xref:System.Data.SqlTypes.SqlSingle>, <xref:System.Data.SqlTypes.SqlDouble>, <xref:System.Data.SqlTypes.SqlMoney>, or other value types defined by the user that contain fields of one of these types.  
-   - The aggregate must not specify a value for `MaxByteSize`.  
-
-   - The aggregate must not have any [NonSerialized] fields.  
-
-   - Fields must not be marked as an explicit layout (with a <xref:System.Runtime.InteropServices.StructLayoutAttribute.Value?displayProperty=nameWithType> of <xref:System.Runtime.InteropServices.LayoutKind.Explicit?displayProperty=nameWithType>).  
-- `Format.UserDefined`
-   The requirements for the `Format.UserDefined` format are:
-   - The aggregate must specify a value for `MaxByteSize`.  
-
-   - Specify the <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsByteOrdered%2A?displayProperty=nameWithType> attribute property. The default value is `false`.  
-
-   - If you omit any field in the <xref:Microsoft.SqlServer.Server.IBinarySerialize.Read%2A?displayProperty=nameWithType> or <xref:Microsoft.SqlServer.Server.IBinarySerialize.Write%2A?displayProperty=nameWithType> methods, the state of that field is not serialized.  
-
-## Examples  
-
-The following example shows the `UserDefinedType` attribute of the Point UDT.  The UDT is byte-ordered, is named "Point", has a validation method named "ValidatePoint", and uses the native serialization format.  
-
-[!code-csharp[SqlUserDefinedTypeAttribute Example#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/DataWorks_SqlUserDefinedTypeAttribute_Sample.cs#1)]
-[!code-vb[SqlUserDefinedTypeAttribute Example#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/visualbasic/DataWorks_SqlUserDefinedTypeAttribute_Sample.vb#1)]
-
- ]]></format>
-            </remarks>
-        </Format>
-        <Native>
-            <summary>This serialization format uses a very simple algorithm that enables SQL Server to store an efficient representation of the UDT on disk. Types marked for <see langword="Native" /> serialization can only have value types (structs in Microsoft Visual C# and structures in Microsoft Visual Basic .NET) as members. Members of reference types (such as classes in Visual C# and Visual Basic), either user-defined or those existing in .NET class libraries (such as <see cref="T:System.String" />), are not supported.</summary>
-        </Native>
-        <Unknown>
-            <summary>The serialization format is unknown.</summary>
-        </Unknown>
-        <UserDefined>
-            <summary>This serialization format gives the developer full control over the binary format through the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write(System.IO.BinaryWriter)" /> and <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read(System.IO.BinaryReader)" /> methods.</summary>
-        </UserDefined>
-    </members>
+﻿<docs>
+  <members name="Format">
+    <Format>
+      <summary>
+        Used by <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute" /> and <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute" /> to indicate the serialization format of a user-defined type (UDT) or aggregate.
+      </summary>
+      <remarks>
+        <para>
+          This enumeration is used by <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute" /> and <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute" /> to indicate the serialization format of a user-defined type (UDT) or aggregate. Use of the <see cref="F:Microsoft.SqlServer.Server.Format.Native" /> and <see cref="F:Microsoft.SqlServer.Server.Format.UserDefined" /> enumeration members has special requirements.
+        </para>
+        <para>
+          The requirements for the <see cref="F:Microsoft.SqlServer.Server.Format.Native" /> format are:
+        </para>
+        <list type="bullet">
+          <item>
+            The <see cref="T:System.Runtime.InteropServices.StructLayoutAttribute" /> with a <see cref="P:System.Runtime.InteropServices.StructLayoutAttribute.Value" /> property value of <see cref="F:System.Runtime.InteropServices.LayoutKind.Sequential" /> must be applied to the aggregate or UDT if it is defined in a class and not a structure. This controls the physical layout of the data fields and is used to force the members to be laid out sequentially in the order they appear. SQL Server uses this attribute to determine the field order for UDTs with multiple fields.
+          </item>
+          <item>
+            The type must contain at least one member (serialized values cannot be zero bytes in size).
+          </item>
+          <item>
+            All the fields of the aggregate must be <i>blittable</i>; that is, they must have a common representation in both managed and unmanaged memory and not require special handling by the interop marshaller.
+          </item>
+          <item>
+            All the fields of the UDT should be of one of the following types that can be serialized: <c>bool</c>, <c>byte</c>, <c>sbyte</c>, <c>short</c>, <c>ushort</c>, <c>int</c>, <c>uint</c>, <c>long</c>, <c>ulong</c>, <c>float</c>, <c>double</c>, <see cref="T:System.Data.SqlTypes.SqlByte" />, <see cref="T:System.Data.SqlTypes.SqlInt16" />, <see cref="T:System.Data.SqlTypes.SqlInt32" />, <see cref="T:System.Data.SqlTypes.SqlInt64" />, <see cref="T:System.Data.SqlTypes.SqlDateTime" />, <see cref="T:System.Data.SqlTypes.SqlSingle" />, <see cref="T:System.Data.SqlTypes.SqlDouble" />, <see cref="T:System.Data.SqlTypes.SqlMoney" />, or other value types defined by the user that contain fields of one of these types.
+          </item>
+          <item>
+            The aggregate must not specify a value for <c>MaxByteSize</c>
+          </item>
+          <item>
+            The aggregate must not have any <c>[NonSerialized]</c> fields.
+          </item>
+          <item>
+            Fields must not be marked as an explicit layout (with a <see cref="P:System.Runtime.InteropServices.StructLayoutAttribute.Value" /> of <see cref="P:System.Runtime.InteropServices.LayoutKind.Explicit" /> ).
+          </item>
+        </list>
+        <para>
+          The requirements for the <see cref="F:Microsoft.SqlServer.Server.Format.UserDefined" /> format are:
+        </para>
+        <list type="bullet">
+          <item>
+            The aggregate must specify a value for <c>MaxByteSize</c>
+          </item>
+          <item>
+            Specify the <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsByteOrdered" /> attribute property. The default value is <see langword="false" />.
+          </item>
+          <item>
+            If you omit any field in the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read" /> or <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write" /> methods, the state of that field is not serialized.
+          </item>
+        </list>
+      </remarks>
+      <example>
+        <para>
+          The following example shows the <c>UserDefinedType</c> attribute of the Point UDT. The UDT is byte-ordered, is named "Point", has a validation method named "ValidatePoint", and uses the native serialization format.
+        </para>
+        <!-- DataWorks_SqlUserDefinedTypeAttribute -->
+        <code language="c#">
+          using System;
+          using System.Data.SqlTypes;
+          using Microsoft.SqlServer.Server;
+          using System.Text;
+          
+          [Serializable]
+          [Microsoft.SqlServer.Server.SqlUserDefinedType(
+               Format.Native,
+               IsByteOrdered=true,
+               Name="Point",ValidationMethodName = "ValidatePoint")]
+          public struct Point : INullable
+          {
+              private bool is_Null;
+              private int _x;
+              private int _y;
+          
+              public bool IsNull
+              {
+                  get
+                  {
+                      return (is_Null);
+                  }
+              }
+          
+              public static Point Null
+              {
+                  get
+                  {
+                      Point pt = new Point();
+                      pt.is_Null = true;
+                      return pt;
+                  }
+              }
+          
+              // Use StringBuilder to provide string representation of UDT.
+              public override string ToString()
+              {
+                  // Since InvokeIfReceiverIsNull defaults to 'true'
+                  // this test is unnecessary if Point is only being called
+                  // from SQL.
+                  if (this.IsNull)
+                  {
+                      return "NULL";
+                  }
+                  else
+                  {
+                      StringBuilder builder = new StringBuilder();
+                      builder.Append(_x);
+                      builder.Append(",");
+                      builder.Append(_y);
+                      return builder.ToString();
+                  }
+              }
+          
+              [SqlMethod(OnNullCall = false)]
+              public static Point Parse(SqlString s)
+              {
+                  // With OnNullCall=false, this check is unnecessary if
+                  // Point only called from SQL.
+                  if (s.IsNull)
+                      return Null;
+          
+                  // Parse input string to separate out points.
+                  Point pt = new Point();
+                  string[] xy = s.Value.Split(",".ToCharArray());
+                  pt.X = int.Parse(xy[0]);
+                  pt.Y = int.Parse(xy[1]);
+          
+                  // Call ValidatePoint to enforce validation
+                  // for string conversions.
+                  if (!pt.ValidatePoint())
+                      throw new ArgumentException("Invalid XY coordinate values.");
+                  return pt;
+              }
+          
+              // X and Y coordinates exposed as properties.
+              public int X
+              {
+                  get
+                  {
+                      return this._x;
+                  }
+                  // Call ValidatePoint to ensure valid range of Point values.
+                  set
+                  {
+                      int temp = _x;
+                      _x = value;
+                      if (!ValidatePoint())
+                      {
+                          _x = temp;
+                          throw new ArgumentException("Invalid X coordinate value.");
+                      }
+                  }
+              }
+          
+              public int Y
+              {
+                  get
+                  {
+                      return this._y;
+                  }
+                  set
+                  {
+                      int temp = _y;
+                      _y = value;
+                      if (!ValidatePoint())
+                      {
+                          _y = temp;
+                          throw new ArgumentException("Invalid Y coordinate value.");
+                      }
+                  }
+              }
+          
+              // Validation method to enforce valid X and Y values.
+              private bool ValidatePoint()
+              {
+                  return true;
+              }
+          }
+        </code>
+        <!-- DataWorks_SqlUserDefinedTypeAttribute_Sample -->
+        <code langugae="vb">
+          Option Explicit On
+          Option Strict On
+          
+          Imports System.Data.SqlTypes
+          Imports Microsoft.SqlServer.Server
+          Imports System.Text
+          
+          &lt;Serializable(), SqlUserDefinedTypeAttribute(_
+            Format.Native, _
+            IsByteOrdered:=True, _
+            Name:="Point", _
+            ValidationMethodName:="ValidatePoint")&gt; _
+            Public Structure Point
+              Implements INullable
+              Private is_Null As Boolean
+              Private _x As Integer
+              Private _y As Integer
+          
+              Public ReadOnly Property IsNull() As Boolean _
+                 Implements INullable.IsNull
+                  Get
+                      Return (is_Null)
+                  End Get
+              End Property
+          
+              Public Shared ReadOnly Property Null() As Point
+                  Get
+                      Dim pt As New Point
+                      pt.is_Null = True
+                      Return (pt)
+                  End Get
+              End Property
+          
+              ' Use StringBuilder to provide string representation of UDT.
+              Public Overrides Function ToString() As String
+                  ' Since InvokeIfReceiverIsNull defaults to 'true'
+                  ' this test is unneccesary if Point is only being called
+                  ' from SQL.
+                  If Me.IsNull Then
+                      Return "NULL"
+                  Else
+                      Dim builder As StringBuilder = New StringBuilder
+                      builder.Append(_x)
+                      builder.Append(",")
+                      builder.Append(_y)
+                      Return builder.ToString
+                  End If
+              End Function
+          
+              &lt;SqlMethod(OnNullCall:=False)&gt; _
+              Public Shared Function Parse(ByVal s As SqlString) As Point
+                  ' With OnNullCall=False, this check is unnecessary if
+                  ' Point only being called from SQL.
+                  If s.IsNull Then
+                      Return Null
+                  End If
+          
+                  ' Parse input string here to separate out points.
+                  Dim pt As New Point()
+                  Dim xy() As String = s.Value.Split(",".ToCharArray())
+                  pt.X = Integer.Parse(xy(0))
+                  pt.Y = Integer.Parse(xy(1))
+          
+                  ' Call ValidatePoint to enforce validation
+                  ' for string conversions.
+                  If Not pt.ValidatePoint() Then
+                      Throw New ArgumentException("Invalid XY coordinate values.")
+                  End If
+                  Return pt
+              End Function
+          
+              ' X and Y coordinates are exposed as properties.
+              Public Property X() As Integer
+                  Get
+                      Return (Me._x)
+                  End Get
+          
+                  Set(ByVal Value As Integer)
+                      Dim temp As Integer = _x
+                      _x = Value
+                      If Not ValidatePoint() Then
+                          _x = temp
+                          Throw New ArgumentException("Invalid X coordinate value.")
+                      End If
+                  End Set
+              End Property
+          
+              Public Property Y() As Integer
+                  Get
+                      Return (Me._y)
+                  End Get
+          
+                  Set(ByVal Value As Integer)
+                      Dim temp As Integer = _y
+                      _y = Value
+                      If Not ValidatePoint() Then
+                          _y = temp
+                          Throw New ArgumentException("Invalid Y coordinate value.")
+                      End If
+                  End Set
+              End Property
+          
+              ' Validation method to enforce valid X and Y values.
+              Private Function ValidatePoint() As Boolean
+                  ' Allow only zero or positive integers for X and Y coordinates.
+                  If (_x >= 0) And (_y >= 0) Then
+                      Return True
+                  Else
+                      Return False
+                  End If
+              End Function
+          
+          End Structure
+        </code>
+      </example>
+    </Format>
+    <Native>
+      <summary>
+        This serialization format uses a very simple algorithm that enables SQL Server to store an efficient representation of the UDT on disk. Types marked for
+        <b>Native</b> serialization can only have value types (structs in Microsoft Visual C# and structures in Microsoft Visual Basic .NET) as members. Members of reference types (such as classes in Visual C# and Visual Basic), either user-defined or those existing in .NET class libraries (such as <see cref="T:System.String" />), are not supported.
+      </summary>
+    </Native>
+    <Unknown>
+      <summary>
+        The serialization format is unknown.
+      </summary>
+    </Unknown>
+    <UserDefined>
+      <summary>
+        This serialization format gives the developer full control over the binary format through the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write(System.IO.BinaryWriter)" /> and <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read(System.IO.BinaryReader)" /> methods.
+      </summary>
+    </UserDefined>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.SqlServer.Server/Format.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/Format.xml
@@ -31,7 +31,7 @@
             The aggregate must not have any <c>[NonSerialized]</c> fields.
           </item>
           <item>
-            Fields must not be marked as an explicit layout (with a <see cref="P:System.Runtime.InteropServices.StructLayoutAttribute.Value" /> of <see cref="P:System.Runtime.InteropServices.LayoutKind.Explicit" /> ).
+            Fields must not be marked as an explicit layout (with a <see cref="P:System.Runtime.InteropServices.StructLayoutAttribute.Value" /> of <see cref="F:System.Runtime.InteropServices.LayoutKind.Explicit" /> ).
           </item>
         </list>
         <para>
@@ -45,13 +45,13 @@
             Specify the <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsByteOrdered" /> attribute property. The default value is <see langword="false" />.
           </item>
           <item>
-            If you omit any field in the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read" /> or <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write" /> methods, the state of that field is not serialized.
+            If you omit any field in the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read(System.IO.BinaryReader)" /> or <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write(System.IO.BinaryWriter)" /> methods, the state of that field is not serialized.
           </item>
         </list>
       </remarks>
       <example>
         <para>
-          The following example shows the <c>UserDefinedType</c> attribute of the Point UDT. The UDT is byte-ordered, is named "Point", has a validation method named "ValidatePoint", and uses the native serialization format.
+          The following example shows the <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute" /> attribute of the Point UDT. The UDT is byte-ordered, is named "Point", has a validation method named "ValidatePoint", and uses the native serialization format.
         </para>
         <!-- DataWorks_SqlUserDefinedTypeAttribute -->
         <code language="c#">
@@ -213,7 +213,7 @@
               ' Use StringBuilder to provide string representation of UDT.
               Public Overrides Function ToString() As String
                   ' Since InvokeIfReceiverIsNull defaults to 'true'
-                  ' this test is unneccesary if Point is only being called
+                  ' this test is unnecessary if Point is only being called
                   ' from SQL.
                   If Me.IsNull Then
                       Return "NULL"

--- a/doc/snippets/Microsoft.SqlServer.Server/IBinarySerialize.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/IBinarySerialize.xml
@@ -24,11 +24,11 @@
         Generates a user-defined type (UDT) or user-defined aggregate from its binary form.
       </summary>
       <remarks>
-        The <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read" /> method must reconstitute your object using the information written by the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write" /> method.
+        The <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read(System.IO.BinaryReader)" /> method must reconstitute your object using the information written by the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write(System.IO.BinaryWriter)" /> method.
       </remarks>
       <example>
         <para>
-          The following example shows the implementation of the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read" /> method of a UDT, which uses a <see cref="T:System.IO.BinaryReader" /> to de-serialize a previously persisted UDT. This example assumes that the UDT has two data properties: <c>StringValue</c> and <c>DoubleValue</c>.
+          The following example shows the implementation of the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read(System.IO.BinaryReader)" /> method of a UDT, which uses a <see cref="T:System.IO.BinaryReader" /> to de-serialize a previously persisted UDT. This example assumes that the UDT has two data properties: <c>StringValue</c> and <c>DoubleValue</c>.
         </para>
         <!-- DataWorks_IBinarySerialize_Sample #1 -->
         <code language="c#">
@@ -117,11 +117,11 @@
         Converts a user-defined type (UDT) or user-defined aggregate into its binary format so that it may be persisted.
       </summary>
       <remarks>
-        Write sufficient information to the binary stream to allow the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read" /> method to reconstitute your UDT or user-defined aggregate.
+        Write sufficient information to the binary stream to allow the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read(System.IO.BinaryReader)" /> method to reconstitute your UDT or user-defined aggregate.
       </remarks>
       <example>
         <para>
-          The following example shows the implementation of the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write" /> method of a UDT, which uses a <see cref="T:System.IO.BinaryWriter" /> to serialize the UDT in the user-defined binary format. The purpose of the null character padding is to ensure that the string value is completely separated from the double value, so that one UDT is compared to another in Transact-SQL code, string bytes are compared to string bytes and double bytes are compared to double bytes.
+          The following example shows the implementation of the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write(System.IO.BinaryWriter)" /> method of a UDT, which uses a <see cref="T:System.IO.BinaryWriter" /> to serialize the UDT in the user-defined binary format. The purpose of the null character padding is to ensure that the string value is completely separated from the double value, so that one UDT is compared to another in Transact-SQL code, string bytes are compared to string bytes and double bytes are compared to double bytes.
         </para>
         <!-- DataWorks_IBinarySerialize_Sample #2 -->
         <code language="c#">

--- a/doc/snippets/Microsoft.SqlServer.Server/IBinarySerialize.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/IBinarySerialize.xml
@@ -1,56 +1,184 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="IBinarySerialize">
-        <IBinarySerialize>
-            <summary>Provides custom implementation for user-defined type (UDT) and user-defined aggregate serialization and deserialization.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
+﻿<docs>
+  <members name="IBinarySerialize">
+    <IBinarySerialize>
+      <summary>
+        Provides custom implementation for user-defined type (UDT) and user-defined aggregate serialization and deserialization.
+      </summary>
+      <remarks>
+        <para>
+          User-defined types (UDTs) and user-defined aggregates are required to define a storage format, which can be either <see cref="F:Microsoft.SqlServer.Server.Format.Native" /> or <see cref="F:Microsoft.SqlServer.Server.Format.UserDefined" />.
+        </para>
+        <para>
+          <see cref="F:Microsoft.SqlServer.Server.Format.Native" /> allows SQL Server to handle serialization and deserialization automatically, but the format has restrictions on the kind of types it can handle. <see cref="F:Microsoft.SqlServer.Server.Format.UserDefined" /> allows user-defined types and aggregates to handle their own serialization. User-defined types and aggregates must be marked with <see cref="F:Microsoft.SqlServer.Server.Format.UserDefined" /> in the <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute" /> or <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute" /> attribute, and must implement the <b>IBinarySerialize</b> interface.
+        </para>
+        <para>
+          Note that even with custom serialization, the total size of each instance must be under the maximum allowed limit, currently 8000 bytes.
+        </para>
+      </remarks>
+    </IBinarySerialize>
+    <Read>
+      <param name="r">
+        The <see cref="T:System.IO.BinaryReader" /> stream from which the object is deserialized.
+      </param>
+      <summary>
+        Generates a user-defined type (UDT) or user-defined aggregate from its binary form.
+      </summary>
+      <remarks>
+        The <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read" /> method must reconstitute your object using the information written by the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write" /> method.
+      </remarks>
+      <example>
+        <para>
+          The following example shows the implementation of the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read" /> method of a UDT, which uses a <see cref="T:System.IO.BinaryReader" /> to de-serialize a previously persisted UDT. This example assumes that the UDT has two data properties: <c>StringValue</c> and <c>DoubleValue</c>.
+        </para>
+        <!-- DataWorks_IBinarySerialize_Sample #1 -->
+        <code language="c#">
+          // The binary layout is as follows:
+          //    Bytes 0 - 19: string text, padded to the right with null characters
+          //    Bytes 20+: Double value
   
-## Remarks  
-User-defined types (UDTs) and user-defined aggregates are required to define a storage format, which can be either <xref:Microsoft.SqlServer.Server.Format>.`Native` or <xref:Microsoft.SqlServer.Server.Format>.`UserDefined`.  
-
-<xref:Microsoft.SqlServer.Server.Format>.`Native` allows SQL Server to handle serialization and deserialization automatically, but the format has restrictions on the kind of types it can handle. <xref:Microsoft.SqlServer.Server.Format>.`UserDefined` allows user-defined types and aggregates to handle their own serialization. User-defined types and aggregates must be marked with <xref:Microsoft.SqlServer.Server.Format>.`UserDefined` in the `SqlUserDefinedType` or `SqlUserDefinedAggregate` attribute, and must implement the <xref:Microsoft.SqlServer.Server.IBinarySerialize> interface.  
-
-Note that even with custom serialization, the total size of each instance must be under the maximum allowed limit, currently 8000 bytes.  
-
- ]]></format>
-            </remarks>
-        </IBinarySerialize>
-        <Read>
-            <param name="r">The <see cref="T:System.IO.BinaryReader" /> stream from which the object is deserialized.</param>
-            <summary>Generates a user-defined type (UDT) or user-defined aggregate from its binary form.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
+          // using Microsoft.SqlServer.Server;
+          public void Read(System.IO.BinaryReader r)
+          {
   
-## Remarks  
-The <xref:Microsoft.SqlServer.Server.IBinarySerialize.Read%2A> method must reconstitute your object using the information written by the <xref:Microsoft.SqlServer.Server.IBinarySerialize.Write%2A> method.  
-
-## Examples  
-The following example shows the implementation of the <xref:Microsoft.SqlServer.Server.IBinarySerialize.Read%2A> method of a UDT, which uses a <xref:System.IO.BinaryReader> to de-serialize a previously persisted UDT. This example assumes that the UDT has two data properties: `StringValue` and `DoubleValue`.  
-
-[!code-csharp[IBinarySerialize Samples#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/DataWorks_IBinarySerialize_Sample.cs#1)]
-[!code-vb[IBinarySerialize Samples#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/visualbasic/DataWorks_IBinarySerialize_Sample.vb#1)]
-
- ]]></format>
-            </remarks>
-        </Read>
-        <Write>
-            <param name="w">The <see cref="T:System.IO.BinaryWriter" /> stream to which the UDT or user-defined aggregate is serialized.</param>
-            <summary>Converts a user-defined type (UDT) or user-defined aggregate into its binary format so that it may be persisted.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
+              int maxStringSize = 20;
+              char[] chars;
+              int stringEnd;
+              string stringValue;
+              double doubleValue;
   
-## Remarks  
-Write sufficient information to the binary stream to allow the <xref:Microsoft.SqlServer.Server.IBinarySerialize.Read%2A> method to reconstitute your UDT or user-defined aggregate.  
-
-## Examples  
-The following example shows the implementation of the <xref:Microsoft.SqlServer.Server.IBinarySerialize.Write%2A> method of a UDT, which uses a <xref:System.IO.BinaryWriter> to serialize the UDT in the user-defined binary format. The purpose of the null character padding is to ensure that the string value is completely separated from the double value, so that one UDT is compared to another in Transact-SQL code, string bytes are compared to string bytes and double bytes are compared to double bytes.  
-
-[!code-csharp[IBinarySerialize Samples#2](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/DataWorks_IBinarySerialize_Sample.cs#2)]
-[!code-vb[IBinarySerialize Samples#2](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/visualbasic/DataWorks_IBinarySerialize_Sample.vb#2)]
-
- ]]></format>
-            </remarks>
-        </Write>
-    </members>
+              // Read the characters from the binary stream.
+              chars = r.ReadChars(maxStringSize);
+  
+              // Find the start of the null character padding.
+              stringEnd = Array.IndexOf(chars, '\0');
+  
+              if (stringEnd == 0)
+              {
+                  stringValue = null;
+                  return;
+              }
+  
+              // Build the string from the array of characters.
+              stringValue = new String(chars, 0, stringEnd);
+  
+              // Read the double value from the binary stream.
+              doubleValue = r.ReadDouble();
+  
+              // Set the object's properties equal to the values.
+              this.StringValue = stringValue;
+              this.DoubleValue = doubleValue;
+          }
+        </code>
+        <!-- DataWorks_IBinarySerialize_Sample #1 -->
+        <code language="vb">
+          ' The binary layout is as follows:
+          '    Bytes 0 - 19: string text, padded to the right with null
+          '    characters
+          '    Bytes 20+: double value
+          Public Sub Read(ByVal r As System.IO.BinaryReader) _
+            Implements Microsoft.SqlServer.Server.IBinarySerialize.Read
+              
+              Dim maxStringSize As Integer = 20
+              Dim chars As Char()
+              Dim stringEnd As Integer
+              Dim stringValue As String
+              Dim value As double
+          
+              ' Read the characters from the binary stream.
+              chars = r.ReadChars(maxStringSize)
+              
+              ' Find the start of the null character padding.
+              stringEnd = Array.IndexOf(chars, ControlChars.NullChar)
+          
+              If StringEnd = 0 Then
+                 stringValue = Nothing
+                 Exit Sub
+              End If
+          
+              ' Build the string from the array of characters.
+              stringValue = new String(chars, 0, stringEnd)
+          
+              ' Read the double value from the binary stream.
+              value = r.ReadDouble()
+          
+              ' Set the object's properties equal to the values.
+              Me.StringValue = stringValue
+              Me.DoubleValue = value
+          
+          End Sub
+        </code>
+      </example>
+    </Read>
+    <Write>
+      <param name="w">
+        The <see cref="T:System.IO.BinaryWriter" /> stream to which the UDT or user-defined aggregate is serialized.
+      </param>
+      <summary>
+        Converts a user-defined type (UDT) or user-defined aggregate into its binary format so that it may be persisted.
+      </summary>
+      <remarks>
+        Write sufficient information to the binary stream to allow the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Read" /> method to reconstitute your UDT or user-defined aggregate.
+      </remarks>
+      <example>
+        <para>
+          The following example shows the implementation of the <see cref="M:Microsoft.SqlServer.Server.IBinarySerialize.Write" /> method of a UDT, which uses a <see cref="T:System.IO.BinaryWriter" /> to serialize the UDT in the user-defined binary format. The purpose of the null character padding is to ensure that the string value is completely separated from the double value, so that one UDT is compared to another in Transact-SQL code, string bytes are compared to string bytes and double bytes are compared to double bytes.
+        </para>
+        <!-- DataWorks_IBinarySerialize_Sample #2 -->
+        <code language="c#">
+          // The binary layout is as follows:
+          //    Bytes 0 - 19: string text, padded to the right with null characters
+          //    Bytes 20+: Double value
+  
+          // using Microsoft.SqlServer.Server;
+          public void Write(System.IO.BinaryWriter w)
+          {
+              int maxStringSize = 20;
+              string stringValue = "The value of PI: ";
+              string paddedString;
+              double value = 3.14159;
+  
+              // Pad the string from the right with null characters.
+              paddedString = stringValue.PadRight(maxStringSize, '\0');
+  
+              // Write the string value one byte at a time.
+              for (int i = 0; i &lt; paddedString.Length; i++)
+              {
+                  w.Write(paddedString[i]);
+              }
+  
+              // Write the double value.
+              w.Write(value);
+          }
+        </code>
+        <!-- DataWorks_IBinarySerialize_Sample #3 -->
+        <code language="vb">
+          ' The binary layout is as follows:
+          '    Bytes 0 - 19: string text, padded to the right with null characters
+          '    Bytes 20+: Double value
+          Public Sub Write(ByVal w As System.IO.BinaryWriter) _
+            Implements Microsoft.SqlServer.Server.IBinarySerialize.Write
+          
+              Dim maxStringSize As Integer = 20
+              Dim stringValue As String = "The value of PI: "
+              Dim paddedString As String
+              Dim value As Double = 3.14159
+          
+              ' Pad the string from the right with null characters.
+              paddedString = stringValue.PadRight(maxStringSize, ControlChars.NullChar)
+              
+              
+              ' Write the string value one byte at a time.
+              Dim i As Integer
+              For i = 0 To paddedString.Length - 1
+                  w.Write(paddedString(i))
+              Next
+          
+              ' Write the double value.
+              w.Write(value)
+              
+          End Sub
+        </code>
+      </example>
+    </Write>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.SqlServer.Server/InvalidUdtException.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/InvalidUdtException.xml
@@ -1,39 +1,45 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="InvalidUdtException">
-        <InvalidUdtException>
-            <summary>Thrown when SQL Server or the ADO.NET <see cref="N:Microsoft.Data.SqlClient" /> provider detects an invalid user-defined type (UDT).</summary>
-            <remarks>To be added.</remarks>
-        </InvalidUdtException>
-        <GetObjectData>
-            <param name="si">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object.</param>
-            <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> object.</param>
-            <summary>Streams all the <see cref="T:Microsoft.SqlServer.Server.InvalidUdtException" /> properties into the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> class for the given <see cref="T:System.Runtime.Serialization.StreamingContext" />.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-This method is present in the <xref:Microsoft.SqlServer.Server.InvalidUdtException> class to make the class serializable.  
-
- ]]></format>
-            </remarks>
-        </GetObjectData>
-        <Create>
-            <param name="udtType">The <see cref="T:System.Type" /> object.</param>
-            <param name="resourceReason">The <see cref="T:System.String" /> object that represents a string in string resources. The default value is `SqlUdtReason_NoUdtAttribute` which looks up a localized string similar to "no UDT attribute".</param>
-            <summary>Creates a new <see cref="T:Microsoft.SqlServer.Server.InvalidUdtException" /> object.</summary>
-            <returns>A new <see cref="T:Microsoft.SqlServer.Server.InvalidUdtException" /> object.</returns>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-This method Looks up a localized string similar to "&apos;{0}&apos; is an invalid user defined type, reason: {1}.", and fills it in order with the corresponding `udtType` and `resourceReason` values.  
-
-> [!IMPORTANT]
-> This function is exposed for backward compatibility and should be used with the default value for the `resourceReason` parameter.
-
- ]]></format>
-            </remarks>
-        </Create>
-    </members>
+﻿<docs>
+  <members name="InvalidUdtException">
+    <InvalidUdtException>
+      <summary>
+        Thrown when SQL Server or the ADO.NET <see cref="N:Microsoft.Data.SqlClient" /> provider detects an invalid user-defined type (UDT).
+      </summary>
+    </InvalidUdtException>
+    <GetObjectData>
+      <param name="si">
+        The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object.
+      </param>
+      <param name="context">
+        The <see cref="T:System.Runtime.Serialization.StreamingContext" /> object.
+      </param>
+      <summary>
+        Streams all the <see cref="T:Microsoft.SqlServer.Server.InvalidUdtException" /> properties into the <see cref="T:System.Runtime.Serialization.SerializationInfo" /> class for the given <see cref="T:System.Runtime.Serialization.StreamingContext" />.
+      </summary>
+      <remarks>
+        This method is present in the <see cref="T:Microsoft.SqlServer.Server.InvalidUdtException" /> class to make the class serializable.
+      </remarks>
+    </GetObjectData>
+    <Create>
+      <param name="udtType">
+        The <see cref="T:System.Type" /> object.
+      </param>
+      <param name="resourceReason">
+        The <see cref="T:System.String" /> object that represents a string in string resources. The default value is `SqlUdtReason_NoUdtAttribute` which looks up a localized string similar to "no UDT attribute".
+      </param>
+      <summary>
+        Creates a new <see cref="T:Microsoft.SqlServer.Server.InvalidUdtException" /> object.
+      </summary>
+      <returns>
+        A new <see cref="T:Microsoft.SqlServer.Server.InvalidUdtException" /> object.
+      </returns>
+      <remarks>
+        <para>
+          This method Looks up a localized string similar to <c>'{0}' is an invalid user defined type, reason: {1}.</c>, and fills it in order with the corresponding <paramref name="udtType" /> and <paramref name="resourceReason" /> values.
+        </para>
+        <note type="important">
+          This function is exposed for backward compatibility and should be used with the default value for the <paramref name="resourceReason" /> parameter.
+        </note>
+      </remarks>
+    </Create>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.SqlServer.Server/SqlFacetAttribute.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/SqlFacetAttribute.xml
@@ -1,124 +1,297 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SqlFacetAttribute">
-        <SqlFacetAttribute>
-            <summary>Annotates the returned result of a user-defined type (UDT) with additional information that can be used in Transact-SQL.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-<xref:Microsoft.SqlServer.Server.SqlFacetAttribute> may only be specified on non-void return values.  
-
-<xref:Microsoft.SqlServer.Server.SqlFacetAttribute> is used only to derive information about the return type, and is not intended to be a constraint specification on what can be stored in the type. Thus, if a field has a <xref:Microsoft.SqlServer.Server.SqlFacetAttribute> indicating its size to be 2 characters, then the SQL Server type of the field access expression is of size 2, but assignments into the field are not restricted by this facet.  
-
-The table below captures the matrix of valid values for the various properties for specific field types. In this table, "Y" indicates that the property is valid, and "N" indicates that the property is not valid.  
-
-The specified <xref:Microsoft.SqlServer.Server.SqlFacetAttribute> must be compatible with the field type. If the property is not valid, type registration will report an error if the user specifies a non-default value for the property. The maximum values for <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision%2A> and <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale%2A> properties are 38. For the <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.MaxSize%2A> property, the value should be in the range of 1-8000 for binary and non-Unicode data, 1-4000 for Unicode data, or -1. All other values are not valid.  
-
-|Type|IsFixedLength|MaxSize|Precision|Scale|IsNullable|  
-|----------|-------------------|-------------|---------------|-----------|----------------|  
-|<xref:System.Data.SqlTypes.SqlBoolean>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlByte>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlInt16>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlInt32>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlInt64>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlSingle>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlDouble>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlDateTime>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlMoney>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlGuid>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlDecimal>|N|N|Y|Y|Y|  
-|<xref:System.Data.SqlTypes.SqlString>|Y|Y|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlBinary>|Y|Y|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlXml>|N|N|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlBytes>|Y|Y|N|N|Y|  
-|<xref:System.Data.SqlTypes.SqlChars>|Y|Y|N|N|Y|  
-|Embedded UDTs|N|N|N|N|Y|  
-|<xref:System.String>|Y|Y|N|N|Y|  
-|Byte[]|Y|Y|N|N|Y|  
-|Char[]|Y|Y|N|N|Y|  
-|<xref:System.DateTime>|N|N|N|Y<sup>1</sup>|N|  
-|<xref:System.Decimal>|N|N|Y|Y|Y|  
-
-(1) Specifying the scale on a DateTime type will cause the value to be returned to Transact-SQL as a DateTime2 type with the specified scale.  
-
- ]]></format>
-            </remarks>
-        </SqlFacetAttribute>
-        <ctor>
-            <summary>An optional attribute on a user-defined type (UDT) return type, used to annotate the returned result with additional information that can be used in Transact-SQL.</summary>
-            <remarks>To be added.</remarks>
-        </ctor>
-        <IsFixedLength>
-            <summary>Indicates whether the return type of the user-defined type is of a fixed length.</summary>
-            <value>
-            <see langword="true" /> if the return type is of a fixed length; otherwise <see langword="false" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-## Remarks  
-This property must be set to `false` if the <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.MaxSize%2A> property is set to 1.  
-
-The default value is `false`.  
-
-]]></format>
-            </remarks>
-        </IsFixedLength>
-        <IsNullable>
-            <summary>Indicates whether the return type of the user-defined type can be <see langword="null" />.</summary>
-            <value>
-            <see langword="true" /> if the return type of the user-defined type can be <see langword="null" />; otherwise <see langword="false" />.</value>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-The default value is `true`.  
-
- ]]></format>
-            </remarks>
-        </IsNullable>
-        <MaxSize>
-            <summary>The maximum size, in logical units, of the underlying field type of the user-defined type.</summary>
-            <value>An <see cref="T:System.Int32" /> representing the maximum size, in logical units, of the underlying field type.</value>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-Logical unit is bytes (with a maximum size of 8000) for the binary and non-Unicode data types, and the number of Unicode characters (with a maximum size of 4000) for the character field types.  
-
-The value -1 is reserved for large character and binary types.  
-
-The default value is 4000 for Unicode character types and 8000 for binary and non-Unicode types.  
-
- ]]></format>
-            </remarks>
-        </MaxSize>
-        <Precision>
-            <summary>The precision of the return type of the user-defined type.</summary>
-            <value>An <see cref="T:System.Int32" /> representing the precision of the return type.</value>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-The <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision%2A> property is valid only for numeric types. The <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale%2A> property must also be specified when setting the <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision%2A> property.  
-
-The maximum value of the <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision%2A> property is 38; the default value is 38.  
-
- ]]></format>
-            </remarks>
-        </Precision>
-        <Scale>
-            <summary>The scale of the return type of the user-defined type.</summary>
-            <value>An <see cref="T:System.Int32" /> representing the scale of the return type.</value>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-The <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale%2A> property is valid only for decimal types. The <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision%2A> property must also be specified when setting the <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale%2A> property.  
-
-The maximum value of the <xref:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale%2A> property is 38; the default value is 0.  
-
- ]]></format>
-            </remarks>
-        </Scale>
-    </members>
+﻿<docs>
+  <members name="SqlFacetAttribute">
+    <SqlFacetAttribute>
+      <summary>
+        Annotates the returned result of a user-defined type (UDT) with additional information that can be used in Transact-SQL.
+      </summary>
+      <remarks>
+        <para>
+          <see cref="T:Microsoft.SqlServer.Server.SqlFacetAttribute" /> may only be specified on non-void return values.
+        </para>
+        <para>
+          <see cref="T:Microsoft.SqlServer.Server.SqlFacetAttribute" /> is used only to derive information about the return type, and is not intended to be a constraint specification on what can be stored in the type. Thus, if a field has a <see cref="T:Microsoft.SqlServer.Server.SqlFacetAttribute" /> indicating its size to be 2 characters, then the SQL Server type of the field access expression is of size 2, but assignments into the field are not restricted by this facet.
+        </para>
+        <para>
+          The table below captures the matrix of valid values for the various properties for specific field types. In this table, "Y" indicates that the property is valid, and "N" indicates that the property is not valid.
+        </para>
+        <para>
+          The specified <see cref="T:Microsoft.SqlServer.Server.SqlFacetAttribute" /> must be compatible with the field type. If the property is not valid, type registration will report an error if the user specifies a non-default value for the property. The maximum values for <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision" /> and <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale" /> properties are 38. For the <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.MaxSize" /> property, the value should be in the range of 1-8000 for binary and non-Unicode data, 1-4000 for Unicode data, or -1. All other values are not valid.
+        </para>
+        <para>
+          <list type="table">
+            <listheader>
+              <term>Type</term>
+              <description>IsFixedLength</description>
+              <description>MaxSize</description>
+              <description>Precision</description>
+              <description>Scale</description>
+              <description>IsNullable</description>
+            </listheader>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlBoolean" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlByte" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlInt16" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlInt32" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlInt64" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlSingle" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlDouble" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlDateTime" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlMoney" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlGuid" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlDecimal" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+              <description>Y</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlString" /></term>
+              <description>Y</description>
+              <description>Y</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlBinary" /></term>
+              <description>Y</description>
+              <description>Y</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlXml" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlBytes" /></term>
+              <description>Y</description>
+              <description>Y</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Data.SqlTypes.SqlChars" /></term>
+              <description>Y</description>
+              <description>Y</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term>Embedded UDTs</term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.String" /></term>
+              <description>Y</description>
+              <description>Y</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term>Byte[]</term>
+              <description>Y</description>
+              <description>Y</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term>Char[]</term>
+              <description>Y</description>
+              <description>Y</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+            </item>
+            <item>
+              <term><see cref="T:System.DateTime" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>N</description>
+              <description>Y<sup>1</sup></description>
+              <description>N</description>
+            </item>
+            <item>
+              <term><see cref="T:System.Decimal" /></term>
+              <description>N</description>
+              <description>N</description>
+              <description>Y</description>
+              <description>Y</description>
+              <description>Y</description>
+            </item>
+          </list>
+        </para>
+        <para>
+          (1) Specifying the scale on a DATETIME type will cause the value to be returned to Transact-SQL as a DATETIME2 type with the specified scale.
+        </para>
+      </remarks>
+    </SqlFacetAttribute>
+    <ctor>
+      <summary>
+        An optional attribute on a user-defined type (UDT) return type, used to annotate the returned result with additional information that can be used in Transact-SQL.
+      </summary>
+    </ctor>
+    <IsFixedLength>
+      <summary>
+        Indicates whether the return type of the user-defined type is of a fixed length.
+      </summary>
+      <value>
+        <see langword="true" /> if the return type is of a fixed length; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        <para>
+          This property must be set to <see langword="false" /> if the <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.MaxSize" /> property is set to 1.
+        </para>
+        <para>
+          The default value is <see langword="false" />.
+        </para>
+      </remarks>
+    </IsFixedLength>
+    <IsNullable>
+      <summary>
+        Indicates whether the return type of the user-defined type can be <see langword="null" />.
+      </summary>
+      <value>
+        <see langword="true" /> if the return type of the user-defined type can be <see langword="null" /> ; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        The default value is <see langword="true" />.
+      </remarks>
+    </IsNullable>
+    <MaxSize>
+      <summary>
+        The maximum size, in logical units, of the underlying field type of the user-defined type.
+      </summary>
+      <value>
+        An <see cref="T:System.Int32" /> representing the maximum size, in logical units, of the underlying field type.
+      </value>
+      <remarks>
+        <para>
+          Logical unit is bytes (with a maximum size of 8000) for the binary and non-Unicode data types, and the number of Unicode characters (with a maximum size of 4000) for the character field types.
+        </para>
+        <para>
+          The value -1 is reserved for large character and binary types.
+        </para>
+        <para>
+          The default value is 4000 for Unicode character types and 8000 for binary and non-Unicode types.
+        </para>
+      </remarks>
+    </MaxSize>
+    <Precision>
+      <summary>
+        The precision of the return type of the user-defined type.
+      </summary>
+      <value>
+        An <see cref="T:System.Int32" /> representing the precision of the return type.
+      </value>
+      <remarks>
+        <para>
+          The <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision" /> property is valid only for numeric types. The <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale" /> property must also be specified when setting the <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision" /> property.
+        </para>
+        <para>
+          The maximum value of the <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision" /> property is 38; the default value is 38.
+        </para>
+      </remarks>
+    </Precision>
+    <Scale>
+      <summary>
+        The scale of the return type of the user-defined type.
+      </summary>
+      <value>
+        An <see cref="T:System.Int32" /> representing the scale of the return type.
+      </value>
+      <remarks>
+        <para>
+          The <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale" /> property is valid only for decimal types. The <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Precision" /> property must also be specified when setting the <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale" /> property.
+        </para>
+        <para>
+          The maximum value of the <see cref="P:Microsoft.SqlServer.Server.SqlFacetAttribute.Scale" /> property is 38; the default value is 0.
+        </para>
+      </remarks>
+    </Scale>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.SqlServer.Server/SqlFunctionAttribute.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/SqlFunctionAttribute.xml
@@ -1,130 +1,226 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SqlFunctionAttribute">
-        <SqlFunctionAttribute>
-            <summary>Used to mark a method definition of a user-defined aggregate as a function in SQL Server. The properties on the attribute reflect the physical characteristics used when the type is registered with SQL Server.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
+﻿<docs>
+  <members name="SqlFunctionAttribute">
+    <SqlFunctionAttribute>
+      <summary>
+        Used to mark a method definition of a user-defined aggregate as a function in SQL Server. The properties on the attribute reflect the physical characteristics used when the type is registered with SQL Server.
+      </summary>
+      <example>
+        <para>
+          The following example shows an aggregate function that returns a list of files in the specified directory path.
+        </para>
+        <!-- DataWorks_SqlFunctionAttribute_Sample -->
+        <code language="c#">
+          using System.IO;
+          using System.Collections;
+          using Microsoft.SqlServer.Server;
+          
+          public class Class1
+          {
+            [SqlFunctionAttribute(FillRowMethodName = "FillFileRow")]
+            public static IEnumerable GetFileDetails(string directoryPath)
+            {
+               try
+               {
+                  DirectoryInfo di = new DirectoryInfo(directoryPath);
+                  return di.GetFiles();
+               }
+               catch (DirectoryNotFoundException dnf)
+               {
+                  return new string[1] { dnf.ToString() };
+               }
+            }
+          }
+        </code>
+        <!-- DataWorks_SqlFunctionAttribute_Sample -->
+        <code language="vb">
+          Option Explicit On
+          Option Strict On
+          
+          Imports System.IO
+          Imports System.Collections
+          Imports Microsoft.SqlServer.Server
+          
+          Public Class Class1
+          
+            &lt;SqlFunction(FillRowMethodName:="FillFileRow")&gt; _
+            Public Shared Function GetFileDetails(ByVal directoryPath As String) As IEnumerable
+               Try
+                  Dim di As DirectoryInfo = new DirectoryInfo(directoryPath)
+                  return di.GetFiles()   
+               Catch dnf As DirectoryNotFoundException
+                  Dim message As String() = {dnf.ToString() }
+                  return message
+               End Try
+            End Function
+            
+          End Class
+        </code>
+      </example>
+    </SqlFunctionAttribute>
+    <ctor>
+      <summary>
+        An optional attribute on a user-defined aggregate, used to indicate that the method should be registered in SQL Server as a function. Also used to set the <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.DataAccess" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.FillRowMethodName" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsDeterministic" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsPrecise" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.Name" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.SystemDataAccess" />, and <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.TableDefinition" /> properties of the function attribute.
+      </summary>
+    </ctor>
+    <DataAccess>
+      <summary>
+        Indicates whether the function involves access to user data stored in the local instance of SQL Server.
+      </summary>
+      <value> <see cref="T:Microsoft.SqlServer.Server.DataAccessKind" />. <see langword="None" /> : Does not access data. <see cref="T:Microsoft.SqlServer.Server.DataAccessKind" />. <see langword="Read" /> : Only reads user data.</value>
+      <remarks>
+        <para>
+          The default is <see cref="F:Microsoft.SqlServer.Server.DataAccessKind.None" />. <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.DataAccess" /> is also required when connecting to remote servers if transactions integration is required (the default).
+        </para>
+        <para>
+          If a Transact-SQL query is executed from inside a table-valued function (TVF), the <see cref="F:Microsoft.SqlServer.Server.DataAccessKind.Read" /> property should be set.
+        </para>
+      </remarks>
+    </DataAccess>
+    <FillRowMethodName>
+      <summary>
+        The name of a method in the same class which is used to fill a row with data in the table returned by the table-valued function.
+      </summary>
+      <value>
+        A <see cref="T:System.String" /> value representing the name of a method in the same class which is used to fill a row with data in the table returned by the table-valued function.
+      </value>
+    </FillRowMethodName>
+    <IsDeterministic>
+      <summary>
+        Indicates whether the user-defined function is deterministic.
+      </summary>
+      <value>
+        <see langword="true" /> if the function is deterministic; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        <para>
+          A user-defined function is said to be deterministic if it always produces the same output values given the same input values and the same database state.
+        </para>
+        <para>
+          The <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsDeterministic" /> property is also useful for indexing the result of the function in the form of indexed computed columns and indexed views. If this property is not specified, the function is assumed to be non-deterministic.
+        </para>
+        <para>
+          Functions that access local data can be deterministic. The data access characteristic is captured separately by the <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.DataAccess" /> and <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.SystemDataAccess" /> properties.
+        </para>
+        <para>
+          Note that data access to remote servers (for example, using a <see cref="T:Microsoft.Data.SqlClient.SqlConnection" /> to connect to another SQL Server instance) is available in user-defined functions. However, you must still honor the <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsDeterministic" /> declaration. If the common language runtime (CLR) function is marked as deterministic, it should not cause side effects in the remote server. While side effects against the context connection are restricted, SQL Server will not enforce the restriction for side effects over remote connections.
+        </para>
+        <para>
+          The default value of this attribute is <see langword="false" />.
+        </para>
+        <para>
+          Do not mark a function as deterministic if the function does not always produce the same output values, given the same input values and the same database state. Marking a function as deterministic when the function is not truly deterministic can result in corrupted indexed views and computed columns.
+        </para>
+      </remarks>
+    </IsDeterministic>
+    <IsPrecise>
+      <summary>
+        Indicates whether the function involves imprecise computations, such as floating point operations.
+      </summary>
+      <value>
+        <see langword="true" /> if the function involves precise computations; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        <para>
+          Precision of a function is one of the properties used to determine if computed columns that use this function can be indexed.
+        </para>
+        <para>
+          The default value of this attribute is <see langword="false" />.
+        </para>
+      </remarks>
+    </IsPrecise>
+    <Name>
+      <summary>
+        The name under which the function should be registered in SQL Server.
+      </summary>
+      <value>
+        A <see cref="T:System.String" /> value representing the name under which the function should be registered.
+      </value>
+      <remarks>
+        <para>
+          This attribute is used only by Microsoft Visual Studio to automatically register the specified method as a user-defined function. It is not used by SQL Server.
+        </para>
+        <para>
+          The following example specifies that the user-defined function is referenced using the name <c>sp_scalarFunc</c>.
+        </para>
+      </remarks>
+      <example>
+        <!-- SqlFunctionAttribute_SqlFunction #10 -->
+        <code language="c#">
+          public partial class UserDefinedFunctions
+          {
+              [SqlFunction(Name="sp_scalarFunc")]
+              public static SqlString SampleScalarFunction(SqlString s)
+              {
+                  //...
+                  return "";
+              }
+          }
+        </code>
+        <!-- SqlFunctionAttribute_SqlFunction #10 -->
+        <code language="vb">
+          Partial Public Class UserDefinedFunctions
+          
+              &lt;SqlFunction(Name:="sp_scalarFunc")&gt; 
+              Public Shared Function SampleScalarFunction(ByVal s As SqlString) As SqlString
+          
+                  '...
+                  Return ""
+              End Function
+              
+          End Class
+        </code>
+      </example>
+    </Name>
+    <SystemDataAccess>
+      <summary>
+        Indicates whether the function requires access to data stored in the system catalogs or virtual system tables of SQL Server.
+      </summary>
+      <value>
+        <see cref="F:Microsoft.SqlServer.Server.DataAccessKind.None" />: Does not access system data. <see cref="T:Microsoft.SqlServer.Server.DataAccessKind.Read" />: Only reads system data.</value>
+      <remarks>
+        The default is <see cref="F:Microsoft.SqlServer.Server.SystemDataAccessKind.None" />.
+      </remarks>
+    </SystemDataAccess>
+    <TableDefinition>
+      <summary>
+        A string that represents the table definition of the results, if the method is used as a table-valued function (TVF).
+      </summary>
+      <value>
+        A <see cref="T:System.String" /> value representing the table definition of the results.
+      </value>
+      <remarks>
+        This attribute is used only by Microsoft Visual Studio to automatically register the specified method as a TVF. It is not used by SQL Server.
+      </remarks>
+      <example>
+        <para>
+          The following example specifies that the user-defined function is referenced using the name <c>sp_tableFunc</c>. The <b>TableDefinition</b> property has the value <c>letter nchar(1)</c>.
+        </para>
+        <!-- SqlFunctionAttribute_SqlFunction #11 -->
+        <code language="c#">
+          public partial class UserDefinedFunctions
+          {
+              [SqlFunction(Name="sp_tableFunc", TableDefinition="letter nchar(1)")]
+              public static IEnumerable SampleTableFunction(SqlString s)
+              {
+                  //...
+                  return new ArrayList(new char[3] {'a', 'b', 'c'});
+              }
+          }
+        </code>
+        <!-- SqlFunctionAttribute_SqlFunction #11 -->
+        <code language="vb">
+          Partial Public Class UserDefinedFunctions
+          
+              &lt;SqlFunction(Name:="sp_tableFunc", TableDefinition:="letter nchar(1)")&gt; 
+              Public Shared Function SampleTableFunction(ByVal s As SqlString) As IEnumerable
+          
+                  '...
+                  Return New Char(2) {"a"c, "b"c, "c"c}
+              End Function
 
-## Examples  
-The following example shows an aggregate function that returns a list of files in the specified directory path.  
-
-[!code-csharp[SqlFunctionAttribute Sample#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/DataWorks_SqlFunctionAttribute_Sample.cs#1)]
-[!code-vb[SqlFunctionAttribute Sample#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/visualbasic/DataWorks_SqlFunctionAttribute_Sample.vb#1)]
-
-]]></format>
-            </remarks>
-        </SqlFunctionAttribute>
-        <ctor>
-            <summary>An optional attribute on a user-defined aggregate, used to indicate that the method should be registered in SQL Server as a function. Also used to set the <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.DataAccess" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.FillRowMethodName" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsDeterministic" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsPrecise" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.Name" />, <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.SystemDataAccess" />, and <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.TableDefinition" /> properties of the function attribute.</summary>
-            <remarks>To be added.</remarks>
-        </ctor>
-        <DataAccess>
-            <summary>Indicates whether the function involves access to user data stored in the local instance of SQL Server.</summary>
-            <value>
-            <see cref="T:Microsoft.SqlServer.Server.DataAccessKind" />.<see langword="None" />: Does not access data. <see cref="T:Microsoft.SqlServer.Server.DataAccessKind" />.<see langword="Read" />: Only reads user data.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default is <xref:Microsoft.SqlServer.Server.DataAccessKind.None>.<xref:Microsoft.SqlServer.Server.SqlFunctionAttribute.DataAccess%2A> is also required when connecting to remote servers if transactions integration is required (the default).  
-
-If a Transact-SQL query is executed from inside a table-valued function (TVF), the <xref:Microsoft.SqlServer.Server.DataAccessKind.Read> property should be set.  
-
-]]></format>
-            </remarks>
-        </DataAccess>
-        <FillRowMethodName>
-            <summary>The name of a method in the same class which is used to fill a row of data in the table returned by the table-valued function.</summary>
-            <value>A <see cref="T:System.String" /> value representing the name of a method in the same class which is used to fill a row of data in the table returned by the table-valued function.</value>
-        </FillRowMethodName>
-        <IsDeterministic>
-            <summary>Indicates whether the user-defined function is deterministic.</summary>
-            <value>
-            <see langword="true" /> if the function is deterministic; otherwise <see langword="false" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-A user-defined function is said to be deterministic if it always produces the same output values given the same input values and the same database state.  
-
-The <xref:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsDeterministic%2A> property is also useful for indexing the result of the function in the form of indexed computed columns and indexed views. If this property is not specified, the function is assumed to be non-deterministic.  
-
-Functions that access local data can be deterministic. The data access characteristic is captured separately by the <xref:Microsoft.SqlServer.Server.SqlFunctionAttribute.DataAccess%2A> and <xref:Microsoft.SqlServer.Server.SqlFunctionAttribute.SystemDataAccess%2A> properties.  
-
-Note that data access to remote servers (for example, using a <xref:Microsoft.Data.SqlClient.SqlConnection> to connect to another SQL Server instance) is available in user-defined functions. However, you must still honor the <xref:Microsoft.SqlServer.Server.SqlFunctionAttribute.IsDeterministic%2A> declaration. If the common language runtime (CLR) function is marked as deterministic, it should not cause side-effects in the remote server. While side-effects against the context connection are restricted, SQL Server will not enforce the restriction for side-effects over remote connections.  
-
-The default value of this attribute is `false`.  
-
-Do not mark a function as deterministic if the function does not always produce the same output values, given the same input values and the same database state. Marking a function as deterministic when the function is not truly deterministic can result in corrupted indexed views and computed columns.  
-
-]]></format>
-            </remarks>
-        </IsDeterministic>
-        <IsPrecise>
-            <summary>Indicates whether the function involves imprecise computations, such as floating point operations.</summary>
-            <value>
-            <see langword="true" /> if the function involves precise computations; otherwise <see langword="false" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Precision of a function is one of the properties used to determine if computed columns that use this function can be indexed.  
-
-The default value of this attribute is `false`.  
-
-]]></format>
-            </remarks>
-        </IsPrecise>
-        <Name>
-            <summary>The name under which the function should be registered in SQL Server.</summary>
-            <value>A <see cref="T:System.String" /> value representing the name under which the function should be registered.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-This attribute is used only by Microsoft Visual Studio to automatically register the specified method as a user-defined function. It is not used by SQL Server.  
-
-The following example specifies that the user-defined function is referenced using the name `sp_scalarFunc`.  
-
-## Examples  
-[!code-csharp[SqlFunctionAttribute Samples#10](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/SqlFunctionAttribute_SqlFunction.cs#10)]
-[!code-vb[SqlFunctionAttribute Samples#10](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/visualbasic/SqlFunctionAttribute_SqlFunction.vb#10)]
-
-]]></format>
-            </remarks>
-        </Name>
-        <SystemDataAccess>
-            <summary>Indicates whether the function requires access to data stored in the system catalogs or virtual system tables of SQL Server.</summary>
-            <value>
-            <see cref="T:Microsoft.SqlServer.Server.DataAccessKind" />.<see langword="None" />: Does not access system data. <see cref="T:Microsoft.SqlServer.Server.DataAccessKind" />.<see langword="Read" />: Only reads system data.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The default is <xref:Microsoft.SqlServer.Server.SystemDataAccessKind.None>.  
-
-]]></format>
-            </remarks>
-        </SystemDataAccess>
-        <TableDefinition>
-            <summary>A string that represents the table definition of the results, if the method is used as a table-valued function (TVF).</summary>
-            <value>A <see cref="T:System.String" /> value representing the table definition of the results.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-This attribute is used only by Microsoft Visual Studio to automatically register the specified method as a TVF. It is not used by SQL Server.  
-
-The following example specifies that the user-defined function is referenced using the name `sp_tableFunc`. The `TableDefinition` property has the value `letter nchar(1)`.  
-
-## Examples  
-
-[!code-csharp[SqlFunctionAttribute Samples#11](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/SqlFunctionAttribute_SqlFunction.cs#11)]
-[!code-vb[SqlFunctionAttribute Samples#11](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/visualbasic/SqlFunctionAttribute_SqlFunction.vb#11)]
-
-]]></format>
-            </remarks>
-        </TableDefinition>
-    </members>
+          End Class
+        </code>
+      </example>
+    </TableDefinition>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.SqlServer.Server/SqlMethodAttribute.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/SqlMethodAttribute.xml
@@ -1,68 +1,95 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SqlMethodAttribute">
-        <SqlMethodAttribute>
-            <summary>Indicates the determinism and data access properties of a method or property on a user-defined type (UDT). The properties on the attribute reflect the physical characteristics that are used when the type is registered with SQL Server.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-For a property, the <xref:Microsoft.SqlServer.Server.SqlMethodAttribute> should be used on the setter or the getter directly.  
-
-<xref:Microsoft.SqlServer.Server.SqlMethodAttribute> inherits from a <xref:Microsoft.SqlServer.Server.SqlFunctionAttribute>, so <xref:Microsoft.SqlServer.Server.SqlMethodAttribute> inherits the `FillRowMethodName` and `TableDefinition` fields from <xref:Microsoft.SqlServer.Server.SqlFunctionAttribute>. Note that it is not possible to write a table-valued method, although the names of these fields might suggest that it is possible.  
-
-## Examples  
-The following example shows a UDT method that is attributed to indicate that the method will not be invoked on null instances of the type, that the method will not change the state of the type, and that the method will not be called when `null` parameters are supplied to the method invocation.  
-
-[!code-csharp[SqlMethodAttribute Samples#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/SqlMethod.cs#1)]
-
-]]></format>
-            </remarks>
-        </SqlMethodAttribute>
-        <ctor>
-            <summary>An attribute on a user-defined type (UDT), used to indicate the determinism and data access properties of a method or a property on a UDT.</summary>
-            <remarks>To be added.</remarks>
-        </ctor>
-        <InvokeIfReceiverIsNull>
-            <summary>Indicates whether SQL Server should invoke the method on null instances.</summary>
-            <value> <see langword="true" /> if SQL Server should invoke the method on null instances; otherwise, <see langword="false" />. If the method cannot be invoked (because of an attribute on the method), the SQL Server <see langword="DbNull" /> is returned.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-
-The default value of the `InvokeIfReceiverIsNull` property is `false`. That is, the method is not invoked on a null instance. If `InvokeIfReceiverIsNull` is `true`, the return value of the method depends upon its type. If the return type of the method is nullable, the distinguished null value for the type is returned. If the return type is non-nullable, the default CLR value for the type is returned. The default value for reference types is `null`. The default value for a value type is the value that is returned when you call the parameterless constructor for the type.
-
-]]></format>
-            </remarks>
-        </InvokeIfReceiverIsNull>
-        <IsMutator>
-            <summary>Indicates whether a method on a user-defined type (UDT) is a mutator.</summary>
-            <value> <see langword="true" /> if the method is a mutator; otherwise <see langword="false" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-If the <xref:Microsoft.SqlServer.Server.SqlMethodAttribute.IsMutator%2A> property is set to `true` and the return type of the method is `void`, SQL Server marks the method as a mutator. A mutator method is one that causes a state change in the UDT instance. Mutator methods can be called in assignment statements or data modification statements, but cannot be used in queries. If a method is marked as a mutator but does not return void, then CREATE TYPE does not fail with an error. Even though a returned value other than `void` does not raise an error, the returned value is not accessible and cannot be used.  
-
-The default value of the <xref:Microsoft.SqlServer.Server.SqlMethodAttribute.IsMutator%2A> property is `false`.  
-
-A property can be a mutator if <xref:Microsoft.SqlServer.Server.SqlMethodAttribute> is used on the setter and <xref:Microsoft.SqlServer.Server.SqlMethodAttribute.IsMutator%2A> is set to `true`. However, a property setter is implicitly treated as a mutator, so it is not necessary to set the <xref:Microsoft.SqlServer.Server.SqlMethodAttribute.IsMutator%2A> property of the <xref:Microsoft.SqlServer.Server.SqlMethodAttribute> to `true`.  
-
-]]></format>
-            </remarks>
-        </IsMutator>
-        <OnNullCall>
-            <summary>Indicates whether the method on a user-defined type (UDT) is called when <see langword="null" /> input arguments are specified in the method invocation.</summary>
-            <value> <see langword="true" /> if the method is called when <see langword="null" /> input arguments are specified in the method invocation; <see langword="false" /> if the method returns a <see langword="null" /> value when any of its input parameters are <see langword="null" />. If the method cannot be invoked (because of an attribute on the method), the SQL Server <see langword="DbNull" /> is returned.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-The default value of the <xref:Microsoft.SqlServer.Server.SqlMethodAttribute.OnNullCall%2A> property is `true`.  
-
-]]></format>
-            </remarks>
-        </OnNullCall>
-    </members>
+﻿<docs>
+  <members name="SqlMethodAttribute">
+    <SqlMethodAttribute>
+      <summary>
+        Indicates the determinism and data access properties of a method or property on a user-defined type (UDT). The properties on the attribute reflect the physical characteristics that are used when the type is registered with SQL Server.
+      </summary>
+      <remarks>
+        <para>
+          For a property, the <see cref="T:Microsoft.SqlServer.Server.SqlMethodAttribute" /> should be used on the setter or the getter directly.
+        </para>
+        <para>
+          <see cref="T:Microsoft.SqlServer.Server.SqlMethodAttribute" /> inherits from a <see cref="T:Microsoft.SqlServer.Server.SqlFunctionAttribute" />, so <see cref="T:Microsoft.SqlServer.Server.SqlMethodAttribute" /> inherits the <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.FillRowMethodName" /> and <see cref="P:Microsoft.SqlServer.Server.SqlFunctionAttribute.TableDefinition" /> fields from <see cref="T:Microsoft.SqlServer.Server.SqlFunctionAttribute" />. Note that it is not possible to write a table-valued method, although the names of these fields might suggest that it is possible.
+        </para>
+      </remarks>
+      <example>
+        <para>
+          The following example shows a UDT method that is attributed to indicate that the method will not be invoked on null instances of the type, that the method will not change the state of the type, and that the method will not be called when <see langword="null" /> parameters are supplied to the method invocation.
+        </para>
+        <!-- SqlMethod -->
+        <code language="c#">
+          using System;
+          using System.Data.SqlTypes;
+          using System.Text;
+          using Microsoft.SqlServer.Server;
+          
+          [Serializable]
+          [SqlUserDefinedType(
+              Format.Native,
+              IsByteOrdered = true,
+              Name = "Point",
+              ValidationMethodName = "ValidatePoint")]
+          public struct Point : INullable
+          {
+              private bool is_Null;
+              private int _x;
+              private int _y;
+          
+              // Distance from Point to the specified x and y values method.
+              [SqlMethod(OnNullCall = false, IsMutator = false, InvokeIfReceiverIsNull = false)]
+              public Double DistanceFromXY(int iX, int iY)
+              {
+                  return Math.Sqrt(Math.Pow(iX - _x, 2.0) + Math.Pow(iY - _y, 2.0));
+              }
+          }
+        </code>
+      </example>
+    </SqlMethodAttribute>
+    <ctor>
+      <summary>
+        An attribute on a user-defined type (UDT), used to indicate the determinism and data access properties of a method or a property on a UDT.
+      </summary>
+    </ctor>
+    <InvokeIfReceiverIsNull>
+      <summary>
+        Indicates whether SQL Server should invoke the method on null instances.
+      </summary>
+      <value>
+        <see langword="true" /> if SQL Server should invoke the method on null instances; otherwise, <see langword="false" />. If the method cannot be invoked (because of an attribute on the method), the SQL Server <see cref="T:System.Data.DbNull" /> is returned.
+      </value>
+      <remarks>
+        The default value of the <b>InvokeIfReceiverIsNull</b> property is <see langword="false" />. That is, the method is not invoked on a null instance. If <b>InvokeIfReceiverIsNull</b> is <see langword="true" />, the return value of the method depends upon its type. If the return type of the method is nullable, the distinguished null value for the type is returned. If the return type is non-nullable, the default CLR value for the type is returned. The default value for reference types is <see langword="null" />. The default value for a value type is the value that is returned when you call the parameterless constructor for the type.
+      </remarks>
+    </InvokeIfReceiverIsNull>
+    <IsMutator>
+      <summary>
+        Indicates whether a method on a user-defined type (UDT) is a mutator.
+      </summary>
+      <value>
+        <see langword="true" /> if the method is a mutator; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        <para>
+          If the <see cref="P:Microsoft.SqlServer.Server.SqlMethodAttribute.IsMutator" /> property is set to <see langword="true" /> and the return type of the method is <see langword="void" />, SQL Server marks the method as a mutator. A mutator method is one that causes a state change in the UDT instance. Mutator methods can be called in assignment statements or data modification statements, but cannot be used in queries. If a method is marked as a mutator but does not return void, then CREATE TYPE does not fail with an error. Even though a returned value other than <see langword="void" /> does not raise an error, the returned value is not accessible and cannot be used.
+        </para>
+        <para>
+          The default value of the <see cref="P:Microsoft.SqlServer.Server.SqlMethodAttribute.IsMutator" /> property is <see langword="false" />.
+        </para>
+        <para>
+          A property can be a mutator if <see cref="T:Microsoft.SqlServer.Server.SqlMethodAttribute" /> is used on the setter and <see cref="P:Microsoft.SqlServer.Server.SqlMethodAttribute.IsMutator" /> is set to <see langword="true" />. However, a property setter is implicitly treated as a mutator, so it is not necessary to set the <see cref="P:Microsoft.SqlServer.Server.SqlMethodAttribute.IsMutator" /> property of the <see cref="T:Microsoft.SqlServer.Server.SqlMethodAttribute" /> to <see langword="true" />.
+        </para>
+      </remarks>
+    </IsMutator>
+    <OnNullCall>
+      <summary>
+        Indicates whether the method on a user-defined type (UDT) is called when <see langword="null" /> input arguments are specified in the method invocation.
+      </summary>
+      <value>
+        <see langword="true" /> if the method is called when <see langword="null" /> input arguments are specified in the method invocation; <see langword="false" /> if the method returns a <see langword="null" /> value when any of its input parameters are <see langword="null" />. If the method cannot be invoked (because of an attribute on the method), the SQL Server <see cref="T:System.Data.DbNull" /> is returned.
+      </value>
+      <remarks>
+        The default value of the <see cref="P:Microsoft.SqlServer.Server.SqlMethodAttribute.OnNullCall" /> property is <see langword="true" />.
+      </remarks>
+    </OnNullCall>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.SqlServer.Server/SqlUserDefinedAggregateAttribute.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/SqlUserDefinedAggregateAttribute.xml
@@ -179,7 +179,7 @@
           You must specify the <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSize" /> property with the UserDefined serialization <see cref="T:Microsoft.SqlServer.Server.Format" />.
         </para>
         <para>
-          The maximum allowed value for this property is specified by the <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSizeValue" /> field.
+          The maximum allowed value for this property is specified by the <see cref="F:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSizeValue" /> field.
         </para>
         <para>
           The maximum size allowed is 2 gigabytes (GB). You can specify a number from 1 to 8000 bytes, or -1 to represent a value larger than 8000 bytes, up to 2 gigabytes.

--- a/doc/snippets/Microsoft.SqlServer.Server/SqlUserDefinedAggregateAttribute.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/SqlUserDefinedAggregateAttribute.xml
@@ -1,134 +1,209 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SqlUserDefinedAggregateAttribute">
-        <SqlUserDefinedAggregateAttribute>
-            <summary>Indicates that the type should be registered as a user-defined aggregate. The properties on the attribute reflect the physical attributes used when the type is registered with SQL Server. This class cannot be inherited.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-SQL Server creates a user-defined aggregate that is bound to the class definition that has the <xref:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute> custom attribute. Every user-defined aggregate must be annotated with this attribute.  
-
-See "CLR User-Defined Aggregates" in SQL Server 2005 Books Online for more information on user-defined aggregates and examples.  
-
-## Examples  
-The following example shows the <xref:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute> attribute for a user-defined aggregate.  The aggregate uses custom serialization, has a maximum size of 8000 bytes when serialized, and is invariant to nulls, duplicates, and order.  
-
-[!code-csharp[SqlUserDefinedAggregateAttribute Samples#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/DataWorks_SqlUserDefinedAggregateAttribute_Sample.cs#1)]
-[!code-vb[SqlUserDefinedAggregateAttribute Samples#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/visualbasic/DataWorks_SqlUserDefinedAggregateAttribute_Sample.vb#1)]
-
-]]></format>
-            </remarks>
-        </SqlUserDefinedAggregateAttribute>
-        <ctor>
-            <param name="format">One of the <see cref="T:Microsoft.SqlServer.Server.Format" /> values representing the serialization format of the aggregate.</param>
-            <summary>A required attribute on a user-defined aggregate, used to indicate that the given type is a user-defined aggregate and the storage format of the user-defined aggregate.</summary>
-        </ctor>
-        <Format>
-            <summary>The serialization format as a <see cref="T:Microsoft.SqlServer.Server.Format" />.</summary>
-            <value>A <see cref="T:Microsoft.SqlServer.Server.Format" /> representing the serialization format.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Examples  
-[!code-csharp[SqlUserDefinedAggregateAttribute Samples#6](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/SqlUserDefinedAggregateAttribute_Aggregate1.cs#6)]
-[!code-vb[SqlUserDefinedAggregateAttribute Samples#6](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/visualbasic/SqlUserDefinedAggregateAttribute_Aggregate1.vb#6)]
-
-]]></format>
-            </remarks>
-        </Format>
-        <IsInvariantToDuplicates>
-            <summary>Indicates whether the aggregate is invariant to duplicates.</summary>
-            <value> <see langword="true" /> if the aggregate is invariant to duplicates; otherwise <see langword="false" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-                    
-## Remarks  
-Used by the query processor, this property is `true` if the aggregate is invariant to duplicates. That is, the aggregate of S, {X} is the same as aggregate of S when X is already in S. For example, aggregate functions such as MIN and MAX satisfy this property, while SUM does not.  
-
-Incorrectly setting this property can result in incorrect query results. This property is not an optimizer hint; it affects both the plan selected and the results returned by the query.  
-
-]]></format>
-            </remarks>
-        </IsInvariantToDuplicates>
-        <IsInvariantToNulls>
-            <summary>Indicates whether the aggregate is invariant to nulls.</summary>
-            <value> <see langword="true" /> if the aggregate is invariant to nulls; otherwise <see langword="false" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Used by the query processor, this property is `true` if the aggregate is invariant to nulls. That is, the aggregate of S, {NULL} is the same as aggregate of S. For example, aggregate functions such as MIN and MAX satisfy this property, while COUNT(*) does not.  
-
-Incorrectly setting this property can result in incorrect query results. This property is not an optimizer hint; it affects the plan selected and the results returned by the query.  
-
-]]></format>
-            </remarks>
-        </IsInvariantToNulls>
-        <IsInvariantToOrder>
-            <summary>Indicates whether the aggregate is invariant to order.</summary>
-            <value> <see langword="true" /> if the aggregate is invariant to order; otherwise <see langword="false" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-Reserved for future use. This property is not currently used by the query processor: order is currently not guaranteed.  
-
-Incorrectly setting this property can result in incorrect query results. This property is not an optimizer hint; it affects the plan selected and the results returned by the query.  
-
-The default value for this property is `false`.  
-
-]]></format>
-            </remarks>
-        </IsInvariantToOrder>
-        <IsNullIfEmpty>
-            <summary>Indicates whether the aggregate returns <see langword="null" /> if no values have been accumulated.</summary>
-            <value> <see langword="true" /> if the aggregate returns <see langword="null" /> if no values have been accumulated; otherwise <see langword="false" />.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-Used by the query processor, this property is `true` if the aggregate returns `null` if no values have been accumulated.  
-
-Incorrectly setting this property can result in incorrect query results. This property is not an optimizer hint; it affects the plan selected and the results returned by the query.  
-
-]]></format>
-            </remarks>
-        </IsNullIfEmpty>
-        <MaxByteSize>
-            <summary>The maximum size, in bytes, of the aggregate instance.</summary>
-            <value>An <see cref="T:System.Int32" /> value representing the maximum size of the aggregate instance.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-This property does not have to be specified for Native format serialization.  
-
-You must specify the <xref:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSize%2A> property with the UserDefined serialization <xref:Microsoft.SqlServer.Server.Format>.  
-
-The maximum allowed value for this property is specified by the <xref:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSizeValue> field.  
-
-The maximum size allowed is 2 gigabytes (GB). You can specify a number from 1 to 8000 bytes, or -1 to represent a value larger than 8000 bytes, up to 2 gigabytes.  
-
-For an aggregate with user-defined serialization specified, <xref:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSize%2A> refers to the total size of the serialized data. Consider an aggregate serializing a string of 10 characters (<xref:System.Char>). When the string is serialized using a <xref:System.IO.BinaryWriter>, the total size of the serialized string is 22 bytes: 2 bytes per Unicode UTF-16 character, multiplied by the maximum number of characters, plus 2 control bytes of overhead incurred from serializing a binary stream. So, when determining the value of <xref:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSize%2A>, the total size of the serialized data must be considered: the size of the data serialized in binary form plus the overhead incurred by serialization.  
-
-]]></format>
-            </remarks>
-        </MaxByteSize>
-        <MaxByteSizeValue>
-            <summary>The maximum size, in bytes, required to store the state of this aggregate instance during computation.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-An <xref:System.Int32> value representing the maximum size of the aggregate instance.  
-
-]]></format>
-            </remarks>
-        </MaxByteSizeValue>
-        <Name>
-            <summary>The name of the aggregate.</summary>
-            <value>A <see cref="T:System.String" /> value representing the name of the aggregate.</value>
-        </Name>
-    </members>
+﻿<docs>
+  <members name="SqlUserDefinedAggregateAttribute">
+    <SqlUserDefinedAggregateAttribute>
+      <summary>
+        Indicates that the type should be registered as a user-defined aggregate. The properties on the attribute reflect the physical attributes used when the type is registered with SQL Server. This class cannot be inherited.
+      </summary>
+      <remarks>
+        <para>
+          SQL Server creates a user-defined aggregate that is bound to the class definition that has the <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute" /> custom attribute. Every user-defined aggregate must be annotated with this attribute.
+        </para>
+        <para>
+          See "CLR User-Defined Aggregates" in SQL Server 2005 Books Online for more information on user-defined aggregates and examples.
+        </para>
+      </remarks>
+      <example>
+        <para>
+          The following example shows the <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute" /> attribute for a user-defined aggregate. The aggregate uses custom serialization, has a maximum size of 8000 bytes when serialized, and is invariant to nulls, duplicates, and order.
+        </para>
+        <!-- DataWorks_SqlUserDefinedAggregateAttribute_Sample #1 -->
+        <code language="c#">
+          using System;
+          using System.IO;
+          using Microsoft.SqlServer.Server;
+          
+          [Serializable]
+          [SqlUserDefinedAggregate(
+            Microsoft.SqlServer.Server.Format.UserDefined,
+            IsInvariantToNulls = true,
+            IsInvariantToDuplicates = false,
+            IsInvariantToOrder = false,
+            MaxByteSize = 8000)]
+          public class Concatenate : Microsoft.SqlServer.Server.IBinarySerialize
+          {
+             public void Read(BinaryReader r)
+             {
+             }
+          
+             public void Write(BinaryWriter w)
+             {
+             }
+          }
+        </code>
+        <!-- DataWorks_SqlUserDefinedAggregateAttribute_Sample #1 -->
+        <code language="vb">
+          Imports System.IO
+          Imports Microsoft.SqlServer.Server
+          
+          &lt;Serializable(), SqlUserDefinedAggregate( _
+              Microsoft.SqlServer.Server.Format.UserDefined, _ 
+              IsInvariantToNulls:=True, _ 
+              IsInvariantToDuplicates:=False, _
+              IsInvariantToOrder:=False, _
+              MaxByteSize:=8000)&gt; _
+          Public Class Concatenate
+              Implements Microsoft.SqlServer.Server.IBinarySerialize
+          
+              Public Sub Read(ByVal r As BinaryReader) Implements Microsoft.SqlServer.Server.IBinarySerialize.Read
+                  
+              End Sub
+          
+              Public Sub Write(ByVal w As BinaryWriter) Implements Microsoft.SqlServer.Server.IBinarySerialize.Write
+                  
+              End Sub
+        </code>
+      </example>
+    </SqlUserDefinedAggregateAttribute>
+    <ctor>
+      <param name="format">
+        One of the <see cref="T:Microsoft.SqlServer.Server.Format" /> values representing the serialization format of the aggregate.
+      </param>
+      <summary>
+        A required attribute on a user-defined aggregate, used to indicate that the given type is a user-defined aggregate and the storage format of the user-defined aggregate.
+      </summary>
+    </ctor>
+    <Format>
+      <summary>
+        The serialization format as a <see cref="T:Microsoft.SqlServer.Server.Format" />.
+      </summary>
+      <value>
+        A <see cref="T:Microsoft.SqlServer.Server.Format" /> representing the serialization format.
+      </value>
+      <example>
+        <!-- SqlUserDefinedAggregateAttribute_Aggregate1 #6 -->
+        <code language="c#">
+          [SqlUserDefinedAggregate(Format.Native)]
+          public class SampleAggregate
+          {
+             //...
+          }
+        </code>
+        <!-- SqlUserDefinedAggregateAttribute_Aggregate1 #6 -->
+        <code language="vb">
+          &lt;SqlUserDefinedAggregate(Format.Native)&gt;
+          Public Class SampleAggregate
+              '...
+          End Class
+        </code>
+      </example>
+    </Format>
+    <IsInvariantToDuplicates>
+      <summary>
+        Indicates whether the aggregate is invariant to duplicates.
+      </summary>
+      <value>
+        <see langword="true" /> if the aggregate is invariant to duplicates; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        <para>
+          Used by the query processor, this property is <see langword="true" /> if the aggregate is invariant to duplicates. That is, the aggregate of S, {X} is the same as aggregate of S when X is already in S. For example, aggregate functions such as MIN and MAX satisfy this property, while SUM does not.
+        </para>
+        <para>
+          Incorrectly setting this property can result in incorrect query results. This property is not an optimizer hint; it affects both the plan selected and the results returned by the query.
+        </para>
+      </remarks>
+    </IsInvariantToDuplicates>
+    <IsInvariantToNulls>
+      <summary>
+        Indicates whether the aggregate is invariant to nulls.
+      </summary>
+      <value>
+        <see langword="true" /> if the aggregate is invariant to nulls; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        <para>
+          Used by the query processor, this property is <see langword="true" /> if the aggregate is invariant to nulls. That is, the aggregate of S, {NULL} is the same as aggregate of S. For example, aggregate functions such as MIN and MAX satisfy this property, while COUNT(*) does not.
+        </para>
+        <para>
+          Incorrectly setting this property can result in incorrect query results. This property is not an optimizer hint; it affects the plan selected and the results returned by the query.
+        </para>
+      </remarks>
+    </IsInvariantToNulls>
+    <IsInvariantToOrder>
+      <summary>
+        Indicates whether the aggregate is invariant to order.
+      </summary>
+      <value>
+        <see langword="true" /> if the aggregate is invariant to order; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        <para>
+          Reserved for future use. This property is not currently used by the query processor: order is currently not guaranteed.
+        </para>
+        <para>
+          Incorrectly setting this property can result in incorrect query results. This property is not an optimizer hint; it affects the plan selected and the results returned by the query.
+        </para>
+        <para>
+          The default value for this property is <see langword="false" />.
+        </para>
+      </remarks>
+    </IsInvariantToOrder>
+    <IsNullIfEmpty>
+      <summary>
+        Indicates whether the aggregate returns <see langword="null" /> if no values have been accumulated.
+      </summary>
+      <value>
+        <see langword="true" /> if the aggregate returns <see langword="null" /> if no values have been accumulated; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        <para>
+          Used by the query processor, this property is <see langword="true" /> if the aggregate returns <see langword="null" /> if no values have been accumulated.
+        </para>
+        <para>
+          Incorrectly setting this property can result in incorrect query results. This property is not an optimizer hint; it affects the plan selected and the results returned by the query.
+        </para>
+      </remarks>
+    </IsNullIfEmpty>
+    <MaxByteSize>
+      <summary>
+        The maximum size, in bytes, of the aggregate instance.
+      </summary>
+      <value>
+        An <see cref="T:System.Int32" /> value representing the maximum size of the aggregate instance.
+      </value>
+      <remarks>
+        <para>
+          This property does not have to be specified for Native format serialization.
+        </para>
+        <para>
+          You must specify the <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSize" /> property with the UserDefined serialization <see cref="T:Microsoft.SqlServer.Server.Format" />.
+        </para>
+        <para>
+          The maximum allowed value for this property is specified by the <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSizeValue" /> field.
+        </para>
+        <para>
+          The maximum size allowed is 2 gigabytes (GB). You can specify a number from 1 to 8000 bytes, or -1 to represent a value larger than 8000 bytes, up to 2 gigabytes.
+        </para>
+        <para>
+          For an aggregate with user-defined serialization specified, <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSize" /> refers to the total size of the serialized data. Consider an aggregate serializing a string of 10 characters ( <see cref="T:System.Char" />). When the string is serialized using a <see cref="T:System.IO.BinaryWriter" />, the total size of the serialized string is 22 bytes: 2 bytes per Unicode UTF-16 character, multiplied by the maximum number of characters, plus 2 control bytes of overhead incurred from serializing a binary stream. So, when determining the value of <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedAggregateAttribute.MaxByteSize" />, the total size of the serialized data must be considered: the size of the data serialized in binary form plus the overhead incurred by serialization.
+        </para>
+      </remarks>
+    </MaxByteSize>
+    <MaxByteSizeValue>
+      <summary>
+        The maximum size, in bytes, required to store the state of this aggregate instance during computation.
+      </summary>
+      <remarks>
+        An <see cref="T:System.Int32" /> value representing the maximum size of the aggregate instance.
+      </remarks>
+    </MaxByteSizeValue>
+    <Name>
+      <summary>
+        The name of the aggregate.
+      </summary>
+      <value>
+        A <see cref="T:System.String" /> value representing the name of the aggregate.
+      </value>
+    </Name>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.SqlServer.Server/SqlUserDefinedTypeAttribute.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/SqlUserDefinedTypeAttribute.xml
@@ -44,7 +44,7 @@
         A required attribute on a user-defined type (UDT), used to confirm that the given type is a UDT and to indicate the storage format of the UDT.
       </summary>
       <remarks>
-        The following example specifies that the <see cref="P:Microsoft.SqlServer.Server.Format" /> of the user-defined type is <see cref="P:Microsoft.SqlServer.Server.SerializedDataWithMetadata" /> and the <see cref="P:Microsoft.SqlServer.Server.Format.MaxByteSize" /> is 8000 bytes.
+        The following example specifies that the <see cref="P:Microsoft.SqlServer.Server.Format" /> of the user-defined type is <see cref="F:Microsoft.SqlServer.Server.Format.Native" /> and the <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize" /> is 8000 bytes.
       </remarks>
       <example>
         <!-- SqlUserDefinedTypeAttribute_Type1 #12 -->

--- a/doc/snippets/Microsoft.SqlServer.Server/SqlUserDefinedTypeAttribute.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/SqlUserDefinedTypeAttribute.xml
@@ -1,139 +1,170 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SqlUserDefinedTypeAttribute">
-        <SqlUserDefinedTypeAttribute>
-            <summary>Used to mark a type definition in an assembly as a user-defined type (UDT) in SQL Server. The properties on the attribute reflect the physical characteristics used when the type is registered with SQL Server. This class cannot be inherited.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-SQL Server creates a user-defined type that is bound to the type definition that has the <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute> custom attribute. Every UDT must be annotated with this attribute. See [CLR User-Defined Types](https://go.microsoft.com/fwlink/?LinkId=128028) for more information about UDTs, including an example of a UDT.  
-
-## Examples  
-The following example shows the `UserDefinedType` attribute of the Point UDT.  The UDT is byte-ordered, is named "Point", has a validation method named "ValidatePoint", and uses the native serialization format.  
-
-[!code-csharp[SqlUserDefinedTypeAttribute Samples#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/DataWorks_SqlUserDefinedTypeAttribute_Sample.cs#1)]
-[!code-vb[SqlUserDefinedTypeAttribute Samples#1](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/visualbasic/DataWorks_SqlUserDefinedTypeAttribute_Sample.vb#1)] 
-
-]]></format>
-            </remarks>
-        </SqlUserDefinedTypeAttribute>
-        <ctor>
-            <param name="format">One of the <see cref="T:Microsoft.SqlServer.Server.Format" /> values representing the serialization format of the type.</param>
-            <summary>A required attribute on a user-defined type (UDT), used to confirm that the given type is a UDT and to indicate the storage format of the UDT.</summary>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The following example specifies that the `Format` of the user-defined type is `SerializedDataWithMetadata` and the `MaxByteSize` is 8000 bytes.  
-
-## Examples  
-[!code-csharp[SqlUserDefinedTypeAttribute Samples#12](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/csharp/SqlUserDefinedTypeAttribute_Type1.cs#12)]
-[!code-vb[SqlUserDefinedTypeAttribute Samples#12](~/../sqlclient/doc/samples/Microsoft.SqlServer.Server/visualbasic/SqlUserDefinedTypeAttribute_Type1.vb#12)] 
-
-]]></format>
-            </remarks>
-        </ctor>
-        <Format>
-            <summary>The serialization format as a <see cref="T:Microsoft.SqlServer.Server.Format" /> .</summary>
-            <value>A <see cref="T:Microsoft.SqlServer.Server.Format" /> value representing the serialization format.</value>
-        </Format>
-        <IsByteOrdered>
-            <summary>Indicates whether the user-defined type is byte ordered.</summary>
-            <value>
-                <see langword="true" /> if the user-defined type is byte ordered; otherwise <see langword="false" /> .</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-When set to `true`, the <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsByteOrdered%2A> property in effect guarantees that the serialized binary data can be used for semantic ordering of the information. Thus, each instance of a byte-ordered UDT object can only have one serialized representation. When a comparison operation is performed in SQL Server on the serialized bytes, its results should be the same as if the same comparison operation had taken place in managed code.  
-
-The following features are supported when <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsByteOrdered%2A> is set to `true`:  
-
-- The ability to create indexes on columns of this type.  
-
-- The ability to create primary and foreign keys as well as CHECK and UNIQUE constraints on columns of this type.  
-
-- The ability to use Transact-SQL ORDER BY, GROUP BY, and PARTITION BY clauses. In these cases, the binary representation of the type is used to determine the order.  
-
-- The ability to use comparison operators in Transact-SQL statements.  
-
-- The ability to persist computed columns of this type.  
-
-Note that both the `Native` and `UserDefined` serialization formats support the following comparison operators when <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsByteOrdered%2A> is set to `true`:  
-
-- Equal to (=)  
-
-- Not equal to (!=)  
-
-- Greater than (>)  
-
-- Less than (\<)  
-
-- Greater than or equal to (>=)  
-
-- Less than or equal to (<=)  
-
-]]></format>
-            </remarks>
-        </IsByteOrdered>
-        <IsFixedLength>
-            <summary>Indicates whether all instances of this user-defined type are the same length.</summary>
-            <value>
-                <see langword="true" /> if all instances of this type are the same length; otherwise <see langword="false" />.
-            </value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-If set to `true`, all instances of UDTs corresponding to this common language runtime (CLR) type must have a length in bytes exactly equal to <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize%2A>. This attribute is only relevant for UDTs with `UserDefined` serialization <xref:Microsoft.SqlServer.Server.Format>.  
-
-]]></format>
-            </remarks>
-        </IsFixedLength>
-        <MaxByteSize>
-            <summary>The maximum size of the instance, in bytes.</summary>
-            <value>An <see cref="T:System.Int32" /> value representing the maximum size of the instance.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-You must specify the <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize%2A> property with the `UserDefined` serialization <xref:Microsoft.SqlServer.Server.Format>.  
-
-When connecting to SQL Server 2005 or earlier, <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize%2A> must be between 1 and 8000.  
-
-When connecting to SQL Server 2008 or later, set <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize%2A> between 1 and 8000, for a type whose instances are always 8,000 bytes or less. For types that can have instances larger than 8000, specify -1.  
-
-For a UDT with user-defined serialization specified, <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize%2A> refers to the total size of the UDT in its serialized form as defined by the user. Consider a UDT with a property of a string of 10 characters (<xref:System.Char>). When the UDT is serialized using a <xref:System.IO.BinaryWriter>, the total size of the serialized string is 22 bytes: 2 bytes per Unicode UTF-16 character, multiplied by the maximum number of characters, plus 2 control bytes of overhead incurred from serializing a binary stream. So, when determining the value of <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize%2A>, the total size of the serialized UDT must be considered: the size of the data serialized in binary form plus the overhead incurred by serialization.  
-
-This property should not be used with `Native` serialization <xref:Microsoft.SqlServer.Server.Format>.  
-
-]]></format>
-            </remarks>
-        </MaxByteSize>
-        <Name>
-            <summary>The SQL Server name of the user-defined type.</summary>
-            <value>A <see cref="T:System.String" /> value representing the SQL Server name of the user-defined type.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The <xref:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.Name%2A> property is not used within SQL Server, but is used by the Microsoft Visual Studio .NET Integrated Development Environment (IDE).  
-
-]]></format>
-            </remarks>
-        </Name>
-        <ValidationMethodName>
-            <summary>The name of the method used to validate instances of the user-defined type.</summary>
-            <value>A <see cref="T:System.String" /> representing the name of the method used to validate instances of the user-defined type.</value>
-            <remarks>
-                <format type="text/markdown"><![CDATA[  
-
-## Remarks  
-The method specified by this attribute validates instances of the UDT when the UDT has been deserialized from a binary value that is not trusted.  
-
-]]></format>
-            </remarks>
-        </ValidationMethodName>
-    </members>
+﻿<docs>
+  <members name="SqlUserDefinedTypeAttribute">
+    <SqlUserDefinedTypeAttribute>
+      <summary>
+        Used to mark a type definition in an assembly as a user-defined type (UDT) in SQL Server. The properties on the attribute reflect the physical characteristics used when the type is registered with SQL Server. This class cannot be inherited.
+      </summary>
+      <remarks>
+        SQL Server creates a user-defined type that is bound to the type definition that has the <see cref="T:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute" /> custom attribute. Every UDT must be annotated with this attribute. See <see href="https://go.microsoft.com/fwlink/?LinkId=128028">CLR User-Defined Types</see>for more information about UDTs, including an example of a UDT.
+      </remarks>
+      <example>
+        <para>
+          The following example shows the <c>UserDefinedType</c> attribute of the Point UDT.  The UDT is byte-ordered, is named "Point", has a validation method named "ValidatePoint", and uses the native serialization format.
+        </para>
+        <!-- DataWorks_SqlUserDefinedTypeAttribute_Sample #1 -->
+        <code language="c#">
+          [Serializable]
+          [Microsoft.SqlServer.Server.SqlUserDefinedType(
+               Format.Native,
+               IsByteOrdered=true,
+               Name="Point",
+               ValidationMethodName = "ValidatePoint")]
+          public struct Point : INullable
+          {
+          }
+        </code>
+        <!-- DataWorks_SqlUserDefinedTypeAttribute_Sample #1 -->
+        <code language="vb">
+          &lt;Serializable(), SqlUserDefinedTypeAttribute( _
+            Format.Native, _
+            IsByteOrdered:=True, _
+            Name:="Point", _
+            ValidationMethodName:="ValidatePoint")> _
+            Public Structure Point
+              Implements INullable
+          End Structure
+        </code>
+      </example>
+    </SqlUserDefinedTypeAttribute>
+    <ctor>
+      <param name="format">
+        One of the <see cref="T:Microsoft.SqlServer.Server.Format" /> values representing the serialization format of the type.
+      </param>
+      <summary>
+        A required attribute on a user-defined type (UDT), used to confirm that the given type is a UDT and to indicate the storage format of the UDT.
+      </summary>
+      <remarks>
+        The following example specifies that the <see cref="P:Microsoft.SqlServer.Server.Format" /> of the user-defined type is <see cref="P:Microsoft.SqlServer.Server.SerializedDataWithMetadata" /> and the <see cref="P:Microsoft.SqlServer.Server.Format.MaxByteSize" /> is 8000 bytes.
+      </remarks>
+      <example>
+        <!-- SqlUserDefinedTypeAttribute_Type1 #12 -->
+        <code language="c#">
+          [SqlUserDefinedType(Format.Native, MaxByteSize=8000)]
+          public class SampleType
+          {
+             //...
+          }
+        </code>
+        <!-- SqlUserDefinedTypeAttribute_Type1 #12 -->
+        <code language="vb">
+          &lt;SqlUserDefinedType(Format.Native, MaxByteSize:=8000)&gt;
+          Public Class SampleType
+             '...
+          End Class
+        </code>
+      </example>
+    </ctor>
+    <Format>
+      <summary>
+        The serialization format as a <see cref="T:Microsoft.SqlServer.Server.Format" />.
+      </summary>
+      <value>
+        A <see cref="T:Microsoft.SqlServer.Server.Format" /> value representing the serialization format.
+      </value>
+    </Format>
+    <IsByteOrdered>
+      <summary>
+        Indicates whether the user-defined type is byte ordered.
+      </summary>
+      <value>
+        <see langword="true" /> if the user-defined type is byte ordered; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        <para>
+          When set to <see langword="true" />, the <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsByteOrdered" /> property in effect guarantees that the serialized binary data can be used for semantic ordering of the information. Thus, each instance of a byte-ordered UDT object can only have one serialized representation. When a comparison operation is performed in SQL Server on the serialized bytes, its results should be the same as if the same comparison operation had taken place in managed code.
+        </para>
+        <para>
+          The following features are supported when <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsByteOrdered" /> is set to <see langword="true" />:
+        </para>
+        <list type="bullet">
+          <item>The ability to create indexes on columns of this type.</item>
+          <item>The ability to create primary and foreign keys as well as CHECK and UNIQUE constraints on columns of this type.</item>
+          <item>The ability to use Transact-SQL ORDER BY, GROUP BY, and PARTITION BY clauses. In these cases, the binary representation of the type is used to determine the order.</item>
+          <item>The ability to use comparison operators in Transact-SQL statements.</item>
+          <item>The ability to persist computed columns of this type.</item>
+        </list>
+        <para>
+          Note that both the <c>Native</c> and <c>UserDefined</c> serialization formats support the following comparison operators when <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.IsByteOrdered" /> is set to <see langword="true" />:
+        </para>
+        <list type="bullet">
+          <item>Equal to (=)</item>
+          <item>Not equal to (!=)</item>
+          <item>Greater than (&gt;)</item>
+          <item>Less than (&lt;)</item>
+          <item>Greater than or equal to (&gt;=)</item>
+          <item>Less than or equal to (&lt;=)</item>
+        </list>
+      </remarks>
+    </IsByteOrdered>
+    <IsFixedLength>
+      <summary>
+        Indicates whether all instances of this user-defined type are the same length.
+      </summary>
+      <value>
+        <see langword="true" /> if all instances of this type are the same length; otherwise <see langword="false" />.
+      </value>
+      <remarks>
+        <para>
+          If set to <see langword="true" />, all instances of UDTs corresponding to this common language runtime (CLR) type must have a length in bytes exactly equal to <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize" />. This attribute is only relevant for UDTs with <c>UserDefined</c> serialization <see cref="T:Microsoft.SqlServer.Server.Format" />.
+        </para>
+      </remarks>
+    </IsFixedLength>
+    <MaxByteSize>
+      <summary>
+        The maximum size of the instance, in bytes.
+      </summary>
+      <value>
+        An <see cref="T:System.Int32" /> value representing the maximum size of the instance.
+      </value>
+      <remarks>
+        <para>
+          You must specify the <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize" /> property with the <c>UserDefined</c> serialization <see cref="T:Microsoft.SqlServer.Server.Format" />.
+        </para>
+        <para>
+          When connecting to SQL Server 2005 or earlier, <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize" /> must be between 1 and 8000.
+        </para>
+        <para>
+          When connecting to SQL Server 2008 or later, set <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize" /> between 1 and 8000, for a type whose instances are always 8,000 bytes or fewer. For types that can have instances larger than 8000, specify -1.
+        </para>
+        <para>
+          For a UDT with user-defined serialization specified, <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize" /> refers to the total size of the UDT in its serialized form as defined by the user. Consider a UDT with a property of a string of 10 characters (<see cref="T:System.Char" />). When the UDT is serialized using a <see cref="T:System.IO.BinaryWriter" />, the total size of the serialized string is 22 bytes: 2 bytes per Unicode UTF-16 character, multiplied by the maximum number of characters, plus 2 control bytes of overhead incurred from serializing a binary stream. So, when determining the value of <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.MaxByteSize" />, the total size of the serialized UDT must be considered: the size of the data serialized in binary form plus the overhead incurred by serialization.
+        </para>
+        <para>
+          This property should not be used with <c>Native</c> serialization <see cref="T:Microsoft.SqlServer.Server.Format" />.
+        </para>
+      </remarks>
+    </MaxByteSize>
+    <Name>
+      <summary>
+        The SQL Server name of the user-defined type.
+      </summary>
+      <value>
+        A <see cref="T:System.String" /> value representing the SQL Server name of the user-defined type.
+      </value>
+      <remarks>
+        The <see cref="P:Microsoft.SqlServer.Server.SqlUserDefinedTypeAttribute.Name" /> property is not used within SQL Server, but is used by the Microsoft Visual Studio .NET Integrated Development Environment (IDE).
+      </remarks>
+    </Name>
+    <ValidationMethodName>
+      <summary>
+        The name of the method used to validate instances of the user-defined type.
+      </summary>
+      <value>
+        A <see cref="T:System.String" /> representing the name of the method used to validate instances of the user-defined type.
+      </value>
+      <remarks>
+        The method specified by this attribute validates instances of the UDT when the UDT has been deserialized from a binary value that is not trusted.
+      </remarks>
+    </ValidationMethodName>
+  </members>
 </docs>

--- a/doc/snippets/Microsoft.SqlServer.Server/SystemDataAccessKind.xml
+++ b/doc/snippets/Microsoft.SqlServer.Server/SystemDataAccessKind.xml
@@ -1,26 +1,30 @@
-<?xml version="1.0"?>
-<docs>
-    <members name="SystemDataAccessKind">
-        <SystemDataAccessKind>
-            <summary>Describes the type of access to system data for a user-defined method or function.</summary>
-            <remarks>
-            <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-Describes the type of access to system data for a user-defined method or function.  
-
-This enumeration is used in <xref:Microsoft.SqlServer.Server.SqlMethodAttribute> and <xref:Microsoft.SqlServer.Server.SqlFunctionAttribute> to indicate what type of access to system data the method or function has.  
-
-Note that methods and functions are not allowed to make changes to the database, so the options for this enumeration are `None` (meaning no data-access performed by the method or function) and `Read` (meaning that the method or function performs read-only data-access operations, such as executing SELECT statements).  
-
- ]]></format>
-            </remarks>
-        </SystemDataAccessKind>
-        <None>
-            <summary>The method or function does not access system data.</summary>
-        </None>
-        <Read>
-            <summary>The method or function reads system data.</summary>
-        </Read>
-    </members>
+﻿<docs>
+  <members name="SystemDataAccessKind">
+    <SystemDataAccessKind>
+      <summary>
+        Describes the type of access to system data for a user-defined method or function.
+      </summary>
+      <remarks>
+        <para>
+          Describes the type of access to system data for a user-defined method or function.
+        </para>
+        <para>
+          This enumeration is used in <see cref="T:Microsoft.SqlServer.Server.SqlMethodAttribute" /> and <see cref="T:Microsoft.SqlServer.Server.SqlFunctionAttribute" /> to indicate what type of access to system data the method or function has.
+        </para>
+        <para>
+          Note that methods and functions are not allowed to make changes to the database, so the options for this enumeration are <see cref="F:Microsoft.SqlServer.Server.SystemDataAccessKind.None" /> (meaning no data-access performed by the method or function) and <see cref="F:Microsoft.SqlServer.Server.SystemDataAccessKind.None" /> (meaning that the method or function performs read-only data-access operations, such as executing SELECT statements).
+        </para>
+      </remarks>
+    </SystemDataAccessKind>
+    <None>
+      <summary>
+        The method or function does not access system data.
+      </summary>
+    </None>
+    <Read>
+      <summary>
+        The method or function reads system data.
+      </summary>
+    </Read>
+  </members>
 </docs>


### PR DESCRIPTION
**Description**: This should be the last batch, it includes more files than before but most of them are pretty small. It focuses on everything not in the Microsoft.Data.SqlClient namespace. This should be the last part for #2013 

**Testing**: I looked through the files and verified the docs are being pulled in correctly. Skimming through the docs in the IDE it looks like all the links are recognized.