### PR TITLE
Fix | Check Connected property of sockets during parallel connect

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -564,7 +564,7 @@ namespace Microsoft.Data.SqlClient.SNI
                 // Try to connect.  If we're successful, store this task into the result task.
                 await connectTask.ConfigureAwait(false);
                 // A connection attempt could return quickly if a server refuses connection or there is some other error
-                success = tcs.TrySetResult(socket) && socket.Connected;
+                success = socket.Connected && tcs.TrySetResult(socket);
                 if (success)
                 {
                     // Whichever connection completes the return task is responsible for disposing

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -563,7 +563,8 @@ namespace Microsoft.Data.SqlClient.SNI
             {
                 // Try to connect.  If we're successful, store this task into the result task.
                 await connectTask.ConfigureAwait(false);
-                success = tcs.TrySetResult(socket);
+                // A connection attempt could return quickly if a server refuses connection or there is some other error
+                success = tcs.TrySetResult(socket) && socket.Connected;
                 if (success)
                 {
                     // Whichever connection completes the return task is responsible for disposing


### PR DESCRIPTION
Address the failure in the DNN scenario described in #2400.

In the MSF parallel connect path, socket connections can fail quickly (as opposed to timing out), resulting in the first socket connect task being the "success" task that closes all other sockets. This happens because in a VNN, there is no listener at the other end of inactive IP addresses and socket connects take a while before they time out. In a DNN, the gateway responds with an RST on the socket for inactive IP addresses and the RST may come in before the connection completes on the active IP address. This means a "success" socket connect task (success just meaning ConnectAsync finished) will disconnect all other attempted sockets.

The change here is to define success as the ConnectAsync task finished **_and_** the socket.Connected property is true.

If this addresses the DNN issue, this simple fix would be a good candidate for backport. There are other code changes that could be made to eliminate tasks on this sync path. I have some drafted up, but the changes would require much more testing.