### PR TITLE
Enhancement tasks for json support

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1365,9 +1365,7 @@ namespace Microsoft.Data.SqlClient
 
             // The SQLDNSCaching feature is implicitly set
             requestedFeatures |= TdsEnums.FeatureExtension.SQLDNSCaching;
-#if DEBUG
             requestedFeatures |= TdsEnums.FeatureExtension.JsonSupport;
-#endif
             _parser.TdsLogin(login, requestedFeatures, _recoverySessionData, _fedAuthFeatureExtensionData, encrypt);
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1641,9 +1641,7 @@ namespace Microsoft.Data.SqlClient
             // The SQLDNSCaching feature is implicitly set
             requestedFeatures |= TdsEnums.FeatureExtension.SQLDNSCaching;
 
-#if DEBUG
             requestedFeatures |= TdsEnums.FeatureExtension.JsonSupport;
-#endif
 
             _parser.TdsLogin(login, requestedFeatures, _recoverySessionData, _fedAuthFeatureExtensionData, _originalNetworkAddressInfo, encrypt);
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -64,9 +64,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public void TestJsonWrite()
-        {       
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
-            string spName = DataTestUtility.GetUniqueNameForSqlServer("spJson_WriteTest");
+        {
+            string tableName = "jsonWriteTest";
+            string spName = "spJsonWriteTest";
 
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string spCreate = "CREATE PROCEDURE " + spName + " (@jsonData json) AS " + tableInsert;
@@ -81,6 +81,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     DataTestUtility.CreateTable(connection, tableName, "(data json)");
 
                     //Create SP for writing json values
+                    DataTestUtility.DropStoredProcedure(connection, spName);
                     command.CommandText = spCreate;
                     command.ExecuteNonQuery();
 
@@ -114,6 +115,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     }
 
                     DataTestUtility.DropTable(connection, tableName);
+                    DataTestUtility.DropStoredProcedure(connection, spName);
                 }
             }
         }
@@ -121,8 +123,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public async Task TestJsonWriteAsync()
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
-            string spName = DataTestUtility.GetUniqueNameForSqlServer("spJson_WriteTest");
+            string tableName = "jsonWriteTest";
+            string spName = "spJsonWriteTest";
 
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string spCreate = "CREATE PROCEDURE " + spName + " (@jsonData json) AS " + tableInsert;
@@ -137,6 +139,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     DataTestUtility.CreateTable(connection, tableName, "(data json)");
 
                     //Create SP for writing json values
+                    DataTestUtility.DropStoredProcedure(connection, spName);
                     command.CommandText = spCreate;
                     await command.ExecuteNonQueryAsync();
 
@@ -170,6 +173,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     }
 
                     DataTestUtility.DropTable(connection, tableName);
+                    DataTestUtility.DropStoredProcedure(connection, spName);
                 }
             }
         }
@@ -177,12 +181,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public void TestJsonRead()
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
-            string spName = DataTestUtility.GetUniqueNameForSqlServer("spJson_ReadTest");
+            string tableName = "jsonReadTest";
+            string spName = "spJsonReadTest";
 
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string tableRead = "SELECT * FROM " + tableName;
-            string spCreate = "CREATE PROCEDURE " + spName + "AS " + tableRead;
+            string spCreate = "CREATE PROCEDURE " + spName + " AS " + tableRead;
 
             using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
@@ -193,6 +197,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     DataTestUtility.CreateTable(connection, tableName, "(data json)");
 
                     //Create SP for reading from json column
+                    DataTestUtility.DropStoredProcedure(connection, spName);
                     command.CommandText = spCreate;
                     command.ExecuteNonQuery();
 
@@ -227,6 +232,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     }
 
                     DataTestUtility.DropTable(connection, tableName);
+                    DataTestUtility.DropStoredProcedure(connection, spName);
                 }
             }
         }
@@ -234,12 +240,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public async Task TestJsonReadAsync()
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
-            string spName = DataTestUtility.GetUniqueNameForSqlServer("spJson_ReadTest");
+            string tableName = "jsonReadTest";
+            string spName = "spJsonReadTest";
 
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string tableRead = "SELECT * FROM " + tableName;
-            string spCreate = "CREATE PROCEDURE " + spName + "AS " + tableRead;
+            string spCreate = "CREATE PROCEDURE " + spName + " AS " + tableRead;
 
             using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
@@ -250,6 +256,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     DataTestUtility.CreateTable(connection, tableName, "(data json)");
 
                     //Create SP for reading from json column
+                    DataTestUtility.DropStoredProcedure(connection, spName);
                     command.CommandText = spCreate;
                     await command.ExecuteNonQueryAsync();
 
@@ -284,6 +291,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     }
 
                     DataTestUtility.DropTable(connection, tableName);
+                    DataTestUtility.DropStoredProcedure(connection, spName);
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -168,6 +168,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         int rowsAffected3 = await command.ExecuteNonQueryAsync();
                         ValidateRowsAffected(rowsAffected3);
                     }
+
+                    DataTestUtility.DropTable(connection, tableName);
                 }
             }
         }
@@ -280,6 +282,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         await ValidateRowsAsync(reader2);
                         reader2.Close();
                     }
+
+                    DataTestUtility.DropTable(connection, tableName);
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -67,8 +67,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {       
             string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
             string spName = DataTestUtility.GetUniqueNameForSqlServer("spJson_WriteTest");
-           
-            string tableCreate = "CREATE TABLE " + tableName + " (Data json)";
+
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string spCreate = "CREATE PROCEDURE " + spName + " (@jsonData json) AS " + tableInsert;
 
@@ -79,8 +78,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 using (SqlCommand command = connection.CreateCommand())
                 {
                     //Create Table
-                    command.CommandText = tableCreate;
-                    command.ExecuteNonQuery();
+                    DataTestUtility.CreateTable(connection, tableName, "(data json)");
 
                     //Create SP for writing json values
                     command.CommandText = spCreate;
@@ -126,7 +124,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
             string spName = DataTestUtility.GetUniqueNameForSqlServer("spJson_WriteTest");
 
-            string tableCreate = "CREATE TABLE " + tableName + " (Data json)";
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string spCreate = "CREATE PROCEDURE " + spName + " (@jsonData json) AS " + tableInsert;
 
@@ -137,8 +134,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 using (SqlCommand command = connection.CreateCommand())
                 {
                     //Create Table
-                    command.CommandText = tableCreate;
-                    await command.ExecuteNonQueryAsync();
+                    DataTestUtility.CreateTable(connection, tableName, "(data json)");
 
                     //Create SP for writing json values
                     command.CommandText = spCreate;
@@ -182,7 +178,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
             string spName = DataTestUtility.GetUniqueNameForSqlServer("spJson_ReadTest");
 
-            string tableCreate = "CREATE TABLE " + tableName + " (Data json)";
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string tableRead = "SELECT * FROM " + tableName;
             string spCreate = "CREATE PROCEDURE " + spName + "AS " + tableRead;
@@ -193,8 +188,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 using (SqlCommand command = connection.CreateCommand())
                 {
                     //Create Table
-                    command.CommandText = tableCreate;
-                    command.ExecuteNonQuery();
+                    DataTestUtility.CreateTable(connection, tableName, "(data json)");
 
                     //Create SP for reading from json column
                     command.CommandText = spCreate;
@@ -241,7 +235,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
             string spName = DataTestUtility.GetUniqueNameForSqlServer("spJson_ReadTest");
 
-            string tableCreate = "CREATE TABLE " + tableName + " (Data json)";
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string tableRead = "SELECT * FROM " + tableName;
             string spCreate = "CREATE PROCEDURE " + spName + "AS " + tableRead;
@@ -252,8 +245,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 using (SqlCommand command = connection.CreateCommand())
                 {
                     //Create Table
-                    command.CommandText = tableCreate;
-                    await command.ExecuteNonQueryAsync();
+                    DataTestUtility.CreateTable(connection, tableName, "(data json)");
 
                     //Create SP for reading from json column
                     command.CommandText = spCreate;

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTDSServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTDSServer.cs
@@ -232,14 +232,12 @@ namespace Microsoft.SqlServer.TDS.Servers
 
                                 break;
                             }
-#if DEBUG
                         case TDSFeatureID.JsonSupport:
                             {
                                 // Enable Json Support
                                 session.IsJsonSupportEnabled = true;
                                 break;
                             }
-#endif
                         default:
                             {
                                 // Do nothing
@@ -552,7 +550,6 @@ namespace Microsoft.SqlServer.TDS.Servers
                 responseMessage.Add(featureExtActToken);
             }
 
-#if DEBUG
             // Check if Json is supported
             if (session.IsJsonSupportEnabled)
             {
@@ -578,7 +575,6 @@ namespace Microsoft.SqlServer.TDS.Servers
                     featureExtAckToken.Options.Add(jsonSupportOption);
                 }
             }
-#endif
 
             // Create DONE token
             TDSDoneToken doneToken = new TDSDoneToken(TDSDoneTokenStatusType.Final);


### PR DESCRIPTION
This PR eliminates the debug flag from the feature extension that supports JSON, and adjusts some of the test code. It ensures that any pre-existing table is removed before a new one with a similar name is created, utilizing `DataTestUtility.CreateTable()`.