### PR TITLE
Fix SqlDataReader.IsDBNull() for json

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -5820,6 +5820,10 @@ namespace Microsoft.Data.SqlClient
                     }
                     break;
 
+                case SqlDbTypeExtensions.Json:
+                    nullVal.SetToNullOfType(SqlBuffer.StorageType.Json);
+                    break;
+
                 default:
                     Debug.Fail("unknown null sqlType!" + md.type.ToString());
                     break;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6667,6 +6667,10 @@ namespace Microsoft.Data.SqlClient
                     }
                     break;
 
+                case SqlDbTypeExtensions.Json:
+                    nullVal.SetToNullOfType(SqlBuffer.StorageType.Json);
+                    break;
+
                 default:
                     Debug.Fail("unknown null sqlType!" + md.type.ToString());
                     break;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -309,9 +309,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public void TestNullJson()
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
+            string tableName = "jsonTest";
 
-            string tableCreate = "CREATE TABLE " + tableName + " (Data json)";
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string tableRead = "SELECT * FROM " + tableName;
 
@@ -320,8 +319,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             using SqlCommand command = connection.CreateCommand();
 
             //Create Table
-            command.CommandText = tableCreate;
-            command.ExecuteNonQuery();
+            DataTestUtility.CreateTable(connection, tableName, "(Data json)");
 
             //Insert Null value
             command.CommandText = tableInsert;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -62,6 +62,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        private void ValidateNullJson(SqlDataReader reader)
+        {
+            while (reader.Read())
+            {
+                bool IsNull = reader.IsDBNull(0);
+                _output.WriteLine(IsNull ? "null" : "not null");
+                Assert.True(IsNull);
+            }
+        }
+
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public void TestJsonWrite()
         {
@@ -294,6 +304,39 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     DataTestUtility.DropStoredProcedure(connection, spName);
                 }
             }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
+        public void TestNullJson()
+        {
+            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Json_Test");
+
+            string tableCreate = "CREATE TABLE " + tableName + " (Data json)";
+            string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
+            string tableRead = "SELECT * FROM " + tableName;
+
+            using SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString);
+            connection.Open();
+            using SqlCommand command = connection.CreateCommand();
+
+            //Create Table
+            command.CommandText = tableCreate;
+            command.ExecuteNonQuery();
+
+            //Insert Null value
+            command.CommandText = tableInsert;
+            var parameter = new SqlParameter("@jsonData", SqlDbTypeExtensions.Json);
+            parameter.Value = DBNull.Value;
+            command.Parameters.Add(parameter);
+            command.ExecuteNonQuery();
+
+            //Query the table
+            command.CommandText = tableRead;
+            var reader = command.ExecuteReader();
+            ValidateNullJson(reader);
+
+            reader.Close();
+            DataTestUtility.DropTable(connection, tableName);
         }
     }
 }


### PR DESCRIPTION
Porting #2830 
This PR aims to fix `SqlDataReader.IsDBNull()` API for json data type.
Currently, it returns false for a null json column. Adding the case for json type returns expected output.
It can be tested using `JsonTest.TestNullJson()`