### PR TITLE
Implements SqlException.IsTransient based on SqlConfigurableRetryFactory known codes

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlException.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlException.xml
@@ -310,6 +310,14 @@
     <GetObjectData>
       <summary>To be added</summary>
     </GetObjectData>
+    <IsTransient>
+      <summary>
+        Indicates whether the error represented by this <see cref="T:Microsoft.Data.SqlClient.SqlException" /> could be a transient error, i.e. if retrying the triggering operation may succeed without any other change. Examples of transient errors include failure to acquire a database lock, networking issues. This allows automatic retry execution strategies to be developed without knowledge of specific database error codes.
+      </summary>
+      <returns>
+        <see langword="true"/> if the error represented could be a transient error; <see langword="false"/> otherwise.
+      </returns>
+    </IsTransient>
     <LineNumber>
       <summary>
         Gets the line number within the Transact-SQL command batch or stored procedure that generated the error.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
@@ -77,6 +77,8 @@ namespace Microsoft.Data.SqlClient
             => InternalCreateRetryProvider(retryLogicOption,
                                             retryLogicOption != null ? new SqlFixedIntervalEnumerator(retryLogicOption.DeltaTime, retryLogicOption.MaxTimeInterval, retryLogicOption.MinTimeInterval) : null);
 
+        internal static bool IsKnownTransientErrorCode(int errorCode) => s_defaultTransientErrors.Contains(errorCode);
+
         private static SqlRetryLogicBaseProvider InternalCreateRetryProvider(SqlRetryLogicOption retryLogicOption, SqlRetryIntervalBaseEnumerator enumerator)
         {
             if (retryLogicOption == null)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -96,6 +96,28 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/Class/*' />
         public byte Class => Errors.Count > 0 ? Errors[0].Class : default;
 
+#if NET6_0_OR_GREATER
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="IsTransient"]/IsTransient/*' />
+        public override bool IsTransient
+        {
+            get
+            {
+                if (Errors.Count == 0)
+                    return false;
+
+                for (int i = 0; i < Errors.Count; i++)
+                {
+                    if (!SqlConfigurableRetryFactory.IsKnownTransientErrorCode(Errors[i].Number))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+#endif
+
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/LineNumber/*' />
         public int LineNumber => Errors.Count > 0 ? Errors[0].LineNumber : default;
 


### PR DESCRIPTION
Fix #649,

This new PR is based on feedback on #2127 and uses the already known codes used in the retry logic.

