### PR TITLE
Retry Build Ext Utilities and Nuget Restore on failure

### DIFF
--- a/eng/pipelines/common/templates/steps/ci-project-build-step.yml
+++ b/eng/pipelines/common/templates/steps/ci-project-build-step.yml
@@ -43,6 +43,7 @@ steps:
         solution: build.proj
         msbuildArchitecture: x64
         msbuildArguments: '-t:restore'
+      retryCountOnTaskFailure: 1
 
     - task: MSBuild@1
       displayName: 'Build Driver [Win]'

--- a/eng/pipelines/common/templates/steps/configure-sql-server-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-step.yml
@@ -101,6 +101,7 @@ steps:
   inputs:
     arguments: '-f ${{parameters.targetNetCoreVersion }}'
     workingDirectory: src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.ExtUtilities
+  retryCountOnTaskFailure: 1
 
 - task: DotNetCoreCLI@2
   displayName: 'Create Test Database ${{parameters.databaseName }}'

--- a/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
@@ -114,14 +114,28 @@ steps:
     
     Write-Host $machineName
     Import-Module "sqlps"
-    Invoke-Sqlcmd -ServerInstance "$machineName" @"
-        CREATE LOGIN [${{parameters.user }}] WITH PASSWORD=N'$password',
-        DEFAULT_DATABASE=[master], DEFAULT_LANGUAGE=[us_english], CHECK_EXPIRATION=OFF, CHECK_POLICY=OFF;
-        CREATE USER [${{parameters.user }}] FROM LOGIN [${{parameters.user }}];
-        ALTER SERVER ROLE [sysadmin] ADD MEMBER [${{parameters.user }}];
-        ALTER LOGIN [${{parameters.saUser }}] ENABLE;
-        ALTER LOGIN [${{parameters.saUser }}] WITH PASSWORD = '$password';
+    $tries = 0
+    while ($true) {
+        $tries++
+        try {
+            Invoke-Sqlcmd -ServerInstance "$machineName" @"
+                CREATE LOGIN [${{parameters.user }}] WITH PASSWORD=N'$password',
+                DEFAULT_DATABASE=[master], DEFAULT_LANGUAGE=[us_english], CHECK_EXPIRATION=OFF, CHECK_POLICY=OFF;
+                CREATE USER [${{parameters.user }}] FROM LOGIN [${{parameters.user }}];
+                ALTER SERVER ROLE [sysadmin] ADD MEMBER [${{parameters.user }}];
+                ALTER LOGIN [${{parameters.saUser }}] ENABLE;
+                ALTER LOGIN [${{parameters.saUser }}] WITH PASSWORD = '$password';
     "@
+            break
+        } catch {
+            if ($tries -ge 5) {
+                Write-Host "##[error]Failed to create database user after $tries tries."
+                break
+            }
+            Write-Host "Failed to connect to server. Retrying in 5 seconds..."
+            Start-Sleep -Seconds 5
+        }
+    }
   displayName: 'Create SQL user [Win]'
   condition: ${{parameters.condition }}
   env:


### PR DESCRIPTION
I've noticed failures pulling packages from the feed with errors like these a few times:

`C:\Program Files\dotnet\sdk\8.0.400\NuGet.targets(174,5): error : The feed 'sqlclient [https://sqlclientdrivers.pkgs.visualstudio.com/public/_packaging/sqlclient/nuget/v3/index.json]' lists package 'Microsoft.SqlServer.SqlManagementObjects.170.8.0' but multiple attempts to download the nupkg have failed. The feed is either invalid or required packages were removed while the current operation was in progress. Verify the package exists on the feed and try again. [D:\a\_work\1\s\src\Microsoft.Data.SqlClient\tests\tools\Microsoft.Data.SqlClient.ExtUtilities\Microsoft.Data.SqlClient.ExtUtilities.csproj]`

`Failed to download package 'System.CodeDom.5.0.0' from 'https://sqlclientdrivers.pkgs.visualstudio.com/904996cc-6198-4d39-8540-eca72bdf0b7b/_packaging/e8fc87e8-fcf4-4bb0-a818-96a9fdd52378/nuget/v3/flat2/system.codedom/5.0.0/system.codedom.5.0.0.nupkg'.
  A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond. (pc2vsblobprodcus360.vsblob.vsassets.io:443)`

`Failed to download package 'System.IO.FileSystem.AccessControl.5.0.0' from 'https://sqlclientdrivers.pkgs.visualstudio.com/904996cc-6198-4d39-8540-eca72bdf0b7b/_packaging/e8fc87e8-fcf4-4bb0-a818-96a9fdd52378/nuget/v3/flat2/system.io.filesystem.accesscontrol/5.0.0/system.io.filesystem.accesscontrol.5.0.0.nupkg'.
  An error occurred while sending the request.
    Unable to connect to the remote server
    A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond 13.107.6.175:443`

Adding a task retry should make the jobs fail less often.