### PR TITLE
Update 1ES image for testing on Ubuntu

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -289,7 +289,7 @@ stages:
           pool: ${{parameters.defaultPoolName }}
           images:
             Ubuntu20_Sql19: ADO-UB20-Sql19
-            Ubuntu20_Sql22: ADO-UB2004-SQL2022
+            Ubuntu20_Sql22: ADO-UB20-SQL22
           TargetFrameworks: ${{parameters.targetFrameworksLinux }}
           buildPlatforms: [AnyCPU]
           testSets: ${{parameters.testSets }}

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -288,7 +288,6 @@ stages:
         linux_sql_19_22:
           pool: ${{parameters.defaultPoolName }}
           images:
-            Ubuntu20_Sql19: ADO-UB20-Sql19
             Ubuntu20_Sql22: ADO-UB20-SQL22
           TargetFrameworks: ${{parameters.targetFrameworksLinux }}
           buildPlatforms: [AnyCPU]
@@ -314,7 +313,7 @@ stages:
         linux_azure_sql:
           pool: ${{parameters.defaultPoolName }}
           images:
-            Ubuntu20_Azure_Sql: ADO-UB20-Sql19
+            Ubuntu20_Azure_Sql: ADO-UB20-Sql22
           TargetFrameworks: ${{parameters.targetFrameworksLinux }}
           buildPlatforms: [AnyCPU]
           testSets: ${{parameters.testSets }}
@@ -340,7 +339,7 @@ stages:
         linux_enclave_sql:
           pool: ADO-CI-AE-1ES-Pool
           images:
-            Ubuntu20_Enclave_Sql19: ADO-UB20-Sql19
+            Ubuntu20_Enclave_Sql19: ADO-UB20-Sql22
           TargetFrameworks: ${{parameters.targetFrameworksLinux }}
           buildPlatforms: [AnyCPU]
           testSets: [AE]


### PR DESCRIPTION
Fixes the Ubuntu pipeline issues.
Using SQL2022 with base Ubuntu image