### PR TITLE
Cleanup | DbConnectionInternal

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDelegatedTransaction.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Data.SqlClient
 
             if (connection != null)
             {
-                SqlClientEventSource.Log.TryTraceEvent("SqlDelegatedTransaction.TransactionEnded | RES | CPOOL | Object Id {0}, Connection Id {1}, transaction completed externally.", ObjectID, connection?._objectID);
+                SqlClientEventSource.Log.TryTraceEvent("SqlDelegatedTransaction.TransactionEnded | RES | CPOOL | Object Id {0}, Connection Id {1}, transaction completed externally.", ObjectID, connection.ObjectID);
                 lock (connection)
                 {
                     if (_atomicTransaction.Equals(transaction))

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -378,7 +378,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (stateObj._attentionSent)
             {
-                SqlClientEventSource.Log.TryTraceEvent("TdsParser.ProcessPendingAck | INFO | Connection Object Id {0}, State Obj Id {1}, Processing Attention.", _connHandler._objectID, stateObj.ObjectID);
+                SqlClientEventSource.Log.TryTraceEvent("TdsParser.ProcessPendingAck | INFO | Connection Object Id {0}, State Obj Id {1}, Processing Attention.", _connHandler.ObjectID, stateObj.ObjectID);
                 ProcessAttention(stateObj);
             }
         }
@@ -422,7 +422,7 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 _sniSpnBuffer = null;
-                SqlClientEventSource.Log.TryTraceEvent("TdsParser.Connect | SEC | Connection Object Id {0}, Authentication Mode: {1}", _connHandler._objectID,
+                SqlClientEventSource.Log.TryTraceEvent("TdsParser.Connect | SEC | Connection Object Id {0}, Authentication Mode: {1}", _connHandler.ObjectID,
                     authType == SqlAuthenticationMethod.NotSpecified ? SqlAuthenticationMethod.SqlPassword.ToString() : authType.ToString());
             }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -32,30 +32,17 @@ namespace Microsoft.Data.ProviderBase
 
         private static int _objectTypeCount;
 
-        private readonly bool _allowSetConnectionString;
-        private readonly bool _hidePassword;
         private readonly int _objectId = Interlocked.Increment(ref _objectTypeCount);
 
         /// <summary>
         /// [usage must be thread safe] the owning object, when not in the pool. (both Pooled and Non-Pooled connections)
         /// </summary>
         private readonly WeakReference<DbConnection> _owningObject = new WeakReference<DbConnection>(null, false);
-        private readonly ConnectionState _state;
 
         /// <summary>
         /// True when the connection should no longer be pooled.
         /// </summary>
         private bool _cannotBePooled;
-
-        /// <summary>
-        /// True when the connection should no longer be used.
-        /// </summary>
-        private bool _connectionIsDoomed;
-
-        /// <summary>
-        /// The pooler that the connection came from (Pooled connections only)
-        /// </summary>
-        private DbConnectionPool _connectionPool;
 
         /// <summary>
         /// When the connection was created.
@@ -76,7 +63,6 @@ namespace Microsoft.Data.ProviderBase
         /// Also, this reference should not be disposed, since we aren't taking ownership of it.
         /// </summary>
         private Transaction _enlistedTransactionOriginal;
-        private bool _isInStasis;
 
         /// <summary>
         /// usage must be thread safe] the number of times this object has been pushed into the
@@ -84,18 +70,13 @@ namespace Microsoft.Data.ProviderBase
         /// </summary>
         private int _pooledCount;
 
-        /// <summary>
-        /// Collection of objects that we need to notify in some way when we're being deactivated
-        /// </summary>
-        private DbReferenceCollection _referenceCollection;
         private TransactionCompletedEventHandler _transactionCompletedEventHandler = null;
 
-        #if NETFRAMEWORK
-        private DbConnectionPoolCounters _performanceCounters;      // the performance counters we're supposed to update
-        #endif
-
         #if DEBUG
-        private int _activateCount;            // debug only counter to verify activate/deactivates are in sync.
+        /// <summary>
+        /// Debug only counter to verify activate/deactivates are in sync.
+        /// </summary>
+        private int _activateCount;
         #endif
 
         #endregion
@@ -107,28 +88,16 @@ namespace Microsoft.Data.ProviderBase
         // Constructor for internal connections
         internal DbConnectionInternal(ConnectionState state, bool hidePassword, bool allowSetConnectionString)
         {
-            _allowSetConnectionString = allowSetConnectionString;
-            _hidePassword = hidePassword;
-            _state = state;
+            AllowSetConnectionString = allowSetConnectionString;
+            ShouldHidePassword = hidePassword;
+            State = state;
         }
 
         #region Properties
 
-        internal bool AllowSetConnectionString
-        {
-            get
-            {
-                return _allowSetConnectionString;
-            }
-        }
+        internal bool AllowSetConnectionString { get; }
 
-        internal bool CanBePooled
-        {
-            get
-            {
-                return (!_connectionIsDoomed && !_cannotBePooled && !_owningObject.TryGetTarget(out _));
-            }
-        }
+        internal bool CanBePooled => !IsConnectionDoomed && !_cannotBePooled && !_owningObject.TryGetTarget(out _);
 
         internal virtual bool IsAccessTokenExpired => false;
 
@@ -168,72 +137,38 @@ namespace Microsoft.Data.ProviderBase
             get
             {
                 Debug.Assert(_pooledCount <= 1 && _pooledCount >= -1, "Pooled count for object is invalid");
-                return (_pooledCount == 1);
+                return _pooledCount == 1;
             }
         }
 
-        virtual internal bool IsTransactionRoot
-        {
-            get
-            {
-                return false; // if you want to have delegated transactions, you better override this...
-            }
-        }
+        /// <remarks>
+        /// If you want to have delegated transactions, you had better override this...
+        /// </remarks>
+        internal virtual bool IsTransactionRoot => false;
 
-        // Is this connection in stasis, waiting for transaction to end before returning to pool?
-        internal bool IsTxRootWaitingForTxEnd
-        {
-            get
-            {
-                return _isInStasis;
-            }
-        }
+        /// <summary>
+        /// Is this connection in stasis, waiting for transaction to end before returning to pool?
+        /// </summary>
+        internal bool IsTxRootWaitingForTxEnd { get; private set; }
 
-        internal int ObjectID
-        {
-            get
-            {
-                return _objectId;
-            }
-        }
+        internal int ObjectID => _objectId;
 
-        internal DbConnectionPool Pool
-        {
-            get
-            {
-                return _connectionPool;
-            }
-        }
+        /// <summary>
+        /// The pooler that the connection came from (Pooled connections only)
+        /// </summary>
+        internal DbConnectionPool Pool { get; private set; }
 
-        abstract public string ServerVersion
-        {
-            get;
-        }
+        public abstract string ServerVersion { get; }
 
         // this should be abstract but until it is added to all the providers virtual will have to do RickFe
-        virtual public string ServerVersionNormalized
+        public virtual string ServerVersionNormalized
         {
-            get
-            {
-                throw ADP.NotSupported();
-            }
+            get => throw ADP.NotSupported();
         }
 
-        public bool ShouldHidePassword
-        {
-            get
-            {
-                return _hidePassword;
-            }
-        }
+        public bool ShouldHidePassword { get; }
 
-        public ConnectionState State
-        {
-            get
-            {
-                return _state;
-            }
-        }
+        public ConnectionState State { get; }
 
         protected internal Transaction EnlistedTransaction
         {
@@ -244,10 +179,9 @@ namespace Microsoft.Data.ProviderBase
             set
             {
                 Transaction currentEnlistedTransaction = _enlistedTransaction;
-                if ((currentEnlistedTransaction == null && value != null)
-                    || (currentEnlistedTransaction != null && !currentEnlistedTransaction.Equals(value)))
-                {  // WebData 20000024
-
+                if ((currentEnlistedTransaction == null && value != null) ||
+                    (currentEnlistedTransaction != null && !currentEnlistedTransaction.Equals(value)))
+                {
                     // Pay attention to the order here:
                     // 1) defect from any notifications
                     // 2) replace the transaction
@@ -295,12 +229,11 @@ namespace Microsoft.Data.ProviderBase
                         // we really need to dispose our clones; they may have
                         // native resources and GC may not happen soon enough.
                         // VSDevDiv 479564: don't dispose if still holding reference in _enlistedTransaction
-                        if (previousTransactionClone != null &&
-                                !Object.ReferenceEquals(previousTransactionClone, _enlistedTransaction))
+                        if (previousTransactionClone != null && !ReferenceEquals(previousTransactionClone, _enlistedTransaction))
                         {
                             previousTransactionClone.Dispose();
                         }
-                        if (valueClone != null && !Object.ReferenceEquals(valueClone, _enlistedTransaction))
+                        if (valueClone != null && !ReferenceEquals(valueClone, _enlistedTransaction))
                         {
                             valueClone.Dispose();
                         }
@@ -324,8 +257,9 @@ namespace Microsoft.Data.ProviderBase
         /// Get boolean value that indicates whether the enlisted transaction has been disposed.
         /// </summary>
         /// <value>
-        /// True if there is an enlisted transaction, and it has been disposed.
-        /// False if there is an enlisted transaction that has not been disposed, or if the transaction reference is null.
+        /// <see langword="true"/> if there is an enlisted transaction, and it has been disposed.
+        /// <see langword="false"/> if there is an enlisted transaction that has not been disposed,
+        /// or if the transaction reference is null.
         /// </value>
         /// <remarks>
         /// This method must be called while holding a lock on the DbConnectionInternal instance.
@@ -362,62 +296,46 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        protected internal bool IsConnectionDoomed
+        /// <summary>
+        /// <see langword="true" /> when the connection should no longer be used.
+        /// </summary>
+        protected internal bool IsConnectionDoomed { get; private set; }
+
+        /// <summary>
+        /// Is this a connection that must be put in stasis (or is already in stasis) pending the
+        /// end of its transaction?
+        /// </summary>
+        /// <remarks>
+        /// If you want to have delegated transactions that are non-poolable, you had better
+        /// override this...
+        /// </remarks>
+        protected internal virtual bool IsNonPoolableTransactionRoot
         {
-            get
-            {
-                return _connectionIsDoomed;
-            }
+            get => false;
         }
 
-        // Is this a connection that must be put in stasis (or is already in stasis) pending the end of it's transaction?
-        virtual protected internal bool IsNonPoolableTransactionRoot
-        {
-            get
-            {
-                return false; // if you want to have delegated transactions that are non-poolable, you better override this...
-            }
-        }
-
+        /// <remarks>
+        /// We use a weak reference to the owning object so we can identify when it has been
+        /// garbage collected without throwing exceptions.
+        /// </remarks>
         protected internal DbConnection Owner
         {
-            // We use a weak reference to the owning object so we can identify when
-            // it has been garbage collected without throwing exceptions.
-            get
-            {
-                if (_owningObject.TryGetTarget(out DbConnection connection))
-                {
-                    return connection;
-                }
-                return null;
-            }
+            get => _owningObject.TryGetTarget(out DbConnection connection) ? connection : null;
         }
 
         #if NETFRAMEWORK
-        protected DbConnectionPoolCounters PerformanceCounters
-        {
-            get
-            {
-                return _performanceCounters;
-            }
-        }
+        protected DbConnectionPoolCounters PerformanceCounters { get; private set; }
         #endif
 
-        virtual protected bool ReadyToPrepareTransaction
+        protected virtual bool ReadyToPrepareTransaction
         {
-            get
-            {
-                return true;
-            }
+            get => true;
         }
 
-        protected internal DbReferenceCollection ReferenceCollection
-        {
-            get
-            {
-                return _referenceCollection;
-            }
-        }
+        /// <summary>
+        /// Collection of objects that we need to notify in some way when we're being deactivated
+        /// </summary>
+        protected internal DbReferenceCollection ReferenceCollection { get; private set; }
 
         /// <summary>
         /// Get boolean that specifies whether an enlisted transaction can be unbound from
@@ -426,12 +344,9 @@ namespace Microsoft.Data.ProviderBase
         /// <value>
         /// True if the enlisted transaction can be unbound on transaction completion; otherwise false.
         /// </value>
-        virtual protected bool UnbindOnTransactionCompletion
+        protected virtual bool UnbindOnTransactionCompletion
         {
-            get
-            {
-                return true;
-            }
+            get => true;
         }
 
         #endregion
@@ -461,15 +376,15 @@ namespace Microsoft.Data.ProviderBase
 
         internal void AddWeakReference(object value, int tag)
         {
-            if (_referenceCollection == null)
+            if (ReferenceCollection == null)
             {
-                _referenceCollection = CreateReferenceCollection();
-                if (_referenceCollection == null)
+                ReferenceCollection = CreateReferenceCollection();
+                if (ReferenceCollection == null)
                 {
                     throw ADP.InternalError(ADP.InternalErrorCode.CreateReferenceCollectionReturnedNull);
                 }
             }
-            _referenceCollection.Add(value, tag);
+            ReferenceCollection.Add(value, tag);
         }
 
         abstract public DbTransaction BeginTransaction(System.Data.IsolationLevel il);
@@ -634,7 +549,7 @@ namespace Microsoft.Data.ProviderBase
             SqlClientEventSource.Log.ExitActiveConnection();
             #endif
 
-            if (!_connectionIsDoomed && Pool.UseLoadBalancing)
+            if (!IsConnectionDoomed && Pool.UseLoadBalancing)
             {
                 // If we're not already doomed, check the connection's lifetime and
                 // doom it if it's lifetime has elapsed.
@@ -761,12 +676,12 @@ namespace Microsoft.Data.ProviderBase
 
         public virtual void Dispose()
         {
-            _connectionPool = null;
-            _connectionIsDoomed = true;
+            Pool = null;
+            IsConnectionDoomed = true;
             _enlistedTransactionOriginal = null; // should not be disposed
 
             #if NETFRAMEWORK
-            _performanceCounters = null;
+            PerformanceCounters = null;
             #endif
 
             // Dispose of the _enlistedTransaction since it is a clone
@@ -802,10 +717,10 @@ namespace Microsoft.Data.ProviderBase
             // a connection pool.
 
             #if NETFRAMEWORK
-            _performanceCounters = performanceCounters;
+            PerformanceCounters = performanceCounters;
             #endif
 
-            _connectionPool = null;
+            Pool = null;
             _owningObject.SetTarget(owningObject);
             _pooledCount = -1;
         }
@@ -816,10 +731,10 @@ namespace Microsoft.Data.ProviderBase
             // a connection pool.
             _createTime = DateTime.UtcNow;
 
-            _connectionPool = connectionPool;
+            Pool = connectionPool;
 
             #if NETFRAMEWORK
-            _performanceCounters = connectionPool.PerformanceCounters;
+            PerformanceCounters = connectionPool.PerformanceCounters;
             #endif
         }
 
@@ -929,7 +844,7 @@ namespace Microsoft.Data.ProviderBase
 
         internal void SetInStasis()
         {
-            _isInStasis = true;
+            IsTxRootWaitingForTxEnd = true;
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.SetInStasis|RES|CPOOL> {0}, Non-Pooled Connection has Delegated Transaction, waiting to Dispose.", ObjectID);
 
             #if NETFRAMEWORK
@@ -984,7 +899,7 @@ namespace Microsoft.Data.ProviderBase
         #endif
         protected internal void DoomThisConnection()
         {
-            _connectionIsDoomed = true;
+            IsConnectionDoomed = true;
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DoomThisConnection|RES|INFO|CPOOL> {0}, Dooming", ObjectID);
         }
 
@@ -1047,7 +962,7 @@ namespace Microsoft.Data.ProviderBase
         // Reset connection doomed status so it can be re-connected and pooled.
         protected internal void UnDoomThisConnection()
         {
-            _connectionIsDoomed = false;
+            IsConnectionDoomed = false;
         }
 
         #endregion
@@ -1071,7 +986,7 @@ namespace Microsoft.Data.ProviderBase
             SqlClientEventSource.Log.ExitStasisConnection();
             #endif
 
-            _isInStasis = false;
+            IsTxRootWaitingForTxEnd = false;
         }
 
         void TransactionCompletedEvent(object sender, TransactionEventArgs e)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -342,7 +342,8 @@ namespace Microsoft.Data.ProviderBase
         /// the connection when that transaction completes.
         /// </summary>
         /// <value>
-        /// True if the enlisted transaction can be unbound on transaction completion; otherwise false.
+        /// <see langword="true" /> if the enlisted transaction can be unbound on transaction
+        /// completion; otherwise <see langword="false" />.
         /// </value>
         protected virtual bool UnbindOnTransactionCompletion
         {
@@ -353,17 +354,12 @@ namespace Microsoft.Data.ProviderBase
 
         #region Public/Internal Methods
 
-        abstract protected void Activate(Transaction transaction);
-
         internal void ActivateConnection(Transaction transaction)
         {
             // Internal method called from the connection pooler so we don't expose
             // the Activate method publicly.
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.ActivateConnection|RES|INFO|CPOOL> {0}, Activating", ObjectID);
-#if DEBUG
-            int activateCount = Interlocked.Increment(ref _activateCount);
-            Debug.Assert(1 == activateCount, "activated multiple times?");
-#endif // DEBUG
+            Debug.Assert(Interlocked.Increment(ref _activateCount) == 1, "activated multiple times?");
 
             Activate(transaction);
 
@@ -376,20 +372,21 @@ namespace Microsoft.Data.ProviderBase
 
         internal void AddWeakReference(object value, int tag)
         {
-            if (ReferenceCollection == null)
+            if (ReferenceCollection is null)
             {
                 ReferenceCollection = CreateReferenceCollection();
-                if (ReferenceCollection == null)
+                if (ReferenceCollection is null)
                 {
                     throw ADP.InternalError(ADP.InternalErrorCode.CreateReferenceCollectionReturnedNull);
                 }
             }
+
             ReferenceCollection.Add(value, tag);
         }
 
-        abstract public DbTransaction BeginTransaction(System.Data.IsolationLevel il);
+        public abstract DbTransaction BeginTransaction(System.Data.IsolationLevel il);
 
-        virtual public void ChangeDatabase(string value)
+        public virtual void ChangeDatabase(string value)
         {
             throw ADP.MethodNotImplemented();
         }
@@ -400,10 +397,7 @@ namespace Microsoft.Data.ProviderBase
             DetachTransaction(transaction, false);
 
             DbConnectionPool pool = Pool;
-            if (pool != null)
-            {
-                pool.TransactionEnded(transaction, this);
-            }
+            pool?.TransactionEnded(transaction, this);
         }
 
         internal virtual void CloseConnection(DbConnection owningObject, DbConnectionFactory connectionFactory)
@@ -444,8 +438,8 @@ namespace Microsoft.Data.ProviderBase
             ////////////////////////////////////////////////////////////////
             // DON'T MESS WITH THIS CODE UNLESS YOU KNOW WHAT YOU'RE DOING!
             ////////////////////////////////////////////////////////////////
-            Debug.Assert(owningObject != null, "null owningObject");
-            Debug.Assert(connectionFactory != null, "null connectionFactory");
+            Debug.Assert(owningObject is not null, "null owningObject");
+            Debug.Assert(connectionFactory is not null, "null connectionFactory");
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.CloseConnection|RES|CPOOL> {0} Closing.", ObjectID);
 
             // if an exception occurs after the state change but before the try block
@@ -455,7 +449,6 @@ namespace Microsoft.Data.ProviderBase
             // Open->Closed: guarantee internal connection is returned to correct pool
             if (connectionFactory.SetInnerConnectionFrom(owningObject, DbConnectionOpenBusy.SingletonInstance, this))
             {
-
                 // Lock to prevent race condition with cancellation
                 lock (this)
                 {
@@ -472,16 +465,20 @@ namespace Microsoft.Data.ProviderBase
                         // The singleton closed classes won't have owners and
                         // connection pools, and we won't want to put them back
                         // into the pool.
-                        if (connectionPool != null)
+                        if (connectionPool is not null)
                         {
-                            connectionPool.PutObject(this, owningObject);   // PutObject calls Deactivate for us...
-                                                                            // NOTE: Before we leave the PutObject call, another
-                                                                            // thread may have already popped the connection from
-                                                                            // the pool, so don't expect to be able to verify it.
+                            // PutObject calls Deactivate for us...
+                            connectionPool.PutObject(this, owningObject);
+
+                            // NOTE: Before we leave the PutObject call, another thread may have
+                            // already popped the connection from the pool, so don't expect to be
+                            // able to verify it.
                         }
                         else
                         {
-                            Deactivate();   // ensure we de-activate non-pooled connections, or the data readers and transactions may not get cleaned up...
+                            // Ensure we de-activate non-pooled connections, or the data readers
+                            // and transactions may not get cleaned up...
+                            Deactivate();
 
                             #if NETFRAMEWORK
                             PerformanceCounters.HardDisconnectsPerSecond.Increment();
@@ -489,13 +486,11 @@ namespace Microsoft.Data.ProviderBase
                             SqlClientEventSource.Log.HardDisconnectRequest();
                             #endif
 
-                            // To prevent an endless recursion, we need to clear
-                            // the owning object before we call dispose so that
-                            // we can't get here a second time... Ordinarily, I
-                            // would call setting the owner to null a hack, but
-                            // this is safe since we're about to dispose the
-                            // object and it won't have an owner after that for
-                            // certain.
+                            // To prevent an endless recursion, we need to clear the owning object
+                            // before we call dispose so that we can't get here a second time...
+                            // Ordinarily, I would call setting the owner to null a hack, but this
+                            // is safe since we're about to dispose the object, and it won't have
+                            // an owner after that for certain.
                             _owningObject.SetTarget(null);
 
                             if (IsTransactionRoot)
@@ -506,7 +501,7 @@ namespace Microsoft.Data.ProviderBase
                             {
                                 #if NETFRAMEWORK
                                 PerformanceCounters.NumberOfNonPooledConnections.Decrement();
-                                if (this.GetType() != typeof(Microsoft.Data.SqlClient.SqlInternalConnectionSmi))
+                                if (this is not SqlInternalConnectionSmi)
                                 {
                                     Dispose();
                                 }
@@ -520,9 +515,13 @@ namespace Microsoft.Data.ProviderBase
                     finally
                     {
                         ReleaseAdditionalLocksForClose(lockToken);
-                        // if a ThreadAbort puts us here then its possible the outer connection will not reference
-                        // this and this will be orphaned, not reclaimed by object pool until outer connection goes out of scope.
-                        connectionFactory.SetInnerConnectionEvent(owningObject, DbConnectionClosedPreviouslyOpened.SingletonInstance);
+
+                        // If a ThreadAbort puts us here then its possible the outer connection
+                        // will not reference this and this will be orphaned, not reclaimed by
+                        // object pool until outer connection goes out of scope.
+                        connectionFactory.SetInnerConnectionEvent(
+                            owningObject,
+                            DbConnectionClosedPreviouslyOpened.SingletonInstance);
                     }
                 }
             }
@@ -533,16 +532,12 @@ namespace Microsoft.Data.ProviderBase
             // Internal method called from the connection pooler so we don't expose
             // the Deactivate method publicly.
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DeactivateConnection|RES|INFO|CPOOL> {0}, Deactivating", ObjectID);
-#if DEBUG
-            int activateCount = Interlocked.Decrement(ref _activateCount);
-            #if NETFRAMEWORK
-            Debug.Assert(0 == activateCount, "activated multiple times?");
-            #endif
-#endif // DEBUG
+            Debug.Assert(Interlocked.Decrement(ref _activateCount) == 0, "activated multiple times?");
 
             #if NETFRAMEWORK
-            if (PerformanceCounters != null)
-            { // Pool.Clear will DestroyObject that will clean performanceCounters before going here
+            if (PerformanceCounters is not null)
+            {
+                // Pool.Clear will DestroyObject that will clean performanceCounters before going here
                 PerformanceCounters.NumberOfActiveConnections.Decrement();
             }
             #else
@@ -553,9 +548,8 @@ namespace Microsoft.Data.ProviderBase
             {
                 // If we're not already doomed, check the connection's lifetime and
                 // doom it if it's lifetime has elapsed.
-
                 DateTime now = DateTime.UtcNow;
-                if ((now.Ticks - _createTime.Ticks) > Pool.LoadBalanceTimeout.Ticks)
+                if (now.Ticks - _createTime.Ticks > Pool.LoadBalanceTimeout.Ticks)
                 {
                     DoNotPoolThisConnection();
                 }
@@ -563,22 +557,21 @@ namespace Microsoft.Data.ProviderBase
             Deactivate();
         }
 
-        virtual internal void DelegatedTransactionEnded()
+        internal virtual void DelegatedTransactionEnded()
         {
-            // Called by System.Transactions when the delegated transaction has
-            // completed.  We need to make closed connections that are in stasis
-            // available again, or disposed closed/leaked non-pooled connections.
+            // Called by System.Transactions when the delegated transaction has completed.  We need
+            // to make closed connections that are in stasis available again, or disposed
+            // closed/leaked non-pooled connections.
 
             // IMPORTANT NOTE: You must have taken a lock on the object before
             // you call this method to prevent race conditions with Clear and
             // ReclaimEmancipatedObjects.
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DelegatedTransactionEnded|RES|CPOOL> {0}, Delegated Transaction Completed.", ObjectID);
 
-            if (1 == _pooledCount)
+            if (_pooledCount == 1)
             {
-                // When _pooledCount is 1, it indicates a closed, pooled,
-                // connection so it is ready to put back into the pool for
-                // general use.
+                // When _pooledCount is 1, it indicates a closed, pooled, connection so it is ready
+                // to put back into the pool for general use.
 
                 TerminateStasis(true);
 
@@ -588,11 +581,13 @@ namespace Microsoft.Data.ProviderBase
 
                 if (pool == null)
                 {
-                    throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectWithoutPool);      // pooled connection does not have a pool
+                    // pooled connection does not have a pool
+                    throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectWithoutPool);
                 }
+
                 pool.PutObjectFromTransactedPool(this);
             }
-            else if (-1 == _pooledCount && !_owningObject.TryGetTarget(out _))
+            else if (_pooledCount == -1 && !_owningObject.TryGetTarget(out _))
             {
                 // When _pooledCount is -1 and the owning object no longer exists,
                 // it indicates a closed (or leaked), non-pooled connection so
@@ -600,7 +595,8 @@ namespace Microsoft.Data.ProviderBase
 
                 TerminateStasis(false);
 
-                Deactivate(); // call it one more time just in case
+                // Call it one more time just in case
+                Deactivate();
 
                 // it's a non-pooled connection, we need to dispose of it
                 // once and for all, or the server will have fits about us
@@ -614,6 +610,7 @@ namespace Microsoft.Data.ProviderBase
 
                 Dispose();
             }
+
             // When _pooledCount is 0, the connection is a pooled connection
             // that is either open (if the owning object is alive) or leaked (if
             // the owning object is not alive)  In either case, we can't muck
@@ -628,11 +625,12 @@ namespace Microsoft.Data.ProviderBase
                 bool transactionIsDead;
                 try
                 {
-                    transactionIsDead = (TransactionStatus.Active != enlistedTransaction.TransactionInformation.Status);
+                    transactionIsDead = enlistedTransaction.TransactionInformation.Status != TransactionStatus.Active;
                 }
                 catch (TransactionException)
                 {
-                    // If the transaction is being processed (i.e. is part way through a rollback\commit\etc then TransactionInformation.Status will throw an exception)
+                    // If the transaction is being processed (i.e. is partially through a rollback\
+                    // commit\etc then TransactionInformation.Status will throw an exception)
                     transactionIsDead = true;
                 }
                 if (transactionIsDead)
@@ -647,10 +645,12 @@ namespace Microsoft.Data.ProviderBase
         {
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DetachTransaction|RES|CPOOL> {0}, Transaction Completed. (pooledCount={1})", ObjectID, _pooledCount);
 
-            // potentially a multi-threaded event, so lock the connection to make sure we don't enlist in a new
-            // transaction between compare and assignment. No need to short circuit outside of lock, since failed comparisons should
-            // be the exception, not the rule.
-            // locking on anything other than the transaction object would lead to a thread deadlock with sys.Transaction.TransactionCompleted event.
+            // Potentially a multithreaded event, so lock the connection to make sure we don't
+            // enlist in a new transaction between compare and assignment. No need to short
+            // circuit outside of lock, since failed comparisons should be the exception, not the
+            // rule.
+            // Locking on anything other than the transaction object would lead to a thread
+            // deadlock with System.Transaction.TransactionCompleted event.
             lock (transaction)
             {
                 // Detach if detach-on-end behavior, or if outer connection was closed
@@ -660,7 +660,8 @@ namespace Microsoft.Data.ProviderBase
                     Transaction currentEnlistedTransaction = _enlistedTransaction;
                     if (currentEnlistedTransaction != null && transaction.Equals(currentEnlistedTransaction))
                     {
-                        // We need to remove the transaction completed event handler to cease listening for the transaction to end.
+                        // We need to remove the transaction completed event handler to cease
+                        // listening for the transaction to end.
                         currentEnlistedTransaction.TransactionCompleted -= _transactionCompletedEventHandler;
 
                         EnlistedTransaction = null;
@@ -684,8 +685,7 @@ namespace Microsoft.Data.ProviderBase
             PerformanceCounters = null;
             #endif
 
-            // Dispose of the _enlistedTransaction since it is a clone
-            // of the original reference.
+            // Dispose of the _enlistedTransaction since it is a clone of the original reference.
             // VSDD 780271 - _enlistedTransaction can be changed by another thread (TX end event)
             Transaction enlistedTransaction = Interlocked.Exchange(ref _enlistedTransaction, null);
             if (enlistedTransaction != null)
@@ -694,28 +694,32 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        abstract public void EnlistTransaction(Transaction transaction);
+        public abstract void EnlistTransaction(Transaction transaction);
 
         /// <summary>
-        /// When overridden in a derived class, will check if the underlying connection is still actually alive
+        /// When overridden in a derived class, will check if the underlying connection is still
+        /// actually alive.
         /// </summary>
-        /// <param name="throwOnException">If true an exception will be thrown if the connection is dead instead of returning true\false
-        /// (this allows the caller to have the real reason that the connection is not alive (e.g. network error, etc))</param>
-        /// <returns>True if the connection is still alive, otherwise false (If not overridden, then always true)</returns>
-        internal virtual bool IsConnectionAlive(bool throwOnException = false)
-        {
-            return true;
-        }
+        /// <param name="throwOnException">
+        /// If true an exception will be thrown if the connection is dead instead of returning
+        /// true\false (this allows the caller to have the real reason that the connection is not
+        /// alive (e.g. network error, etc.)).
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if the connection is still alive, otherwise <see langword="false"/>.
+        /// (If not overridden, then always true)
+        /// </returns>
+        internal virtual bool IsConnectionAlive(bool throwOnException = false) => true;
 
+        /// <summary>
+        /// Used by DbConnectionFactory to indicate that this object IS NOT part of a connection pool.
+        /// </summary>
         #if NETFRAMEWORK
         internal void MakeNonPooledObject(DbConnection owningObject, DbConnectionPoolCounters performanceCounters)
         #else
         internal void MakeNonPooledObject(DbConnection owningObject)
         #endif
         {
-            // Used by DbConnectionFactory to indicate that this object IS NOT part of
-            // a connection pool.
-
             #if NETFRAMEWORK
             PerformanceCounters = performanceCounters;
             #endif
@@ -725,12 +729,13 @@ namespace Microsoft.Data.ProviderBase
             _pooledCount = -1;
         }
 
+        /// <summary>
+        /// Used by DbConnectionFactory to indicate that this object IS part of a connection pool.
+        /// </summary>
+        /// <param name="connectionPool"></param>
         internal void MakePooledConnection(DbConnectionPool connectionPool)
         {
-            // Used by DbConnectionFactory to indicate that this object IS part of
-            // a connection pool.
             _createTime = DateTime.UtcNow;
-
             Pool = connectionPool;
 
             #if NETFRAMEWORK
@@ -738,14 +743,8 @@ namespace Microsoft.Data.ProviderBase
             #endif
         }
 
-        internal void NotifyWeakReference(int message)
-        {
-            DbReferenceCollection referenceCollection = ReferenceCollection;
-            if (referenceCollection != null)
-            {
-                referenceCollection.Notify(message);
-            }
-        }
+        internal void NotifyWeakReference(int message) =>
+            ReferenceCollection?.Notify(message);
 
         internal virtual void OpenConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory)
         {
@@ -757,90 +756,84 @@ namespace Microsoft.Data.ProviderBase
 
         internal void PostPop(DbConnection newOwner)
         {
-            // Called by DbConnectionPool right after it pulls this from it's pool, we
-            // take this opportunity to ensure ownership and pool counts are legit.
-
+            // Called by DbConnectionPool right after it pulls this from its pool, we take this
+            // opportunity to ensure ownership and pool counts are legit.
             Debug.Assert(!IsEmancipated, "pooled object not in pool");
 
-            // SQLBUDT #356871 -- When another thread is clearing this pool, it
-            // will doom all connections in this pool without prejudice which
-            // causes the following assert to fire, which really mucks up stress
-            // against checked bits.  The assert is benign, so we're commenting
-            // it out.
-            //Debug.Assert(CanBePooled,   "pooled object is not poolable");
-
-            // IMPORTANT NOTE: You must have taken a lock on the object before
-            // you call this method to prevent race conditions with Clear and
-            // ReclaimEmancipatedObjects.
+            // IMPORTANT NOTE: You must have taken a lock on the object before you call this method
+            //    to prevent race conditions with Clear and ReclaimEmancipatedObjects.
             if (_owningObject.TryGetTarget(out _))
             {
-                throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectHasOwner);        // pooled connection already has an owner!
+                // Pooled connection already has an owner!
+                throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectHasOwner);
             }
+
             _owningObject.SetTarget(newOwner);
             _pooledCount--;
 
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.PostPop|RES|CPOOL> {0}, Preparing to pop from pool,  owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
 
             //3 // The following tests are retail assertions of things we can't allow to happen.
-            if (Pool != null)
+            if (Pool is not null)
             {
-                if (0 != _pooledCount)
+                if (_pooledCount != 0)
                 {
-                    throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectInPoolMoreThanOnce);  // popping object off stack with multiple pooledCount
+                    // Popping object off stack with multiple pooledCount
+                    throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectInPoolMoreThanOnce);
                 }
             }
-            else if (-1 != _pooledCount)
+            else if (_pooledCount != -1)
             {
-                throw ADP.InternalError(ADP.InternalErrorCode.NonPooledObjectUsedMoreThanOnce); // popping object off stack with multiple pooledCount
+                // Popping object off stack with multiple pooledCount
+                throw ADP.InternalError(ADP.InternalErrorCode.NonPooledObjectUsedMoreThanOnce);
             }
         }
 
-        virtual internal void PrepareForReplaceConnection()
+        internal virtual void PrepareForReplaceConnection()
         {
             // By default, there is no preparation required
         }
 
         internal void PrePush(object expectedOwner)
         {
-            // Called by DbConnectionPool when we're about to be put into it's pool, we
-            // take this opportunity to ensure ownership and pool counts are legit.
+            // Called by DbConnectionPool when we're about to be put into it's pool, we take this
+            // opportunity to ensure ownership and pool counts are legit.
 
-            // IMPORTANT NOTE: You must have taken a lock on the object before
-            // you call this method to prevent race conditions with Clear and
-            // ReclaimEmancipatedObjects.
+            // IMPORTANT NOTE: You must have taken a lock on the object before you call this method
+            //     to prevent race conditions with Clear and ReclaimEmancipatedObjects.
 
-            //3 // The following tests are retail assertions of things we can't allow to happen.
+            // The following tests are retail assertions of things we can't allow to happen.
             bool isAlive = _owningObject.TryGetTarget(out DbConnection connection);
-            if (expectedOwner == null)
+            if (expectedOwner is null)
             {
                 if (isAlive)
                 {
-                    throw ADP.InternalError(ADP.InternalErrorCode.UnpooledObjectHasOwner);      // new unpooled object has an owner
+                    // New unpooled object has an owner
+                    throw ADP.InternalError(ADP.InternalErrorCode.UnpooledObjectHasOwner);
                 }
             }
             else if (isAlive && connection != expectedOwner)
             {
-                throw ADP.InternalError(ADP.InternalErrorCode.UnpooledObjectHasWrongOwner); // unpooled object has incorrect owner
+                // Unpooled object has incorrect owner
+                throw ADP.InternalError(ADP.InternalErrorCode.UnpooledObjectHasWrongOwner);
             }
-            if (0 != _pooledCount)
+            if (_pooledCount != 0)
             {
-                throw ADP.InternalError(ADP.InternalErrorCode.PushingObjectSecondTime);         // pushing object onto stack a second time
+                // Pushing object onto stack a second time
+                throw ADP.InternalError(ADP.InternalErrorCode.PushingObjectSecondTime);
             }
 
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.PrePush|RES|CPOOL> {0}, Preparing to push into pool, owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
 
             _pooledCount++;
-            _owningObject.SetTarget(null); // NOTE: doing this and checking for InternalError.PooledObjectHasOwner degrades the close by 2%
+
+            // NOTE: doing this and checking for InternalError.PooledObjectHasOwner degrades the
+            //    close by 2%
+            _owningObject.SetTarget(null);
         }
 
-        internal void RemoveWeakReference(object value)
-        {
-            DbReferenceCollection referenceCollection = ReferenceCollection;
-            if (referenceCollection != null)
-            {
-                referenceCollection.Remove(value);
-            }
-        }
+        internal void RemoveWeakReference(object value) =>
+            ReferenceCollection?.Remove(value);
 
         internal void SetInStasis()
         {
@@ -854,17 +847,27 @@ namespace Microsoft.Data.ProviderBase
             #endif
         }
 
-        /// <devdoc>The default implementation is for the open connection objects, and
-        /// it simply throws.  Our private closed-state connection objects
-        /// override this and do the correct thing.</devdoc>
-        // User code should either override DbConnectionInternal.Activate when it comes out of the pool
-        // or override DbConnectionFactory.CreateConnection when the connection is created for non-pooled connections
-        internal virtual bool TryOpenConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
+        /// <remarks>
+        /// The default implementation is for the open connection objects, and it simply throws.
+        /// Our private closed-state connection objects override this and do the correct thing.
+        /// User code should either override DbConnectionInternal.Activate when it comes out of the
+        /// pool or override DbConnectionFactory.CreateConnection when the connection is created
+        /// for non-pooled connections.
+        /// </remarks>
+        internal virtual bool TryOpenConnection(
+            DbConnection outerConnection,
+            DbConnectionFactory connectionFactory,
+            TaskCompletionSource<DbConnectionInternal> retry,
+            DbConnectionOptions userOptions)
         {
             throw ADP.ConnectionAlreadyOpen(State);
         }
 
-        internal virtual bool TryReplaceConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
+        internal virtual bool TryReplaceConnection(
+            DbConnection outerConnection,
+            DbConnectionFactory connectionFactory,
+            TaskCompletionSource<DbConnectionInternal> retry,
+            DbConnectionOptions userOptions)
         {
             throw ADP.MethodNotImplemented();
         }
@@ -872,6 +875,8 @@ namespace Microsoft.Data.ProviderBase
         #endregion
 
         #region Protected Methods
+
+        protected abstract void Activate(Transaction transaction);
 
         // Cleanup connection's transaction-specific structures (currently used by Delegated transaction).
         //  This is a separate method because cleanup can be triggered in multiple ways for a delegated

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -878,19 +878,21 @@ namespace Microsoft.Data.ProviderBase
 
         protected abstract void Activate(Transaction transaction);
 
-        // Cleanup connection's transaction-specific structures (currently used by Delegated transaction).
-        //  This is a separate method because cleanup can be triggered in multiple ways for a delegated
-        //  transaction.
-        virtual protected void CleanupTransactionOnCompletion(Transaction transaction)
+        /// <summary>
+        /// Cleanup connection's transaction-specific structures (currently used by Delegated transaction).
+        /// This is a separate method because cleanup can be triggered in multiple ways for a delegated
+        /// transaction.
+        /// </summary>
+        protected virtual void CleanupTransactionOnCompletion(Transaction transaction)
         {
         }
 
-        virtual protected DbReferenceCollection CreateReferenceCollection()
+        protected virtual DbReferenceCollection CreateReferenceCollection()
         {
             throw ADP.InternalError(ADP.InternalErrorCode.AttemptingToConstructReferenceCollectionOnStaticObject);
         }
 
-        abstract protected void Deactivate();
+        protected abstract void Deactivate();
 
         protected internal void DoNotPoolThisConnection()
         {
@@ -898,7 +900,9 @@ namespace Microsoft.Data.ProviderBase
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DoNotPoolThisConnection|RES|INFO|CPOOL> {0}, Marking pooled object as non-poolable so it will be disposed", ObjectID);
         }
 
-        /// <devdoc>Ensure that this connection cannot be put back into the pool.</devdoc>
+        /// <summary>
+        /// Ensure that this connection cannot be put back into the pool.
+        /// </summary>
         #if NETFRAMEWORK
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         #endif
@@ -908,29 +912,35 @@ namespace Microsoft.Data.ProviderBase
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DoomThisConnection|RES|INFO|CPOOL> {0}, Dooming", ObjectID);
         }
 
-        protected internal virtual DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
+        protected internal virtual DataTable GetSchema(
+            DbConnectionFactory factory,
+            DbConnectionPoolGroup poolGroup,
+            DbConnection outerConnection,
+            string collectionName,
+            string[] restrictions)
         {
-            Debug.Assert(outerConnection != null, "outerConnection may not be null.");
+            Debug.Assert(outerConnection is not null, "outerConnection may not be null.");
 
             DbMetaDataFactory metaDataFactory = factory.GetMetaDataFactory(poolGroup, this);
-            Debug.Assert(metaDataFactory != null, "metaDataFactory may not be null.");
+            Debug.Assert(metaDataFactory is not null, "metaDataFactory may not be null.");
 
             return metaDataFactory.GetSchema(outerConnection, collectionName, restrictions);
         }
 
-        virtual protected bool ObtainAdditionalLocksForClose()
+        protected virtual bool ObtainAdditionalLocksForClose()
         {
-            return false; // no additional locks in default implementation
+            // No additional locks in default implementation
+            return false;
         }
 
-        virtual protected void PrepareForCloseConnection()
+        protected virtual void PrepareForCloseConnection()
         {
             // By default, there is no preparation required
         }
 
-        virtual protected void ReleaseAdditionalLocksForClose(bool lockToken)
+        protected virtual void ReleaseAdditionalLocksForClose(bool lockToken)
         {
-            // no additional locks in default implementation
+            // No additional locks in default implementation
         }
 
         protected bool TryOpenConnectionInternal(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
@@ -938,7 +948,7 @@ namespace Microsoft.Data.ProviderBase
             // ?->Connecting: prevent set_ConnectionString during Open
             if (connectionFactory.SetInnerConnectionFrom(outerConnection, DbConnectionClosedConnecting.SingletonInstance, this))
             {
-                DbConnectionInternal openConnection = null;
+                DbConnectionInternal openConnection;
                 try
                 {
                     connectionFactory.PermissionDemand(outerConnection);
@@ -953,21 +963,26 @@ namespace Microsoft.Data.ProviderBase
                     connectionFactory.SetInnerConnectionTo(outerConnection, this);
                     throw;
                 }
+
                 if (openConnection == null)
                 {
                     connectionFactory.SetInnerConnectionTo(outerConnection, this);
                     throw ADP.InternalConnectionError(ADP.ConnectionError.GetConnectionReturnsNull);
                 }
+
                 connectionFactory.SetInnerConnectionEvent(outerConnection, openConnection);
             }
 
             return true;
         }
 
-        // Reset connection doomed status so it can be re-connected and pooled.
-        protected internal void UnDoomThisConnection()
+        /// <summary>
+        /// Reset connection doomed status so it can be re-connected and pooled.
+        /// </summary>
+        protected void UnDoomThisConnection()
         {
             IsConnectionDoomed = false;
+            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.UnDoomThisConnection|RES|INFO|CPOOL> {0}, UnDooming", ObjectID);
         }
 
         #endregion

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -359,7 +359,11 @@ namespace Microsoft.Data.ProviderBase
             // Internal method called from the connection pooler so we don't expose
             // the Activate method publicly.
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.ActivateConnection|RES|INFO|CPOOL> {0}, Activating", ObjectID);
-            Debug.Assert(Interlocked.Increment(ref _activateCount) == 1, "activated multiple times?");
+
+            #if DEBUG
+            int activateCount = Interlocked.Increment(ref _activateCount);
+            Debug.Assert(activateCount == 1, "activated multiple times?");
+            #endif
 
             Activate(transaction);
 
@@ -532,7 +536,11 @@ namespace Microsoft.Data.ProviderBase
             // Internal method called from the connection pooler so we don't expose
             // the Deactivate method publicly.
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DeactivateConnection|RES|INFO|CPOOL> {0}, Deactivating", ObjectID);
-            Debug.Assert(Interlocked.Decrement(ref _activateCount) == 0, "activated multiple times?");
+
+            #if DEBUG
+            int activateCount = Interlocked.Decrement(ref _activateCount);
+            Debug.Assert(activateCount == 0, "activated multiple times?");
+            #endif
 
             #if NETFRAMEWORK
             if (PerformanceCounters is not null)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -21,36 +21,33 @@ namespace Microsoft.Data.ProviderBase
 {
     internal abstract class DbConnectionInternal
     {
-        private static int _objectTypeCount;
-        internal readonly int _objectID = Interlocked.Increment(ref _objectTypeCount);
-        private TransactionCompletedEventHandler _transactionCompletedEventHandler = null;
+        #region Fields
 
         internal static readonly StateChangeEventArgs StateChangeClosed = new StateChangeEventArgs(ConnectionState.Open, ConnectionState.Closed);
         internal static readonly StateChangeEventArgs StateChangeOpen = new StateChangeEventArgs(ConnectionState.Closed, ConnectionState.Open);
 
+        private static int _objectTypeCount;
+
         private readonly bool _allowSetConnectionString;
         private readonly bool _hidePassword;
+        private readonly int _objectID = Interlocked.Increment(ref _objectTypeCount);
+        private readonly WeakReference<DbConnection> _owningObject = new WeakReference<DbConnection>(null, false);  // [usage must be thread safe] the owning object, when not in the pool. (both Pooled and Non-Pooled connections)
         private readonly ConnectionState _state;
 
-        private readonly WeakReference<DbConnection> _owningObject = new WeakReference<DbConnection>(null, false);  // [usage must be thread safe] the owning object, when not in the pool. (both Pooled and Non-Pooled connections)
-
-        private DbConnectionPool _connectionPool;           // the pooler that the connection came from (Pooled connections only)
-        private DbReferenceCollection _referenceCollection;      // collection of objects that we need to notify in some way when we're being deactivated
-        private int _pooledCount;              // [usage must be thread safe] the number of times this object has been pushed into the pool less the number of times it's been popped (0 != inPool)
-
-        private bool _connectionIsDoomed;       // true when the connection should no longer be used.
         private bool _cannotBePooled;           // true when the connection should no longer be pooled.
-        private bool _isInStasis;
-
+        private bool _connectionIsDoomed;       // true when the connection should no longer be used.
+        private DbConnectionPool _connectionPool;           // the pooler that the connection came from (Pooled connections only)
         private DateTime _createTime;               // when the connection was created.
-
         private Transaction _enlistedTransaction;      // [usage must be thread-safe] the transaction that we're enlisted in, either manually or automatically
-
         // _enlistedTransaction is a clone, so that transaction information can be queried even if the original transaction object is disposed.
         // However, there are times when we need to know if the original transaction object was disposed, so we keep a reference to it here.
         // This field should only be assigned a value at the same time _enlistedTransaction is updated.
         // Also, this reference should not be disposed, since we aren't taking ownership of it.
         private Transaction _enlistedTransactionOriginal;
+        private bool _isInStasis;
+        private int _pooledCount;              // [usage must be thread safe] the number of times this object has been pushed into the pool less the number of times it's been popped (0 != inPool)
+        private DbReferenceCollection _referenceCollection;      // collection of objects that we need to notify in some way when we're being deactivated
+        private TransactionCompletedEventHandler _transactionCompletedEventHandler = null;
 
         #if NETFRAMEWORK
         private DbConnectionPoolCounters _performanceCounters;      // the performance counters we're supposed to update
@@ -59,6 +56,8 @@ namespace Microsoft.Data.ProviderBase
         #if DEBUG
         private int _activateCount;            // debug only counter to verify activate/deactivates are in sync.
         #endif
+
+        #endregion
 
         protected DbConnectionInternal() : this(ConnectionState.Open, true, false)
         {
@@ -71,6 +70,8 @@ namespace Microsoft.Data.ProviderBase
             _hidePassword = hidePassword;
             _state = state;
         }
+
+        #region Properties
 
         internal bool AllowSetConnectionString
         {
@@ -85,6 +86,111 @@ namespace Microsoft.Data.ProviderBase
             get
             {
                 return (!_connectionIsDoomed && !_cannotBePooled && !_owningObject.TryGetTarget(out _));
+            }
+        }
+
+        internal virtual bool IsAccessTokenExpired => false;
+
+        internal bool IsEmancipated
+        {
+            get
+            {
+                // NOTE: There are race conditions between PrePush, PostPop and this
+                //       property getter -- only use this while this object is locked;
+                //       (DbConnectionPool.Clear and ReclaimEmancipatedObjects
+                //       do this for us)
+
+                // The functionality is as follows:
+                //
+                //    _pooledCount is incremented when the connection is pushed into the pool
+                //    _pooledCount is decremented when the connection is popped from the pool
+                //    _pooledCount is set to -1 when the connection is not pooled (just in case...)
+                //
+                // That means that:
+                //
+                //    _pooledCount > 1    connection is in the pool multiple times (This should not happen)
+                //    _pooledCount == 1   connection is in the pool
+                //    _pooledCount == 0   connection is out of the pool
+                //    _pooledCount == -1  connection is not a pooled connection; we shouldn't be here for non-pooled connections.
+                //    _pooledCount < -1   connection out of the pool multiple times
+                //
+                // Now, our job is to return TRUE when the connection is out
+                // of the pool and it's owning object is no longer around to
+                // return it.
+
+                return !IsTxRootWaitingForTxEnd && (_pooledCount < 1) && !_owningObject.TryGetTarget(out _);
+            }
+        }
+
+        internal bool IsInPool
+        {
+            get
+            {
+                Debug.Assert(_pooledCount <= 1 && _pooledCount >= -1, "Pooled count for object is invalid");
+                return (_pooledCount == 1);
+            }
+        }
+
+        virtual internal bool IsTransactionRoot
+        {
+            get
+            {
+                return false; // if you want to have delegated transactions, you better override this...
+            }
+        }
+
+        // Is this connection in stasis, waiting for transaction to end before returning to pool?
+        internal bool IsTxRootWaitingForTxEnd
+        {
+            get
+            {
+                return _isInStasis;
+            }
+        }
+
+        internal int ObjectID
+        {
+            get
+            {
+                return _objectID;
+            }
+        }
+
+        internal DbConnectionPool Pool
+        {
+            get
+            {
+                return _connectionPool;
+            }
+        }
+
+        abstract public string ServerVersion
+        {
+            get;
+        }
+
+        // this should be abstract but until it is added to all the providers virtual will have to do RickFe
+        virtual public string ServerVersionNormalized
+        {
+            get
+            {
+                throw ADP.NotSupported();
+            }
+        }
+
+        public bool ShouldHidePassword
+        {
+            get
+            {
+                return _hidePassword;
+            }
+        }
+
+        public ConnectionState State
+        {
+            get
+            {
+                return _state;
             }
         }
 
@@ -215,27 +321,11 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        // Is this connection in stasis, waiting for transaction to end before returning to pool?
-        internal bool IsTxRootWaitingForTxEnd
+        protected internal bool IsConnectionDoomed
         {
             get
             {
-                return _isInStasis;
-            }
-        }
-
-        /// <summary>
-        /// Get boolean that specifies whether an enlisted transaction can be unbound from 
-        /// the connection when that transaction completes.
-        /// </summary>
-        /// <value>
-        /// True if the enlisted transaction can be unbound on transaction completion; otherwise false.
-        /// </value>
-        virtual protected bool UnbindOnTransactionCompletion
-        {
-            get
-            {
-                return true;
+                return _connectionIsDoomed;
             }
         }
 
@@ -245,70 +335,6 @@ namespace Microsoft.Data.ProviderBase
             get
             {
                 return false; // if you want to have delegated transactions that are non-poolable, you better override this...
-            }
-        }
-
-        virtual internal bool IsTransactionRoot
-        {
-            get
-            {
-                return false; // if you want to have delegated transactions, you better override this...
-            }
-        }
-
-        protected internal bool IsConnectionDoomed
-        {
-            get
-            {
-                return _connectionIsDoomed;
-            }
-        }
-
-        internal bool IsEmancipated
-        {
-            get
-            {
-                // NOTE: There are race conditions between PrePush, PostPop and this
-                //       property getter -- only use this while this object is locked;
-                //       (DbConnectionPool.Clear and ReclaimEmancipatedObjects
-                //       do this for us)
-
-                // The functionality is as follows:
-                //
-                //    _pooledCount is incremented when the connection is pushed into the pool
-                //    _pooledCount is decremented when the connection is popped from the pool
-                //    _pooledCount is set to -1 when the connection is not pooled (just in case...)
-                //
-                // That means that:
-                //
-                //    _pooledCount > 1    connection is in the pool multiple times (This should not happen)
-                //    _pooledCount == 1   connection is in the pool
-                //    _pooledCount == 0   connection is out of the pool
-                //    _pooledCount == -1  connection is not a pooled connection; we shouldn't be here for non-pooled connections.
-                //    _pooledCount < -1   connection out of the pool multiple times
-                //
-                // Now, our job is to return TRUE when the connection is out
-                // of the pool and it's owning object is no longer around to
-                // return it.
-                
-                return !IsTxRootWaitingForTxEnd && (_pooledCount < 1) && !_owningObject.TryGetTarget(out _);
-            }
-        }
-
-        internal bool IsInPool
-        {
-            get
-            {
-                Debug.Assert(_pooledCount <= 1 && _pooledCount >= -1, "Pooled count for object is invalid");
-                return (_pooledCount == 1);
-            }
-        }
-
-        internal int ObjectID
-        {
-            get
-            {
-                return _objectID;
             }
         }
 
@@ -323,14 +349,6 @@ namespace Microsoft.Data.ProviderBase
                     return connection;
                 }
                 return null;
-            }
-        }
-
-        internal DbConnectionPool Pool
-        {
-            get
-            {
-                return _connectionPool;
             }
         }
 
@@ -360,37 +378,24 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        abstract public string ServerVersion
-        {
-            get;
-        }
-
-        // this should be abstract but until it is added to all the providers virtual will have to do RickFe
-        virtual public string ServerVersionNormalized
-        {
-            get
-            {
-                throw ADP.NotSupported();
-            }
-        }
-
-        public bool ShouldHidePassword
+        /// <summary>
+        /// Get boolean that specifies whether an enlisted transaction can be unbound from
+        /// the connection when that transaction completes.
+        /// </summary>
+        /// <value>
+        /// True if the enlisted transaction can be unbound on transaction completion; otherwise false.
+        /// </value>
+        virtual protected bool UnbindOnTransactionCompletion
         {
             get
             {
-                return _hidePassword;
+                return true;
             }
         }
 
-        public ConnectionState State
-        {
-            get
-            {
-                return _state;
-            }
-        }
+        #endregion
 
-        internal virtual bool IsAccessTokenExpired => false;
+        #region Public/Internal Methods
 
         abstract protected void Activate(Transaction transaction);
 
@@ -431,6 +436,18 @@ namespace Microsoft.Data.ProviderBase
         virtual public void ChangeDatabase(string value)
         {
             throw ADP.MethodNotImplemented();
+        }
+
+        // Handle transaction detach, pool cleanup and other post-transaction cleanup tasks associated with
+        internal void CleanupConnectionOnTransactionCompletion(Transaction transaction)
+        {
+            DetachTransaction(transaction, false);
+
+            DbConnectionPool pool = Pool;
+            if (pool != null)
+            {
+                pool.TransactionEnded(transaction, this);
+            }
         }
 
         internal virtual void CloseConnection(DbConnection owningObject, DbConnectionFactory connectionFactory)
@@ -555,33 +572,6 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        virtual internal void PrepareForReplaceConnection()
-        {
-            // By default, there is no preparation required
-        }
-
-        virtual protected void PrepareForCloseConnection()
-        {
-            // By default, there is no preparation required
-        }
-
-        virtual protected bool ObtainAdditionalLocksForClose()
-        {
-            return false; // no additional locks in default implementation
-        }
-
-        virtual protected void ReleaseAdditionalLocksForClose(bool lockToken)
-        {
-            // no additional locks in default implementation
-        }
-
-        virtual protected DbReferenceCollection CreateReferenceCollection()
-        {
-            throw ADP.InternalError(ADP.InternalErrorCode.AttemptingToConstructReferenceCollectionOnStaticObject);
-        }
-
-        abstract protected void Deactivate();
-
         internal void DeactivateConnection()
         {
             // Internal method called from the connection pooler so we don't expose
@@ -596,7 +586,7 @@ namespace Microsoft.Data.ProviderBase
 
             #if NETFRAMEWORK
             if (PerformanceCounters != null)
-            { // Pool.Clear will DestroyObject that will clean performanceCounters before going here 
+            { // Pool.Clear will DestroyObject that will clean performanceCounters before going here
                 PerformanceCounters.NumberOfActiveConnections.Decrement();
             }
             #else
@@ -649,7 +639,7 @@ namespace Microsoft.Data.ProviderBase
             else if (-1 == _pooledCount && !_owningObject.TryGetTarget(out _))
             {
                 // When _pooledCount is -1 and the owning object no longer exists,
-                // it indicates a closed (or leaked), non-pooled connection so 
+                // it indicates a closed (or leaked), non-pooled connection so
                 // it is safe to dispose.
 
                 TerminateStasis(false);
@@ -658,7 +648,7 @@ namespace Microsoft.Data.ProviderBase
 
                 // it's a non-pooled connection, we need to dispose of it
                 // once and for all, or the server will have fits about us
-                // leaving connections open until the client-side GC kicks 
+                // leaving connections open until the client-side GC kicks
                 // in.
                 #if NETFRAMEWORK
                 PerformanceCounters.NumberOfNonPooledConnections.Decrement();
@@ -670,245 +660,8 @@ namespace Microsoft.Data.ProviderBase
             }
             // When _pooledCount is 0, the connection is a pooled connection
             // that is either open (if the owning object is alive) or leaked (if
-            // the owning object is not alive)  In either case, we can't muck 
+            // the owning object is not alive)  In either case, we can't muck
             // with the connection here.
-        }
-
-        public virtual void Dispose()
-        {
-            _connectionPool = null;
-            _connectionIsDoomed = true;
-            _enlistedTransactionOriginal = null; // should not be disposed
-
-            #if NETFRAMEWORK
-            _performanceCounters = null;
-            #endif
-
-            // Dispose of the _enlistedTransaction since it is a clone
-            // of the original reference.
-            // VSDD 780271 - _enlistedTransaction can be changed by another thread (TX end event)
-            Transaction enlistedTransaction = Interlocked.Exchange(ref _enlistedTransaction, null);
-            if (enlistedTransaction != null)
-            {
-                enlistedTransaction.Dispose();
-            }
-        }
-
-        protected internal void DoNotPoolThisConnection()
-        {
-            _cannotBePooled = true;
-            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DoNotPoolThisConnection|RES|INFO|CPOOL> {0}, Marking pooled object as non-poolable so it will be disposed", ObjectID);
-        }
-
-        /// <devdoc>Ensure that this connection cannot be put back into the pool.</devdoc>
-        #if NETFRAMEWORK
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-        #endif
-        protected internal void DoomThisConnection()
-        {
-            _connectionIsDoomed = true;
-            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DoomThisConnection|RES|INFO|CPOOL> {0}, Dooming", ObjectID);
-        }
-
-        // Reset connection doomed status so it can be re-connected and pooled.
-        protected internal void UnDoomThisConnection()
-        {
-            _connectionIsDoomed = false;
-        }
-
-        abstract public void EnlistTransaction(Transaction transaction);
-
-        protected internal virtual DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
-        {
-            Debug.Assert(outerConnection != null, "outerConnection may not be null.");
-
-            DbMetaDataFactory metaDataFactory = factory.GetMetaDataFactory(poolGroup, this);
-            Debug.Assert(metaDataFactory != null, "metaDataFactory may not be null.");
-
-            return metaDataFactory.GetSchema(outerConnection, collectionName, restrictions);
-        }
-
-        #if NETFRAMEWORK
-        internal void MakeNonPooledObject(DbConnection owningObject, DbConnectionPoolCounters performanceCounters)
-        #else
-        internal void MakeNonPooledObject(DbConnection owningObject)
-        #endif
-        {
-            // Used by DbConnectionFactory to indicate that this object IS NOT part of
-            // a connection pool.
-
-            #if NETFRAMEWORK
-            _performanceCounters = performanceCounters;
-            #endif
-
-            _connectionPool = null;
-            _owningObject.SetTarget(owningObject);
-            _pooledCount = -1;
-        }
-
-        internal void MakePooledConnection(DbConnectionPool connectionPool)
-        {
-            // Used by DbConnectionFactory to indicate that this object IS part of
-            // a connection pool.
-            _createTime = DateTime.UtcNow;
-
-            _connectionPool = connectionPool;
-
-            #if NETFRAMEWORK
-            _performanceCounters = connectionPool.PerformanceCounters;
-            #endif
-        }
-
-        internal void NotifyWeakReference(int message)
-        {
-            DbReferenceCollection referenceCollection = ReferenceCollection;
-            if (referenceCollection != null)
-            {
-                referenceCollection.Notify(message);
-            }
-        }
-
-        internal virtual void OpenConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory)
-        {
-            if (!TryOpenConnection(outerConnection, connectionFactory, null, null))
-            {
-                throw ADP.InternalError(ADP.InternalErrorCode.SynchronousConnectReturnedPending);
-            }
-        }
-
-        /// <devdoc>The default implementation is for the open connection objects, and
-        /// it simply throws.  Our private closed-state connection objects
-        /// override this and do the correct thing.</devdoc>
-        // User code should either override DbConnectionInternal.Activate when it comes out of the pool
-        // or override DbConnectionFactory.CreateConnection when the connection is created for non-pooled connections
-        internal virtual bool TryOpenConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
-        {
-            throw ADP.ConnectionAlreadyOpen(State);
-        }
-
-        internal virtual bool TryReplaceConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
-        {
-            throw ADP.MethodNotImplemented();
-        }
-
-        protected bool TryOpenConnectionInternal(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
-        {
-            // ?->Connecting: prevent set_ConnectionString during Open
-            if (connectionFactory.SetInnerConnectionFrom(outerConnection, DbConnectionClosedConnecting.SingletonInstance, this))
-            {
-                DbConnectionInternal openConnection = null;
-                try
-                {
-                    connectionFactory.PermissionDemand(outerConnection);
-                    if (!connectionFactory.TryGetConnection(outerConnection, retry, userOptions, this, out openConnection))
-                    {
-                        return false;
-                    }
-                }
-                catch
-                {
-                    // This should occur for all exceptions, even ADP.UnCatchableExceptions.
-                    connectionFactory.SetInnerConnectionTo(outerConnection, this);
-                    throw;
-                }
-                if (openConnection == null)
-                {
-                    connectionFactory.SetInnerConnectionTo(outerConnection, this);
-                    throw ADP.InternalConnectionError(ADP.ConnectionError.GetConnectionReturnsNull);
-                }
-                connectionFactory.SetInnerConnectionEvent(outerConnection, openConnection);
-            }
-
-            return true;
-        }
-
-        internal void PrePush(object expectedOwner)
-        {
-            // Called by DbConnectionPool when we're about to be put into it's pool, we
-            // take this opportunity to ensure ownership and pool counts are legit.
-
-            // IMPORTANT NOTE: You must have taken a lock on the object before
-            // you call this method to prevent race conditions with Clear and
-            // ReclaimEmancipatedObjects.
-
-            //3 // The following tests are retail assertions of things we can't allow to happen.
-            bool isAlive = _owningObject.TryGetTarget(out DbConnection connection);
-            if (expectedOwner == null)
-            {
-                if (isAlive)
-                {
-                    throw ADP.InternalError(ADP.InternalErrorCode.UnpooledObjectHasOwner);      // new unpooled object has an owner
-                }
-            }
-            else if (isAlive && connection != expectedOwner)
-            {
-                throw ADP.InternalError(ADP.InternalErrorCode.UnpooledObjectHasWrongOwner); // unpooled object has incorrect owner
-            }
-            if (0 != _pooledCount)
-            {
-                throw ADP.InternalError(ADP.InternalErrorCode.PushingObjectSecondTime);         // pushing object onto stack a second time
-            }
-
-            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.PrePush|RES|CPOOL> {0}, Preparing to push into pool, owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
-
-            _pooledCount++;
-            _owningObject.SetTarget(null); // NOTE: doing this and checking for InternalError.PooledObjectHasOwner degrades the close by 2%
-        }
-
-        internal void PostPop(DbConnection newOwner)
-        {
-            // Called by DbConnectionPool right after it pulls this from it's pool, we
-            // take this opportunity to ensure ownership and pool counts are legit.
-
-            Debug.Assert(!IsEmancipated, "pooled object not in pool");
-
-            // SQLBUDT #356871 -- When another thread is clearing this pool, it 
-            // will doom all connections in this pool without prejudice which 
-            // causes the following assert to fire, which really mucks up stress 
-            // against checked bits.  The assert is benign, so we're commenting 
-            // it out.
-            //Debug.Assert(CanBePooled,   "pooled object is not poolable");
-
-            // IMPORTANT NOTE: You must have taken a lock on the object before
-            // you call this method to prevent race conditions with Clear and
-            // ReclaimEmancipatedObjects.
-            if (_owningObject.TryGetTarget(out _))
-            {
-                throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectHasOwner);        // pooled connection already has an owner!
-            }
-            _owningObject.SetTarget(newOwner);
-            _pooledCount--;
-
-            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.PostPop|RES|CPOOL> {0}, Preparing to pop from pool,  owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
-
-            //3 // The following tests are retail assertions of things we can't allow to happen.
-            if (Pool != null)
-            {
-                if (0 != _pooledCount)
-                {
-                    throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectInPoolMoreThanOnce);  // popping object off stack with multiple pooledCount
-                }
-            }
-            else if (-1 != _pooledCount)
-            {
-                throw ADP.InternalError(ADP.InternalErrorCode.NonPooledObjectUsedMoreThanOnce); // popping object off stack with multiple pooledCount
-            }
-        }
-
-        internal void RemoveWeakReference(object value)
-        {
-            DbReferenceCollection referenceCollection = ReferenceCollection;
-            if (referenceCollection != null)
-            {
-                referenceCollection.Remove(value);
-            }
-        }
-
-        // Cleanup connection's transaction-specific structures (currently used by Delegated transaction).
-        //  This is a separate method because cleanup can be triggered in multiple ways for a delegated
-        //  transaction.
-        virtual protected void CleanupTransactionOnCompletion(Transaction transaction)
-        {
         }
 
         internal void DetachCurrentTransactionIfEnded()
@@ -965,36 +718,172 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        // Handle transaction detach, pool cleanup and other post-transaction cleanup tasks associated with
-        internal void CleanupConnectionOnTransactionCompletion(Transaction transaction)
+        public virtual void Dispose()
         {
-            DetachTransaction(transaction, false);
+            _connectionPool = null;
+            _connectionIsDoomed = true;
+            _enlistedTransactionOriginal = null; // should not be disposed
 
-            DbConnectionPool pool = Pool;
-            if (pool != null)
+            #if NETFRAMEWORK
+            _performanceCounters = null;
+            #endif
+
+            // Dispose of the _enlistedTransaction since it is a clone
+            // of the original reference.
+            // VSDD 780271 - _enlistedTransaction can be changed by another thread (TX end event)
+            Transaction enlistedTransaction = Interlocked.Exchange(ref _enlistedTransaction, null);
+            if (enlistedTransaction != null)
             {
-                pool.TransactionEnded(transaction, this);
+                enlistedTransaction.Dispose();
             }
         }
 
-        void TransactionCompletedEvent(object sender, TransactionEventArgs e)
-        {
-            Transaction transaction = e.Transaction;
-            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.TransactionCompletedEvent|RES|CPOOL> {0}, Transaction Completed. (pooledCount = {1})", ObjectID, _pooledCount);
+        abstract public void EnlistTransaction(Transaction transaction);
 
-            CleanupTransactionOnCompletion(transaction);
-            CleanupConnectionOnTransactionCompletion(transaction);
+        /// <summary>
+        /// When overridden in a derived class, will check if the underlying connection is still actually alive
+        /// </summary>
+        /// <param name="throwOnException">If true an exception will be thrown if the connection is dead instead of returning true\false
+        /// (this allows the caller to have the real reason that the connection is not alive (e.g. network error, etc))</param>
+        /// <returns>True if the connection is still alive, otherwise false (If not overridden, then always true)</returns>
+        internal virtual bool IsConnectionAlive(bool throwOnException = false)
+        {
+            return true;
         }
 
-
         #if NETFRAMEWORK
-        // TODO: Review whether we need the unmanaged code permission when we have the new object model available.
-        [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        internal void MakeNonPooledObject(DbConnection owningObject, DbConnectionPoolCounters performanceCounters)
+        #else
+        internal void MakeNonPooledObject(DbConnection owningObject)
         #endif
-        private void TransactionOutcomeEnlist(Transaction transaction)
         {
-            _transactionCompletedEventHandler ??= new TransactionCompletedEventHandler(TransactionCompletedEvent);
-            transaction.TransactionCompleted += _transactionCompletedEventHandler;
+            // Used by DbConnectionFactory to indicate that this object IS NOT part of
+            // a connection pool.
+
+            #if NETFRAMEWORK
+            _performanceCounters = performanceCounters;
+            #endif
+
+            _connectionPool = null;
+            _owningObject.SetTarget(owningObject);
+            _pooledCount = -1;
+        }
+
+        internal void MakePooledConnection(DbConnectionPool connectionPool)
+        {
+            // Used by DbConnectionFactory to indicate that this object IS part of
+            // a connection pool.
+            _createTime = DateTime.UtcNow;
+
+            _connectionPool = connectionPool;
+
+            #if NETFRAMEWORK
+            _performanceCounters = connectionPool.PerformanceCounters;
+            #endif
+        }
+
+        internal void NotifyWeakReference(int message)
+        {
+            DbReferenceCollection referenceCollection = ReferenceCollection;
+            if (referenceCollection != null)
+            {
+                referenceCollection.Notify(message);
+            }
+        }
+
+        internal virtual void OpenConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory)
+        {
+            if (!TryOpenConnection(outerConnection, connectionFactory, null, null))
+            {
+                throw ADP.InternalError(ADP.InternalErrorCode.SynchronousConnectReturnedPending);
+            }
+        }
+
+        internal void PostPop(DbConnection newOwner)
+        {
+            // Called by DbConnectionPool right after it pulls this from it's pool, we
+            // take this opportunity to ensure ownership and pool counts are legit.
+
+            Debug.Assert(!IsEmancipated, "pooled object not in pool");
+
+            // SQLBUDT #356871 -- When another thread is clearing this pool, it
+            // will doom all connections in this pool without prejudice which
+            // causes the following assert to fire, which really mucks up stress
+            // against checked bits.  The assert is benign, so we're commenting
+            // it out.
+            //Debug.Assert(CanBePooled,   "pooled object is not poolable");
+
+            // IMPORTANT NOTE: You must have taken a lock on the object before
+            // you call this method to prevent race conditions with Clear and
+            // ReclaimEmancipatedObjects.
+            if (_owningObject.TryGetTarget(out _))
+            {
+                throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectHasOwner);        // pooled connection already has an owner!
+            }
+            _owningObject.SetTarget(newOwner);
+            _pooledCount--;
+
+            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.PostPop|RES|CPOOL> {0}, Preparing to pop from pool,  owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
+
+            //3 // The following tests are retail assertions of things we can't allow to happen.
+            if (Pool != null)
+            {
+                if (0 != _pooledCount)
+                {
+                    throw ADP.InternalError(ADP.InternalErrorCode.PooledObjectInPoolMoreThanOnce);  // popping object off stack with multiple pooledCount
+                }
+            }
+            else if (-1 != _pooledCount)
+            {
+                throw ADP.InternalError(ADP.InternalErrorCode.NonPooledObjectUsedMoreThanOnce); // popping object off stack with multiple pooledCount
+            }
+        }
+
+        virtual internal void PrepareForReplaceConnection()
+        {
+            // By default, there is no preparation required
+        }
+
+        internal void PrePush(object expectedOwner)
+        {
+            // Called by DbConnectionPool when we're about to be put into it's pool, we
+            // take this opportunity to ensure ownership and pool counts are legit.
+
+            // IMPORTANT NOTE: You must have taken a lock on the object before
+            // you call this method to prevent race conditions with Clear and
+            // ReclaimEmancipatedObjects.
+
+            //3 // The following tests are retail assertions of things we can't allow to happen.
+            bool isAlive = _owningObject.TryGetTarget(out DbConnection connection);
+            if (expectedOwner == null)
+            {
+                if (isAlive)
+                {
+                    throw ADP.InternalError(ADP.InternalErrorCode.UnpooledObjectHasOwner);      // new unpooled object has an owner
+                }
+            }
+            else if (isAlive && connection != expectedOwner)
+            {
+                throw ADP.InternalError(ADP.InternalErrorCode.UnpooledObjectHasWrongOwner); // unpooled object has incorrect owner
+            }
+            if (0 != _pooledCount)
+            {
+                throw ADP.InternalError(ADP.InternalErrorCode.PushingObjectSecondTime);         // pushing object onto stack a second time
+            }
+
+            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.PrePush|RES|CPOOL> {0}, Preparing to push into pool, owning connection {1}, pooledCount={2}", ObjectID, 0, _pooledCount);
+
+            _pooledCount++;
+            _owningObject.SetTarget(null); // NOTE: doing this and checking for InternalError.PooledObjectHasOwner degrades the close by 2%
+        }
+
+        internal void RemoveWeakReference(object value)
+        {
+            DbReferenceCollection referenceCollection = ReferenceCollection;
+            if (referenceCollection != null)
+            {
+                referenceCollection.Remove(value);
+            }
         }
 
         internal void SetInStasis()
@@ -1008,6 +897,121 @@ namespace Microsoft.Data.ProviderBase
             SqlClientEventSource.Log.EnterStasisConnection();
             #endif
         }
+
+        /// <devdoc>The default implementation is for the open connection objects, and
+        /// it simply throws.  Our private closed-state connection objects
+        /// override this and do the correct thing.</devdoc>
+        // User code should either override DbConnectionInternal.Activate when it comes out of the pool
+        // or override DbConnectionFactory.CreateConnection when the connection is created for non-pooled connections
+        internal virtual bool TryOpenConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
+        {
+            throw ADP.ConnectionAlreadyOpen(State);
+        }
+
+        internal virtual bool TryReplaceConnection(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
+        {
+            throw ADP.MethodNotImplemented();
+        }
+
+        #endregion
+
+        #region Protected Methods
+
+        // Cleanup connection's transaction-specific structures (currently used by Delegated transaction).
+        //  This is a separate method because cleanup can be triggered in multiple ways for a delegated
+        //  transaction.
+        virtual protected void CleanupTransactionOnCompletion(Transaction transaction)
+        {
+        }
+
+        virtual protected DbReferenceCollection CreateReferenceCollection()
+        {
+            throw ADP.InternalError(ADP.InternalErrorCode.AttemptingToConstructReferenceCollectionOnStaticObject);
+        }
+
+        abstract protected void Deactivate();
+
+        protected internal void DoNotPoolThisConnection()
+        {
+            _cannotBePooled = true;
+            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DoNotPoolThisConnection|RES|INFO|CPOOL> {0}, Marking pooled object as non-poolable so it will be disposed", ObjectID);
+        }
+
+        /// <devdoc>Ensure that this connection cannot be put back into the pool.</devdoc>
+        #if NETFRAMEWORK
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        #endif
+        protected internal void DoomThisConnection()
+        {
+            _connectionIsDoomed = true;
+            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DoomThisConnection|RES|INFO|CPOOL> {0}, Dooming", ObjectID);
+        }
+
+        protected internal virtual DataTable GetSchema(DbConnectionFactory factory, DbConnectionPoolGroup poolGroup, DbConnection outerConnection, string collectionName, string[] restrictions)
+        {
+            Debug.Assert(outerConnection != null, "outerConnection may not be null.");
+
+            DbMetaDataFactory metaDataFactory = factory.GetMetaDataFactory(poolGroup, this);
+            Debug.Assert(metaDataFactory != null, "metaDataFactory may not be null.");
+
+            return metaDataFactory.GetSchema(outerConnection, collectionName, restrictions);
+        }
+
+        virtual protected bool ObtainAdditionalLocksForClose()
+        {
+            return false; // no additional locks in default implementation
+        }
+
+        virtual protected void PrepareForCloseConnection()
+        {
+            // By default, there is no preparation required
+        }
+
+        virtual protected void ReleaseAdditionalLocksForClose(bool lockToken)
+        {
+            // no additional locks in default implementation
+        }
+
+        protected bool TryOpenConnectionInternal(DbConnection outerConnection, DbConnectionFactory connectionFactory, TaskCompletionSource<DbConnectionInternal> retry, DbConnectionOptions userOptions)
+        {
+            // ?->Connecting: prevent set_ConnectionString during Open
+            if (connectionFactory.SetInnerConnectionFrom(outerConnection, DbConnectionClosedConnecting.SingletonInstance, this))
+            {
+                DbConnectionInternal openConnection = null;
+                try
+                {
+                    connectionFactory.PermissionDemand(outerConnection);
+                    if (!connectionFactory.TryGetConnection(outerConnection, retry, userOptions, this, out openConnection))
+                    {
+                        return false;
+                    }
+                }
+                catch
+                {
+                    // This should occur for all exceptions, even ADP.UnCatchableExceptions.
+                    connectionFactory.SetInnerConnectionTo(outerConnection, this);
+                    throw;
+                }
+                if (openConnection == null)
+                {
+                    connectionFactory.SetInnerConnectionTo(outerConnection, this);
+                    throw ADP.InternalConnectionError(ADP.ConnectionError.GetConnectionReturnsNull);
+                }
+                connectionFactory.SetInnerConnectionEvent(outerConnection, openConnection);
+            }
+
+            return true;
+        }
+
+        // Reset connection doomed status so it can be re-connected and pooled.
+        protected internal void UnDoomThisConnection()
+        {
+            _connectionIsDoomed = false;
+        }
+
+        #endregion
+
+        #region Private Methods
 
         private void TerminateStasis(bool returningToPool)
         {
@@ -1029,15 +1033,25 @@ namespace Microsoft.Data.ProviderBase
             _isInStasis = false;
         }
 
-        /// <summary>
-        /// When overridden in a derived class, will check if the underlying connection is still actually alive
-        /// </summary>
-        /// <param name="throwOnException">If true an exception will be thrown if the connection is dead instead of returning true\false
-        /// (this allows the caller to have the real reason that the connection is not alive (e.g. network error, etc))</param>
-        /// <returns>True if the connection is still alive, otherwise false (If not overridden, then always true)</returns>
-        internal virtual bool IsConnectionAlive(bool throwOnException = false)
+        void TransactionCompletedEvent(object sender, TransactionEventArgs e)
         {
-            return true;
+            Transaction transaction = e.Transaction;
+            SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.TransactionCompletedEvent|RES|CPOOL> {0}, Transaction Completed. (pooledCount = {1})", ObjectID, _pooledCount);
+
+            CleanupTransactionOnCompletion(transaction);
+            CleanupConnectionOnTransactionCompletion(transaction);
         }
+
+        #if NETFRAMEWORK
+        // TODO: Review whether we need the unmanaged code permission when we have the new object model available.
+        [SecurityPermission(SecurityAction.Assert, Flags = SecurityPermissionFlag.UnmanagedCode)]
+        #endif
+        private void TransactionOutcomeEnlist(Transaction transaction)
+        {
+            _transactionCompletedEventHandler ??= new TransactionCompletedEventHandler(TransactionCompletedEvent);
+            transaction.TransactionCompleted += _transactionCompletedEventHandler;
+        }
+
+        #endregion
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -23,30 +23,71 @@ namespace Microsoft.Data.ProviderBase
     {
         #region Fields
 
-        internal static readonly StateChangeEventArgs StateChangeClosed = new StateChangeEventArgs(ConnectionState.Open, ConnectionState.Closed);
-        internal static readonly StateChangeEventArgs StateChangeOpen = new StateChangeEventArgs(ConnectionState.Closed, ConnectionState.Open);
+        internal static readonly StateChangeEventArgs StateChangeClosed = new StateChangeEventArgs(
+            ConnectionState.Open,
+            ConnectionState.Closed);
+        internal static readonly StateChangeEventArgs StateChangeOpen = new StateChangeEventArgs(
+            ConnectionState.Closed,
+            ConnectionState.Open);
 
         private static int _objectTypeCount;
 
         private readonly bool _allowSetConnectionString;
         private readonly bool _hidePassword;
-        private readonly int _objectID = Interlocked.Increment(ref _objectTypeCount);
-        private readonly WeakReference<DbConnection> _owningObject = new WeakReference<DbConnection>(null, false);  // [usage must be thread safe] the owning object, when not in the pool. (both Pooled and Non-Pooled connections)
+        private readonly int _objectId = Interlocked.Increment(ref _objectTypeCount);
+
+        /// <summary>
+        /// [usage must be thread safe] the owning object, when not in the pool. (both Pooled and Non-Pooled connections)
+        /// </summary>
+        private readonly WeakReference<DbConnection> _owningObject = new WeakReference<DbConnection>(null, false);
         private readonly ConnectionState _state;
 
-        private bool _cannotBePooled;           // true when the connection should no longer be pooled.
-        private bool _connectionIsDoomed;       // true when the connection should no longer be used.
-        private DbConnectionPool _connectionPool;           // the pooler that the connection came from (Pooled connections only)
-        private DateTime _createTime;               // when the connection was created.
-        private Transaction _enlistedTransaction;      // [usage must be thread-safe] the transaction that we're enlisted in, either manually or automatically
-        // _enlistedTransaction is a clone, so that transaction information can be queried even if the original transaction object is disposed.
-        // However, there are times when we need to know if the original transaction object was disposed, so we keep a reference to it here.
-        // This field should only be assigned a value at the same time _enlistedTransaction is updated.
-        // Also, this reference should not be disposed, since we aren't taking ownership of it.
+        /// <summary>
+        /// True when the connection should no longer be pooled.
+        /// </summary>
+        private bool _cannotBePooled;
+
+        /// <summary>
+        /// True when the connection should no longer be used.
+        /// </summary>
+        private bool _connectionIsDoomed;
+
+        /// <summary>
+        /// The pooler that the connection came from (Pooled connections only)
+        /// </summary>
+        private DbConnectionPool _connectionPool;
+
+        /// <summary>
+        /// When the connection was created.
+        /// </summary>
+        private DateTime _createTime;
+
+        /// <summary>
+        /// [usage must be thread-safe] the transaction that we're enlisted in, either manually or automatically.
+        /// </summary>
+        private Transaction _enlistedTransaction;
+
+        /// <summary>
+        /// <see cref="_enlistedTransaction"/> is a clone, so that transaction information can be
+        /// queried even if the original transaction object is disposed. However, there are times
+        /// when we need to know if the original transaction object was disposed, so we keep a
+        /// reference to it here. This field should only be assigned a value at the same time
+        /// <see cref="_enlistedTransaction"/> is updated.
+        /// Also, this reference should not be disposed, since we aren't taking ownership of it.
+        /// </summary>
         private Transaction _enlistedTransactionOriginal;
         private bool _isInStasis;
-        private int _pooledCount;              // [usage must be thread safe] the number of times this object has been pushed into the pool less the number of times it's been popped (0 != inPool)
-        private DbReferenceCollection _referenceCollection;      // collection of objects that we need to notify in some way when we're being deactivated
+
+        /// <summary>
+        /// usage must be thread safe] the number of times this object has been pushed into the
+        /// pool less the number of times it's been popped (0 != inPool)
+        /// </summary>
+        private int _pooledCount;
+
+        /// <summary>
+        /// Collection of objects that we need to notify in some way when we're being deactivated
+        /// </summary>
+        private DbReferenceCollection _referenceCollection;
         private TransactionCompletedEventHandler _transactionCompletedEventHandler = null;
 
         #if NETFRAMEWORK
@@ -152,7 +193,7 @@ namespace Microsoft.Data.ProviderBase
         {
             get
             {
-                return _objectID;
+                return _objectId;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.stub.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnectionSmi.stub.cs
@@ -2,14 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 #if NETFRAMEWORK
 
 namespace Microsoft.Data.SqlClient
 {
     // DO NOT USE THIS FILE IN ANY PROJECT!
     // This is a temporary stub to enable migrating DbConnectionInternal to the common project.
-    internal class SqlInternalConnectionSmi
+    internal abstract class SqlInternalConnectionSmi : SqlInternalConnection
     {
+        protected SqlInternalConnectionSmi(SqlConnectionString connectionOptions) : base(connectionOptions)
+        {
+            throw new NotImplementedException();
+        }
     }
 }
 


### PR DESCRIPTION
**Description**: This is the second half of #2910 that applies cleanup to DbConnectionInternal. The PR is meant to be highly granular with each commit being individually reviewable. Ideally, I'd recommend going through the PR commit-by-commit and review each cleanup change.

**Testing**: Test cases are still passing, so I suspect this is a safe change.