### PR TITLE
Suppress roslyn errors and warnings

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -405,11 +405,12 @@ namespace Microsoft.Data.SqlClient
             uint returnValue = SNINativeMethodWrapper.SNIWaitForSSLHandshakeToComplete(Handle, GetTimeoutRemaining(), out uint nativeProtocolVersion);
             var nativeProtocol = (NativeProtocols)nativeProtocolVersion;
 
+#pragma warning disable CA5398 // Avoid hardcoded SslProtocols values
             if (nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_2_CLIENT) || nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_2_SERVER))
             {
                 protocolVersion = (int)SslProtocols.Tls12;
             }
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER 
             else if (nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_3_CLIENT) || nativeProtocol.HasFlag(NativeProtocols.SP_PROT_TLS1_3_SERVER))
             {
                 /* The SslProtocols.Tls13 is supported by netcoreapp3.1 and later */
@@ -439,6 +440,7 @@ namespace Microsoft.Data.SqlClient
             {
                 protocolVersion = (int)SslProtocols.None;
             }
+#pragma warning restore CA5398 // Avoid hardcoded SslProtocols values 
             return returnValue;
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -767,6 +767,7 @@ namespace Microsoft.Data.SqlClient
             {
                 name = "TLS 1.3";
             }*/
+#pragma warning disable CA5398 // Avoid hardcoded SslProtocols values
             if ((protocol & SslProtocols.Tls12) == SslProtocols.Tls12)
             {
                 name = "TLS 1.2";
@@ -795,6 +796,7 @@ namespace Microsoft.Data.SqlClient
             {
                 name = "SSL 2.0";
             }
+#pragma warning restore CA5398 // Avoid hardcoded SslProtocols values
             else
             {
 #if !NETFRAMEWORK
@@ -818,9 +820,11 @@ namespace Microsoft.Data.SqlClient
 #if NET8_0_OR_GREATER
 #pragma warning disable SYSLIB0039 // Type or member is obsolete: TLS 1.0 & 1.1 are deprecated
 #endif
-#pragma warning disable CS0618 // Type or member is obsolete : SSL is depricated
+#pragma warning disable CS0618 // Type or member is obsolete : SSL is deprecated
+#pragma warning disable CA5398 // Do not use deprecated SslProtocols values
             if ((protocol & (SslProtocols.Ssl2 | SslProtocols.Ssl3 | SslProtocols.Tls | SslProtocols.Tls11)) != SslProtocols.None)
-#pragma warning restore CS0618 // Type or member is obsolete : SSL is depricated
+#pragma warning restore CA5398 // Do not use deprecated SslProtocols values
+#pragma warning restore CS0618 // Type or member is obsolete : SSL is deprecated
 #if NET8_0_OR_GREATER
 #pragma warning restore SYSLIB0039 // Type or member is obsolete: SSL and TLS 1.0 & 1.1 is deprecated
 #endif


### PR DESCRIPTION
Suppresses roslyn errors/warnings captured in CI:


```
##[warning]3. RoslynAnalyzers Warning CA5398 - File: file:///C:/__w/1/s/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs. Line: 770. Column 52. 
Tool: RoslynAnalyzers: Rule: CA5398 (Avoid hardcoded SslProtocols values). https://docs.microsoft.com/visualstudio/code-quality/ca5398
Avoid hardcoding SslProtocols 'Tls12' to ensure your application remains secure in the future. Use 'None' to let the Operating System choose a version.

##[error]4. RoslynAnalyzers Error CA5397 - File: file:///C:/__w/1/s/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs. Line: 822. Column 89. 
Tool: RoslynAnalyzers: Rule: CA5397 (Do not use deprecated SslProtocols values). https://docs.microsoft.com/visualstudio/code-quality/ca5397
Transport Layer Security protocol version 'Tls11' is deprecated.  Use 'None' to let the Operating System choose a version.

##[warning]5. RoslynAnalyzers Warning CA5398 - File: file:///C:/__w/1/s/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs. Line: 416. Column 40. 
Tool: RoslynAnalyzers: Rule: CA5398 (Avoid hardcoded SslProtocols values). https://docs.microsoft.com/visualstudio/code-quality/ca5398
Avoid hardcoding SslProtocols 'Tls13' to ensure your application remains secure in the future. Use 'None' to let the Operating System choose a version.
```