### PR TITLE
Mark InternalException, NetEventSource & SecPkgContext_ApplicationProtocol as .NET 6.0-only

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/System/Net/InternalException.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/System/Net/InternalException.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NET && !NET8_0_OR_GREATER
+
 namespace System.Net
 {
     [Serializable]
@@ -21,3 +23,5 @@ namespace System.Net
         }
     }
 }
+
+#endif

--- a/src/Microsoft.Data.SqlClient/netcore/src/Common/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Common/System/Net/Logging/NetEventSource.Common.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NET && !NET8_0_OR_GREATER
+
 #if DEBUG
 // Uncomment to enable runtime checks to help validate that NetEventSource isn't being misused
 // in a way that will cause performance problems, e.g. unexpected boxing of value types.
@@ -771,3 +773,5 @@ namespace System.Net
         #endregion
     }
 }
+
+#endif

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/SChannel/Interop.SecPkgContext_ApplicationProtocol.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/SChannel/Interop.SecPkgContext_ApplicationProtocol.netcore.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if NET
+#if NET && !NET8_0_OR_GREATER
 
 using System;
 using System.Runtime.InteropServices;


### PR DESCRIPTION
This picks up from the comments on #2828, to resolve the merge race between @benrr101, @mdaigle and I.

InternalException, NetEventSource and the types associated with SecPkgContext_ApplicationProtocol are only used by the old .NET 6.0 target. This PR guards these behind `#if NET && !NET8_0_OR_GREATER`, ready to join the rest of the .NET 6.0-only files and types when they're removed.

Is the removal of the .NET 6.0-only code already in motion, or will this happen after the SqlClient 6.0 release?