### PR TITLE
Complete port of PR 521 to netfx

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -3054,7 +3054,7 @@ namespace Microsoft.Data.SqlClient
 
                 for (int i = 0; i < copyLen; i++)
                 {
-                    values[_metaData.GetVisibleColumnIndex(i)] = GetSqlValueInternal(i);
+                    values[i] = GetSqlValueInternal(_metaData.GetVisibleColumnIndex(i));
                 }
                 return copyLen;
             }
@@ -3500,7 +3500,7 @@ namespace Microsoft.Data.SqlClient
                     // If this is sequential access, then we need to wipe the internal buffer
                     if ((sequentialAccess) && (i < maximumColumn))
                     {
-                        _data[i].Clear();
+                        _data[fieldIndex].Clear();
                         if (fieldIndex > i && fieldIndex > 0)
                         {
                             // if we jumped an index forward because of a hidden column see if the buffer before the 


### PR DESCRIPTION
PR #521 was originally made to .NET Core, and cross-ported to .NET Framework by PR #1443. There were two lines missing from this PR, in GetValues and GetSqlValues. This PR completes that work.