### PR TITLE
Reduce automated test crashes

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -1983,29 +1983,34 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
                     CommandHelper.s_sleepDuringTryFetchInputParameterEncryptionInfo?.SetValue(null, true);
 
-                    Thread[] threads = new Thread[2];
+                    Task[] tasks = new Task[2];
 
                     // Invoke ExecuteReader or ExecuteNonQuery in another thread.
+                    // Use long-running tasks to create the thread. This enables any failed assertions to propagate, rather than
+                    // allowing the exception to kill the thread and the process.
                     if (executeMethod == @"ExecuteReader")
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteReader));
+                        tasks[0] = new Task(Thread_ExecuteReader,
+                            new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls),
+                            TaskCreationOptions.LongRunning);
                     }
                     else
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteNonQuery));
+                        tasks[0] = new Task(Thread_ExecuteNonQuery,
+                            new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls),
+                            TaskCreationOptions.LongRunning);
                     }
-
-                    threads[1] = new Thread(new ParameterizedThreadStart(Thread_Cancel));
+                    tasks[1] = new Task(Thread_Cancel, TaskCreationOptions.LongRunning);
 
                     // Start the execute thread.
-                    threads[0].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[0].Start();
 
                     // Start the thread which cancels the above command started by the execute thread.
-                    threads[1].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[1].Start();
 
                     // Wait for the threads to finish.
-                    threads[0].Join();
-                    threads[1].Join();
+                    tasks[0].Wait();
+                    tasks[1].Wait();
 
                     CommandHelper.s_sleepDuringTryFetchInputParameterEncryptionInfo?.SetValue(null, false);
 
@@ -2033,26 +2038,30 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                     CommandHelper.s_sleepDuringRunExecuteReaderTdsForSpDescribeParameterEncryption?.SetValue(null, true);
 
                     // Invoke ExecuteReader or ExecuteNonQuery in another thread.
-                    threads = new Thread[2];
+                    tasks = new Task[2];
                     if (executeMethod == @"ExecuteReader")
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteReader));
+                        tasks[0] = new Task(Thread_ExecuteReader,
+                            new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls),
+                            TaskCreationOptions.LongRunning);
                     }
                     else
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteNonQuery));
+                        tasks[0] = new Task(Thread_ExecuteNonQuery,
+                            new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls),
+                            TaskCreationOptions.LongRunning);
                     }
-                    threads[1] = new Thread(new ParameterizedThreadStart(Thread_Cancel));
+                    tasks[1] = new Task(Thread_Cancel, TaskCreationOptions.LongRunning);
 
                     // Start the execute thread.
-                    threads[0].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[0].Start();
 
                     // Start the thread which cancels the above command started by the execute thread.
-                    threads[1].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[1].Start();
 
                     // Wait for the threads to finish.
-                    threads[0].Join();
-                    threads[1].Join();
+                    tasks[0].Wait();
+                    tasks[1].Wait();
 
                     CommandHelper.s_sleepDuringRunExecuteReaderTdsForSpDescribeParameterEncryption?.SetValue(null, false);
 
@@ -2079,26 +2088,30 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
                     CommandHelper.s_sleepAfterReadDescribeEncryptionParameterResults?.SetValue(null, true);
 
-                    threads = new Thread[2];
+                    tasks = new Task[2];
                     if (executeMethod == @"ExecuteReader")
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteReader));
+                        tasks[0] = new Task(Thread_ExecuteReader,
+                            new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls),
+                            TaskCreationOptions.LongRunning);
                     }
                     else
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteNonQuery));
+                        tasks[0] = new Task(Thread_ExecuteNonQuery,
+                            new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls),
+                            TaskCreationOptions.LongRunning);
                     }
-                    threads[1] = new Thread(new ParameterizedThreadStart(Thread_Cancel));
+                    tasks[1] = new Task(Thread_Cancel, TaskCreationOptions.LongRunning);
 
                     // Start the execute thread.
-                    threads[0].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[0].Start();
 
                     // Start the thread which cancels the above command started by the execute thread.
-                    threads[1].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[1].Start();
 
                     // Wait for the threads to finish.
-                    threads[0].Join();
-                    threads[1].Join();
+                    tasks[0].Wait();
+                    tasks[1].Wait();
 
                     CommandHelper.s_sleepAfterReadDescribeEncryptionParameterResults?.SetValue(null, false);
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
@@ -170,7 +171,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             private static List<ConnectionWorker> s_workerList = new();
             private ManualResetEventSlim _doneEvent = new(false);
             private double _timeElapsed;
-            private Thread _thread;
+            private Task _task;
             private string _connectionString;
             private int _numOfTry;
 
@@ -179,7 +180,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 s_workerList.Add(this);
                 _connectionString = connectionString;
                 _numOfTry = numOfTry;
-                _thread = new Thread(new ThreadStart(SqlConnectionOpen));
+                _task = new Task(SqlConnectionOpen, TaskCreationOptions.LongRunning);
             }
 
             public static List<ConnectionWorker> WorkerList => s_workerList;
@@ -190,7 +191,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 foreach (ConnectionWorker w in s_workerList)
                 {
-                    w._thread.Start();
+                    w._task.Start();
                 }
             }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
@@ -28,17 +29,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 builder.ConnectTimeout = 0;
 
                 TestWorker worker = new TestWorker(builder.ConnectionString);
-                Thread childThread = new Thread(() => worker.TestMultipleConnection());
-                childThread.Start();
+                Task childTask = Task.Factory.StartNew(() => worker.TestMultipleConnection(), TaskCreationOptions.LongRunning);
 
                 if (workerCompletedEvent.WaitOne(10000))
                 {
-                    childThread.Join();
+                    childTask.Wait();
                 }
                 else
                 {
-                    // currently Thread.Abort() throws PlatformNotSupportedException in CoreFx.
-                    childThread.Interrupt();
                     throw new Exception("SqlConnection could not open and close successfully in timely manner. Possibly connection hangs.");
                 }
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
@@ -8,6 +8,7 @@ using System.Data;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
@@ -70,8 +71,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 for (int tcount = 0; tcount < ThreadCountDefault; tcount++)
                 {
-                    Thread t = new Thread(TestThread);
-                    t.Start();
+                    _ = Task.Factory.StartNew(TestThread, TaskCreationOptions.LongRunning);
                 }
             }
 


### PR DESCRIPTION
This is an attempt to stabilise the automated tests slightly. They sometimes crash and need to be restarted; I've recently been able to reproduce the same behaviour in my local testing.

Several tests instantiate a number of threads, and these threads don't handle exceptions (such as failed test assertions.) If these assertions fail, the testhost exits.

I've converted these threads to tasks, specifying TaskCreationOptions.LongRunning. This will force the task scheduler to give the task its own thread, and it'll mean that the exceptions are propagated back to the caller. The test will thus fail, but the testhost will stay running.

This should hopefully mean that ManualTests takes about 15-20 minutes to run, rather than 30-40 minutes.