### PR TITLE
Switch mac image to latest tag

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -384,7 +384,7 @@ stages:
           pool: $(defaultHostedPoolName)
           hostedPool: true
           images:
-            MacOS12_Azure_Sql: macOS-12
+            MacOSLatest_Azure_Sql: macos-latest
           TargetFrameworks: ${{parameters.targetFrameworksLinux }}
           netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
           buildPlatforms: [AnyCPU]


### PR DESCRIPTION
The macOS-12 image is deprecated and will be unsupported in December: https://github.com/actions/runner-images/issues/10721

Updating to the latest image. We don't test any version specific functionality.