### PR TITLE
Remove NetStandard from AddOns scripts

### DIFF
--- a/RunProjectReferenceTests.cmd
+++ b/RunProjectReferenceTests.cmd
@@ -28,7 +28,6 @@ call :pauseOnError msbuild -t:Clean
 
 echo Building .NET Framework %netfxVersion% Tests ...
 call :pauseOnError msbuild -p:Configuration="Release"
-call :pauseOnError msbuild -p:Configuration="Release" -t:BuildAKVNetStAllOS
 call :pauseOnError msbuild -p:Configuration="Release" -t:BuildAKVNetFx
 call :pauseOnError msbuild -p:Configuration="Release" -t:BuildTestsNetFx -p:TargetNetFxVersion=%netfxVersion%
 
@@ -40,7 +39,6 @@ echo Building .NET %netcoreVersion% Tests ...
 call pause
 call :pauseOnError msbuild -t:Clean
 call :pauseOnError msbuild -p:Configuration="Release"
-call :pauseOnError msbuild -p:Configuration="Release" -t:BuildAKVNetStAllOS
 call :pauseOnError msbuild -p:Configuration="Release" -t:BuildAKVNetCoreAllOS
 call :pauseOnError msbuild -p:Configuration="Release" -t:BuildTestsNetCore -p:TargetNetCoreVersion=%netcoreVersion%
 

--- a/buildAddons.cmd
+++ b/buildAddons.cmd
@@ -2,7 +2,6 @@ call :pauseOnError msbuild -p:configuration=Release -t:clean
 call :pauseOnError msbuild -p:configuration=Release -t:BuildAllConfigurations
 call :pauseOnError msbuild -p:configuration=Release -t:BuildAKVNetFx
 call :pauseOnError msbuild -p:configuration=Release -t:BuildAKVNetCoreAllOS
-call :pauseOnError msbuild -p:configuration=Release -t:BuildAKVNetStAllOS
 call :pauseOnError msbuild -p:configuration=Release -t:GenerateAKVProviderNugetPackage
 
 goto :eof


### PR DESCRIPTION
The scripts are trying to build configurations there were removed in #2386 , looks like these instances were missed