### PR TITLE
Add default label for all new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'Triage Needed'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: 'Triage Needed'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -2,7 +2,7 @@
 name: Other
 about: Ask a question or file a different type of issue
 title: ''
-labels: ''
+labels: 'Triage Needed'
 assignees: ''
 
 ---


### PR DESCRIPTION
Adding a default label `Triage Needed` for all newly created issues. The default label helps categorize and prioritize new issues.