### PR TITLE
Cleanup | Move SniErrors to be uint

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/LocalDBAPI.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/LocalDBAPI.Windows.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data
                             else
                             {
                                 SNINativeMethodWrapper.SNIGetLastError(out SniError sniError);
-                                throw CreateLocalDBException(errorMessage: StringsHelper.GetString("LocalDB_FailedGetDLLHandle"), sniError: (int)sniError.sniError);
+                                throw CreateLocalDBException(StringsHelper.GetString("LocalDB_FailedGetDLLHandle"), sniError.sniError);
                             }
                         }
                     }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1577,7 +1577,7 @@ namespace Microsoft.Data.SqlClient
                     if (TdsParserStateObjectFactory.UseManagedSNI)
                     {
                         // SNI error. Append additional error message info if available and hasn't been included.
-                        string sniLookupMessage = SQL.GetSNIErrorMessage((int)details.sniErrorNumber);
+                        string sniLookupMessage = SQL.GetSNIErrorMessage(details.sniErrorNumber);
                         errorMessage = (string.IsNullOrEmpty(errorMessage) || errorMessage.Contains(sniLookupMessage))
                                         ? sniLookupMessage
                                         : (sniLookupMessage + ": " + errorMessage);
@@ -1585,7 +1585,7 @@ namespace Microsoft.Data.SqlClient
                     else
                     {
                         // SNI error. Replace the entire message.
-                        errorMessage = SQL.GetSNIErrorMessage((int)details.sniErrorNumber);
+                        errorMessage = SQL.GetSNIErrorMessage(details.sniErrorNumber);
 
                         // If its a LocalDB error, then nativeError actually contains a LocalDB-specific error code, not a win32 error code
                         if (details.sniErrorNumber == SniErrors.LocalDBErrorCode)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/LocalDBAPI.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/LocalDBAPI.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Data
                             {
                                 SniError sniError = new SniError();
                                 SNINativeMethodWrapper.SNIGetLastError(out sniError);
-                                throw CreateLocalDBException(errorMessage: StringsHelper.GetString("LocalDB_FailedGetDLLHandle"), sniError: (int)sniError.sniError);
+                                throw CreateLocalDBException(errorMessage: StringsHelper.GetString("LocalDB_FailedGetDLLHandle"), sniError: sniError.sniError);
                             }
                         }
                     }
@@ -224,13 +224,13 @@ namespace Microsoft.Data
         }
 
 
-        static SqlException CreateLocalDBException(string errorMessage, string instance = null, int localDbError = 0, int sniError = 0)
+        static SqlException CreateLocalDBException(string errorMessage, string instance = null, int localDbError = 0, uint sniError = 0)
         {
             Debug.Assert((localDbError == 0) || (sniError == 0), "LocalDB error and SNI error cannot be specified simultaneously");
             Debug.Assert(!string.IsNullOrEmpty(errorMessage), "Error message should not be null or empty");
             SqlErrorCollection collection = new SqlErrorCollection();
 
-            int errorCode = (localDbError == 0) ? sniError : localDbError;
+            int errorCode = (localDbError == 0) ? (int)sniError : localDbError;
 
             if (sniError != 0)
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1872,9 +1872,9 @@ namespace Microsoft.Data.SqlClient
             }
             else
             {
-                    // SNI error. Replace the entire message
-                    //
-                    errorMessage = SQL.GetSNIErrorMessage((int)sniError.sniError);
+                // SNI error. Replace the entire message
+                //
+                errorMessage = SQL.GetSNIErrorMessage(sniError.sniError);
 
                 // If its a LocalDB error, then nativeError actually contains a LocalDB-specific error code, not a win32 error code
                 if (sniError.sniError == SniErrors.LocalDBErrorCode)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -1421,22 +1421,19 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception MultiSubnetFailoverWithMoreThan64IPs()
         {
-            // @TODO: This can be uint
-            string msg = GetSNIErrorMessage((int)SniErrors.MultiSubnetFailoverWithMoreThan64IPs);
+            string msg = GetSNIErrorMessage(SniErrors.MultiSubnetFailoverWithMoreThan64IPs);
             return ADP.InvalidOperation(msg);
         }
 
         internal static Exception MultiSubnetFailoverWithInstanceSpecified()
         {
-            // @TODO: This can be uint
-            string msg = GetSNIErrorMessage((int)SniErrors.MultiSubnetFailoverWithInstanceSpecified);
+            string msg = GetSNIErrorMessage(SniErrors.MultiSubnetFailoverWithInstanceSpecified);
             return ADP.Argument(msg);
         }
 
         internal static Exception MultiSubnetFailoverWithNonTcpProtocol()
         {
-            // @TODO: This can be uint
-            string msg = GetSNIErrorMessage((int)SniErrors.MultiSubnetFailoverWithNonTcpProtocol);
+            string msg = GetSNIErrorMessage(SniErrors.MultiSubnetFailoverWithNonTcpProtocol);
             return ADP.Argument(msg);
         }
 
@@ -2485,10 +2482,9 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// gets a message for SNI error (sniError must be valid, non-zero error code)
         /// </summary>
-        // @TODO: This can be uint
-        internal static string GetSNIErrorMessage(int sniError)
+        internal static string GetSNIErrorMessage(uint sniError)
         {
-            Debug.Assert(sniError > 0 && sniError <= (int)SniErrors.MaxErrorValue, "SNI error is out of range");
+            Debug.Assert(sniError > 0 && sniError <= SniErrors.MaxErrorValue, "SNI error is out of range");
 
             string errorMessageId = string.Format("SNI_ERROR_{0}", sniError);
             return StringsHelper.GetResourceString(errorMessageId);


### PR DESCRIPTION
**Description**: This is a fairly small change to avoid casting SNI error codes to int as much as possible. The error codes are uint and can be treated as such in most situations.

The other change here is to clean up the CreateLocalDbException methods to drop unnecessary arguments. This kinda sets me up for failure when merging LocalDBAPI, buuuuuut that's a risk I'm willing to take.

**Testing**: Builds still work just fine, and there's no real change to functionality.