### PR TITLE
Add package vulnerability information

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,4 +4,8 @@
     <clear />
     <add key="sqlclient" value="https://sqlclientdrivers.pkgs.visualstudio.com/public/_packaging/sqlclient/nuget/v3/index.json" />
   </packageSources>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </auditSources>
 </configuration>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -64,10 +64,16 @@
     <NuGetCmd>$(NuGetRoot)nuget.exe</NuGetCmd>
     <!-- Respect environment variable for the .NET install directory if set; otherwise, use the current default location -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904;NU1905</WarningsNotAsErrors>
     <BuildSimulator Condition="'$(BuildSimulator)' != 'true'">false</BuildSimulator>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildSimulator)' == 'true'">
     <DefineConstants>$(DefineConstants);ENCLAVE_SIMULATOR</DefineConstants>
+  </PropertyGroup>
+  
+  <!-- Audit Settings -->
+  <PropertyGroup>
+    <NuGetAuditMode>all</NuGetAuditMode>
   </PropertyGroup>
 
   <!-- Packaging  for source link-->


### PR DESCRIPTION
# AI Blurp
---
This pull request includes changes to the NuGet configuration and build properties to improve package source auditing and manage warnings more effectively. The most important changes are as follows:

### NuGet Configuration Updates:

* [`NuGet.config`](diffhunk://#diff-9c5952957709545aad811b400e7e516eebade1e44fc4fbc23203403ffeb92c34R7-R10): Added an `auditSources` section to specify sources for auditing, including `nuget.org` as an audit source.

### Build Properties Enhancements:

* [`src/Directory.Build.props`](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907R67-R78): Introduced a `WarningsNotAsErrors` property to exclude specific warnings from being treated as errors.
* [`src/Directory.Build.props`](diffhunk://#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907R67-R78): Added a `NuGetAuditMode` property to enable auditing for all package sources.
---

# Description
Adding new functionality for .NET 9 / VS 17.12 / NuGet 6.12 with Audit Sources.
Also adding that the vulnerabilities (currently) are not treated as errors, but this can of course be enabled in the future

The idea is that package vulnerabilities get visibility at least on a warning level everywhere.
I'm sure I don't have to remind anyone of this, but I still do 😁 :
https://blogs.microsoft.com/blog/2024/05/03/prioritizing-security-above-all-else/

> If you’re faced with the tradeoff between security and another priority, your answer is clear: Do security.  -- Satya Nadella