### PR TITLE
Tests | Fix SqlBatch Test Deadlocks

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Batch/BatchTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Batch/BatchTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Threading.Tasks;
@@ -74,9 +75,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void StoredProcedureBatchSupported()
         {
+            SqlRetryLogicOption rto = new() { NumberOfTries = 3, DeltaTime = TimeSpan.FromMilliseconds(100), TransientErrors = new[] { 1205 } }; // Retry on 1205 / Deadlock
+            SqlRetryLogicBaseProvider prov = SqlConfigurableRetryFactory.CreateIncrementalRetryProvider(rto);
+
             using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
-            using (var batch = new SqlBatch { Connection = connection, BatchCommands = { new SqlBatchCommand("sp_help", CommandType.StoredProcedure) } })
+            using (var batch = new SqlBatch { Connection = connection, BatchCommands = { new SqlBatchCommand("sp_help", CommandType.StoredProcedure, new List<SqlParameter> { new("@objname", "sys.indexes") }) } })
             {
+                connection.RetryLogicProvider = prov;
                 connection.Open();
                 batch.ExecuteNonQuery();
             }
@@ -102,19 +107,24 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void MixedBatchSupported()
         {
+            SqlRetryLogicOption rto = new() { NumberOfTries = 3, DeltaTime = TimeSpan.FromMilliseconds(100), TransientErrors = new[] { 1205 } }; // Retry on 1205 / Deadlock
+            SqlRetryLogicBaseProvider prov = SqlConfigurableRetryFactory.CreateIncrementalRetryProvider(rto);
+
             using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             using (var batch = new SqlBatch
+                   {
+                       Connection = connection,
+                       BatchCommands =
+                       {
+                           new SqlBatchCommand("select @@SPID", CommandType.Text),
+                           new SqlBatchCommand("sp_help", CommandType.StoredProcedure, new List<SqlParameter> { new("@objname", "sys.indexes") })
+                       }
+                   })
             {
-                Connection = connection,
-                BatchCommands =
-                {
-                    new SqlBatchCommand("select @@SPID", CommandType.Text),
-                    new SqlBatchCommand("sp_help",CommandType.StoredProcedure)
-            }
-            })
-            {
+                connection.RetryLogicProvider = prov;
                 connection.Open();
                 batch.ExecuteNonQuery();
+                return;
             }
         }
 


### PR DESCRIPTION
# AI Blurp
This pull request includes changes to the `BatchTests.cs` file to add retry logic for SQL commands and to enhance the `SqlBatchCommand` functionality. The most important changes are as follows:

Enhancements to SQL retry logic:

* Added retry logic configuration using `SqlRetryLogicOption` and `SqlRetryLogicBaseProvider` to handle transient errors like deadlocks by retrying the operation up to three times with a delay of 100 milliseconds.

Improvements to `SqlBatchCommand`:

* Modified `StoredProcedureBatchSupported` and `MixedBatchSupported` methods to include parameters in `SqlBatchCommand` for executing stored procedures, specifically adding a parameter for the `sp_help` stored procedure. 

Additional imports:

* Added `System.Collections.Generic` import to support the use of `List<SqlParameter>` in the updated methods.

# Description
I regularly see deadlocks for the tests that use `sp_help`.
I'll try to mitigate this in 2 different ways:
- Add a retry for ErrorNumber 1205 (Deadlock)
- Add a parameter `@objname` that does less work so it's less likely to get a deadlock

It can probably also be solved by just using another stored procedure that's not prone to deadlocks, but I chose this way as the easiest path

Example test failure:
https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=101959&view=logs&j=700ebecb-e440-5400-66bb-488206e790af&t=d8ae6a68-b967-5b1e-ef3d-1b53d82075ee&l=826