### PR TITLE
Improve timeout of tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ConversionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ConversionTests.cs
@@ -70,7 +70,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
             foreach (string connectionStr in DataTestUtility.AEConnStringsSetup)
             {
-                using (SqlConnection sqlConnection = new SqlConnection(connectionStr))
+                var connectionString = new SqlConnectionStringBuilder(connectionStr);
+                connectionString.ConnectTimeout = Math.Max(connectionString.ConnectTimeout, 30); // The AE tests often fail with a connect timeout in this constructor. Making sure we have a reasonable timeout.
+
+                using (SqlConnection sqlConnection = new SqlConnection(connectionString.ConnectionString))
                 {
                     sqlConnection.Open();
                     _databaseObjects.ForEach(o => o.Create(sqlConnection));

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/ColumnEncryptionKey.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/ColumnEncryptionKey.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup
             using (SqlCommand command = sqlConnection.CreateCommand())
             {
                 command.CommandText = sql;
+                command.CommandTimeout = 60;
                 command.ExecuteNonQuery();
             }
         }
@@ -47,6 +48,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup
             using (SqlCommand command = sqlConnection.CreateCommand())
             {
                 command.CommandText = sql;
+                command.CommandTimeout = 60;
                 command.ExecuteNonQuery();
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/ColumnMasterKey.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/ColumnMasterKey.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup
                 if (!string.IsNullOrEmpty(sql))
                 {
                     command.CommandText = sql;
+                    command.CommandTimeout = 60;
                     command.ExecuteNonQuery();
                 }
             }
@@ -54,6 +55,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup
             using (SqlCommand command = sqlConnection.CreateCommand())
             {
                 command.CommandText = sql;
+                command.CommandTimeout = 60;
                 command.ExecuteNonQuery();
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/EventCounterTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/EventCounterTest.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             // clean pools and pool groups
             ClearConnectionPools();
             var stringBuilder = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString) { Pooling = true, MaxPoolSize = 1 };
+            stringBuilder.ConnectTimeout = Math.Max(stringBuilder.ConnectTimeout, 30);
 
             long rc = SqlClientEventSourceProps.ReclaimedConnections;
 


### PR DESCRIPTION
# AI Blurp
This pull request includes changes to improve the reliability of connection tests by adjusting connection timeouts. The most important changes include setting a minimum connection timeout in the `ConversionTests` and `EventCounterTest` classes.

Improvements to connection tests:

* [`src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ConversionTests.cs`](diffhunk://#diff-5ad0f64ac1d4ce2bc291748c724a38719f12d97b23e01cae5267cfb845de2800L73-R76): Adjusted the connection timeout to a minimum of 30 seconds in the `public ConversionTests()` method to reduce the likelihood of connection timeouts during tests.
* [`src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/EventCounterTest.cs`](diffhunk://#diff-e582a1eb0713f26f2224cfb8627f5b06030a00371c8b995b12f65acce342ecefR155): Added a minimum connection timeout of 30 seconds in the `public void EventCounter_ReclaimedConnectionsCounter_Functional()` method to ensure consistent test execution.

# Description
There are quite a few test failures on these methods:
https://sqlclientdrivers.visualstudio.com/public/_test/analytics?definitionId=1879&contextType=build

Many of the failures are timeouts, so I'm trying to see if increasing the timeout a bit could help make these tests more stable