### PR TITLE
Merge | Deprecate Code Access Security

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -450,6 +450,7 @@ namespace Microsoft.Data.SqlClient
         public static readonly string StructuredTypeMembers;
     }
     /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/SqlClientPermission/*'/>
+    [System.Obsolete("Code Access Security is not supported or honored by the runtime.")]
     public sealed partial class SqlClientPermission : System.Data.Common.DBDataPermission
     {
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/ctor[@name="default"]/*'/>
@@ -467,6 +468,7 @@ namespace Microsoft.Data.SqlClient
     }
     /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermissionAttribute.xml' path='docs/members[@name="SqlClientPermissionAttribute"]/SqlClientPermissionAttribute/*'/>
     [System.AttributeUsageAttribute(System.AttributeTargets.Method | System.AttributeTargets.Constructor | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+    [System.Obsolete("Code Access Security is not supported or honored by the runtime.")]
     public sealed partial class SqlClientPermissionAttribute : System.Data.Common.DBDataPermissionAttribute
     {
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermissionAttribute.xml' path='docs/members[@name="SqlClientPermissionAttribute"]/ctor/*'/>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientPermission.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlClientPermission.cs
@@ -3,418 +3,82 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Data;
 using System.Data.Common;
-using System.Globalization;
-using System.Reflection;
 using System.Security;
 using System.Security.Permissions;
-using Microsoft.Data.Common;
-using DBDataPermission = System.Data.Common.DBDataPermission;
 
 namespace Microsoft.Data.SqlClient
 {
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/SqlClientPermission/*' />
     [Serializable]
-    public sealed class SqlClientPermission : System.Data.Common.DBDataPermission
+    [Obsolete("Code Access Security is not supported or honored by the runtime.")]
+    public sealed class SqlClientPermission : DBDataPermission
     {
+        private static readonly string SecurityElementXml = $"<IPermission class=\"{typeof(SqlClientPermission).AssemblyQualifiedName.Replace('\"', '\'')}\" version=\"1\" Unrestricted=\"true\" />";
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/ctor[@name="default"]/*' />
         [Obsolete("SqlClientPermission() has been deprecated.  Use the SqlClientPermission(PermissionState.None) constructor.  http://go.microsoft.com/fwlink/?linkid=14202", true)] // MDAC 86034
-        public SqlClientPermission() : this(PermissionState.None)
+        public SqlClientPermission() : base(PermissionState.Unrestricted)
         {
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/ctor[@name="PermissionState"]/*' />
-        public SqlClientPermission(PermissionState state) : base(state)
+        public SqlClientPermission(PermissionState state) : base(PermissionState.Unrestricted)
         {
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/ctor[@name="PermissionStateAndallowBlankPasswordBool"]/*' />
         [Obsolete("SqlClientPermission(PermissionState state, Boolean allowBlankPassword) has been deprecated.  Use the SqlClientPermission(PermissionState.None) constructor.  http://go.microsoft.com/fwlink/?linkid=14202", true)] // MDAC 86034
-        public SqlClientPermission(PermissionState state, bool allowBlankPassword) : this(state)
+        public SqlClientPermission(PermissionState state, bool allowBlankPassword) : base(PermissionState.Unrestricted)
         {
-            AllowBlankPassword = allowBlankPassword;
-        }
-
-        private SqlClientPermission(SqlClientPermission permission) : base(permission)
-        { // for Copy
-            // Explicitly copyFrom to clone the key value pairs
-            CopyFrom(permission);
-        }
-
-        internal SqlClientPermission(SqlClientPermissionAttribute permissionAttribute) : base(permissionAttribute)
-        { // for CreatePermission
-        }
-
-        internal SqlClientPermission(SqlConnectionString constr) : base(PermissionState.None)
-        { // for Open
-            if (constr != null)
-            {
-                AllowBlankPassword = constr.HasBlankPassword; // MDAC 84563
-                AddPermissionEntry(new DBConnectionString(constr));
-            }
-            if (constr == null || constr.IsEmpty)
-            {
-                base.Add("", "", KeyRestrictionBehavior.AllowOnly);
-            }
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/Add[@name="connectionStringAndrestrictionsStringAndBehavior"]/*' />
         public override void Add(string connectionString, string restrictions, KeyRestrictionBehavior behavior)
         {
-            DBConnectionString constr = new DBConnectionString(connectionString, restrictions, behavior, SqlConnectionString.GetParseSynonyms(), false);
-            AddPermissionEntry(constr);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/Copy/*' />
-        override public IPermission Copy()
+        public override IPermission Copy()
         {
-            return new SqlClientPermission(this);
-        }
-
-        // Modifications
-
-        private NameValuePermission _keyvaluetree = NameValuePermission.Default;
-        private /*DBConnectionString[]*/ArrayList _keyvalues; // = null;
-
-        internal void AddPermissionEntry(DBConnectionString entry)
-        {
-            if (_keyvaluetree == null)
-            {
-                _keyvaluetree = new NameValuePermission();
-            }
-            if (_keyvalues == null)
-            {
-                _keyvalues = new ArrayList();
-            }
-            NameValuePermission.AddEntry(_keyvaluetree, _keyvalues, entry);
-            _IsUnrestricted = false; // MDAC 84639
-        }
-
-        private bool _IsUnrestricted
-        {
-            set
-            {
-                // Use Reflection to access the base class _isUnrestricted. There is no other way to alter this externally.
-                FieldInfo fieldInfo = GetType().BaseType.GetField("_isUnrestricted", BindingFlags.Instance
-                | BindingFlags.NonPublic);
-                fieldInfo.SetValue(this, value);
-            }
-
-            get
-            {
-                return base.IsUnrestricted();
-            }
-        }
-
-        // Modified CopyFrom to make sure that we copy the Name Value Pair
-        private void CopyFrom(SqlClientPermission permission)
-        {
-            if (!_IsUnrestricted)
-            {
-                if (permission._keyvalues != null)
-                {
-                    _keyvalues = (ArrayList)permission._keyvalues.Clone();
-
-                    if (permission._keyvaluetree != null)
-                    {
-                        _keyvaluetree = permission._keyvaluetree.CopyNameValue();
-                    }
-                }
-            }
+            return new SqlClientPermission(PermissionState.Unrestricted);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/Intersect/*' />
-        override public IPermission Intersect(IPermission target)
-        { // used during Deny actions
-            if (target == null)
-            {
-                return null;
-            }
-            if (target.GetType() != this.GetType())
-            {
-                throw ADP.PermissionTypeMismatch();
-            }
-            if (this.IsUnrestricted())
-            { // MDAC 84803, NDPWhidbey 29121
-                return target.Copy();
-            }
-
-            DBDataPermission operand = (DBDataPermission)target;
-            if (operand.IsUnrestricted())
-            { // NDPWhidbey 29121
-                return this.Copy();
-            }
-
-            SqlClientPermission newPermission = (SqlClientPermission)operand.Copy();
-            newPermission.AllowBlankPassword &= AllowBlankPassword;
-
-            if (_keyvalues != null && newPermission._keyvalues != null)
-            {
-                newPermission._keyvalues.Clear();
-
-                newPermission._keyvaluetree.Intersect(newPermission._keyvalues, _keyvaluetree);
-            }
-            else
-            {
-                // either target.Add or this.Add have not been called
-                // return a non-null object so IsSubset calls will fail
-                newPermission._keyvalues = null;
-                newPermission._keyvaluetree = null;
-            }
-
-            if (newPermission.IsEmpty())
-            { // no intersection, MDAC 86773
-                newPermission = null;
-            }
-            return newPermission;
-        }
-
-        private bool IsEmpty()
-        { // MDAC 84804
-            ArrayList keyvalues = _keyvalues;
-            bool flag = !IsUnrestricted() && !AllowBlankPassword && (keyvalues == null || (0 == keyvalues.Count));
-            return flag;
+        public override IPermission Intersect(IPermission target)
+        {
+            return target.Copy();
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/IsSubsetOf/*' />
-        override public bool IsSubsetOf(IPermission target)
+        public override bool IsSubsetOf(IPermission target)
         {
-            if (null == target)
-            {
-                return IsEmpty();
-            }
-            if (target.GetType() != this.GetType())
-            {
-                throw ADP.PermissionTypeMismatch();
-            }
-
-            SqlClientPermission superset = (target as SqlClientPermission);
-
-            bool subset = superset.IsUnrestricted();
-            if (!subset)
-            {
-                if (!IsUnrestricted() &&
-                    (!AllowBlankPassword || superset.AllowBlankPassword) &&
-                    (_keyvalues == null || superset._keyvaluetree != null))
-                {
-
-                    subset = true;
-                    if (_keyvalues != null)
-                    {
-                        foreach (DBConnectionString kventry in _keyvalues)
-                        {
-                            if (!superset._keyvaluetree.CheckValueForKeyPermit(kventry))
-                            {
-                                subset = false;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-            return subset;
+            return true;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/Union/*' />
-        override public IPermission Union(IPermission target)
+        public override IPermission Union(IPermission target)
         {
-            if (target == null)
-            {
-                return this.Copy();
-            }
-            if (target.GetType() != this.GetType())
-            {
-                throw ADP.PermissionTypeMismatch();
-            }
-            if (IsUnrestricted())
-            { // MDAC 84803
-                return this.Copy();
-            }
-
-            SqlClientPermission newPermission = (SqlClientPermission)target.Copy();
-            if (!newPermission.IsUnrestricted())
-            {
-                newPermission.AllowBlankPassword |= AllowBlankPassword;
-
-                if (_keyvalues != null)
-                {
-                    foreach (DBConnectionString entry in _keyvalues)
-                    {
-                        newPermission.AddPermissionEntry(entry);
-                    }
-                }
-            }
-            return (newPermission.IsEmpty() ? null : newPermission);
+            return Copy();
         }
 
-        private string DecodeXmlValue(string value)
-        {
-            if (value != null && (0 < value.Length))
-            {
-                value = value.Replace("&quot;", "\"");
-                value = value.Replace("&apos;", "\'");
-                value = value.Replace("&lt;", "<");
-                value = value.Replace("&gt;", ">");
-                value = value.Replace("&amp;", "&");
-            }
-            return value;
-        }
-
-        private string EncodeXmlValue(string value)
-        {
-            if (value != null && (0 < value.Length))
-            {
-                value = value.Replace('\0', ' '); // assumption that '\0' will only be at end of string
-                value = value.Trim();
-                value = value.Replace("&", "&amp;");
-                value = value.Replace(">", "&gt;");
-                value = value.Replace("<", "&lt;");
-                value = value.Replace("\'", "&apos;");
-                value = value.Replace("\"", "&quot;");
-            }
-            return value;
-        }
-
-        // <IPermission class="...Permission" version="1" AllowBlankPassword=false>
-        //     <add ConnectionString="provider=x;data source=y;" KeyRestrictions="address=;server=" KeyRestrictionBehavior=PreventUsage/>
-        // </IPermission>
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/FromXml/*' />
-        override public void FromXml(SecurityElement securityElement)
+        public override void FromXml(SecurityElement securityElement)
         {
-            // code derived from CodeAccessPermission.ValidateElement
-            if (securityElement == null)
-            {
-                throw ADP.ArgumentNull("securityElement");
-            }
-            string tag = securityElement.Tag;
-            if (!tag.Equals(XmlStr._Permission) && !tag.Equals(XmlStr._IPermission))
-            {
-                throw ADP.NotAPermissionElement();
-            }
-            String version = securityElement.Attribute(XmlStr._Version);
-            if (version != null && !version.Equals(XmlStr._VersionNumber))
-            {
-                throw ADP.InvalidXMLBadVersion();
-            }
-
-            string unrestrictedValue = securityElement.Attribute(XmlStr._Unrestricted);
-            _IsUnrestricted = unrestrictedValue != null && Boolean.Parse(unrestrictedValue);
-
-            Clear(); // MDAC 83105
-            if (!_IsUnrestricted)
-            {
-                string allowNull = securityElement.Attribute(XmlStr._AllowBlankPassword);
-                AllowBlankPassword = allowNull != null && Boolean.Parse(allowNull);
-
-                ArrayList children = securityElement.Children;
-                if (children != null)
-                {
-                    foreach (SecurityElement keyElement in children)
-                    {
-                        tag = keyElement.Tag;
-                        if (XmlStr._add == tag || (tag != null && XmlStr._add == tag.ToLower(CultureInfo.InvariantCulture)))
-                        {
-                            string constr = keyElement.Attribute(XmlStr._ConnectionString);
-                            string restrt = keyElement.Attribute(XmlStr._KeyRestrictions);
-                            string behavr = keyElement.Attribute(XmlStr._KeyRestrictionBehavior);
-
-                            KeyRestrictionBehavior behavior = KeyRestrictionBehavior.AllowOnly;
-                            if (behavr != null)
-                            {
-                                behavior = (KeyRestrictionBehavior)Enum.Parse(typeof(KeyRestrictionBehavior), behavr, true);
-                            }
-                            constr = DecodeXmlValue(constr);
-                            restrt = DecodeXmlValue(restrt);
-                            Add(constr, restrt, behavior);
-                        }
-                    }
-                }
-            }
-            else
-            {
-                AllowBlankPassword = false;
-            }
         }
 
-        // <IPermission class="...Permission" version="1" AllowBlankPassword=false>
-        //     <add ConnectionString="provider=x;data source=y;"/>
-        //     <add ConnectionString="provider=x;data source=y;" KeyRestrictions="user id=;password=;" KeyRestrictionBehavior=AllowOnly/>
-        //     <add ConnectionString="provider=x;data source=y;" KeyRestrictions="address=;server=" KeyRestrictionBehavior=PreventUsage/>
-        // </IPermission>
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/ToXml/*' />
-        override public SecurityElement ToXml()
+        public override SecurityElement ToXml()
         {
-            Type type = this.GetType();
-            SecurityElement root = new SecurityElement(XmlStr._IPermission);
-            root.AddAttribute(XmlStr._class, type.AssemblyQualifiedName.Replace('\"', '\''));
-            root.AddAttribute(XmlStr._Version, XmlStr._VersionNumber);
-
-            if (IsUnrestricted())
-            {
-                root.AddAttribute(XmlStr._Unrestricted, XmlStr._true);
-            }
-            else
-            {
-                root.AddAttribute(XmlStr._AllowBlankPassword, AllowBlankPassword.ToString(CultureInfo.InvariantCulture));
-
-                if (_keyvalues != null)
-                {
-                    foreach (DBConnectionString value in _keyvalues)
-                    {
-                        SecurityElement valueElement = new SecurityElement(XmlStr._add);
-                        string tmp;
-
-                        tmp = value.ConnectionString; // WebData 97375
-                        tmp = EncodeXmlValue(tmp);
-                        if (!ADP.IsEmpty(tmp))
-                        {
-                            valueElement.AddAttribute(XmlStr._ConnectionString, tmp);
-                        }
-                        tmp = value.Restrictions;
-                        tmp = EncodeXmlValue(tmp);
-                        if (tmp == null)
-                        {
-                            tmp = "";
-                        }
-                        valueElement.AddAttribute(XmlStr._KeyRestrictions, tmp);
-
-                        tmp = value.Behavior.ToString();
-                        valueElement.AddAttribute(XmlStr._KeyRestrictionBehavior, tmp);
-
-                        root.AddChild(valueElement);
-                    }
-                }
-            }
-            return root;
+            return SecurityElement.FromString(SecurityElementXml);
         }
-
-        private static class XmlStr
-        {
-            internal const string _class = "class";
-            internal const string _IPermission = "IPermission";
-            internal const string _Permission = "Permission";
-            internal const string _Unrestricted = "Unrestricted";
-            internal const string _AllowBlankPassword = "AllowBlankPassword";
-            internal const string _true = "true";
-            internal const string _Version = "version";
-            internal const string _VersionNumber = "1";
-
-            internal const string _add = "add";
-
-            internal const string _ConnectionString = "ConnectionString";
-            internal const string _KeyRestrictions = "KeyRestrictions";
-            internal const string _KeyRestrictionBehavior = "KeyRestrictionBehavior";
-        }
-
-
     }
 
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermissionAttribute.xml' path='docs/members[@name="SqlClientPermissionAttribute"]/SqlClientPermissionAttribute/*' />
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
     [Serializable]
+    [Obsolete("Code Access Security is not supported or honored by the runtime.")]
     public sealed class SqlClientPermissionAttribute : DBDataPermissionAttribute
     {
 
@@ -424,9 +88,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermissionAttribute.xml' path='docs/members[@name="SqlClientPermissionAttribute"]/CreatePermission/*' />
-        override public IPermission CreatePermission()
+        public override IPermission CreatePermission()
         {
-            return new SqlClientPermission(this);
+            return new SqlClientPermission(PermissionState.Unrestricted);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1472,7 +1472,9 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/ClearAllPools/*' />
         static public void ClearAllPools()
         {
+#pragma warning disable CS0618
             (new SqlClientPermission(PermissionState.Unrestricted)).Demand();
+#pragma warning restore CS0618
             SqlConnectionFactory.SingletonInstance.ClearAllPools();
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientFactory.cs
@@ -68,7 +68,9 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientFactory.xml' path='docs/members[@name="SqlClientFactory"]/CreatePermission/*'/>
         public override CodeAccessPermission CreatePermission(PermissionState state)
         {
+#pragma warning disable CS0618
             return new SqlClientPermission(state);
+#pragma warning restore CS0618
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -1156,7 +1156,9 @@ namespace Microsoft.Data.SqlClient
         protected internal override PermissionSet CreatePermissionSet()
         {
             PermissionSet permissionSet = new(PermissionState.None);
-            permissionSet.AddPermission(new SqlClientPermission(this));
+#pragma warning disable CS0618
+            permissionSet.AddPermission(new SqlClientPermission(PermissionState.Unrestricted));
+#pragma warning restore CS0618
             return permissionSet;
         }
 


### PR DESCRIPTION
This PR removes the implementation of the public `SqlClientPermission` and `SqlClientPermissionAttribute` types, obsoleting them with the message "Code Access Security is not supported or honored by the runtime." The SqlClientPermission CAS behaviour now aligns with the rest of .NET Framework 4.0+ and .NET Core.

CAS is still present in various places throughout the library, but none of these are public. A subsequent PR can remove these references, they looked like they'd make this one harder to review.

/cc @benrr101 - this eliminates the need to merge `DBConnectionString` and `NameValuePermission`: these types are internal, and unreferenced after this PR is merged. I'm planning to delete them. I've not got any strong opinions on how to tackle the merge of `SqlClientPermission` and `SqlClientPermissionAttribute` though; it seems odd to merge already-obsolete classes, but it's a divergence in the API surface to leave them apart.