### PR TITLE
SDL | Update SMO

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.ExtUtilities/Microsoft.Data.SqlClient.ExtUtilities.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.ExtUtilities/Microsoft.Data.SqlClient.ExtUtilities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <StartupObject>Microsoft.Data.SqlClient.ExtUtilities.Runner</StartupObject>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -57,7 +57,7 @@
     <MicrosoftNETCoreRuntimeCoreCLRVersion>2.0.8</MicrosoftNETCoreRuntimeCoreCLRVersion>
     <MicrosoftNETFrameworkReferenceAssembliesVersion>1.0.3</MicrosoftNETFrameworkReferenceAssembliesVersion>
     <MicrosoftNETTestSdkVersion>17.8.0</MicrosoftNETTestSdkVersion>
-    <MicrosoftSqlServerSqlManagementObjectsVersion>170.8.0</MicrosoftSqlServerSqlManagementObjectsVersion>
+    <MicrosoftSqlServerSqlManagementObjectsVersion>172.52.0</MicrosoftSqlServerSqlManagementObjectsVersion>
     <MicrosoftSqlServerTypesVersion>10.50.1600.1</MicrosoftSqlServerTypesVersion>
     <MicrosoftSqlServerTypesVersionNet>160.1000.6</MicrosoftSqlServerTypesVersionNet>
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>


### PR DESCRIPTION
**Description**: As part of release activities, MSAL versions are required to be above 4.48.1. One of the test utility projects is referencing an out of date version of SMO that is pulling in a v4.45.0 which is below the minimum version. Although this is not a project that ships, we should still try to update SMO to bring in a newer version of MSAL.