### PR TITLE
Tests | Disable flaky tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ConnectionExceptionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ExceptionTest/ConnectionExceptionTest.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private const string orderIdQuery = "select orderid from orders where orderid < 10250";
         private static bool IsNotKerberos() => DataTestUtility.IsKerberosTest != true;
 
+        [ActiveIssue("https://github.com/dotnet/SqlClient/issues/3031")]
         [ConditionalFact(nameof(IsNotKerberos))]
         public void TestConnectionStateWithErrorClass20()
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/EventCounterTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/EventCounterTest.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.Equal(0, SqlClientEventSourceProps.StasisConnections);
         }
 
+        [ActiveIssue("https://github.com/dotnet/SqlClient/issues/3031")]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public void EventCounter_ReclaimedConnectionsCounter_Functional()
         {


### PR DESCRIPTION
To make builds more reliable I think it's good practice to disable flaky tests until the issues are resolved.
The tests have been marked with an ActiveIssue in code

Issue: https://github.com/dotnet/SqlClient/issues/3031