### PR TITLE
Cleanup/Merge | Remove Reliability Section

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -257,33 +257,14 @@ namespace Microsoft.Data.SqlClient
                     {
                         throw SQL.PendingBeginXXXExists();
                     }
-
-#if NETFRAMEWORK
-                    RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-#if NETFRAMEWORK && DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
+                    
+                    Debug.Assert(_stateObj == null || _stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+                    if (TryConsumeMetaData() != TdsOperationStatus.Done)
                     {
-                        tdsReliabilitySection.Start();
-#else
-                    {
-#endif
-                        Debug.Assert(_stateObj == null || _stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                        if (TryConsumeMetaData() != TdsOperationStatus.Done)
-                        {
-                            throw SQL.SynchronousCallMayNotPend();
-                        }
+                        throw SQL.SynchronousCallMayNotPend();
                     }
-#if NETFRAMEWORK && DEBUG
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif
                 }
+
                 return _metaData;
             }
         }
@@ -856,30 +837,10 @@ namespace Microsoft.Data.SqlClient
         private void CleanPartialReadReliable()
         {
             AssertReaderState(requireData: true, permitAsync: false);
-
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-#if NETFRAMEWORK && DEBUG
-            TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                tdsReliabilitySection.Start();
-#else
-            {
-#endif
-                TdsOperationStatus result = TryCleanPartialRead();
-                Debug.Assert(result == TdsOperationStatus.Done, "Should not pend on sync call");
-                Debug.Assert(!_sharedState._dataReady, "_dataReady should be cleared");
-            }
-#if NETFRAMEWORK && DEBUG
-            finally
-            {
-                tdsReliabilitySection.Stop();
-            }
-#endif
+            
+            TdsOperationStatus result = TryCleanPartialRead();
+            Debug.Assert(result == TdsOperationStatus.Done, "Should not pend on sync call");
+            Debug.Assert(!_sharedState._dataReady, "_dataReady should be cleared");
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Dispose/*' />
@@ -1004,77 +965,60 @@ namespace Microsoft.Data.SqlClient
 #endif
             try
             {
-#if NETFRAMEWORK && DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
+                if ((!_isClosed) && (parser != null) && (stateObj != null) && (stateObj.HasPendingData))
                 {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif
-                    if ((!_isClosed) && (parser != null) && (stateObj != null) && (stateObj.HasPendingData))
+                    // It is possible for this to be called during connection close on a
+                    // broken connection, so check state first.
+                    if (parser.State == TdsParserState.OpenLoggedIn)
                     {
-                        // It is possible for this to be called during connection close on a
-                        // broken connection, so check state first.
-                        if (parser.State == TdsParserState.OpenLoggedIn)
+                        // if user called read but didn't fetch any values, skip the row
+                        // same applies after NextResult on ALTROW because NextResult starts rowconsumption in that case ...
+
+                        Debug.Assert(SniContext.Snix_Read == stateObj.SniContext, $"The SniContext should be Snix_Read but it actually is {stateObj.SniContext}");
+
+                        if (_altRowStatus == ALTROWSTATUS.AltRow)
                         {
-                            // if user called read but didn't fetch any values, skip the row
-                            // same applies after NextResult on ALTROW because NextResult starts rowconsumption in that case ...
-
-                            Debug.Assert(SniContext.Snix_Read == stateObj.SniContext, $"The SniContext should be Snix_Read but it actually is {stateObj.SniContext}");
-
-                            if (_altRowStatus == ALTROWSTATUS.AltRow)
+                            _sharedState._dataReady = true;      // set _sharedState._dataReady to not confuse CleanPartialRead
+                        }
+                        _stateObj.SetTimeoutStateStopped();
+                        if (_sharedState._dataReady)
+                        {
+                            cleanDataFailed = true;
+                            result = TryCleanPartialRead();
+                            if (result == TdsOperationStatus.Done)
                             {
-                                _sharedState._dataReady = true;      // set _sharedState._dataReady to not confuse CleanPartialRead
+                                cleanDataFailed = false;
                             }
-                            _stateObj.SetTimeoutStateStopped();
-                            if (_sharedState._dataReady)
-                            {
-                                cleanDataFailed = true;
-                                result = TryCleanPartialRead();
-                                if (result == TdsOperationStatus.Done)
-                                {
-                                    cleanDataFailed = false;
-                                }
-                                else
-                                {
-                                    return result;
-                                }
-                            }
-#if DEBUG
                             else
-                            {
-                                byte token;
-                                result = _stateObj.TryPeekByte(out token);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    return result;
-                                }
-
-                                Debug.Assert(TdsParser.IsValidTdsToken(token), $"DataReady is false, but next token is invalid: {token,-2:X2}");
-                            }
-#endif
-
-
-                            result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out _);
-                            if (result != TdsOperationStatus.Done)
                             {
                                 return result;
                             }
                         }
-                    }
+#if DEBUG
+                        else
+                        {
+                            byte token;
+                            result = _stateObj.TryPeekByte(out token);
+                            if (result != TdsOperationStatus.Done)
+                            {
+                                return result;
+                            }
 
-                    RestoreServerSettings(parser, stateObj);
-                    return TdsOperationStatus.Done;
-                }
-#if NETFRAMEWORK && DEBUG
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
+                            Debug.Assert(TdsParser.IsValidTdsToken(token), $"DataReady is false, but next token is invalid: {token,-2:X2}");
+                        }
 #endif
+
+
+                        result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out _);
+                        if (result != TdsOperationStatus.Done)
+                        {
+                            return result;
+                        }
+                    }
+                }
+
+                RestoreServerSettings(parser, stateObj);
+                return TdsOperationStatus.Done;
             }
             finally
             {
@@ -1113,45 +1057,25 @@ namespace Microsoft.Data.SqlClient
                     {
                         Connection.RemoveWeakReference(this);  // This doesn't catch everything -- the connection may be closed, but it prevents dead readers from clogging the collection
                     }
-
-#if NETFRAMEWORK
-                    RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-#if NETFRAMEWORK && DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
+                    
+                    // IsClosed may be true if CloseReaderFromConnection was called - in which case, the session has already been closed
+                    if (!wasClosed && stateObj != null)
                     {
-                        tdsReliabilitySection.Start();
-#else
-                    {
-#endif
-                        // IsClosed may be true if CloseReaderFromConnection was called - in which case, the session has already been closed
-                        if (!wasClosed && stateObj != null)
+                        if (!cleanDataFailed)
                         {
-                            if (!cleanDataFailed)
+                            stateObj.CloseSession();
+                        }
+                        else
+                        {
+                            if (parser != null)
                             {
-                                stateObj.CloseSession();
-                            }
-                            else
-                            {
-                                if (parser != null)
-                                {
-                                    parser.State = TdsParserState.Broken; // We failed while draining data, so TDS pointer can be between tokens - cannot recover
-                                    parser.PutSession(stateObj);
-                                    parser.Connection.BreakConnection();
-                                }
+                                parser.State = TdsParserState.Broken; // We failed while draining data, so TDS pointer can be between tokens - cannot recover
+                                parser.PutSession(stateObj);
+                                parser.Connection.BreakConnection();
                             }
                         }
-                        // DO NOT USE stateObj after this point - it has been returned to the TdsParser's session pool and potentially handed out to another thread
                     }
-#if NETFRAMEWORK && DEBUG
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif
+                    // DO NOT USE stateObj after this point - it has been returned to the TdsParser's session pool and potentially handed out to another thread
 
                     // do not retry here
                     result = TrySetMetaData(null, false);
@@ -1731,251 +1655,232 @@ namespace Microsoft.Data.SqlClient
         {
             remaining = 0;
             TdsOperationStatus result;
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-#if NETFRAMEWORK && DEBUG
-            TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
 
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                tdsReliabilitySection.Start();
-#else
-            {
-#endif
-                int cbytes = 0;
-                AssertReaderState(requireData: true, permitAsync: true, columnIndex: i, enforceSequentialAccess: true);
+            int cbytes = 0;
+            AssertReaderState(requireData: true, permitAsync: true, columnIndex: i, enforceSequentialAccess: true);
 
-                // sequential reading
-                if (IsCommandBehavior(CommandBehavior.SequentialAccess))
+            // sequential reading
+            if (IsCommandBehavior(CommandBehavior.SequentialAccess))
+            {
+                Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has an active Stream or TextReader");
+
+                if (_metaData[i] != null && _metaData[i].cipherMD != null)
                 {
-                    Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has an active Stream or TextReader");
-
-                    if (_metaData[i] != null && _metaData[i].cipherMD != null)
-                    {
-                        throw SQL.SequentialAccessNotSupportedOnEncryptedColumn(_metaData[i].column);
-                    }
-
-                    if (_sharedState._nextColumnHeaderToRead <= i)
-                    {
-                        result = TryReadColumnHeader(i);
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            return result;
-                        }
-                    }
-
-                    // If data is null, ReadColumnHeader sets the data.IsNull bit.
-                    if (_data[i] != null && _data[i].IsNull)
-                    {
-                        throw new SqlNullValueException();
-                    }
-
-                    // If there are an unknown (-1) number of bytes left for a PLP, read its size
-                    if ((-1 == _sharedState._columnDataBytesRemaining) && (_metaData[i].metaType.IsPlp))
-                    {
-                        ulong left;
-                        result = _parser.TryPlpBytesLeft(_stateObj, out left);
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            return result;
-                        }
-                        _sharedState._columnDataBytesRemaining = (long)left;
-                    }
-
-                    if (0 == _sharedState._columnDataBytesRemaining)
-                    {
-                        return TdsOperationStatus.Done; // We've read this column to the end
-                    }
-
-                    // if no buffer is passed in, return the number total of bytes, or -1
-                    if (buffer == null)
-                    {
-                        if (_metaData[i].metaType.IsPlp)
-                        {
-                            remaining = (long)_parser.PlpBytesTotalLength(_stateObj);
-                            return TdsOperationStatus.Done;
-                        }
-                        remaining = _sharedState._columnDataBytesRemaining;
-                        return TdsOperationStatus.Done;
-                    }
-
-                    if (dataIndex < 0)
-                    {
-                        throw ADP.NegativeParameter(nameof(dataIndex));
-                    }
-
-                    if (dataIndex < _columnDataBytesRead)
-                    {
-                        throw ADP.NonSeqByteAccess(dataIndex, _columnDataBytesRead, nameof(GetBytes));
-                    }
-
-                    // if the dataIndex is not equal to bytes read, then we have to skip bytes
-                    long cb = dataIndex - _columnDataBytesRead;
-
-                    // if dataIndex is outside of the data range, return 0
-                    if ((cb > _sharedState._columnDataBytesRemaining) && !_metaData[i].metaType.IsPlp)
-                    {
-                        return TdsOperationStatus.Done;
-                    }
-
-                    // if bad buffer index, throw
-                    if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                    {
-                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
-                    }
-
-                    // if there is not enough room in the buffer for data
-                    if (length + bufferIndex > buffer.Length)
-                    {
-                        throw ADP.InvalidBufferSizeOrIndex(length, bufferIndex);
-                    }
-
-                    if (length < 0)
-                    {
-                        throw ADP.InvalidDataLength(length);
-                    }
-
-                    // Skip if needed
-                    if (cb > 0)
-                    {
-                        if (_metaData[i].metaType.IsPlp)
-                        {
-                            ulong skipped;
-                            result = _parser.TrySkipPlpValue((ulong)cb, _stateObj, out skipped);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                return result;
-                            }
-                            _columnDataBytesRead += (long)skipped;
-                        }
-                        else
-                        {
-                            result = _stateObj.TrySkipLongBytes(cb);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                return result;
-                            }
-                            _columnDataBytesRead += cb;
-                            _sharedState._columnDataBytesRemaining -= cb;
-                        }
-                    }
-
-                    int bytesRead;
-                    result = TryGetBytesInternalSequential(i, buffer, bufferIndex, length, out bytesRead);
-                    remaining = (int)bytesRead;
-                    return result;
+                    throw SQL.SequentialAccessNotSupportedOnEncryptedColumn(_metaData[i].column);
                 }
 
-                // random access now!
-                // note that since we are caching in an array, and arrays aren't 64 bit ready yet,
-                // we need can cast to int if the dataIndex is in range
+                if (_sharedState._nextColumnHeaderToRead <= i)
+                {
+                    result = TryReadColumnHeader(i);
+                    if (result != TdsOperationStatus.Done)
+                    {
+                        return result;
+                    }
+                }
+
+                // If data is null, ReadColumnHeader sets the data.IsNull bit.
+                if (_data[i] != null && _data[i].IsNull)
+                {
+                    throw new SqlNullValueException();
+                }
+
+                // If there are an unknown (-1) number of bytes left for a PLP, read its size
+                if ((-1 == _sharedState._columnDataBytesRemaining) && (_metaData[i].metaType.IsPlp))
+                {
+                    ulong left;
+                    result = _parser.TryPlpBytesLeft(_stateObj, out left);
+                    if (result != TdsOperationStatus.Done)
+                    {
+                        return result;
+                    }
+                    _sharedState._columnDataBytesRemaining = (long)left;
+                }
+
+                if (0 == _sharedState._columnDataBytesRemaining)
+                {
+                    return TdsOperationStatus.Done; // We've read this column to the end
+                }
+
+                // if no buffer is passed in, return the number total of bytes, or -1
+                if (buffer == null)
+                {
+                    if (_metaData[i].metaType.IsPlp)
+                    {
+                        remaining = (long)_parser.PlpBytesTotalLength(_stateObj);
+                        return TdsOperationStatus.Done;
+                    }
+                    remaining = _sharedState._columnDataBytesRemaining;
+                    return TdsOperationStatus.Done;
+                }
+
                 if (dataIndex < 0)
                 {
                     throw ADP.NegativeParameter(nameof(dataIndex));
                 }
 
-                if (dataIndex > int.MaxValue)
+                if (dataIndex < _columnDataBytesRead)
                 {
-                    throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
+                    throw ADP.NonSeqByteAccess(dataIndex, _columnDataBytesRead, nameof(GetBytes));
                 }
 
-                int ndataIndex = (int)dataIndex;
-                byte[] data;
+                // if the dataIndex is not equal to bytes read, then we have to skip bytes
+                long cb = dataIndex - _columnDataBytesRead;
 
-                // WebData 99342 - in the non-sequential case, we need to support
-                //                 the use of GetBytes on string data columns, but
-                //                 GetSqlBinary isn't supposed to.  What we end up
-                //                 doing isn't exactly pretty, but it does work.
-                if (_metaData[i].metaType.IsBinType)
+                // if dataIndex is outside of the data range, return 0
+                if ((cb > _sharedState._columnDataBytesRemaining) && !_metaData[i].metaType.IsPlp)
                 {
-                    data = GetSqlBinary(i).Value;
+                    return TdsOperationStatus.Done;
                 }
-                else
-                {
-                    Debug.Assert(_metaData[i].metaType.IsLong, "non long type?");
-                    Debug.Assert(_metaData[i].metaType.IsCharType, "non-char type?");
 
-                    SqlString temp = GetSqlString(i);
-                    if (_metaData[i].metaType.IsNCharType)
+                // if bad buffer index, throw
+                if (bufferIndex < 0 || bufferIndex >= buffer.Length)
+                {
+                    throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
+                }
+
+                // if there is not enough room in the buffer for data
+                if (length + bufferIndex > buffer.Length)
+                {
+                    throw ADP.InvalidBufferSizeOrIndex(length, bufferIndex);
+                }
+
+                if (length < 0)
+                {
+                    throw ADP.InvalidDataLength(length);
+                }
+
+                // Skip if needed
+                if (cb > 0)
+                {
+                    if (_metaData[i].metaType.IsPlp)
                     {
-                        data = temp.GetUnicodeBytes();
+                        ulong skipped;
+                        result = _parser.TrySkipPlpValue((ulong)cb, _stateObj, out skipped);
+                        if (result != TdsOperationStatus.Done)
+                        {
+                            return result;
+                        }
+                        _columnDataBytesRead += (long)skipped;
                     }
                     else
                     {
-                        data = temp.GetNonUnicodeBytes();
-                    }
-                }
-
-                cbytes = data.Length;
-
-                // if no buffer is passed in, return the number of characters we have
-                if (buffer == null)
-                {
-                    remaining = cbytes;
-                    return TdsOperationStatus.Done;
-                }
-
-                // if dataIndex is outside of data range, return 0
-                if (ndataIndex < 0 || ndataIndex >= cbytes)
-                {
-                    return TdsOperationStatus.Done;
-                }
-                try
-                {
-                    if (ndataIndex < cbytes)
-                    {
-                        // help the user out in the case where there's less data than requested
-                        if ((ndataIndex + length) > cbytes)
+                        result = _stateObj.TrySkipLongBytes(cb);
+                        if (result != TdsOperationStatus.Done)
                         {
-                            cbytes = cbytes - ndataIndex;
+                            return result;
                         }
-                        else
-                        {
-                            cbytes = length;
-                        }
+                        _columnDataBytesRead += cb;
+                        _sharedState._columnDataBytesRemaining -= cb;
                     }
-
-                    Buffer.BlockCopy(data, ndataIndex, buffer, bufferIndex, cbytes);
                 }
-                catch (Exception e)
+
+                int bytesRead;
+                result = TryGetBytesInternalSequential(i, buffer, bufferIndex, length, out bytesRead);
+                remaining = (int)bytesRead;
+                return result;
+            }
+
+            // random access now!
+            // note that since we are caching in an array, and arrays aren't 64 bit ready yet,
+            // we need can cast to int if the dataIndex is in range
+            if (dataIndex < 0)
+            {
+                throw ADP.NegativeParameter(nameof(dataIndex));
+            }
+
+            if (dataIndex > int.MaxValue)
+            {
+                throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
+            }
+
+            int ndataIndex = (int)dataIndex;
+            byte[] data;
+
+            // WebData 99342 - in the non-sequential case, we need to support
+            //                 the use of GetBytes on string data columns, but
+            //                 GetSqlBinary isn't supposed to.  What we end up
+            //                 doing isn't exactly pretty, but it does work.
+            if (_metaData[i].metaType.IsBinType)
+            {
+                data = GetSqlBinary(i).Value;
+            }
+            else
+            {
+                Debug.Assert(_metaData[i].metaType.IsLong, "non long type?");
+                Debug.Assert(_metaData[i].metaType.IsCharType, "non-char type?");
+
+                SqlString temp = GetSqlString(i);
+                if (_metaData[i].metaType.IsNCharType)
                 {
-                    if (!ADP.IsCatchableExceptionType(e))
-                    {
-                        throw;
-                    }
-                    cbytes = data.Length;
-
-                    if (length < 0)
-                    {
-                        throw ADP.InvalidDataLength(length);
-                    }
-
-                    // if bad buffer index, throw
-                    if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                    {
-                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
-                    }
-
-                    // if there is not enough room in the buffer for data
-                    if (cbytes + bufferIndex > buffer.Length)
-                    {
-                        throw ADP.InvalidBufferSizeOrIndex(cbytes, bufferIndex);
-                    }
-
-                    throw;
+                    data = temp.GetUnicodeBytes();
                 }
+                else
+                {
+                    data = temp.GetNonUnicodeBytes();
+                }
+            }
 
+            cbytes = data.Length;
+
+            // if no buffer is passed in, return the number of characters we have
+            if (buffer == null)
+            {
                 remaining = cbytes;
                 return TdsOperationStatus.Done;
             }
-#if NETFRAMEWORK && DEBUG
-            finally
+
+            // if dataIndex is outside of data range, return 0
+            if (ndataIndex < 0 || ndataIndex >= cbytes)
             {
-                tdsReliabilitySection.Stop();
+                return TdsOperationStatus.Done;
             }
-#endif //DEBUG
+            try
+            {
+                if (ndataIndex < cbytes)
+                {
+                    // help the user out in the case where there's less data than requested
+                    if ((ndataIndex + length) > cbytes)
+                    {
+                        cbytes = cbytes - ndataIndex;
+                    }
+                    else
+                    {
+                        cbytes = length;
+                    }
+                }
+
+                Buffer.BlockCopy(data, ndataIndex, buffer, bufferIndex, cbytes);
+            }
+            catch (Exception e)
+            {
+                if (!ADP.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+                cbytes = data.Length;
+
+                if (length < 0)
+                {
+                    throw ADP.InvalidDataLength(length);
+                }
+
+                // if bad buffer index, throw
+                if (bufferIndex < 0 || bufferIndex >= buffer.Length)
+                {
+                    throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
+                }
+
+                // if there is not enough room in the buffer for data
+                if (cbytes + bufferIndex > buffer.Length)
+                {
+                    throw ADP.InvalidBufferSizeOrIndex(cbytes, bufferIndex);
+                }
+
+                throw;
+            }
+
+            remaining = cbytes;
+            return TdsOperationStatus.Done;
         }
 
         internal int GetBytesInternalSequential(int i, byte[] buffer, int index, int length, long? timeoutMilliseconds = null)
@@ -2027,66 +1932,47 @@ namespace Microsoft.Data.SqlClient
 
             bytesRead = 0;
             TdsOperationStatus result;
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-#if NETFRAMEWORK && DEBUG
-            TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
 
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
+            if ((_sharedState._columnDataBytesRemaining == 0) || (length == 0))
             {
-                tdsReliabilitySection.Start();
-#else
+                // No data left or nothing requested, return 0
+                bytesRead = 0;
+                return TdsOperationStatus.Done;
+            }
+            else
             {
-#endif
-                if ((_sharedState._columnDataBytesRemaining == 0) || (length == 0))
+                // if plp columns, do partial reads. Don't read the entire value in one shot.
+                if (_metaData[i].metaType.IsPlp)
                 {
-                    // No data left or nothing requested, return 0
-                    bytesRead = 0;
+                    // Read in data
+                    result = _stateObj.TryReadPlpBytes(ref buffer, index, length, out bytesRead);
+                    _columnDataBytesRead += bytesRead;
+                    if (result != TdsOperationStatus.Done)
+                    {
+                        return result;
+                    }
+
+                    // Query for number of bytes left
+                    ulong left;
+                    result = _parser.TryPlpBytesLeft(_stateObj, out left);
+                    if (result != TdsOperationStatus.Done)
+                    {
+                        _sharedState._columnDataBytesRemaining = -1;
+                        return result;
+                    }
+                    _sharedState._columnDataBytesRemaining = (long)left;
                     return TdsOperationStatus.Done;
                 }
                 else
                 {
-                    // if plp columns, do partial reads. Don't read the entire value in one shot.
-                    if (_metaData[i].metaType.IsPlp)
-                    {
-                        // Read in data
-                        result = _stateObj.TryReadPlpBytes(ref buffer, index, length, out bytesRead);
-                        _columnDataBytesRead += bytesRead;
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            return result;
-                        }
-
-                        // Query for number of bytes left
-                        ulong left;
-                        result = _parser.TryPlpBytesLeft(_stateObj, out left);
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            _sharedState._columnDataBytesRemaining = -1;
-                            return result;
-                        }
-                        _sharedState._columnDataBytesRemaining = (long)left;
-                        return TdsOperationStatus.Done;
-                    }
-                    else
-                    {
-                        // Read data (not exceeding the total amount of data available)
-                        int bytesToRead = (int)Math.Min((long)length, _sharedState._columnDataBytesRemaining);
-                        result = _stateObj.TryReadByteArray(buffer.AsSpan(index), bytesToRead, out bytesRead);
-                        _columnDataBytesRead += bytesRead;
-                        _sharedState._columnDataBytesRemaining -= bytesRead;
-                        return result;
-                    }
+                    // Read data (not exceeding the total amount of data available)
+                    int bytesToRead = (int)Math.Min((long)length, _sharedState._columnDataBytesRemaining);
+                    result = _stateObj.TryReadByteArray(buffer.AsSpan(index), bytesToRead, out bytesRead);
+                    _columnDataBytesRead += bytesRead;
+                    _sharedState._columnDataBytesRemaining -= bytesRead;
+                    return result;
                 }
             }
-#if NETFRAMEWORK && DEBUG
-            finally
-            {
-                tdsReliabilitySection.Stop();
-            }
-#endif
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetTextReader/*' />
@@ -2358,113 +2244,93 @@ namespace Microsoft.Data.SqlClient
 
         private long GetCharsFromPlpData(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
         {
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-#if NETFRAMEWORK && DEBUG
-            TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+            long cch;
 
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
+            AssertReaderState(requireData: true, permitAsync: false, columnIndex: i, enforceSequentialAccess: true);
+            Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has active Stream or TextReader");
+            // don't allow get bytes on non-long or non-binary columns
+            Debug.Assert(_metaData[i].metaType.IsPlp, "GetCharsFromPlpData called on a non-plp column!");
+            // Must be sequential reading
+            Debug.Assert(IsCommandBehavior(CommandBehavior.SequentialAccess), "GetCharsFromPlpData called for non-Sequential access");
+
+            if (!_metaData[i].metaType.IsCharType)
             {
-                tdsReliabilitySection.Start();
-#else
+                throw SQL.NonCharColumn(_metaData[i].column);
+            }
+
+            if (_sharedState._nextColumnHeaderToRead <= i)
             {
-#endif
-                long cch;
+                ReadColumnHeader(i);
+            }
 
-                AssertReaderState(requireData: true, permitAsync: false, columnIndex: i, enforceSequentialAccess: true);
-                Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has active Stream or TextReader");
-                // don't allow get bytes on non-long or non-binary columns
-                Debug.Assert(_metaData[i].metaType.IsPlp, "GetCharsFromPlpData called on a non-plp column!");
-                // Must be sequential reading
-                Debug.Assert(IsCommandBehavior(CommandBehavior.SequentialAccess), "GetCharsFromPlpData called for non-Sequential access");
+            // If data is null, ReadColumnHeader sets the data.IsNull bit.
+            if (_data[i] != null && _data[i].IsNull)
+            {
+                throw new SqlNullValueException();
+            }
 
-                if (!_metaData[i].metaType.IsCharType)
-                {
-                    throw SQL.NonCharColumn(_metaData[i].column);
-                }
+            if (dataIndex < _columnDataCharsRead)
+            {
+                // Don't allow re-read of same chars in sequential access mode
+                throw ADP.NonSeqByteAccess(dataIndex, _columnDataCharsRead, nameof(GetChars));
+            }
 
-                if (_sharedState._nextColumnHeaderToRead <= i)
-                {
-                    ReadColumnHeader(i);
-                }
+            // If we start reading the new column, either dataIndex is 0 or
+            // _columnDataCharsRead is 0 and dataIndex > _columnDataCharsRead is true below.
+            // In both cases we will clean decoder
+            if (dataIndex == 0)
+            {
+                _stateObj._plpdecoder = null;
+            }
 
-                // If data is null, ReadColumnHeader sets the data.IsNull bit.
-                if (_data[i] != null && _data[i].IsNull)
-                {
-                    throw new SqlNullValueException();
-                }
+            bool isUnicode = _metaData[i].metaType.IsNCharType;
 
-                if (dataIndex < _columnDataCharsRead)
-                {
-                    // Don't allow re-read of same chars in sequential access mode
-                    throw ADP.NonSeqByteAccess(dataIndex, _columnDataCharsRead, nameof(GetChars));
-                }
-
-                // If we start reading the new column, either dataIndex is 0 or
-                // _columnDataCharsRead is 0 and dataIndex > _columnDataCharsRead is true below.
-                // In both cases we will clean decoder
-                if (dataIndex == 0)
-                {
-                    _stateObj._plpdecoder = null;
-                }
-
-                bool isUnicode = _metaData[i].metaType.IsNCharType;
-
-                // If there are an unknown (-1) number of bytes left for a PLP, read its size
-                if (-1 == _sharedState._columnDataBytesRemaining)
-                {
-                    _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
-                }
-
-                if (0 == _sharedState._columnDataBytesRemaining)
-                {
-                    _stateObj._plpdecoder = null;
-                    return 0; // We've read this column to the end
-                }
-
-                // if no buffer is passed in, return the total number of characters or -1
-                if (buffer == null)
-                {
-                    cch = (long)_parser.PlpBytesTotalLength(_stateObj);
-                    return (isUnicode && (cch > 0)) ? cch >> 1 : cch;
-                }
-                if (dataIndex > _columnDataCharsRead)
-                {
-                    // Skip chars
-
-                    // Clean decoder state: we do not reset it, but destroy to ensure
-                    // that we do not start decoding the column with decoder from the old one
-                    _stateObj._plpdecoder = null;
-                    cch = dataIndex - _columnDataCharsRead;
-                    cch = isUnicode ? (cch << 1) : cch;
-                    cch = (long)_parser.SkipPlpValue((ulong)(cch), _stateObj);
-                    _columnDataBytesRead += cch;
-                    _columnDataCharsRead += (isUnicode && (cch > 0)) ? cch >> 1 : cch;
-                }
-                cch = length;
-
-                if (isUnicode)
-                {
-                    cch = (long)_parser.ReadPlpUnicodeChars(ref buffer, bufferIndex, length, _stateObj);
-                    _columnDataBytesRead += (cch << 1);
-                }
-                else
-                {
-                    cch = (long)_parser.ReadPlpAnsiChars(ref buffer, bufferIndex, length, _metaData[i], _stateObj);
-                    _columnDataBytesRead += cch << 1;
-                }
-                _columnDataCharsRead += cch;
+            // If there are an unknown (-1) number of bytes left for a PLP, read its size
+            if (-1 == _sharedState._columnDataBytesRemaining)
+            {
                 _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
-                return cch;
             }
-#if NETFRAMEWORK && DEBUG
-            finally
+
+            if (0 == _sharedState._columnDataBytesRemaining)
             {
-                tdsReliabilitySection.Stop();
+                _stateObj._plpdecoder = null;
+                return 0; // We've read this column to the end
             }
-#endif
+
+            // if no buffer is passed in, return the total number of characters or -1
+            if (buffer == null)
+            {
+                cch = (long)_parser.PlpBytesTotalLength(_stateObj);
+                return (isUnicode && (cch > 0)) ? cch >> 1 : cch;
+            }
+            if (dataIndex > _columnDataCharsRead)
+            {
+                // Skip chars
+
+                // Clean decoder state: we do not reset it, but destroy to ensure
+                // that we do not start decoding the column with decoder from the old one
+                _stateObj._plpdecoder = null;
+                cch = dataIndex - _columnDataCharsRead;
+                cch = isUnicode ? (cch << 1) : cch;
+                cch = (long)_parser.SkipPlpValue((ulong)(cch), _stateObj);
+                _columnDataBytesRead += cch;
+                _columnDataCharsRead += (isUnicode && (cch > 0)) ? cch >> 1 : cch;
+            }
+            cch = length;
+
+            if (isUnicode)
+            {
+                cch = (long)_parser.ReadPlpUnicodeChars(ref buffer, bufferIndex, length, _stateObj);
+                _columnDataBytesRead += (cch << 1);
+            }
+            else
+            {
+                cch = (long)_parser.ReadPlpAnsiChars(ref buffer, bufferIndex, length, _metaData[i], _stateObj);
+                _columnDataBytesRead += cch << 1;
+            }
+            _columnDataCharsRead += cch;
+            _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
+            return cch;
         }
 
         internal long GetStreamingXmlChars(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
@@ -3565,155 +3431,138 @@ namespace Microsoft.Data.SqlClient
 
                 try
                 {
-#if NETFRAMEWORK && DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                    statistics = SqlStatistics.StartTimer(Statistics);
 
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
+                    SetTimeout(_defaultTimeoutMilliseconds);
+
+                    if (IsClosed)
                     {
-               	        tdsReliabilitySection.Start();
-#else
+                        throw ADP.DataReaderClosed(nameof(NextResult));
+                    }
+                    _fieldNameLookup = null;
+
+                    bool success = false; // WebData 100390
+                    _hasRows = false; // reset HasRows
+
+                    // if we are specifically only processing a single result, then read all the results off the wire and detach
+                    if (IsCommandBehavior(CommandBehavior.SingleResult))
                     {
-#endif
-                        statistics = SqlStatistics.StartTimer(Statistics);
-
-                        SetTimeout(_defaultTimeoutMilliseconds);
-
-                        if (IsClosed)
+                        result = TryCloseInternal(closeReader: false);
+                        if (result != TdsOperationStatus.Done)
                         {
-                            throw ADP.DataReaderClosed(nameof(NextResult));
+                            more = false;
+                            return result;
                         }
-                        _fieldNameLookup = null;
 
-                        bool success = false; // WebData 100390
-                        _hasRows = false; // reset HasRows
+                        // In the case of not closing the reader, null out the metadata AFTER
+                        // CloseInternal finishes - since CloseInternal may go to the wire
+                        // and use the metadata.
+                        ClearMetaData();
+                        more = success;
+                        return TdsOperationStatus.Done;
+                    }
 
-                        // if we are specifically only processing a single result, then read all the results off the wire and detach
-                        if (IsCommandBehavior(CommandBehavior.SingleResult))
+                    if (_parser != null)
+                    {
+                        // if there are more rows, then skip them, the user wants the next result
+                        bool moreRows = true;
+                        while (moreRows)
                         {
+                            result = TryReadInternal(false, out moreRows);
+                            if (result != TdsOperationStatus.Done)
+                            {
+                                // don't reset set the timeout value
+                                more = false;
+                                return result;
+                            }
+                        }
+                    }
+
+                    // we may be done, so continue only if we have not detached ourselves from the parser
+                    if (_parser != null)
+                    {
+                        bool moreResults;
+                        result = TryHasMoreResults(out moreResults);
+                        if (result != TdsOperationStatus.Done)
+                        {
+                            more = false;
+                            return result;
+                        }
+                        if (moreResults)
+                        {
+                            _metaDataConsumed = false;
+                            _browseModeInfoConsumed = false;
+
+                            switch (_altRowStatus)
+                            {
+                                case ALTROWSTATUS.AltRow:
+                                    int altRowId;
+                                    result = _parser.TryGetAltRowId(_stateObj, out altRowId);
+                                    if (result != TdsOperationStatus.Done)
+                                    {
+                                        more = false;
+                                        return result;
+                                    }
+                                    _SqlMetaDataSet altMetaDataSet = _altMetaDataSetCollection.GetAltMetaData(altRowId);
+                                    if (altMetaDataSet != null)
+                                    {
+                                        _metaData = altMetaDataSet;
+                                    }
+                                    Debug.Assert((_metaData != null), "Can't match up altrowmetadata");
+                                    break;
+                                case ALTROWSTATUS.Done:
+                                    // restore the row-metaData
+                                    _metaData = _altMetaDataSetCollection.metaDataSet;
+                                    Debug.Assert(_altRowStatus == ALTROWSTATUS.Done, "invalid AltRowStatus");
+                                    _altRowStatus = ALTROWSTATUS.Null;
+                                    break;
+                                default:
+                                    result = TryConsumeMetaData();
+                                    if (result != TdsOperationStatus.Done)
+                                    {
+                                        more = false;
+                                        return result;
+                                    }
+                                    if (_metaData == null)
+                                    {
+                                        more = false;
+                                        return TdsOperationStatus.Done;
+                                    }
+                                    break;
+                            }
+
+                            success = true;
+                        }
+                        else
+                        {
+                            // detach the parser from this reader now
                             result = TryCloseInternal(closeReader: false);
                             if (result != TdsOperationStatus.Done)
                             {
                                 more = false;
-                                return result;
+                                return TdsOperationStatus.Done;
                             }
 
                             // In the case of not closing the reader, null out the metadata AFTER
                             // CloseInternal finishes - since CloseInternal may go to the wire
                             // and use the metadata.
-                            ClearMetaData();
-                            more = success;
-                            return TdsOperationStatus.Done;
-                        }
-
-                        if (_parser != null)
-                        {
-                            // if there are more rows, then skip them, the user wants the next result
-                            bool moreRows = true;
-                            while (moreRows)
-                            {
-                                result = TryReadInternal(false, out moreRows);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    // don't reset set the timeout value
-                                    more = false;
-                                    return result;
-                                }
-                            }
-                        }
-
-                        // we may be done, so continue only if we have not detached ourselves from the parser
-                        if (_parser != null)
-                        {
-                            bool moreResults;
-                            result = TryHasMoreResults(out moreResults);
+                            result = TrySetMetaData(null, false);
                             if (result != TdsOperationStatus.Done)
                             {
                                 more = false;
                                 return result;
                             }
-                            if (moreResults)
-                            {
-                                _metaDataConsumed = false;
-                                _browseModeInfoConsumed = false;
-
-                                switch (_altRowStatus)
-                                {
-                                    case ALTROWSTATUS.AltRow:
-                                        int altRowId;
-                                        result = _parser.TryGetAltRowId(_stateObj, out altRowId);
-                                        if (result != TdsOperationStatus.Done)
-                                        {
-                                            more = false;
-                                            return result;
-                                        }
-                                        _SqlMetaDataSet altMetaDataSet = _altMetaDataSetCollection.GetAltMetaData(altRowId);
-                                        if (altMetaDataSet != null)
-                                        {
-                                            _metaData = altMetaDataSet;
-                                        }
-                                        Debug.Assert((_metaData != null), "Can't match up altrowmetadata");
-                                        break;
-                                    case ALTROWSTATUS.Done:
-                                        // restore the row-metaData
-                                        _metaData = _altMetaDataSetCollection.metaDataSet;
-                                        Debug.Assert(_altRowStatus == ALTROWSTATUS.Done, "invalid AltRowStatus");
-                                        _altRowStatus = ALTROWSTATUS.Null;
-                                        break;
-                                    default:
-                                        result = TryConsumeMetaData();
-                                        if (result != TdsOperationStatus.Done)
-                                        {
-                                            more = false;
-                                            return result;
-                                        }
-                                        if (_metaData == null)
-                                        {
-                                            more = false;
-                                            return TdsOperationStatus.Done;
-                                        }
-                                        break;
-                                }
-
-                                success = true;
-                            }
-                            else
-                            {
-                                // detach the parser from this reader now
-                                result = TryCloseInternal(closeReader: false);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    more = false;
-                                    return TdsOperationStatus.Done;
-                                }
-
-                                // In the case of not closing the reader, null out the metadata AFTER
-                                // CloseInternal finishes - since CloseInternal may go to the wire
-                                // and use the metadata.
-                                result = TrySetMetaData(null, false);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    more = false;
-                                    return result;
-                                }
-                            }
                         }
-                        else
-                        {
-                            // Clear state in case of Read calling CloseInternal() then user calls NextResult()
-                            // and the case where the Read() above will do essentially the same thing.
-                            ClearMetaData();
-                        }
-
-                        more = success;
-                        return TdsOperationStatus.Done;
                     }
-#if NETFRAMEWORK && DEBUG
-                    finally 
+                    else
                     {
-                	    tdsReliabilitySection.Stop();
+                        // Clear state in case of Read calling CloseInternal() then user calls NextResult()
+                        // and the case where the Read() above will do essentially the same thing.
+                        ClearMetaData();
                     }
-#endif
+
+                    more = success;
+                    return TdsOperationStatus.Done;
                 }
                 finally
                 {
@@ -3755,140 +3604,107 @@ namespace Microsoft.Data.SqlClient
 
                 try
                 {
-#if NETFRAMEWORK && DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                    TdsOperationStatus result;
+                    statistics = SqlStatistics.StartTimer(Statistics);
 
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
+                    if (_parser != null)
                     {
-                        tdsReliabilitySection.Start();
-#else
-                    {
-#endif
-                        TdsOperationStatus result;
-                        statistics = SqlStatistics.StartTimer(Statistics);
-
-                        if (_parser != null)
+                        if (setTimeout)
                         {
-                            if (setTimeout)
+                            SetTimeout(_defaultTimeoutMilliseconds);
+                        }
+                        if (_sharedState._dataReady)
+                        {
+                            result = TryCleanPartialRead();
+                            if (result != TdsOperationStatus.Done)
                             {
-                                SetTimeout(_defaultTimeoutMilliseconds);
+                                more = false;
+                                return result;
                             }
-                            if (_sharedState._dataReady)
+                        }
+
+                        // clear out our buffers
+                        SqlBuffer.Clear(_data);
+
+                        _sharedState._nextColumnHeaderToRead = 0;
+                        _sharedState._nextColumnDataToRead = 0;
+                        _sharedState._columnDataBytesRemaining = -1; // unknown
+                        _lastColumnWithDataChunkRead = -1;
+
+                        if (!_haltRead)
+                        {
+                            bool moreRows;
+                            result = TryHasMoreRows(out moreRows);
+                            if (result != TdsOperationStatus.Done)
                             {
-                                result = TryCleanPartialRead();
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    more = false;
-                                    return result;
-                                }
+                                more = false;
+                                return result;
                             }
-
-                            // clear out our buffers
-                            SqlBuffer.Clear(_data);
-
-                            _sharedState._nextColumnHeaderToRead = 0;
-                            _sharedState._nextColumnDataToRead = 0;
-                            _sharedState._columnDataBytesRemaining = -1; // unknown
-                            _lastColumnWithDataChunkRead = -1;
-
-                            if (!_haltRead)
+                            if (moreRows)
                             {
-                                bool moreRows;
-                                result = TryHasMoreRows(out moreRows);
-                                if (result != TdsOperationStatus.Done)
+                                // read the row from the backend (unless it's an altrow were the marker is already inside the altrow ...)
+                                while (_stateObj.HasPendingData)
                                 {
-                                    more = false;
-                                    return result;
-                                }
-                                if (moreRows)
-                                {
-                                    // read the row from the backend (unless it's an altrow were the marker is already inside the altrow ...)
-                                    while (_stateObj.HasPendingData)
+                                    if (_altRowStatus != ALTROWSTATUS.AltRow)
                                     {
-                                        if (_altRowStatus != ALTROWSTATUS.AltRow)
-                                        {
-                                            // if this is an ordinary row we let the run method consume the ROW token
-                                            result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady);
-                                            if (result != TdsOperationStatus.Done)
-                                            {
-                                                more = false;
-                                                return result;
-                                            }
-                                            if (_sharedState._dataReady)
-                                            {
-                                                break;
-                                            }
-                                        }
-                                        else
-                                        {
-                                            // ALTROW token and AltrowId are already consumed ...
-                                            Debug.Assert(_altRowStatus == ALTROWSTATUS.AltRow, "invalid AltRowStatus");
-                                            _altRowStatus = ALTROWSTATUS.Done;
-                                            _sharedState._dataReady = true;
-                                            break;
-                                        }
-                                    }
-                                    if (_sharedState._dataReady)
-                                    {
-                                        _haltRead = IsCommandBehavior(CommandBehavior.SingleRow);
-                                        more = true;
-                                        return TdsOperationStatus.Done;
-                                    }
-                                }
-
-                                if (!_stateObj.HasPendingData)
-                                {
-                                    result = TryCloseInternal(closeReader: false);
-                                    if (result != TdsOperationStatus.Done)
-                                    {
-                                        more = false;
-                                        return result;
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                // if we did not get a row and halt is true, clean off rows of result
-                                // success must be false - or else we could have just read off row and set
-                                // halt to true
-                                bool moreRows;
-                                result = TryHasMoreRows(out moreRows);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    more = false;
-                                    return result;
-                                }
-                                while (moreRows)
-                                {
-                                    // if we are in SingleRow mode, and we've read the first row,
-                                    // read the rest of the rows, if any
-                                    while (_stateObj.HasPendingData && !_sharedState._dataReady)
-                                    {
+                                        // if this is an ordinary row we let the run method consume the ROW token
                                         result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady);
                                         if (result != TdsOperationStatus.Done)
                                         {
                                             more = false;
                                             return result;
                                         }
-                                    }
-
-                                    if (_sharedState._dataReady)
-                                    {
-                                        result = TryCleanPartialRead();
-                                        if (result != TdsOperationStatus.Done)
+                                        if (_sharedState._dataReady)
                                         {
-                                            more = false;
-                                            return result;
+                                            break;
                                         }
                                     }
+                                    else
+                                    {
+                                        // ALTROW token and AltrowId are already consumed ...
+                                        Debug.Assert(_altRowStatus == ALTROWSTATUS.AltRow, "invalid AltRowStatus");
+                                        _altRowStatus = ALTROWSTATUS.Done;
+                                        _sharedState._dataReady = true;
+                                        break;
+                                    }
+                                }
+                                if (_sharedState._dataReady)
+                                {
+                                    _haltRead = IsCommandBehavior(CommandBehavior.SingleRow);
+                                    more = true;
+                                    return TdsOperationStatus.Done;
+                                }
+                            }
 
-                                    // clear out our buffers
-                                    SqlBuffer.Clear(_data);
-
-                                    _sharedState._nextColumnHeaderToRead = 0;
-
-                                    result = TryHasMoreRows(out moreRows);
+                            if (!_stateObj.HasPendingData)
+                            {
+                                result = TryCloseInternal(closeReader: false);
+                                if (result != TdsOperationStatus.Done)
+                                {
+                                    more = false;
+                                    return result;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // if we did not get a row and halt is true, clean off rows of result
+                            // success must be false - or else we could have just read off row and set
+                            // halt to true
+                            bool moreRows;
+                            result = TryHasMoreRows(out moreRows);
+                            if (result != TdsOperationStatus.Done)
+                            {
+                                more = false;
+                                return result;
+                            }
+                            while (moreRows)
+                            {
+                                // if we are in SingleRow mode, and we've read the first row,
+                                // read the rest of the rows, if any
+                                while (_stateObj.HasPendingData && !_sharedState._dataReady)
+                                {
+                                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady);
                                     if (result != TdsOperationStatus.Done)
                                     {
                                         more = false;
@@ -3896,38 +3712,54 @@ namespace Microsoft.Data.SqlClient
                                     }
                                 }
 
-                                // reset haltRead
-                                _haltRead = false;
+                                if (_sharedState._dataReady)
+                                {
+                                    result = TryCleanPartialRead();
+                                    if (result != TdsOperationStatus.Done)
+                                    {
+                                        more = false;
+                                        return result;
+                                    }
+                                }
+
+                                // clear out our buffers
+                                SqlBuffer.Clear(_data);
+
+                                _sharedState._nextColumnHeaderToRead = 0;
+
+                                result = TryHasMoreRows(out moreRows);
+                                if (result != TdsOperationStatus.Done)
+                                {
+                                    more = false;
+                                    return result;
+                                }
                             }
+
+                            // reset haltRead
+                            _haltRead = false;
                         }
-                        else if (IsClosed)
-                        {
-                            throw ADP.DataReaderClosed(nameof(Read));
-                        }
-                        more = false;
+                    }
+                    else if (IsClosed)
+                    {
+                        throw ADP.DataReaderClosed(nameof(Read));
+                    }
+                    more = false;
 
 #if DEBUG
-                        if ((!_sharedState._dataReady) && (_stateObj.HasPendingData))
+                    if ((!_sharedState._dataReady) && (_stateObj.HasPendingData))
+                    {
+                        byte token;
+                        result = _stateObj.TryPeekByte(out token);
+                        if (result != TdsOperationStatus.Done)
                         {
-                            byte token;
-                            result = _stateObj.TryPeekByte(out token);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                return result;
-                            }
-
-                            Debug.Assert(TdsParser.IsValidTdsToken(token), $"DataReady is false, but next token is invalid: {token,-2:X2}");
+                            return result;
                         }
+
+                        Debug.Assert(TdsParser.IsValidTdsToken(token), $"DataReady is false, but next token is invalid: {token,-2:X2}");
+                    }
 #endif
 
-                        return TdsOperationStatus.Done;
-                    }
-#if NETFRAMEWORK && DEBUG
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif //DEBUG
+                    return TdsOperationStatus.Done;
                 }
                 catch (OutOfMemoryException e)
                 {
@@ -3987,41 +3819,22 @@ namespace Microsoft.Data.SqlClient
         private TdsOperationStatus TryReadColumn(int i, bool setTimeout, bool allowPartiallyReadColumn = false, bool forStreaming = false)
         {
             CheckDataIsReady(columnIndex: i, permitAsync: true, allowPartiallyReadColumn: allowPartiallyReadColumn, methodName: null);
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-#if NETFRAMEWORK && DEBUG
-            TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
 
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                tdsReliabilitySection.Start();
-#else
-            {
-#endif
-	            Debug.Assert(_sharedState._nextColumnHeaderToRead <= _metaData.Length, "_sharedState._nextColumnHeaderToRead too large");
-	            Debug.Assert(_sharedState._nextColumnDataToRead <= _metaData.Length, "_sharedState._nextColumnDataToRead too large");
-	
-	            if (setTimeout)
-	            {
-	                SetTimeout(_defaultTimeoutMilliseconds);
-	            }
-	
-	            TdsOperationStatus result = TryReadColumnInternal(i, readHeaderOnly: false, forStreaming: forStreaming);
-	            if (result != TdsOperationStatus.Done)
-	            {
-	                return result;
-	            }
-	
-	            Debug.Assert(_data[i] != null, " data buffer is null?");
-            }
-#if NETFRAMEWORK && DEBUG
-            finally
-            {
-                tdsReliabilitySection.Stop();
-            }
-#endif
+	        Debug.Assert(_sharedState._nextColumnHeaderToRead <= _metaData.Length, "_sharedState._nextColumnHeaderToRead too large");
+	        Debug.Assert(_sharedState._nextColumnDataToRead <= _metaData.Length, "_sharedState._nextColumnDataToRead too large");
+
+	        if (setTimeout)
+	        {
+	            SetTimeout(_defaultTimeoutMilliseconds);
+	        }
+
+	        TdsOperationStatus result = TryReadColumnInternal(i, readHeaderOnly: false, forStreaming: forStreaming);
+	        if (result != TdsOperationStatus.Done)
+	        {
+	            return result;
+	        }
+
+	        Debug.Assert(_data[i] != null, " data buffer is null?");
 
             return TdsOperationStatus.Done;
         }
@@ -4065,27 +3878,7 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.InvalidRead();
             }
 
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-#if NETFRAMEWORK && DEBUG
-            TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                tdsReliabilitySection.Start();
-#else
-            {
-#endif
-                return TryReadColumnInternal(i, readHeaderOnly: true);
-            }
-#if NETFRAMEWORK && DEBUG
-            finally
-            {
-                tdsReliabilitySection.Stop();
-            }
-#endif
+            return TryReadColumnInternal(i, readHeaderOnly: true);
         }
 
         internal TdsOperationStatus TryReadColumnInternal(int i, bool readHeaderOnly = false, bool forStreaming = false)
@@ -5556,25 +5349,7 @@ namespace Microsoft.Data.SqlClient
             {
                 if (reader.IsCommandBehavior(CommandBehavior.SequentialAccess) && reader._sharedState._dataReady)
                 {
-                    bool internalReadSuccess = false;
-#if NETFRAMEWORK
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
-                    {
-                        tdsReliabilitySection.Start();
-#else
-                    {
-#endif
-                        internalReadSuccess = reader.TryReadColumnInternal(context._columnIndex, readHeaderOnly: true) == TdsOperationStatus.Done;
-                    }
-#if NETFRAMEWORK
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif
-
+                    bool internalReadSuccess = reader.TryReadColumnInternal(context._columnIndex, readHeaderOnly: true) == TdsOperationStatus.Done;
                     if (internalReadSuccess)
                     {
                         return Task.FromResult<T>(reader.GetFieldValueFromSqlBufferInternal<T>(reader._data[columnIndex], reader._metaData[columnIndex], isAsync: true));

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.netcore.cs
@@ -21,27 +21,6 @@ namespace Microsoft.Data.SqlClient
             public Exception exception;
         }
 
-        internal struct ReliabilitySection
-        {
-            /// <summary>
-            /// This is a no-op in netcore version. Only needed for merging with netfx codebase.
-            /// </summary>
-            [Conditional("NETFRAMEWORK")]
-            internal static void Assert(string message)
-            {
-            }
-
-            [Conditional("NETFRAMEWORK")]
-            internal void Start()
-            {
-            }
-
-            [Conditional("NETFRAMEWORK")]
-            internal void Stop()
-            {
-            }
-        }
-
         internal static void FillGuidBytes(Guid guid, Span<byte> buffer) => guid.TryWriteBytes(buffer);
 
         internal static void FillDoubleBytes(double value, Span<byte> buffer) => BinaryPrimitives.TryWriteInt64LittleEndian(buffer, BitConverter.DoubleToInt64Bits(value));

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
@@ -298,8 +298,6 @@ namespace Microsoft.Data.SqlClient
         // This method should only be called by ReadSni!  If not - it may have problems with timeouts!
         private void ReadSniError(TdsParserStateObject stateObj, uint error)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadSniSyncError");  // you need to setup for a thread abort somewhere before you call this method
-
             if (TdsEnums.SNI_WAIT_TIMEOUT == error)
             {
                 Debug.Assert(_syncOverAsync, "Should never reach here with async on!");
@@ -753,8 +751,6 @@ namespace Microsoft.Data.SqlClient
         //
         internal void WriteSecureString(SecureString secureString)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to WriteSecureString");  // you need to setup for a thread abort somewhere before you call this method
-
             Debug.Assert(_securePasswords[0] == null || _securePasswords[1] == null, "There are more than two secure passwords");
 
             int index = _securePasswords[0] != null ? 1 : 0;
@@ -829,8 +825,6 @@ namespace Microsoft.Data.SqlClient
         // and then the buffer is re-initialized in flush() and then the byte is put in the buffer.
         internal void WriteByte(byte b)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to WriteByte");  // you need to setup for a thread abort somewhere before you call this method
-
             Debug.Assert(_outBytesUsed <= _outBuff.Length, "ERROR - TDSParser: _outBytesUsed > _outBuff.Length");
 
             // check to make sure we haven't used the full amount of space available in the buffer, if so, flush it
@@ -866,8 +860,6 @@ namespace Microsoft.Data.SqlClient
             }
             try
             {
-                TdsParser.ReliabilitySection.Assert("unreliable call to WriteByteArray");  // you need to setup for a thread abort somewhere before you call this method
-
                 bool async = _parser._asyncWrite;  // NOTE: We are capturing this now for the assert after the Task is returned, since WritePacket will turn off async if there is an exception
                 Debug.Assert(async || _asyncWriteCount == 0);
                 // Do we have to send out in packet size chunks, or can we rely on netlib layer to break it up?

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1426,26 +1426,9 @@ namespace Microsoft.Data.SqlClient
 
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
-                {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
-                    statistics = SqlStatistics.StartTimer(Statistics);
-                    InnerConnection.ChangeDatabase(database);
-                }
-#if DEBUG
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
-#endif //DEBUG
+                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
+                statistics = SqlStatistics.StartTimer(Statistics);
+                InnerConnection.ChangeDatabase(database);
             }
             catch (System.OutOfMemoryException e)
             {
@@ -1524,48 +1507,31 @@ namespace Microsoft.Data.SqlClient
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-#if DEBUG
-                        TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
+                    statistics = SqlStatistics.StartTimer(Statistics);
 
-                        RuntimeHelpers.PrepareConstrainedRegions();
-                        try
-                        {
-                            tdsReliabilitySection.Start();
-#else
+                    Task reconnectTask = _currentReconnectionTask;
+                    if (reconnectTask != null && !reconnectTask.IsCompleted)
                     {
-#endif //DEBUG
-                        bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
-                        statistics = SqlStatistics.StartTimer(Statistics);
-
-                        Task reconnectTask = _currentReconnectionTask;
-                        if (reconnectTask != null && !reconnectTask.IsCompleted)
+                        CancellationTokenSource cts = _reconnectionCancellationSource;
+                        if (cts != null)
                         {
-                            CancellationTokenSource cts = _reconnectionCancellationSource;
-                            if (cts != null)
-                            {
-                                cts.Cancel();
-                            }
-                            AsyncHelper.WaitForCompletion(reconnectTask, 0, null, rethrowExceptions: false); // we do not need to deal with possible exceptions in reconnection
-                            if (State != ConnectionState.Open)
-                            {// if we cancelled before the connection was opened
-                                OnStateChange(DbConnectionInternal.StateChangeClosed);
-                            }
+                            cts.Cancel();
                         }
-                        CancelOpenAndWait();
-                        CloseInnerConnection();
-                        GC.SuppressFinalize(this);
-
-                        if (Statistics != null)
-                        {
-                            _statistics._closeTimestamp = ADP.TimerCurrent();
+                        AsyncHelper.WaitForCompletion(reconnectTask, 0, null, rethrowExceptions: false); // we do not need to deal with possible exceptions in reconnection
+                        if (State != ConnectionState.Open)
+                        {// if we cancelled before the connection was opened
+                            OnStateChange(DbConnectionInternal.StateChangeClosed);
                         }
                     }
-#if DEBUG
-                        finally
-                        {
-                            tdsReliabilitySection.Stop();
-                        }
-#endif //DEBUG
+                    CancelOpenAndWait();
+                    CloseInnerConnection();
+                    GC.SuppressFinalize(this);
+
+                    if (Statistics != null)
+                    {
+                        _statistics._closeTimestamp = ADP.TimerCurrent();
+                    }
                 }
                 catch (System.OutOfMemoryException e)
                 {
@@ -2138,69 +2104,52 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
+                if (ForceNewConnection)
                 {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                    if (ForceNewConnection)
+                    if (!InnerConnection.TryReplaceConnection(this, ConnectionFactory, retry, UserConnectionOptions))
                     {
-                        if (!InnerConnection.TryReplaceConnection(this, ConnectionFactory, retry, UserConnectionOptions))
-                        {
-                            return false;
-                        }
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (!InnerConnection.TryOpenConnection(this, ConnectionFactory, retry, UserConnectionOptions))
+                    {
+                        return false;
+                    }
+                }
+                // does not require GC.KeepAlive(this) because of OnStateChange
+
+                // GetBestEffortCleanup must happen AFTER OpenConnection to get the correct target.
+                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
+
+                var tdsInnerConnection = (InnerConnection as SqlInternalConnectionTds);
+                if (tdsInnerConnection == null)
+                {
+                    SqlInternalConnectionSmi innerConnection = (InnerConnection as SqlInternalConnectionSmi);
+                    innerConnection.AutomaticEnlistment();
+                }
+                else
+                {
+                    Debug.Assert(tdsInnerConnection.Parser != null, "Where's the parser?");
+
+                    if (!tdsInnerConnection.ConnectionOptions.Pooling)
+                    {
+                        // For non-pooled connections, we need to make sure that the finalizer does actually run to avoid leaking SNI handles
+                        GC.ReRegisterForFinalize(this);
+                    }
+
+                    if (StatisticsEnabled)
+                    {
+                        _statistics._openTimestamp = ADP.TimerCurrent();
+                        tdsInnerConnection.Parser.Statistics = _statistics;
                     }
                     else
                     {
-                        if (!InnerConnection.TryOpenConnection(this, ConnectionFactory, retry, UserConnectionOptions))
-                        {
-                            return false;
-                        }
-                    }
-                    // does not require GC.KeepAlive(this) because of OnStateChange
-
-                    // GetBestEffortCleanup must happen AFTER OpenConnection to get the correct target.
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
-
-                    var tdsInnerConnection = (InnerConnection as SqlInternalConnectionTds);
-                    if (tdsInnerConnection == null)
-                    {
-                        SqlInternalConnectionSmi innerConnection = (InnerConnection as SqlInternalConnectionSmi);
-                        innerConnection.AutomaticEnlistment();
-                    }
-                    else
-                    {
-                        Debug.Assert(tdsInnerConnection.Parser != null, "Where's the parser?");
-
-                        if (!tdsInnerConnection.ConnectionOptions.Pooling)
-                        {
-                            // For non-pooled connections, we need to make sure that the finalizer does actually run to avoid leaking SNI handles
-                            GC.ReRegisterForFinalize(this);
-                        }
-
-                        if (StatisticsEnabled)
-                        {
-                            _statistics._openTimestamp = ADP.TimerCurrent();
-                            tdsInnerConnection.Parser.Statistics = _statistics;
-                        }
-                        else
-                        {
-                            tdsInnerConnection.Parser.Statistics = null;
-                            _statistics = null; // in case of previous Open/Close/reset_CollectStats sequence
-                        }
+                        tdsInnerConnection.Parser.Statistics = null;
+                        _statistics = null; // in case of previous Open/Close/reset_CollectStats sequence
                     }
                 }
-#if DEBUG
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
-#endif //DEBUG
             }
             catch (System.OutOfMemoryException e)
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -5640,7 +5640,6 @@ namespace Microsoft.Data.SqlClient
             {
                 if (reader.IsCommandBehavior(CommandBehavior.SequentialAccess) && reader._sharedState._dataReady)
                 {
-                    RuntimeHelpers.PrepareConstrainedRegions();
                     bool internalReadSuccess = reader.TryReadColumnInternal(context._columnIndex, readHeaderOnly: true, forStreaming: false) == TdsOperationStatus.Done;
 
                     if (internalReadSuccess)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -264,29 +264,11 @@ namespace Microsoft.Data.SqlClient
                     RuntimeHelpers.PrepareConstrainedRegions();
                     try
                     {
-#if DEBUG
-                        TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                        RuntimeHelpers.PrepareConstrainedRegions();
-                        try
+                        Debug.Assert(_stateObj == null || _stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+                        if (TryConsumeMetaData() != TdsOperationStatus.Done)
                         {
-                            tdsReliabilitySection.Start();
-#else
-                        {
-#endif //DEBUG
-
-                            Debug.Assert(_stateObj == null || _stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                            if (TryConsumeMetaData() != TdsOperationStatus.Done)
-                            {
-                                throw SQL.SynchronousCallMayNotPend();
-                            }
+                            throw SQL.SynchronousCallMayNotPend();
                         }
-#if DEBUG
-                        finally
-                        {
-                            tdsReliabilitySection.Stop();
-                        }
-#endif //DEBUG
                     }
                     catch (System.OutOfMemoryException e)
                     {
@@ -891,26 +873,9 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
-                {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                    TdsOperationStatus result = TryCleanPartialRead();
-                    Debug.Assert(result == TdsOperationStatus.Done, "Should not pend on sync call");
-                    Debug.Assert(!_sharedState._dataReady, "_dataReady should be cleared");
-                }
-#if DEBUG
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
-#endif //DEBUG
+                TdsOperationStatus result = TryCleanPartialRead();
+                Debug.Assert(result == TdsOperationStatus.Done, "Should not pend on sync call");
+                Debug.Assert(!_sharedState._dataReady, "_dataReady should be cleared");
             }
             catch (System.OutOfMemoryException e)
             {
@@ -1060,77 +1025,60 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
+                if ((!_isClosed) && (parser != null) && (stateObj != null) && (stateObj.HasPendingData))
                 {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                    if ((!_isClosed) && (parser != null) && (stateObj != null) && (stateObj.HasPendingData))
+                    // It is possible for this to be called during connection close on a
+                    // broken connection, so check state first.
+                    if (parser.State == TdsParserState.OpenLoggedIn)
                     {
-                        // It is possible for this to be called during connection close on a
-                        // broken connection, so check state first.
-                        if (parser.State == TdsParserState.OpenLoggedIn)
+                        // if user called read but didn't fetch any values, skip the row
+                        // same applies after NextResult on ALTROW because NextResult starts rowconsumption in that case ...
+
+                        Debug.Assert(SniContext.Snix_Read == stateObj.SniContext, String.Format((IFormatProvider)null, "The SniContext should be Snix_Read but it actually is {0}", stateObj.SniContext));
+
+                        if (_altRowStatus == ALTROWSTATUS.AltRow)
                         {
-                            // if user called read but didn't fetch any values, skip the row
-                            // same applies after NextResult on ALTROW because NextResult starts rowconsumption in that case ...
-
-                            Debug.Assert(SniContext.Snix_Read == stateObj.SniContext, String.Format((IFormatProvider)null, "The SniContext should be Snix_Read but it actually is {0}", stateObj.SniContext));
-
-                            if (_altRowStatus == ALTROWSTATUS.AltRow)
+                            _sharedState._dataReady = true;      // set _sharedState._dataReady to not confuse CleanPartialRead
+                        }
+                        _stateObj.SetTimeoutStateStopped();
+                        if (_sharedState._dataReady)
+                        {
+                            cleanDataFailed = true;
+                            result = TryCleanPartialRead();
+                            if (result == TdsOperationStatus.Done)
                             {
-                                _sharedState._dataReady = true;      // set _sharedState._dataReady to not confuse CleanPartialRead
+                                cleanDataFailed = false;
                             }
-                            _stateObj.SetTimeoutStateStopped();
-                            if (_sharedState._dataReady)
-                            {
-                                cleanDataFailed = true;
-                                result = TryCleanPartialRead();
-                                if (result == TdsOperationStatus.Done)
-                                {
-                                    cleanDataFailed = false;
-                                }
-                                else
-                                {
-                                    return result;
-                                }
-                            }
-#if DEBUG
                             else
-                            {
-                                byte token;
-                                result = _stateObj.TryPeekByte(out token);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    return result;
-                                }
-
-                                Debug.Assert(TdsParser.IsValidTdsToken(token), $"DataReady is false, but next token is invalid: {token,-2:X2}");
-                            }
-#endif
-
-
-                            result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out _);
-                            if (result != TdsOperationStatus.Done)
                             {
                                 return result;
                             }
                         }
-                    }
-
-                    RestoreServerSettings(parser, stateObj);
-                    return TdsOperationStatus.Done;
-                }
 #if DEBUG
-                finally
-                {
-                    tdsReliabilitySection.Stop();
+                        else
+                        {
+                            byte token;
+                            result = _stateObj.TryPeekByte(out token);
+                            if (result != TdsOperationStatus.Done)
+                            {
+                                return result;
+                            }
+
+                            Debug.Assert(TdsParser.IsValidTdsToken(token), $"DataReady is false, but next token is invalid: {token,-2:X2}");
+                        }
+#endif
+
+
+                        result = parser.TryRun(RunBehavior.Clean, _command, this, null, stateObj, out _);
+                        if (result != TdsOperationStatus.Done)
+                        {
+                            return result;
+                        }
+                    }
                 }
-#endif //DEBUG
+
+                RestoreServerSettings(parser, stateObj);
+                return TdsOperationStatus.Done;
             }
             catch (System.OutOfMemoryException e)
             {
@@ -1204,41 +1152,24 @@ namespace Microsoft.Data.SqlClient
                     RuntimeHelpers.PrepareConstrainedRegions();
                     try
                     {
-#if DEBUG
-                        TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                        RuntimeHelpers.PrepareConstrainedRegions();
-                        try
+                        // IsClosed may be true if CloseReaderFromConnection was called - in which case, the session has already been closed
+                        if (!wasClosed && stateObj != null)
                         {
-                            tdsReliabilitySection.Start();
-#else
-                        {
-#endif //DEBUG
-                            // IsClosed may be true if CloseReaderFromConnection was called - in which case, the session has already been closed
-                            if (!wasClosed && stateObj != null)
+                            if (!cleanDataFailed)
                             {
-                                if (!cleanDataFailed)
+                                stateObj.CloseSession();
+                            }
+                            else
+                            {
+                                if (parser != null)
                                 {
-                                    stateObj.CloseSession();
-                                }
-                                else
-                                {
-                                    if (parser != null)
-                                    {
-                                        parser.State = TdsParserState.Broken; // We failed while draining data, so TDS pointer can be between tokens - cannot recover
-                                        parser.PutSession(stateObj);
-                                        parser.Connection.BreakConnection();
-                                    }
+                                    parser.State = TdsParserState.Broken; // We failed while draining data, so TDS pointer can be between tokens - cannot recover
+                                    parser.PutSession(stateObj);
+                                    parser.Connection.BreakConnection();
                                 }
                             }
-                            // DO NOT USE stateObj after this point - it has been returned to the TdsParser's session pool and potentially handed out to another thread
                         }
-#if DEBUG
-                        finally
-                        {
-                            tdsReliabilitySection.Stop();
-                        }
-#endif //DEBUG
+                        // DO NOT USE stateObj after this point - it has been returned to the TdsParser's session pool and potentially handed out to another thread
                     }
                     catch (System.OutOfMemoryException e)
                     {
@@ -1851,249 +1782,232 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                int cbytes = 0;
+                AssertReaderState(requireData: true, permitAsync: true, columnIndex: i, enforceSequentialAccess: true);
 
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
+                // sequential reading
+                if (IsCommandBehavior(CommandBehavior.SequentialAccess))
                 {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                    int cbytes = 0;
-                    AssertReaderState(requireData: true, permitAsync: true, columnIndex: i, enforceSequentialAccess: true);
+                    Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has an active Stream or TextReader");
 
-                    // sequential reading
-                    if (IsCommandBehavior(CommandBehavior.SequentialAccess))
+                    if (_metaData[i] != null && _metaData[i].cipherMD != null)
                     {
-                        Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has an active Stream or TextReader");
-
-                        if (_metaData[i] != null && _metaData[i].cipherMD != null)
-                        {
-                            throw SQL.SequentialAccessNotSupportedOnEncryptedColumn(_metaData[i].column);
-                        }
-
-                        if (_sharedState._nextColumnHeaderToRead <= i)
-                        {
-                            result = TryReadColumnHeader(i);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                return result;
-                            }
-                        }
-
-                        // If data is null, ReadColumnHeader sets the data.IsNull bit.
-                        if (_data[i] != null && _data[i].IsNull)
-                        {
-                            throw new SqlNullValueException();
-                        }
-
-                        // If there are an unknown (-1) number of bytes left for a PLP, read its size
-                        if ((-1 == _sharedState._columnDataBytesRemaining) && (_metaData[i].metaType.IsPlp))
-                        {
-                            ulong left;
-                            result = _parser.TryPlpBytesLeft(_stateObj, out left);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                return result;
-                            }
-                            _sharedState._columnDataBytesRemaining = (long)left;
-                        }
-
-                        if (0 == _sharedState._columnDataBytesRemaining)
-                        {
-                            return TdsOperationStatus.Done; // We've read this column to the end
-                        }
-
-                        // if no buffer is passed in, return the number total of bytes, or -1
-                        if (buffer == null)
-                        {
-                            if (_metaData[i].metaType.IsPlp)
-                            {
-                                remaining = (long)_parser.PlpBytesTotalLength(_stateObj);
-                                return TdsOperationStatus.Done;
-                            }
-                            remaining = _sharedState._columnDataBytesRemaining;
-                            return TdsOperationStatus.Done;
-                        }
-
-                        if (dataIndex < 0)
-                        {
-                            throw ADP.NegativeParameter(nameof(dataIndex));
-                        }
-
-                        if (dataIndex < _columnDataBytesRead)
-                        {
-                            throw ADP.NonSeqByteAccess(dataIndex, _columnDataBytesRead, nameof(GetBytes));
-                        }
-
-                        // if the dataIndex is not equal to bytes read, then we have to skip bytes
-                        long cb = dataIndex - _columnDataBytesRead;
-
-                        // if dataIndex is outside of the data range, return 0
-                        if ((cb > _sharedState._columnDataBytesRemaining) && !_metaData[i].metaType.IsPlp)
-                        {
-                            return TdsOperationStatus.Done;
-                        }
-
-                        // if bad buffer index, throw
-                        if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                        {
-                            throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
-                        }
-
-                        // if there is not enough room in the buffer for data
-                        if (length + bufferIndex > buffer.Length)
-                        {
-                            throw ADP.InvalidBufferSizeOrIndex(length, bufferIndex);
-                        }
-
-                        if (length < 0)
-                        {
-                            throw ADP.InvalidDataLength(length);
-                        }
-
-                        // Skip if needed
-                        if (cb > 0)
-                        {
-                            if (_metaData[i].metaType.IsPlp)
-                            {
-                                ulong skipped;
-                                result = _parser.TrySkipPlpValue((ulong)cb, _stateObj, out skipped);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    return result;
-                                }
-                                _columnDataBytesRead += (long)skipped;
-                            }
-                            else
-                            {
-                                result = _stateObj.TrySkipLongBytes(cb);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    return result;
-                                }
-                                _columnDataBytesRead += cb;
-                                _sharedState._columnDataBytesRemaining -= cb;
-                            }
-                        }
-
-                        int bytesRead;
-                        result = TryGetBytesInternalSequential(i, buffer, bufferIndex, length, out bytesRead);
-                        remaining = (int)bytesRead;
-                        return result;
+                        throw SQL.SequentialAccessNotSupportedOnEncryptedColumn(_metaData[i].column);
                     }
 
-                    // random access now!
-                    // note that since we are caching in an array, and arrays aren't 64 bit ready yet,
-                    // we need can cast to int if the dataIndex is in range
+                    if (_sharedState._nextColumnHeaderToRead <= i)
+                    {
+                        result = TryReadColumnHeader(i);
+                        if (result != TdsOperationStatus.Done)
+                        {
+                            return result;
+                        }
+                    }
+
+                    // If data is null, ReadColumnHeader sets the data.IsNull bit.
+                    if (_data[i] != null && _data[i].IsNull)
+                    {
+                        throw new SqlNullValueException();
+                    }
+
+                    // If there are an unknown (-1) number of bytes left for a PLP, read its size
+                    if ((-1 == _sharedState._columnDataBytesRemaining) && (_metaData[i].metaType.IsPlp))
+                    {
+                        ulong left;
+                        result = _parser.TryPlpBytesLeft(_stateObj, out left);
+                        if (result != TdsOperationStatus.Done)
+                        {
+                            return result;
+                        }
+                        _sharedState._columnDataBytesRemaining = (long)left;
+                    }
+
+                    if (0 == _sharedState._columnDataBytesRemaining)
+                    {
+                        return TdsOperationStatus.Done; // We've read this column to the end
+                    }
+
+                    // if no buffer is passed in, return the number total of bytes, or -1
+                    if (buffer == null)
+                    {
+                        if (_metaData[i].metaType.IsPlp)
+                        {
+                            remaining = (long)_parser.PlpBytesTotalLength(_stateObj);
+                            return TdsOperationStatus.Done;
+                        }
+                        remaining = _sharedState._columnDataBytesRemaining;
+                        return TdsOperationStatus.Done;
+                    }
+
                     if (dataIndex < 0)
                     {
                         throw ADP.NegativeParameter(nameof(dataIndex));
                     }
 
-                    if (dataIndex > int.MaxValue)
+                    if (dataIndex < _columnDataBytesRead)
                     {
-                        throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
+                        throw ADP.NonSeqByteAccess(dataIndex, _columnDataBytesRead, nameof(GetBytes));
                     }
 
-                    int ndataIndex = (int)dataIndex;
-                    byte[] data;
+                    // if the dataIndex is not equal to bytes read, then we have to skip bytes
+                    long cb = dataIndex - _columnDataBytesRead;
 
-                    // WebData 99342 - in the non-sequential case, we need to support
-                    //                 the use of GetBytes on string data columns, but
-                    //                 GetSqlBinary isn't supposed to.  What we end up
-                    //                 doing isn't exactly pretty, but it does work.
-                    if (_metaData[i].metaType.IsBinType)
+                    // if dataIndex is outside of the data range, return 0
+                    if ((cb > _sharedState._columnDataBytesRemaining) && !_metaData[i].metaType.IsPlp)
                     {
-                        data = GetSqlBinary(i).Value;
+                        return TdsOperationStatus.Done;
                     }
-                    else
-                    {
-                        Debug.Assert(_metaData[i].metaType.IsLong, "non long type?");
-                        Debug.Assert(_metaData[i].metaType.IsCharType, "non-char type?");
 
-                        SqlString temp = GetSqlString(i);
-                        if (_metaData[i].metaType.IsNCharType)
+                    // if bad buffer index, throw
+                    if (bufferIndex < 0 || bufferIndex >= buffer.Length)
+                    {
+                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
+                    }
+
+                    // if there is not enough room in the buffer for data
+                    if (length + bufferIndex > buffer.Length)
+                    {
+                        throw ADP.InvalidBufferSizeOrIndex(length, bufferIndex);
+                    }
+
+                    if (length < 0)
+                    {
+                        throw ADP.InvalidDataLength(length);
+                    }
+
+                    // Skip if needed
+                    if (cb > 0)
+                    {
+                        if (_metaData[i].metaType.IsPlp)
                         {
-                            data = temp.GetUnicodeBytes();
+                            ulong skipped;
+                            result = _parser.TrySkipPlpValue((ulong)cb, _stateObj, out skipped);
+                            if (result != TdsOperationStatus.Done)
+                            {
+                                return result;
+                            }
+                            _columnDataBytesRead += (long)skipped;
                         }
                         else
                         {
-                            data = temp.GetNonUnicodeBytes();
-                        }
-                    }
-
-                    cbytes = data.Length;
-
-                    // if no buffer is passed in, return the number of characters we have
-                    if (buffer == null)
-                    {
-                        remaining = cbytes;
-                        return TdsOperationStatus.Done;
-                    }
-
-                    // if dataIndex is outside of data range, return 0
-                    if (ndataIndex < 0 || ndataIndex >= cbytes)
-                    {
-                        return TdsOperationStatus.Done;
-                    }
-                    try
-                    {
-                        if (ndataIndex < cbytes)
-                        {
-                            // help the user out in the case where there's less data than requested
-                            if ((ndataIndex + length) > cbytes)
+                            result = _stateObj.TrySkipLongBytes(cb);
+                            if (result != TdsOperationStatus.Done)
                             {
-                                cbytes = cbytes - ndataIndex;
+                                return result;
                             }
-                            else
-                            {
-                                cbytes = length;
-                            }
+                            _columnDataBytesRead += cb;
+                            _sharedState._columnDataBytesRemaining -= cb;
                         }
-
-                        Buffer.BlockCopy(data, ndataIndex, buffer, bufferIndex, cbytes);
                     }
-                    catch (Exception e)
+
+                    int bytesRead;
+                    result = TryGetBytesInternalSequential(i, buffer, bufferIndex, length, out bytesRead);
+                    remaining = (int)bytesRead;
+                    return result;
+                }
+
+                // random access now!
+                // note that since we are caching in an array, and arrays aren't 64 bit ready yet,
+                // we need can cast to int if the dataIndex is in range
+                if (dataIndex < 0)
+                {
+                    throw ADP.NegativeParameter(nameof(dataIndex));
+                }
+
+                if (dataIndex > int.MaxValue)
+                {
+                    throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
+                }
+
+                int ndataIndex = (int)dataIndex;
+                byte[] data;
+
+                // WebData 99342 - in the non-sequential case, we need to support
+                //                 the use of GetBytes on string data columns, but
+                //                 GetSqlBinary isn't supposed to.  What we end up
+                //                 doing isn't exactly pretty, but it does work.
+                if (_metaData[i].metaType.IsBinType)
+                {
+                    data = GetSqlBinary(i).Value;
+                }
+                else
+                {
+                    Debug.Assert(_metaData[i].metaType.IsLong, "non long type?");
+                    Debug.Assert(_metaData[i].metaType.IsCharType, "non-char type?");
+
+                    SqlString temp = GetSqlString(i);
+                    if (_metaData[i].metaType.IsNCharType)
                     {
-                        // UNDONE - should not be catching all exceptions!!!
-                        if (!ADP.IsCatchableExceptionType(e))
-                        {
-                            throw;
-                        }
-                        cbytes = data.Length;
-
-                        if (length < 0)
-                        {
-                            throw ADP.InvalidDataLength(length);
-                        }
-
-                        // if bad buffer index, throw
-                        if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                        {
-                            throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
-                        }
-
-                        // if there is not enough room in the buffer for data
-                        if (cbytes + bufferIndex > buffer.Length)
-                        {
-                            throw ADP.InvalidBufferSizeOrIndex(cbytes, bufferIndex);
-                        }
-
-                        throw;
+                        data = temp.GetUnicodeBytes();
                     }
+                    else
+                    {
+                        data = temp.GetNonUnicodeBytes();
+                    }
+                }
 
+                cbytes = data.Length;
+
+                // if no buffer is passed in, return the number of characters we have
+                if (buffer == null)
+                {
                     remaining = cbytes;
                     return TdsOperationStatus.Done;
                 }
-#if DEBUG
-                finally
+
+                // if dataIndex is outside of data range, return 0
+                if (ndataIndex < 0 || ndataIndex >= cbytes)
                 {
-                    tdsReliabilitySection.Stop();
+                    return TdsOperationStatus.Done;
                 }
-#endif //DEBUG
+                try
+                {
+                    if (ndataIndex < cbytes)
+                    {
+                        // help the user out in the case where there's less data than requested
+                        if ((ndataIndex + length) > cbytes)
+                        {
+                            cbytes = cbytes - ndataIndex;
+                        }
+                        else
+                        {
+                            cbytes = length;
+                        }
+                    }
+
+                    Buffer.BlockCopy(data, ndataIndex, buffer, bufferIndex, cbytes);
+                }
+                catch (Exception e)
+                {
+                    // UNDONE - should not be catching all exceptions!!!
+                    if (!ADP.IsCatchableExceptionType(e))
+                    {
+                        throw;
+                    }
+                    cbytes = data.Length;
+
+                    if (length < 0)
+                    {
+                        throw ADP.InvalidDataLength(length);
+                    }
+
+                    // if bad buffer index, throw
+                    if (bufferIndex < 0 || bufferIndex >= buffer.Length)
+                    {
+                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
+                    }
+
+                    // if there is not enough room in the buffer for data
+                    if (cbytes + bufferIndex > buffer.Length)
+                    {
+                        throw ADP.InvalidBufferSizeOrIndex(cbytes, bufferIndex);
+                    }
+
+                    throw;
+                }
+
+                remaining = cbytes;
+                return TdsOperationStatus.Done;
             }
             catch (System.OutOfMemoryException e)
             {
@@ -2177,61 +2091,46 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
+                if ((_sharedState._columnDataBytesRemaining == 0) || (length == 0))
                 {
-                    tdsReliabilitySection.Start();
-#endif //DEBUG
-                    if ((_sharedState._columnDataBytesRemaining == 0) || (length == 0))
+                    // No data left or nothing requested, return 0
+                    bytesRead = 0;
+                    return TdsOperationStatus.Done;
+                }
+                else
+                {
+                    // if plp columns, do partial reads. Don't read the entire value in one shot.
+                    if (_metaData[i].metaType.IsPlp)
                     {
-                        // No data left or nothing requested, return 0
-                        bytesRead = 0;
+                        // Read in data
+                        result = _stateObj.TryReadPlpBytes(ref buffer, index, length, out bytesRead);
+                        _columnDataBytesRead += bytesRead;
+                        if (result != TdsOperationStatus.Done)
+                        {
+                            return result;
+                        }
+
+                        // Query for number of bytes left
+                        ulong left;
+                        result = _parser.TryPlpBytesLeft(_stateObj, out left);
+                        if (result != TdsOperationStatus.Done)
+                        {
+                            _sharedState._columnDataBytesRemaining = -1;
+                            return result;
+                        }
+                        _sharedState._columnDataBytesRemaining = (long)left;
                         return TdsOperationStatus.Done;
                     }
                     else
                     {
-                        // if plp columns, do partial reads. Don't read the entire value in one shot.
-                        if (_metaData[i].metaType.IsPlp)
-                        {
-                            // Read in data
-                            result = _stateObj.TryReadPlpBytes(ref buffer, index, length, out bytesRead);
-                            _columnDataBytesRead += bytesRead;
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                return result;
-                            }
-
-                            // Query for number of bytes left
-                            ulong left;
-                            result = _parser.TryPlpBytesLeft(_stateObj, out left);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                _sharedState._columnDataBytesRemaining = -1;
-                                return result;
-                            }
-                            _sharedState._columnDataBytesRemaining = (long)left;
-                            return TdsOperationStatus.Done;
-                        }
-                        else
-                        {
-                            // Read data (not exceeding the total amount of data available)
-                            int bytesToRead = (int)Math.Min((long)length, _sharedState._columnDataBytesRemaining);
-                            result = _stateObj.TryReadByteArray(buffer.AsSpan(index), bytesToRead, out bytesRead);
-                            _columnDataBytesRead += bytesRead;
-                            _sharedState._columnDataBytesRemaining -= bytesRead;
-                            return result;
-                        }
+                        // Read data (not exceeding the total amount of data available)
+                        int bytesToRead = (int)Math.Min((long)length, _sharedState._columnDataBytesRemaining);
+                        result = _stateObj.TryReadByteArray(buffer.AsSpan(index), bytesToRead, out bytesRead);
+                        _columnDataBytesRead += bytesRead;
+                        _sharedState._columnDataBytesRemaining -= bytesRead;
+                        return result;
                     }
-#if DEBUG
                 }
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
-#endif //DEBUG
             }
             catch (System.OutOfMemoryException e)
             {
@@ -2534,113 +2433,96 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                long cch;
 
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
+                AssertReaderState(requireData: true, permitAsync: false, columnIndex: i, enforceSequentialAccess: true);
+                Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has active Stream or TextReader");
+                // don't allow get bytes on non-long or non-binary columns
+                Debug.Assert(_metaData[i].metaType.IsPlp, "GetCharsFromPlpData called on a non-plp column!");
+                // Must be sequential reading
+                Debug.Assert(IsCommandBehavior(CommandBehavior.SequentialAccess), "GetCharsFromPlpData called for non-Sequential access");
+
+                if (!_metaData[i].metaType.IsCharType)
                 {
-                    tdsReliabilitySection.Start();
-#else
+                    throw SQL.NonCharColumn(_metaData[i].column);
+                }
+
+                if (_sharedState._nextColumnHeaderToRead <= i)
                 {
-#endif //DEBUG
-                    long cch;
+                    ReadColumnHeader(i);
+                }
 
-                    AssertReaderState(requireData: true, permitAsync: false, columnIndex: i, enforceSequentialAccess: true);
-                    Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has active Stream or TextReader");
-                    // don't allow get bytes on non-long or non-binary columns
-                    Debug.Assert(_metaData[i].metaType.IsPlp, "GetCharsFromPlpData called on a non-plp column!");
-                    // Must be sequential reading
-                    Debug.Assert(IsCommandBehavior(CommandBehavior.SequentialAccess), "GetCharsFromPlpData called for non-Sequential access");
+                // If data is null, ReadColumnHeader sets the data.IsNull bit.
+                if (_data[i] != null && _data[i].IsNull)
+                {
+                    throw new SqlNullValueException();
+                }
 
-                    if (!_metaData[i].metaType.IsCharType)
-                    {
-                        throw SQL.NonCharColumn(_metaData[i].column);
-                    }
+                if (dataIndex < _columnDataCharsRead)
+                {
+                    // Don't allow re-read of same chars in sequential access mode
+                    throw ADP.NonSeqByteAccess(dataIndex, _columnDataCharsRead, nameof(GetChars));
+                }
 
-                    if (_sharedState._nextColumnHeaderToRead <= i)
-                    {
-                        ReadColumnHeader(i);
-                    }
+                // If we start reading the new column, either dataIndex is 0 or
+                // _columnDataCharsRead is 0 and dataIndex > _columnDataCharsRead is true below.
+                // In both cases we will clean decoder
+                if (dataIndex == 0)
+                {
+                    _stateObj._plpdecoder = null;
+                }
 
-                    // If data is null, ReadColumnHeader sets the data.IsNull bit.
-                    if (_data[i] != null && _data[i].IsNull)
-                    {
-                        throw new SqlNullValueException();
-                    }
+                bool isUnicode = _metaData[i].metaType.IsNCharType;
 
-                    if (dataIndex < _columnDataCharsRead)
-                    {
-                        // Don't allow re-read of same chars in sequential access mode
-                        throw ADP.NonSeqByteAccess(dataIndex, _columnDataCharsRead, nameof(GetChars));
-                    }
-
-                    // If we start reading the new column, either dataIndex is 0 or
-                    // _columnDataCharsRead is 0 and dataIndex > _columnDataCharsRead is true below.
-                    // In both cases we will clean decoder
-                    if (dataIndex == 0)
-                    {
-                        _stateObj._plpdecoder = null;
-                    }
-
-                    bool isUnicode = _metaData[i].metaType.IsNCharType;
-
-                    // If there are an unknown (-1) number of bytes left for a PLP, read its size
-                    if (-1 == _sharedState._columnDataBytesRemaining)
-                    {
-                        _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
-                    }
-
-                    if (0 == _sharedState._columnDataBytesRemaining)
-                    {
-                        _stateObj._plpdecoder = null;
-                        return 0; // We've read this column to the end
-                    }
-
-                    // if no buffer is passed in, return the total number of characters or -1
-                    // TODO: for DBCS encoding it returns number of bytes, not number of chars
-                    if (buffer == null)
-                    {
-                        cch = (long)_parser.PlpBytesTotalLength(_stateObj);
-                        return (isUnicode && (cch > 0)) ? cch >> 1 : cch;
-                    }
-                    if (dataIndex > _columnDataCharsRead)
-                    {
-                        // Skip chars
-
-                        // Clean decoder state: we do not reset it, but destroy to ensure
-                        // that we do not start decoding the column with decoder from the old one
-                        _stateObj._plpdecoder = null;
-                        // TODO: for DBCS encoding skip positioning dataIndex is not in characters but is interpreted as
-                        // number of chars already read + number of bytes to skip
-                        cch = dataIndex - _columnDataCharsRead;
-                        cch = isUnicode ? (cch << 1) : cch;
-                        cch = (long)_parser.SkipPlpValue((ulong)(cch), _stateObj);
-                        _columnDataBytesRead += cch;
-                        _columnDataCharsRead += (isUnicode && (cch > 0)) ? cch >> 1 : cch;
-                    }
-                    cch = length;
-
-                    if (isUnicode)
-                    {
-                        cch = (long)_parser.ReadPlpUnicodeChars(ref buffer, bufferIndex, length, _stateObj);
-                        _columnDataBytesRead += (cch << 1);
-                    }
-                    else
-                    {
-                        cch = (long)_parser.ReadPlpAnsiChars(ref buffer, bufferIndex, length, _metaData[i], _stateObj);
-                        _columnDataBytesRead += cch << 1;
-                    }
-                    _columnDataCharsRead += cch;
+                // If there are an unknown (-1) number of bytes left for a PLP, read its size
+                if (-1 == _sharedState._columnDataBytesRemaining)
+                {
                     _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
-                    return cch;
                 }
-#if DEBUG
-                finally
+
+                if (0 == _sharedState._columnDataBytesRemaining)
                 {
-                    tdsReliabilitySection.Stop();
+                    _stateObj._plpdecoder = null;
+                    return 0; // We've read this column to the end
                 }
-#endif //DEBUG
+
+                // if no buffer is passed in, return the total number of characters or -1
+                // TODO: for DBCS encoding it returns number of bytes, not number of chars
+                if (buffer == null)
+                {
+                    cch = (long)_parser.PlpBytesTotalLength(_stateObj);
+                    return (isUnicode && (cch > 0)) ? cch >> 1 : cch;
+                }
+                if (dataIndex > _columnDataCharsRead)
+                {
+                    // Skip chars
+
+                    // Clean decoder state: we do not reset it, but destroy to ensure
+                    // that we do not start decoding the column with decoder from the old one
+                    _stateObj._plpdecoder = null;
+                    // TODO: for DBCS encoding skip positioning dataIndex is not in characters but is interpreted as
+                    // number of chars already read + number of bytes to skip
+                    cch = dataIndex - _columnDataCharsRead;
+                    cch = isUnicode ? (cch << 1) : cch;
+                    cch = (long)_parser.SkipPlpValue((ulong)(cch), _stateObj);
+                    _columnDataBytesRead += cch;
+                    _columnDataCharsRead += (isUnicode && (cch > 0)) ? cch >> 1 : cch;
+                }
+                cch = length;
+
+                if (isUnicode)
+                {
+                    cch = (long)_parser.ReadPlpUnicodeChars(ref buffer, bufferIndex, length, _stateObj);
+                    _columnDataBytesRead += (cch << 1);
+                }
+                else
+                {
+                    cch = (long)_parser.ReadPlpAnsiChars(ref buffer, bufferIndex, length, _metaData[i], _stateObj);
+                    _columnDataBytesRead += cch << 1;
+                }
+                _columnDataCharsRead += cch;
+                _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
+                return cch;
             }
             catch (System.OutOfMemoryException e)
             {
@@ -3785,32 +3667,111 @@ namespace Microsoft.Data.SqlClient
 
                 try
                 {
-#if DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                    statistics = SqlStatistics.StartTimer(Statistics);
 
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
+                    SetTimeout(_defaultTimeoutMilliseconds);
+
+                    if (IsClosed)
                     {
-                        tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                        statistics = SqlStatistics.StartTimer(Statistics);
+                        throw ADP.DataReaderClosed(nameof(NextResult));
+                    }
+                    _fieldNameLookup = null;
 
-                        SetTimeout(_defaultTimeoutMilliseconds);
+                    bool success = false; // WebData 100390
+                    _hasRows = false; // reset HasRows
 
-                        if (IsClosed)
+                    // if we are specifically only processing a single result, then read all the results off the wire and detach
+                    if (IsCommandBehavior(CommandBehavior.SingleResult))
+                    {
+                        result = TryCloseInternal(closeReader: false);
+                        if (result != TdsOperationStatus.Done)
                         {
-                            throw ADP.DataReaderClosed(nameof(NextResult));
+                            more = false;
+                            return result;
                         }
-                        _fieldNameLookup = null;
 
-                        bool success = false; // WebData 100390
-                        _hasRows = false; // reset HasRows
+                        // In the case of not closing the reader, null out the metadata AFTER
+                        // CloseInternal finishes - since CloseInternal may go to the wire
+                        // and use the metadata.
+                        ClearMetaData();
+                        more = success;
+                        return TdsOperationStatus.Done;
+                    }
 
-                        // if we are specifically only processing a single result, then read all the results off the wire and detach
-                        if (IsCommandBehavior(CommandBehavior.SingleResult))
+                    if (_parser != null)
+                    {
+                        // if there are more rows, then skip them, the user wants the next result
+                        bool moreRows = true;
+                        while (moreRows)
                         {
+                            result = TryReadInternal(false, out moreRows);
+                            if (result != TdsOperationStatus.Done)
+                            {
+                                // don't reset set the timeout value
+                                more = false;
+                                return result;
+                            }
+                        }
+                    }
+
+                    // we may be done, so continue only if we have not detached ourselves from the parser
+                    if (_parser != null)
+                    {
+                        bool moreResults;
+                        result = TryHasMoreResults(out moreResults);
+                        if (result != TdsOperationStatus.Done)
+                        {
+                            more = false;
+                            return result;
+                        }
+                        if (moreResults)
+                        {
+                            _metaDataConsumed = false;
+                            _browseModeInfoConsumed = false;
+
+                            switch (_altRowStatus)
+                            {
+                                case ALTROWSTATUS.AltRow:
+                                    int altRowId;
+                                    result = _parser.TryGetAltRowId(_stateObj, out altRowId);
+                                    if (result != TdsOperationStatus.Done)
+                                    {
+                                        more = false;
+                                        return result;
+                                    }
+                                    _SqlMetaDataSet altMetaDataSet = _altMetaDataSetCollection.GetAltMetaData(altRowId);
+                                    if (altMetaDataSet != null)
+                                    {
+                                        _metaData = altMetaDataSet;
+                                    }
+                                    Debug.Assert((_metaData != null), "Can't match up altrowmetadata");
+                                    break;
+                                case ALTROWSTATUS.Done:
+                                    // restore the row-metaData
+                                    _metaData = _altMetaDataSetCollection.metaDataSet;
+                                    Debug.Assert(_altRowStatus == ALTROWSTATUS.Done, "invalid AltRowStatus");
+                                    _altRowStatus = ALTROWSTATUS.Null;
+                                    break;
+                                default:
+                                    result = TryConsumeMetaData();
+                                    if (result != TdsOperationStatus.Done)
+                                    {
+                                        more = false;
+                                        return result;
+                                    }
+                                    if (_metaData == null)
+                                    {
+                                        more = false;
+                                        return TdsOperationStatus.Done;
+                                    }
+                                    break;
+                            }
+
+                            success = true;
+                        }
+                        else
+                        {
+                            // detach the parser from this reader now
                             result = TryCloseInternal(closeReader: false);
                             if (result != TdsOperationStatus.Done)
                             {
@@ -3821,120 +3782,24 @@ namespace Microsoft.Data.SqlClient
                             // In the case of not closing the reader, null out the metadata AFTER
                             // CloseInternal finishes - since CloseInternal may go to the wire
                             // and use the metadata.
-                            ClearMetaData();
-                            more = success;
-                            return TdsOperationStatus.Done;
-                        }
-
-                        if (_parser != null)
-                        {
-                            // if there are more rows, then skip them, the user wants the next result
-                            bool moreRows = true;
-                            while (moreRows)
-                            {
-                                result = TryReadInternal(false, out moreRows);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    // don't reset set the timeout value
-                                    more = false;
-                                    return result;
-                                }
-                            }
-                        }
-
-                        // we may be done, so continue only if we have not detached ourselves from the parser
-                        if (_parser != null)
-                        {
-                            bool moreResults;
-                            result = TryHasMoreResults(out moreResults);
+                            result = TrySetMetaData(null, false);
                             if (result != TdsOperationStatus.Done)
                             {
                                 more = false;
                                 return result;
                             }
-                            if (moreResults)
-                            {
-                                _metaDataConsumed = false;
-                                _browseModeInfoConsumed = false;
-
-                                switch (_altRowStatus)
-                                {
-                                    case ALTROWSTATUS.AltRow:
-                                        int altRowId;
-                                        result = _parser.TryGetAltRowId(_stateObj, out altRowId);
-                                        if (result != TdsOperationStatus.Done)
-                                        {
-                                            more = false;
-                                            return result;
-                                        }
-                                        _SqlMetaDataSet altMetaDataSet = _altMetaDataSetCollection.GetAltMetaData(altRowId);
-                                        if (altMetaDataSet != null)
-                                        {
-                                            _metaData = altMetaDataSet;
-                                        }
-                                        Debug.Assert((_metaData != null), "Can't match up altrowmetadata");
-                                        break;
-                                    case ALTROWSTATUS.Done:
-                                        // restore the row-metaData
-                                        _metaData = _altMetaDataSetCollection.metaDataSet;
-                                        Debug.Assert(_altRowStatus == ALTROWSTATUS.Done, "invalid AltRowStatus");
-                                        _altRowStatus = ALTROWSTATUS.Null;
-                                        break;
-                                    default:
-                                        result = TryConsumeMetaData();
-                                        if (result != TdsOperationStatus.Done)
-                                        {
-                                            more = false;
-                                            return result;
-                                        }
-                                        if (_metaData == null)
-                                        {
-                                            more = false;
-                                            return TdsOperationStatus.Done;
-                                        }
-                                        break;
-                                }
-
-                                success = true;
-                            }
-                            else
-                            {
-                                // detach the parser from this reader now
-                                result = TryCloseInternal(closeReader: false);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    more = false;
-                                    return result;
-                                }
-
-                                // In the case of not closing the reader, null out the metadata AFTER
-                                // CloseInternal finishes - since CloseInternal may go to the wire
-                                // and use the metadata.
-                                result = TrySetMetaData(null, false);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    more = false;
-                                    return result;
-                                }
-                            }
                         }
-                        else
-                        {
-                            // Clear state in case of Read calling CloseInternal() then user calls NextResult()
-                            // MDAC 81986.  Or, also the case where the Read() above will do essentially the same
-                            // thing.
-                            ClearMetaData();
-                        }
-
-                        more = success;
-                        return TdsOperationStatus.Done;
                     }
-#if DEBUG
-                    finally
+                    else
                     {
-                        tdsReliabilitySection.Stop();
+                        // Clear state in case of Read calling CloseInternal() then user calls NextResult()
+                        // MDAC 81986.  Or, also the case where the Read() above will do essentially the same
+                        // thing.
+                        ClearMetaData();
                     }
-#endif //DEBUG
+
+                    more = success;
+                    return TdsOperationStatus.Done;
                 }
                 catch (System.OutOfMemoryException e)
                 {
@@ -4001,140 +3866,107 @@ namespace Microsoft.Data.SqlClient
 
                 try
                 {
-#if DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                    TdsOperationStatus result;
+                    statistics = SqlStatistics.StartTimer(Statistics);
 
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
+                    if (_parser != null)
                     {
-                        tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                        TdsOperationStatus result;
-                        statistics = SqlStatistics.StartTimer(Statistics);
-
-                        if (_parser != null)
+                        if (setTimeout)
                         {
-                            if (setTimeout)
+                            SetTimeout(_defaultTimeoutMilliseconds);
+                        }
+                        if (_sharedState._dataReady)
+                        {
+                            result = TryCleanPartialRead();
+                            if (result != TdsOperationStatus.Done)
                             {
-                                SetTimeout(_defaultTimeoutMilliseconds);
+                                more = false;
+                                return result;
                             }
-                            if (_sharedState._dataReady)
+                        }
+
+                        // clear out our buffers
+                        SqlBuffer.Clear(_data);
+
+                        _sharedState._nextColumnHeaderToRead = 0;
+                        _sharedState._nextColumnDataToRead = 0;
+                        _sharedState._columnDataBytesRemaining = -1; // unknown
+                        _lastColumnWithDataChunkRead = -1;
+
+                        if (!_haltRead)
+                        {
+                            bool moreRows;
+                            result = TryHasMoreRows(out moreRows);
+                            if (result != TdsOperationStatus.Done)
                             {
-                                result = TryCleanPartialRead();
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    more = false;
-                                    return result;
-                                }
+                                more = false;
+                                return result;
                             }
-
-                            // clear out our buffers
-                            SqlBuffer.Clear(_data);
-
-                            _sharedState._nextColumnHeaderToRead = 0;
-                            _sharedState._nextColumnDataToRead = 0;
-                            _sharedState._columnDataBytesRemaining = -1; // unknown
-                            _lastColumnWithDataChunkRead = -1;
-
-                            if (!_haltRead)
+                            if (moreRows)
                             {
-                                bool moreRows;
-                                result = TryHasMoreRows(out moreRows);
-                                if (result != TdsOperationStatus.Done)
+                                // read the row from the backend (unless it's an altrow were the marker is already inside the altrow ...)
+                                while (_stateObj.HasPendingData)
                                 {
-                                    more = false;
-                                    return result;
-                                }
-                                if (moreRows)
-                                {
-                                    // read the row from the backend (unless it's an altrow were the marker is already inside the altrow ...)
-                                    while (_stateObj.HasPendingData)
+                                    if (_altRowStatus != ALTROWSTATUS.AltRow)
                                     {
-                                        if (_altRowStatus != ALTROWSTATUS.AltRow)
-                                        {
-                                            // if this is an ordinary row we let the run method consume the ROW token
-                                            result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady);
-                                            if (result != TdsOperationStatus.Done)
-                                            {
-                                                more = false;
-                                                return result;
-                                            }
-                                            if (_sharedState._dataReady)
-                                            {
-                                                break;
-                                            }
-                                        }
-                                        else
-                                        {
-                                            // ALTROW token and AltrowId are already consumed ...
-                                            Debug.Assert(_altRowStatus == ALTROWSTATUS.AltRow, "invalid AltRowStatus");
-                                            _altRowStatus = ALTROWSTATUS.Done;
-                                            _sharedState._dataReady = true;
-                                            break;
-                                        }
-                                    }
-                                    if (_sharedState._dataReady)
-                                    {
-                                        _haltRead = IsCommandBehavior(CommandBehavior.SingleRow);
-                                        more = true;
-                                        return TdsOperationStatus.Done;
-                                    }
-                                }
-
-                                if (!_stateObj.HasPendingData)
-                                {
-                                    result = TryCloseInternal(closeReader: false);
-                                    if (result != TdsOperationStatus.Done)
-                                    {
-                                        more = false;
-                                        return result;
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                // if we did not get a row and halt is true, clean off rows of result
-                                // success must be false - or else we could have just read off row and set
-                                // halt to true
-                                bool moreRows;
-                                result = TryHasMoreRows(out moreRows);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    more = false;
-                                    return result;
-                                }
-                                while (moreRows)
-                                {
-                                    // if we are in SingleRow mode, and we've read the first row,
-                                    // read the rest of the rows, if any
-                                    while (_stateObj.HasPendingData && !_sharedState._dataReady)
-                                    {
+                                        // if this is an ordinary row we let the run method consume the ROW token
                                         result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady);
                                         if (result != TdsOperationStatus.Done)
                                         {
                                             more = false;
                                             return result;
                                         }
-                                    }
-
-                                    if (_sharedState._dataReady)
-                                    {
-                                        result = TryCleanPartialRead();
-                                        if (result != TdsOperationStatus.Done)
+                                        if (_sharedState._dataReady)
                                         {
-                                            more = false;
-                                            return result;
+                                            break;
                                         }
                                     }
+                                    else
+                                    {
+                                        // ALTROW token and AltrowId are already consumed ...
+                                        Debug.Assert(_altRowStatus == ALTROWSTATUS.AltRow, "invalid AltRowStatus");
+                                        _altRowStatus = ALTROWSTATUS.Done;
+                                        _sharedState._dataReady = true;
+                                        break;
+                                    }
+                                }
+                                if (_sharedState._dataReady)
+                                {
+                                    _haltRead = IsCommandBehavior(CommandBehavior.SingleRow);
+                                    more = true;
+                                    return TdsOperationStatus.Done;
+                                }
+                            }
 
-                                    // clear out our buffers
-                                    SqlBuffer.Clear(_data);
-
-                                    _sharedState._nextColumnHeaderToRead = 0;
-
-                                    result = TryHasMoreRows(out moreRows);
+                            if (!_stateObj.HasPendingData)
+                            {
+                                result = TryCloseInternal(closeReader: false);
+                                if (result != TdsOperationStatus.Done)
+                                {
+                                    more = false;
+                                    return result;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // if we did not get a row and halt is true, clean off rows of result
+                            // success must be false - or else we could have just read off row and set
+                            // halt to true
+                            bool moreRows;
+                            result = TryHasMoreRows(out moreRows);
+                            if (result != TdsOperationStatus.Done)
+                            {
+                                more = false;
+                                return result;
+                            }
+                            while (moreRows)
+                            {
+                                // if we are in SingleRow mode, and we've read the first row,
+                                // read the rest of the rows, if any
+                                while (_stateObj.HasPendingData && !_sharedState._dataReady)
+                                {
+                                    result = _parser.TryRun(RunBehavior.ReturnImmediately, _command, this, null, _stateObj, out _sharedState._dataReady);
                                     if (result != TdsOperationStatus.Done)
                                     {
                                         more = false;
@@ -4142,38 +3974,54 @@ namespace Microsoft.Data.SqlClient
                                     }
                                 }
 
-                                // reset haltRead
-                                _haltRead = false;
+                                if (_sharedState._dataReady)
+                                {
+                                    result = TryCleanPartialRead();
+                                    if (result != TdsOperationStatus.Done)
+                                    {
+                                        more = false;
+                                        return result;
+                                    }
+                                }
+
+                                // clear out our buffers
+                                SqlBuffer.Clear(_data);
+
+                                _sharedState._nextColumnHeaderToRead = 0;
+
+                                result = TryHasMoreRows(out moreRows);
+                                if (result != TdsOperationStatus.Done)
+                                {
+                                    more = false;
+                                    return result;
+                                }
                             }
+
+                            // reset haltRead
+                            _haltRead = false;
                         }
-                        else if (IsClosed)
-                        {
-                            throw ADP.DataReaderClosed(nameof(Read));
-                        }
-                        more = false;
+                    }
+                    else if (IsClosed)
+                    {
+                        throw ADP.DataReaderClosed(nameof(Read));
+                    }
+                    more = false;
 
 #if DEBUG
-                        if ((!_sharedState._dataReady) && (_stateObj.HasPendingData))
+                    if ((!_sharedState._dataReady) && (_stateObj.HasPendingData))
+                    {
+                        byte token;
+                        result = _stateObj.TryPeekByte(out token);
+                        if (result != TdsOperationStatus.Done)
                         {
-                            byte token;
-                            result = _stateObj.TryPeekByte(out token);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                return result;
-                            }
-
-                            Debug.Assert(TdsParser.IsValidTdsToken(token), $"DataReady is false, but next token is invalid: {token,-2:X2}");
+                            return result;
                         }
+
+                        Debug.Assert(TdsParser.IsValidTdsToken(token), $"DataReady is false, but next token is invalid: {token,-2:X2}");
+                    }
 #endif
 
-                        return TdsOperationStatus.Done;
-                    }
-#if DEBUG
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif //DEBUG
+                    return TdsOperationStatus.Done;
                 }
                 catch (OutOfMemoryException e)
                 {
@@ -4234,38 +4082,21 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                Debug.Assert(_sharedState._nextColumnHeaderToRead <= _metaData.Length, "_sharedState._nextColumnHeaderToRead too large");
+                Debug.Assert(_sharedState._nextColumnDataToRead <= _metaData.Length, "_sharedState._nextColumnDataToRead too large");
 
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
+                if (setTimeout)
                 {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                    Debug.Assert(_sharedState._nextColumnHeaderToRead <= _metaData.Length, "_sharedState._nextColumnHeaderToRead too large");
-                    Debug.Assert(_sharedState._nextColumnDataToRead <= _metaData.Length, "_sharedState._nextColumnDataToRead too large");
-
-                    if (setTimeout)
-                    {
-                        SetTimeout(_defaultTimeoutMilliseconds);
-                    }
-
-                    TdsOperationStatus result = TryReadColumnInternal(i, readHeaderOnly: false, forStreaming: forStreaming);
-                    if (result != TdsOperationStatus.Done)
-                    {
-                        return result;
-                    }
-
-                    Debug.Assert(_data[i] != null, " data buffer is null?");
+                    SetTimeout(_defaultTimeoutMilliseconds);
                 }
-#if DEBUG
-                finally
+
+                TdsOperationStatus result = TryReadColumnInternal(i, readHeaderOnly: false, forStreaming: forStreaming);
+                if (result != TdsOperationStatus.Done)
                 {
-                    tdsReliabilitySection.Stop();
+                    return result;
                 }
-#endif //DEBUG
+
+                Debug.Assert(_data[i] != null, " data buffer is null?");
             }
             catch (System.OutOfMemoryException e)
             {
@@ -4339,22 +4170,7 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
-                {
-                    tdsReliabilitySection.Start();
-#endif //DEBUG
-                    return TryReadColumnInternal(i, readHeaderOnly: true, forStreaming: false);
-#if DEBUG
-                }
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
-#endif //DEBUG
+                return TryReadColumnInternal(i, readHeaderOnly: true, forStreaming: false);
             }
             catch (System.OutOfMemoryException e)
             {
@@ -5824,18 +5640,8 @@ namespace Microsoft.Data.SqlClient
             {
                 if (reader.IsCommandBehavior(CommandBehavior.SequentialAccess) && reader._sharedState._dataReady)
                 {
-                    bool internalReadSuccess = false;
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
                     RuntimeHelpers.PrepareConstrainedRegions();
-                    try
-                    {
-                        tdsReliabilitySection.Start();
-                        internalReadSuccess = reader.TryReadColumnInternal(context._columnIndex, readHeaderOnly: true, forStreaming: false) == TdsOperationStatus.Done;
-                    }
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
+                    bool internalReadSuccess = reader.TryReadColumnInternal(context._columnIndex, readHeaderOnly: true, forStreaming: false) == TdsOperationStatus.Done;
 
                     if (internalReadSuccess)
                     {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -511,51 +511,34 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
+                _timeout = TimeoutTimer.StartSecondsTimeout(connectionOptions.ConnectTimeout);
 
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
+                // If transient fault handling is enabled then we can retry the login upto the ConnectRetryCount.
+                int connectionEstablishCount = applyTransientFaultHandling ? connectionOptions.ConnectRetryCount + 1 : 1;
+                int transientRetryIntervalInMilliSeconds = connectionOptions.ConnectRetryInterval * 1000; // Max value of transientRetryInterval is 60*1000 ms. The max value allowed for ConnectRetryInterval is 60
+                for (int i = 0; i < connectionEstablishCount; i++)
                 {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                    _timeout = TimeoutTimer.StartSecondsTimeout(connectionOptions.ConnectTimeout);
-
-                    // If transient fault handling is enabled then we can retry the login upto the ConnectRetryCount.
-                    int connectionEstablishCount = applyTransientFaultHandling ? connectionOptions.ConnectRetryCount + 1 : 1;
-                    int transientRetryIntervalInMilliSeconds = connectionOptions.ConnectRetryInterval * 1000; // Max value of transientRetryInterval is 60*1000 ms. The max value allowed for ConnectRetryInterval is 60
-                    for (int i = 0; i < connectionEstablishCount; i++)
+                    try
                     {
-                        try
+                        OpenLoginEnlist(_timeout, connectionOptions, credential, newPassword, newSecurePassword, redirectedUserInstance);
+                        break;
+                    }
+                    catch (SqlException sqlex)
+                    {
+                        if (i + 1 == connectionEstablishCount
+                          || !applyTransientFaultHandling
+                          || _timeout.IsExpired
+                          || _timeout.MillisecondsRemaining < transientRetryIntervalInMilliSeconds
+                          || !IsTransientError(sqlex))
                         {
-                            OpenLoginEnlist(_timeout, connectionOptions, credential, newPassword, newSecurePassword, redirectedUserInstance);
-                            break;
+                            throw;
                         }
-                        catch (SqlException sqlex)
+                        else
                         {
-                            if (i + 1 == connectionEstablishCount
-                              || !applyTransientFaultHandling
-                              || _timeout.IsExpired
-                              || _timeout.MillisecondsRemaining < transientRetryIntervalInMilliSeconds
-                              || !IsTransientError(sqlex))
-                            {
-                                throw;
-                            }
-                            else
-                            {
-                                Thread.Sleep(transientRetryIntervalInMilliSeconds);
-                            }
+                            Thread.Sleep(transientRetryIntervalInMilliSeconds);
                         }
                     }
                 }
-#if DEBUG
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
-#endif //DEBUG
             }
             catch (System.OutOfMemoryException)
             {
@@ -973,29 +956,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal override bool IsConnectionAlive(bool throwOnException)
-        {
-            bool isAlive = false;
-#if DEBUG
-            TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                tdsReliabilitySection.Start();
-#endif //DEBUG
-
-                isAlive = _parser._physicalStateObj.IsConnectionAlive(throwOnException);
-
-#if DEBUG
-            }
-            finally
-            {
-                tdsReliabilitySection.Stop();
-            }
-#endif //DEBUG
-            return isAlive;
-        }
+        internal override bool IsConnectionAlive(bool throwOnException) =>
+            _parser._physicalStateObj.IsConnectionAlive(throwOnException);
 
         ////////////////////////////////////////////////////////////////////////////////////////
         // POOLING METHODS
@@ -2374,32 +2336,18 @@ namespace Microsoft.Data.SqlClient
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-#if DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
+                    Task reconnectTask = parent.ValidateAndReconnect(() =>
                     {
-                        tdsReliabilitySection.Start();
-#endif //DEBUG
-                        Task reconnectTask = parent.ValidateAndReconnect(() =>
-                        {
-                            ThreadHasParserLockForClose = false;
-                            _parserLock.Release();
-                            releaseConnectionLock = false;
-                        }, timeout);
-                        if (reconnectTask != null)
-                        {
-                            AsyncHelper.WaitForCompletion(reconnectTask, timeout);
-                            return true;
-                        }
-                        return false;
-#if DEBUG
-                    }
-                    finally
+                        ThreadHasParserLockForClose = false;
+                        _parserLock.Release();
+                        releaseConnectionLock = false;
+                    }, timeout);
+                    if (reconnectTask != null)
                     {
-                        tdsReliabilitySection.Stop();
+                        AsyncHelper.WaitForCompletion(reconnectTask, timeout);
+                        return true;
                     }
-#endif //DEBUG
+                    return false;
                 }
                 catch (System.OutOfMemoryException)
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -32,29 +32,12 @@ namespace Microsoft.Data.SqlClient
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-#if DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new();
+                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
+                    statistics = SqlStatistics.StartTimer(Statistics);
 
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
-                    {
-                        tdsReliabilitySection.Start();
-#else
-                    {
-#endif //DEBUG
-                        bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                        statistics = SqlStatistics.StartTimer(Statistics);
+                    _isFromAPI = true;
 
-                        _isFromAPI = true;
-
-                        _internalTransaction.Commit();
-                    }
-#if DEBUG
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif //DEBUG
+                    _internalTransaction.Commit();
                 }
                 catch (System.OutOfMemoryException e)
                 {
@@ -101,28 +84,11 @@ namespace Microsoft.Data.SqlClient
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-#if DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new();
-
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
+                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
+                    if (!IsZombied && !Is2005PartialZombie)
                     {
-                        tdsReliabilitySection.Start();
-#else
-                    {
-#endif //DEBUG
-                        bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                        if (!IsZombied && !Is2005PartialZombie)
-                        {
-                            _internalTransaction.Dispose();
-                        }
+                        _internalTransaction.Dispose();
                     }
-#if DEBUG
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif //DEBUG
                 }
                 catch (System.OutOfMemoryException e)
                 {
@@ -167,29 +133,12 @@ namespace Microsoft.Data.SqlClient
                     RuntimeHelpers.PrepareConstrainedRegions();
                     try
                     {
-#if DEBUG
-                        TdsParser.ReliabilitySection tdsReliabilitySection = new();
+                        bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
+                        statistics = SqlStatistics.StartTimer(Statistics);
 
-                        RuntimeHelpers.PrepareConstrainedRegions();
-                        try
-                        {
-                            tdsReliabilitySection.Start();
-#else
-                        {
-#endif //DEBUG
-                            bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                            statistics = SqlStatistics.StartTimer(Statistics);
+                        _isFromAPI = true;
 
-                            _isFromAPI = true;
-
-                            _internalTransaction.Rollback();
-                        }
-#if DEBUG
-                        finally
-                        {
-                            tdsReliabilitySection.Stop();
-                        }
-#endif //DEBUG
+                        _internalTransaction.Rollback();
                     }
                     catch (System.OutOfMemoryException e)
                     {
@@ -231,29 +180,12 @@ namespace Microsoft.Data.SqlClient
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-#if DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new();
+                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
+                    statistics = SqlStatistics.StartTimer(Statistics);
 
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
-                    {
-                        tdsReliabilitySection.Start();
-#else
-                    {
-#endif //DEBUG
-                        bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                        statistics = SqlStatistics.StartTimer(Statistics);
+                    _isFromAPI = true;
 
-                        _isFromAPI = true;
-
-                        _internalTransaction.Rollback(transactionName);
-                    }
-#if DEBUG
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif //DEBUG
+                    _internalTransaction.Rollback(transactionName);
                 }
                 catch (System.OutOfMemoryException e)
                 {
@@ -295,27 +227,10 @@ namespace Microsoft.Data.SqlClient
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-#if DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new();
+                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
+                    statistics = SqlStatistics.StartTimer(Statistics);
 
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
-                    {
-                        tdsReliabilitySection.Start();
-#else
-                    {
-#endif //DEBUG
-                        bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                        statistics = SqlStatistics.StartTimer(Statistics);
-
-                        _internalTransaction.Save(savePointName);
-                    }
-#if DEBUG
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif //DEBUG
+                    _internalTransaction.Save(savePointName);
                 }
                 catch (System.OutOfMemoryException e)
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Data.SqlClient
         /// Verify client encryption possibility.
         /// </summary>
         private bool ClientOSEncryptionSupport => SNILoadHandle.SingletonInstance.ClientOSEncryptionSupport;
-        
+
         // Default state object for parser
         internal TdsParserStateObject _physicalStateObj = null; // Default stateObj and connection for Dbnetlib and non-MARS SNI.
 
@@ -159,7 +159,7 @@ namespace Microsoft.Data.SqlClient
         // size of Guid  (e.g. _clientConnectionId, ActivityId.Id)
         private const int GUID_SIZE = 16;
         private byte[] _tempGuidBytes;
-        
+
         // now data length is 1 byte
         // First bit is 1 indicating client support failover partner with readonly intent
         private static readonly byte[] s_FeatureExtDataAzureSQLSupportFeatureRequest = { 0x01 };
@@ -1812,8 +1812,6 @@ namespace Microsoft.Data.SqlClient
         //
         internal void WriteShort(int v, TdsParserStateObject stateObj)
         {
-            ReliabilitySection.Assert("unreliable call to WriteShort");  // you need to setup for a thread abort somewhere before you call this method
-
             if ((stateObj._outBytesUsed + 2) > stateObj._outBuff.Length)
             {
                 // if all of the short doesn't fit into the buffer
@@ -1872,8 +1870,6 @@ namespace Microsoft.Data.SqlClient
 
         internal void WriteInt(int v, TdsParserStateObject stateObj)
         {
-            ReliabilitySection.Assert("unreliable call to WriteInt");  // you need to setup for a thread abort somewhere before you call this method
-
             if ((stateObj._outBytesUsed + 4) > stateObj._outBuff.Length)
             {
                 // if all of the int doesn't fit into the buffer
@@ -1942,8 +1938,6 @@ namespace Microsoft.Data.SqlClient
 
         internal void WriteLong(long v, TdsParserStateObject stateObj)
         {
-            ReliabilitySection.Assert("unreliable call to WriteLong");  // you need to setup for a thread abort somewhere before you call this method
-
             if ((stateObj._outBytesUsed + 8) > stateObj._outBuff.Length)
             {
                 // if all of the long doesn't fit into the buffer
@@ -1989,7 +1983,6 @@ namespace Microsoft.Data.SqlClient
 
         internal void WritePartialLong(long v, int length, TdsParserStateObject stateObj)
         {
-            ReliabilitySection.Assert("unreliable call to WritePartialLong");  // you need to setup for a thread abort somewhere before you call this method
             Debug.Assert(length <= 8, "Length specified is longer than the size of a long");
             Debug.Assert(length >= 0, "Length should not be negative");
 
@@ -2107,7 +2100,6 @@ namespace Microsoft.Data.SqlClient
         // Main parse loop for the top-level tds tokens, calls back into the I*Handler interfaces
         internal TdsOperationStatus TryRun(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj, out bool dataReady)
         {
-            ReliabilitySection.Assert("unreliable call to Run");  // you need to setup for a thread abort somewhere before you call this method
             Debug.Assert((SniContext.Undefined != stateObj.SniContext) &&       // SniContext must not be Undefined
                 ((stateObj._attentionSent) || ((SniContext.Snix_Execute != stateObj.SniContext) && (SniContext.Snix_SendRows != stateObj.SniContext))),  // SniContext should not be Execute or SendRows unless attention was sent (and, therefore, we are looking for an ACK)
                         $"Unexpected SniContext on call to TryRun; SniContext={stateObj.SniContext}");
@@ -4936,89 +4928,72 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                    try
+                    SqlDataReader.SharedState sharedState = stateObj._readerState;
+                    if (sharedState != null && sharedState._dataReady)
                     {
-                        SqlDataReader.SharedState sharedState = stateObj._readerState;
-                        if (sharedState != null && sharedState._dataReady)
+                        var metadata = stateObj._cleanupMetaData;
+                        if (stateObj._partialHeaderBytesRead > 0)
                         {
-                            var metadata = stateObj._cleanupMetaData;
-                            if (stateObj._partialHeaderBytesRead > 0)
+                            TdsOperationStatus result = stateObj.TryProcessHeader();
+                            if (result != TdsOperationStatus.Done)
                             {
-                                TdsOperationStatus result = stateObj.TryProcessHeader();
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    throw SQL.SynchronousCallMayNotPend();
-                                }
+                                throw SQL.SynchronousCallMayNotPend();
                             }
-                            if (0 == sharedState._nextColumnHeaderToRead)
+                        }
+                        if (0 == sharedState._nextColumnHeaderToRead)
+                        {
+                            // i. user called read but didn't fetch anything
+                            TdsOperationStatus result = stateObj.Parser.TrySkipRow(stateObj._cleanupMetaData, stateObj);
+                            if (result != TdsOperationStatus.Done)
                             {
-                                // i. user called read but didn't fetch anything
-                                TdsOperationStatus result = stateObj.Parser.TrySkipRow(stateObj._cleanupMetaData, stateObj);
-                                if (result != TdsOperationStatus.Done)
-                                {
-                                    throw SQL.SynchronousCallMayNotPend();
-                                }
+                                throw SQL.SynchronousCallMayNotPend();
                             }
-                            else
+                        }
+                        else
+                        {
+                            // iia.  if we still have bytes left from a partially read column, skip
+                            if (sharedState._nextColumnDataToRead < sharedState._nextColumnHeaderToRead)
                             {
-                                // iia.  if we still have bytes left from a partially read column, skip
-                                if (sharedState._nextColumnDataToRead < sharedState._nextColumnHeaderToRead)
+                                if ((sharedState._nextColumnHeaderToRead > 0) && (metadata[sharedState._nextColumnHeaderToRead - 1].metaType.IsPlp))
                                 {
-                                    if ((sharedState._nextColumnHeaderToRead > 0) && (metadata[sharedState._nextColumnHeaderToRead - 1].metaType.IsPlp))
+                                    if (stateObj._longlen != 0)
                                     {
-                                        if (stateObj._longlen != 0)
-                                        {
-                                            TdsOperationStatus result = TrySkipPlpValue(UInt64.MaxValue, stateObj, out _);
-                                            if (result != TdsOperationStatus.Done)
-                                            {
-                                                throw SQL.SynchronousCallMayNotPend();
-                                            }
-                                        }
-                                    }
-
-                                    else if (0 < sharedState._columnDataBytesRemaining)
-                                    {
-                                        TdsOperationStatus result = stateObj.TrySkipLongBytes(sharedState._columnDataBytesRemaining);
+                                        TdsOperationStatus result = TrySkipPlpValue(UInt64.MaxValue, stateObj, out _);
                                         if (result != TdsOperationStatus.Done)
                                         {
                                             throw SQL.SynchronousCallMayNotPend();
                                         }
                                     }
-
                                 }
 
-
-                                // Read the remaining values off the wire for this row
-                                if (stateObj.Parser.TrySkipRow(metadata, sharedState._nextColumnHeaderToRead, stateObj) != TdsOperationStatus.Done)
+                                else if (0 < sharedState._columnDataBytesRemaining)
                                 {
-                                    throw SQL.SynchronousCallMayNotPend();
+                                    TdsOperationStatus result = stateObj.TrySkipLongBytes(sharedState._columnDataBytesRemaining);
+                                    if (result != TdsOperationStatus.Done)
+                                    {
+                                        throw SQL.SynchronousCallMayNotPend();
+                                    }
                                 }
+
+                            }
+
+
+                            // Read the remaining values off the wire for this row
+                            if (stateObj.Parser.TrySkipRow(metadata, sharedState._nextColumnHeaderToRead, stateObj) != TdsOperationStatus.Done)
+                            {
+                                throw SQL.SynchronousCallMayNotPend();
                             }
                         }
-                        Run(RunBehavior.Clean, null, null, null, stateObj);
                     }
-                    catch
-                    {
-                        _connHandler.DoomThisConnection();
-                        throw;
-                    }
+                    Run(RunBehavior.Clean, null, null, null, stateObj);
                 }
-#if DEBUG
-                finally
+                catch
                 {
-                    tdsReliabilitySection.Stop();
+                    _connHandler.DoomThisConnection();
+                    throw;
                 }
-#endif //DEBUG
             }
             catch (System.OutOfMemoryException)
             {
@@ -10581,24 +10556,7 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
-                {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif //DEBUG
-                    FailureCleanup(stateObj, exc);
-                }
-#if DEBUG
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
-#endif //DEBUG
+                FailureCleanup(stateObj, exc);
             }
             catch (System.OutOfMemoryException)
             {
@@ -10628,24 +10586,7 @@ namespace Microsoft.Data.SqlClient
                     RuntimeHelpers.PrepareConstrainedRegions();
                     try
                     {
-#if DEBUG
-                        TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                        RuntimeHelpers.PrepareConstrainedRegions();
-                        try
-                        {
-                            tdsReliabilitySection.Start();
-#else
-                        {
-#endif //DEBUG
-                            FailureCleanup(stateObj, tsk.Exception);
-                        }
-#if DEBUG
-                        finally
-                        {
-                            tdsReliabilitySection.Stop();
-                        }
-#endif //DEBUG
+                        FailureCleanup(stateObj, tsk.Exception);
                     }
                     catch (System.OutOfMemoryException e)
                     {
@@ -12353,31 +12294,14 @@ namespace Microsoft.Data.SqlClient
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-#if DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
+                    Task task = null;
+                    if (count > 0)
                     {
-                        tdsReliabilitySection.Start();
-#else
-                    {
-#endif //DEBUG
-                        Task task = null;
-                        if (count > 0)
-                        {
-                            _parser.WriteInt(count, _stateObj); // write length of chunk
-                            task = _stateObj.WriteByteArray(buffer, count, offset, canAccumulate: false);
-                        }
-                        
-                        return task ?? Task.CompletedTask;
+                        _parser.WriteInt(count, _stateObj); // write length of chunk
+                        task = _stateObj.WriteByteArray(buffer, count, offset, canAccumulate: false);
                     }
-#if DEBUG
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif //DEBUG
+                    
+                    return task ?? Task.CompletedTask;
                 }
                 catch (System.OutOfMemoryException)
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.netfx.cs
@@ -9,88 +9,6 @@ namespace Microsoft.Data.SqlClient
 {
     internal sealed partial class TdsParser
     {
-        // ReliabilitySection Usage:
-        //
-        // #if DEBUG
-        //        TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-        //
-        //        RuntimeHelpers.PrepareConstrainedRegions();
-        //        try {
-        //            tdsReliabilitySection.Start();
-        // #else
-        //        {
-        // #endif //DEBUG
-        //
-        //        // code that requires reliability
-        //
-        //        }
-        // #if DEBUG
-        //        finally {
-        //            tdsReliabilitySection.Stop();
-        //        }
-        //  #endif //DEBUG
-
-        internal struct ReliabilitySection
-        {
-#if DEBUG
-            // do not allocate TLS data in RETAIL bits
-            [ThreadStatic]
-            private static int s_reliabilityCount; // initialized to 0 by CLR
-
-            private bool m_started;  // initialized to false (not started) by CLR
-#endif //DEBUG
-
-            [Conditional("DEBUG")]
-            internal void Start()
-            {
-#if DEBUG
-                Debug.Assert(!m_started);
-
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
-                {
-                }
-                finally
-                {
-                    ++s_reliabilityCount;
-                    m_started = true;
-                }
-#endif //DEBUG
-            }
-
-            [Conditional("DEBUG")]
-            internal void Stop()
-            {
-#if DEBUG
-                // cannot assert m_started - ThreadAbortException can be raised before Start is called
-
-                if (m_started)
-                {
-                    Debug.Assert(s_reliabilityCount > 0);
-
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
-                    {
-                    }
-                    finally
-                    {
-                        --s_reliabilityCount;
-                        m_started = false;
-                    }
-                }
-#endif //DEBUG
-            }
-
-            // you need to setup for a thread abort somewhere before you call this method
-            [Conditional("DEBUG")]
-            internal static void Assert(string message)
-            {
-#if DEBUG
-                Debug.Assert(s_reliabilityCount > 0, message);
-#endif //DEBUG
-            }
-        }
-
         // This is called from a ThreadAbort - ensure that it can be run from a CER Catch
         internal void BestEffortCleanup()
         {
@@ -185,21 +103,7 @@ namespace Microsoft.Data.SqlClient
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
-                {
-                    tdsReliabilitySection.Start();
-#endif //DEBUG
-                    return Run(runBehavior, cmdHandler, dataStream, bulkCopyHandler, stateObj);
-#if DEBUG
-                }
-                finally
-                {
-                    tdsReliabilitySection.Stop();
-                }
-#endif //DEBUG
+                return Run(runBehavior, cmdHandler, dataStream, bulkCopyHandler, stateObj);
             }
             catch (OutOfMemoryException)
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
@@ -214,22 +214,7 @@ namespace Microsoft.Data.SqlClient
                     // We serialize Cancel/CloseSession to prevent a race condition between these two states.
                     // The problem is that both sending and receiving attentions are time taking
                     // operations.
-#if DEBUG
-                    TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
-                    {
-                        tdsReliabilitySection.Start();
-#endif //DEBUG
-                        Parser.ProcessPendingAck(this);
-#if DEBUG
-                    }
-                    finally
-                    {
-                        tdsReliabilitySection.Stop();
-                    }
-#endif //DEBUG
+                    Parser.ProcessPendingAck(this);
                 }
                 SetTimeoutStateStopped();
             }
@@ -429,8 +414,6 @@ namespace Microsoft.Data.SqlClient
         // This method should only be called by ReadSni!  If not - it may have problems with timeouts!
         private void ReadSniError(TdsParserStateObject stateObj, uint error)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadSniSyncError");  // you need to setup for a thread abort somewhere before you call this method
-
             if (TdsEnums.SNI_WAIT_TIMEOUT == error)
             {
                 Debug.Assert(_syncOverAsync, "Should never reach here with async on!");
@@ -840,8 +823,6 @@ namespace Microsoft.Data.SqlClient
         //
         internal void WriteSecureString(SecureString secureString)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to WriteSecureString");  // you need to setup for a thread abort somewhere before you call this method
-
             Debug.Assert(_securePasswords[0] == null || _securePasswords[1] == null, "There are more than two secure passwords");
 
             int index = _securePasswords[0] != null ? 1 : 0;
@@ -919,8 +900,6 @@ namespace Microsoft.Data.SqlClient
         // and then the buffer is re-initialized in flush() and then the byte is put in the buffer.
         internal void WriteByte(byte b)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to WriteByte");  // you need to setup for a thread abort somewhere before you call this method
-
             Debug.Assert(_outBytesUsed <= _outBuff.Length, "ERROR - TDSParser: _outBytesUsed > _outBuff.Length");
 
             // check to make sure we haven't used the full amount of space available in the buffer, if so, flush it
@@ -936,8 +915,6 @@ namespace Microsoft.Data.SqlClient
         {
             try
             {
-                TdsParser.ReliabilitySection.Assert("unreliable call to WriteByteArray");  // you need to setup for a thread abort somewhere before you call this method
-
                 bool async = _parser._asyncWrite;  // NOTE: We are capturing this now for the assert after the Task is returned, since WritePacket will turn off async if there is an exception
                 Debug.Assert(async || _asyncWriteCount == 0);
                 // Do we have to send out in packet size chunks, or can we rely on netlib layer to break it up?

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPool.cs
@@ -1158,29 +1158,14 @@ namespace Microsoft.Data.ProviderBase
 #endif
                         try
                         {
-#if DEBUG
-                            Microsoft.Data.SqlClient.TdsParser.ReliabilitySection tdsReliabilitySection = new Microsoft.Data.SqlClient.TdsParser.ReliabilitySection();
-
-#if NETFRAMEWORK
-                            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                            try
-                            {
-                                tdsReliabilitySection.Start();
-#else
-                            {
-#endif //DEBUG
-                                bool allowCreate = true;
-                                bool onlyOneCheckConnection = false;
-                                ADP.SetCurrentTransaction(next.Completion.Task.AsyncState as Transaction);
-                                timeout = !TryGetConnection(next.Owner, delay, allowCreate, onlyOneCheckConnection, next.UserOptions, out connection);
-                            }
-#if DEBUG
-                            finally
-                            {
-                                tdsReliabilitySection.Stop();
-                            }
-#endif //DEBUG
+                            ADP.SetCurrentTransaction(next.Completion.Task.AsyncState as Transaction);
+                            timeout = !TryGetConnection(
+                                next.Owner,
+                                delay,
+                                allowCreate: true,
+                                onlyOneCheckConnection: false,
+                                next.UserOptions,
+                                out connection);
                         }
                         catch (System.OutOfMemoryException)
                         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
@@ -260,27 +260,11 @@ namespace Microsoft.Data.SqlClient
 #endif
             try
             {
-#if NETFRAMEWORK
-#if DEBUG
-                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try {
-                    tdsReliabilitySection.Start();
-#else
-                {
-#endif // DEBUG
+                    #if NETFRAMEWORK
                     bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(command.Connection);
-#endif // NETFRAMEWORK
+                    #endif
+
                     command.DeriveParameters();
-#if NETFRAMEWORK
-                }
-#if DEBUG
-                finally {
-                    tdsReliabilitySection.Stop();
-                }
-#endif // DEBUG
-#endif // NETFRAMEWORK
             }
             catch (OutOfMemoryException e)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -203,7 +203,6 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                TdsParser.ReliabilitySection.Assert("unreliable call to CloseFromConnection");  // you need to setup for a thread abort somewhere before you call this method
                 if (processFinallyBlock)
                 {
                     // Always ensure we're zombied; 2005 will send an EnvChange that

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -183,21 +183,7 @@ namespace Microsoft.Data.SqlClient
                             RuntimeHelpers.PrepareConstrainedRegions();
                             try
                             {
-#if DEBUG
-                                TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-                                RuntimeHelpers.PrepareConstrainedRegions();
-                                try
-                                {
-                                    tdsReliabilitySection.Start();
-#endif //DEBUG
-                                    onSuccess();
-#if DEBUG
-                                }
-                                finally
-                                {
-                                    tdsReliabilitySection.Stop();
-                                }
-#endif //DEBUG
+                                onSuccess();
                             }
                             catch (System.OutOfMemoryException e)
                             {
@@ -330,21 +316,7 @@ namespace Microsoft.Data.SqlClient
                         RuntimeHelpers.PrepareConstrainedRegions();
                         try
                         {
-#if DEBUG
-                            TdsParser.ReliabilitySection tdsReliabilitySection = new TdsParser.ReliabilitySection();
-                            RuntimeHelpers.PrepareConstrainedRegions();
-                            try
-                            {
-                                tdsReliabilitySection.Start();
-#endif //DEBUG
-                                onSuccess(state2);
-#if DEBUG
-                            }
-                            finally
-                            {
-                                tdsReliabilitySection.Stop();
-                            }
-#endif //DEBUG
+                            onSuccess(state2);
                         }
                         catch (System.OutOfMemoryException e)
                         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -1018,7 +1018,6 @@ namespace Microsoft.Data.SqlClient
         // NOTE: This method (and all it calls) should be retryable without replaying a snapshot
         internal TdsOperationStatus TryPrepareBuffer()
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadBuffer");  // you need to setup for a thread abort somewhere before you call this method
             Debug.Assert(_inBuff != null, "packet buffer should not be null!");
 
             // Header spans packets, or we haven't read the header yet - process header
@@ -1208,7 +1207,6 @@ namespace Microsoft.Data.SqlClient
         // Every time you call this method increment the offset and decrease len by the value of totalRead
         public TdsOperationStatus TryReadByteArray(Span<byte> buff, int len, out int totalRead)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadByteArray");  // you need to setup for a thread abort somewhere before you call this method
             totalRead = 0;
 
 #if DEBUG
@@ -1268,7 +1266,6 @@ namespace Microsoft.Data.SqlClient
         // before the byte is returned.
         internal TdsOperationStatus TryReadByte(out byte value)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadByte");  // you need to setup for a thread abort somewhere before you call this method
             Debug.Assert(_inBytesUsed >= 0 && _inBytesUsed <= _inBytesRead, "ERROR - TDSParser: _inBytesUsed < 0 or _inBytesUsed > _inBytesRead");
             value = 0;
 
@@ -1375,7 +1372,6 @@ namespace Microsoft.Data.SqlClient
 
         internal TdsOperationStatus TryReadInt32(out int value)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadInt32");  // you need to setup for a thread abort somewhere before you call this method
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
             Span<byte> buffer = stackalloc byte[4];
             if (((_inBytesUsed + 4) > _inBytesRead) || (_inBytesPacket < 4))
@@ -1406,7 +1402,6 @@ namespace Microsoft.Data.SqlClient
         // This method is safe to call when doing async without snapshot
         internal TdsOperationStatus TryReadInt64(out long value)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadInt64");  // you need to setup for a thread abort somewhere before you call this method
             if ((_inBytesPacket == 0) || (_inBytesUsed == _inBytesRead))
             {
                 TdsOperationStatus result = TryPrepareBuffer();
@@ -1488,7 +1483,6 @@ namespace Microsoft.Data.SqlClient
         // This method is safe to call when doing async without replay
         internal TdsOperationStatus TryReadUInt32(out uint value)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadUInt32");  // you need to setup for a thread abort somewhere before you call this method
             if ((_inBytesPacket == 0) || (_inBytesUsed == _inBytesRead))
             {
                 TdsOperationStatus result = TryPrepareBuffer();
@@ -1539,7 +1533,6 @@ namespace Microsoft.Data.SqlClient
 
         internal TdsOperationStatus TryReadSingle(out float value)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadSingle");  // you need to setup for a thread abort somewhere before you call this method
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
             if (((_inBytesUsed + 4) > _inBytesRead) || (_inBytesPacket < 4))
             {
@@ -1574,7 +1567,6 @@ namespace Microsoft.Data.SqlClient
 
         internal TdsOperationStatus TryReadDouble(out double value)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadDouble");  // you need to setup for a thread abort somewhere before you call this method
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
             if (((_inBytesUsed + 8) > _inBytesRead) || (_inBytesPacket < 8))
             {
@@ -1609,7 +1601,6 @@ namespace Microsoft.Data.SqlClient
 
         internal TdsOperationStatus TryReadString(int length, out string value)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadString");  // you need to setup for a thread abort somewhere before you call this method
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
             int cBytes = length << 1;
             byte[] buf;
@@ -1651,7 +1642,6 @@ namespace Microsoft.Data.SqlClient
 
         internal TdsOperationStatus TryReadStringWithEncoding(int length, System.Text.Encoding encoding, bool isPlp, out string value)
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to ReadStringWithEncoding");  // you need to setup for a thread abort somewhere before you call this method
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
 
             if (encoding == null)
@@ -1992,8 +1982,6 @@ namespace Microsoft.Data.SqlClient
 
         internal TdsOperationStatus TryReadNetworkPacket()
         {
-            TdsParser.ReliabilitySection.Assert("unreliable call to TryReadNetworkPacket");  // you need to setup for a thread abort somewhere before you call this method
-
 #if DEBUG
             Debug.Assert(!_shouldHaveEnoughData || _attentionSent, "Caller said there should be enough data, but we are currently reading a packet");
 #endif
@@ -2077,8 +2065,6 @@ namespace Microsoft.Data.SqlClient
             bool shouldDecrement = false;
             try
             {
-                TdsParser.ReliabilitySection.Assert("unreliable call to ReadSniSync");  // you need to setup for a thread abort somewhere before you call this method
-
                 Interlocked.Increment(ref _readingCount);
                 shouldDecrement = true;
 
@@ -2499,8 +2485,6 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    TdsParser.ReliabilitySection.Assert("unreliable call to IsConnectionAlive");  // you need to setup for a thread abort somewhere before you call this method
-
                     SniContext = SniContext.Snix_Connect;
 
                     uint error = CheckConnection();


### PR DESCRIPTION
**Description**: After some discussion with @saurabh500 we came to the conclusion that it's just not beneficial to have the ReliabilitySection code in the netfx project. It is only included in debug builds (which we don't even use for CI builds anyhow), and it makes massive clutter in the code base. Although I've experimented with some ideas to leave it in place but cleanup the code, simply removing it is probably the easiest solution.

**Testing**: Project still builds without it and since it provides no functionality, it won't break anything to remove it.