### PR TITLE
Synchronize versions/packages across nuspec and ref project, Add .NET9

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.csproj
@@ -34,5 +34,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelProtocolsOpenIdConnectVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(SystemConfigurationConfigurationManagerVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="$(MicrosoftBclCryptographyVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.csproj
@@ -44,5 +44,7 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
+    <PackageReference Include="Microsoft.Bcl.Cryptography" Version="$(MicrosoftBclCryptographyVersion)" />
   </ItemGroup>
 </Project>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -31,21 +31,36 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       <group targetFramework="net462">
         <dependency id="Microsoft.Data.SqlClient.SNI" version="6.0.0-preview1.24226.4" />
         <dependency id="Azure.Identity" version="1.11.4" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.1" exclude="Compile" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.0" exclude="Compile" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="7.5.0" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="7.5.0" />
         <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
         <dependency id="System.Text.Json" version="6.0.10" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.0"/>
+        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.0"/>
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.0-preview1.24226.4" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.11.4" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" exclude="Compile" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.0" exclude="Compile" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="7.5.0" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="7.5.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
-        <dependency id="System.Configuration.ConfigurationManager" version="8.0.1" exclude="Compile" />
+        <dependency id="System.Configuration.ConfigurationManager" version="9.0.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.0"/>
+        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.0"/>
+      </group>
+      <group targetFramework="net9.0">
+        <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.0-preview1.24226.4" exclude="Compile" />
+        <dependency id="Azure.Identity" version="1.11.4" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.0" exclude="Compile" />
+        <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="7.5.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="7.5.0" />
+        <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
+        <dependency id="System.Configuration.ConfigurationManager" version="9.0.0" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.0"/>
+        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.0"/>
       </group>
     </dependencies>
     <frameworkAssemblies>
@@ -61,6 +76,10 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
           <reference file="Microsoft.Data.SqlClient.dll" />
           <reference file="Microsoft.Data.SqlClient.xml" />
       </group>
+      <group targetFramework="net9.0">
+          <reference file="Microsoft.Data.SqlClient.dll" />
+          <reference file="Microsoft.Data.SqlClient.xml" />
+      </group>
     </references>
   </metadata>
   <files>
@@ -71,9 +90,13 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$\Microsoft.Data.SqlClient\ref\net462\Microsoft.Data.SqlClient.dll" target="ref\net462\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$\Microsoft.Data.SqlClient\ref\net462\Microsoft.Data.SqlClient.xml" target="ref\net462\" exclude="" />
 
-    <!-- ref NetCore -->
+    <!-- ref NetCore for Net 8 -->
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\net8.0\Microsoft.Data.SqlClient.dll" target="ref\net8.0\" exclude="" />
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\net8.0\Microsoft.Data.SqlClient.xml" target="ref\net8.0\" exclude="" />
+
+    <!-- ref NetCore for Net 9 -->
+    <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\net9.0\Microsoft.Data.SqlClient.dll" target="ref\net9.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$\Microsoft.Data.SqlClient\ref\net9.0\Microsoft.Data.SqlClient.xml" target="ref\net9.0\" exclude="" />
 
     <!-- Localized Resource Files for NetFx -->
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netfx\net462\cs\Microsoft.Data.SqlClient.resources.dll" target="lib\net462\cs\" exclude="" />
@@ -95,12 +118,17 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netfx\net462\Microsoft.Data.SqlClient.pdb" target="lib\net462\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netfx\net462\Microsoft.Data.SqlClient.xml" target="lib\net462\" exclude="" />
 
-    <!-- lib NetCore -->
+    <!-- lib NetCore for Net 8 -->
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\Microsoft.Data.SqlClient.dll" target="lib\net8.0\" exclude="" />
     <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\Microsoft.Data.SqlClient.pdb" target="lib\net8.0\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\Microsoft.Data.SqlClient.xml" target="lib\net8.0\" exclude="" />
     
-	<!-- Localization files for Net 8 -->
+    <!-- lib NetCore for Net 9 -->
+    <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\Microsoft.Data.SqlClient.dll" target="lib\net9.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\AnyOS\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\Microsoft.Data.SqlClient.pdb" target="lib\net9.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\Microsoft.Data.SqlClient.xml" target="lib\net9.0\" exclude="" />
+    
+	  <!-- Localization files for Net 8 -->
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\cs\Microsoft.Data.SqlClient.resources.dll" target="lib\net8.0\cs\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\de\Microsoft.Data.SqlClient.resources.dll" target="lib\net8.0\de\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\es\Microsoft.Data.SqlClient.resources.dll" target="lib\net8.0\es\" exclude="" />
@@ -116,14 +144,36 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\zh-Hant\Microsoft.Data.SqlClient.resources.dll" target="lib\net8.0\zh-Hant\" exclude="" />
     <!-- End of Localization files for Net 8 -->	
 
+    <!-- Localization files for Net 9 -->
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\cs\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\cs\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\de\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\de\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\es\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\es\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\fr\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\fr\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\it\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\it\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\ja\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\ja\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\ko\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\ko\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\pl\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\pl\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\pt-BR\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\pt-BR\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\ru\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\ru\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\tr\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\tr\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\zh-Hans\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\zh-Hans\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\zh-Hant\Microsoft.Data.SqlClient.resources.dll" target="lib\net9.0\zh-Hant\" exclude="" />
+    <!-- End of Localization files for Net 9 -->	
+
     <!-- runtimes NetFx -->
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netfx\net462\Microsoft.Data.SqlClient.dll" target="runtimes\win\lib\net462\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netfx\net462\Microsoft.Data.SqlClient.pdb" target="runtimes\win\lib\net462\" exclude="" />
 
-    <!-- runtimes NetCore -->
+    <!-- runtimes NetCore for Net 8 -->
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\Microsoft.Data.SqlClient.dll" target="runtimes\win\lib\net8.0\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\Microsoft.Data.SqlClient.pdb" target="runtimes\win\lib\net8.0\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Unix\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\Microsoft.Data.SqlClient.dll" target="runtimes\unix\lib\net8.0\" exclude="" />
     <file src="..\..\artifacts\Project\bin\Unix\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net8.0\Microsoft.Data.SqlClient.pdb" target="runtimes\unix\lib\net8.0\" exclude="" />
+
+    <!-- runtimes NetCore for Net 9 -->
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\Microsoft.Data.SqlClient.dll" target="runtimes\win\lib\net9.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Windows_NT\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\Microsoft.Data.SqlClient.pdb" target="runtimes\win\lib\net9.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Unix\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\Microsoft.Data.SqlClient.dll" target="runtimes\unix\lib\net9.0\" exclude="" />
+    <file src="..\..\artifacts\Project\bin\Unix\$Configuration$.AnyCPU\Microsoft.Data.SqlClient\netcore\net9.0\Microsoft.Data.SqlClient.pdb" target="runtimes\unix\lib\net9.0\" exclude="" />
   </files>
 </package>


### PR DESCRIPTION
# Copilot Summary
This pull request includes several updates to the `Microsoft.Data.SqlClient` package to add support for .NET 9.0 and update dependencies. The most important changes include adding new package references, updating existing dependencies, and adding support for .NET 9.0 in the nuspec file.

### Dependency Updates:
* Added `System.Security.Cryptography.Pkcs` and `Microsoft.Bcl.Cryptography` package references in `netcore` and `netfx` project files. [[1]](diffhunk://#diff-f43b034f4adbdf6691e25ff332dabae19a72dbb2f73169377288a9d221096938R37-R38) [[2]](diffhunk://#diff-d6cdac7c9f92790e995dce24e966c09119385fdc076757b8f70b08bd14dde23fR47-R48)

### Nuspec File Updates:
* Updated `Microsoft.Extensions.Caching.Memory` to version 9.0.0 and other dependencies to version 9.0.0 for .NET 8.0 and .NET 9.0.
* Added support for .NET 9.0, including dependency and reference groups. [[1]](diffhunk://#diff-765d86cd1fa8e81a53f741ddcefe6340ce78361d548c5e700d6882d382d1a8f9R79-R82) [[2]](diffhunk://#diff-765d86cd1fa8e81a53f741ddcefe6340ce78361d548c5e700d6882d382d1a8f9L74-R100) [[3]](diffhunk://#diff-765d86cd1fa8e81a53f741ddcefe6340ce78361d548c5e700d6882d382d1a8f9L98-R130) [[4]](diffhunk://#diff-765d86cd1fa8e81a53f741ddcefe6340ce78361d548c5e700d6882d382d1a8f9R147-R177)

# Human description
This synchronizes versions to the `nuspec` file, it also adds missing packages and adds` .NET9 `support
Also, 2 libraries were missing from the `ref `projects

I'm not sure if this is all needed or not, but I think it is?