### PR TITLE
Disable auditing for internal projects

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/Directory.Build.props
+++ b/src/Microsoft.Data.SqlClient/tests/Directory.Build.props
@@ -13,6 +13,11 @@
     <Platforms>AnyCPU;x86;x64</Platforms>
     <ReferenceType Condition="'$(ReferenceType)'==''">Project</ReferenceType>
   </PropertyGroup>
+  
+    <!-- Audit Settings -->
+  <PropertyGroup>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
 
   <!--These properties can be modified locally to target .NET version of choice to build and test entire test suite-->
   <PropertyGroup>

--- a/src/Microsoft.Data.SqlClient/tests/Directory.Build.props
+++ b/src/Microsoft.Data.SqlClient/tests/Directory.Build.props
@@ -14,7 +14,7 @@
     <ReferenceType Condition="'$(ReferenceType)'==''">Project</ReferenceType>
   </PropertyGroup>
   
-    <!-- Audit Settings -->
+  <!-- Audit Settings -->
   <PropertyGroup>
     <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>

--- a/tools/GenAPI/Directory.Build.Props
+++ b/tools/GenAPI/Directory.Build.Props
@@ -5,4 +5,7 @@
   <!-- Import parent Directory.build.props -->
   <Import Project="..\..\src\Directory.Build.props" />
 
+  <PropertyGroup>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
 </Project>

--- a/tools/GenAPI/Directory.Build.Props
+++ b/tools/GenAPI/Directory.Build.Props
@@ -5,6 +5,7 @@
   <!-- Import parent Directory.build.props -->
   <Import Project="..\..\src\Directory.Build.props" />
 
+  <!-- Audit Settings -->
   <PropertyGroup>
     <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>


### PR DESCRIPTION
This relates to #3024 and disables auditing for all "internal" projects like test projects and helper projects.

I think it makes sense to cut through the noise and focus on the important part, the MDS library itself