### PR TITLE
Cleanup | SNI Native Wrapper

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/LocalDBAPI.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/LocalDBAPI.Windows.cs
@@ -24,14 +24,14 @@ namespace Microsoft.Data
                     {
                         if (s_userInstanceDLLHandle == IntPtr.Zero)
                         {
-                            SniNativeWrapper.SNIQueryInfo(QueryType.SNI_QUERY_LOCALDB_HMODULE, ref s_userInstanceDLLHandle);
+                            SniNativeWrapper.SniQueryInfo(QueryType.SNI_QUERY_LOCALDB_HMODULE, ref s_userInstanceDLLHandle);
                             if (s_userInstanceDLLHandle != IntPtr.Zero)
                             {
                                 SqlClientEventSource.Log.TryTraceEvent("LocalDBAPI.UserInstanceDLLHandle | LocalDB - handle obtained");
                             }
                             else
                             {
-                                SniNativeWrapper.SNIGetLastError(out SniError sniError);
+                                SniNativeWrapper.SniGetLastError(out SniError sniError);
                                 throw CreateLocalDBException(errorMessage: StringsHelper.GetString("LocalDB_FailedGetDLLHandle"), sniError: sniError.sniError);
                             }
                         }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Windows.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Data.SqlClient
             }
             else
             {
-                SniNativeWrapper.SNIGetLastError(out SniError sniError);
+                SniNativeWrapper.SniGetLastError(out SniError sniError);
                 details.sniErrorNumber = sniError.sniError;
                 details.errorMessage = sniError.errorMessage;
                 details.nativeError = sniError.nativeError;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Data.SqlClient
         protected override uint SNIPacketGetData(PacketHandle packet, byte[] _inBuff, ref uint dataSize)
         {
             Debug.Assert(packet.Type == PacketHandle.NativePointerType, "unexpected packet type when requiring NativePointer");
-            return SniNativeWrapper.SNIPacketGetData(packet.NativePointer, _inBuff, ref dataSize);
+            return SniNativeWrapper.SniPacketGetData(packet.NativePointer, _inBuff, ref dataSize);
         }
 
         protected override bool CheckPacket(PacketHandle packet, TaskCompletionSource<object> source)
@@ -267,7 +267,7 @@ namespace Microsoft.Data.SqlClient
                 throw ADP.ClosedConnectionError();
             }
             IntPtr readPacketPtr = IntPtr.Zero;
-            error = SniNativeWrapper.SNIReadSyncOverAsync(handle, ref readPacketPtr, GetTimeoutRemaining());
+            error = SniNativeWrapper.SniReadSyncOverAsync(handle, ref readPacketPtr, GetTimeoutRemaining());
             return PacketHandle.FromNativePointer(readPacketPtr);
         }
 
@@ -284,20 +284,20 @@ namespace Microsoft.Data.SqlClient
         internal override void ReleasePacket(PacketHandle syncReadPacket)
         {
             Debug.Assert(syncReadPacket.Type == PacketHandle.NativePointerType, "unexpected packet type when requiring NativePointer");
-            SniNativeWrapper.SNIPacketRelease(syncReadPacket.NativePointer);
+            SniNativeWrapper.SniPacketRelease(syncReadPacket.NativePointer);
         }
 
         internal override uint CheckConnection()
         {
             SNIHandle handle = Handle;
-            return handle == null ? TdsEnums.SNI_SUCCESS : SniNativeWrapper.SNICheckConnection(handle);
+            return handle == null ? TdsEnums.SNI_SUCCESS : SniNativeWrapper.SniCheckConnection(handle);
         }
 
         internal override PacketHandle ReadAsync(SessionHandle handle, out uint error)
         {
             Debug.Assert(handle.Type == SessionHandle.NativeHandleType, "unexpected handle type when requiring NativePointer");
             IntPtr readPacketPtr = IntPtr.Zero;
-            error = SniNativeWrapper.SNIReadAsync(handle.NativeHandle, ref readPacketPtr);
+            error = SniNativeWrapper.SniReadAsync(handle.NativeHandle, ref readPacketPtr);
             return PacketHandle.FromNativePointer(readPacketPtr);
         }
 
@@ -313,7 +313,7 @@ namespace Microsoft.Data.SqlClient
         internal override uint WritePacket(PacketHandle packet, bool sync)
         {
             Debug.Assert(packet.Type == PacketHandle.NativePacketType, "unexpected packet type when requiring NativePacket");
-            return SniNativeWrapper.SNIWritePacket(Handle, packet.NativePacket, sync);
+            return SniNativeWrapper.SniWritePacket(Handle, packet.NativePacket, sync);
         }
 
         internal override PacketHandle AddPacketToPendingList(PacketHandle packetToAdd)
@@ -346,7 +346,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (_sniPacket != null)
             {
-                SniNativeWrapper.SNIPacketReset(Handle, IoType.WRITE, _sniPacket, ConsumerNumber.SNI_Consumer_SNI);
+                SniNativeWrapper.SniPacketReset(Handle, IoType.WRITE, _sniPacket, ConsumerNumber.SNI_Consumer_SNI);
             }
             else
             {
@@ -375,17 +375,17 @@ namespace Microsoft.Data.SqlClient
         internal override void SetPacketData(PacketHandle packet, byte[] buffer, int bytesUsed)
         {
             Debug.Assert(packet.Type == PacketHandle.NativePacketType, "unexpected packet type when requiring NativePacket");
-            SniNativeWrapper.SNIPacketSetData(packet.NativePacket, buffer, bytesUsed);
+            SniNativeWrapper.SniPacketSetData(packet.NativePacket, buffer, bytesUsed);
         }
 
         internal override uint SniGetConnectionId(ref Guid clientConnectionId)
             => SniNativeWrapper.SniGetConnectionId(Handle, ref clientConnectionId);
 
         internal override uint DisableSsl()
-            => SniNativeWrapper.SNIRemoveProvider(Handle, Provider.SSL_PROV);
+            => SniNativeWrapper.SniRemoveProvider(Handle, Provider.SSL_PROV);
 
         internal override uint EnableMars(ref uint info)
-            => SniNativeWrapper.SNIAddProvider(Handle, Provider.SMUX_PROV, ref info);
+            => SniNativeWrapper.SniAddProvider(Handle, Provider.SMUX_PROV, ref info);
 
         internal override uint EnableSsl(ref uint info, bool tlsFirst, string serverCertificateFilename)
         {
@@ -395,15 +395,15 @@ namespace Microsoft.Data.SqlClient
             authInfo.serverCertFileName = serverCertificateFilename;
 
             // Add SSL (Encryption) SNI provider.
-            return SniNativeWrapper.SNIAddProvider(Handle, Provider.SSL_PROV, ref authInfo);
+            return SniNativeWrapper.SniAddProvider(Handle, Provider.SSL_PROV, ref authInfo);
         }
 
         internal override uint SetConnectionBufferSize(ref uint unsignedPacketSize)
-            => SniNativeWrapper.SNISetInfo(Handle, QueryType.SNI_QUERY_CONN_BUFSIZE, ref unsignedPacketSize);
+            => SniNativeWrapper.SniSetInfo(Handle, QueryType.SNI_QUERY_CONN_BUFSIZE, ref unsignedPacketSize);
 
         internal override uint WaitForSSLHandShakeToComplete(out int protocolVersion)
         {
-            uint returnValue = SniNativeWrapper.SNIWaitForSSLHandshakeToComplete(Handle, GetTimeoutRemaining(), out uint nativeProtocolVersion);
+            uint returnValue = SniNativeWrapper.SniWaitForSslHandshakeToComplete(Handle, GetTimeoutRemaining(), out uint nativeProtocolVersion);
             var nativeProtocol = (NativeProtocols)nativeProtocolVersion;
 
 #pragma warning disable CA5398 // Avoid hardcoded SslProtocols values
@@ -472,7 +472,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // Success - reset the packet
                     packet = _packets.Pop();
-                    SniNativeWrapper.SNIPacketReset(sniHandle, IoType.WRITE, packet, ConsumerNumber.SNI_Consumer_SNI);
+                    SniNativeWrapper.SniPacketReset(sniHandle, IoType.WRITE, packet, ConsumerNumber.SNI_Consumer_SNI);
                 }
                 else
                 {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Data.SqlClient
                 result = SniNativeWrapper.SniGetConnectionPort(Handle, ref portFromSNI);
                 Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionPort");
 
-                result = SniNativeWrapper.SniGetConnectionIPString(Handle, ref IPStringFromSNI);
+                result = SniNativeWrapper.SniGetConnectionIpString(Handle, ref IPStringFromSNI);
                 Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionIPString");
 
                 pendingDNSInfo = new SQLDNSInfo(DNSCacheKey, null, null, portFromSNI.ToString());

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/LocalDBAPI.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/LocalDBAPI.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Data
                         Monitor.Enter(s_dllLock, ref lockTaken);
                         if (s_userInstanceDLLHandle == IntPtr.Zero)
                         {
-                            SniNativeWrapper.SNIQueryInfo(QueryType.SNI_QUERY_LOCALDB_HMODULE, ref s_userInstanceDLLHandle);
+                            SniNativeWrapper.SniQueryInfo(QueryType.SNI_QUERY_LOCALDB_HMODULE, ref s_userInstanceDLLHandle);
                             if (s_userInstanceDLLHandle != IntPtr.Zero)
                             {
                                 SqlClientEventSource.Log.TryTraceEvent("<sc.LocalDBAPI.UserInstanceDLLHandle> LocalDB - handle obtained");
@@ -89,7 +89,7 @@ namespace Microsoft.Data
                             else
                             {
                                 SniError sniError = new SniError();
-                                SniNativeWrapper.SNIGetLastError(out sniError);
+                                SniNativeWrapper.SniGetLastError(out sniError);
                                 throw CreateLocalDBException(errorMessage: StringsHelper.GetString("LocalDB_FailedGetDLLHandle"), sniError: sniError.sniError);
                             }
                         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -700,7 +700,7 @@ namespace Microsoft.Data.SqlClient
             uint error = 0;
 
             // Remove SSL (Encryption) SNI provider since we only wanted to encrypt login.
-            error = SniNativeWrapper.SNIRemoveProvider(_physicalStateObj.Handle, Provider.SSL_PROV);
+            error = SniNativeWrapper.SniRemoveProvider(_physicalStateObj.Handle, Provider.SSL_PROV);
             if (error != TdsEnums.SNI_SUCCESS)
             {
                 _physicalStateObj.AddError(ProcessSNIError(_physicalStateObj));
@@ -727,7 +727,7 @@ namespace Microsoft.Data.SqlClient
                 uint info = 0;
 
                 // Add SMUX (MARS) SNI provider.
-                error = SniNativeWrapper.SNIAddProvider(_pMarsPhysicalConObj.Handle, Provider.SMUX_PROV, ref info);
+                error = SniNativeWrapper.SniAddProvider(_pMarsPhysicalConObj.Handle, Provider.SMUX_PROV, ref info);
 
                 if (error != TdsEnums.SNI_SUCCESS)
                 {
@@ -748,12 +748,12 @@ namespace Microsoft.Data.SqlClient
                 {
                     _pMarsPhysicalConObj.IncrementPendingCallbacks();
 
-                    error = SniNativeWrapper.SNIReadAsync(_pMarsPhysicalConObj.Handle, ref temp);
+                    error = SniNativeWrapper.SniReadAsync(_pMarsPhysicalConObj.Handle, ref temp);
 
                     if (temp != IntPtr.Zero)
                     {
                         // Be sure to release packet, otherwise it will be leaked by native.
-                        SniNativeWrapper.SNIPacketRelease(temp);
+                        SniNativeWrapper.SniPacketRelease(temp);
                     }
                 }
                 Debug.Assert(IntPtr.Zero == temp, "unexpected syncReadPacket without corresponding SNIPacketRelease");
@@ -1026,7 +1026,7 @@ namespace Microsoft.Data.SqlClient
 
             Debug.Assert((_encryptionOption & EncryptionOptions.CLIENT_CERT) == 0, "Client certificate authentication support has been removed");
 
-            error = SniNativeWrapper.SNIAddProvider(_physicalStateObj.Handle, Provider.SSL_PROV, authInfo);
+            error = SniNativeWrapper.SniAddProvider(_physicalStateObj.Handle, Provider.SSL_PROV, authInfo);
 
             if (error != TdsEnums.SNI_SUCCESS)
             {
@@ -1038,7 +1038,7 @@ namespace Microsoft.Data.SqlClient
             // wait for SSL handshake to complete, so that the SSL context is fully negotiated before we try to use its
             // Channel Bindings as part of the Windows Authentication context build (SSL handshake must complete
             // before calling SNISecGenClientContext).
-            error = SniNativeWrapper.SNIWaitForSSLHandshakeToComplete(_physicalStateObj.Handle, _physicalStateObj.GetTimeoutRemaining(), out uint protocolVersion);
+            error = SniNativeWrapper.SniWaitForSslHandshakeToComplete(_physicalStateObj.Handle, _physicalStateObj.GetTimeoutRemaining(), out uint protocolVersion);
 
             if (error != TdsEnums.SNI_SUCCESS)
             {
@@ -1592,7 +1592,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(SniContext.Undefined != stateObj.DebugOnlyCopyOfSniContext || ((_fMARS) && ((_state == TdsParserState.Closed) || (_state == TdsParserState.Broken))), "SniContext must not be None");
 #endif
             SniError sniError = new SniError();
-            SniNativeWrapper.SNIGetLastError(out sniError);
+            SniNativeWrapper.SniGetLastError(out sniError);
 
             if (sniError.sniError != 0)
             {
@@ -2915,7 +2915,7 @@ namespace Microsoft.Data.SqlClient
 
                             // Update SNI ConsumerInfo value to be resulting packet size
                             uint unsignedPacketSize = (uint)packetSize;
-                            uint bufferSizeResult = SniNativeWrapper.SNISetInfo(_physicalStateObj.Handle, QueryType.SNI_QUERY_CONN_BUFSIZE, ref unsignedPacketSize);
+                            uint bufferSizeResult = SniNativeWrapper.SniSetInfo(_physicalStateObj.Handle, QueryType.SNI_QUERY_CONN_BUFSIZE, ref unsignedPacketSize);
 
                             Debug.Assert(bufferSizeResult == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SNISetInfo");
                         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.netfx.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Data.SqlClient
                 Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionPort");
 
 
-                result = SniNativeWrapper.SniGetConnectionIPString(_physicalStateObj.Handle, ref IPStringFromSNI);
+                result = SniNativeWrapper.SniGetConnectionIpString(_physicalStateObj.Handle, ref IPStringFromSNI);
                 Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionIPString");
 
                 _connHandler.pendingSQLDNSObject = new SQLDNSInfo(DNSCacheKey, null, null, portFromSNI.ToString());

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
@@ -285,20 +285,20 @@ namespace Microsoft.Data.SqlClient
         {
             SNIHandle handle = Handle ?? throw ADP.ClosedConnectionError();
             PacketHandle readPacket = default;
-            error = SniNativeWrapper.SNIReadSyncOverAsync(handle, ref readPacket, timeoutRemaining);
+            error = SniNativeWrapper.SniReadSyncOverAsync(handle, ref readPacket, timeoutRemaining);
             return readPacket;
         }
 
         internal PacketHandle ReadAsync(SessionHandle handle, out uint error)
         {
             PacketHandle readPacket = default;
-            error = SniNativeWrapper.SNIReadAsync(handle.NativeHandle, ref readPacket);
+            error = SniNativeWrapper.SniReadAsync(handle.NativeHandle, ref readPacket);
             return readPacket;
         }
 
-        internal uint CheckConnection() => SniNativeWrapper.SNICheckConnection(Handle);
+        internal uint CheckConnection() => SniNativeWrapper.SniCheckConnection(Handle);
 
-        internal void ReleasePacket(PacketHandle syncReadPacket) => SniNativeWrapper.SNIPacketRelease(syncReadPacket);
+        internal void ReleasePacket(PacketHandle syncReadPacket) => SniNativeWrapper.SniPacketRelease(syncReadPacket);
         
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         internal int DecrementPendingCallbacks(bool release)
@@ -416,7 +416,7 @@ namespace Microsoft.Data.SqlClient
                 SNIHandle handle = Handle;
                 if (handle != null)
                 {
-                    error = SniNativeWrapper.SNICheckConnection(handle);
+                    error = SniNativeWrapper.SniCheckConnection(handle);
                 }
             }
             finally
@@ -543,7 +543,7 @@ namespace Microsoft.Data.SqlClient
             {
                 uint dataSize = 0;
 
-                uint getDataError = SniNativeWrapper.SNIPacketGetData(packet, _inBuff, ref dataSize);
+                uint getDataError = SniNativeWrapper.SniPacketGetData(packet, _inBuff, ref dataSize);
 
                 if (getDataError == TdsEnums.SNI_SUCCESS)
                 {
@@ -1169,7 +1169,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                sniError = SniNativeWrapper.SNIWritePacket(handle, packet, sync);
+                sniError = SniNativeWrapper.SniWritePacket(handle, packet, sync);
             }
 
             if (sniError == TdsEnums.SNI_SUCCESS_IO_PENDING)
@@ -1281,7 +1281,7 @@ namespace Microsoft.Data.SqlClient
                 SNIPacket attnPacket = new SNIPacket(Handle);
                 _sniAsyncAttnPacket = attnPacket;
 
-                SniNativeWrapper.SNIPacketSetData(attnPacket, SQL.AttentionHeader, TdsEnums.HEADER_LEN, null, null);
+                SniNativeWrapper.SniPacketSetData(attnPacket, SQL.AttentionHeader, TdsEnums.HEADER_LEN, null, null);
 
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
@@ -1345,7 +1345,7 @@ namespace Microsoft.Data.SqlClient
         {
             // Prepare packet, and write to packet.
             SNIPacket packet = GetResetWritePacket();
-            SniNativeWrapper.SNIPacketSetData(packet, _outBuff, _outBytesUsed, _securePasswords, _securePasswordOffsetsInBuffer);
+            SniNativeWrapper.SniPacketSetData(packet, _outBuff, _outBytesUsed, _securePasswords, _securePasswordOffsetsInBuffer);
 
             Debug.Assert(Parser.Connection._parserLock.ThreadMayHaveLock(), "Thread is writing without taking the connection lock");
             Task task = SNIWritePacket(Handle, packet, out _, canAccumulate, callerHasConnectionLock: true);
@@ -1400,7 +1400,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (_sniPacket != null)
             {
-                SniNativeWrapper.SNIPacketReset(Handle, IoType.WRITE, _sniPacket, ConsumerNumber.SNI_Consumer_SNI);
+                SniNativeWrapper.SniPacketReset(Handle, IoType.WRITE, _sniPacket, ConsumerNumber.SNI_Consumer_SNI);
             }
             else
             {

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -456,18 +456,7 @@ namespace Microsoft.Data.SqlClient
         
         #endregion
         
-        
         #if NETFRAMEWORK
-        static AppDomain GetDefaultAppDomainInternal()
-        {
-            return AppDomain.CurrentDomain;
-        }
-
-        internal static _AppDomain GetDefaultAppDomain()
-        {
-            return GetDefaultAppDomainInternal();
-        }
-
         [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
         internal static unsafe byte[] GetData()

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -17,8 +17,13 @@ namespace Microsoft.Data.SqlClient
 {
     internal static class SniNativeWrapper
     {
+        #region Member Variables
+        
+        private const int SniIpv6AddrStringBufferLength = 48;
+        private const int SniOpenTimeOut = -1;
+        
         #if NETFRAMEWORK
-        private static readonly ISniNativeMethods NativeMethods = RuntimeInformation.ProcessArchitecture switch
+        private static readonly ISniNativeMethods s_nativeMethods = RuntimeInformation.ProcessArchitecture switch
         {
             Architecture.Arm64 => new SniNativeMethodsArm64(),
             Architecture.X64 => new SniNativeMethodsX64(),
@@ -26,15 +31,13 @@ namespace Microsoft.Data.SqlClient
             _ => new SniNativeMethodsNotSupported(RuntimeInformation.ProcessArchitecture)
         };
         #else
-        private static readonly ISniNativeMethods NativeMethods = new SniNativeMethods();
+        private static readonly SniNativeMethods s_nativeMethods = new SniNativeMethods();
         #endif
-
+        
         private static int s_sniMaxComposedSpnLength = -1;
-
-        private const int SniOpenTimeOut = -1; // infinite
-
-        internal const int SniIP6AddrStringBufferLength = 48; // from SNI layer
-
+        
+        #endregion
+        
         internal static int SniMaxComposedSpnLength
         {
             get
@@ -90,81 +93,81 @@ namespace Microsoft.Data.SqlClient
         #region DLL Imports
         
         internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref uint pInfo) =>
-            NativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
+            s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
 
         internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref AuthProviderInfo pInfo) =>
-            NativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
+            s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
 
         internal static uint SNICheckConnection([In] SNIHandle pConn) =>
-            NativeMethods.SniCheckConnection(pConn);
+            s_nativeMethods.SniCheckConnection(pConn);
 
         internal static uint SNIClose(IntPtr pConn) =>
-            NativeMethods.SniClose(pConn);
+            s_nativeMethods.SniClose(pConn);
 
         internal static void SNIGetLastError(out SniError pErrorStruct) =>
-            NativeMethods.SniGetLastError(out pErrorStruct);
+            s_nativeMethods.SniGetLastError(out pErrorStruct);
 
         internal static void SNIPacketRelease(IntPtr pPacket) =>
-            NativeMethods.SniPacketRelease(pPacket);
+            s_nativeMethods.SniPacketRelease(pPacket);
 
         internal static void SNIPacketReset([In] SNIHandle pConn, IoType IOType, SNIPacket pPacket, ConsumerNumber ConsNum) =>
-            NativeMethods.SniPacketReset(pConn, IOType, pPacket, ConsNum);
+            s_nativeMethods.SniPacketReset(pConn, IOType, pPacket, ConsNum);
 
         internal static uint SNIQueryInfo(QueryType QType, ref uint pbQInfo) =>
-            NativeMethods.SniQueryInfo(QType, ref pbQInfo);
+            s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
 
         internal static uint SNIQueryInfo(QueryType QType, ref IntPtr pbQInfo) =>
-            NativeMethods.SniQueryInfo(QType, ref pbQInfo);
+            s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
 
         internal static uint SNIReadAsync(SNIHandle pConn, ref IntPtr ppNewPacket) =>
-            NativeMethods.SniReadAsync(pConn, ref ppNewPacket);
+            s_nativeMethods.SniReadAsync(pConn, ref ppNewPacket);
 
         internal static uint SNIReadSyncOverAsync(SNIHandle pConn, ref IntPtr ppNewPacket, int timeout) =>
-            NativeMethods.SniReadSyncOverAsync(pConn, ref ppNewPacket, timeout);
+            s_nativeMethods.SniReadSyncOverAsync(pConn, ref ppNewPacket, timeout);
 
         internal static uint SNIRemoveProvider(SNIHandle pConn, Provider ProvNum) =>
-            NativeMethods.SniRemoveProvider(pConn, ProvNum);
+            s_nativeMethods.SniRemoveProvider(pConn, ProvNum);
 
         internal static uint SNISecInitPackage(ref uint pcbMaxToken) =>
-            NativeMethods.SniSecInitPackage(ref pcbMaxToken);
+            s_nativeMethods.SniSecInitPackage(ref pcbMaxToken);
 
         internal static uint SNISetInfo(SNIHandle pConn, QueryType QType, [In] ref uint pbQInfo) =>
-            NativeMethods.SniSetInfo(pConn, QType, ref pbQInfo);
+            s_nativeMethods.SniSetInfo(pConn, QType, ref pbQInfo);
 
         internal static uint SNITerminate() =>
-            NativeMethods.SniTerminate();
+            s_nativeMethods.SniTerminate();
 
         internal static uint SNIWaitForSSLHandshakeToComplete([In] SNIHandle pConn, int dwMilliseconds, out uint pProtocolVersion) =>
-            NativeMethods.SniWaitForSslHandshakeToComplete(pConn, dwMilliseconds, out pProtocolVersion);
+            s_nativeMethods.SniWaitForSslHandshakeToComplete(pConn, dwMilliseconds, out pProtocolVersion);
 
         internal static uint UnmanagedIsTokenRestricted([In] IntPtr token, [MarshalAs(UnmanagedType.Bool)] out bool isRestricted) =>
-            NativeMethods.SniIsTokenRestricted(token, out isRestricted);
+            s_nativeMethods.SniIsTokenRestricted(token, out isRestricted);
 
         private static uint GetSniMaxComposedSpnLength() =>
-            NativeMethods.SniGetMaxComposedSpnLength();
+            s_nativeMethods.SniGetMaxComposedSpnLength();
 
         private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out Guid pbQInfo) =>
-            NativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
 
         #if NETFRAMEWORK
         private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, [MarshalAs(UnmanagedType.Bool)] out bool pbQInfo) =>
-            NativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
         #endif
 
         private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out ushort portNum) =>
-            NativeMethods.SniGetInfoWrapper(pConn, QType, out portNum);
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out portNum);
 
         private static uint SNIGetPeerAddrStrWrapper([In] SNIHandle pConn, int bufferSize, StringBuilder addrBuffer, out uint addrLen) =>
-            NativeMethods.SniGetPeerAddrStrWrapper(pConn, bufferSize, addrBuffer, out addrLen);
+            s_nativeMethods.SniGetPeerAddrStrWrapper(pConn, bufferSize, addrBuffer, out addrLen);
 
         private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out Provider provNum) =>
-            NativeMethods.SniGetInfoWrapper(pConn, QType, out provNum);
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out provNum);
 
         private static uint SNIInitialize([In] IntPtr pmo) =>
-            NativeMethods.SniInitialize(pmo);
+            s_nativeMethods.SniInitialize(pmo);
 
         private static uint SNIOpenSyncExWrapper(ref SniClientConsumerInfo pClientConsumerInfo, out IntPtr ppConn) =>
-            NativeMethods.SniOpenSyncExWrapper(ref pClientConsumerInfo, out ppConn);
+            s_nativeMethods.SniOpenSyncExWrapper(ref pClientConsumerInfo, out ppConn);
 
         private static uint SNIOpenWrapper(
             [In] ref SniConsumerInfo pConsumerInfo,
@@ -174,7 +177,7 @@ namespace Microsoft.Data.SqlClient
             [MarshalAs(UnmanagedType.Bool)] bool fSync,
             SqlConnectionIPAddressPreference ipPreference,
             [In] ref SniDnsCacheInfo pDNSCachedInfo) =>
-            NativeMethods.SniOpenWrapper(
+            s_nativeMethods.SniOpenWrapper(
                 ref pConsumerInfo,
                 szConnect,
                 pConn,
@@ -184,13 +187,13 @@ namespace Microsoft.Data.SqlClient
                 ref pDNSCachedInfo);
 
         private static IntPtr SNIPacketAllocateWrapper([In] SafeHandle pConn, IoType IOType) =>
-            NativeMethods.SniPacketAllocateWrapper(pConn, IOType);
+            s_nativeMethods.SniPacketAllocateWrapper(pConn, IOType);
 
         private static uint SNIPacketGetDataWrapper([In] IntPtr packet, [In, Out] byte[] readBuffer, uint readBufferLength, out uint dataSize) =>
-            NativeMethods.SniPacketGetDataWrapper(packet, readBuffer, readBufferLength, out dataSize);
+            s_nativeMethods.SniPacketGetDataWrapper(packet, readBuffer, readBufferLength, out dataSize);
 
         private static unsafe void SNIPacketSetData(SNIPacket pPacket, [In] byte* pbBuf, uint cbBuf) =>
-            NativeMethods.SniPacketSetData(pPacket, pbBuf, cbBuf);
+            s_nativeMethods.SniPacketSetData(pPacket, pbBuf, cbBuf);
         
         private static unsafe uint SNISecGenClientContextWrapper(
             [In] SNIHandle pConn,
@@ -208,7 +211,7 @@ namespace Microsoft.Data.SqlClient
         {
             fixed (byte* pInPtr = pIn)
             {
-                return NativeMethods.SniSecGenClientContextWrapper(
+                return s_nativeMethods.SniSecGenClientContextWrapper(
                     pConn,
                     pInPtr,
                     (uint)pIn.Length,
@@ -223,23 +226,23 @@ namespace Microsoft.Data.SqlClient
         }
 
         private static uint SNIWriteAsyncWrapper(SNIHandle pConn, [In] SNIPacket pPacket) =>
-            NativeMethods.SniWriteAsyncWrapper(pConn, pPacket);
+            s_nativeMethods.SniWriteAsyncWrapper(pConn, pPacket);
 
         private static uint SNIWriteSyncOverAsync(SNIHandle pConn, [In] SNIPacket pPacket) =>
-            NativeMethods.SniWriteSyncOverAsync(pConn, pPacket);
+            s_nativeMethods.SniWriteSyncOverAsync(pConn, pPacket);
         
         internal static IntPtr SNIServerEnumOpen() =>
-            NativeMethods.SniServerEnumOpen();
+            s_nativeMethods.SniServerEnumOpen();
 
         internal static void SNIServerEnumClose([In] IntPtr packet) =>
-            NativeMethods.SniServerEnumClose(packet);
+            s_nativeMethods.SniServerEnumClose(packet);
 
         internal static int SNIServerEnumRead(
             [In] IntPtr packet,
             [In] [MarshalAs(UnmanagedType.LPArray)] char[] readBuffer,
             [In] int bufferLength,
             [MarshalAs(UnmanagedType.Bool)] out bool more) =>
-            NativeMethods.SniServerEnumRead(packet, readBuffer, bufferLength, out more);
+            s_nativeMethods.SniServerEnumRead(packet, readBuffer, bufferLength, out more);
         
         #endregion
 
@@ -263,7 +266,7 @@ namespace Microsoft.Data.SqlClient
             UInt32 ret;
             uint connIPLen = 0;
 
-            int bufferSize = SniIP6AddrStringBufferLength;
+            int bufferSize = SniIpv6AddrStringBufferLength;
             StringBuilder addrBuffer = new StringBuilder(bufferSize);
 
             ret = SNIGetPeerAddrStrWrapper(pConn, bufferSize, addrBuffer, out connIPLen);

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -52,13 +52,13 @@ namespace Microsoft.Data.SqlClient
 
         #region Public Methods
         
-        internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref AuthProviderInfo pInfo) =>
+        internal static uint SniAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref AuthProviderInfo pInfo) =>
             s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
         
         #if NETFRAMEWORK
         [ResourceExposure(ResourceScope.None)]
         [ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)]
-        internal static uint SNIAddProvider(SNIHandle pConn,
+        internal static uint SniAddProvider(SNIHandle pConn,
             Provider providerEnum,
             AuthProviderInfo authInfo)
         {
@@ -67,7 +67,7 @@ namespace Microsoft.Data.SqlClient
 
             Debug.Assert(authInfo.clientCertificateCallback == null, "CTAIP support has been removed");
 
-            ret = SNIAddProvider(pConn, providerEnum, ref authInfo);
+            ret = SniAddProvider(pConn, providerEnum, ref authInfo);
 
             if (ret == ERROR_SUCCESS)
             {
@@ -80,13 +80,13 @@ namespace Microsoft.Data.SqlClient
         }
         #endif
         
-        internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref uint pInfo) =>
+        internal static uint SniAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref uint pInfo) =>
             s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
         
-        internal static uint SNICheckConnection([In] SNIHandle pConn) =>
+        internal static uint SniCheckConnection([In] SNIHandle pConn) =>
             s_nativeMethods.SniCheckConnection(pConn);
         
-        internal static uint SNIClose(IntPtr pConn) =>
+        internal static uint SniClose(IntPtr pConn) =>
             s_nativeMethods.SniClose(pConn);
         
         internal static uint SniGetConnectionId(SNIHandle pConn, ref Guid connId) =>
@@ -112,7 +112,7 @@ namespace Microsoft.Data.SqlClient
             return s_nativeMethods.SniGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PEERPORT, out portNum);
         }
         
-        internal static void SNIGetLastError(out SniError pErrorStruct) =>
+        internal static void SniGetLastError(out SniError pErrorStruct) =>
             s_nativeMethods.SniGetLastError(out pErrorStruct);
         
         internal static uint SniGetProviderNumber(SNIHandle pConn, ref Provider provNum)
@@ -120,13 +120,13 @@ namespace Microsoft.Data.SqlClient
             return s_nativeMethods.SniGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PROVIDERNUM, out provNum);
         }
 
-        internal static uint SNIInitialize() =>
+        internal static uint SniInitialize() =>
             s_nativeMethods.SniInitialize(IntPtr.Zero);
         
-        internal static uint UnmanagedIsTokenRestricted([In] IntPtr token, [MarshalAs(UnmanagedType.Bool)] out bool isRestricted) =>
+        internal static uint SniIsTokenRestricted([In] IntPtr token, [MarshalAs(UnmanagedType.Bool)] out bool isRestricted) =>
             s_nativeMethods.SniIsTokenRestricted(token, out isRestricted);
         
-        internal static unsafe uint SNIOpenMarsSession(ConsumerInfo consumerInfo, SNIHandle parent, ref IntPtr pConn, bool fSync, SqlConnectionIPAddressPreference ipPreference, SQLDNSInfo cachedDNSInfo)
+        internal static unsafe uint SniOpenMarsSession(ConsumerInfo consumerInfo, SNIHandle parent, ref IntPtr pConn, bool fSync, SqlConnectionIPAddressPreference ipPreference, SQLDNSInfo cachedDNSInfo)
         {
             // initialize consumer info for MARS
             SniConsumerInfo native_consumerInfo = new SniConsumerInfo();
@@ -141,7 +141,7 @@ namespace Microsoft.Data.SqlClient
             return s_nativeMethods.SniOpenWrapper(ref native_consumerInfo, "session:", parent, out pConn, fSync, ipPreference, ref native_cachedDNSInfo);
         }
         
-        internal static unsafe uint SNIOpenSyncEx(
+        internal static unsafe uint SniOpenSyncEx(
             ConsumerInfo consumerInfo,
             string constring,
             ref IntPtr pConn,
@@ -222,16 +222,16 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal static void SNIPacketAllocate(SafeHandle pConn, IoType IOType, ref IntPtr pPacket) =>
+        internal static void SniPacketAllocate(SafeHandle pConn, IoType IOType, ref IntPtr pPacket) =>
             pPacket = s_nativeMethods.SniPacketAllocateWrapper(pConn, IOType);
         
-        internal static unsafe uint SNIPacketGetData(IntPtr packet, byte[] readBuffer, ref uint dataSize) =>
+        internal static unsafe uint SniPacketGetData(IntPtr packet, byte[] readBuffer, ref uint dataSize) =>
             s_nativeMethods.SniPacketGetDataWrapper(packet, readBuffer, (uint)readBuffer.Length, out dataSize);
         
-        internal static void SNIPacketRelease(IntPtr pPacket) =>
+        internal static void SniPacketRelease(IntPtr pPacket) =>
             s_nativeMethods.SniPacketRelease(pPacket);
         
-        internal static unsafe void SNIPacketSetData(SNIPacket packet, byte[] data, int length)
+        internal static unsafe void SniPacketSetData(SNIPacket packet, byte[] data, int length)
         {
             fixed (byte* pin_data = &data[0])
             {
@@ -251,7 +251,7 @@ namespace Microsoft.Data.SqlClient
         //    to loose encryption algorithm is changed it should be done in both in this method as well as TdsParserStaticMethods.EncryptPassword.
         //  Up to current release, it is also guaranteed that both password and new change password will fit into a single login packet whose size is fixed to 4096
         //        So, there is no splitting logic is needed.
-        internal static void SNIPacketSetData(SNIPacket packet,
+        internal static void SniPacketSetData(SNIPacket packet,
                                       Byte[] data,
                                       Int32 length,
                                       SecureString[] passwords,            // pointer to the passwords which need to be written out to SNI Packet
@@ -339,7 +339,7 @@ namespace Microsoft.Data.SqlClient
                     packet.DangerousAddRef(ref mustRelease);
                     Debug.Assert(mustRelease, "AddRef Failed!");
 
-                    SNIPacketSetData(packet, data, length);
+                    SniPacketSetData(packet, data, length);
                 }
             }
             finally
@@ -362,22 +362,25 @@ namespace Microsoft.Data.SqlClient
         }
         #endif
         
-        internal static void SNIPacketReset([In] SNIHandle pConn, IoType IOType, SNIPacket pPacket, ConsumerNumber ConsNum) =>
+        internal static void SniPacketReset([In] SNIHandle pConn, IoType IOType, SNIPacket pPacket, ConsumerNumber ConsNum) =>
             s_nativeMethods.SniPacketReset(pConn, IOType, pPacket, ConsNum);
         
-        internal static uint SNIQueryInfo(QueryType QType, ref uint pbQInfo) =>
+        internal static uint SniQueryInfo(QueryType QType, ref uint pbQInfo) =>
             s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
         
-        internal static uint SNIQueryInfo(QueryType QType, ref IntPtr pbQInfo) =>
+        internal static uint SniQueryInfo(QueryType QType, ref IntPtr pbQInfo) =>
             s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
         
-        internal static uint SNIReadAsync(SNIHandle pConn, ref IntPtr ppNewPacket) =>
+        internal static uint SniReadAsync(SNIHandle pConn, ref IntPtr ppNewPacket) =>
             s_nativeMethods.SniReadAsync(pConn, ref ppNewPacket);
         
-        internal static uint SNIReadSyncOverAsync(SNIHandle pConn, ref IntPtr ppNewPacket, int timeout) =>
+        internal static uint SniReadSyncOverAsync(SNIHandle pConn, ref IntPtr ppNewPacket, int timeout) =>
             s_nativeMethods.SniReadSyncOverAsync(pConn, ref ppNewPacket, timeout);
         
-        internal static unsafe uint SNISecGenClientContext(
+        internal static uint SniRemoveProvider(SNIHandle pConn, Provider ProvNum) =>
+            s_nativeMethods.SniRemoveProvider(pConn, ProvNum);
+        
+        internal static unsafe uint SniSecGenClientContext(
             SNIHandle pConnectionObject,
             ReadOnlySpan<byte> inBuff,
             byte[] OutBuff,
@@ -401,32 +404,32 @@ namespace Microsoft.Data.SqlClient
             }
         }
         
-        internal static uint SNISecInitPackage(ref uint pcbMaxToken) =>
+        internal static uint SniSecInitPackage(ref uint pcbMaxToken) =>
             s_nativeMethods.SniSecInitPackage(ref pcbMaxToken);
         
-        internal static void SNIServerEnumClose([In] IntPtr packet) =>
+        internal static void SniServerEnumClose([In] IntPtr packet) =>
             s_nativeMethods.SniServerEnumClose(packet);
         
-        internal static IntPtr SNIServerEnumOpen() =>
+        internal static IntPtr SniServerEnumOpen() =>
             s_nativeMethods.SniServerEnumOpen();
         
-        internal static int SNIServerEnumRead(
+        internal static int SniServerEnumRead(
             [In] IntPtr packet,
             [In] [MarshalAs(UnmanagedType.LPArray)] char[] readBuffer,
             [In] int bufferLength,
             [MarshalAs(UnmanagedType.Bool)] out bool more) =>
             s_nativeMethods.SniServerEnumRead(packet, readBuffer, bufferLength, out more);
         
-        internal static uint SNISetInfo(SNIHandle pConn, QueryType QType, [In] ref uint pbQInfo) =>
+        internal static uint SniSetInfo(SNIHandle pConn, QueryType QType, [In] ref uint pbQInfo) =>
             s_nativeMethods.SniSetInfo(pConn, QType, ref pbQInfo);
         
-        internal static uint SNITerminate() =>
+        internal static uint SniTerminate() =>
             s_nativeMethods.SniTerminate();
         
-        internal static uint SNIWaitForSSLHandshakeToComplete([In] SNIHandle pConn, int dwMilliseconds, out uint pProtocolVersion) =>
+        internal static uint SniWaitForSslHandshakeToComplete([In] SNIHandle pConn, int dwMilliseconds, out uint pProtocolVersion) =>
             s_nativeMethods.SniWaitForSslHandshakeToComplete(pConn, dwMilliseconds, out pProtocolVersion);
         
-        internal static uint SNIWritePacket(SNIHandle pConn, SNIPacket packet, bool sync)
+        internal static uint SniWritePacket(SNIHandle pConn, SNIPacket packet, bool sync)
         {
             if (sync)
             {
@@ -506,7 +509,7 @@ namespace Microsoft.Data
         internal static bool IsTokenRestrictedWrapper(IntPtr token)
         {
             bool isRestricted;
-            uint result = SniNativeWrapper.UnmanagedIsTokenRestricted(token, out isRestricted);
+            uint result = SniNativeWrapper.SniIsTokenRestricted(token, out isRestricted);
 
             if (result != 0)
             {

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -462,33 +462,5 @@ namespace Microsoft.Data.SqlClient
         }
         
         #endregion
-        
-        #if NETFRAMEWORK
-        [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
-        [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        internal static unsafe byte[] GetData()
-        {
-            IntPtr ptr = (IntPtr)SqlDependencyProcessDispatcherStorage.NativeGetData(out int size);
-            byte[] result = null;
-
-            if (ptr != IntPtr.Zero)
-            {
-                result = new byte[size];
-                Marshal.Copy(ptr, result, 0, size);
-            }
-
-            return result;
-        }
-
-        [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
-        [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        internal static unsafe void SetData(byte[] data)
-        {
-            fixed (byte* pDispatcher = data)
-            {
-                SqlDependencyProcessDispatcherStorage.NativeSetData(pDispatcher, data.Length);
-            }
-        }
-        #endif
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/SystemErrors.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/SystemErrors.cs
@@ -5,8 +5,10 @@
 namespace Interop.Windows
 {
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382.aspx
-    internal partial class SystemErrors
+    internal class SystemErrors
     {
+        internal const int ERROR_SUCCESS = 0x00;
+        
         internal const int ERROR_FILE_NOT_FOUND = 0x2;
         internal const int ERROR_INVALID_HANDLE = 0x6;
         internal const int ERROR_SHARING_VIOLATION = 0x20;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolIdentity.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolIdentity.Windows.cs
@@ -43,10 +43,13 @@ namespace Microsoft.Data.ProviderBase
                 string sidString = user.Value;
 
                 // Win32NativeMethods.IsTokenRestricted will raise exception if the native call fails
-                bool isRestricted = Win32NativeMethods.IsTokenRestrictedWrapper(token);
+                SniNativeWrapper.SniIsTokenRestricted(token, out bool isRestricted);
 
                 var lastIdentity = s_lastIdentity;
-                if ((lastIdentity != null) && (lastIdentity._sidString == sidString) && (lastIdentity._isRestricted == isRestricted) && (lastIdentity._isNetwork == isNetwork))
+                if (lastIdentity != null && 
+                    lastIdentity._sidString == sidString &&
+                    lastIdentity._isRestricted == isRestricted &&
+                    lastIdentity._isNetwork == isNetwork)
                 {
                     current = lastIdentity;
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
@@ -50,23 +50,23 @@ namespace Microsoft.Data.Sql
                 { }
                 finally
                 {
-                    handle = SniNativeWrapper.SNIServerEnumOpen();
+                    handle = SniNativeWrapper.SniServerEnumOpen();
                     SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {2} returned handle = {3}.",
                                                            nameof(SqlDataSourceEnumeratorNativeHelper),
                                                            nameof(GetDataSources),
-                                                           nameof(SniNativeWrapper.SNIServerEnumOpen), handle);
+                                                           nameof(SniNativeWrapper.SniServerEnumOpen), handle);
                 }
 
                 if (handle != ADP.s_ptrZero)
                 {
                     while (more && !TdsParserStaticMethods.TimeoutHasExpired(s_timeoutTime))
                     {
-                        readLength = SniNativeWrapper.SNIServerEnumRead(handle, buffer, bufferSize, out more);
+                        readLength = SniNativeWrapper.SniServerEnumRead(handle, buffer, bufferSize, out more);
 
                         SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {2} returned 'readlength':{3}, and 'more':{4} with 'bufferSize' of {5}",
                                                                nameof(SqlDataSourceEnumeratorNativeHelper),
                                                                nameof(GetDataSources),
-                                                               nameof(SniNativeWrapper.SNIServerEnumRead),
+                                                               nameof(SniNativeWrapper.SniServerEnumRead),
                                                                readLength, more, bufferSize);
                         if (readLength > bufferSize)
                         {
@@ -84,21 +84,21 @@ namespace Microsoft.Data.Sql
             {
                 if (handle != ADP.s_ptrZero)
                 {
-                    SniNativeWrapper.SNIServerEnumClose(handle);
+                    SniNativeWrapper.SniServerEnumClose(handle);
                     SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {2} called.",
                                                            nameof(SqlDataSourceEnumeratorNativeHelper),
                                                            nameof(GetDataSources),
-                                                           nameof(SniNativeWrapper.SNIServerEnumClose));
+                                                           nameof(SniNativeWrapper.SniServerEnumClose));
                 }
             }
 
             if (failure)
             {
-                Debug.Assert(false, $"{nameof(GetDataSources)}:{nameof(SniNativeWrapper.SNIServerEnumRead)} returned bad length");
+                Debug.Assert(false, $"{nameof(GetDataSources)}:{nameof(SniNativeWrapper.SniServerEnumRead)} returned bad length");
                 SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|ERR> {2} returned bad length, requested buffer {3}, received {4}",
                                                        nameof(SqlDataSourceEnumeratorNativeHelper),
                                                        nameof(GetDataSources),
-                                                       nameof(SniNativeWrapper.SNIServerEnumRead),
+                                                       nameof(SniNativeWrapper.SniServerEnumRead),
                                                        bufferSize, readLength);
 
                 throw ADP.ArgumentOutOfRange(StringsHelper.GetString(Strings.ADP_ParameterValueOutOfRange, readLength), nameof(readLength));

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NativeSSPIContextProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NativeSSPIContextProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.SqlClient
                         // use local for ref param to defer setting s_maxSSPILength until we know the call succeeded.
                         uint maxLength = 0;
 
-                        if (0 != SniNativeWrapper.SNISecInitPackage(ref maxLength))
+                        if (0 != SniNativeWrapper.SniSecInitPackage(ref maxLength))
                             SSPIError(SQLMessage.SSPIInitializeError(), TdsEnums.INIT_SSPI_PACKAGE);
 
                         s_maxSSPILength = maxLength;
@@ -58,7 +58,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(_physicalStateObj.SessionHandle.Type == SessionHandle.NativeHandleType);
             SNIHandle handle = _physicalStateObj.SessionHandle.NativeHandle;
 #endif
-            if (0 != SniNativeWrapper.SNISecGenClientContext(handle, receivedBuff.Span, sendBuff, ref sendLength, _sniSpnBuffer[0]))
+            if (0 != SniNativeWrapper.SniSecGenClientContext(handle, receivedBuff.Span, sendBuff, ref sendLength, _sniSpnBuffer[0]))
             {
                 throw new InvalidOperationException(SQLMessage.SSPIGenerateError());
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -13,6 +13,7 @@ using System.Runtime.Remoting;
 using System.Runtime.Serialization;
 using System.Runtime.Versioning;
 using System.Security.Permissions;
+using Interop.Windows.Sni;
 #endif
 using System.Text;
 using System.Threading;
@@ -462,7 +463,7 @@ namespace Microsoft.Data.SqlClient
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
         private static void ObtainProcessDispatcher()
         {
-            byte[] nativeStorage = SniNativeWrapper.GetData();
+            byte[] nativeStorage = SqlDependencyProcessDispatcherStorage.NativeGetData();
 
             if (nativeStorage == null)
             {
@@ -489,7 +490,9 @@ namespace Microsoft.Data.SqlClient
                             SqlClientObjRef objRef = new(s_processDispatcher);
                             DataContractSerializer serializer = new(objRef.GetType());
                             GetSerializedObject(objRef, serializer, stream);
-                            SniNativeWrapper.SetData(stream.ToArray()); // Native will be forced to synchronize and not overwrite.
+                            
+                            // Native will be forced to synchronize and not overwrite.
+                            SqlDependencyProcessDispatcherStorage.NativeSetData(stream.ToArray()); 
                         }
                     }
                     else

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -470,47 +470,38 @@ namespace Microsoft.Data.SqlClient
 
 #if DEBUG       // Possibly expensive, limit to debug.
                 SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> AppDomain.CurrentDomain.FriendlyName: {0}", AppDomain.CurrentDomain.FriendlyName);
-
 #endif // DEBUG
-                _AppDomain masterDomain = SniNativeWrapper.GetDefaultAppDomain();
-
-                if (masterDomain != null)
+                
+                _AppDomain masterDomain = AppDomain.CurrentDomain;
+                
+                ObjectHandle handle = CreateProcessDispatcher(masterDomain);
+                if (handle != null)
                 {
-                    ObjectHandle handle = CreateProcessDispatcher(masterDomain);
+                    SqlDependencyProcessDispatcher dependency = (SqlDependencyProcessDispatcher)handle.Unwrap();
 
-                    if (handle != null)
+                    if (dependency != null)
                     {
-                        SqlDependencyProcessDispatcher dependency = (SqlDependencyProcessDispatcher)handle.Unwrap();
+                        s_processDispatcher = SqlDependencyProcessDispatcher.SingletonProcessDispatcher; // Set to static instance.
 
-                        if (dependency != null)
+                        // Serialize and set in native.
+                        using (MemoryStream stream = new())
                         {
-                            s_processDispatcher = SqlDependencyProcessDispatcher.SingletonProcessDispatcher; // Set to static instance.
-
-                            // Serialize and set in native.
-                            using (MemoryStream stream = new())
-                            {
-                                SqlClientObjRef objRef = new(s_processDispatcher);
-                                DataContractSerializer serializer = new(objRef.GetType());
-                                GetSerializedObject(objRef, serializer, stream);
-                                SniNativeWrapper.SetData(stream.ToArray()); // Native will be forced to synchronize and not overwrite.
-                            }
-                        }
-                        else
-                        {
-                            SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - ObjectHandle.Unwrap returned null!");
-                            throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyObtainProcessDispatcherFailureObjectHandle);
+                            SqlClientObjRef objRef = new(s_processDispatcher);
+                            DataContractSerializer serializer = new(objRef.GetType());
+                            GetSerializedObject(objRef, serializer, stream);
+                            SniNativeWrapper.SetData(stream.ToArray()); // Native will be forced to synchronize and not overwrite.
                         }
                     }
                     else
                     {
-                        SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - AppDomain.CreateInstance returned null!");
-                        throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyProcessDispatcherFailureCreateInstance);
+                        SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - ObjectHandle.Unwrap returned null!");
+                        throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyObtainProcessDispatcherFailureObjectHandle);
                     }
                 }
                 else
                 {
-                    SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - unable to obtain default AppDomain!");
-                    throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyProcessDispatcherFailureAppDomain);
+                    SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - AppDomain.CreateInstance returned null!");
+                    throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyProcessDispatcherFailureCreateInstance);
                 }
             }
             else

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.Windows.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Data.SqlClient
             { }
             finally
             {
-                _sniStatus = SniNativeWrapper.SNIInitialize();
+                _sniStatus = SniNativeWrapper.SniInitialize();
                 base.handle = (IntPtr)1; // Initialize to non-zero dummy variable.
             }
         }
@@ -56,7 +56,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             uint value = 0;
                             // Query OS to find out whether encryption is supported.
-                            SniNativeWrapper.SNIQueryInfo(QueryType.SNI_QUERY_CLIENT_ENCRYPT_POSSIBLE, ref value);
+                            SniNativeWrapper.SniQueryInfo(QueryType.SNI_QUERY_CLIENT_ENCRYPT_POSSIBLE, ref value);
                             _clientOSEncryptionSupport = value != 0;
                         }
                         catch (Exception e)
@@ -78,7 +78,7 @@ namespace Microsoft.Data.SqlClient
                 if (TdsEnums.SNI_SUCCESS == _sniStatus)
                 {
                     LocalDBAPI.ReleaseDLLHandles();
-                    SniNativeWrapper.SNITerminate();
+                    SniNativeWrapper.SniTerminate();
                 }
                 base.handle = IntPtr.Zero;
             }
@@ -185,7 +185,7 @@ namespace Microsoft.Data.SqlClient
 
                 #if NETFRAMEWORK
                 int transparentNetworkResolutionStateNo = (int)transparentNetworkResolutionState;
-                _status = SniNativeWrapper.SNIOpenSyncEx(
+                _status = SniNativeWrapper.SniOpenSyncEx(
                     myInfo,
                     serverName,
                     ref base.handle,
@@ -201,7 +201,7 @@ namespace Microsoft.Data.SqlClient
                     cachedDNSInfo,
                     hostNameInCertificate);
                 #else
-                _status = SniNativeWrapper.SNIOpenSyncEx(
+                _status = SniNativeWrapper.SniOpenSyncEx(
                     myInfo,
                     serverName,
                     ref base.handle,
@@ -225,7 +225,7 @@ namespace Microsoft.Data.SqlClient
             { }
             finally
             {
-                _status = SniNativeWrapper.SNIOpenMarsSession(myInfo, parent, ref base.handle, parent._fSync, ipPreference, cachedDNSInfo);
+                _status = SniNativeWrapper.SniOpenMarsSession(myInfo, parent, ref base.handle, parent._fSync, ipPreference, cachedDNSInfo);
             }
         }
 
@@ -244,7 +244,7 @@ namespace Microsoft.Data.SqlClient
             base.handle = IntPtr.Zero;
             if (IntPtr.Zero != ptr)
             {
-                if (0 != SniNativeWrapper.SNIClose(ptr))
+                if (0 != SniNativeWrapper.SniClose(ptr))
                 {
                     return false;   // SNIClose should never fail.
                 }
@@ -265,7 +265,7 @@ namespace Microsoft.Data.SqlClient
     {
         internal SNIPacket(SafeHandle sniHandle) : base(IntPtr.Zero, true)
         {
-            SniNativeWrapper.SNIPacketAllocate(sniHandle, IoType.WRITE, ref base.handle);
+            SniNativeWrapper.SniPacketAllocate(sniHandle, IoType.WRITE, ref base.handle);
             if (IntPtr.Zero == base.handle)
             {
                 throw SQL.SNIPacketAllocationFailure();
@@ -287,7 +287,7 @@ namespace Microsoft.Data.SqlClient
             base.handle = IntPtr.Zero;
             if (IntPtr.Zero != ptr)
             {
-                SniNativeWrapper.SNIPacketRelease(ptr);
+                SniNativeWrapper.SniPacketRelease(ptr);
             }
             return true;
         }
@@ -311,7 +311,7 @@ namespace Microsoft.Data.SqlClient
             {
                 // Success - reset the packet
                 packet = _packets.Pop();
-                SniNativeWrapper.SNIPacketReset(sniHandle, IoType.WRITE, packet, ConsumerNumber.SNI_Consumer_SNI);
+                SniNativeWrapper.SniPacketReset(sniHandle, IoType.WRITE, packet, ConsumerNumber.SNI_Consumer_SNI);
             }
             else
             {


### PR DESCRIPTION
**Description**: This is a followup to the SNI Native Wrapper code merge. Each commit in this PR is an atomic change, so if the PR gets too cluttered to review all up, it can be stepped through one commit at a time. Most of these changes are just renaming and moving code around. One larger change is removing a bunch of private methods that were no longer necessary after extracting the DLL imports (as mentioned by @edwardneal). 

**Testing**: There aren't really any functional changes here, so CI pass should be sufficient validation.