### PR TITLE
Tests | Fix RemoteCertificateNameMismatchErrorTest (ActiveIssue 31754)

### DIFF
--- a/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
@@ -196,6 +196,44 @@ steps:
   condition: ${{parameters.condition }}
 
 - powershell: |
+    # Create Certificate
+    $computerDnsName = [System.Net.Dns]::Resolve($null).HostName
+    $certificate = New-SelfSignedCertificate -DnsName $computerDnsName,localhost -CertStoreLocation cert:\LocalMachine\My -FriendlyName test99 -KeySpec KeyExchange
+
+    # Get path to Private key (used later)
+    $keyPath = $certificate.PrivateKey.CspKeyContainerInfo.UniqueKeyContainerName
+    $machineKeyPath = "$env:ProgramData\Microsoft\Crypto\RSA\MachineKeys\$keyPath"
+
+    # Add certificate to trusted roots
+    $store = new-object System.Security.Cryptography.X509Certificates.X509Store(
+        [System.Security.Cryptography.X509Certificates.StoreName]::Root,
+        "localmachine"
+    )
+
+    $store.open("MaxAllowed") 
+    $store.add($certificate) 
+    $store.close()
+
+    # Get SQL Server instances and add the Certificate
+    $instances = Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\Instance Names\SQL'
+    foreach ($instance in $instances){
+        $instance | ForEach-Object {
+        $_.PSObject.Properties | Where-Object { $_.Name -notmatch '^PS.*' } | ForEach-Object {
+                Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\$($_.Value)\MSSQLServer\SuperSocketNetLib" -Name Certificate -Value $certificate.Thumbprint.ToLower()
+                
+                # Grant read access to Private Key for SQL Service Account
+                if ($($_.Name) -eq "MSSQLSERVER") {
+                    icacls $machineKeyPath /grant "NT Service\MSSQLSERVER:R"
+                } else {
+                    icacls $machineKeyPath /grant "NT Service\MSSQL`$$($_.Name):R"
+                }
+            }
+        }
+    }
+  displayName: 'Add SQL Certificate [Win]'
+  condition: ${{parameters.condition }}
+
+- powershell: |
     # You need to restart SQL Server for the change to persist
     # -Force takes care of any dependent services, like SQL Agent.
     # Note: if the instance is named, replace MSSQLSERVER with MSSQL$ followed by

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionTestWithSSLCert/CertificateTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionTestWithSSLCert/CertificateTest.cs
@@ -166,7 +166,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ActiveIssue("31754")]
         [ConditionalFact(nameof(AreConnStringsSetup), nameof(UseManagedSNIOnWindows), nameof(IsNotAzureServer), nameof(IsLocalHost))]
         [PlatformSpecific(TestPlatforms.Windows)]
         public void RemoteCertificateNameMismatchErrorTest()
@@ -175,6 +174,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 DataSource = GetLocalIpAddress(),
                 Encrypt = SqlConnectionEncryptOption.Mandatory,
+                TrustServerCertificate = false,
                 HostNameInCertificate = "BadHostName"
             };
             using SqlConnection connection = new(builder.ConnectionString);


### PR DESCRIPTION
This pull request includes significant changes to the configuration and testing of SQL Server certificates. The most important changes involve adding a PowerShell script to configure SQL Server certificates on Windows and updating tests to reflect these changes.

### Configuration changes:
* [`eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml`](diffhunk://#diff-3f88da1a3ac89f790f1ab69a95e2d381f4fb605c12cc6bf9e0ed7efd1c1d9c1eR198-R235): Added a PowerShell script to create a self-signed certificate, add it to trusted roots, and configure SQL Server instances to use the certificate. This script also grants read access to the private key for the SQL Service Account.

### Test updates:
* [`src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionTestWithSSLCert/CertificateTest.cs`](diffhunk://#diff-86b1f1ce1b426fa2270261b1fe04e6db0d14e5442c1ee8991e7c5e02b0443054L169): Removed the `ActiveIssue` attribute from the `RemoteCertificateNameMismatchErrorTest` method to enable the test.
* [`src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionTestWithSSLCert/CertificateTest.cs`](diffhunk://#diff-86b1f1ce1b426fa2270261b1fe04e6db0d14e5442c1ee8991e7c5e02b0443054R177): Updated the `RemoteCertificateNameMismatchErrorTest` method to set `TrustServerCertificate` to `false`, ensuring the test checks for certificate name mismatches.

This is in addition to #3012 which activates other tests in this Class