### PR TITLE
Tests | Activate SplitPacket Tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -457,6 +457,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return !AreConnStringsSetup() || !Utils.IsAzureSqlServer(new SqlConnectionStringBuilder(TCPConnectionString).DataSource);
         }
 
+        public static bool IsNotNamedInstance()
+        {
+            return !AreConnStringsSetup() || !new SqlConnectionStringBuilder(TCPConnectionString).DataSource.Contains(@"\");
+        }
+
         public static bool IsLocalHost()
         {
             SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -454,7 +454,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static bool IsNotAzureServer()
         {
-            return !AreConnStringsSetup() || !Utils.IsAzureSqlServer(new SqlConnectionStringBuilder((TCPConnectionString)).DataSource);
+            return !AreConnStringsSetup() || !Utils.IsAzureSqlServer(new SqlConnectionStringBuilder(TCPConnectionString).DataSource);
+        }
+
+        public static bool IsLocalHost()
+        {
+            SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString);
+            return ParseDataSource(builder.DataSource, out string hostname, out _, out _) && string.Equals("localhost", hostname, StringComparison.OrdinalIgnoreCase);
         }
 
         // Synapse: Always Encrypted is not supported with Azure Synapse.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SplitPacketTest/SplitPacketTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SplitPacketTest/SplitPacketTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             _baseConnString = builder.ConnectionString;
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost), nameof(DataTestUtility.IsNotNamedInstance))]
         public void OneByteSplitTest()
         {
             _splitPacketSize = 1;
@@ -45,7 +45,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.True(true);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost), nameof(DataTestUtility.IsNotNamedInstance))]
         public void AlmostFullHeaderTest()
         {
             _splitPacketSize = 7;
@@ -53,7 +53,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.True(true);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost), nameof(DataTestUtility.IsNotNamedInstance))]
         public void FullHeaderTest()
         {
             _splitPacketSize = 8;
@@ -61,7 +61,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.True(true);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost), nameof(DataTestUtility.IsNotNamedInstance))]
         public void HeaderPlusOneTest()
         {
             _splitPacketSize = 9;
@@ -69,7 +69,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.True(true);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost), nameof(DataTestUtility.IsNotNamedInstance))]
         public void MARSSplitTest()
         {
             _splitPacketSize = 1;
@@ -77,7 +77,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.True(true);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost), nameof(DataTestUtility.IsNotNamedInstance))]
         public void MARSReplicateTest()
         {
             _splitPacketSize = 1;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SplitPacketTest/SplitPacketTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SplitPacketTest/SplitPacketTest.cs
@@ -190,7 +190,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 _cts.Cancel();
                 _cts.Dispose();
+#if NETFRAMEWORK
                 _listener?.Stop();
+#else
+                _listener?.Dispose();
+#endif
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SplitPacketTest/SplitPacketTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SplitPacketTest/SplitPacketTest.cs
@@ -11,79 +11,83 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
-    [ActiveIssue("5538")] // Only testable on localhost
-    public class SplitPacketTest
+    public class SplitPacketTest : IDisposable
     {
-        private int Port = -1;
-        private int SplitPacketSize = 1;
-        private string BaseConnString;
+        private int _port = -1;
+        private int _splitPacketSize = 1;
+        private string _baseConnString;
+        private TcpListener _listener;
+        private CancellationTokenSource _cts = new CancellationTokenSource();
 
         public SplitPacketTest()
         {
-            string actualHost;
-            int actualPort;
-
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString);
-            GetTcpInfoFromDataSource(builder.DataSource, out actualHost, out actualPort);
+            GetTcpInfoFromDataSource(builder.DataSource, out string actualHost, out int actualPort);
 
-            Task.Factory.StartNew(() => { SetupProxy(actualHost, actualPort); });
+            Task.Factory.StartNew(() => { SetupProxy(actualHost, actualPort, _cts.Token); });
 
-            for (int i = 0; i < 10 && Port == -1; i++)
+            for (int i = 0; i < 10 && _port == -1; i++)
             {
                 Thread.Sleep(500);
             }
-            if (Port == -1)
+            if (_port == -1)
                 throw new InvalidOperationException("Proxy local port not defined!");
 
-            builder.DataSource = "tcp:127.0.0.1," + Port;
-            BaseConnString = builder.ConnectionString;
+            builder.DataSource = "tcp:127.0.0.1," + _port;
+            _baseConnString = builder.ConnectionString;
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
         public void OneByteSplitTest()
         {
-            SplitPacketSize = 1;
+            _splitPacketSize = 1;
             OpenConnection();
+            Assert.True(true);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
         public void AlmostFullHeaderTest()
         {
-            SplitPacketSize = 7;
+            _splitPacketSize = 7;
             OpenConnection();
+            Assert.True(true);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
         public void FullHeaderTest()
         {
-            SplitPacketSize = 8;
+            _splitPacketSize = 8;
             OpenConnection();
+            Assert.True(true);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
         public void HeaderPlusOneTest()
         {
-            SplitPacketSize = 9;
+            _splitPacketSize = 9;
             OpenConnection();
+            Assert.True(true);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
         public void MARSSplitTest()
         {
-            SplitPacketSize = 1;
+            _splitPacketSize = 1;
             OpenMarsConnection("select * from Orders");
+            Assert.True(true);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsTCPConnStringSetup), nameof(DataTestUtility.IsLocalHost))]
         public void MARSReplicateTest()
         {
-            SplitPacketSize = 1;
+            _splitPacketSize = 1;
             OpenMarsConnection("select REPLICATE('A', 10000)");
+            Assert.True(true);
         }
 
         private void OpenMarsConnection(string cmdText)
         {
-            using (SqlConnection conn = new SqlConnection((new SqlConnectionStringBuilder(BaseConnString) { MultipleActiveResultSets = true }).ConnectionString))
+            using (SqlConnection conn = new SqlConnection((new SqlConnectionStringBuilder(_baseConnString) { MultipleActiveResultSets = true }).ConnectionString))
             {
                 conn.Open();
                 using (SqlCommand cmd1 = new SqlCommand(cmdText, conn))
@@ -102,7 +106,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private void OpenConnection()
         {
-            using (SqlConnection conn = new SqlConnection(BaseConnString))
+            using (SqlConnection conn = new SqlConnection(_baseConnString))
             {
                 conn.Open();
                 using (SqlCommand cmd = new SqlCommand("select * from Orders", conn))
@@ -114,23 +118,23 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        private void SetupProxy(string actualHost, int actualPort)
+        private void SetupProxy(string actualHost, int actualPort, CancellationToken cancellationToken)
         {
-            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            Port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var client = listener.AcceptTcpClientAsync().GetAwaiter().GetResult();
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            _port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            var client = _listener.AcceptTcpClientAsync().GetAwaiter().GetResult();
 
             var sqlClient = new TcpClient();
-            sqlClient.ConnectAsync(actualHost, actualPort).Wait();
+            sqlClient.ConnectAsync(actualHost, actualPort).Wait(cancellationToken);
 
-            Task.Factory.StartNew(() => { ForwardToSql(client, sqlClient); });
-            Task.Factory.StartNew(() => { ForwardToClient(client, sqlClient); });
+            Task.Factory.StartNew(() => { ForwardToSql(client, sqlClient, cancellationToken); }, cancellationToken);
+            Task.Factory.StartNew(() => { ForwardToClient(client, sqlClient, cancellationToken); }, cancellationToken);
         }
 
-        private void ForwardToSql(TcpClient ourClient, TcpClient sqlClient)
+        private void ForwardToSql(TcpClient ourClient, TcpClient sqlClient, CancellationToken cancellationToken)
         {
-            while (true)
+            while (!cancellationToken.IsCancellationRequested)
             {
                 byte[] buffer = new byte[1024];
                 int bytesRead = ourClient.GetStream().Read(buffer, 0, buffer.Length);
@@ -139,11 +143,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        private void ForwardToClient(TcpClient ourClient, TcpClient sqlClient)
+        private void ForwardToClient(TcpClient ourClient, TcpClient sqlClient, CancellationToken cancellationToken)
         {
-            while (true)
+            while (!cancellationToken.IsCancellationRequested)
             {
-                byte[] buffer = new byte[SplitPacketSize];
+                byte[] buffer = new byte[_splitPacketSize];
                 int bytesRead = sqlClient.GetStream().Read(buffer, 0, buffer.Length);
 
                 ourClient.GetStream().Write(buffer, 0, bytesRead);
@@ -171,6 +175,22 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             else
             {
                 throw new InvalidOperationException("TCP Connection String not in correct format!");
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _cts.Cancel();
+                _cts.Dispose();
+                _listener?.Stop();
             }
         }
     }


### PR DESCRIPTION
## AI Blurp
This pull request includes several improvements and refactorings to the `SplitPacketTest` class and the `DataTestUtility` class in the Microsoft.Data.SqlClient test suite. The most important changes include adding new utility methods, refactoring existing methods, and enhancing the test class with proper resource disposal.

Improvements and refactorings:

* [`src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs`](diffhunk://#diff-35448375b6c8bed7139e7d307c08d7f1f3eddb7aeb3b89cb97e3c3958196ff3bL457-R468): Added new methods `IsNotNamedInstance` and `IsLocalHost` to the `DataTestUtility` class for better connection string handling and test conditions.

Enhancements to test class:

* [`src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SplitPacketTest/SplitPacketTest.cs`](diffhunk://#diff-56cc177d24858fee1538b2b34ca8230cde6bbfd2f8800865c349d169ccc860c1L14-R90): Refactored the `SplitPacketTest` class to use private fields with underscores, added `CancellationToken` support to the `SetupProxy` method, and implemented the `IDisposable` interface for proper resource cleanup. [[1]](diffhunk://#diff-56cc177d24858fee1538b2b34ca8230cde6bbfd2f8800865c349d169ccc860c1L14-R90) [[2]](diffhunk://#diff-56cc177d24858fee1538b2b34ca8230cde6bbfd2f8800865c349d169ccc860c1L105-R109) [[3]](diffhunk://#diff-56cc177d24858fee1538b2b34ca8230cde6bbfd2f8800865c349d169ccc860c1L117-R137) [[4]](diffhunk://#diff-56cc177d24858fee1538b2b34ca8230cde6bbfd2f8800865c349d169ccc860c1L142-R150) [[5]](diffhunk://#diff-56cc177d24858fee1538b2b34ca8230cde6bbfd2f8800865c349d169ccc860c1L158-R179)

These changes enhance the code readability, maintainability, and ensure that resources are properly managed during the tests.

## Human stuff
This removes the ActiveIssue 5538 from the SplitPacketTest
It makes sure that the test is only run on localhost and without named instances due to the fact that the tests are proxying the requests.

Also added IDisposable cleanup so that the started threads don't hang around.