### PR TITLE
Fix CVE issue

### DIFF
--- a/tools/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
+++ b/tools/GenAPI/Microsoft.DotNet.GenAPI/Microsoft.DotNet.GenAPI.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix for vulnerable package `System.Private.Uri` to` 4.3.2` version, according to recommendation on https://msrc.microsoft.com/update-guide/en-US/advisory/CVE-2019-0820