### PR TITLE
Enhance Test Coverage for JSON datatype support (#3062)

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonBulkCopyTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonBulkCopyTest.cs
@@ -2,35 +2,51 @@
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using Xunit.Abstractions;
 using Xunit;
+using System.Collections;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
 {
+    public class JsonBulkCopyTestData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { CommandBehavior.Default, false, 300, 100 };
+            yield return new object[] { CommandBehavior.Default, true, 300, 100 };
+            yield return new object[] { CommandBehavior.SequentialAccess, false, 300, 100 };
+            yield return new object[] { CommandBehavior.SequentialAccess, true, 300, 100 };
+        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
     public class JsonBulkCopyTest
     {
         private readonly ITestOutputHelper _output;
-        private static readonly string _jsonFile = "randomRecords.json";
-        private static readonly string _outputFile = "serverRecords.json";
+        private static readonly string _generatedJsonFile = DataTestUtility.GenerateRandomCharacters("randomRecords");
+        private static readonly string _outputFile = DataTestUtility.GenerateRandomCharacters("serverResults");
+        private static readonly string _sourceTableName = DataTestUtility.GenerateObjectName();
+        private static readonly string _destinationTableName = DataTestUtility.GenerateObjectName();
         
         public JsonBulkCopyTest(ITestOutputHelper output)
         {
             _output = output;
         }
 
-        private void PopulateData(int noOfRecords)
+        private void PopulateData(int noOfRecords, int rows)
         {
             using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
-                DataTestUtility.CreateTable(connection, "jsonTab", "(data json)");
-                DataTestUtility.CreateTable(connection, "jsonTabCopy", "(data json)");
-                GenerateJsonFile(50000, _jsonFile);
-                StreamJsonFileToServer(connection);
+                DataTestUtility.CreateTable(connection, _sourceTableName, "(data json)");
+                DataTestUtility.CreateTable(connection, _destinationTableName, "(data json)");
+                GenerateJsonFile(noOfRecords, _generatedJsonFile);
+                while (rows-- > 0)
+                {
+                    StreamJsonFileToServer(connection);
+                }
             }
         }
 
@@ -59,7 +75,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
 
         private void CompareJsonFiles()
         {
-            using (var stream1 = File.OpenText(_jsonFile))
+            using (var stream1 = File.OpenText(_generatedJsonFile))
             using (var stream2 = File.OpenText(_outputFile))
             using (var reader1 = new JsonTextReader(stream1))
             using (var reader2 = new JsonTextReader(stream2))
@@ -70,14 +86,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
             }
         }
 
-        private void PrintJsonDataToFile(SqlConnection connection)
+        private void PrintJsonDataToFileAndCompare(SqlConnection connection)
         {
-            DeleteFile(_outputFile);
-            using (SqlCommand command = new SqlCommand("SELECT [data] FROM [jsonTabCopy]", connection))
+            try
             {
-                using (SqlDataReader reader = command.ExecuteReader(CommandBehavior.SequentialAccess))
+                DeleteFile(_outputFile);
+                using (SqlCommand command = new SqlCommand("SELECT [data] FROM [" + _destinationTableName + "]", connection))
                 {
-                    using (StreamWriter sw = new StreamWriter(_outputFile))
+                    using (SqlDataReader reader = command.ExecuteReader(CommandBehavior.SequentialAccess))
                     {
                         while (reader.Read())
                         {
@@ -86,28 +102,36 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
 
                             using (TextReader data = reader.GetTextReader(0))
                             {
-                                do
+                                using (StreamWriter sw = new StreamWriter(_outputFile))
                                 {
-                                    charsRead = data.Read(buffer, 0, buffer.Length);
-                                    sw.Write(buffer, 0, charsRead);
+                                    do
+                                    {
+                                        charsRead = data.Read(buffer, 0, buffer.Length);
+                                        sw.Write(buffer, 0, charsRead);
 
-                                } while (charsRead > 0);
+                                    } while (charsRead > 0);
+                                }
                             }
-                            _output.WriteLine("Output written to " + _outputFile);
+                            CompareJsonFiles();
                         }
                     }
                 }
             }
+            finally
+            {
+                DeleteFile(_outputFile);
+            }
+
         }
 
-        private async Task PrintJsonDataToFileAsync(SqlConnection connection)
+        private async Task PrintJsonDataToFileAndCompareAsync(SqlConnection connection)
         {
-            DeleteFile(_outputFile);
-            using (SqlCommand command = new SqlCommand("SELECT [data] FROM [jsonTab]", connection))
+            try
             {
-                using (SqlDataReader reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess))
+                DeleteFile(_outputFile);
+                using (SqlCommand command = new SqlCommand("SELECT [data] FROM [" + _destinationTableName + "]", connection))
                 {
-                    using (StreamWriter sw = new StreamWriter(_outputFile))
+                    using (SqlDataReader reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess))
                     {
                         while (await reader.ReadAsync())
                         {
@@ -116,25 +140,32 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
 
                             using (TextReader data = reader.GetTextReader(0))
                             {
-                                do
+                                using (StreamWriter sw = new StreamWriter(_outputFile))
                                 {
-                                    charsRead = await data.ReadAsync(buffer, 0, buffer.Length);
-                                    await sw.WriteAsync(buffer, 0, charsRead);
+                                    do
+                                    {
+                                        charsRead = await data.ReadAsync(buffer, 0, buffer.Length);
+                                        await sw.WriteAsync(buffer, 0, charsRead);
 
-                                } while (charsRead > 0);
+                                    } while (charsRead > 0);
+                                }
                             }
-                            _output.WriteLine("Output written to file " + _outputFile);
+                            CompareJsonFiles();
                         }
                     }
                 }
+            }
+            finally
+            {
+                DeleteFile(_outputFile);
             }
         }
 
         private void StreamJsonFileToServer(SqlConnection connection)
         {
-            using (SqlCommand cmd = new SqlCommand("INSERT INTO [jsonTab] (data) VALUES (@jsondata)", connection))
+            using (SqlCommand cmd = new SqlCommand("INSERT INTO [" + _sourceTableName + "] (data) VALUES (@jsondata)", connection))
             {
-                using (StreamReader jsonFile = File.OpenText(_jsonFile))
+                using (StreamReader jsonFile = File.OpenText(_generatedJsonFile))
                 {
                     cmd.Parameters.Add("@jsondata", Microsoft.Data.SqlDbTypeExtensions.Json, -1).Value = jsonFile;
                     cmd.ExecuteNonQuery();
@@ -144,9 +175,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
 
         private async Task StreamJsonFileToServerAsync(SqlConnection connection)
         {
-            using (SqlCommand cmd = new SqlCommand("INSERT INTO [jsonTab] (data) VALUES (@jsondata)", connection))
+            using (SqlCommand cmd = new SqlCommand("INSERT INTO [" + _sourceTableName + "] (data) VALUES (@jsondata)", connection))
             {
-                using (StreamReader jsonFile = File.OpenText(_jsonFile))
+                using (StreamReader jsonFile = File.OpenText(_generatedJsonFile))
                 {
                     cmd.Parameters.Add("@jsondata", Microsoft.Data.SqlDbTypeExtensions.Json, -1).Value = jsonFile;
                     await cmd.ExecuteNonQueryAsync();
@@ -162,15 +193,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
             }
         }
 
-        private void BulkCopyData(CommandBehavior cb, bool enableStraming)
+        private void BulkCopyData(CommandBehavior cb, bool enableStraming, int expectedTransferCount)
         {
             using (SqlConnection sourceConnection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
                 sourceConnection.Open();
-                SqlCommand commandRowCount = new SqlCommand("SELECT COUNT(*) FROM " + "dbo.jsonTabCopy;", sourceConnection);
+                SqlCommand commandRowCount = new SqlCommand("SELECT COUNT(*) FROM " + _destinationTableName, sourceConnection);
                 long countStart = System.Convert.ToInt32(commandRowCount.ExecuteScalar());
                 _output.WriteLine("Starting row count = {0}", countStart);
-                SqlCommand commandSourceData = new SqlCommand("SELECT data FROM dbo.jsonTab;", sourceConnection);
+                SqlCommand commandSourceData = new SqlCommand("SELECT data FROM " + _sourceTableName, sourceConnection);
                 SqlDataReader reader = commandSourceData.ExecuteReader(cb);
                 using (SqlConnection destinationConnection = new SqlConnection(DataTestUtility.TCPConnectionString))
                 {
@@ -178,7 +209,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
                     using (SqlBulkCopy bulkCopy = new SqlBulkCopy(destinationConnection))
                     {
                         bulkCopy.EnableStreaming = enableStraming;
-                        bulkCopy.DestinationTableName = "dbo.jsonTabCopy";
+                        bulkCopy.DestinationTableName = _destinationTableName;
                         try
                         {
                             bulkCopy.WriteToServer(reader);
@@ -195,19 +226,20 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
                     long countEnd = System.Convert.ToInt32(commandRowCount.ExecuteScalar());
                     _output.WriteLine("Ending row count = {0}", countEnd);
                     _output.WriteLine("{0} rows were added.", countEnd - countStart);
+                    Assert.Equal(expectedTransferCount, countEnd - countStart);
                 }
             }
         }
 
-        private async Task BulkCopyDataAsync(CommandBehavior cb, bool enableStraming)
+        private async Task BulkCopyDataAsync(CommandBehavior cb, bool enableStraming, int expectedTransferCount)
         {
             using (SqlConnection sourceConnection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
                 await sourceConnection.OpenAsync();
-                SqlCommand commandRowCount = new SqlCommand("SELECT COUNT(*) FROM " + "dbo.jsonTabCopy;", sourceConnection);
+                SqlCommand commandRowCount = new SqlCommand("SELECT COUNT(*) FROM " + _destinationTableName, sourceConnection);
                 long countStart = System.Convert.ToInt32(await commandRowCount.ExecuteScalarAsync());
                 _output.WriteLine("Starting row count = {0}", countStart);
-                SqlCommand commandSourceData = new SqlCommand("SELECT data FROM dbo.jsonTab;", sourceConnection);
+                SqlCommand commandSourceData = new SqlCommand("SELECT data FROM " + _sourceTableName, sourceConnection);
                 SqlDataReader reader = await commandSourceData.ExecuteReaderAsync(cb);
                 using (SqlConnection destinationConnection = new SqlConnection(DataTestUtility.TCPConnectionString))
                 {
@@ -215,7 +247,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
                     using (SqlBulkCopy bulkCopy = new SqlBulkCopy(destinationConnection))
                     {
                         bulkCopy.EnableStreaming = enableStraming;
-                        bulkCopy.DestinationTableName = "dbo.jsonTabCopy";
+                        bulkCopy.DestinationTableName = _destinationTableName;
                         try
                         {
                             await bulkCopy.WriteToServerAsync(reader);
@@ -232,44 +264,37 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
                     long countEnd = System.Convert.ToInt32(await commandRowCount.ExecuteScalarAsync());
                     _output.WriteLine("Ending row count = {0}", countEnd);
                     _output.WriteLine("{0} rows were added.", countEnd - countStart);
+                    Assert.Equal(expectedTransferCount, countEnd - countStart);
                 }
             }
         }
 
-        [InlineData(CommandBehavior.Default, false)]
-        [InlineData(CommandBehavior.Default, true)]
-        [InlineData(CommandBehavior.SequentialAccess, false)]
-        [InlineData(CommandBehavior.SequentialAccess, true)]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
-        public void TestJsonBulkCopy(CommandBehavior cb, bool enableStraming)
+        [ClassData(typeof(JsonBulkCopyTestData))]
+        public void TestJsonBulkCopy(CommandBehavior cb, bool enableStraming, int jsonArrayElements, int rows)
         {
-            PopulateData(10000);
+            PopulateData(jsonArrayElements, rows);
             using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
-                BulkCopyData(cb, enableStraming);
+                BulkCopyData(cb, enableStraming, rows);
                 connection.Open();
-                PrintJsonDataToFile(connection);
-                CompareJsonFiles();
-                DeleteFile(_jsonFile);
+                PrintJsonDataToFileAndCompare(connection);
+                DeleteFile(_generatedJsonFile);
                 DeleteFile(_outputFile);
             }
         }
 
-        [InlineData(CommandBehavior.Default, false)]
-        [InlineData(CommandBehavior.Default, true)]
-        [InlineData(CommandBehavior.SequentialAccess, false)]
-        [InlineData(CommandBehavior.SequentialAccess, true)]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
-        public async Task TestJsonBulkCopyAsync(CommandBehavior cb, bool enableStraming)
+        [ClassData(typeof(JsonBulkCopyTestData))]
+        public async Task TestJsonBulkCopyAsync(CommandBehavior cb, bool enableStraming, int jsonArrayElements, int rows)
         {
-            PopulateData(10000);
+            PopulateData(jsonArrayElements, rows);
             using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {
-                await BulkCopyDataAsync(cb, enableStraming);
+                await BulkCopyDataAsync(cb, enableStraming, rows);
                 await connection.OpenAsync();
-                await PrintJsonDataToFileAsync(connection);
-                CompareJsonFiles();
-                DeleteFile(_jsonFile);
+                await PrintJsonDataToFileAndCompareAsync(connection);
+                DeleteFile(_generatedJsonFile);
                 DeleteFile(_outputFile);
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -4,12 +4,12 @@
 
 using System;
 using System.Data;
-using Microsoft.Data;
 using System.Data.Common;
 using System.Data.SqlTypes;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
+using System.Text.Json;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
@@ -21,8 +21,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             _output = output;
         }
-
-        private static readonly string jsonDataString = "[{\"name\":\"Dave\",\"skills\":[\"Python\"]},{\"name\":\"Ron\",\"surname\":\"Peter\"}]";
+            
+        private static readonly string JsonDataString = "[{\"name\":\"Dave\",\"skills\":[\"Python\"]},{\"name\":\"Ron\",\"surname\":\"Peter\"}]";
 
         private void ValidateRowsAffected(int rowsAffected)
         {
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 string jsonData = reader.GetString(0);
                 _output.WriteLine(jsonData);
-                Assert.Equal(jsonDataString, jsonData);
+                Assert.Equal(JsonDataString, jsonData);
             }
         }
 
@@ -46,7 +46,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 string jsonData = reader.GetString(0);
                 _output.WriteLine(jsonData);
-                Assert.Equal(jsonDataString, jsonData);
+                Assert.Equal(JsonDataString, jsonData);
             }
         }
 
@@ -75,8 +75,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public void TestJsonWrite()
         {
-            string tableName = "jsonWriteTest";
-            string spName = "spJsonWriteTest";
+            string tableName = DataTestUtility.GenerateObjectName();
+            string spName = DataTestUtility.GenerateObjectName();
 
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string spCreate = "CREATE PROCEDURE " + spName + " (@jsonData json) AS " + tableInsert;
@@ -101,13 +101,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                     //Test 1
                     //Write json value using a parameterized query
-                    parameter.Value = jsonDataString;
+                    parameter.Value = JsonDataString;
                     int rowsAffected = command.ExecuteNonQuery();
                     ValidateRowsAffected(rowsAffected);
 
                     //Test 2 
                     //Write a SqlString type as json
-                    parameter.Value = new SqlString(jsonDataString);
+                    parameter.Value = new SqlString(JsonDataString);
                     int rowsAffected2 = command.ExecuteNonQuery();
                     ValidateRowsAffected(rowsAffected2);
 
@@ -118,7 +118,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         command2.CommandText = spName;
                         command2.CommandType = CommandType.StoredProcedure;
                         var parameter2 = new SqlParameter("@jsonData", SqlDbTypeExtensions.Json);
-                        parameter2.Value = jsonDataString;
+                        parameter2.Value = JsonDataString;
                         command2.Parameters.Add(parameter2);
                         int rowsAffected3 = command2.ExecuteNonQuery();
                         ValidateRowsAffected(rowsAffected3);
@@ -133,8 +133,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public async Task TestJsonWriteAsync()
         {
-            string tableName = "jsonWriteTest";
-            string spName = "spJsonWriteTest";
+            string tableName = DataTestUtility.GenerateObjectName();
+            string spName = DataTestUtility.GenerateObjectName();
 
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string spCreate = "CREATE PROCEDURE " + spName + " (@jsonData json) AS " + tableInsert;
@@ -159,13 +159,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                     //Test 1
                     //Write json value using a parameterized query
-                    parameter.Value = jsonDataString;
+                    parameter.Value = JsonDataString;
                     int rowsAffected = await command.ExecuteNonQueryAsync();
                     ValidateRowsAffected(rowsAffected);
 
                     //Test 2 
                     //Write a SqlString type as json
-                    parameter.Value = new SqlString(jsonDataString);
+                    parameter.Value = new SqlString(JsonDataString);
                     int rowsAffected2 = await command.ExecuteNonQueryAsync();
                     ValidateRowsAffected(rowsAffected2);
 
@@ -176,7 +176,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         command2.CommandText = spName;
                         command2.CommandType = CommandType.StoredProcedure;
                         var parameter2 = new SqlParameter("@jsonData", SqlDbTypeExtensions.Json);
-                        parameter2.Value = jsonDataString;
+                        parameter2.Value = JsonDataString;
                         command2.Parameters.Add(parameter2);
                         int rowsAffected3 = await command.ExecuteNonQueryAsync();
                         ValidateRowsAffected(rowsAffected3);
@@ -191,8 +191,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public void TestJsonRead()
         {
-            string tableName = "jsonReadTest";
-            string spName = "spJsonReadTest";
+            string tableName = DataTestUtility.GenerateObjectName();
+            string spName = DataTestUtility.GenerateObjectName();
 
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string tableRead = "SELECT * FROM " + tableName;
@@ -215,7 +215,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     //This will be used for reading
                     command.CommandText = tableInsert;
                     var parameter = new SqlParameter("@jsonData", SqlDbTypeExtensions.Json);
-                    parameter.Value = jsonDataString;
+                    parameter.Value = JsonDataString;
                     command.Parameters.Add(parameter);
                     command.ExecuteNonQuery();
 
@@ -250,8 +250,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public async Task TestJsonReadAsync()
         {
-            string tableName = "jsonReadTest";
-            string spName = "spJsonReadTest";
+            string tableName = DataTestUtility.GenerateObjectName();
+            string spName = DataTestUtility.GenerateObjectName();
 
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string tableRead = "SELECT * FROM " + tableName;
@@ -274,7 +274,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     //This will be used for reading
                     command.CommandText = tableInsert;
                     var parameter = new SqlParameter("@jsonData", SqlDbTypeExtensions.Json);
-                    parameter.Value = jsonDataString;
+                    parameter.Value = JsonDataString;
                     command.Parameters.Add(parameter);
                     await command.ExecuteNonQueryAsync();
 
@@ -309,7 +309,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
         public void TestNullJson()
         {
-            string tableName = "jsonTest";
+            string tableName = DataTestUtility.GenerateObjectName();
 
             string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
             string tableRead = "SELECT * FROM " + tableName;
@@ -335,6 +335,109 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             reader.Close();
             DataTestUtility.DropTable(connection, tableName);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
+        public void TestJsonAPIs()
+        {
+            string tableName = DataTestUtility.GenerateObjectName();
+            string tableInsert = "INSERT INTO " + tableName + " VALUES (@jsonData)";
+            string tableRead = "SELECT * FROM " + tableName;
+
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            {
+                connection.Open();
+                using (SqlCommand command = connection.CreateCommand())
+                {
+                    try
+                    {
+                        // Create Table
+                        DataTestUtility.CreateTable(connection, tableName, "(Data json)");
+
+                        // Insert Null value
+                        command.CommandText = tableInsert;
+                        var parameter = new SqlParameter("@jsonData", SqlDbTypeExtensions.Json);
+                        parameter.Value = JsonDataString;
+                        command.Parameters.Add(parameter);
+                        command.ExecuteNonQuery();
+
+                        // Query the table
+                        command.CommandText = tableRead;
+                        using (var reader = command.ExecuteReader())
+                        {
+                            while (reader.Read())
+                            {
+                                string data = reader.GetFieldValue<string>(0);
+                                Assert.Equal(JsonDataString, data);
+                                JsonDocument jsonDocument = reader.GetFieldValue<JsonDocument>(0);
+                                Assert.Equal(JsonDataString, jsonDocument.RootElement.ToString());
+                                Assert.Equal("json", reader.GetDataTypeName(0));
+                                Assert.Equal("System.String", reader.GetFieldType(0).ToString());
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        DataTestUtility.DropTable(connection, tableName);
+                    }
+                }
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
+        public void TestJsonWithMARS()
+        {
+            string table1Name = DataTestUtility.GenerateObjectName();
+            string table2Name = DataTestUtility.GenerateObjectName();
+
+            using (SqlConnection connection = new SqlConnection(DataTestUtility.TCPConnectionString + "MultipleActiveResultSets=True;"))
+            {
+                connection.Open();
+                try
+                {
+                    // Create Table
+                    DataTestUtility.CreateTable(connection, table1Name, "(Data json)");
+                    DataTestUtility.CreateTable(connection, table2Name, "(Id int, Data json)");
+
+                    // Insert Data
+                    string table1Insert = "INSERT INTO " + table1Name + " VALUES ('" + JsonDataString + "')";
+                    string table2Insert = "INSERT INTO " + table2Name + " VALUES (1,'" + JsonDataString + "')";
+                    using (SqlCommand command = connection.CreateCommand())
+                    {
+                        command.CommandText = table1Insert;
+                        command.ExecuteNonQuery();
+                        command.CommandText = table2Insert;
+                        command.ExecuteNonQuery();
+                    }
+
+                    // Read Data
+                    using (SqlCommand command1 = new SqlCommand("select * from " + table1Name, connection))
+                    using (SqlCommand command2 = new SqlCommand("select * from " + table2Name, connection))
+                    {
+                        using (SqlDataReader reader1 = command1.ExecuteReader())
+                        {
+                            while (reader1.Read())
+                            {
+                                Assert.Equal(JsonDataString, reader1["data"]);
+                            }
+
+                            using (SqlDataReader reader2 = command2.ExecuteReader())
+                            {
+                                while (reader2.Read())
+                                {
+                                    Assert.Equal(1, reader2["Id"]);
+                                    Assert.Equal(JsonDataString, reader2["data"]);
+                                }
+                            }
+                        }
+                    }
+                }
+                finally
+                {
+                    DataTestUtility.DropTable(connection, table1Name);
+                    DataTestUtility.DropTable(connection, table2Name);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Porting from main (#3062 )
Enhanced BCP tests to transfer multiple rows
Added SqlDataReader specific API tests
Added scenario of read MARS involving json datatype Parameterized jsonArrayElements and rows for JsonBulkCopyTests