### PR TITLE
Reduce AOT binary size

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -396,12 +396,12 @@ namespace Microsoft.Data.SqlClient
             if (_networkLibrary != null)
             { // MDAC 83525
                 string networkLibrary = _networkLibrary.Trim().ToLower(CultureInfo.InvariantCulture);
-                Hashtable netlib = NetlibMapping();
+                Dictionary<string, string> netlib = NetlibMapping();
                 if (!netlib.ContainsKey(networkLibrary))
                 {
                     throw ADP.InvalidConnectionOptionValue(KEY.Network_Library);
                 }
-                _networkLibrary = (string)netlib[networkLibrary];
+                _networkLibrary = netlib[networkLibrary];
             }
             else
             {
@@ -1101,14 +1101,14 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        static internal Hashtable NetlibMapping()
+        static internal Dictionary<string, string> NetlibMapping()
         {
             const int NetLibCount = 8;
 
-            Hashtable hash = s_netlibMapping;
+            Dictionary<string, string> hash = s_netlibMapping;
             if (hash == null)
             {
-                hash = new Hashtable(NetLibCount)
+                hash = new Dictionary<string, string>(NetLibCount)
                 {
                     { NETLIB.TCPIP, TdsEnums.TCP },
                     { NETLIB.NamedPipes, TdsEnums.NP },
@@ -1150,7 +1150,7 @@ namespace Microsoft.Data.SqlClient
             internal const string VIA = "dbmsgnet";
         }
 
-        private static Hashtable s_netlibMapping;
+        private static Dictionary<string, string> s_netlibMapping;
 
 #if NETFRAMEWORK
         protected internal override PermissionSet CreatePermissionSet()

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
@@ -139,10 +139,14 @@ namespace Microsoft.Data.SqlClient
                 // Pick up the process Id from the current process instead of randomly generating it.
                 // This would be helpful while tracing application related issues.
                 int processId;
+#if NET
+                processId = Environment.ProcessId;
+#else
                 using (System.Diagnostics.Process p = System.Diagnostics.Process.GetCurrentProcess())
                 {
                     processId = p.Id;
                 }
+#endif
                 System.Threading.Volatile.Write(ref s_currentProcessId, processId);
             }
             return s_currentProcessId;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs
@@ -7,8 +7,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
-using System.Runtime.Serialization.Json;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
 using System.Threading;
 
 namespace Microsoft.Data.SqlClient
@@ -57,7 +57,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Makes a web request to the provided url and returns the response as a byte[]
-        protected override byte[] MakeRequest(string url)
+        protected override List<byte> MakeRequest(string url)
         {
             Exception exception = null;
 
@@ -72,8 +72,7 @@ namespace Microsoft.Data.SqlClient
 
                     using (Stream stream = s_client.GetStreamAsync(url).ConfigureAwait(false).GetAwaiter().GetResult())
                     {
-                        var deserializer = new DataContractJsonSerializer(typeof(byte[]));
-                        return (byte[])deserializer.ReadObject(stream);
+                        return JsonSerializer.Deserialize<List<byte>>(stream);
                     }
                 }
                 catch (Exception e)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Makes a web request to the provided url and returns the response as a byte[]
-        protected override List<byte> MakeRequest(string url)
+        protected override byte[] MakeRequest(string url)
         {
             Exception exception = null;
 
@@ -72,7 +72,7 @@ namespace Microsoft.Data.SqlClient
 
                     using (Stream stream = s_client.GetStreamAsync(url).ConfigureAwait(false).GetAwaiter().GetResult())
                     {
-                        return JsonSerializer.Deserialize<List<byte>>(stream);
+                        return JsonSerializer.Deserialize<List<byte>>(stream)?.ToArray();
                     }
                 }
                 catch (Exception e)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -184,8 +184,8 @@ namespace Microsoft.Data.SqlClient
             VerifyEnclaveReportSignature(enclaveReportPackage, healthReport.Certificate);
         }
 
-        // Makes a web request to the provided url and returns the response as a List<byte>
-        protected abstract List<byte> MakeRequest(string url);
+        // Makes a web request to the provided url and returns the response as a byte[]
+        protected abstract byte[] MakeRequest(string url);
 
         // Gets the root signing certificate for the provided attestation service.
         // If the certificate does not exist in the cache, this will make a call to the
@@ -198,18 +198,13 @@ namespace Microsoft.Data.SqlClient
             X509Certificate2Collection signingCertificates = rootSigningCertificateCache.Get<X509Certificate2Collection>(attestationUrl);
             if (forceUpdate || signingCertificates == null || AnyCertificatesExpired(signingCertificates))
             {
-                List<byte> data = MakeRequest(attestationUrl);
+                byte[] data = MakeRequest(attestationUrl);
                 var certificateCollection = new X509Certificate2Collection();
 
                 try
                 {
                     SignedCms s = new SignedCms();
-#if NET
-                    Span<byte> dataSpan = System.Runtime.InteropServices.CollectionsMarshal.AsSpan(data);
-                    s.Decode(dataSpan);
-#else
-                    s.Decode(data.ToArray());
-#endif
+                    s.Decode(data);
                     certificateCollection.AddRange(s.Certificates);
                 }
                 catch (CryptographicException exception)
@@ -269,10 +264,10 @@ namespace Microsoft.Data.SqlClient
             // An Always Encrypted-enabled driver doesn't verify an expiration date or a certificate authority chain.
             // A certificate is simply used as a key pair consisting of a public and private key. This is by design.
 
-#pragma warning disable IA5352
+            #pragma warning disable IA5352
             // CodeQL [SM00395] By design. Always Encrypted certificates should not be checked.
             chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-#pragma warning restore IA5352
+            #pragma warning restore IA5352
 
             if (!chain.Build(healthReportCert))
             {
@@ -430,6 +425,6 @@ namespace Microsoft.Data.SqlClient
                 return KeyConverter.DeriveKey(clientDHKey, ecdh.PublicKey);
             }
         }
-#endregion
+        #endregion
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;


### PR DESCRIPTION
Contributes to #1942.

For win-x64, the pre-PR binary size is 21MB. Sizoscope indicates that these changes trim 0.9MB (~4.25%) from the final binary.

This has two small changes and one which requires explanation:
1. Replace a Hashtable in the connection string parsing with a generic Dictionary.
2. Remove a reference to Process.GetCurrentProcess, replacing it with the new Environment.ProcessId property.

In both cases, I'm just removing references to types which aren't used frequently. The Azure dependency drags the Process class in, but when that dependency's refactored out there'll be nothing else using it in the core library.

The third change removes the only reference to `DataContractJsonSerializer`, which is used to get the signing certificates for the attestation authority. I've built a standalone server running the Host Guardian Services role, and confirmed that the API endpoint returns the certificate data in text format as a JSON array. Example output from this API endpoint is thus the text string `[ 128, 0, 35, 0, ... ]`.

JsonSerializer only returns a byte[] when passed a base64-encoded string, so I've returned a List<byte> instead.