### PR TITLE
Handle missing secrets

### DIFF
--- a/eng/pipelines/common/templates/steps/configure-sql-server-linux-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-linux-step.yml
@@ -19,7 +19,7 @@ steps:
     
     # Password for the SA user (required)
     MSSQL_SA_PW=${{parameters.password }}
-    if [ "$MSSQL_SA_PW" = "generated_placeholder" ]; then
+    if [ "$MSSQL_SA_PW" = "generated_placeholder" ] || [ "$MSSQL_SA_PW" = "$(password)" ]; then
       exit 0
     fi
     

--- a/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
@@ -100,7 +100,16 @@ steps:
   retryCountOnTaskFailure: 2
 
 - powershell: |
-    $password = "${{parameters.password }}"
+    $password = "generated_placeholder"
+    try
+    {
+        $password = "${{parameters.password }}"
+    }
+    catch
+    {
+        "Failed to retrieve password parameter. Pipeline may not have access to secret variable. Defaulting to generated password."
+    }
+
     if ( "generated_placeholder" -eq $password )
     {
         $password = [guid]::NewGuid().ToString()

--- a/eng/pipelines/common/templates/steps/update-config-file-step.yml
+++ b/eng/pipelines/common/templates/steps/update-config-file-step.yml
@@ -130,7 +130,12 @@ steps:
     $jdata = Get-Content -Raw "config.default.json" | ConvertFrom-Json
     foreach ($p in $jdata)
     {
-        $p.TCPConnectionString="${{parameters.TCPConnectionString }}"
+        try {
+            $p.TCPConnectionString="${{parameters.TCPConnectionString }}"
+        }
+        catch {
+            "Couldn't load TCPConnectionString"
+        }
 
         $p.NPConnectionString="${{parameters.NPConnectionString }}"
 

--- a/eng/pipelines/common/templates/steps/update-config-file-step.yml
+++ b/eng/pipelines/common/templates/steps/update-config-file-step.yml
@@ -130,61 +130,266 @@ steps:
     $jdata = Get-Content -Raw "config.default.json" | ConvertFrom-Json
     foreach ($p in $jdata)
     {
-        try {
+        try
+        {
             $p.TCPConnectionString="${{parameters.TCPConnectionString }}"
         }
-        catch {
+        catch
+        {
             "Couldn't load TCPConnectionString"
         }
 
-        $p.NPConnectionString="${{parameters.NPConnectionString }}"
+        try
+        {
+            $p.NPConnectionString="${{parameters.NPConnectionString }}"
+        }
+        catch
+        {
+            "Couldn't load NPConnectionString"
+        }
 
-        $p.AADAuthorityURL="${{parameters.AADAuthorityURL }}"
+        try
+        {
+            $p.AADAuthorityURL="${{parameters.AADAuthorityURL }}"
+        }
+        catch
+        {
+            "Couldn't load AADAuthorityURL"
+        }
 
-        $p.AADPasswordConnectionString="${{parameters.AADPasswordConnectionString }}"
+        try
+        {
+            $p.AADPasswordConnectionString="${{parameters.AADPasswordConnectionString }}"
+        }
+        catch
+        {
+            "Couldn't load AADPasswordConnectionString"
+        }
 
-        $p.AADServicePrincipalId="${{parameters.AADServicePrincipalId }}"
+        try
+        {
+            $p.AADServicePrincipalId="${{parameters.AADServicePrincipalId }}"
+        }
+        catch
+        {
+            "Couldn't load AADServicePrincipalId"
+        }
 
-        $p.AADServicePrincipalSecret="${{parameters.AADServicePrincipalSecret }}"
+        try
+        {
+            $p.AADServicePrincipalSecret="${{parameters.AADServicePrincipalSecret }}"
+        }
+        catch
+        {
+            "Couldn't load AADServicePrincipalSecret"
+        }
 
-        $p.AzureKeyVaultUrl="${{parameters.AzureKeyVaultUrl }}"
+        try
+        {
+            $p.AzureKeyVaultUrl="${{parameters.AzureKeyVaultUrl }}"
+        }
+        catch
+        {
+            "Couldn't load AzureKeyVaultUrl"
+        }
 
-        $p.AzureKeyVaultTenantId="${{parameters.AzureKeyVaultTenantId }}"
+        try
+        {
+            $p.AzureKeyVaultTenantId="${{parameters.AzureKeyVaultTenantId }}"
+        }
+        catch
+        {
+            "Couldn't load AzureKeyVaultTenantId"
+        }
 
-        $p.UserManagedIdentityClientId="${{parameters.UserManagedIdentityClientId }}"
+        try
+        {
+            $p.UserManagedIdentityClientId="${{parameters.UserManagedIdentityClientId }}"
+        }
+        catch
+        {
+            "Couldn't load UserManagedIdentityClientId"
+        }
 
-        $p.FileStreamDirectory="${{parameters.FileStreamDirectory }}"
+        try
+        {
+            $p.FileStreamDirectory="${{parameters.FileStreamDirectory }}"
+        }
+        catch
+        {
+            "Couldn't load FileStreamDirectory"
+        }
 
-        $p.LocalDbSharedInstanceName="${{parameters.LocalDbSharedInstanceName }}"
+        try
+        {
+            $p.LocalDbSharedInstanceName="${{parameters.LocalDbSharedInstanceName }}"
+        }
+        catch
+        {
+            "Couldn't load LocalDbSharedInstanceName"
+        }
 
-        $p.AliasName="${{parameters.AliasName }}"
+        try
+        {
+            $p.AliasName="${{parameters.AliasName }}"
+        }
+        catch
+        {
+            "Couldn't load AliasName"
+        }
 
-        $p.EnclaveAzureDatabaseConnString="${{parameters.EnclaveAzureDatabaseConnString }}"
+        try
+        {
+            $p.EnclaveAzureDatabaseConnString="${{parameters.EnclaveAzureDatabaseConnString }}"
+        }
+        catch
+        {
+            "Couldn't load EnclaveAzureDatabaseConnString"
+        }
 
-        $p.DNSCachingServerTR="${{parameters.DNSCachingServerTR }}"
+        try
+        {
+            $p.DNSCachingServerTR="${{parameters.DNSCachingServerTR }}"
+        }
+        catch
+        {
+            "Couldn't load DNSCachingServerTR"
+        }
 
-        $p.DNSCachingServerCR="${{parameters.DNSCachingServerCR }}"
+        try
+        {
+            $p.DNSCachingServerCR="${{parameters.DNSCachingServerCR }}"
+        }
+        catch
+        {
+            "Couldn't load DNSCachingServerCR"
+        }
 
-        $p.DNSCachingConnString="${{parameters.DNSCachingConnString }}"
+        try
+        {
+            $p.DNSCachingConnString="${{parameters.DNSCachingConnString }}"
+        }
+        catch
+        {
+            "Couldn't load DNSCachingConnString"
+        }
 
-        $p.SupportsFileStream="${{parameters.SupportsFileStream }}"
+        try
+        {
+            $p.SupportsFileStream="${{parameters.SupportsFileStream }}"
+        }
+        catch
+        {
+            "Couldn't load SupportsFileStream"
+        }
 
-        $p.LocalDbAppName="${{parameters.LocalDbAppName }}"
+        try
+        {
+            $p.LocalDbAppName="${{parameters.LocalDbAppName }}"
+        }
+        catch
+        {
+            "Couldn't load LocalDbAppName"
+        }
 
-        $p.TCPConnectionStringAASSGX="${{parameters.TCPConnectionStringAASSGX }}"
+        try
+        {
+            $p.TCPConnectionStringAASSGX="${{parameters.TCPConnectionStringAASSGX }}"
+        }
+        catch
+        {
+            "Couldn't load TCPConnectionStringAASSGX"
+        }
 
-        $p.TCPConnectionStringNoneVBS="${{parameters.TCPConnectionStringNoneVBS }}"
+        try
+        {
+            $p.TCPConnectionStringNoneVBS="${{parameters.TCPConnectionStringNoneVBS }}"
+        }
+        catch
+        {
+            "Couldn't load TCPConnectionStringNoneVBS"
+        }
 
-        $p.TCPConnectionStringHGSVBS="${{parameters.TCPConnectionStringHGSVBS }}"
+        try
+        {
+            $p.TCPConnectionStringHGSVBS="${{parameters.TCPConnectionStringHGSVBS }}"
+        }
+        catch
+        {
+            "Couldn't load TCPConnectionStringHGSVBS"
+        }
 
-        $p.UseManagedSNIOnWindows=[System.Convert]::ToBoolean("${{parameters.UseManagedSNIOnWindows }}")
-        $p.SupportsIntegratedSecurity=[System.Convert]::ToBoolean("${{parameters.SupportsIntegratedSecurity }}")
-        $p.ManagedIdentitySupported=[System.Convert]::ToBoolean("${{parameters.ManagedIdentitySupported }}")
-        $p.IsAzureSynapse=[System.Convert]::ToBoolean("${{parameters.IsAzureSynapse }}")
-        $p.IsDNSCachingSupportedTR=[System.Convert]::ToBoolean("${{parameters.IsDNSCachingSupportedTR }}")
-        $p.IsDNSCachingSupportedCR=[System.Convert]::ToBoolean("${{parameters.IsDNSCachingSupportedCR }}")
-        $p.TracingEnabled=[System.Convert]::ToBoolean("${{parameters.TracingEnabled }}")
-        $p.EnclaveEnabled=[System.Convert]::ToBoolean("${{parameters.EnclaveEnabled }}")
+        try
+        {
+            $p.UseManagedSNIOnWindows=[System.Convert]::ToBoolean("${{parameters.UseManagedSNIOnWindows }}")
+        }
+        catch
+        {
+            "Couldn't load UseManagedSNIOnWindows"
+        }
+
+        try
+        {
+            $p.SupportsIntegratedSecurity=[System.Convert]::ToBoolean("${{parameters.SupportsIntegratedSecurity }}")
+        }
+        catch
+        {
+            "Couldn't load SupportsIntegratedSecurity"
+        }
+
+        try
+        {
+            $p.ManagedIdentitySupported=[System.Convert]::ToBoolean("${{parameters.ManagedIdentitySupported }}")
+        }
+        catch
+        {
+            "Couldn't load ManagedIdentitySupported"
+        }
+
+        try
+        {
+            $p.IsAzureSynapse=[System.Convert]::ToBoolean("${{parameters.IsAzureSynapse }}")
+        }
+        catch
+        {
+            "Couldn't load IsAzureSynapse"
+        }
+
+        try
+        {
+            $p.IsDNSCachingSupportedTR=[System.Convert]::ToBoolean("${{parameters.IsDNSCachingSupportedTR }}")
+        }
+        catch
+        {
+            "Couldn't load IsDNSCachingSupportedTR"
+        }
+
+        try
+        {
+            $p.IsDNSCachingSupportedCR=[System.Convert]::ToBoolean("${{parameters.IsDNSCachingSupportedCR }}")
+        }
+        catch
+        {
+            "Couldn't load IsDNSCachingSupportedCR"
+        }
+
+        try
+        {
+            $p.TracingEnabled=[System.Convert]::ToBoolean("${{parameters.TracingEnabled }}")
+        }
+        catch
+        {
+            "Couldn't load TracingEnabled"
+        }
+
+        try
+        {
+            $p.EnclaveEnabled=[System.Convert]::ToBoolean("${{parameters.EnclaveEnabled }}")
+        }
+        catch
+        {
+            "Couldn't load EnclaveEnabled"
+        }
     }
     $jdata | ConvertTo-Json | Set-Content "config.json"
   workingDirectory: src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -81,15 +81,15 @@ stages:
       ${{ if eq(parameters.buildType, 'Package') }}:
         dependsOn: build_nugets
 
-      prebuildSteps: # steps to run prior to building and running tests on each job
+      prebuildSteps:
       - template: common/templates/steps/ci-prebuild-step.yml@self
         parameters:
           debug: ${{ parameters.debug }}
           artifactName: $(artifactName)
           buildType: ${{ parameters.buildType }}
 
-      ${{ if eq(parameters.buildType, 'Project') }}: # only run the code coverage job if the build type is project
-        postTestJobs: # jobs to run after the tests are done
+      ${{ if eq(parameters.buildType, 'Project') }}:
+        postTestJobs:
         - template: common/templates/jobs/ci-code-coverage-job.yml@self
           parameters:
             debug: ${{ parameters.debug }}
@@ -104,22 +104,20 @@ stages:
                     ${{ else }}:
                       targetPath: '$(Build.SourcesDirectory)\coverageNetCore'
 
-# test stages configurations
-  # self hosted SQL Server on Windows
       testConfigurations:
-        windows_sql_19_x64: # configuration name
-          pool: ${{parameters.defaultPoolName }} # pool name
-          hostedPool: false # whether the pool is hosted or not
-          images: # list of images to run tests on
-            Win22_Sql19: ADO-MMS22-SQL19 # stage display name: image name from the pool
-          TargetFrameworks: ${{parameters.targetFrameworks }} #[net462, net8.0] # list of target frameworks to run
+        windows_sql_19_x64:
+          pool: ${{parameters.defaultPoolName }}
+          hostedPool: false
+          images:
+            Win22_Sql19: ADO-MMS22-SQL19
+          TargetFrameworks: ${{parameters.targetFrameworks }}
           netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
           buildPlatforms: ${{parameters.buildPlatforms }}
-          testSets: ${{parameters.testSets }} # [1, 2, 3] # list of test sets to run
-          useManagedSNI: ${{parameters.useManagedSNI }} # can be used for .NET Core only tests on Windows: [false, true], [false] or [true] values are allowed
-          codeCovTargetFrameworks: ${{parameters.codeCovTargetFrameworks }} # targeted frameworks that is going to participate in test result report generation
-          configSqlFor: local # setup Sql Server (local | azure | enclave)
-          operatingSystem: Windows # operating system to run tests on (Windows | Linux | Mac)
+          testSets: ${{parameters.testSets }}
+          useManagedSNI: ${{parameters.useManagedSNI }}
+          codeCovTargetFrameworks: ${{parameters.codeCovTargetFrameworks }}
+          configSqlFor: local
+          operatingSystem: Windows
           configProperties:
             # config.json properties
             TCPConnectionString: $(SQL_TCP_CONN_STRING)
@@ -139,34 +137,21 @@ stages:
             # extra config properties
             SQLRootPath: $(SQL19RootPath)
             enableLocalDB: true
-            # instanceName: default: MSSQLSERVER
-            # user: default: $(user)
-            # saUser: default: $(saUser)
-            # password: default: $(password)
-            # fileStreamDirectory: default: ''
-            # x64AliasRegistryPath: default: $(x64AliasRegistryPath)
-            # x86AliasRegistryPath: default: $(x86AliasRegistryPath)
-            # SQLAliasName: default: $(SQLAliasName)
-            # SQLAliasPort: default: $(SQLAliasPort)
-            # databaseName: default: Northwind
-            # localDbAppName: default: $(LocalDbAppName)
-            # localDbSharedInstanceName: default: $(LocalDbSharedInstanceName)
-            # skipSqlConfiguration: # skips the SQL configuration step
 
 
-        windows_sql_19_x86: # configuration name
-          pool: ${{parameters.defaultPoolName }} # pool name
-          hostedPool: false # whether the pool is hosted or not
-          images: # list of images to run tests on
-            Win22_Sql19_x86: ADO-MMS22-SQL19 # stage display name: image name from the pool
-          TargetFrameworks: [net8.0] #[net462, net8.0] # list of target frameworks to run
+        windows_sql_19_x86:
+          pool: ${{parameters.defaultPoolName }}
+          hostedPool: false
+          images:
+            Win22_Sql19_x86: ADO-MMS22-SQL19
+          TargetFrameworks: [net8.0]
           netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
           buildPlatforms: ${{parameters.buildPlatforms }}
-          testSets: ${{parameters.testSets }} # [1, 2, 3] # list of test sets to run
-          useManagedSNI: [false] # can be used for .NET Core only tests on Windows: [false, true], [false] or [true] values are allowed
-          codeCovTargetFrameworks: ${{parameters.codeCovTargetFrameworks }} # targeted frameworks that is going to participate in test result report generation
-          configSqlFor: local # setup Sql Server (local | azure | enclave)
-          operatingSystem: Windows # operating system to run tests on (Windows | Linux | Mac)
+          testSets: ${{parameters.testSets }}
+          useManagedSNI: [false]
+          codeCovTargetFrameworks: ${{parameters.codeCovTargetFrameworks }}
+          configSqlFor: local
+          operatingSystem: Windows
           configProperties:
             # config.json properties
             TCPConnectionString: $(SQL_TCP_CONN_STRING)
@@ -184,23 +169,9 @@ stages:
             LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
             AliasName: $(SQLAliasName)
             # extra config properties
-            x86TestTargetFrameworks: [net8.0] # target frameworks should run tests on x86
+            x86TestTargetFrameworks: [net8.0]
             SQLRootPath: $(SQL19RootPath)
             enableLocalDB: true
-            # instanceName: default: MSSQLSERVER
-            # user: default: $(user)
-            # saUser: default: $(saUser)
-            # password: default: $(password)
-            # fileStreamDirectory: default: ''
-            # x64AliasRegistryPath: default: $(x64AliasRegistryPath)
-            # x86AliasRegistryPath: default: $(x86AliasRegistryPath)
-            # SQLAliasName: default: $(SQLAliasName)
-            # SQLAliasPort: default: $(SQLAliasPort)
-            # databaseName: default: Northwind
-            # localDbAppName: default: $(LocalDbAppName)
-            # localDbSharedInstanceName: default: $(LocalDbSharedInstanceName)
-            # skipSqlConfiguration: # skips the SQL configuration step
-
 
         windows_sql_22_x64: 
           pool: ${{parameters.defaultPoolName }}
@@ -264,7 +235,7 @@ stages:
             LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
             AliasName: $(SQLAliasName)
             # extra config properties
-            x86TestTargetFrameworks: [net462] # target frameworks should run tests on x86 as well
+            x86TestTargetFrameworks: [net462]
             SQLRootPath: $(SQL22RootPath)
             enableLocalDB: true
 
@@ -290,8 +261,6 @@ stages:
             SQLRootPath: $(SQL22RootPath)
             instanceName: $(NamedInstance)
 
-
-    # Azure SQL Server - Windows
         windows_azure_sql:
           pool: ${{parameters.defaultPoolName }} 
           images: 
@@ -377,7 +346,6 @@ stages:
             LocalDbAppName: $(LocalDbAppName)
             LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
 
-    # self hosted SQL Server on Linux
         linux_sql_19_22:
           pool: ${{parameters.defaultPoolName }}
           images:
@@ -403,7 +371,6 @@ stages:
             LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
             AliasName: $(SQLAliasName)
 
-    # Azure Sql Server - Linux
         linux_azure_sql:
           pool: ${{parameters.defaultPoolName }}
           images:
@@ -460,7 +427,6 @@ stages:
             LocalDbAppName: $(LocalDbAppName)
             LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
 
-    # Azure Sql Server - Mac
         mac_azure_sql:
           pool: $(defaultHostedPoolName)
           hostedPool: true


### PR DESCRIPTION
Forked builds are no longer allowed to access pipeline secrets. The pipeline fails when secret substitution doesn't occur (due to  invalid powershell command). This PR unblocks forked builds by swallowing errors when passing in test config parameters. This is a short term fix that should be replaced by updating tests to use dynamically created resources (see #2750 for inspiration).