### PR TITLE
Construct client interface name with additional info

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
@@ -946,12 +946,7 @@ namespace Microsoft.Data.Common
     internal static class DbConnectionStringDefaults
     {
         internal const ApplicationIntent ApplicationIntent = Microsoft.Data.SqlClient.ApplicationIntent.ReadWrite;
-        internal const string ApplicationName =
-#if NETFRAMEWORK
-            "Framework Microsoft SqlClient Data Provider";
-#else
-            "Core Microsoft SqlClient Data Provider";
-#endif
+        internal const string ApplicationName = "Microsoft SqlClient";
         internal const string AttachDBFilename = "";
         internal const int CommandTimeout = 30;
         internal const int ConnectTimeout = 15;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -12,9 +12,8 @@ namespace Microsoft.Data.SqlClient
     internal static class TdsEnums
     {
         // internal tdsparser constants
-
-
         public const string SQL_PROVIDER_NAME = Common.DbConnectionStringDefaults.ApplicationName;
+        public const string UNKNOWN = "Unknown";
 
         public static readonly decimal SQL_SMALL_MONEY_MIN = new(-214748.3648);
         public static readonly decimal SQL_SMALL_MONEY_MAX = new(214748.3647);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Data.SqlClient
             _physicalStateObj._messageStatus = 0;
         }// tdsLogin
 
-
+        // Returns the OS information in the format: {OS Name} {OS Version}
         private static string GetOSInfo()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Data.SqlClient
             // Construct client interface name in format: Microsoft SqlClient - {OS}, {Platform} - {architecture}
             // e.g. "Microsoft SqlClient - Microsoft Windows 10.0.26100, .NET 8.0.11 - X64"
             string clientInterfaceName = new StringBuilder(TdsEnums.SQL_PROVIDER_NAME)
-                .Append(" - ").Append(RuntimeInformation.OSDescription ?? TdsEnums.UNKNOWN)
+                .Append(" - ").Append(GetOSInfo())
                 .Append(", ").Append(RuntimeInformation.FrameworkDescription ?? TdsEnums.UNKNOWN)
                 .Append(" - ").Append(RuntimeInformation.ProcessArchitecture)
                 .ToString();
@@ -220,5 +220,24 @@ namespace Microsoft.Data.SqlClient
             _physicalStateObj.HasPendingData = true;
             _physicalStateObj._messageStatus = 0;
         }// tdsLogin
+
+
+        private static string GetOSInfo()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return $"Windows {Environment.OSVersion.Version}";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return $"macOS {Environment.OSVersion.Version}";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return $"Linux {Environment.OSVersion.Version}";
+            }
+
+            return TdsEnums.UNKNOWN;
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
 
 #nullable enable
 
@@ -121,11 +123,17 @@ namespace Microsoft.Data.SqlClient
             // length in bytes
             int length = TdsEnums.SQL2005_LOG_REC_FIXED_LEN;
 
-            string clientInterfaceName = TdsEnums.SQL_PROVIDER_NAME;
+            // Construct client interface name in format: Microsoft SqlClient - {OS}, {Platform} - {architecture}
+            // e.g. "Microsoft SqlClient - Microsoft Windows 10.0.26100, .NET 8.0.11 - X64"
+            string clientInterfaceName = new StringBuilder(TdsEnums.SQL_PROVIDER_NAME)
+                .Append(" - ").Append(RuntimeInformation.OSDescription ?? TdsEnums.UNKNOWN)
+                .Append(", ").Append(RuntimeInformation.FrameworkDescription ?? TdsEnums.UNKNOWN)
+                .Append(" - ").Append(RuntimeInformation.ProcessArchitecture)
+                .ToString();
+
             Debug.Assert(TdsEnums.MAXLEN_CLIENTINTERFACE >= clientInterfaceName.Length, "cchCltIntName can specify at most 128 unicode characters. See Tds spec");
 
             // add up variable-len portions (multiply by 2 for byte len of char strings)
-            //
             checked
             {
                 length += (rec.hostName.Length + rec.applicationName.Length +


### PR DESCRIPTION
Appends additional information to the client interface name in the `TdsLogin` method that is sent to the server.

The Client inferface name format with this change includes:
"Microsoft SqlClient - {OS Name} {OS Version}, {Framework Description} - {Architecture}"

e.g. on Windows , "Microsoft SqlClient - Windows 10.0.26100.0, .NET 8.0.11 - X64"