### PR TITLE
Fix down-level SSL/TLS version warnings

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -765,18 +765,18 @@ namespace Microsoft.Data.SqlClient
             }*/
 #pragma warning disable CA5397 // Do not use deprecated SslProtocols values
 #pragma warning disable CA5398 // Avoid hardcoded SslProtocols values
-            if ((protocol & SslProtocols.Tls12) == SslProtocols.Tls12)
+            if ((protocol & SslProtocols.Tls12) != SslProtocols.None)
             {
                 name = "TLS 1.2";
             }
 #if NET8_0_OR_GREATER
 #pragma warning disable SYSLIB0039 // Type or member is obsolete: TLS 1.0 & 1.1 are deprecated
 #endif
-            else if ((protocol & SslProtocols.Tls11) == SslProtocols.Tls11)
+            else if ((protocol & SslProtocols.Tls11) != SslProtocols.None)
             {
                 name = "TLS 1.1";
             }
-            else if ((protocol & SslProtocols.Tls) == SslProtocols.Tls)
+            else if ((protocol & SslProtocols.Tls) != SslProtocols.None)
             {
                 name = "TLS 1.0";
             }
@@ -784,11 +784,11 @@ namespace Microsoft.Data.SqlClient
 #pragma warning restore SYSLIB0039 // Type or member is obsolete: SSL and TLS 1.0 & 1.1 is deprecated
 #endif
 #pragma warning disable CS0618 // Type or member is obsolete: SSL is deprecated
-            else if ((protocol & SslProtocols.Ssl3) == SslProtocols.Ssl3)
+            else if ((protocol & SslProtocols.Ssl3) != SslProtocols.None)
             {
                 name = "SSL 3.0";
             }
-            else if ((protocol & SslProtocols.Ssl2) == SslProtocols.Ssl2)
+            else if ((protocol & SslProtocols.Ssl2) != SslProtocols.None)
 #pragma warning restore CS0618 // Type or member is obsolete: SSL and TLS 1.0 & 1.1 is deprecated
             {
                 name = "SSL 2.0";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionTestParameters.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionTestParameters.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Authentication;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.SqlServer.TDS.PreLogin;
@@ -26,8 +27,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
         public string HostNameInCertificate => _hnic;
         public bool TestResult => _result;
         public TDSPreLoginTokenEncryptionType TdsEncryptionType => _encryptionType;
+        public SslProtocols EncryptionProtocols { get; }
 
         public ConnectionTestParameters(TDSPreLoginTokenEncryptionType tdsEncryptionType, SqlConnectionEncryptOption encryptOption, bool trustServerCert, string cert, string hnic, bool result)
+            : this(tdsEncryptionType, encryptOption, trustServerCert, cert, hnic, SslProtocols.Tls12, result)
+        { }
+
+        public ConnectionTestParameters(TDSPreLoginTokenEncryptionType tdsEncryptionType, SqlConnectionEncryptOption encryptOption, bool trustServerCert, string cert, string hnic, SslProtocols sslProtocols, bool result)
         {
             _encryptionOption = encryptOption;
             _trustServerCert = trustServerCert;
@@ -35,6 +41,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
             _hnic = hnic;
             _result = result;
             _encryptionType = tdsEncryptionType;
+            EncryptionProtocols = sslProtocols;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionTestParametersData.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionTestParametersData.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
                 new(TDSPreLoginTokenEncryptionType.On, SqlConnectionEncryptOption.Mandatory, false, s_fullPathToCer, _empty, SslProtocols.Tls | SslProtocols.Tls11, true),
                 new(TDSPreLoginTokenEncryptionType.Required, SqlConnectionEncryptOption.Mandatory, false, s_fullPathToCer, _empty, SslProtocols.Tls | SslProtocols.Tls11, true),
 #if NET
-#pragma warning disable SYSLIB0039 // Type or member is obsolete: TLS 1.0 & 1.1 are deprecated
+#pragma warning restore SYSLIB0039 // Type or member is obsolete: TLS 1.0 & 1.1 are deprecated
 #endif
 #pragma warning restore CA5397 // Do not use deprecated SslProtocols values
 #pragma warning restore CA5398 // Avoid hardcoded SslProtocols values

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionTestParametersData.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionTestParametersData.cs
@@ -4,13 +4,13 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Authentication;
 using Microsoft.SqlServer.TDS.PreLogin;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
 {
     public class ConnectionTestParametersData
     {
-        private const int CASES = 30;
         private string _empty = string.Empty;
         // It was advised to store the client certificate in its own folder.
         private static readonly string s_fullPathToCer = Path.Combine(Directory.GetCurrentDirectory(), "clientcert", "localhostcert.cer");
@@ -22,7 +22,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
 
         public static IEnumerable<object[]> GetConnectionTestParameters()
         {
-            for (int i = 0; i < CASES; i++)
+            for (int i = 0; i < Data.ConnectionTestParametersList.Count; i++)
             {
                 yield return new object[] { Data.ConnectionTestParametersList[i] };
             }
@@ -33,11 +33,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
             // Test cases possible field values for connection parameters:
             // These combinations are based on the possible values of Encrypt, TrustServerCertificate, Certificate, HostNameInCertificate
             /*
-             * TDSEncryption | Encrypt    | TrustServerCertificate | Certificate  | HNIC         | TestResults
-             * ----------------------------------------------------------------------------------------------
-             *   Off         | Optional   |  true                  | valid        | valid name   | true
-             *   On          | Mandatory  |  false                 | mismatched   | empty        | false
-             *   Required    |            |    x                   | ChainError?  | wrong name?  | 
+             * TDSEncryption | Encrypt    | TrustServerCertificate | Certificate  | HNIC         | SSL Protocols    | TestResults
+             * ---------------------------------------------------------------------------------------------------------------
+             *   Off         | Optional   |  true                  | valid        | valid name   | TLS 1.2          | true
+             *   On          | Mandatory  |  false                 | mismatched   | empty        | TLS 1.0, TLS 1.1 | false
+             *   Required    |            |    x                   | ChainError?  | wrong name?  |                  |
              */
             ConnectionTestParametersList = new List<ConnectionTestParameters>
             {
@@ -79,6 +79,21 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
                 new(TDSPreLoginTokenEncryptionType.On, SqlConnectionEncryptOption.Mandatory, true, s_mismatchedcert, _empty, true),
                 new(TDSPreLoginTokenEncryptionType.Required, SqlConnectionEncryptOption.Mandatory, false, s_mismatchedcert, _empty, false),
                 new(TDSPreLoginTokenEncryptionType.Required, SqlConnectionEncryptOption.Mandatory, true, s_mismatchedcert, _empty, true),
+
+                // Multiple SSL protocols test
+#pragma warning disable CA5397 // Do not use deprecated SslProtocols values
+#pragma warning disable CA5398 // Avoid hardcoded SslProtocols values
+#if NET
+#pragma warning disable SYSLIB0039 // Type or member is obsolete: TLS 1.0 & 1.1 are deprecated
+#endif
+                new(TDSPreLoginTokenEncryptionType.Off, SqlConnectionEncryptOption.Mandatory, false, s_fullPathToCer, _empty, SslProtocols.Tls | SslProtocols.Tls11, true),
+                new(TDSPreLoginTokenEncryptionType.On, SqlConnectionEncryptOption.Mandatory, false, s_fullPathToCer, _empty, SslProtocols.Tls | SslProtocols.Tls11, true),
+                new(TDSPreLoginTokenEncryptionType.Required, SqlConnectionEncryptOption.Mandatory, false, s_fullPathToCer, _empty, SslProtocols.Tls | SslProtocols.Tls11, true),
+#if NET
+#pragma warning disable SYSLIB0039 // Type or member is obsolete: TLS 1.0 & 1.1 are deprecated
+#endif
+#pragma warning restore CA5397 // Do not use deprecated SslProtocols values
+#pragma warning restore CA5398 // Avoid hardcoded SslProtocols values
             };
         }
     }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionTestWithSSLCert/CertificateTestWithTdsServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionTestWithSSLCert/CertificateTestWithTdsServer.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 #else
                 new X509Certificate2(s_fullPathToPfx, "nopassword", X509KeyStorageFlags.UserKeySet),
 #endif
+                encryptionProtocols: connectionTestParameters.EncryptionProtocols,
                 encryptionType: connectionTestParameters.TdsEncryptionType);
 
             builder = new(server.ConnectionString)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/TestTdsServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/TestTdsServer.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.SqlServer.TDS.EndPoint;
 using Microsoft.SqlServer.TDS.PreLogin;
@@ -31,7 +32,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static TestTdsServer StartServerWithQueryEngine(QueryEngine engine, bool enableFedAuth = false, bool enableLog = false,
             int connectionTimeout = DefaultConnectionTimeout, [CallerMemberName] string methodName = "",
-            X509Certificate2 encryptionCertificate = null, TDSPreLoginTokenEncryptionType encryptionType = TDSPreLoginTokenEncryptionType.NotSupported)
+            X509Certificate2 encryptionCertificate = null, SslProtocols encryptionProtocols = SslProtocols.Tls12, TDSPreLoginTokenEncryptionType encryptionType = TDSPreLoginTokenEncryptionType.NotSupported)
         {
             TDSServerArguments args = new TDSServerArguments()
             {
@@ -44,6 +45,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
 
             args.EncryptionCertificate = encryptionCertificate;
+            args.EncryptionProtocols = encryptionProtocols;
             args.Encryption = encryptionType;
 
             TestTdsServer server = engine == null ? new TestTdsServer(args) : new TestTdsServer(engine, args);
@@ -79,9 +81,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static TestTdsServer StartTestServer(bool enableFedAuth = false, bool enableLog = false,
             int connectionTimeout = DefaultConnectionTimeout, [CallerMemberName] string methodName = "",
-            X509Certificate2 encryptionCertificate = null, TDSPreLoginTokenEncryptionType encryptionType = TDSPreLoginTokenEncryptionType.NotSupported)
+            X509Certificate2 encryptionCertificate = null, SslProtocols encryptionProtocols = SslProtocols.Tls12, TDSPreLoginTokenEncryptionType encryptionType = TDSPreLoginTokenEncryptionType.NotSupported)
         {
-            return StartServerWithQueryEngine(null, enableFedAuth, enableLog, connectionTimeout, methodName, encryptionCertificate, encryptionType);
+            return StartServerWithQueryEngine(null, enableFedAuth, enableLog, connectionTimeout, methodName, encryptionCertificate, encryptionProtocols, encryptionType);
         }
 
         public void Dispose() => _endpoint?.Stop();

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.EndPoint/ITDSServerSession.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.EndPoint/ITDSServerSession.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.SqlServer.TDS.EndPoint.SSPI;
 
@@ -67,6 +68,11 @@ namespace Microsoft.SqlServer.TDS.EndPoint
         /// Certificate to use for encryption
         /// </summary>
         X509Certificate EncryptionCertificate { get; }
+
+        /// <summary>
+        /// SSL/TLS protocols to use for transport encryption
+        /// </summary>
+        SslProtocols EncryptionProtocols { get; }
 
         /// <summary>
         /// Counter of connection reset requests for this session

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.EndPoint/TDSParser.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.EndPoint/TDSParser.cs
@@ -26,11 +26,6 @@ namespace Microsoft.SqlServer.TDS.EndPoint
         public TextWriter EventLog { get; set; }
 
         /// <summary>
-        /// Encryption protocol for server to use with AuthenticateAsServer
-        /// </summary>
-        public static SslProtocols ServerSslProtocol { get; set; }
-
-        /// <summary>
         /// Protocol stream between the client and the server
         /// </summary>
         protected TDSStream Transport { get; set; }
@@ -43,8 +38,6 @@ namespace Microsoft.SqlServer.TDS.EndPoint
             // Save original transport
             _originalTransport = transport;
 
-            ServerSslProtocol = SslProtocols.Tls12;
-
             // Wrap transport layer with TDS
             Transport = new TDSStream(transport, false);
         }
@@ -55,14 +48,6 @@ namespace Microsoft.SqlServer.TDS.EndPoint
         public void SetTDSStreamPreWriteCallback(Func<byte[], int, int, ushort> funcTDSStreamPreWriteCallBack)
         {
             Transport.PreWriteCallBack = funcTDSStreamPreWriteCallBack;
-        }
-
-        /// <summary>
-        /// Resets the targeted encryption protocol for the server.
-        /// </summary>
-        public static void ResetTargetProtocol()
-        {
-            ServerSslProtocol = SslProtocols.Tls12;
         }
 
         /// <summary>
@@ -105,7 +90,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint
         /// <summary>
         /// Enable transport encryption
         /// </summary>
-        protected void EnableServerTransportEncryption(X509Certificate certificate)
+        protected void EnableServerTransportEncryption(X509Certificate certificate, SslProtocols encryptionProtocols)
         {
             // Check if transport encryption is applied
             if (Transport.InnerStream is SslStream)
@@ -134,7 +119,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint
             SslStream ssl = new SslStream(multiplexer, true);
 
             // Secure the channel
-            ssl.AuthenticateAsServer(certificate, false, ServerSslProtocol, false);
+            ssl.AuthenticateAsServer(certificate, false, encryptionProtocols, false);
 
             // Replace TDS stream with raw transport stream in multiplexer
             multiplexer.InnerStream = Transport.InnerStream;

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.EndPoint/TDSServerParser.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.EndPoint/TDSServerParser.cs
@@ -146,7 +146,7 @@ namespace Microsoft.SqlServer.TDS.EndPoint
                     if (Session.Encryption == TDSEncryptionType.LoginOnly || Session.Encryption == TDSEncryptionType.Full)
                     {
                         // Enable server side encryption
-                        EnableServerTransportEncryption(Session.EncryptionCertificate);
+                        EnableServerTransportEncryption(Session.EncryptionCertificate, Session.EncryptionProtocols);
                     }
                 }
 

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTDSServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTDSServer.cs
@@ -85,8 +85,9 @@ namespace Microsoft.SqlServer.TDS.Servers
             // Create a new session
             GenericTDSServerSession session = new GenericTDSServerSession(this, (uint)_sessionCount);
 
-            // Use configured encryption certificate
+            // Use configured encryption certificate and protocols
             session.EncryptionCertificate = Arguments.EncryptionCertificate;
+            session.EncryptionProtocols = Arguments.EncryptionProtocols;
 
             return session;
         }

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTDSServerSession.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTDSServerSession.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.SqlServer.TDS.EndPoint;
 using Microsoft.SqlServer.TDS.EndPoint.SSPI;
@@ -77,6 +78,11 @@ namespace Microsoft.SqlServer.TDS.Servers
         /// Certificate to use for encryption
         /// </summary>
         public X509Certificate EncryptionCertificate { get; set; }
+
+        /// <summary>
+        /// SSL/TLS protocols to use for transport encryption
+        /// </summary>
+        public SslProtocols EncryptionProtocols { get; set; }
 
         /// <summary>
         /// Nonce option sent by client

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TDSServerArguments.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TDSServerArguments.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.SqlServer.TDS.PreLogin;
 
@@ -70,6 +71,11 @@ namespace Microsoft.SqlServer.TDS.Servers
         public X509Certificate EncryptionCertificate { get; set; }
 
         /// <summary>
+        /// SSL/TLS protocols to use for transport encryption
+        /// </summary>
+        public SslProtocols EncryptionProtocols { get; set; }
+
+        /// <summary>
         /// Initialization constructor
         /// </summary>
         public TDSServerArguments()
@@ -88,6 +94,7 @@ namespace Microsoft.SqlServer.TDS.Servers
             FedAuthRequiredPreLoginOption = TdsPreLoginFedAuthRequiredOption.FedAuthNotRequired;
 
             EncryptionCertificate = null;
+            EncryptionProtocols = SslProtocols.Tls12;
 
             ServerPrincipalName = AzureADServicePrincipalName;
             StsUrl = AzureADProductionTokenEndpoint;


### PR DESCRIPTION
Contributes to #3120. I'll backport this to 6.0 if this is merged.

To verify this, I've expanded our test TDS server, adding support for using a named SSL protocol. It adds to the data for `CertificateTestWithTdsServer.BeginWindowsConnectionTest` and `BeginLinuxConnectionTest`, including an end-to-end connection test to a TDS server which only supports TLS 1.0 & 1.1.