### PR TITLE
Disable failing TLS 1.0/1.1 tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionTestParametersData.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionTestParametersData.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
 {
     public class ConnectionTestParametersData
     {
-        private const int CASES = 30;
         private string _empty = string.Empty;
         // It was advised to store the client certificate in its own folder.
         private static readonly string s_fullPathToCer = Path.Combine(Directory.GetCurrentDirectory(), "clientcert", "localhostcert.cer");
@@ -22,7 +21,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
 
         public static IEnumerable<object[]> GetConnectionTestParameters()
         {
-            for (int i = 0; i < CASES; i++)
+            for (int i = 0; i < Data.ConnectionTestParametersList.Count; i++)
             {
                 yield return new object[] { Data.ConnectionTestParametersList[i] };
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionTestParametersData.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ConnectionTestParametersData.cs
@@ -4,13 +4,13 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Authentication;
 using Microsoft.SqlServer.TDS.PreLogin;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
 {
     public class ConnectionTestParametersData
     {
+        private const int CASES = 30;
         private string _empty = string.Empty;
         // It was advised to store the client certificate in its own folder.
         private static readonly string s_fullPathToCer = Path.Combine(Directory.GetCurrentDirectory(), "clientcert", "localhostcert.cer");
@@ -22,7 +22,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
 
         public static IEnumerable<object[]> GetConnectionTestParameters()
         {
-            for (int i = 0; i < Data.ConnectionTestParametersList.Count; i++)
+            for (int i = 0; i < CASES; i++)
             {
                 yield return new object[] { Data.ConnectionTestParametersList[i] };
             }
@@ -33,11 +33,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
             // Test cases possible field values for connection parameters:
             // These combinations are based on the possible values of Encrypt, TrustServerCertificate, Certificate, HostNameInCertificate
             /*
-             * TDSEncryption | Encrypt    | TrustServerCertificate | Certificate  | HNIC         | SSL Protocols    | TestResults
-             * ---------------------------------------------------------------------------------------------------------------
-             *   Off         | Optional   |  true                  | valid        | valid name   | TLS 1.2          | true
-             *   On          | Mandatory  |  false                 | mismatched   | empty        | TLS 1.0, TLS 1.1 | false
-             *   Required    |            |    x                   | ChainError?  | wrong name?  |                  |
+             * TDSEncryption | Encrypt    | TrustServerCertificate | Certificate  | HNIC         | TestResults
+             * ----------------------------------------------------------------------------------------------
+             *   Off         | Optional   |  true                  | valid        | valid name   | true
+             *   On          | Mandatory  |  false                 | mismatched   | empty        | false
+             *   Required    |            |    x                   | ChainError?  | wrong name?  | 
              */
             ConnectionTestParametersList = new List<ConnectionTestParameters>
             {
@@ -79,21 +79,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.DataCommon
                 new(TDSPreLoginTokenEncryptionType.On, SqlConnectionEncryptOption.Mandatory, true, s_mismatchedcert, _empty, true),
                 new(TDSPreLoginTokenEncryptionType.Required, SqlConnectionEncryptOption.Mandatory, false, s_mismatchedcert, _empty, false),
                 new(TDSPreLoginTokenEncryptionType.Required, SqlConnectionEncryptOption.Mandatory, true, s_mismatchedcert, _empty, true),
-
-                // Multiple SSL protocols test
-#pragma warning disable CA5397 // Do not use deprecated SslProtocols values
-#pragma warning disable CA5398 // Avoid hardcoded SslProtocols values
-#if NET
-#pragma warning disable SYSLIB0039 // Type or member is obsolete: TLS 1.0 & 1.1 are deprecated
-#endif
-                new(TDSPreLoginTokenEncryptionType.Off, SqlConnectionEncryptOption.Mandatory, false, s_fullPathToCer, _empty, SslProtocols.Tls | SslProtocols.Tls11, true),
-                new(TDSPreLoginTokenEncryptionType.On, SqlConnectionEncryptOption.Mandatory, false, s_fullPathToCer, _empty, SslProtocols.Tls | SslProtocols.Tls11, true),
-                new(TDSPreLoginTokenEncryptionType.Required, SqlConnectionEncryptOption.Mandatory, false, s_fullPathToCer, _empty, SslProtocols.Tls | SslProtocols.Tls11, true),
-#if NET
-#pragma warning restore SYSLIB0039 // Type or member is obsolete: TLS 1.0 & 1.1 are deprecated
-#endif
-#pragma warning restore CA5397 // Do not use deprecated SslProtocols values
-#pragma warning restore CA5398 // Avoid hardcoded SslProtocols values
             };
         }
     }


### PR DESCRIPTION
Rolls up change from original connection test matrix #3127. Corrects #3126, removing its associated test.
CI is currently failing on main branch - it no longer supports TLS 1.0/1.1, so the tests which require TLS 1.2 are failing. This PR removes them.

Does not require porting to release/6.0.

cc @benrr101 