### PR TITLE
Address CodeQL warnings

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Data.SqlClient
                     RequireExpirationTime = true,
                     ValidateLifetime = true,
                     ValidateIssuer = true,
-                    ValidateAudience = false,
+                    ValidateAudience = true,
                     RequireSignedTokens = true,
                     ValidIssuers = GenerateListOfIssuers(tokenIssuerUrl),
                     IssuerSigningKeys = issuerSigningKeys

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(certificate.HasPrivateKey, "Attempting to encrypt with cert without privatekey");
 
             RSA rsa = certificate.GetRSAPublicKey();
-            return rsa.Encrypt(plainText, RSAEncryptionPadding.OaepSHA1);
+            return rsa.Encrypt(plainText, RSAEncryptionPadding.OaepSHA256);
         }
 
         /// <summary>
@@ -490,7 +490,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(certificate.HasPrivateKey, "Attempting to decrypt with cert without privatekey");
 
             RSA rsa = certificate.GetRSAPrivateKey();
-            return rsa.Decrypt(cipherText, RSAEncryptionPadding.OaepSHA1);
+            return rsa.Decrypt(cipherText, RSAEncryptionPadding.OaepSHA256);
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(columnEncryptionKey != null);
             Debug.Assert(rsaCngProvider != null);
 
-            return rsaCngProvider.Encrypt(columnEncryptionKey, RSAEncryptionPadding.OaepSHA1);
+            return rsaCngProvider.Encrypt(columnEncryptionKey, RSAEncryptionPadding.OaepSHA256);
         }
 
         /// <summary>
@@ -287,7 +287,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert((encryptedColumnEncryptionKey != null) && (encryptedColumnEncryptionKey.Length != 0));
             Debug.Assert(rsaCngProvider != null);
 
-            return rsaCngProvider.Decrypt(encryptedColumnEncryptionKey, RSAEncryptionPadding.OaepSHA1);
+            return rsaCngProvider.Decrypt(encryptedColumnEncryptionKey, RSAEncryptionPadding.OaepSHA256);
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlExceptionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlExceptionTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.SqlClient.Tests
 
             var settings = new JsonSerializerSettings()
             {
-                TypeNameHandling = TypeNameHandling.All,
+                TypeNameHandling = TypeNameHandling.None,
             };
 
             // TODO: Deserialization fails on Unix with "Member 'ClassName' was not found."
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient.Tests
 #if NETFRAMEWORK
         [Fact]
         [ActiveIssue("12161", TestPlatforms.AnyUnix)]
-        public static void SqlExcpetionSerializationTest()
+        public static void SqlExceptionSerializationTest()
         {
             var formatter = new BinaryFormatter();
             SqlException e = CreateException();
@@ -83,7 +83,7 @@ namespace Microsoft.Data.SqlClient.Tests
 
             var settings = new JsonSerializerSettings()
             {
-                TypeNameHandling = TypeNameHandling.All,
+                TypeNameHandling = TypeNameHandling.None,
             };
 
             var sqlEx = JsonConvert.DeserializeObject<SqlException>(json, settings);


### PR DESCRIPTION
This is a draft PR to solicit feedback on the proposed changes to fix CodeQL warnings.
I am concerned with changing `RSAEncryptionPadding.OaepSHA1` to `RSAEncryptionPadding.OaepSHA256`. Is the required encryption padding to use specified anywhere? Is there other code that depends on the current behavior?