### PR TITLE
Cleanup | SNI Native Wrapper

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Windows.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Data.SqlClient
             }
             else
             {
-                SniNativeWrapper.SNIGetLastError(out SniError sniError);
+                SniNativeWrapper.SniGetLastError(out SniError sniError);
                 details.sniErrorNumber = sniError.sniError;
                 details.errorMessage = sniError.errorMessage;
                 details.nativeError = sniError.nativeError;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Data.SqlClient
 
         internal abstract void ReleasePacket(PacketHandle syncReadPacket);
 
-        protected abstract uint SNIPacketGetData(PacketHandle packet, byte[] _inBuff, ref uint dataSize);
+        protected abstract uint SniPacketGetData(PacketHandle packet, byte[] _inBuff, ref uint dataSize);
 
         internal abstract PacketHandle GetResetWritePacket(int dataSize);
 
@@ -401,7 +401,7 @@ namespace Microsoft.Data.SqlClient
 
         private uint GetSniPacket(PacketHandle packet, ref uint dataSize)
         {
-            return SNIPacketGetData(packet, _inBuff, ref dataSize);
+            return SniPacketGetData(packet, _inBuff, ref dataSize);
         }
 
         private void ChangeNetworkPacketTimeout(int dueTime, int period)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Data.SqlClient.SNI
         /// <param name="inBuff">Destination byte array where data packets are copied to</param>
         /// <param name="dataSize">Length of data packets</param>
         /// <returns>SNI error status</returns>
-        protected override uint SNIPacketGetData(PacketHandle packet, byte[] inBuff, ref uint dataSize)
+        protected override uint SniPacketGetData(PacketHandle packet, byte[] inBuff, ref uint dataSize)
         {
             int dataSizeInt = 0;
             packet.ManagedPacket.GetData(inBuff, ref dataSizeInt);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Data.SqlClient
                 result = SniNativeWrapper.SniGetConnectionPort(Handle, ref portFromSNI);
                 Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionPort");
 
-                result = SniNativeWrapper.SniGetConnectionIPString(Handle, ref IPStringFromSNI);
+                result = SniNativeWrapper.SniGetConnectionIpString(Handle, ref IPStringFromSNI);
                 Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionIPString");
 
                 pendingDNSInfo = new SQLDNSInfo(DNSCacheKey, null, null, portFromSNI.ToString());

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Data.SqlClient
             spns = new[] { serverSPN.TrimEnd() };
         }
 
-        protected override uint SNIPacketGetData(PacketHandle packet, byte[] _inBuff, ref uint dataSize)
+        protected override uint SniPacketGetData(PacketHandle packet, byte[] _inBuff, ref uint dataSize)
         {
             Debug.Assert(packet.Type == PacketHandle.NativePointerType, "unexpected packet type when requiring NativePointer");
             return SniNativeWrapper.SniPacketGetData(packet.NativePointer, _inBuff, ref dataSize);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Data.SqlClient
         protected override uint SNIPacketGetData(PacketHandle packet, byte[] _inBuff, ref uint dataSize)
         {
             Debug.Assert(packet.Type == PacketHandle.NativePointerType, "unexpected packet type when requiring NativePointer");
-            return SniNativeWrapper.SNIPacketGetData(packet.NativePointer, _inBuff, ref dataSize);
+            return SniNativeWrapper.SniPacketGetData(packet.NativePointer, _inBuff, ref dataSize);
         }
 
         protected override bool CheckPacket(PacketHandle packet, TaskCompletionSource<object> source)
@@ -264,7 +264,7 @@ namespace Microsoft.Data.SqlClient
                 throw ADP.ClosedConnectionError();
             }
             IntPtr readPacketPtr = IntPtr.Zero;
-            error = SniNativeWrapper.SNIReadSyncOverAsync(handle, ref readPacketPtr, GetTimeoutRemaining());
+            error = SniNativeWrapper.SniReadSyncOverAsync(handle, ref readPacketPtr, GetTimeoutRemaining());
             return PacketHandle.FromNativePointer(readPacketPtr);
         }
 
@@ -281,20 +281,20 @@ namespace Microsoft.Data.SqlClient
         internal override void ReleasePacket(PacketHandle syncReadPacket)
         {
             Debug.Assert(syncReadPacket.Type == PacketHandle.NativePointerType, "unexpected packet type when requiring NativePointer");
-            SniNativeWrapper.SNIPacketRelease(syncReadPacket.NativePointer);
+            SniNativeWrapper.SniPacketRelease(syncReadPacket.NativePointer);
         }
 
         internal override uint CheckConnection()
         {
             SNIHandle handle = Handle;
-            return handle == null ? TdsEnums.SNI_SUCCESS : SniNativeWrapper.SNICheckConnection(handle);
+            return handle == null ? TdsEnums.SNI_SUCCESS : SniNativeWrapper.SniCheckConnection(handle);
         }
 
         internal override PacketHandle ReadAsync(SessionHandle handle, out uint error)
         {
             Debug.Assert(handle.Type == SessionHandle.NativeHandleType, "unexpected handle type when requiring NativePointer");
             IntPtr readPacketPtr = IntPtr.Zero;
-            error = SniNativeWrapper.SNIReadAsync(handle.NativeHandle, ref readPacketPtr);
+            error = SniNativeWrapper.SniReadAsync(handle.NativeHandle, ref readPacketPtr);
             return PacketHandle.FromNativePointer(readPacketPtr);
         }
 
@@ -310,7 +310,7 @@ namespace Microsoft.Data.SqlClient
         internal override uint WritePacket(PacketHandle packet, bool sync)
         {
             Debug.Assert(packet.Type == PacketHandle.NativePacketType, "unexpected packet type when requiring NativePacket");
-            return SniNativeWrapper.SNIWritePacket(Handle, packet.NativePacket, sync);
+            return SniNativeWrapper.SniWritePacket(Handle, packet.NativePacket, sync);
         }
 
         internal override PacketHandle AddPacketToPendingList(PacketHandle packetToAdd)
@@ -343,7 +343,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (_sniPacket != null)
             {
-                SniNativeWrapper.SNIPacketReset(Handle, IoType.WRITE, _sniPacket, ConsumerNumber.SNI_Consumer_SNI);
+                SniNativeWrapper.SniPacketReset(Handle, IoType.WRITE, _sniPacket, ConsumerNumber.SNI_Consumer_SNI);
             }
             else
             {
@@ -372,17 +372,17 @@ namespace Microsoft.Data.SqlClient
         internal override void SetPacketData(PacketHandle packet, byte[] buffer, int bytesUsed)
         {
             Debug.Assert(packet.Type == PacketHandle.NativePacketType, "unexpected packet type when requiring NativePacket");
-            SniNativeWrapper.SNIPacketSetData(packet.NativePacket, buffer, bytesUsed);
+            SniNativeWrapper.SniPacketSetData(packet.NativePacket, buffer, bytesUsed);
         }
 
         internal override uint SniGetConnectionId(ref Guid clientConnectionId)
             => SniNativeWrapper.SniGetConnectionId(Handle, ref clientConnectionId);
 
         internal override uint DisableSsl()
-            => SniNativeWrapper.SNIRemoveProvider(Handle, Provider.SSL_PROV);
+            => SniNativeWrapper.SniRemoveProvider(Handle, Provider.SSL_PROV);
 
         internal override uint EnableMars(ref uint info)
-            => SniNativeWrapper.SNIAddProvider(Handle, Provider.SMUX_PROV, ref info);
+            => SniNativeWrapper.SniAddProvider(Handle, Provider.SMUX_PROV, ref info);
 
         internal override uint EnableSsl(ref uint info, bool tlsFirst, string serverCertificateFilename)
         {
@@ -392,15 +392,15 @@ namespace Microsoft.Data.SqlClient
             authInfo.serverCertFileName = serverCertificateFilename;
 
             // Add SSL (Encryption) SNI provider.
-            return SniNativeWrapper.SNIAddProvider(Handle, Provider.SSL_PROV, ref authInfo);
+            return SniNativeWrapper.SniAddProvider(Handle, Provider.SSL_PROV, ref authInfo);
         }
 
         internal override uint SetConnectionBufferSize(ref uint unsignedPacketSize)
-            => SniNativeWrapper.SNISetInfo(Handle, QueryType.SNI_QUERY_CONN_BUFSIZE, ref unsignedPacketSize);
+            => SniNativeWrapper.SniSetInfo(Handle, QueryType.SNI_QUERY_CONN_BUFSIZE, ref unsignedPacketSize);
 
         internal override uint WaitForSSLHandShakeToComplete(out int protocolVersion)
         {
-            uint returnValue = SniNativeWrapper.SNIWaitForSSLHandshakeToComplete(Handle, GetTimeoutRemaining(), out uint nativeProtocolVersion);
+            uint returnValue = SniNativeWrapper.SniWaitForSslHandshakeToComplete(Handle, GetTimeoutRemaining(), out uint nativeProtocolVersion);
             var nativeProtocol = (NativeProtocols)nativeProtocolVersion;
 
 #pragma warning disable CA5398 // Avoid hardcoded SslProtocols values
@@ -469,7 +469,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     // Success - reset the packet
                     packet = _packets.Pop();
-                    SniNativeWrapper.SNIPacketReset(sniHandle, IoType.WRITE, packet, ConsumerNumber.SNI_Consumer_SNI);
+                    SniNativeWrapper.SniPacketReset(sniHandle, IoType.WRITE, packet, ConsumerNumber.SNI_Consumer_SNI);
                 }
                 else
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -699,7 +699,7 @@ namespace Microsoft.Data.SqlClient
             uint error = 0;
 
             // Remove SSL (Encryption) SNI provider since we only wanted to encrypt login.
-            error = SniNativeWrapper.SNIRemoveProvider(_physicalStateObj.Handle, Provider.SSL_PROV);
+            error = SniNativeWrapper.SniRemoveProvider(_physicalStateObj.Handle, Provider.SSL_PROV);
             if (error != TdsEnums.SNI_SUCCESS)
             {
                 _physicalStateObj.AddError(ProcessSNIError(_physicalStateObj));
@@ -726,7 +726,7 @@ namespace Microsoft.Data.SqlClient
                 uint info = 0;
 
                 // Add SMUX (MARS) SNI provider.
-                error = SniNativeWrapper.SNIAddProvider(_pMarsPhysicalConObj.Handle, Provider.SMUX_PROV, ref info);
+                error = SniNativeWrapper.SniAddProvider(_pMarsPhysicalConObj.Handle, Provider.SMUX_PROV, ref info);
 
                 if (error != TdsEnums.SNI_SUCCESS)
                 {
@@ -747,12 +747,12 @@ namespace Microsoft.Data.SqlClient
                 {
                     _pMarsPhysicalConObj.IncrementPendingCallbacks();
 
-                    error = SniNativeWrapper.SNIReadAsync(_pMarsPhysicalConObj.Handle, ref temp);
+                    error = SniNativeWrapper.SniReadAsync(_pMarsPhysicalConObj.Handle, ref temp);
 
                     if (temp != IntPtr.Zero)
                     {
                         // Be sure to release packet, otherwise it will be leaked by native.
-                        SniNativeWrapper.SNIPacketRelease(temp);
+                        SniNativeWrapper.SniPacketRelease(temp);
                     }
                 }
                 Debug.Assert(IntPtr.Zero == temp, "unexpected syncReadPacket without corresponding SNIPacketRelease");
@@ -1025,7 +1025,7 @@ namespace Microsoft.Data.SqlClient
 
             Debug.Assert((_encryptionOption & EncryptionOptions.CLIENT_CERT) == 0, "Client certificate authentication support has been removed");
 
-            error = SniNativeWrapper.SNIAddProvider(_physicalStateObj.Handle, Provider.SSL_PROV, authInfo);
+            error = SniNativeWrapper.SniAddProvider(_physicalStateObj.Handle, Provider.SSL_PROV, authInfo);
 
             if (error != TdsEnums.SNI_SUCCESS)
             {
@@ -1037,7 +1037,7 @@ namespace Microsoft.Data.SqlClient
             // wait for SSL handshake to complete, so that the SSL context is fully negotiated before we try to use its
             // Channel Bindings as part of the Windows Authentication context build (SSL handshake must complete
             // before calling SNISecGenClientContext).
-            error = SniNativeWrapper.SNIWaitForSSLHandshakeToComplete(_physicalStateObj.Handle, _physicalStateObj.GetTimeoutRemaining(), out uint protocolVersion);
+            error = SniNativeWrapper.SniWaitForSslHandshakeToComplete(_physicalStateObj.Handle, _physicalStateObj.GetTimeoutRemaining(), out uint protocolVersion);
 
             if (error != TdsEnums.SNI_SUCCESS)
             {
@@ -1591,7 +1591,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(SniContext.Undefined != stateObj.DebugOnlyCopyOfSniContext || ((_fMARS) && ((_state == TdsParserState.Closed) || (_state == TdsParserState.Broken))), "SniContext must not be None");
 #endif
             SniError sniError = new SniError();
-            SniNativeWrapper.SNIGetLastError(out sniError);
+            SniNativeWrapper.SniGetLastError(out sniError);
 
             if (sniError.sniError != 0)
             {
@@ -2906,7 +2906,7 @@ namespace Microsoft.Data.SqlClient
 
                             // Update SNI ConsumerInfo value to be resulting packet size
                             uint unsignedPacketSize = (uint)packetSize;
-                            uint bufferSizeResult = SniNativeWrapper.SNISetInfo(_physicalStateObj.Handle, QueryType.SNI_QUERY_CONN_BUFSIZE, ref unsignedPacketSize);
+                            uint bufferSizeResult = SniNativeWrapper.SniSetInfo(_physicalStateObj.Handle, QueryType.SNI_QUERY_CONN_BUFSIZE, ref unsignedPacketSize);
 
                             Debug.Assert(bufferSizeResult == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SNISetInfo");
                         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.netfx.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Data.SqlClient
                 Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionPort");
 
 
-                result = SniNativeWrapper.SniGetConnectionIPString(_physicalStateObj.Handle, ref IPStringFromSNI);
+                result = SniNativeWrapper.SniGetConnectionIpString(_physicalStateObj.Handle, ref IPStringFromSNI);
                 Debug.Assert(result == TdsEnums.SNI_SUCCESS, "Unexpected failure state upon calling SniGetConnectionIPString");
 
                 _connHandler.pendingSQLDNSObject = new SQLDNSInfo(DNSCacheKey, null, null, portFromSNI.ToString());

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
@@ -270,20 +270,20 @@ namespace Microsoft.Data.SqlClient
         {
             SNIHandle handle = Handle ?? throw ADP.ClosedConnectionError();
             PacketHandle readPacket = default;
-            error = SniNativeWrapper.SNIReadSyncOverAsync(handle, ref readPacket, timeoutRemaining);
+            error = SniNativeWrapper.SniReadSyncOverAsync(handle, ref readPacket, timeoutRemaining);
             return readPacket;
         }
 
         internal PacketHandle ReadAsync(SessionHandle handle, out uint error)
         {
             PacketHandle readPacket = default;
-            error = SniNativeWrapper.SNIReadAsync(handle.NativeHandle, ref readPacket);
+            error = SniNativeWrapper.SniReadAsync(handle.NativeHandle, ref readPacket);
             return readPacket;
         }
 
-        internal uint CheckConnection() => SniNativeWrapper.SNICheckConnection(Handle);
+        internal uint CheckConnection() => SniNativeWrapper.SniCheckConnection(Handle);
 
-        internal void ReleasePacket(PacketHandle syncReadPacket) => SniNativeWrapper.SNIPacketRelease(syncReadPacket);
+        internal void ReleasePacket(PacketHandle syncReadPacket) => SniNativeWrapper.SniPacketRelease(syncReadPacket);
         
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         internal int DecrementPendingCallbacks(bool release)
@@ -401,7 +401,7 @@ namespace Microsoft.Data.SqlClient
                 SNIHandle handle = Handle;
                 if (handle != null)
                 {
-                    error = SniNativeWrapper.SNICheckConnection(handle);
+                    error = SniNativeWrapper.SniCheckConnection(handle);
                 }
             }
             finally
@@ -518,7 +518,7 @@ namespace Microsoft.Data.SqlClient
 
         private uint GetSniPacket(PacketHandle packet, ref uint dataSize)
         {
-            return SniNativeWrapper.SNIPacketGetData(packet, _inBuff, ref dataSize);
+            return SniNativeWrapper.SniPacketGetData(packet, _inBuff, ref dataSize);
         }
 
         private void ChangeNetworkPacketTimeout(int dueTime, int period)
@@ -1007,7 +1007,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                sniError = SniNativeWrapper.SNIWritePacket(handle, packet, sync);
+                sniError = SniNativeWrapper.SniWritePacket(handle, packet, sync);
             }
 
             if (sniError == TdsEnums.SNI_SUCCESS_IO_PENDING)
@@ -1119,7 +1119,7 @@ namespace Microsoft.Data.SqlClient
                 SNIPacket attnPacket = new SNIPacket(Handle);
                 _sniAsyncAttnPacket = attnPacket;
 
-                SniNativeWrapper.SNIPacketSetData(attnPacket, SQL.AttentionHeader, TdsEnums.HEADER_LEN, null, null);
+                SniNativeWrapper.SniPacketSetData(attnPacket, SQL.AttentionHeader, TdsEnums.HEADER_LEN, null, null);
 
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
@@ -1183,7 +1183,7 @@ namespace Microsoft.Data.SqlClient
         {
             // Prepare packet, and write to packet.
             SNIPacket packet = GetResetWritePacket();
-            SniNativeWrapper.SNIPacketSetData(packet, _outBuff, _outBytesUsed, _securePasswords, _securePasswordOffsetsInBuffer);
+            SniNativeWrapper.SniPacketSetData(packet, _outBuff, _outBytesUsed, _securePasswords, _securePasswordOffsetsInBuffer);
 
             Debug.Assert(Parser.Connection._parserLock.ThreadMayHaveLock(), "Thread is writing without taking the connection lock");
             Task task = SNIWritePacket(Handle, packet, out _, canAccumulate, callerHasConnectionLock: true);
@@ -1238,7 +1238,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (_sniPacket != null)
             {
-                SniNativeWrapper.SNIPacketReset(Handle, IoType.WRITE, _sniPacket, ConsumerNumber.SNI_Consumer_SNI);
+                SniNativeWrapper.SniPacketReset(Handle, IoType.WRITE, _sniPacket, ConsumerNumber.SNI_Consumer_SNI);
             }
             else
             {

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -53,13 +53,13 @@ namespace Microsoft.Data.SqlClient
 
         #region Public Methods
         
-        internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref AuthProviderInfo pInfo) =>
+        internal static uint SniAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref AuthProviderInfo pInfo) =>
             s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
         
         #if NETFRAMEWORK
         [ResourceExposure(ResourceScope.None)]
         [ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)]
-        internal static uint SNIAddProvider(SNIHandle pConn,
+        internal static uint SniAddProvider(SNIHandle pConn,
             Provider providerEnum,
             AuthProviderInfo authInfo)
         {
@@ -68,7 +68,7 @@ namespace Microsoft.Data.SqlClient
 
             Debug.Assert(authInfo.clientCertificateCallback == null, "CTAIP support has been removed");
 
-            ret = SNIAddProvider(pConn, providerEnum, ref authInfo);
+            ret = SniAddProvider(pConn, providerEnum, ref authInfo);
 
             if (ret == ERROR_SUCCESS)
             {
@@ -81,13 +81,13 @@ namespace Microsoft.Data.SqlClient
         }
         #endif
         
-        internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref uint pInfo) =>
+        internal static uint SniAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref uint pInfo) =>
             s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
         
-        internal static uint SNICheckConnection([In] SNIHandle pConn) =>
+        internal static uint SniCheckConnection([In] SNIHandle pConn) =>
             s_nativeMethods.SniCheckConnection(pConn);
         
-        internal static uint SNIClose(IntPtr pConn) =>
+        internal static uint SniClose(IntPtr pConn) =>
             s_nativeMethods.SniClose(pConn);
         
         internal static uint SniGetConnectionId(SNIHandle pConn, ref Guid connId) =>
@@ -113,7 +113,7 @@ namespace Microsoft.Data.SqlClient
             return s_nativeMethods.SniGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PEERPORT, out portNum);
         }
         
-        internal static void SNIGetLastError(out SniError pErrorStruct) =>
+        internal static void SniGetLastError(out SniError pErrorStruct) =>
             s_nativeMethods.SniGetLastError(out pErrorStruct);
         
         internal static uint SniGetProviderNumber(SNIHandle pConn, ref Provider provNum)
@@ -121,13 +121,13 @@ namespace Microsoft.Data.SqlClient
             return s_nativeMethods.SniGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PROVIDERNUM, out provNum);
         }
 
-        internal static uint SNIInitialize() =>
+        internal static uint SniInitialize() =>
             s_nativeMethods.SniInitialize(IntPtr.Zero);
         
-        internal static uint UnmanagedIsTokenRestricted([In] IntPtr token, [MarshalAs(UnmanagedType.Bool)] out bool isRestricted) =>
+        internal static uint SniIsTokenRestricted([In] IntPtr token, [MarshalAs(UnmanagedType.Bool)] out bool isRestricted) =>
             s_nativeMethods.SniIsTokenRestricted(token, out isRestricted);
         
-        internal static unsafe uint SNIOpenMarsSession(ConsumerInfo consumerInfo, SNIHandle parent, ref IntPtr pConn, bool fSync, SqlConnectionIPAddressPreference ipPreference, SQLDNSInfo cachedDNSInfo)
+        internal static unsafe uint SniOpenMarsSession(ConsumerInfo consumerInfo, SNIHandle parent, ref IntPtr pConn, bool fSync, SqlConnectionIPAddressPreference ipPreference, SQLDNSInfo cachedDNSInfo)
         {
             // initialize consumer info for MARS
             SniConsumerInfo native_consumerInfo = new SniConsumerInfo();
@@ -142,7 +142,7 @@ namespace Microsoft.Data.SqlClient
             return s_nativeMethods.SniOpenWrapper(ref native_consumerInfo, "session:", parent, out pConn, fSync, ipPreference, ref native_cachedDNSInfo);
         }
 
-        internal static unsafe uint SNIOpenSyncEx(
+        internal static unsafe uint SniOpenSyncEx(
             ConsumerInfo consumerInfo,
             string constring,
             ref IntPtr pConn,
@@ -268,23 +268,23 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal static void SNIPacketAllocate(SafeHandle pConn, IoType IOType, ref IntPtr pPacket) =>
+        internal static void SniPacketAllocate(SafeHandle pConn, IoType IOType, ref IntPtr pPacket) =>
             pPacket = s_nativeMethods.SniPacketAllocateWrapper(pConn, IOType);
         
-        internal static unsafe uint SNIPacketGetData(IntPtr packet, byte[] readBuffer, ref uint dataSize) =>
+        internal static unsafe uint SniPacketGetData(IntPtr packet, byte[] readBuffer, ref uint dataSize) =>
             s_nativeMethods.SniPacketGetDataWrapper(packet, readBuffer, (uint)readBuffer.Length, out dataSize);
         
-        internal static void SNIPacketRelease(IntPtr pPacket) =>
+        internal static void SniPacketRelease(IntPtr pPacket) =>
             s_nativeMethods.SniPacketRelease(pPacket);
         
-        internal static unsafe void SNIPacketSetData(SNIPacket packet, byte[] data, int length)
+        internal static unsafe void SniPacketSetData(SNIPacket packet, byte[] data, int length)
         {
             fixed (byte* pin_data = &data[0])
             {
                 s_nativeMethods.SniPacketSetData(packet, pin_data, (uint)length);
             }
         }
-
+        
         #if NETFRAMEWORK
         //[ResourceExposure(ResourceScope::None)]
         //
@@ -297,7 +297,7 @@ namespace Microsoft.Data.SqlClient
         //    to loose encryption algorithm is changed it should be done in both in this method as well as TdsParserStaticMethods.EncryptPassword.
         //  Up to current release, it is also guaranteed that both password and new change password will fit into a single login packet whose size is fixed to 4096
         //        So, there is no splitting logic is needed.
-        internal static void SNIPacketSetData(SNIPacket packet,
+        internal static void SniPacketSetData(SNIPacket packet,
                                       Byte[] data,
                                       Int32 length,
                                       SecureString[] passwords,            // pointer to the passwords which need to be written out to SNI Packet
@@ -385,7 +385,7 @@ namespace Microsoft.Data.SqlClient
                     packet.DangerousAddRef(ref mustRelease);
                     Debug.Assert(mustRelease, "AddRef Failed!");
 
-                    SNIPacketSetData(packet, data, length);
+                    SniPacketSetData(packet, data, length);
                 }
             }
             finally
@@ -408,22 +408,25 @@ namespace Microsoft.Data.SqlClient
         }
         #endif
         
-        internal static void SNIPacketReset([In] SNIHandle pConn, IoType IOType, SNIPacket pPacket, ConsumerNumber ConsNum) =>
+        internal static void SniPacketReset([In] SNIHandle pConn, IoType IOType, SNIPacket pPacket, ConsumerNumber ConsNum) =>
             s_nativeMethods.SniPacketReset(pConn, IOType, pPacket, ConsNum);
         
-        internal static uint SNIQueryInfo(QueryType QType, ref uint pbQInfo) =>
+        internal static uint SniQueryInfo(QueryType QType, ref uint pbQInfo) =>
             s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
         
-        internal static uint SNIQueryInfo(QueryType QType, ref IntPtr pbQInfo) =>
+        internal static uint SniQueryInfo(QueryType QType, ref IntPtr pbQInfo) =>
             s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
         
-        internal static uint SNIReadAsync(SNIHandle pConn, ref IntPtr ppNewPacket) =>
+        internal static uint SniReadAsync(SNIHandle pConn, ref IntPtr ppNewPacket) =>
             s_nativeMethods.SniReadAsync(pConn, ref ppNewPacket);
         
-        internal static uint SNIReadSyncOverAsync(SNIHandle pConn, ref IntPtr ppNewPacket, int timeout) =>
+        internal static uint SniReadSyncOverAsync(SNIHandle pConn, ref IntPtr ppNewPacket, int timeout) =>
             s_nativeMethods.SniReadSyncOverAsync(pConn, ref ppNewPacket, timeout);
         
-        internal static unsafe uint SNISecGenClientContext(
+        internal static uint SniRemoveProvider(SNIHandle pConn, Provider ProvNum) =>
+            s_nativeMethods.SniRemoveProvider(pConn, ProvNum);
+        
+        internal static unsafe uint SniSecGenClientContext(
             SNIHandle pConnectionObject,
             ReadOnlySpan<byte> inBuff,
             Span<byte> outBuff,
@@ -459,32 +462,32 @@ namespace Microsoft.Data.SqlClient
             }
         }
         
-        internal static uint SNISecInitPackage(ref uint pcbMaxToken) =>
+        internal static uint SniSecInitPackage(ref uint pcbMaxToken) =>
             s_nativeMethods.SniSecInitPackage(ref pcbMaxToken);
         
-        internal static void SNIServerEnumClose([In] IntPtr packet) =>
+        internal static void SniServerEnumClose([In] IntPtr packet) =>
             s_nativeMethods.SniServerEnumClose(packet);
         
-        internal static IntPtr SNIServerEnumOpen() =>
+        internal static IntPtr SniServerEnumOpen() =>
             s_nativeMethods.SniServerEnumOpen();
         
-        internal static int SNIServerEnumRead(
+        internal static int SniServerEnumRead(
             [In] IntPtr packet,
             [In] [MarshalAs(UnmanagedType.LPArray)] char[] readBuffer,
             [In] int bufferLength,
             [MarshalAs(UnmanagedType.Bool)] out bool more) =>
             s_nativeMethods.SniServerEnumRead(packet, readBuffer, bufferLength, out more);
         
-        internal static uint SNISetInfo(SNIHandle pConn, QueryType QType, [In] ref uint pbQInfo) =>
+        internal static uint SniSetInfo(SNIHandle pConn, QueryType QType, [In] ref uint pbQInfo) =>
             s_nativeMethods.SniSetInfo(pConn, QType, ref pbQInfo);
         
-        internal static uint SNITerminate() =>
+        internal static uint SniTerminate() =>
             s_nativeMethods.SniTerminate();
         
-        internal static uint SNIWaitForSSLHandshakeToComplete([In] SNIHandle pConn, int dwMilliseconds, out uint pProtocolVersion) =>
+        internal static uint SniWaitForSslHandshakeToComplete([In] SNIHandle pConn, int dwMilliseconds, out uint pProtocolVersion) =>
             s_nativeMethods.SniWaitForSslHandshakeToComplete(pConn, dwMilliseconds, out pProtocolVersion);
         
-        internal static uint SNIWritePacket(SNIHandle pConn, SNIPacket packet, bool sync)
+        internal static uint SniWritePacket(SNIHandle pConn, SNIPacket packet, bool sync)
         {
             if (sync)
             {
@@ -564,7 +567,7 @@ namespace Microsoft.Data
         internal static bool IsTokenRestrictedWrapper(IntPtr token)
         {
             bool isRestricted;
-            uint result = SniNativeWrapper.UnmanagedIsTokenRestricted(token, out isRestricted);
+            uint result = SniNativeWrapper.SniIsTokenRestricted(token, out isRestricted);
 
             if (result != 0)
             {

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -18,24 +18,27 @@ namespace Microsoft.Data.SqlClient
 {
     internal static class SniNativeWrapper
     {
-#if NETFRAMEWORK
-        private static readonly ISniNativeMethods NativeMethods = RuntimeInformation.ProcessArchitecture switch
+        #region Member Variables
+        
+        private const int SniIpv6AddrStringBufferLength = 48;
+        private const int SniOpenTimeOut = -1;
+        
+        #if NETFRAMEWORK
+        private static readonly ISniNativeMethods s_nativeMethods = RuntimeInformation.ProcessArchitecture switch
         {
             Architecture.Arm64 => new SniNativeMethodsArm64(),
             Architecture.X64 => new SniNativeMethodsX64(),
             Architecture.X86 => new SniNativeMethodsX86(),
             _ => new SniNativeMethodsNotSupported(RuntimeInformation.ProcessArchitecture)
         };
-#else
-        private static readonly ISniNativeMethods NativeMethods = new SniNativeMethods();
-#endif
-
+        #else
+        private static readonly SniNativeMethods s_nativeMethods = new SniNativeMethods();
+        #endif
+        
         private static int s_sniMaxComposedSpnLength = -1;
-
-        private const int SniOpenTimeOut = -1; // infinite
-
-        internal const int SniIP6AddrStringBufferLength = 48; // from SNI layer
-
+        
+        #endregion
+        
         internal static int SniMaxComposedSpnLength
         {
             get
@@ -48,7 +51,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-#if NETFRAMEWORK
+        #if NETFRAMEWORK
         static AppDomain GetDefaultAppDomainInternal()
         {
             return AppDomain.CurrentDomain;
@@ -86,86 +89,86 @@ namespace Microsoft.Data.SqlClient
                 SqlDependencyProcessDispatcherStorage.NativeSetData(pin_dispatcher, data.Length);
             }
         }
-#endif
+        #endif
 
         #region DLL Imports
 
         internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref uint pInfo) =>
-            NativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
+            s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
 
         internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref AuthProviderInfo pInfo) =>
-            NativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
+            s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
 
         internal static uint SNICheckConnection([In] SNIHandle pConn) =>
-            NativeMethods.SniCheckConnection(pConn);
+            s_nativeMethods.SniCheckConnection(pConn);
 
         internal static uint SNIClose(IntPtr pConn) =>
-            NativeMethods.SniClose(pConn);
+            s_nativeMethods.SniClose(pConn);
 
         internal static void SNIGetLastError(out SniError pErrorStruct) =>
-            NativeMethods.SniGetLastError(out pErrorStruct);
+            s_nativeMethods.SniGetLastError(out pErrorStruct);
 
         internal static void SNIPacketRelease(IntPtr pPacket) =>
-            NativeMethods.SniPacketRelease(pPacket);
+            s_nativeMethods.SniPacketRelease(pPacket);
 
         internal static void SNIPacketReset([In] SNIHandle pConn, IoType IOType, SNIPacket pPacket, ConsumerNumber ConsNum) =>
-            NativeMethods.SniPacketReset(pConn, IOType, pPacket, ConsNum);
+            s_nativeMethods.SniPacketReset(pConn, IOType, pPacket, ConsNum);
 
         internal static uint SNIQueryInfo(QueryType QType, ref uint pbQInfo) =>
-            NativeMethods.SniQueryInfo(QType, ref pbQInfo);
+            s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
 
         internal static uint SNIQueryInfo(QueryType QType, ref IntPtr pbQInfo) =>
-            NativeMethods.SniQueryInfo(QType, ref pbQInfo);
+            s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
 
         internal static uint SNIReadAsync(SNIHandle pConn, ref IntPtr ppNewPacket) =>
-            NativeMethods.SniReadAsync(pConn, ref ppNewPacket);
+            s_nativeMethods.SniReadAsync(pConn, ref ppNewPacket);
 
         internal static uint SNIReadSyncOverAsync(SNIHandle pConn, ref IntPtr ppNewPacket, int timeout) =>
-            NativeMethods.SniReadSyncOverAsync(pConn, ref ppNewPacket, timeout);
+            s_nativeMethods.SniReadSyncOverAsync(pConn, ref ppNewPacket, timeout);
 
         internal static uint SNIRemoveProvider(SNIHandle pConn, Provider ProvNum) =>
-            NativeMethods.SniRemoveProvider(pConn, ProvNum);
+            s_nativeMethods.SniRemoveProvider(pConn, ProvNum);
 
         internal static uint SNISecInitPackage(ref uint pcbMaxToken) =>
-            NativeMethods.SniSecInitPackage(ref pcbMaxToken);
+            s_nativeMethods.SniSecInitPackage(ref pcbMaxToken);
 
         internal static uint SNISetInfo(SNIHandle pConn, QueryType QType, [In] ref uint pbQInfo) =>
-            NativeMethods.SniSetInfo(pConn, QType, ref pbQInfo);
+            s_nativeMethods.SniSetInfo(pConn, QType, ref pbQInfo);
 
         internal static uint SNITerminate() =>
-            NativeMethods.SniTerminate();
+            s_nativeMethods.SniTerminate();
 
         internal static uint SNIWaitForSSLHandshakeToComplete([In] SNIHandle pConn, int dwMilliseconds, out uint pProtocolVersion) =>
-            NativeMethods.SniWaitForSslHandshakeToComplete(pConn, dwMilliseconds, out pProtocolVersion);
+            s_nativeMethods.SniWaitForSslHandshakeToComplete(pConn, dwMilliseconds, out pProtocolVersion);
 
         internal static uint UnmanagedIsTokenRestricted([In] IntPtr token, [MarshalAs(UnmanagedType.Bool)] out bool isRestricted) =>
-            NativeMethods.SniIsTokenRestricted(token, out isRestricted);
+            s_nativeMethods.SniIsTokenRestricted(token, out isRestricted);
 
         private static uint GetSniMaxComposedSpnLength() =>
-            NativeMethods.SniGetMaxComposedSpnLength();
+            s_nativeMethods.SniGetMaxComposedSpnLength();
 
         private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out Guid pbQInfo) =>
-            NativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
 
-#if NETFRAMEWORK
+        #if NETFRAMEWORK
         private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, [MarshalAs(UnmanagedType.Bool)] out bool pbQInfo) =>
-            NativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
-#endif
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
+        #endif
 
         private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out ushort portNum) =>
-            NativeMethods.SniGetInfoWrapper(pConn, QType, out portNum);
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out portNum);
 
         private static uint SNIGetPeerAddrStrWrapper([In] SNIHandle pConn, int bufferSize, StringBuilder addrBuffer, out uint addrLen) =>
-            NativeMethods.SniGetPeerAddrStrWrapper(pConn, bufferSize, addrBuffer, out addrLen);
+            s_nativeMethods.SniGetPeerAddrStrWrapper(pConn, bufferSize, addrBuffer, out addrLen);
 
         private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out Provider provNum) =>
-            NativeMethods.SniGetInfoWrapper(pConn, QType, out provNum);
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out provNum);
 
         private static uint SNIInitialize([In] IntPtr pmo) =>
-            NativeMethods.SniInitialize(pmo);
+            s_nativeMethods.SniInitialize(pmo);
 
         private static uint SNIOpenSyncExWrapper(ref SniClientConsumerInfo pClientConsumerInfo, out IntPtr ppConn) =>
-            NativeMethods.SniOpenSyncExWrapper(ref pClientConsumerInfo, out ppConn);
+            s_nativeMethods.SniOpenSyncExWrapper(ref pClientConsumerInfo, out ppConn);
 
         private static uint SNIOpenWrapper(
             [In] ref SniConsumerInfo pConsumerInfo,
@@ -175,7 +178,7 @@ namespace Microsoft.Data.SqlClient
             [MarshalAs(UnmanagedType.Bool)] bool fSync,
             SqlConnectionIPAddressPreference ipPreference,
             [In] ref SniDnsCacheInfo pDNSCachedInfo) =>
-            NativeMethods.SniOpenWrapper(
+            s_nativeMethods.SniOpenWrapper(
                 ref pConsumerInfo,
                 szConnect,
                 pConn,
@@ -185,14 +188,14 @@ namespace Microsoft.Data.SqlClient
                 ref pDNSCachedInfo);
 
         private static IntPtr SNIPacketAllocateWrapper([In] SafeHandle pConn, IoType IOType) =>
-            NativeMethods.SniPacketAllocateWrapper(pConn, IOType);
+            s_nativeMethods.SniPacketAllocateWrapper(pConn, IOType);
 
         private static uint SNIPacketGetDataWrapper([In] IntPtr packet, [In, Out] byte[] readBuffer, uint readBufferLength, out uint dataSize) =>
-            NativeMethods.SniPacketGetDataWrapper(packet, readBuffer, readBufferLength, out dataSize);
+            s_nativeMethods.SniPacketGetDataWrapper(packet, readBuffer, readBufferLength, out dataSize);
 
         private static unsafe void SNIPacketSetData(SNIPacket pPacket, [In] byte* pbBuf, uint cbBuf) =>
-            NativeMethods.SniPacketSetData(pPacket, pbBuf, cbBuf);
-
+            s_nativeMethods.SniPacketSetData(pPacket, pbBuf, cbBuf);
+        
         private static unsafe uint SNISecGenClientContextWrapper(
             [In] SNIHandle pConn,
             [In, Out] ReadOnlySpan<byte> pIn,
@@ -210,7 +213,7 @@ namespace Microsoft.Data.SqlClient
             fixed (byte* pOutPtr = pOut)
             fixed (byte* pServerInfo = serverInfo)
             {
-                return NativeMethods.SniSecGenClientContextWrapper(
+                return s_nativeMethods.SniSecGenClientContextWrapper(
                     pConn,
                     pInPtr,
                     (uint)pIn.Length,
@@ -225,23 +228,23 @@ namespace Microsoft.Data.SqlClient
         }
 
         private static uint SNIWriteAsyncWrapper(SNIHandle pConn, [In] SNIPacket pPacket) =>
-            NativeMethods.SniWriteAsyncWrapper(pConn, pPacket);
+            s_nativeMethods.SniWriteAsyncWrapper(pConn, pPacket);
 
         private static uint SNIWriteSyncOverAsync(SNIHandle pConn, [In] SNIPacket pPacket) =>
-            NativeMethods.SniWriteSyncOverAsync(pConn, pPacket);
+            s_nativeMethods.SniWriteSyncOverAsync(pConn, pPacket);
 
         internal static IntPtr SNIServerEnumOpen() =>
-            NativeMethods.SniServerEnumOpen();
+            s_nativeMethods.SniServerEnumOpen();
 
         internal static void SNIServerEnumClose([In] IntPtr packet) =>
-            NativeMethods.SniServerEnumClose(packet);
+            s_nativeMethods.SniServerEnumClose(packet);
 
         internal static int SNIServerEnumRead(
             [In] IntPtr packet,
             [In][MarshalAs(UnmanagedType.LPArray)] char[] readBuffer,
             [In] int bufferLength,
             [MarshalAs(UnmanagedType.Bool)] out bool more) =>
-            NativeMethods.SniServerEnumRead(packet, readBuffer, bufferLength, out more);
+            s_nativeMethods.SniServerEnumRead(packet, readBuffer, bufferLength, out more);
 
         #endregion
 
@@ -265,7 +268,7 @@ namespace Microsoft.Data.SqlClient
             UInt32 ret;
             uint connIPLen = 0;
 
-            int bufferSize = SniIP6AddrStringBufferLength;
+            int bufferSize = SniIpv6AddrStringBufferLength;
             StringBuilder addrBuffer = new StringBuilder(bufferSize);
 
             ret = SNIGetPeerAddrStrWrapper(pConn, bufferSize, addrBuffer, out connIPLen);
@@ -305,12 +308,12 @@ namespace Microsoft.Data.SqlClient
             bool fSync,
             int timeout,
             bool fParallel,
-
-#if NETFRAMEWORK
+            
+            #if NETFRAMEWORK
             Int32 transparentNetworkResolutionStateNo,
             Int32 totalTimeout,
-#endif
-
+            #endif
+            
             SqlConnectionIPAddressPreference ipPreference,
             SQLDNSInfo cachedDNSInfo,
             string hostNameInCertificate)
@@ -332,7 +335,7 @@ namespace Microsoft.Data.SqlClient
                 clientConsumerInfo.timeout = timeout;
                 clientConsumerInfo.fParallel = fParallel;
 
-#if NETFRAMEWORK
+                #if NETFRAMEWORK
                 switch (transparentNetworkResolutionStateNo)
                 {
                     case (0):
@@ -346,10 +349,10 @@ namespace Microsoft.Data.SqlClient
                         break;
                 };
                 clientConsumerInfo.totalTimeout = totalTimeout;
-#else
+                #else
                 clientConsumerInfo.transparentNetworkResolution = TransparentNetworkResolutionMode.DisabledMode;
                 clientConsumerInfo.totalTimeout = SniOpenTimeOut;
-#endif
+                #endif
 
                 clientConsumerInfo.isAzureSqlServerEndpoint = ADP.IsAzureSqlServerEndpoint(constring);
 
@@ -422,7 +425,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-#if NETFRAMEWORK
+	    #if NETFRAMEWORK
         [ResourceExposure(ResourceScope.None)]
         [ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)]
         internal static uint SNIAddProvider(SNIHandle pConn,
@@ -445,7 +448,7 @@ namespace Microsoft.Data.SqlClient
 
             return ret;
         }
-#endif
+	    #endif
 
         internal static void SNIPacketAllocate(SafeHandle pConn, IoType IOType, ref IntPtr pPacket)
         {
@@ -465,7 +468,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-#if NETFRAMEWORK
+        #if NETFRAMEWORK
         //[ResourceExposure(ResourceScope::None)]
         //
         // Notes on SecureString: Writing out security sensitive information to managed buffer should be avoid as these can be moved
@@ -589,7 +592,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
         }
-#endif
+        #endif
 
         internal static unsafe uint SNISecGenClientContext(SNIHandle pConnectionObject, ReadOnlySpan<byte> inBuff, Span<byte> outBuff, ref uint sendLength, string serverUserName)
         {

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -5,14 +5,12 @@
 using System;
 using System.Buffers;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Interop.Windows.Sni;
 using Microsoft.Data.Common;
 
 #if NETFRAMEWORK
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Security;

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -51,218 +51,50 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        #if NETFRAMEWORK
-        static AppDomain GetDefaultAppDomainInternal()
-        {
-            return AppDomain.CurrentDomain;
-        }
-
-        internal static _AppDomain GetDefaultAppDomain()
-        {
-            return GetDefaultAppDomainInternal();
-        }
-
-        [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
-        [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        internal unsafe static byte[] GetData()
-        {
-            int size;
-            IntPtr ptr = (IntPtr)(SqlDependencyProcessDispatcherStorage.NativeGetData(out size));
-            byte[] result = null;
-
-            if (ptr != IntPtr.Zero)
-            {
-                result = new byte[size];
-                Marshal.Copy(ptr, result, 0, size);
-            }
-
-            return result;
-        }
-
-        [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
-        [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        internal unsafe static void SetData(Byte[] data)
-        {
-            //cli::pin_ptr<System::Byte> pin_dispatcher = &data[0];
-            fixed (byte* pin_dispatcher = &data[0])
-            {
-                SqlDependencyProcessDispatcherStorage.NativeSetData(pin_dispatcher, data.Length);
-            }
-        }
-        #endif
-
-        #region DLL Imports
-
-        internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref uint pInfo) =>
-            s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
-
+        #region Public Methods
+        
         internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref AuthProviderInfo pInfo) =>
             s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
+        
+        #if NETFRAMEWORK
+        [ResourceExposure(ResourceScope.None)]
+        [ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)]
+        internal static uint SNIAddProvider(SNIHandle pConn,
+            Provider providerEnum,
+            AuthProviderInfo authInfo)
+        {
+            UInt32 ret;
+            uint ERROR_SUCCESS = 0;
 
+            Debug.Assert(authInfo.clientCertificateCallback == null, "CTAIP support has been removed");
+
+            ret = SNIAddProvider(pConn, providerEnum, ref authInfo);
+
+            if (ret == ERROR_SUCCESS)
+            {
+                // added a provider, need to requery for sync over async support
+                ret = SNIGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_SUPPORTS_SYNC_OVER_ASYNC, out bool _);
+                Debug.Assert(ret == ERROR_SUCCESS, "SNIGetInfo cannot fail with this QType");
+            }
+
+            return ret;
+        }
+        #endif
+        
+        internal static uint SNIAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref uint pInfo) =>
+            s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
+        
         internal static uint SNICheckConnection([In] SNIHandle pConn) =>
             s_nativeMethods.SniCheckConnection(pConn);
-
+        
         internal static uint SNIClose(IntPtr pConn) =>
             s_nativeMethods.SniClose(pConn);
-
-        internal static void SNIGetLastError(out SniError pErrorStruct) =>
-            s_nativeMethods.SniGetLastError(out pErrorStruct);
-
-        internal static void SNIPacketRelease(IntPtr pPacket) =>
-            s_nativeMethods.SniPacketRelease(pPacket);
-
-        internal static void SNIPacketReset([In] SNIHandle pConn, IoType IOType, SNIPacket pPacket, ConsumerNumber ConsNum) =>
-            s_nativeMethods.SniPacketReset(pConn, IOType, pPacket, ConsNum);
-
-        internal static uint SNIQueryInfo(QueryType QType, ref uint pbQInfo) =>
-            s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
-
-        internal static uint SNIQueryInfo(QueryType QType, ref IntPtr pbQInfo) =>
-            s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
-
-        internal static uint SNIReadAsync(SNIHandle pConn, ref IntPtr ppNewPacket) =>
-            s_nativeMethods.SniReadAsync(pConn, ref ppNewPacket);
-
-        internal static uint SNIReadSyncOverAsync(SNIHandle pConn, ref IntPtr ppNewPacket, int timeout) =>
-            s_nativeMethods.SniReadSyncOverAsync(pConn, ref ppNewPacket, timeout);
-
-        internal static uint SNIRemoveProvider(SNIHandle pConn, Provider ProvNum) =>
-            s_nativeMethods.SniRemoveProvider(pConn, ProvNum);
-
-        internal static uint SNISecInitPackage(ref uint pcbMaxToken) =>
-            s_nativeMethods.SniSecInitPackage(ref pcbMaxToken);
-
-        internal static uint SNISetInfo(SNIHandle pConn, QueryType QType, [In] ref uint pbQInfo) =>
-            s_nativeMethods.SniSetInfo(pConn, QType, ref pbQInfo);
-
-        internal static uint SNITerminate() =>
-            s_nativeMethods.SniTerminate();
-
-        internal static uint SNIWaitForSSLHandshakeToComplete([In] SNIHandle pConn, int dwMilliseconds, out uint pProtocolVersion) =>
-            s_nativeMethods.SniWaitForSslHandshakeToComplete(pConn, dwMilliseconds, out pProtocolVersion);
-
-        internal static uint UnmanagedIsTokenRestricted([In] IntPtr token, [MarshalAs(UnmanagedType.Bool)] out bool isRestricted) =>
-            s_nativeMethods.SniIsTokenRestricted(token, out isRestricted);
-
-        private static uint GetSniMaxComposedSpnLength() =>
-            s_nativeMethods.SniGetMaxComposedSpnLength();
-
-        private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out Guid pbQInfo) =>
-            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
-
-        #if NETFRAMEWORK
-        private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, [MarshalAs(UnmanagedType.Bool)] out bool pbQInfo) =>
-            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
-        #endif
-
-        private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out ushort portNum) =>
-            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out portNum);
-
-        private static uint SNIGetPeerAddrStrWrapper([In] SNIHandle pConn, int bufferSize, StringBuilder addrBuffer, out uint addrLen) =>
-            s_nativeMethods.SniGetPeerAddrStrWrapper(pConn, bufferSize, addrBuffer, out addrLen);
-
-        private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out Provider provNum) =>
-            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out provNum);
-
-        private static uint SNIInitialize([In] IntPtr pmo) =>
-            s_nativeMethods.SniInitialize(pmo);
-
-        private static uint SNIOpenSyncExWrapper(ref SniClientConsumerInfo pClientConsumerInfo, out IntPtr ppConn) =>
-            s_nativeMethods.SniOpenSyncExWrapper(ref pClientConsumerInfo, out ppConn);
-
-        private static uint SNIOpenWrapper(
-            [In] ref SniConsumerInfo pConsumerInfo,
-            [MarshalAs(UnmanagedType.LPWStr)] string szConnect,
-            [In] SNIHandle pConn,
-            out IntPtr ppConn,
-            [MarshalAs(UnmanagedType.Bool)] bool fSync,
-            SqlConnectionIPAddressPreference ipPreference,
-            [In] ref SniDnsCacheInfo pDNSCachedInfo) =>
-            s_nativeMethods.SniOpenWrapper(
-                ref pConsumerInfo,
-                szConnect,
-                pConn,
-                out ppConn,
-                fSync,
-                ipPreference,
-                ref pDNSCachedInfo);
-
-        private static IntPtr SNIPacketAllocateWrapper([In] SafeHandle pConn, IoType IOType) =>
-            s_nativeMethods.SniPacketAllocateWrapper(pConn, IOType);
-
-        private static uint SNIPacketGetDataWrapper([In] IntPtr packet, [In, Out] byte[] readBuffer, uint readBufferLength, out uint dataSize) =>
-            s_nativeMethods.SniPacketGetDataWrapper(packet, readBuffer, readBufferLength, out dataSize);
-
-        private static unsafe void SNIPacketSetData(SNIPacket pPacket, [In] byte* pbBuf, uint cbBuf) =>
-            s_nativeMethods.SniPacketSetData(pPacket, pbBuf, cbBuf);
         
-        private static unsafe uint SNISecGenClientContextWrapper(
-            [In] SNIHandle pConn,
-            [In, Out] ReadOnlySpan<byte> pIn,
-            [In, Out] Span<byte> pOut,
-            [In] ref uint pcbOut,
-            [MarshalAsAttribute(UnmanagedType.Bool)]
-            out bool pfDone,
-            ReadOnlySpan<byte> serverInfo,
-            [MarshalAsAttribute(UnmanagedType.LPWStr)]
-            string pwszUserName,
-            [MarshalAsAttribute(UnmanagedType.LPWStr)]
-            string pwszPassword)
-        {
-            fixed (byte* pInPtr = pIn)
-            fixed (byte* pOutPtr = pOut)
-            fixed (byte* pServerInfo = serverInfo)
-            {
-                return s_nativeMethods.SniSecGenClientContextWrapper(
-                    pConn,
-                    pInPtr,
-                    (uint)pIn.Length,
-                    pOutPtr,
-                    ref pcbOut,
-                    out pfDone,
-                    pServerInfo,
-                    (uint)serverInfo.Length,
-                    pwszUserName,
-                    pwszPassword);
-            }
-        }
-
-        private static uint SNIWriteAsyncWrapper(SNIHandle pConn, [In] SNIPacket pPacket) =>
-            s_nativeMethods.SniWriteAsyncWrapper(pConn, pPacket);
-
-        private static uint SNIWriteSyncOverAsync(SNIHandle pConn, [In] SNIPacket pPacket) =>
-            s_nativeMethods.SniWriteSyncOverAsync(pConn, pPacket);
-
-        internal static IntPtr SNIServerEnumOpen() =>
-            s_nativeMethods.SniServerEnumOpen();
-
-        internal static void SNIServerEnumClose([In] IntPtr packet) =>
-            s_nativeMethods.SniServerEnumClose(packet);
-
-        internal static int SNIServerEnumRead(
-            [In] IntPtr packet,
-            [In][MarshalAs(UnmanagedType.LPArray)] char[] readBuffer,
-            [In] int bufferLength,
-            [MarshalAs(UnmanagedType.Bool)] out bool more) =>
-            s_nativeMethods.SniServerEnumRead(packet, readBuffer, bufferLength, out more);
-
-        #endregion
-
         internal static uint SniGetConnectionId(SNIHandle pConn, ref Guid connId)
         {
             return SNIGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_CONNID, out connId);
         }
-
-        internal static uint SniGetProviderNumber(SNIHandle pConn, ref Provider provNum)
-        {
-            return SNIGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PROVIDERNUM, out provNum);
-        }
-
-        internal static uint SniGetConnectionPort(SNIHandle pConn, ref ushort portNum)
-        {
-            return SNIGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PEERPORT, out portNum);
-        }
-
+        
         internal static uint SniGetConnectionIPString(SNIHandle pConn, ref string connIPStr)
         {
             UInt32 ret;
@@ -277,12 +109,28 @@ namespace Microsoft.Data.SqlClient
 
             return ret;
         }
-
+        
+        internal static uint SniGetConnectionPort(SNIHandle pConn, ref ushort portNum)
+        {
+            return SNIGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PEERPORT, out portNum);
+        }
+        
+        internal static void SNIGetLastError(out SniError pErrorStruct) =>
+            s_nativeMethods.SniGetLastError(out pErrorStruct);
+        
+        internal static uint SniGetProviderNumber(SNIHandle pConn, ref Provider provNum)
+        {
+            return SNIGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PROVIDERNUM, out provNum);
+        }
+        
         internal static uint SNIInitialize()
         {
             return SNIInitialize(IntPtr.Zero);
         }
-
+        
+        internal static uint UnmanagedIsTokenRestricted([In] IntPtr token, [MarshalAs(UnmanagedType.Bool)] out bool isRestricted) =>
+            s_nativeMethods.SniIsTokenRestricted(token, out isRestricted);
+        
         internal static unsafe uint SNIOpenMarsSession(ConsumerInfo consumerInfo, SNIHandle parent, ref IntPtr pConn, bool fSync, SqlConnectionIPAddressPreference ipPreference, SQLDNSInfo cachedDNSInfo)
         {
             // initialize consumer info for MARS
@@ -425,31 +273,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-	    #if NETFRAMEWORK
-        [ResourceExposure(ResourceScope.None)]
-        [ResourceConsumption(ResourceScope.Machine, ResourceScope.Machine)]
-        internal static uint SNIAddProvider(SNIHandle pConn,
-                                            Provider providerEnum,
-                                            AuthProviderInfo authInfo)
-        {
-            UInt32 ret;
-            uint ERROR_SUCCESS = 0;
-
-            Debug.Assert(authInfo.clientCertificateCallback == null, "CTAIP support has been removed");
-
-            ret = SNIAddProvider(pConn, providerEnum, ref authInfo);
-
-            if (ret == ERROR_SUCCESS)
-            {
-                // added a provider, need to requery for sync over async support
-                ret = SNIGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_SUPPORTS_SYNC_OVER_ASYNC, out bool _);
-                Debug.Assert(ret == ERROR_SUCCESS, "SNIGetInfo cannot fail with this QType");
-            }
-
-            return ret;
-        }
-	    #endif
-
         internal static void SNIPacketAllocate(SafeHandle pConn, IoType IOType, ref IntPtr pPacket)
         {
             pPacket = SNIPacketAllocateWrapper(pConn, IOType);
@@ -459,7 +282,10 @@ namespace Microsoft.Data.SqlClient
         {
             return SNIPacketGetDataWrapper(packet, readBuffer, (uint)readBuffer.Length, out dataSize);
         }
-
+        
+        internal static void SNIPacketRelease(IntPtr pPacket) =>
+            s_nativeMethods.SniPacketRelease(pPacket);
+        
         internal static unsafe void SNIPacketSetData(SNIPacket packet, byte[] data, int length)
         {
             fixed (byte* pin_data = &data[0])
@@ -593,7 +419,22 @@ namespace Microsoft.Data.SqlClient
             }
         }
         #endif
-
+        
+        internal static void SNIPacketReset([In] SNIHandle pConn, IoType IOType, SNIPacket pPacket, ConsumerNumber ConsNum) =>
+            s_nativeMethods.SniPacketReset(pConn, IOType, pPacket, ConsNum);
+        
+        internal static uint SNIQueryInfo(QueryType QType, ref uint pbQInfo) =>
+            s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
+        
+        internal static uint SNIQueryInfo(QueryType QType, ref IntPtr pbQInfo) =>
+            s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
+        
+        internal static uint SNIReadAsync(SNIHandle pConn, ref IntPtr ppNewPacket) =>
+            s_nativeMethods.SniReadAsync(pConn, ref ppNewPacket);
+        
+        internal static uint SNIReadSyncOverAsync(SNIHandle pConn, ref IntPtr ppNewPacket, int timeout) =>
+            s_nativeMethods.SniReadSyncOverAsync(pConn, ref ppNewPacket, timeout);
+        
         internal static unsafe uint SNISecGenClientContext(SNIHandle pConnectionObject, ReadOnlySpan<byte> inBuff, Span<byte> outBuff, ref uint sendLength, string serverUserName)
         {
             var serverWriter = SqlObjectPools.BufferWriter.Rent();
@@ -617,7 +458,32 @@ namespace Microsoft.Data.SqlClient
                 SqlObjectPools.BufferWriter.Return(serverWriter);
             }
         }
-
+        
+        internal static uint SNISecInitPackage(ref uint pcbMaxToken) =>
+            s_nativeMethods.SniSecInitPackage(ref pcbMaxToken);
+        
+        internal static void SNIServerEnumClose([In] IntPtr packet) =>
+            s_nativeMethods.SniServerEnumClose(packet);
+        
+        internal static IntPtr SNIServerEnumOpen() =>
+            s_nativeMethods.SniServerEnumOpen();
+        
+        internal static int SNIServerEnumRead(
+            [In] IntPtr packet,
+            [In] [MarshalAs(UnmanagedType.LPArray)] char[] readBuffer,
+            [In] int bufferLength,
+            [MarshalAs(UnmanagedType.Bool)] out bool more) =>
+            s_nativeMethods.SniServerEnumRead(packet, readBuffer, bufferLength, out more);
+        
+        internal static uint SNISetInfo(SNIHandle pConn, QueryType QType, [In] ref uint pbQInfo) =>
+            s_nativeMethods.SniSetInfo(pConn, QType, ref pbQInfo);
+        
+        internal static uint SNITerminate() =>
+            s_nativeMethods.SniTerminate();
+        
+        internal static uint SNIWaitForSSLHandshakeToComplete([In] SNIHandle pConn, int dwMilliseconds, out uint pProtocolVersion) =>
+            s_nativeMethods.SniWaitForSslHandshakeToComplete(pConn, dwMilliseconds, out pProtocolVersion);
+        
         internal static uint SNIWritePacket(SNIHandle pConn, SNIPacket packet, bool sync)
         {
             if (sync)
@@ -629,6 +495,143 @@ namespace Microsoft.Data.SqlClient
                 return SNIWriteAsyncWrapper(pConn, packet);
             }
         }
+        
+        #endregion
+        
+        
+        
+        #if NETFRAMEWORK
+        static AppDomain GetDefaultAppDomainInternal()
+        {
+            return AppDomain.CurrentDomain;
+        }
+
+        internal static _AppDomain GetDefaultAppDomain()
+        {
+            return GetDefaultAppDomainInternal();
+        }
+
+        [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
+        [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
+        internal unsafe static byte[] GetData()
+        {
+            int size;
+            IntPtr ptr = (IntPtr)(SqlDependencyProcessDispatcherStorage.NativeGetData(out size));
+            byte[] result = null;
+
+            if (ptr != IntPtr.Zero)
+            {
+                result = new byte[size];
+                Marshal.Copy(ptr, result, 0, size);
+            }
+
+            return result;
+        }
+
+        [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
+        [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
+        internal unsafe static void SetData(Byte[] data)
+        {
+            //cli::pin_ptr<System::Byte> pin_dispatcher = &data[0];
+            fixed (byte* pin_dispatcher = &data[0])
+            {
+                SqlDependencyProcessDispatcherStorage.NativeSetData(pin_dispatcher, data.Length);
+            }
+        }
+        #endif
+
+        #region DLL Imports
+
+        private static uint GetSniMaxComposedSpnLength() =>
+            s_nativeMethods.SniGetMaxComposedSpnLength();
+
+        private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out Guid pbQInfo) =>
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
+
+        #if NETFRAMEWORK
+        private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, [MarshalAs(UnmanagedType.Bool)] out bool pbQInfo) =>
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out pbQInfo);
+        #endif
+
+        private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out ushort portNum) =>
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out portNum);
+
+        private static uint SNIGetPeerAddrStrWrapper([In] SNIHandle pConn, int bufferSize, StringBuilder addrBuffer, out uint addrLen) =>
+            s_nativeMethods.SniGetPeerAddrStrWrapper(pConn, bufferSize, addrBuffer, out addrLen);
+
+        private static uint SNIGetInfoWrapper([In] SNIHandle pConn, QueryType QType, out Provider provNum) =>
+            s_nativeMethods.SniGetInfoWrapper(pConn, QType, out provNum);
+
+        private static uint SNIInitialize([In] IntPtr pmo) =>
+            s_nativeMethods.SniInitialize(pmo);
+
+        private static uint SNIOpenSyncExWrapper(ref SniClientConsumerInfo pClientConsumerInfo, out IntPtr ppConn) =>
+            s_nativeMethods.SniOpenSyncExWrapper(ref pClientConsumerInfo, out ppConn);
+
+        private static uint SNIOpenWrapper(
+            [In] ref SniConsumerInfo pConsumerInfo,
+            [MarshalAs(UnmanagedType.LPWStr)] string szConnect,
+            [In] SNIHandle pConn,
+            out IntPtr ppConn,
+            [MarshalAs(UnmanagedType.Bool)] bool fSync,
+            SqlConnectionIPAddressPreference ipPreference,
+            [In] ref SniDnsCacheInfo pDNSCachedInfo) =>
+            s_nativeMethods.SniOpenWrapper(
+                ref pConsumerInfo,
+                szConnect,
+                pConn,
+                out ppConn,
+                fSync,
+                ipPreference,
+                ref pDNSCachedInfo);
+
+        private static IntPtr SNIPacketAllocateWrapper([In] SafeHandle pConn, IoType IOType) =>
+            s_nativeMethods.SniPacketAllocateWrapper(pConn, IOType);
+
+        private static uint SNIPacketGetDataWrapper([In] IntPtr packet, [In, Out] byte[] readBuffer, uint readBufferLength, out uint dataSize) =>
+            s_nativeMethods.SniPacketGetDataWrapper(packet, readBuffer, readBufferLength, out dataSize);
+
+        private static unsafe void SNIPacketSetData(SNIPacket pPacket, [In] byte* pbBuf, uint cbBuf) =>
+            s_nativeMethods.SniPacketSetData(pPacket, pbBuf, cbBuf);
+        
+        private static unsafe uint SNISecGenClientContextWrapper(
+            [In] SNIHandle pConn,
+            [In, Out] ReadOnlySpan<byte> pIn,
+            [In, Out] Span<byte> pOut,
+            [In] ref uint pcbOut,
+            [MarshalAsAttribute(UnmanagedType.Bool)]
+            out bool pfDone,
+            ReadOnlySpan<byte> serverInfo,
+            [MarshalAsAttribute(UnmanagedType.LPWStr)]
+            string pwszUserName,
+            [MarshalAsAttribute(UnmanagedType.LPWStr)]
+            string pwszPassword)
+        {
+            fixed (byte* pInPtr = pIn)
+            fixed (byte* pOutPtr = pOut)
+            fixed (byte* pServerInfo = serverInfo)
+            {
+                return s_nativeMethods.SniSecGenClientContextWrapper(
+                    pConn,
+                    pInPtr,
+                    (uint)pIn.Length,
+                    pOutPtr,
+                    ref pcbOut,
+                    out pfDone,
+                    pServerInfo,
+                    (uint)serverInfo.Length,
+                    pwszUserName,
+                    pwszPassword);
+            }
+        }
+
+        private static uint SNIWriteAsyncWrapper(SNIHandle pConn, [In] SNIPacket pPacket) =>
+            s_nativeMethods.SniWriteAsyncWrapper(pConn, pPacket);
+
+        private static uint SNIWriteSyncOverAsync(SNIHandle pConn, [In] SNIPacket pPacket) =>
+            s_nativeMethods.SniWriteSyncOverAsync(pConn, pPacket);
+
+        #endregion
 
         private static void MarshalConsumerInfo(ConsumerInfo consumerInfo, ref SniConsumerInfo native_consumerInfo)
         {

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -522,33 +522,5 @@ namespace Microsoft.Data.SqlClient
         }
         
         #endregion
-        
-        #if NETFRAMEWORK
-        [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
-        [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        internal static unsafe byte[] GetData()
-        {
-            IntPtr ptr = (IntPtr)SqlDependencyProcessDispatcherStorage.NativeGetData(out int size);
-            byte[] result = null;
-
-            if (ptr != IntPtr.Zero)
-            {
-                result = new byte[size];
-                Marshal.Copy(ptr, result, 0, size);
-            }
-
-            return result;
-        }
-
-        [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
-        [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        internal static unsafe void SetData(byte[] data)
-        {
-            fixed (byte* pDispatcher = data)
-            {
-                SqlDependencyProcessDispatcherStorage.NativeSetData(pDispatcher, data.Length);
-            }
-        }
-        #endif
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -516,18 +516,7 @@ namespace Microsoft.Data.SqlClient
         
         #endregion
         
-        
         #if NETFRAMEWORK
-        static AppDomain GetDefaultAppDomainInternal()
-        {
-            return AppDomain.CurrentDomain;
-        }
-
-        internal static _AppDomain GetDefaultAppDomain()
-        {
-            return GetDefaultAppDomainInternal();
-        }
-
         [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
         internal static unsafe byte[] GetData()

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -7,12 +7,18 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Versioning;
-using System.Security;
 using System.Text;
 using Interop.Windows.Sni;
 using Microsoft.Data.Common;
 using Microsoft.Data.SqlClient;
+
+#if NETFRAMEWORK
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using System.Security;
+using Interop.Windows;
+#endif
 
 namespace Microsoft.Data.SqlClient
 {
@@ -21,7 +27,10 @@ namespace Microsoft.Data.SqlClient
         #region Member Variables
         
         private const int SniIpv6AddrStringBufferLength = 48;
+        
+        #if NET
         private const int SniOpenTimeOut = -1;
+        #endif
         
         #if NETFRAMEWORK
         private static readonly ISniNativeMethods s_nativeMethods = RuntimeInformation.ProcessArchitecture switch
@@ -53,8 +62,8 @@ namespace Microsoft.Data.SqlClient
 
         #region Public Methods
         
-        internal static uint SniAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref AuthProviderInfo pInfo) =>
-            s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
+        internal static uint SniAddProvider(SNIHandle pConn, Provider provNum, ref AuthProviderInfo pInfo) =>
+            s_nativeMethods.SniAddProvider(pConn, provNum, ref pInfo);
         
         #if NETFRAMEWORK
         [ResourceExposure(ResourceScope.None)]
@@ -63,28 +72,24 @@ namespace Microsoft.Data.SqlClient
             Provider providerEnum,
             AuthProviderInfo authInfo)
         {
-            UInt32 ret;
-            uint ERROR_SUCCESS = 0;
-
             Debug.Assert(authInfo.clientCertificateCallback == null, "CTAIP support has been removed");
 
-            ret = SniAddProvider(pConn, providerEnum, ref authInfo);
-
-            if (ret == ERROR_SUCCESS)
+            uint ret = SniAddProvider(pConn, providerEnum, ref authInfo);
+            if (ret == SystemErrors.ERROR_SUCCESS)
             {
                 // added a provider, need to requery for sync over async support
                 ret = s_nativeMethods.SniGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_SUPPORTS_SYNC_OVER_ASYNC, out bool _);
-                Debug.Assert(ret == ERROR_SUCCESS, "SNIGetInfo cannot fail with this QType");
+                Debug.Assert(ret == SystemErrors.ERROR_SUCCESS, "SNIGetInfo cannot fail with this QType");
             }
 
             return ret;
         }
         #endif
         
-        internal static uint SniAddProvider(SNIHandle pConn, Provider ProvNum, [In] ref uint pInfo) =>
-            s_nativeMethods.SniAddProvider(pConn, ProvNum, ref pInfo);
+        internal static uint SniAddProvider(SNIHandle pConn, Provider provNum, ref uint pInfo) =>
+            s_nativeMethods.SniAddProvider(pConn, provNum, ref pInfo);
         
-        internal static uint SniCheckConnection([In] SNIHandle pConn) =>
+        internal static uint SniCheckConnection(SNIHandle pConn) =>
             s_nativeMethods.SniCheckConnection(pConn);
         
         internal static uint SniClose(IntPtr pConn) =>
@@ -93,58 +98,69 @@ namespace Microsoft.Data.SqlClient
         internal static uint SniGetConnectionId(SNIHandle pConn, ref Guid connId) =>
             s_nativeMethods.SniGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_CONNID, out connId);
         
-        internal static uint SniGetConnectionIPString(SNIHandle pConn, ref string connIPStr)
+        internal static uint SniGetConnectionIpString(SNIHandle pConn, ref string connIpStr)
         {
-            UInt32 ret;
-            uint connIPLen = 0;
+            StringBuilder addrBuffer = new StringBuilder(SniIpv6AddrStringBufferLength);
 
-            int bufferSize = SniIpv6AddrStringBufferLength;
-            StringBuilder addrBuffer = new StringBuilder(bufferSize);
+            uint ret = s_nativeMethods.SniGetPeerAddrStrWrapper(
+                pConn,
+                SniIpv6AddrStringBufferLength,
+                addrBuffer,
+                out uint connIpLen);
 
-            ret = s_nativeMethods.SniGetPeerAddrStrWrapper(pConn, bufferSize, addrBuffer, out connIPLen);
-
-            connIPStr = addrBuffer.ToString(0, Convert.ToInt32(connIPLen));
+            connIpStr = addrBuffer.ToString(0, Convert.ToInt32(connIpLen));
 
             return ret;
         }
         
-        internal static uint SniGetConnectionPort(SNIHandle pConn, ref ushort portNum)
-        {
-            return s_nativeMethods.SniGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PEERPORT, out portNum);
-        }
+        internal static uint SniGetConnectionPort(SNIHandle pConn, ref ushort portNum) =>
+            s_nativeMethods.SniGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PEERPORT, out portNum);
         
         internal static void SniGetLastError(out SniError pErrorStruct) =>
             s_nativeMethods.SniGetLastError(out pErrorStruct);
         
-        internal static uint SniGetProviderNumber(SNIHandle pConn, ref Provider provNum)
-        {
-            return s_nativeMethods.SniGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PROVIDERNUM, out provNum);
-        }
+        internal static uint SniGetProviderNumber(SNIHandle pConn, ref Provider provNum) =>
+            s_nativeMethods.SniGetInfoWrapper(pConn, QueryType.SNI_QUERY_CONN_PROVIDERNUM, out provNum);
 
         internal static uint SniInitialize() =>
             s_nativeMethods.SniInitialize(IntPtr.Zero);
         
-        internal static uint SniIsTokenRestricted([In] IntPtr token, [MarshalAs(UnmanagedType.Bool)] out bool isRestricted) =>
+        internal static uint SniIsTokenRestricted(IntPtr token, out bool isRestricted) =>
             s_nativeMethods.SniIsTokenRestricted(token, out isRestricted);
         
-        internal static unsafe uint SniOpenMarsSession(ConsumerInfo consumerInfo, SNIHandle parent, ref IntPtr pConn, bool fSync, SqlConnectionIPAddressPreference ipPreference, SQLDNSInfo cachedDNSInfo)
+        internal static uint SniOpenMarsSession(
+            ConsumerInfo consumerInfo,
+            SNIHandle parent,
+            ref IntPtr pConn,
+            bool fSync,
+            SqlConnectionIPAddressPreference ipPreference,
+            SQLDNSInfo cachedDnsInfo)
         {
             // initialize consumer info for MARS
-            SniConsumerInfo native_consumerInfo = new SniConsumerInfo();
-            MarshalConsumerInfo(consumerInfo, ref native_consumerInfo);
+            SniConsumerInfo nativeConsumerInfo = new SniConsumerInfo();
+            MarshalConsumerInfo(consumerInfo, ref nativeConsumerInfo);
 
-            SniDnsCacheInfo native_cachedDNSInfo = new SniDnsCacheInfo();
-            native_cachedDNSInfo.wszCachedFQDN = cachedDNSInfo?.FQDN;
-            native_cachedDNSInfo.wszCachedTcpIPv4 = cachedDNSInfo?.AddrIPv4;
-            native_cachedDNSInfo.wszCachedTcpIPv6 = cachedDNSInfo?.AddrIPv6;
-            native_cachedDNSInfo.wszCachedTcpPort = cachedDNSInfo?.Port;
+            SniDnsCacheInfo nativeCachedDnsInfo = new SniDnsCacheInfo()
+            {
+                wszCachedFQDN = cachedDnsInfo?.FQDN,
+                wszCachedTcpIPv4 = cachedDnsInfo?.AddrIPv4,
+                wszCachedTcpIPv6 = cachedDnsInfo?.AddrIPv6,
+                wszCachedTcpPort = cachedDnsInfo?.Port,
+            };
 
-            return s_nativeMethods.SniOpenWrapper(ref native_consumerInfo, "session:", parent, out pConn, fSync, ipPreference, ref native_cachedDNSInfo);
+            return s_nativeMethods.SniOpenWrapper(
+                pConsumerInfo: ref nativeConsumerInfo,
+                connect: "session:",
+                pConn: parent,
+                ppConn: out pConn,
+                fSync,
+                ipPreference,
+                pDnsCacheInfo: ref nativeCachedDnsInfo);
         }
 
         internal static unsafe uint SniOpenSyncEx(
             ConsumerInfo consumerInfo,
-            string constring,
+            string connString,
             ref IntPtr pConn,
             ref string spn,
             byte[] instanceName,
@@ -154,25 +170,25 @@ namespace Microsoft.Data.SqlClient
             bool fParallel,
             
             #if NETFRAMEWORK
-            Int32 transparentNetworkResolutionStateNo,
-            Int32 totalTimeout,
+            int transparentNetworkResolutionStateNo,
+            int totalTimeout,
             #endif
             
             SqlConnectionIPAddressPreference ipPreference,
-            SQLDNSInfo cachedDNSInfo,
+            SQLDNSInfo cachedDnsInfo,
             string hostNameInCertificate)
         {
-            fixed (byte* pin_instanceName = &instanceName[0])
+            fixed (byte* pInstanceName = instanceName)
             {
                 SniClientConsumerInfo clientConsumerInfo = new SniClientConsumerInfo();
 
                 // initialize client ConsumerInfo part first
                 MarshalConsumerInfo(consumerInfo, ref clientConsumerInfo.ConsumerInfo);
 
-                clientConsumerInfo.wszConnectionString = constring;
+                clientConsumerInfo.wszConnectionString = connString;
                 clientConsumerInfo.HostNameInCertificate = hostNameInCertificate;
                 clientConsumerInfo.networkLibrary = Prefix.UNKNOWN_PREFIX;
-                clientConsumerInfo.szInstanceName = pin_instanceName;
+                clientConsumerInfo.szInstanceName = pInstanceName;
                 clientConsumerInfo.cchInstanceName = (uint)instanceName.Length;
                 clientConsumerInfo.fOverrideLastConnectCache = fOverrideCache;
                 clientConsumerInfo.fSynchronousConnection = fSync;
@@ -182,13 +198,13 @@ namespace Microsoft.Data.SqlClient
                 #if NETFRAMEWORK
                 switch (transparentNetworkResolutionStateNo)
                 {
-                    case (0):
+                    case 0:
                         clientConsumerInfo.transparentNetworkResolution = TransparentNetworkResolutionMode.DisabledMode;
                         break;
-                    case (1):
+                    case 1:
                         clientConsumerInfo.transparentNetworkResolution = TransparentNetworkResolutionMode.SequentialMode;
                         break;
-                    case (2):
+                    case 2:
                         clientConsumerInfo.transparentNetworkResolution = TransparentNetworkResolutionMode.ParallelMode;
                         break;
                 };
@@ -198,15 +214,15 @@ namespace Microsoft.Data.SqlClient
                 clientConsumerInfo.totalTimeout = SniOpenTimeOut;
                 #endif
 
-                clientConsumerInfo.isAzureSqlServerEndpoint = ADP.IsAzureSqlServerEndpoint(constring);
+                clientConsumerInfo.isAzureSqlServerEndpoint = ADP.IsAzureSqlServerEndpoint(connString);
 
                 clientConsumerInfo.ipAddressPreference = ipPreference;
-                clientConsumerInfo.DNSCacheInfo.wszCachedFQDN = cachedDNSInfo?.FQDN;
-                clientConsumerInfo.DNSCacheInfo.wszCachedTcpIPv4 = cachedDNSInfo?.AddrIPv4;
-                clientConsumerInfo.DNSCacheInfo.wszCachedTcpIPv6 = cachedDNSInfo?.AddrIPv6;
-                clientConsumerInfo.DNSCacheInfo.wszCachedTcpPort = cachedDNSInfo?.Port;
+                clientConsumerInfo.DNSCacheInfo.wszCachedFQDN = cachedDnsInfo?.FQDN;
+                clientConsumerInfo.DNSCacheInfo.wszCachedTcpIPv4 = cachedDnsInfo?.AddrIPv4;
+                clientConsumerInfo.DNSCacheInfo.wszCachedTcpIPv6 = cachedDnsInfo?.AddrIPv6;
+                clientConsumerInfo.DNSCacheInfo.wszCachedTcpPort = cachedDnsInfo?.Port;
 
-                if (spn != null)
+                if (spn is not null)
                 {
                     if (spn.Length == 0)
                     {
@@ -260,18 +276,16 @@ namespace Microsoft.Data.SqlClient
                         }
                     }
                 }
-                else
-                {
-                    // else leave szSPN null (SQL Auth)
-                    return s_nativeMethods.SniOpenSyncExWrapper(ref clientConsumerInfo, out pConn);
-                }
+
+                // Otherwise leave szSPN null (SQL Auth)
+                return s_nativeMethods.SniOpenSyncExWrapper(ref clientConsumerInfo, out pConn);
             }
         }
 
-        internal static void SniPacketAllocate(SafeHandle pConn, IoType IOType, ref IntPtr pPacket) =>
-            pPacket = s_nativeMethods.SniPacketAllocateWrapper(pConn, IOType);
+        internal static void SniPacketAllocate(SafeHandle pConn, IoType ioType, ref IntPtr pPacket) =>
+            pPacket = s_nativeMethods.SniPacketAllocateWrapper(pConn, ioType);
         
-        internal static unsafe uint SniPacketGetData(IntPtr packet, byte[] readBuffer, ref uint dataSize) =>
+        internal static uint SniPacketGetData(IntPtr packet, byte[] readBuffer, ref uint dataSize) =>
             s_nativeMethods.SniPacketGetDataWrapper(packet, readBuffer, (uint)readBuffer.Length, out dataSize);
         
         internal static void SniPacketRelease(IntPtr pPacket) =>
@@ -279,46 +293,47 @@ namespace Microsoft.Data.SqlClient
         
         internal static unsafe void SniPacketSetData(SNIPacket packet, byte[] data, int length)
         {
-            fixed (byte* pin_data = &data[0])
+            fixed (byte* pData = data)
             {
-                s_nativeMethods.SniPacketSetData(packet, pin_data, (uint)length);
+                s_nativeMethods.SniPacketSetData(packet, pData, (uint)length);
             }
         }
         
         #if NETFRAMEWORK
-        //[ResourceExposure(ResourceScope::None)]
-        //
-        // Notes on SecureString: Writing out security sensitive information to managed buffer should be avoid as these can be moved
-        //    around by GC. There are two set of information which falls into this category: passwords and new changed password which
-        //    are passed in as SecureString by a user. Writing out clear passwords information is delayed until this layer to ensure that
-        //    the information is written out to buffer which is pinned in this method already. This also ensures that processing a clear password
-        //    is done right before it is written out to SNI_Packet where gets encrypted properly. 
-        //    TdsParserStaticMethods.EncryptPassword operation is also done here to minimize the time the clear password is held in memory. Any changes
-        //    to loose encryption algorithm is changed it should be done in both in this method as well as TdsParserStaticMethods.EncryptPassword.
-        //  Up to current release, it is also guaranteed that both password and new change password will fit into a single login packet whose size is fixed to 4096
-        //        So, there is no splitting logic is needed.
-        internal static void SniPacketSetData(SNIPacket packet,
-                                      Byte[] data,
-                                      Int32 length,
-                                      SecureString[] passwords,            // pointer to the passwords which need to be written out to SNI Packet
-                                      Int32[] passwordOffsets    // Offset into data buffer where the password to be written out to
-                                      )
+        // Notes on SecureString: Writing out security sensitive information to managed buffer
+        //    should be avoided as these can be moved around by GC. There are two set of
+        //    information which falls into this category: passwords and new changed password which
+        //    are passed in as SecureString by a user. Writing out clear passwords information is
+        //    delayed until this layer to ensure that the information is written out to buffer
+        //    which is pinned in this method already. This also ensures that processing a clear
+        //    password is done right before it is written out to SNI_Packet where gets encrypted
+        //    properly. TdsParserStaticMethods.EncryptPassword operation is also done here to
+        //    minimize the time the clear password is held in memory. Any time loose encryption
+        //    algorithms are changed it should be done in both in this method and
+        //    TdsParserStaticMethods.EncryptPassword.
+        //    Up to current release, it is also guaranteed that both password and new change
+        //    password will fit into a single login packet whose size is fixed to 4096 So, no
+        //    splitting logic is needed.
+        internal static void SniPacketSetData(
+            SNIPacket packet,
+            byte[] data,
+            int length,
+            SecureString[] passwords, // pointer to the passwords which need to be written out to SNI Packet
+            int[] passwordOffsets)    // Offset into data buffer where the password to be written out to
         {
-            Debug.Assert(passwords == null || (passwordOffsets != null && passwords.Length == passwordOffsets.Length), "The number of passwords does not match the number of password offsets");
+            Debug.Assert(passwords is null || (passwordOffsets is not null && passwords.Length == passwordOffsets.Length), "The number of passwords does not match the number of password offsets");
 
             bool mustRelease = false;
             bool mustClearBuffer = false;
             IntPtr clearPassword = IntPtr.Zero;
 
-            // provides a guaranteed finally block – without this it isn’t guaranteed – non interruptable by fatal exceptions
+            // provides a guaranteed finally block – without this it isn’t guaranteed – non-
+            // interruptible by fatal exceptions
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
                 unsafe
                 {
-
-                    fixed (byte* pin_data = &data[0])
-                    { }
                     if (passwords != null)
                     {
                         // Process SecureString
@@ -327,48 +342,40 @@ namespace Microsoft.Data.SqlClient
                             // SecureString is used
                             if (passwords[i] != null)
                             {
-                                // provides a guaranteed finally block – without this it isn’t guaranteed – non interruptable by fatal exceptions
+                                // provides a guaranteed finally block – without this it isn’t
+                                // guaranteed – non-interruptible by fatal exceptions
                                 RuntimeHelpers.PrepareConstrainedRegions();
                                 try
                                 {
-                                    // ==========================================================================
-                                    //  Get the clear text of secure string without converting it to String type
-                                    // ==========================================================================
+                                    // ============================================================
+                                    // Get the clear text of secure string without converting it
+                                    // to string type
+                                    // ============================================================
                                     clearPassword = Marshal.SecureStringToCoTaskMemUnicode(passwords[i]);
 
-                                    // ==========================================================================================================================
-                                    //  Losely encrypt the clear text - The encryption algorithm should exactly match the TdsParserStaticMethods.EncryptPassword
-                                    // ==========================================================================================================================
+                                    // ============================================================
+                                    // Loosely encrypt the clear text - The encryption algorithm
+                                    // should exactly match the TdsParserStaticMethods.EncryptPassword
+                                    // ============================================================
+                                    char* pwChar = (char*)clearPassword.ToPointer();
+                                    byte* pByte = (byte*)clearPassword.ToPointer();
 
-                                    unsafe
+                                    int passwordsLength = passwords[i].Length;
+                                    for (int j = 0; j < passwordsLength; ++j)
                                     {
-
-                                        char* pwChar = (char*)clearPassword.ToPointer();
-                                        byte* pByte = (byte*)(clearPassword.ToPointer());
-
-
-
-
-                                        int s;
-                                        byte bLo;
-                                        byte bHi;
-                                        int passwordsLength = passwords[i].Length;
-                                        for (int j = 0; j < passwordsLength; ++j)
-                                        {
-                                            s = (int)*pwChar;
-                                            bLo = (byte)(s & 0xff);
-                                            bHi = (byte)((s >> 8) & 0xff);
-                                            *(pByte++) = (Byte)((((bLo & 0x0f) << 4) | (bLo >> 4)) ^ 0xa5);
-                                            *(pByte++) = (Byte)((((bHi & 0x0f) << 4) | (bHi >> 4)) ^ 0xa5);
-                                            ++pwChar;
-                                        }
-
-                                        // ===========================================================
-                                        //  Write out the losely encrypted passwords to data buffer
-                                        // ===========================================================
-                                        mustClearBuffer = true;
-                                        Marshal.Copy(clearPassword, data, passwordOffsets[i], passwordsLength * 2);
+                                        int s = *pwChar;
+                                        byte bLo = (byte)(s & 0xff);
+                                        byte bHi = (byte)((s >> 8) & 0xff);
+                                        *(pByte++) = (byte)((((bLo & 0x0f) << 4) | (bLo >> 4)) ^ 0xa5);
+                                        *(pByte++) = (byte)((((bHi & 0x0f) << 4) | (bHi >> 4)) ^ 0xa5);
+                                        ++pwChar;
                                     }
+
+                                    // ============================================================
+                                    //  Write out the loosely encrypted passwords to data buffer
+                                    // ============================================================
+                                    mustClearBuffer = true;
+                                    Marshal.Copy(clearPassword, data, passwordOffsets[i], passwordsLength * 2);
                                 }
                                 finally
                                 {
@@ -408,14 +415,14 @@ namespace Microsoft.Data.SqlClient
         }
         #endif
         
-        internal static void SniPacketReset([In] SNIHandle pConn, IoType IOType, SNIPacket pPacket, ConsumerNumber ConsNum) =>
-            s_nativeMethods.SniPacketReset(pConn, IOType, pPacket, ConsNum);
+        internal static void SniPacketReset(SNIHandle pConn, IoType ioType, SNIPacket pPacket, ConsumerNumber consNum) =>
+            s_nativeMethods.SniPacketReset(pConn, ioType, pPacket, consNum);
         
-        internal static uint SniQueryInfo(QueryType QType, ref uint pbQInfo) =>
-            s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
+        internal static uint SniQueryInfo(QueryType qType, ref uint pbQInfo) =>
+            s_nativeMethods.SniQueryInfo(qType, ref pbQInfo);
         
-        internal static uint SniQueryInfo(QueryType QType, ref IntPtr pbQInfo) =>
-            s_nativeMethods.SniQueryInfo(QType, ref pbQInfo);
+        internal static uint SniQueryInfo(QueryType qType, ref IntPtr pbQInfo) =>
+            s_nativeMethods.SniQueryInfo(qType, ref pbQInfo);
         
         internal static uint SniReadAsync(SNIHandle pConn, ref IntPtr ppNewPacket) =>
             s_nativeMethods.SniReadAsync(pConn, ref ppNewPacket);
@@ -423,8 +430,8 @@ namespace Microsoft.Data.SqlClient
         internal static uint SniReadSyncOverAsync(SNIHandle pConn, ref IntPtr ppNewPacket, int timeout) =>
             s_nativeMethods.SniReadSyncOverAsync(pConn, ref ppNewPacket, timeout);
         
-        internal static uint SniRemoveProvider(SNIHandle pConn, Provider ProvNum) =>
-            s_nativeMethods.SniRemoveProvider(pConn, ProvNum);
+        internal static uint SniRemoveProvider(SNIHandle pConn, Provider provNum) =>
+            s_nativeMethods.SniRemoveProvider(pConn, provNum);
         
         internal static unsafe uint SniSecGenClientContext(
             SNIHandle pConnectionObject,
@@ -465,54 +472,46 @@ namespace Microsoft.Data.SqlClient
         internal static uint SniSecInitPackage(ref uint pcbMaxToken) =>
             s_nativeMethods.SniSecInitPackage(ref pcbMaxToken);
         
-        internal static void SniServerEnumClose([In] IntPtr packet) =>
+        internal static void SniServerEnumClose(IntPtr packet) =>
             s_nativeMethods.SniServerEnumClose(packet);
         
         internal static IntPtr SniServerEnumOpen() =>
             s_nativeMethods.SniServerEnumOpen();
         
-        internal static int SniServerEnumRead(
-            [In] IntPtr packet,
-            [In] [MarshalAs(UnmanagedType.LPArray)] char[] readBuffer,
-            [In] int bufferLength,
-            [MarshalAs(UnmanagedType.Bool)] out bool more) =>
+        internal static int SniServerEnumRead(IntPtr packet, char[] readBuffer, int bufferLength, out bool more) =>
             s_nativeMethods.SniServerEnumRead(packet, readBuffer, bufferLength, out more);
         
-        internal static uint SniSetInfo(SNIHandle pConn, QueryType QType, [In] ref uint pbQInfo) =>
-            s_nativeMethods.SniSetInfo(pConn, QType, ref pbQInfo);
+        internal static uint SniSetInfo(SNIHandle pConn, QueryType qType, ref uint pbQInfo) =>
+            s_nativeMethods.SniSetInfo(pConn, qType, ref pbQInfo);
         
         internal static uint SniTerminate() =>
             s_nativeMethods.SniTerminate();
         
-        internal static uint SniWaitForSslHandshakeToComplete([In] SNIHandle pConn, int dwMilliseconds, out uint pProtocolVersion) =>
+        internal static uint SniWaitForSslHandshakeToComplete(
+            SNIHandle pConn,
+            int dwMilliseconds,
+            out uint pProtocolVersion) =>
             s_nativeMethods.SniWaitForSslHandshakeToComplete(pConn, dwMilliseconds, out pProtocolVersion);
-        
-        internal static uint SniWritePacket(SNIHandle pConn, SNIPacket packet, bool sync)
-        {
-            if (sync)
-            {
-                return s_nativeMethods.SniWriteSyncOverAsync(pConn, packet);
-            }
-            else
-            {
-                return s_nativeMethods.SniWriteAsyncWrapper(pConn, packet);
-            }
-        }
+
+        internal static uint SniWritePacket(SNIHandle pConn, SNIPacket packet, bool sync) =>
+            sync
+                ? s_nativeMethods.SniWriteSyncOverAsync(pConn, packet)
+                : s_nativeMethods.SniWriteAsyncWrapper(pConn, packet);
         
         #endregion
 
         #region Private Methods
 
-        private static void MarshalConsumerInfo(ConsumerInfo consumerInfo, ref SniConsumerInfo native_consumerInfo)
+        private static void MarshalConsumerInfo(ConsumerInfo consumerInfo, ref SniConsumerInfo nativeConsumerInfo)
         {
-            native_consumerInfo.DefaultUserDataLength = consumerInfo.defaultBufferSize;
-            native_consumerInfo.fnReadComp = consumerInfo.readDelegate != null
+            nativeConsumerInfo.DefaultUserDataLength = consumerInfo.defaultBufferSize;
+            nativeConsumerInfo.fnReadComp = consumerInfo.readDelegate is not null
                 ? Marshal.GetFunctionPointerForDelegate(consumerInfo.readDelegate)
                 : IntPtr.Zero;
-            native_consumerInfo.fnWriteComp = consumerInfo.writeDelegate != null
+            nativeConsumerInfo.fnWriteComp = consumerInfo.writeDelegate is not null
                 ? Marshal.GetFunctionPointerForDelegate(consumerInfo.writeDelegate)
                 : IntPtr.Zero;
-            native_consumerInfo.ConsumerKey = consumerInfo.key;
+            nativeConsumerInfo.ConsumerKey = consumerInfo.key;
         }
         
         #endregion
@@ -531,10 +530,9 @@ namespace Microsoft.Data.SqlClient
 
         [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        internal unsafe static byte[] GetData()
+        internal static unsafe byte[] GetData()
         {
-            int size;
-            IntPtr ptr = (IntPtr)(SqlDependencyProcessDispatcherStorage.NativeGetData(out size));
+            IntPtr ptr = (IntPtr)SqlDependencyProcessDispatcherStorage.NativeGetData(out int size);
             byte[] result = null;
 
             if (ptr != IntPtr.Zero)
@@ -548,12 +546,11 @@ namespace Microsoft.Data.SqlClient
 
         [ResourceExposure(ResourceScope.Process)] // SxS: there is no way to set scope = Instance, using Process which is wider
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
-        internal unsafe static void SetData(Byte[] data)
+        internal static unsafe void SetData(byte[] data)
         {
-            //cli::pin_ptr<System::Byte> pin_dispatcher = &data[0];
-            fixed (byte* pin_dispatcher = &data[0])
+            fixed (byte* pDispatcher = data)
             {
-                SqlDependencyProcessDispatcherStorage.NativeSetData(pin_dispatcher, data.Length);
+                SqlDependencyProcessDispatcherStorage.NativeSetData(pDispatcher, data.Length);
             }
         }
         #endif

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Interop.Windows.Sni;
 using Microsoft.Data.Common;
-using Microsoft.Data.SqlClient;
 
 #if NETFRAMEWORK
 using System.Diagnostics;
@@ -124,9 +123,17 @@ namespace Microsoft.Data.SqlClient
 
         internal static uint SniInitialize() =>
             s_nativeMethods.SniInitialize(IntPtr.Zero);
-        
-        internal static uint SniIsTokenRestricted(IntPtr token, out bool isRestricted) =>
-            s_nativeMethods.SniIsTokenRestricted(token, out isRestricted);
+
+        internal static uint SniIsTokenRestricted(IntPtr token, out bool isRestricted)
+        {
+            uint result = s_nativeMethods.SniIsTokenRestricted(token, out isRestricted);
+            if (result != 0)
+            {
+                Marshal.ThrowExceptionForHR(unchecked((int)result));
+            }
+
+            return result;
+        }
         
         internal static uint SniOpenMarsSession(
             ConsumerInfo consumerInfo,
@@ -543,24 +550,5 @@ namespace Microsoft.Data.SqlClient
             }
         }
         #endif
-    }
-}
-
-namespace Microsoft.Data
-{
-    internal static class Win32NativeMethods
-    {
-        internal static bool IsTokenRestrictedWrapper(IntPtr token)
-        {
-            bool isRestricted;
-            uint result = SniNativeWrapper.SniIsTokenRestricted(token, out isRestricted);
-
-            if (result != 0)
-            {
-                Marshal.ThrowExceptionForHR(unchecked((int)result));
-            }
-
-            return isRestricted;
-        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/SystemErrors.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/SystemErrors.cs
@@ -5,8 +5,10 @@
 namespace Interop.Windows
 {
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382.aspx
-    internal partial class SystemErrors
+    internal class SystemErrors
     {
+        internal const int ERROR_SUCCESS = 0x00;
+        
         internal const int ERROR_FILE_NOT_FOUND = 0x2;
         internal const int ERROR_INVALID_HANDLE = 0x6;
         internal const int ERROR_SHARING_VIOLATION = 0x20;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -945,7 +945,7 @@ namespace Microsoft.Data.Common
 
             SqlDependencyObtainProcessDispatcherFailureObjectHandle = 50,
             SqlDependencyProcessDispatcherFailureCreateInstance = 51,
-            SqlDependencyProcessDispatcherFailureAppDomain = 52,
+            
             SqlDependencyCommandHashIsNotAssociatedWithNotification = 53,
 
             UnknownTransactionFailure = 60,

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
@@ -50,23 +50,23 @@ namespace Microsoft.Data.Sql
                 { }
                 finally
                 {
-                    handle = SniNativeWrapper.SNIServerEnumOpen();
+                    handle = SniNativeWrapper.SniServerEnumOpen();
                     SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {2} returned handle = {3}.",
                                                            nameof(SqlDataSourceEnumeratorNativeHelper),
                                                            nameof(GetDataSources),
-                                                           nameof(SniNativeWrapper.SNIServerEnumOpen), handle);
+                                                           nameof(SniNativeWrapper.SniServerEnumOpen), handle);
                 }
 
                 if (handle != ADP.s_ptrZero)
                 {
                     while (more && !TdsParserStaticMethods.TimeoutHasExpired(s_timeoutTime))
                     {
-                        readLength = SniNativeWrapper.SNIServerEnumRead(handle, buffer, bufferSize, out more);
+                        readLength = SniNativeWrapper.SniServerEnumRead(handle, buffer, bufferSize, out more);
 
                         SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {2} returned 'readlength':{3}, and 'more':{4} with 'bufferSize' of {5}",
                                                                nameof(SqlDataSourceEnumeratorNativeHelper),
                                                                nameof(GetDataSources),
-                                                               nameof(SniNativeWrapper.SNIServerEnumRead),
+                                                               nameof(SniNativeWrapper.SniServerEnumRead),
                                                                readLength, more, bufferSize);
                         if (readLength > bufferSize)
                         {
@@ -84,21 +84,21 @@ namespace Microsoft.Data.Sql
             {
                 if (handle != ADP.s_ptrZero)
                 {
-                    SniNativeWrapper.SNIServerEnumClose(handle);
+                    SniNativeWrapper.SniServerEnumClose(handle);
                     SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {2} called.",
                                                            nameof(SqlDataSourceEnumeratorNativeHelper),
                                                            nameof(GetDataSources),
-                                                           nameof(SniNativeWrapper.SNIServerEnumClose));
+                                                           nameof(SniNativeWrapper.SniServerEnumClose));
                 }
             }
 
             if (failure)
             {
-                Debug.Assert(false, $"{nameof(GetDataSources)}:{nameof(SniNativeWrapper.SNIServerEnumRead)} returned bad length");
+                Debug.Assert(false, $"{nameof(GetDataSources)}:{nameof(SniNativeWrapper.SniServerEnumRead)} returned bad length");
                 SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|ERR> {2} returned bad length, requested buffer {3}, received {4}",
                                                        nameof(SqlDataSourceEnumeratorNativeHelper),
                                                        nameof(GetDataSources),
-                                                       nameof(SniNativeWrapper.SNIServerEnumRead),
+                                                       nameof(SniNativeWrapper.SniServerEnumRead),
                                                        bufferSize, readLength);
 
                 throw ADP.ArgumentOutOfRange(StringsHelper.GetString(Strings.ADP_ParameterValueOutOfRange, readLength), nameof(readLength));

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolIdentity.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolIdentity.Windows.cs
@@ -43,10 +43,13 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 string sidString = user.Value;
 
                 // Win32NativeMethods.IsTokenRestricted will raise exception if the native call fails
-                bool isRestricted = Win32NativeMethods.IsTokenRestrictedWrapper(token);
+                SniNativeWrapper.SniIsTokenRestricted(token, out bool isRestricted);
 
                 var lastIdentity = s_lastIdentity;
-                if ((lastIdentity != null) && (lastIdentity._sidString == sidString) && (lastIdentity._isRestricted == isRestricted) && (lastIdentity._isNetwork == isNetwork))
+                if (lastIdentity != null && 
+                    lastIdentity._sidString == sidString &&
+                    lastIdentity._isRestricted == isRestricted &&
+                    lastIdentity._isNetwork == isNetwork)
                 {
                     current = lastIdentity;
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalDb/LocalDbApi.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalDb/LocalDbApi.Windows.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Data.SqlClient.LocalDb
                     {
                         if (s_userInstanceDllHandle == IntPtr.Zero)
                         {
-                            SniNativeWrapper.SNIQueryInfo(QueryType.SNI_QUERY_LOCALDB_HMODULE, ref s_userInstanceDllHandle);
+                            SniNativeWrapper.SniQueryInfo(QueryType.SNI_QUERY_LOCALDB_HMODULE, ref s_userInstanceDllHandle);
                             if (s_userInstanceDllHandle != IntPtr.Zero)
                             {
                                 #if NETFRAMEWORK
@@ -161,7 +161,7 @@ namespace Microsoft.Data.SqlClient.LocalDb
                             }
                             else
                             {
-                                SniNativeWrapper.SNIGetLastError(out SniError sniError);
+                                SniNativeWrapper.SniGetLastError(out SniError sniError);
                                 throw CreateLocalDbException(
                                     errorMessage: StringsHelper.GetString("LocalDB_FailedGetDLLHandle"),
                                     sniError: sniError.sniError);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NativeSSPIContextProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SSPI/NativeSSPIContextProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.SqlClient
                         // use local for ref param to defer setting s_maxSSPILength until we know the call succeeded.
                         uint maxLength = 0;
 
-                        if (0 != SniNativeWrapper.SNISecInitPackage(ref maxLength))
+                        if (0 != SniNativeWrapper.SniSecInitPackage(ref maxLength))
                             SSPIError(SQLMessage.SSPIInitializeError(), TdsEnums.INIT_SSPI_PACKAGE);
 
                         s_maxSSPILength = maxLength;
@@ -62,7 +62,7 @@ namespace Microsoft.Data.SqlClient
             var sendLength = s_maxSSPILength;
             var outBuff = outgoingBlobWriter.GetSpan((int)sendLength);
 
-            if (0 != SniNativeWrapper.SNISecGenClientContext(handle, incomingBlob, outBuff, ref sendLength, serverSpns[0]))
+            if (0 != SniNativeWrapper.SniSecGenClientContext(handle, incomingBlob, outBuff, ref sendLength, serverSpns[0]))
             {
                 throw new InvalidOperationException(SQLMessage.SSPIGenerateError());
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Data.SqlClient
         [ResourceConsumption(ResourceScope.Process, ResourceScope.Process)]
         private static void ObtainProcessDispatcher()
         {
-            byte[] nativeStorage = SniNativeWrapper.GetData();
+            byte[] nativeStorage = SqlDependencyProcessDispatcherStorage.NativeGetData();
 
             if (nativeStorage == null)
             {
@@ -492,7 +492,9 @@ namespace Microsoft.Data.SqlClient
                             SqlClientObjRef objRef = new(s_processDispatcher);
                             DataContractSerializer serializer = new(objRef.GetType());
                             GetSerializedObject(objRef, serializer, stream);
-                            SniNativeWrapper.SetData(stream.ToArray()); // Native will be forced to synchronize and not overwrite.
+                            
+                            // Native will be forced to synchronize and not overwrite.
+                            SqlDependencyProcessDispatcherStorage.NativeSetData(stream.ToArray()); 
                         }
                     }
                     else

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -473,47 +473,38 @@ namespace Microsoft.Data.SqlClient
 
 #if DEBUG       // Possibly expensive, limit to debug.
                 SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP> AppDomain.CurrentDomain.FriendlyName: {0}", AppDomain.CurrentDomain.FriendlyName);
-
 #endif // DEBUG
-                _AppDomain masterDomain = SniNativeWrapper.GetDefaultAppDomain();
-
-                if (masterDomain != null)
+                
+                _AppDomain masterDomain = AppDomain.CurrentDomain;
+                
+                ObjectHandle handle = CreateProcessDispatcher(masterDomain);
+                if (handle != null)
                 {
-                    ObjectHandle handle = CreateProcessDispatcher(masterDomain);
+                    SqlDependencyProcessDispatcher dependency = (SqlDependencyProcessDispatcher)handle.Unwrap();
 
-                    if (handle != null)
+                    if (dependency != null)
                     {
-                        SqlDependencyProcessDispatcher dependency = (SqlDependencyProcessDispatcher)handle.Unwrap();
+                        s_processDispatcher = SqlDependencyProcessDispatcher.SingletonProcessDispatcher; // Set to static instance.
 
-                        if (dependency != null)
+                        // Serialize and set in native.
+                        using (MemoryStream stream = new())
                         {
-                            s_processDispatcher = SqlDependencyProcessDispatcher.SingletonProcessDispatcher; // Set to static instance.
-
-                            // Serialize and set in native.
-                            using (MemoryStream stream = new())
-                            {
-                                SqlClientObjRef objRef = new(s_processDispatcher);
-                                DataContractSerializer serializer = new(objRef.GetType());
-                                GetSerializedObject(objRef, serializer, stream);
-                                SniNativeWrapper.SetData(stream.ToArray()); // Native will be forced to synchronize and not overwrite.
-                            }
-                        }
-                        else
-                        {
-                            SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - ObjectHandle.Unwrap returned null!");
-                            throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyObtainProcessDispatcherFailureObjectHandle);
+                            SqlClientObjRef objRef = new(s_processDispatcher);
+                            DataContractSerializer serializer = new(objRef.GetType());
+                            GetSerializedObject(objRef, serializer, stream);
+                            SniNativeWrapper.SetData(stream.ToArray()); // Native will be forced to synchronize and not overwrite.
                         }
                     }
                     else
                     {
-                        SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - AppDomain.CreateInstance returned null!");
-                        throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyProcessDispatcherFailureCreateInstance);
+                        SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - ObjectHandle.Unwrap returned null!");
+                        throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyObtainProcessDispatcherFailureObjectHandle);
                     }
                 }
                 else
                 {
-                    SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - unable to obtain default AppDomain!");
-                    throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyProcessDispatcherFailureAppDomain);
+                    SqlClientEventSource.Log.TryNotificationTraceEvent("<sc.SqlDependency.ObtainProcessDispatcher|DEP|ERR> ERROR - AppDomain.CreateInstance returned null!");
+                    throw ADP.InternalError(ADP.InternalErrorCode.SqlDependencyProcessDispatcherFailureCreateInstance);
                 }
             }
             else

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.Windows.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.SqlClient
             { }
             finally
             {
-                _sniStatus = SniNativeWrapper.SNIInitialize();
+                _sniStatus = SniNativeWrapper.SniInitialize();
                 base.handle = (IntPtr)1; // Initialize to non-zero dummy variable.
             }
         }
@@ -57,7 +57,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             uint value = 0;
                             // Query OS to find out whether encryption is supported.
-                            SniNativeWrapper.SNIQueryInfo(QueryType.SNI_QUERY_CLIENT_ENCRYPT_POSSIBLE, ref value);
+                            SniNativeWrapper.SniQueryInfo(QueryType.SNI_QUERY_CLIENT_ENCRYPT_POSSIBLE, ref value);
                             _clientOSEncryptionSupport = value != 0;
                         }
                         catch (Exception e)
@@ -79,7 +79,7 @@ namespace Microsoft.Data.SqlClient
                 if (TdsEnums.SNI_SUCCESS == _sniStatus)
                 {
                     LocalDbApi.ReleaseDllHandles();
-                    SniNativeWrapper.SNITerminate();
+                    SniNativeWrapper.SniTerminate();
                 }
                 base.handle = IntPtr.Zero;
             }
@@ -186,7 +186,7 @@ namespace Microsoft.Data.SqlClient
 
                 #if NETFRAMEWORK
                 int transparentNetworkResolutionStateNo = (int)transparentNetworkResolutionState;
-                _status = SniNativeWrapper.SNIOpenSyncEx(
+                _status = SniNativeWrapper.SniOpenSyncEx(
                     myInfo,
                     serverName,
                     ref base.handle,
@@ -202,7 +202,7 @@ namespace Microsoft.Data.SqlClient
                     cachedDNSInfo,
                     hostNameInCertificate);
                 #else
-                _status = SniNativeWrapper.SNIOpenSyncEx(
+                _status = SniNativeWrapper.SniOpenSyncEx(
                     myInfo,
                     serverName,
                     ref base.handle,
@@ -226,7 +226,7 @@ namespace Microsoft.Data.SqlClient
             { }
             finally
             {
-                _status = SniNativeWrapper.SNIOpenMarsSession(myInfo, parent, ref base.handle, parent._fSync, ipPreference, cachedDNSInfo);
+                _status = SniNativeWrapper.SniOpenMarsSession(myInfo, parent, ref base.handle, parent._fSync, ipPreference, cachedDNSInfo);
             }
         }
 
@@ -245,7 +245,7 @@ namespace Microsoft.Data.SqlClient
             base.handle = IntPtr.Zero;
             if (IntPtr.Zero != ptr)
             {
-                if (0 != SniNativeWrapper.SNIClose(ptr))
+                if (0 != SniNativeWrapper.SniClose(ptr))
                 {
                     return false;   // SNIClose should never fail.
                 }
@@ -266,7 +266,7 @@ namespace Microsoft.Data.SqlClient
     {
         internal SNIPacket(SafeHandle sniHandle) : base(IntPtr.Zero, true)
         {
-            SniNativeWrapper.SNIPacketAllocate(sniHandle, IoType.WRITE, ref base.handle);
+            SniNativeWrapper.SniPacketAllocate(sniHandle, IoType.WRITE, ref base.handle);
             if (IntPtr.Zero == base.handle)
             {
                 throw SQL.SNIPacketAllocationFailure();
@@ -288,7 +288,7 @@ namespace Microsoft.Data.SqlClient
             base.handle = IntPtr.Zero;
             if (IntPtr.Zero != ptr)
             {
-                SniNativeWrapper.SNIPacketRelease(ptr);
+                SniNativeWrapper.SniPacketRelease(ptr);
             }
             return true;
         }
@@ -312,7 +312,7 @@ namespace Microsoft.Data.SqlClient
             {
                 // Success - reset the packet
                 packet = _packets.Pop();
-                SniNativeWrapper.SNIPacketReset(sniHandle, IoType.WRITE, packet, ConsumerNumber.SNI_Consumer_SNI);
+                SniNativeWrapper.SniPacketReset(sniHandle, IoType.WRITE, packet, ConsumerNumber.SNI_Consumer_SNI);
             }
             else
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.Multiplexer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.Multiplexer.cs
@@ -513,12 +513,12 @@ namespace Microsoft.Data.SqlClient
             else
             {
                 uint dataSize = 0;
-
-                uint getDataError =
-#if NETFRAMEWORK
-                    SniNativeWrapper.
-#endif
-                        SNIPacketGetData(packet, _inBuff, ref dataSize);
+                
+                #if NETFRAMEWORK
+                uint getDataError = SniNativeWrapper.SniPacketGetData(packet, _inBuff, ref dataSize);
+                #else
+                uint getDataError = SniPacketGetData(packet, _inBuff, ref dataSize);
+                #endif
 
                 if (getDataError == TdsEnums.SNI_SUCCESS)
                 {

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/TdsParserStateObject.TestHarness.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/TdsParserStateObject.TestHarness.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Data.SqlClient
 
         public class Parser
         {
-            internal object ProcessSniError(TdsParserStateObject tdsParserStateObject) => "ProcessSNIError";
+            internal object ProcessSNIError(TdsParserStateObject tdsParserStateObject) => "ProcessSNIError";
             public TdsParserState State = TdsParserState.OpenLoggedIn;
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/TdsParserStateObject.TestHarness.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/TdsParserStateObject.TestHarness.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Data.SqlClient
 
         private uint GetSniPacket(PacketHandle packet, ref uint dataSize)
         {
-            return SNIPacketGetData(packet, _inBuff, ref dataSize);
+            return SniPacketGetData(packet, _inBuff, ref dataSize);
         }
 
         private class StringsHelper
@@ -71,7 +71,7 @@ namespace Microsoft.Data.SqlClient
 
         public class Parser
         {
-            internal object ProcessSNIError(TdsParserStateObject tdsParserStateObject) => "ProcessSNIError";
+            internal object ProcessSniError(TdsParserStateObject tdsParserStateObject) => "ProcessSNIError";
             public TdsParserState State = TdsParserState.OpenLoggedIn;
         }
 
@@ -118,7 +118,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
         [DebuggerStepThrough]
-        private uint SNIPacketGetData(PacketHandle packet, byte[] inBuff, ref uint dataSize)
+        private uint SniPacketGetData(PacketHandle packet, byte[] inBuff, ref uint dataSize)
         {
             Span<byte> target = inBuff.AsSpan(0, _packetSize);
             Span<byte> source = Current.Array.AsSpan(Current.Start, Current.Length);
@@ -161,7 +161,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-#if NETFRAMEWORK
+        #if NETFRAMEWORK
         private SniNativeWrapperImpl _native;
         internal SniNativeWrapperImpl SniNativeWrapper
         {
@@ -180,9 +180,9 @@ namespace Microsoft.Data.SqlClient
             private readonly TdsParserStateObject _parent;
             internal SniNativeWrapperImpl(TdsParserStateObject parent) => _parent = parent;
 
-            internal uint SNIPacketGetData(PacketHandle packet, byte[] inBuff, ref uint dataSize) => _parent.SNIPacketGetData(packet, inBuff, ref dataSize);
+            internal uint SniPacketGetData(PacketHandle packet, byte[] inBuff, ref uint dataSize) => _parent.SniPacketGetData(packet, inBuff, ref dataSize);
         }
-#endif
+        #endif
     }
 
     internal static class TdsEnums


### PR DESCRIPTION
_This is a replacement of #3056 that will give us the complete CI_

**Description**: This is a followup to the SNI Native Wrapper code merge. Each commit in this PR is an atomic change, so if the PR gets too cluttered to review all up, it can be stepped through one commit at a time. Most of these changes are just renaming and moving code around. One larger change is removing a bunch of private methods that were no longer necessary after extracting the DLL imports (as mentioned by @edwardneal). 

**Testing**: There aren't really any functional changes here, so CI pass should be sufficient validation.