### PR TITLE
Fix | Remove TargetFramework From ExtUtilities Project

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.ExtUtilities/Microsoft.Data.SqlClient.ExtUtilities.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.ExtUtilities/Microsoft.Data.SqlClient.ExtUtilities.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
     <StartupObject>Microsoft.Data.SqlClient.ExtUtilities.Runner</StartupObject>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
**Description**: I spent far too long trying to track down completely unrelated errors that were resolved by this. The Directory.Build.props file two directories up includes definitions for TargetFrameworks, as well as in the ExtUtilities project. So when attempting certain builds from the IDE, it will throw errors that net9.0 is specified >1 and refuse to build. Removing the line in the csproj file resolves the issue.

**Testing**: Local builds are working again, will wait to see if it causes CI issues.