### PR TITLE
Merge | Merge netfx-specific exception handling

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1970,6 +1970,9 @@ namespace Microsoft.Data.SqlClient
             _parserLock.Wait(canReleaseFromAnyThread: _isAsyncBulkCopy);
 
             TdsParser bestEffortCleanupTarget = null;
+#if NETFRAMEWORK
+            RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
@@ -2690,6 +2693,9 @@ namespace Microsoft.Data.SqlClient
         private void CopyBatchesAsyncContinuedOnError(bool cleanupParser)
         {
             SqlInternalConnectionTds internalConnection = _connection.GetOpenTdsConnection();
+#if NETFRAMEWORK
+            RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 if ((cleanupParser) && (_parser != null) && (_stateObj != null))

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -2020,7 +2020,9 @@ namespace Microsoft.Data.SqlClient
             catch (System.Threading.ThreadAbortException e)
             {
                 _connection.Abort(e);
+#if NETFRAMEWORK
                 SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                 throw;
             }
             finally
@@ -2448,10 +2450,10 @@ namespace Microsoft.Data.SqlClient
                                         connectionToDoom: _connection.GetOpenTdsConnection()
                                     );
                                 }
-                           },
+                            },
                             connectionToDoom: _connection.GetOpenTdsConnection()
-                       );
-                       return resultTask;
+                        );
+                        return resultTask;
                     }
                 }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1235,6 +1235,9 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.ChangeDatabase | API | Correlation | Object Id {0}, Activity Id {1}, Database {2}", ObjectID, ActivityCorrelator.Current, database);
             TdsParser bestEffortCleanupTarget = null;
 
+#if NETFRAMEWORK
+            RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
@@ -1323,8 +1326,11 @@ namespace Microsoft.Data.SqlClient
 
                 SqlStatistics statistics = null;
                 TdsParser bestEffortCleanupTarget = null;
-
                 Exception e = null;
+
+#if NETFRAMEWORK
+                RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                     bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1254,7 +1254,9 @@ namespace Microsoft.Data.SqlClient
             catch (System.Threading.ThreadAbortException e)
             {
                 Abort(e);
+#if NETFRAMEWORK
                 SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                 throw;
             }
             finally
@@ -1367,7 +1369,9 @@ namespace Microsoft.Data.SqlClient
                 {
                     e = ex;
                     Abort(ex);
+#if NETFRAMEWORK
                     SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                     throw;
                 }
                 catch (Exception ex)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -258,6 +258,9 @@ namespace Microsoft.Data.SqlClient
                         throw SQL.PendingBeginXXXExists();
                     }
 
+#if NETFRAMEWORK
+                    RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                     try
                     {
                         Debug.Assert(_stateObj == null || _stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
@@ -868,6 +871,9 @@ namespace Microsoft.Data.SqlClient
         {
             AssertReaderState(requireData: true, permitAsync: false);
 
+#if NETFRAMEWORK
+            RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 TdsOperationStatus result = TryCleanPartialRead();
@@ -1148,6 +1154,9 @@ namespace Microsoft.Data.SqlClient
                         Connection.RemoveWeakReference(this);  // This doesn't catch everything -- the connection may be closed, but it prevents dead readers from clogging the collection
                     }
 
+#if NETFRAMEWORK
+                    RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                     try
                     {
                         // IsClosed may be true if CloseReaderFromConnection was called - in which case, the session has already been closed
@@ -1774,6 +1783,9 @@ namespace Microsoft.Data.SqlClient
             remaining = 0;
             TdsOperationStatus result;
 
+#if NETFRAMEWORK
+            RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 int cbytes = 0;
@@ -2081,6 +2093,9 @@ namespace Microsoft.Data.SqlClient
             bytesRead = 0;
             TdsOperationStatus result;
 
+#if NETFRAMEWORK
+            RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 if ((_sharedState._columnDataBytesRemaining == 0) || (length == 0))
@@ -2422,6 +2437,9 @@ namespace Microsoft.Data.SqlClient
 
         private long GetCharsFromPlpData(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
         {
+#if NETFRAMEWORK
+            RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 long cch;
@@ -4055,6 +4073,9 @@ namespace Microsoft.Data.SqlClient
         {
             CheckDataIsReady(columnIndex: i, permitAsync: true, allowPartiallyReadColumn: allowPartiallyReadColumn, methodName: null);
 
+#if NETFRAMEWORK
+            RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 Debug.Assert(_sharedState._nextColumnHeaderToRead <= _metaData.Length, "_sharedState._nextColumnHeaderToRead too large");
@@ -4143,6 +4164,9 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.InvalidRead();
             }
 
+#if NETFRAMEWORK
+            RuntimeHelpers.PrepareConstrainedRegions();
+#endif
             try
             {
                 return TryReadColumnInternal(i, readHeaderOnly: true);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -56,7 +56,9 @@ namespace Microsoft.Data.SqlClient
                     {
                         diagnosticScope.SetException(e);
                         _connection.Abort(e);
+#if NETFRAMEWORK
                         SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                         throw;
                     }
                     catch (SqlException ex)
@@ -112,7 +114,9 @@ namespace Microsoft.Data.SqlClient
                 catch (System.Threading.ThreadAbortException e)
                 {
                     _connection.Abort(e);
+#if NETFRAMEWORK
                     SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                     throw;
                 }
             }
@@ -165,7 +169,9 @@ namespace Microsoft.Data.SqlClient
                         {
                             diagnosticScope.SetException(e);
                             _connection.Abort(e);
+#if NETFRAMEWORK
                             SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                             throw;
                         }
                         catch (Exception ex)
@@ -219,7 +225,9 @@ namespace Microsoft.Data.SqlClient
                     {
                         diagnosticScope.SetException(e);
                         _connection.Abort(e);
+#if NETFRAMEWORK
                         SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                         throw;
                     }
                     catch (Exception ex)
@@ -265,7 +273,9 @@ namespace Microsoft.Data.SqlClient
                 catch (System.Threading.ThreadAbortException e)
                 {
                     _connection.Abort(e);
+#if NETFRAMEWORK
                     SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                     throw;
                 }
                 finally

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -31,6 +31,9 @@ namespace Microsoft.Data.SqlClient
                     TdsParser bestEffortCleanupTarget = null;
 
                     SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlTransaction.Commit | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId);
+#if NETFRAMEWORK
+                    RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                     try
                     {
                         bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
@@ -93,6 +96,9 @@ namespace Microsoft.Data.SqlClient
             if (disposing)
             {
                 TdsParser bestEffortCleanupTarget = null;
+#if NETFRAMEWORK
+                RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                     bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
@@ -144,6 +150,9 @@ namespace Microsoft.Data.SqlClient
                         SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlTransaction.Rollback | API | Correlation | Object Id {0}, ActivityID {1}, Client Connection Id {2}", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId);
 
                         TdsParser bestEffortCleanupTarget = null;
+#if NETFRAMEWORK
+                        RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                         try
                         {
                             bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
@@ -200,6 +209,9 @@ namespace Microsoft.Data.SqlClient
                 {
                     SqlStatistics statistics = null;
                     TdsParser bestEffortCleanupTarget = null;
+#if NETFRAMEWORK
+                    RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                     try
                     {
                         bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
@@ -253,6 +265,9 @@ namespace Microsoft.Data.SqlClient
             using (TryEventScope.Create("SqlTransaction.Save | API | Object Id {0} | Save Point Name '{1}'", ObjectID, savePointName))
             {
                 TdsParser bestEffortCleanupTarget = null;
+#if NETFRAMEWORK
+                RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                 try
                 {
                     bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1502,8 +1502,8 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlConnection.Close|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
                 SqlStatistics statistics = null;
-
                 TdsParser bestEffortCleanupTarget = null;
+
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -23,12 +23,12 @@ namespace Microsoft.Data.SqlClient
 
             ZombieCheck();
 
-            SqlStatistics statistics = null;
             using (TryEventScope.Create("<sc.SqlTransaction.Commit|API> {0}", ObjectID))
             {
-                SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlTransaction.Commit|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
-
+                SqlStatistics statistics = null;
                 TdsParser bestEffortCleanupTarget = null;
+
+                SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlTransaction.Commit|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
@@ -173,9 +173,9 @@ namespace Microsoft.Data.SqlClient
 
             ZombieCheck();
 
-            SqlStatistics statistics = null;
             using (TryEventScope.Create("<sc.SqlTransaction.Rollback|API> {0} transactionName='{1}'", ObjectID, transactionName))
             {
+                SqlStatistics statistics = null;
                 TdsParser bestEffortCleanupTarget = null;
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try
@@ -222,7 +222,6 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = null;
             using (TryEventScope.Create("<sc.SqlTransaction.Save|API> {0} savePointName='{1}'", ObjectID, savePointName))
             {
-
                 TdsParser bestEffortCleanupTarget = null;
                 RuntimeHelpers.PrepareConstrainedRegions();
                 try

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
@@ -254,17 +254,15 @@ namespace Microsoft.Data.SqlClient
             {
                 throw ADP.ArgumentNull(nameof(command));
             }
-#if NETFRAMEWORK
             TdsParser bestEffortCleanupTarget = null;
+#if NETFRAMEWORK
             RuntimeHelpers.PrepareConstrainedRegions();
 #endif
             try
             {
-                    #if NETFRAMEWORK
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(command.Connection);
-                    #endif
+                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(command.Connection);
 
-                    command.DeriveParameters();
+                command.DeriveParameters();
             }
             catch (OutOfMemoryException e)
             {
@@ -279,9 +277,7 @@ namespace Microsoft.Data.SqlClient
             catch (ThreadAbortException e)
             {
                 command?.Connection?.Abort(e);
-#if NETFRAMEWORK
                 SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-#endif
                 throw;
             }
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
@@ -277,7 +277,9 @@ namespace Microsoft.Data.SqlClient
             catch (ThreadAbortException e)
             {
                 command?.Connection?.Abort(e);
+#if NETFRAMEWORK
                 SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                 throw;
             }
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -276,7 +276,9 @@ namespace Microsoft.Data.SqlClient
             catch (System.Threading.ThreadAbortException e)
             {
                 Connection.Abort(e);
+#if NETFRAMEWORK
                 BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                 throw;
             }
             finally
@@ -349,7 +351,9 @@ namespace Microsoft.Data.SqlClient
             catch (System.Threading.ThreadAbortException)
             {
                 DoomThisConnection();
+#if NETFRAMEWORK
                 BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                 throw;
             }
             catch (Exception e)
@@ -639,7 +643,7 @@ namespace Microsoft.Data.SqlClient
             TdsParser bestEffortCleanupTarget = null;
 #if NETFRAMEWORK
             RuntimeHelpers.PrepareConstrainedRegions();
- #endif // NETFRAMEWORK
+#endif // NETFRAMEWORK
            try
             {
                 bestEffortCleanupTarget = GetBestEffortCleanupTarget(Connection);
@@ -658,7 +662,9 @@ namespace Microsoft.Data.SqlClient
             catch (System.Threading.ThreadAbortException e)
             {
                 Connection.Abort(e);
+#if NETFRAMEWORK
                 BestEffortCleanup(bestEffortCleanupTarget);
+#endif
                 throw;
             }
         }
@@ -732,14 +738,7 @@ namespace Microsoft.Data.SqlClient
             return null;
         }
 
-#if NET
-        // This method is called only by ThreadAbortException, which is only thrown in .NET Framework.
-        // The empty method body facilitates the code merge.
-        static internal void BestEffortCleanup(TdsParser target)
-        {
-            _ = target;
-        }
-#else
+#if NETFRAMEWORK
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         static internal void BestEffortCleanup(TdsParser target)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -265,12 +265,12 @@ namespace Microsoft.Data.SqlClient
             Action<Exception, object> onFailure = null,
             Action<object> onCancellation = null,
 #if NET
-            Func<Exception, Exception> exceptionConverter = null
+            Func<Exception, Exception> exceptionConverter = null,
 #else
             Func<Exception, object, Exception> exceptionConverter = null,
+#endif
             SqlInternalConnectionTds connectionToDoom = null,
             SqlConnection connectionToAbort = null
-#endif
         )
         {
 #if NETFRAMEWORK
@@ -310,10 +310,11 @@ namespace Microsoft.Data.SqlClient
                             completion.TrySetCanceled();
                         }
                     }
-#if NETFRAMEWORK
                     else if (connectionToDoom != null || connectionToAbort != null)
                     {
+#if NETFRAMEWORK
                         RuntimeHelpers.PrepareConstrainedRegions();
+#endif
                         try
                         {
                             onSuccess(state2);
@@ -362,7 +363,6 @@ namespace Microsoft.Data.SqlClient
                             completion.SetException(e);
                         }
                     }
-#endif
                     else
                     {
                         try


### PR DESCRIPTION
Contributes to #2965 and #1261.

This PR merges the exception handling for ThreadAbortException, StackOverflowException and OutOfMemoryException between .NET Core and .NET Framework.

Following this PR, it becomes fairly trivial to merge SqlBulkCopy, SqlDataReader and SqlTransaction.

Given the number of indentation changes from try/catch blocks, I'd recommend switching off whitespace when checking the diff - it eliminates around a third of it.

I'd appreciate a CI run for this.