### PR TITLE
SqlBulkCopy: Explicitly state column name that mismatches(#3170)

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -582,6 +582,7 @@ namespace Microsoft.Data.SqlClient
 
             HashSet<string> destColumnNames = new HashSet<string>();
 
+            Dictionary<string, bool> columnMappingStatusLookup = new Dictionary<string, bool>();
             // Loop over the metadata for each column
             _SqlMetaDataSet metaDataSet = internalResults[MetaDataResultId].MetaData;
             _sortedColumnMappings = new List<_ColumnMapping>(metaDataSet.Length);
@@ -604,9 +605,16 @@ namespace Microsoft.Data.SqlClient
                 int assocId;
                 for (assocId = 0; assocId < _localColumnMappings.Count; assocId++)
                 {
+                    if (!columnMappingStatusLookup.ContainsKey(_localColumnMappings[assocId].DestinationColumn))
+		    {
+                        columnMappingStatusLookup.Add(_localColumnMappings[assocId].DestinationColumn, false);
+		    }
+
                     if ((_localColumnMappings[assocId]._destinationColumnOrdinal == metadata.ordinal) ||
                         (UnquotedName(_localColumnMappings[assocId]._destinationColumnName) == metadata.column))
                     {
+                        columnMappingStatusLookup[_localColumnMappings[assocId].DestinationColumn] = true;
+
                         if (rejectColumn)
                         {
                             nrejected++; // Count matched columns only
@@ -754,7 +762,17 @@ namespace Microsoft.Data.SqlClient
             // All columnmappings should have matched up
             if (nmatched + nrejected != _localColumnMappings.Count)
             {
-                throw (SQL.BulkLoadNonMatchingColumnMapping());
+                List<string> unmatchedColumns = new List<string>();
+
+                foreach(KeyValuePair<string, bool> keyValuePair in columnMappingStatusLookup)
+                {
+                    if (!keyValuePair.Value)
+		    {
+                        unmatchedColumns.Add(keyValuePair.Key);
+		    }
+                }
+
+                throw SQL.BulkLoadNonMatchingColumnName(unmatchedColumns);
             }
 
             updateBulkCommandText.Append(")");

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -1257,6 +1257,10 @@ namespace Microsoft.Data.SqlClient
         {
             return BulkLoadNonMatchingColumnName(columnName, null);
         }
+        internal static Exception BulkLoadNonMatchingColumnName(IEnumerable<string> columns)
+        {
+            return BulkLoadNonMatchingColumnName(String.Join(",", columns), null);
+        }
         internal static Exception BulkLoadNonMatchingColumnName(string columnName, Exception e)
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_BulkLoadNonMatchingColumnName, columnName), e);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="SQL\SqlBulkCopyTest\FireTrigger.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\Helpers.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\MissingTargetColumn.cs" />
+    <Compile Include="SQL\SqlBulkCopyTest\MissingTargetColumns.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\MissingTargetTable.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\SqlBulkCopyTest.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\Transaction.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/MissingTargetColumns.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/MissingTargetColumns.cs
@@ -7,7 +7,7 @@ using System.Data.Common;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 {
-    public class MissingTargetColumn
+    public class MissingTargetColumns
     {
         public static void Test(string srcConstr, string dstConstr, string dstTable)
         {
@@ -18,7 +18,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 try
                 {
-                    Helpers.TryExecute(dstCmd, "create table " + dstTable + " (col1 int, col3 nvarchar(10))");
+                    Helpers.TryExecute(dstCmd, "create table " + dstTable + " (col1 int, col2 nvarchar(10))");
 
                     using (SqlConnection srcConn = new SqlConnection(srcConstr))
                     using (SqlCommand srcCmd = new SqlCommand("select top 5 EmployeeID, LastName, FirstName from employees", srcConn))
@@ -32,11 +32,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             SqlBulkCopyColumnMappingCollection ColumnMappings = bulkcopy.ColumnMappings;
 
                             ColumnMappings.Add("EmployeeID", "col1");
-                            ColumnMappings.Add("LastName", "col2"); // this column does not exist
-                            ColumnMappings.Add("FirstName", "col3");
+                            ColumnMappings.Add("LastName", "col3"); // this column does not exist
+                            ColumnMappings.Add("FirstName", "col4"); // this column does not exist
 
                             string errorMsg = SystemDataResourceManager.Instance.SQL_BulkLoadNonMatchingColumnName;
-                            errorMsg = string.Format(errorMsg, "col2");
+                            errorMsg = string.Format(errorMsg, "col3,col4");
 
                             DataTestUtility.AssertThrowsWrapper<InvalidOperationException>(() => bulkcopy.WriteToServer(reader), exceptionMessage: errorMsg);
                         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/SqlBulkCopyTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/SqlBulkCopyTest.cs
@@ -105,6 +105,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
+        public void MissingTargetColumnsTest()
+        {
+            MissingTargetColumns.Test(_connStr, _connStr, AddGuid("SqlBulkCopyTest_MissingTargetColumns"));
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
         public void Bug85007Test()
         {
             Bug85007.Test(_connStr, _connStr, AddGuid("SqlBulkCopyTest_Bug85007"));


### PR DESCRIPTION
Throwing `SQL.BulkLoadNonMatchingColumnMapping` exception when column mappings mismatch does not provide enough information about where the error occurred. Throwing `SQL.BulkLoadNonMatchingColumnName` exception is more appropriate.

Fixes (#3170)