### PR TITLE
Add Azure DevOps code coverage config file

### DIFF
--- a/azurepipelines-coverage.yml
+++ b/azurepipelines-coverage.yml
@@ -1,0 +1,16 @@
+# Azure DevOps code coverage settings:
+#
+# https://learn.microsoft.com/en-us/azure/devops/pipelines/test/codecoverage-for-pullrequests?view=azure-devops#configuring-coverage-settings
+#
+coverage:
+  # Code coverage status will be posted to pull requests based on targets
+  # defined below.
+  status:
+    # Off by default. When on, details about coverage for each file changed will
+    # be posted as a pull request comment.
+    comments: on
+    # Diff coverage is code coverage only for the lines changed in a pull
+    # request.
+    diff:
+      # Set this to a desired %. Default is 70%.
+      target: 50%

--- a/azurepipelines-coverage.yml
+++ b/azurepipelines-coverage.yml
@@ -13,4 +13,4 @@ coverage:
     # request.
     diff:
       # Set this to a desired %. Default is 70%.
-      target: 50%
+      target: 70%


### PR DESCRIPTION
User Story 34103: [S360] dotnet-sqlclient repository is not meeting Differential Dode Coverage standard, classified as Bucket 2: CodeCoverage data present, missing config file

https://learn.microsoft.com/en-us/azure/devops/pipelines/test/codecoverage-for-pullrequests?view=azure-devops#configuring-coverage-settings

- Added Azure DevOps code coverage config file to the repo root.