### PR TITLE
CodeQL | RSA Padding Scheme Upgrades

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.Windows.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(certificate.HasPrivateKey, "Attempting to encrypt with cert without privatekey");
 
             RSA rsa = certificate.GetRSAPublicKey();
-            return rsa.Encrypt(plainText, RSAEncryptionPadding.OaepSHA1);
+            return rsa.Encrypt(plainText, RSAEncryptionPadding.OaepSHA256);
         }
 
         /// <summary>
@@ -485,12 +485,12 @@ namespace Microsoft.Data.SqlClient
         /// <returns>Returns a decrypted blob or throws an exception if there are any errors.</returns>
         private byte[] RSADecrypt(byte[] cipherText, X509Certificate2 certificate)
         {
-            Debug.Assert((cipherText != null) && (cipherText.Length != 0));
+            Debug.Assert(cipherText != null && (cipherText.Length != 0));
             Debug.Assert(certificate != null);
             Debug.Assert(certificate.HasPrivateKey, "Attempting to decrypt with cert without privatekey");
 
             RSA rsa = certificate.GetRSAPrivateKey();
-            return rsa.Decrypt(cipherText, RSAEncryptionPadding.OaepSHA1);
+            return rsa.Decrypt(cipherText, RSAEncryptionPadding.OaepSHA256);
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Data.SqlClient
         /// <returns>Returns the decrypted plaintext Column Encryption Key or throws an exception if there are any errors.</returns>
         private byte[] RSADecrypt(RSACng rsaCngProvider, byte[] encryptedColumnEncryptionKey)
         {
-            Debug.Assert((encryptedColumnEncryptionKey != null) && (encryptedColumnEncryptionKey.Length != 0));
+            Debug.Assert(encryptedColumnEncryptionKey != null && encryptedColumnEncryptionKey.Length != 0);
             Debug.Assert(rsaCngProvider != null);
 
             return rsaCngProvider.Decrypt(encryptedColumnEncryptionKey, RSAEncryptionPadding.OaepSHA256);
@@ -298,10 +298,10 @@ namespace Microsoft.Data.SqlClient
         /// <returns>Signature</returns>
         private byte[] RSASignHashedData(byte[] dataToSign, RSACng rsaCngProvider)
         {
-            Debug.Assert((dataToSign != null) && (dataToSign.Length != 0));
+            Debug.Assert(dataToSign != null && dataToSign.Length != 0);
             Debug.Assert(rsaCngProvider != null);
 
-            return rsaCngProvider.SignData(dataToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            return rsaCngProvider.SignData(dataToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
         }
 
         /// <summary>
@@ -313,11 +313,11 @@ namespace Microsoft.Data.SqlClient
         /// <returns>true if signature is valid, false if it is not valid</returns>
         private bool RSAVerifySignature(byte[] dataToVerify, byte[] signature, RSACng rsaCngProvider)
         {
-            Debug.Assert((dataToVerify != null) && (dataToVerify.Length != 0));
-            Debug.Assert((signature != null) && (signature.Length != 0));
+            Debug.Assert(dataToVerify != null && dataToVerify.Length != 0);
+            Debug.Assert(signature != null && signature.Length != 0);
             Debug.Assert(rsaCngProvider != null);
 
-            return rsaCngProvider.VerifyData(dataToVerify, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            return rsaCngProvider.VerifyData(dataToVerify, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(columnEncryptionKey != null);
             Debug.Assert(rsaCngProvider != null);
 
-            return rsaCngProvider.Encrypt(columnEncryptionKey, RSAEncryptionPadding.OaepSHA1);
+            return rsaCngProvider.Encrypt(columnEncryptionKey, RSAEncryptionPadding.OaepSHA256);
         }
 
         /// <summary>
@@ -287,7 +287,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert((encryptedColumnEncryptionKey != null) && (encryptedColumnEncryptionKey.Length != 0));
             Debug.Assert(rsaCngProvider != null);
 
-            return rsaCngProvider.Decrypt(encryptedColumnEncryptionKey, RSAEncryptionPadding.OaepSHA1);
+            return rsaCngProvider.Decrypt(encryptedColumnEncryptionKey, RSAEncryptionPadding.OaepSHA256);
         }
 
         /// <summary>


### PR DESCRIPTION
**Description**: As per CodeQL reports, we need to upgrade our RSA padding schemes. In this PR, there are three main changes:

* Change encrypt/decrypt padding for CNG provider from OaepSHA1 to OaepSHA256
* Change encrypt/decrypt padding for Certificate Store provider from OaepSHA1 to OaepSHA256
* Change sign/verify padding for CNG provider from Pkcs1 to PSS (probabilistic signature scheme)

(there's also some extraneous parens removed for good measure - they were looking at me funny)

**Testing**: These should only be impacting enclave, so ... I need the CI to do the testing.