### PR TITLE
[Port main->6.0] Enhance TDS Login ClientInterfaceName field with client info

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -155,6 +155,9 @@
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\AzureAttestationBasedEnclaveProvider.cs">
       <Link>Microsoft\Data\SqlClient\AzureAttestationBasedEnclaveProvider.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\ClientInterface.cs">
+      <Link>Microsoft\Data\SqlClient\ClientInterface.cs</Link>
+    </Compile>
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\ColumnEncryptionKeyInfo.cs">
       <Link>Microsoft\Data\SqlClient\ColumnEncryptionKeyInfo.cs</Link>
     </Compile>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -340,6 +340,9 @@
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\AzureAttestationBasedEnclaveProvider.cs">
       <Link>Microsoft\Data\SqlClient\AzureAttestationBasedEnclaveProvider.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\ClientInterface.cs">
+      <Link>Microsoft\Data\SqlClient\ClientInterface.cs</Link>
+    </Compile>
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\ColumnEncryptionKeyInfo.cs">
       <Link>Microsoft\Data\SqlClient\ColumnEncryptionKeyInfo.cs</Link>
     </Compile>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ClientInterface.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ClientInterface.cs
@@ -1,0 +1,428 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+#nullable enable
+
+namespace Microsoft.Data.SqlClient
+{
+    // ========================================================================
+    /// <summary>
+    ///   <para>
+    ///     This class uses runtime environment information to produce a value
+    ///     suitable for use in the TDS LOGIN7 Client Interface Name field.
+    ///   </para>
+    ///   <para>
+    ///     See the spec here:
+    ///
+    ///     <see href="https://microsoft.sharepoint-df.com/:w:/t/sqldevx/EZYUHqdnoXhKoQv0kxcM1QUB2V_uTCWN9GHfrDQY2tojmA?e=1Coybd">
+    ///       SQL Drivers Client Interface Name Specification
+    ///     </see>
+    ///   </para>
+    /// </summary>
+    internal static class ClientInterface
+    {
+        #region Properties
+        
+        // ====================================================================
+        // Properties
+
+        /// <summary>
+        ///   <para>
+        ///     The Client Interface Name, never null, never empty, and never 
+        ///     larger than
+        ///     <see cref="TdsEnums.MAXLEN_CLIENTINTERFACE">
+        ///       MAXLEN_CLIENTINTERFACE
+        ///     </see>
+        ///     (currently 128) characters.
+        ///   </para>
+        ///   <para> 
+        ///     The format is pipe ('|') delimited into 5 parts:
+        ///
+        ///     <code>MS-MDS|{OS Type}|{Arch}|{OS Info}|{Runtime Info}</code>
+        ///   </para>
+        ///   <para>
+        ///     The <c>{OS Type}</c> part will be one of the following strings:
+        ///     <list type="bullet">
+        ///       <item><description>Windows</description></item>
+        ///       <item><description>Linux</description></item>
+        ///       <item><description>macOS</description></item>
+        ///       <item><description>FreeBSD</description></item>
+        ///       <item><description>Unknown</description></item>
+        ///     </list>
+        ///   </para>
+        ///
+        ///   <para> 
+        ///     The <c>{Arch}</c> part will be the process architecture, either
+        ///     the bare metal hardware architecture or the virtualized
+        ///     architecture.  See
+        ///     <see cref="RuntimeInformation.ProcessArchitecture">
+        ///       ProcessArchitecture
+        ///     </see>
+        ///     for possible values.  This value will never be longer than 10
+        ///     Unicode characters.
+        ///   </para>
+        ///   <para>
+        ///     The <c>{OS Info}</c> part will be sourced from the the
+        ///     <see cref="RuntimeInformation.OSDescription">
+        ///       OSDescription
+        ///     </see> 
+        ///     value, or "Unknown" if that value is empty or all whitespace.
+        ///     This value will never be longer than 44 Unicode characters.
+        ///   </para>
+        ///   <para>
+        ///     The <c>{Runtime Info}</c> part will be sourced from the
+        ///     <see cref="RuntimeInformation.FrameworkDescription">
+        ///       FrameworkDescription
+        ///    </see>
+        ///     value, or "Unknown" if that value is empty or all whitespace.
+        ///     This value will never be longer than 44 Unicode characters.
+        ///   </para>
+        ///   <para>
+        ///     This adheres to the TDS v37.0 spec, which specifies that the
+        ///     Client Interface Name has a maximum length as noted above.  If
+        ///     the fully formed Name length is beyond that limit, it will be
+        ///     truncated to the maximum with no regard for preserving certain
+        ///     parts or pipe ('|') delimiters.
+        ///   </para>
+        ///   <para>
+        ///     Any characters that are not one of the following are replaced
+        ///     with underscore ('_'):
+        ///     <list type="bullet">
+        ///       <item>
+        ///         <description>ASCII letters ([A-za-z])</description>
+        ///       </item>
+        ///       <item><description>ASCII digits ([0-9])</description></item>
+        ///       <item><description>Space (' ')</description></item>
+        ///       <item><description>Period ('.')</description></item>
+        ///       <item><description>Plus ('+')</description></item>
+        ///       <item><description>Underscore ('_')</description></item>
+        ///       <item><description>Hyphen ('-')</description></item>
+        ///     </list>
+        ///   </para>
+        ///   <para> 
+        ///     All known exceptions are caught and handled by injecting the
+        ///     fallback value of "Unknown".  However, no effort is made to
+        ///     catch all exceptions, for example process-fatal memory
+        ///     allocation errors.
+        ///   </para>
+        /// </summary>
+        public static string Name => _name;
+
+        #endregion Properties
+        
+        #region Helpers
+
+        // ====================================================================
+        // Helpers
+
+        /// <summary>
+        ///   <para>Static construction builds the Client Interface Name.</para>
+        ///   <para>All known exceptions are consumed.</para>
+        /// </summary>
+        static ClientInterface()
+        {
+            // Determine the OS type.
+            //
+            // This is done outside of Build() to allow tests to inject
+            // specific values.
+            //
+            string osType = Unknown;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                osType = Windows;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                osType = Linux;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                osType = macOS;
+            }
+// The FreeBSD platform doesn't exist in .NET Framework at all.
+#if NET
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                osType = FreeBSD;
+            }
+#endif // NET
+
+            // Build it!
+            _name = Build(
+                MaxLenOverall,
+                DriverName,
+                osType,
+                RuntimeInformation.ProcessArchitecture,
+                RuntimeInformation.OSDescription,
+                RuntimeInformation.FrameworkDescription);
+        }
+
+        /// <summary>
+        ///   <para>Build the Client Interface Name and return it.</para>
+        ///   <para>
+        ///     The length of the returned value will never be longer than
+        ///     <paramref name="maxLen"/>.
+        ///   </para>
+        ///   <para>All known exceptions are consumed.</para>
+        /// </summary>
+        /// <param name="maxLen">
+        ///   The maximum length of the returned value.
+        /// </param>
+        /// <param name="driverName">
+        ///   The value of the driver name part. 
+        /// </param>
+        /// <param name="osType">
+        ///   The value of the OS Type part. 
+        /// </param>
+        /// <param name="arch">
+        ///   The value of the Architecture part.
+        /// </param>
+        /// <param name="osInfo">
+        ///   The value of the OS Info part. 
+        /// </param>
+        /// <param name="runtimeInfo">
+        ///   The value of the Runtime Info part. 
+        /// </param>
+        /// <returns>
+        ///   The Client Interface Name value, never null, never empty, and
+        ///   never longer than <paramref name="maxLen"/>.
+        /// </returns>
+        public static string Build(
+            ushort maxLen,
+            string driverName,
+            string osType,
+            Architecture arch,
+            string osInfo,
+            string runtimeInfo)
+        {
+            string result;
+
+            // Clean and truncate the driver name.  We will need it for error
+            // handling.
+            driverName = Truncate(Clean(driverName), MaxLenDriverName);
+
+            try
+            {
+                // Expect to build a string whose length is up to our max
+                // length.
+                //
+                // This isn't a max capacity, but a hint for initial buffer
+                // allocation.  We will truncate to our max length after all of
+                // the pieces have been appended.
+                //
+                StringBuilder name = new StringBuilder(maxLen);
+
+                // Start with the (clean) driver name.
+                name.Append(driverName);
+                name.Append('|');
+
+                // Add the OS Type, truncating to its max length.
+                name.Append(Truncate(Clean(osType), MaxLenOsType));
+                name.Append('|');
+
+                // Add the Architecture, truncating to its max length.
+                name.Append(Truncate(Clean(arch.ToString()), MaxLenArch));
+                name.Append('|');
+                
+                // Add the OS Info, truncating to its max length.
+                name.Append(Truncate(Clean(osInfo), MaxLenOsInfo));
+                name.Append('|');
+                
+                // Add the Runtime Info, truncating to its max length.
+                name.Append(Truncate(Clean(runtimeInfo), MaxLenRuntimeInfo));
+
+                // Remember the name we've built up.
+                result = name.ToString();
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // StringBuilder failed in an unexpected way, so use our
+                // fallback value.
+                result =
+                    $"{driverName}|{Unknown}|{Unknown}|{Unknown}|{Unknown}";
+            }
+
+            // Truncate to our max length if necessary.
+            //
+            // This is a paranoia check to ensure we don't violate our API
+            // promise.
+            //
+            if (result.Length > maxLen)
+            {
+                // We know this won't throw ArgumentOutOfRangeException because
+                // we've already confirmed that Length is greater than maxLen.
+                result = result.Substring(0, maxLen);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///   <para>
+        ///     Clean the given value of any disallowed characters, replacing
+        ///     them with underscore ('_'), and return the cleaned value.
+        ///   </para>
+        ///   <para>Leading and trailing whitespace are removed.</para>
+        ///   <para>
+        ///     Each disallowed character is replaced with an underscore,
+        ///     preserving the original length of the value.  No effort is made
+        ///     to collapse adjacent disallowed characters.
+        ///   </para>
+        ///   <para>
+        ///     Permitted characters are:
+        ///     <list type="bullet">
+        ///       <item>
+        ///         <description>ASCII letters ([A-za-z])</description>
+        ///       </item>
+        ///       <item><description>ASCII digits ([0-9])</description></item>
+        ///       <item><description>Space (' ')</description></item>
+        ///       <item><description>Period ('.')</description></item>
+        ///       <item><description>Plus ('+')</description></item>
+        ///       <item><description>Underscore ('_')</description></item>
+        ///       <item><description>Hyphen ('-')</description></item>
+        ///     </list>
+        ///   </para>
+        ///   <para>
+        ///     If the given value is null, empty, or all whitespace, or an
+        ///     error occurs, the fallback value is returned.
+        ///   </para>
+        /// </summary>
+        /// <param name="value">The value to clean.</param>
+        /// <returns>The cleaned value, or the fallback value.</returns>
+        public static string Clean(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value)
+#if NETFRAMEWORK
+                // .NET Framework doesn't consider IsNullOrWhiteSpace()
+                // sufficient for nullable checks, so add an explicit check for
+                // null.
+                || value == null
+#endif // NETFRAMEWORK
+               )
+            {
+                return Unknown;
+            }
+            
+            // Remove any leading and trailing whitespace.
+            value = value.Trim();
+
+            try
+            {
+                // Build the cleaned value by hand, avoiding the overhead and
+                // failure scenarios of regexes or other more complex solutions.
+                //
+                // We expect the value to be short, and this code is called only
+                // a few times per process.  Robustness and simplicity are more
+                // important than performance here.
+                //
+                StringBuilder cleaned = new StringBuilder(value.Length);
+                foreach (char c in value)
+                {
+                    // Is it a permitted character?
+                    if (
+#if NET
+                        char.IsAsciiLetter(c)
+                        || char.IsAsciiDigit(c)
+#else
+                        (c >= 'A' && c <= 'Z')
+                        || (c >= 'a' && c <= 'z')
+                        || (c >= '0' && c <= '9')
+#endif // NET
+                        || c == ' '
+                        || c == '.'
+                        || c == '+'
+                        || c == '_'
+                        || c == '-')
+                    {
+                        // Yes, so append it as-is.
+                        cleaned.Append(c);
+                    }
+                    else
+                    {
+                        // No, so replace it with an underscore.
+                        cleaned.Append('_');
+                    }
+                }
+
+                return cleaned.ToString();
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // StringBuilder failed in an unexpected way, so use our
+                // fallback value.
+                return Unknown;
+            }
+        }
+
+        /// <summary>
+        ///   Truncate the given value to the given max length, and return the
+        ///   result.
+        /// </summary>
+        /// <param name="value">The value to truncate.</param>
+        /// <param name="maxLength">The maximum length to truncate to.</param>
+        /// <returns>
+        ///   The truncated value, or the original <paramref name="value"/>
+        ///   if no truncation occurred.
+        /// </returns>
+        public static string Truncate(string value, ushort maxLength)
+        {
+            if (value.Length <= maxLength)
+            {
+                return value;
+            }
+
+            // We know this won't throw ArgumentOutOfRangeException because
+            // we've already confirmed that Length is greater than maxLength.
+            return value.Substring(0, maxLength);
+        }
+
+        #endregion Helpers
+
+        #region Private Fields
+
+        // ====================================================================
+        // Private Fields
+
+        // The client interface name.
+        private static readonly string _name;
+
+        // Our well-known .NET driver name.
+        private const string DriverName = "MS-MDS";
+
+        // The overall maximum length of Name.
+        //
+        // C# doesn't have compile-time type traits, so we can't confirm that
+        // MAXLEN_CLIENTINTERFACE is unsigned.  Instead, we capture it into a
+        // ushort, and let the compiler decide if that is a permitted operation.
+        //
+        private const ushort MaxLenOverall = TdsEnums.MAXLEN_CLIENTINTERFACE;
+        
+        // Maximum part lengths as promised in our API.
+        private const ushort MaxLenDriverName = 16;
+        private const ushort MaxLenOsType = 10;
+        private const ushort MaxLenArch = 10;
+        private const ushort MaxLenOsInfo = 44;
+        private const ushort MaxLenRuntimeInfo = 44;
+
+        // The OS Type values we promise in our API.
+        private const string Windows = "Windows";
+        private const string Linux = "Linux";
+        private const string macOS = "macOS";
+// The FreeBSD platform doesn't exist in .NET Framework at all.
+#if NET
+        private const string FreeBSD = "FreeBSD";
+#endif // NET
+
+        // A fallback value for parts of the client interface name that are
+        // unknown, invalid, or when errors occur.
+        private const string Unknown = "Unknown";
+
+        #endregion Private Fields
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlError.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlError.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.SqlClient
     public sealed class SqlError
     {
         // bug fix - MDAC 48965 - missing source of exception
-        private readonly string _source = TdsEnums.SQL_PROVIDER_NAME;
+        private readonly string _source = Common.DbConnectionStringDefaults.ApplicationName;
         private readonly int _number;
         private readonly byte _state;
         private readonly byte _errorClass;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Data.SqlClient
         public byte State => Errors.Count > 0 ? Errors[0].State : default;
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/Source/*' />
-        override public string Source => TdsEnums.SQL_PROVIDER_NAME;
+        override public string Source => Common.DbConnectionStringDefaults.ApplicationName;
 
 
 #if NET

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -13,9 +13,6 @@ namespace Microsoft.Data.SqlClient
     {
         // internal tdsparser constants
 
-
-        public const string SQL_PROVIDER_NAME = Common.DbConnectionStringDefaults.ApplicationName;
-
         public static readonly decimal SQL_SMALL_MONEY_MIN = new(-214748.3648);
         public static readonly decimal SQL_SMALL_MONEY_MAX = new(214748.3647);
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -121,11 +121,10 @@ namespace Microsoft.Data.SqlClient
             // length in bytes
             int length = TdsEnums.SQL2005_LOG_REC_FIXED_LEN;
 
-            string clientInterfaceName = TdsEnums.SQL_PROVIDER_NAME;
-            Debug.Assert(TdsEnums.MAXLEN_CLIENTINTERFACE >= clientInterfaceName.Length, "cchCltIntName can specify at most 128 unicode characters. See Tds spec");
+            // Obtain the client interface name.
+            string clientInterfaceName = ClientInterface.Name;
 
             // add up variable-len portions (multiply by 2 for byte len of char strings)
-            //
             checked
             {
                 length += (rec.hostName.Length + rec.applicationName.Length +

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/ClientInterfaceTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/ClientInterfaceTests.cs
@@ -1,0 +1,511 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+using Xunit;
+using Xunit.Abstractions;
+
+#nullable enable
+
+namespace Microsoft.Data.SqlClient.Tests
+{
+    public sealed class ClientInterfaceTests
+    {
+        #region Test Setup
+
+        // ====================================================================
+        // Test Setup
+
+        // Setup to test by acquiring handles to the internal ClientInterface
+        // APIs we need.
+        public ClientInterfaceTests(ITestOutputHelper output)
+        {
+            // Use --logger option to see the output for successful test runs:
+            //
+            //   dotnet test --logger "console;verbosity=detailed"
+            //
+            // The output will appear by default if a test fails.
+            //
+            _output = output;
+
+            // The ClientInterface class is internal, so we need to use
+            // reflection to access it.
+            //
+            // Alternatively, we could use the [assembly:InternalsVisibleTo]
+            // attribute in the main project to allow these tests to access
+            // internals directly.
+            
+            // Find the internal ClientInterface class' type.
+            var clientInterfaceType =
+              // Get the assembly of a public type from the same assembly as
+              // ClientInterface, and then use that to find its type.
+                typeof(SqlCommand).Assembly
+                .GetType("Microsoft.Data.SqlClient.ClientInterface");
+            Assert.NotNull(clientInterfaceType);
+            _output.WriteLine($"ClientInterface type: {clientInterfaceType}");
+
+            // Find the Name property.
+            var nameProperty =
+                clientInterfaceType.GetProperty(
+                    "Name",
+                    BindingFlags.Public | BindingFlags.Static);
+            Assert.NotNull(nameProperty);
+            _nameProperty = nameProperty;
+            _output.WriteLine($"Name property: {_nameProperty}");
+
+            // Find the Build() function.
+            var buildFunction =
+                clientInterfaceType.GetMethod(
+                    "Build",
+                    BindingFlags.Public | BindingFlags.Static);
+            Assert.NotNull(buildFunction);
+            _buildFunction = buildFunction;
+            _output.WriteLine($"Build function: {_buildFunction}");
+
+            // Find the Clean() function.
+            var cleanFunction =
+                clientInterfaceType.GetMethod(
+                    "Clean",
+                    BindingFlags.Public | BindingFlags.Static);
+            Assert.NotNull(cleanFunction);
+            _cleanFunction = cleanFunction;
+            _output.WriteLine($"Clean function: {_cleanFunction}");
+
+            // Find the Truncate() function.
+            var truncateFunction =
+                clientInterfaceType.GetMethod(
+                    "Truncate",
+                    BindingFlags.Public | BindingFlags.Static);
+            Assert.NotNull(truncateFunction);
+            _truncateFunction = truncateFunction;
+            _output.WriteLine($"Truncate function: {_truncateFunction}");
+        }
+
+        #endregion Test Setup
+
+        #region Tests
+
+        // ====================================================================
+        // Tests
+
+        // Test the Name property.
+        //
+        // This test assumes that values returned by the runtime used to
+        // construct the Name property will all fit within the
+        // TdsEnums.MAXLEN_CLIENTINTERFACE_NAME max length (currently 128).
+        //
+        // If this test fails, then either the max length has changed or the
+        // runtime values have changed in a meaningful way.
+        //
+        [Fact]
+        public void Name()
+        {
+            var name = _nameProperty.GetValue(null) as string;
+
+            _output.WriteLine($"ClientInterface.Name: {name}");
+
+            // Check the basic properties of the name.
+            Assert.NotNull(name);
+            Assert.True(name.Length > 0);
+            Assert.True(name.Length <= 128);
+
+            // Ensure we can split it into the expected parts.
+            //
+            // The format should be:
+            //
+            // MS-MDS|{OS Type}|{Arch}|{OS Info}|{Runtime Info}
+            //
+            var parts = name.Split('|');
+            Assert.Equal(5, parts.Length);
+            Assert.Equal("MS-MDS", parts[0]);
+            
+            // Check the OS Type against the guaranteed values.
+            var osType = parts[1];
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Equal("Windows", osType);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Assert.Equal("Linux", osType);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Assert.Equal("macOS", osType);
+            }
+#if NET
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                Assert.Equal("FreeBSD", osType);
+            }
+#endif // NET
+            else
+            {
+                Assert.Equal("Unknown", osType);
+            }
+
+            // Architecture must be non-empty and 10 characters or less.
+            Assert.True(parts[2] == "Unknown" || parts[2].Length > 0);
+            Assert.True(parts[2].Length <= 10);
+
+            // OS Info must be non-empty and 44 characters or less.
+            Assert.True(parts[3] == "Unknown" || parts[3].Length > 0);
+            Assert.True(parts[3].Length <= 44);
+            
+            // Runtime Info must be non-empty and 44 characters or less.
+            Assert.True(parts[4] == "Unknown" || parts[4].Length > 0);
+            Assert.True(parts[4].Length <= 44);
+        }
+
+        // Test the Build() function when it truncates the overall length.
+        [Theory]
+        [InlineData(0, "")]
+        [InlineData(1, "A")]
+        [InlineData(2, "A|")]
+        [InlineData(3, "A|B")]
+        [InlineData(4, "A|B|")]
+        [InlineData(5, "A|B|X")]
+        [InlineData(6, "A|B|X6")]
+        [InlineData(7, "A|B|X64")]
+        [InlineData(8, "A|B|X64|")]
+        [InlineData(9, "A|B|X64|C")]
+        [InlineData(10, "A|B|X64|C|")]
+        [InlineData(11, "A|B|X64|C|D")]
+        [InlineData(12, "A|B|X64|C|D")]
+        public void Build_Truncate_Overall(ushort maxLen, string expected)
+        {
+            Assert.Equal(
+                expected,
+                DoBuild(maxLen, "A", "B", Architecture.X64, "C", "D"));
+        }
+
+        // Test the Build() function when it truncates the driver name.
+        [Fact]
+        public void Build_Truncate_Driver_Name()
+        {
+            // The driver name is longer than max length.
+            Assert.Equal(
+                "DriverNa",
+                DoBuild(8, "DriverName", "B", Architecture.X64, "C", "D"));
+            
+            // The driver name is longer than its per-field max length of 16.
+            Assert.Equal(
+                "ReallyLongDriver|B|X64|C|D",
+                DoBuild(
+                    128, "ReallyLongDriverName", "B", Architecture.X64, "C",
+                    "D"));
+        }
+
+        // Test the Build() function when it truncates the OS Type.
+        [Fact]
+        public void Build_Truncate_OS_Type()
+        {
+            // The OS Type puts the overall length over the max.
+            Assert.Equal(
+                "A|LongOs",
+                DoBuild(8, "A", "LongOsName", Architecture.X64, "C", "D"));
+            
+            // The OS Type is longer than its per-field max length of 10.
+            Assert.Equal(
+                "A|VeryLongOs|X64|C|D",
+                DoBuild(
+                    128, "A", "VeryLongOsName", Architecture.X64, "C", "D"));
+        }
+
+        // Test the Build() function when it truncates the Architecture.
+        [Fact]
+        public void Build_Truncate_Arch()
+        {
+            // The Architecture puts the overall length over the max.
+            Assert.Equal(
+                "A|B|Arm6",
+                DoBuild(8, "A", "B", Architecture.Arm64, "C", "D"));
+
+#if NET
+            // There are no Architecture enum values defined in .NET Framework
+            // with a length longer than 10, so we can only check truncation
+            // in .NET.
+
+            // The Architecture is longer than its per-field max length of 10.
+            Assert.Equal(
+                "A|B|LoongArch6|C|D",
+                DoBuild(
+                    128, "A", "B", Architecture.LoongArch64, "C", "D"));
+#endif // NET
+        }
+
+        // Test the Build() function when it truncates the OS Info.
+        [Fact]
+        public void Build_Truncate_OS_Info()
+        {
+            // The OS Info puts the overall length over the max.
+            Assert.Equal(
+                "A|B|X64|LongOsI",
+                DoBuild(15, "A", "B", Architecture.X64, "LongOsInfo", "D"));
+            
+            // The OS Type is longer than its per-field max length of 44.
+            Assert.Equal(
+                "A|B|X64|01234567890123456789012345678901234567890123|D",
+                DoBuild(
+                    128, "A", "B", Architecture.X64,
+                    "01234567890123456789012345678901234567890123456789",
+                    "D"));
+        }
+
+        // Test the Build() function when it truncates the Runtime Info.
+        [Fact]
+        public void Build_Truncate_Runtime_Info()
+        {
+            // The Runtime Info puts the overall length over the max.
+            Assert.Equal(
+                "A|B|X64|C|LongRunt",
+                DoBuild(18, "A", "B", Architecture.X64, "C",
+                "LongRuntimeInfo"));
+            
+            // The Runtime Type is longer than its per-field max length of 44.
+            Assert.Equal(
+                "A|B|X64|C|01234567890123456789012345678901234567890123",
+                DoBuild(
+                    128, "A", "B", Architecture.X64, "C",
+                    "01234567890123456789012345678901234567890123456789"));
+        }
+
+        // Test the Build() function when most of the fields are truncated.
+        [Fact]
+        public void Build_Truncate_Most()
+        {
+            var name = 
+                DoBuild(
+                    128,
+                    // Driver name > 16 chars.
+                    "A01234567890123456789",
+                    // OS Type > 10 chars.
+                    "B01234567890123456789",
+                    // Architecture isn't truncated (because .NET Framework
+                    // doesn't have any enum values long enough).
+                    Architecture.X64,
+                    // OS Info > 44 chars.
+                    "C01234567890123456789012345678901234567890123456789",
+                    // Runtime Info > 44 chars.
+                    "D01234567890123456789012345678901234567890123456789");
+            Assert.Equal(121, name.Length);
+            Assert.Equal(
+                "A012345678901234|" +
+                "B012345678|" +
+                "X64|" +
+                "C0123456789012345678901234567890123456789012|" +
+                "D0123456789012345678901234567890123456789012",
+                name);
+        }
+
+#if NET
+        // Test the Build() function when all the fields are truncated.
+        [Fact]
+        public void Build_Truncate_All()
+        {
+            var name = 
+                DoBuild(
+                    128,
+                    // Driver name > 16 chars.
+                    "A01234567890123456789",
+                    // OS Type > 10 chars.
+                    "B01234567890123456789",
+                    // Architecture > 10 chars.
+                    Architecture.LoongArch64,
+                    // OS Info > 44 chars.
+                    "C01234567890123456789012345678901234567890123456789",
+                    // Runtime Info > 44 chars.
+                    "D01234567890123456789012345678901234567890123456789");
+            Assert.Equal(128, name.Length);
+            Assert.Equal(
+                "A012345678901234|" +
+                "B012345678|" +
+                "LoongArch6|" +
+                "C0123456789012345678901234567890123456789012|" +
+                "D0123456789012345678901234567890123456789012",
+                name);
+        }
+#endif // NET
+
+        // Test the Clean() function.
+        [Fact]
+        public void Clean()
+        {
+            // Null becomes "Unknown".
+            Assert.Equal("Unknown", DoClean(null));
+
+            // Empty string becomes "Unknown".
+            Assert.Equal("Unknown", DoClean(string.Empty));
+
+            // Whitespace string becomes "Unknown".
+            Assert.Equal("Unknown", DoClean(" "));
+            Assert.Equal("Unknown", DoClean("\t"));
+            Assert.Equal("Unknown", DoClean("\r"));
+            Assert.Equal("Unknown", DoClean("\n"));
+            Assert.Equal("Unknown", DoClean(" \t\r\n"));
+
+            // Leading and trailing whitespace are removed.
+            Assert.Equal("A", DoClean(" A"));
+            Assert.Equal("A", DoClean("A\t"));
+            Assert.Equal("A", DoClean("\rA\n"));
+
+            // All permitted characters are preserved.
+            const string AllPermitted =
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+                "abcdefghijklmnopqrstuvwxyz" +
+                "0123456789" +
+                " .+_-";
+            Assert.Equal(AllPermitted, DoClean(AllPermitted));
+
+            // Each disallowed character is replaced with underscore.
+            Assert.Equal(
+                "A_B_C_D_E_F_G_H_I_J_K_L_M_N_O_P",
+                DoClean("A|B,C;D:E'F\"G[H{I]J}K\\L/M<N>O?P"));
+            Assert.Equal(
+                "Q_R_S_T_U_V_W_X+Y-Z_a.b_c_d_e_f_g_h_i_j_k_l_m_n_o",
+                DoClean("Q^R_S`T~U(V)W*X+Y-Z_a.b,c/d:e<f>g'h\"i[j]k{l}m|n\\o"));
+
+            // All disallowed characters are replaced with underscore.
+            for (char c = (char)0u; /* see condition below */ ; ++c)
+            {
+                var clean = DoClean(c.ToString());
+
+                // Whitespace becomes "Unknown".
+                if (char.IsWhiteSpace(c))
+                {
+                    Assert.Equal("Unknown", clean);
+                }
+                else if (
+#if NET
+                    AllPermitted.Contains(c)
+#else
+                    AllPermitted.Contains(c.ToString())
+#endif          
+                )
+                {
+                    Assert.Equal(c.ToString(), clean);
+                }
+                else
+                {
+                    Assert.Equal("_", clean);
+                }
+
+                // We can't check for c <= 0xffff in the for statement because
+                // ++c will overflow back to 0x0000 and the loop will iterate
+                // forever.
+                if (c == 0xffff)
+                {
+                    break;
+                }
+            }
+        }
+
+        // Test the Trunc() function.
+        [Fact]
+        public void Trunc()
+        {
+            // Max length of 0.
+            Assert.Equal("", DoTruncate("", 0));
+            Assert.Equal("", DoTruncate(" ", 0));
+            Assert.Equal("", DoTruncate("A", 0));
+            Assert.Equal("", DoTruncate("ABCDE FGHIJ", 0));
+            
+            // Max length of 1.
+            Assert.Equal("", DoTruncate("", 1));
+            Assert.Equal(" ", DoTruncate(" ", 1));
+            Assert.Equal("A", DoTruncate("A", 1));
+            Assert.Equal("A", DoTruncate("ABCDE FGHIJ", 1));
+            
+            // Max length of 5.
+            Assert.Equal("", DoTruncate("", 5));
+            Assert.Equal(" ", DoTruncate(" ", 5));
+            Assert.Equal("A", DoTruncate("A", 5));
+            Assert.Equal("ABCDE", DoTruncate("ABCDE FGHIJ", 5));
+            
+            // Max length of 100.
+            Assert.Equal("", DoTruncate("", 100));
+            Assert.Equal(" ", DoTruncate(" ", 100));
+            Assert.Equal("A", DoTruncate("A", 100));
+            Assert.Equal("ABCDE FGHIJ", DoTruncate("ABCDE FGHIJ", 100));
+        }
+
+        #endregion Tests
+
+        #region Private Helpers
+
+        // ====================================================================
+        // Private Helpers
+        
+        // Convenience helper to call the Build() function.
+        private string DoBuild(
+            ushort maxLen,
+            string driverName,
+            string osType,
+            Architecture arch,
+            string osDesc,
+            string frameworkDesc)
+        {
+            var result =
+                _buildFunction.Invoke(
+                    null,
+                    new object[]
+                    {
+                        maxLen,
+                        driverName,
+                        osType,
+                        arch,
+                        osDesc,
+                        frameworkDesc
+                    }) as string;
+            Assert.NotNull(result);
+            return result;
+        }
+        
+        // Convenience helper to call the Clean() function.
+        private string DoClean(string? value)
+        {
+            var result =
+                _cleanFunction.Invoke(null, new object?[] { value }) as string;
+            Assert.NotNull(result);
+            return result;
+        }
+        
+        // Convenience helper to call the Truncate() function.
+        private string DoTruncate(string value, ushort maxLen)
+        {
+            var result =
+                _truncateFunction.Invoke(
+                    null, new object?[] { value, maxLen }) as string;
+            Assert.NotNull(result);
+            return result;
+        }
+
+        #endregion Private Helpers
+
+        #region Private Fields
+
+        // ====================================================================
+        // Private Fields
+        
+        // The xUnit output helper.
+        private readonly ITestOutputHelper _output;
+        
+        // The ClientInterface.Name property.
+        private readonly PropertyInfo _nameProperty;
+        
+        // The ClientInterface.Build() function.
+        private readonly MethodInfo _buildFunction;
+        
+        // The ClientInterface.Clean() function.
+        private readonly MethodInfo _cleanFunction;
+        
+        // The ClientInterface.Truncate() function.
+        private readonly MethodInfo _truncateFunction;
+
+        #endregion Private Fields
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -101,6 +101,27 @@
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <PackageReference Include="Microsoft.Bcl.Cryptography" Version="$(MicrosoftBclCryptographyVersion)" />
   </ItemGroup>
+  <!-- Avoid vulnerabilities in transitive packages. -->
+  <ItemGroup>
+    <!--
+      System.Net.Http 4.3.0:
+
+      https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+    -->
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
+    <!--
+      System.Text.Json 6.0.0:
+
+      https://github.com/advisories/GHSA-8g4q-xg66-9fp4
+    -->
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+    <!--
+      System.Text.RegularExpressions 4.3.0:
+
+      https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+    -->
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">
     <PackageReference Include="System.Data.Odbc" Version="$(SystemDataOdbcVersion)" />
   </ItemGroup>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.Tests.csproj
@@ -24,6 +24,7 @@
     <Compile Include="AlwaysEncryptedTests\TestFixtures.cs" />
     <Compile Include="AlwaysEncryptedTests\Utility.cs" />
     <Compile Include="AssertExtensions.cs" />
+    <Compile Include="ClientInterfaceTests.cs" />
     <Compile Include="DataCommon\AssemblyResourceManager.cs" />
     <Compile Include="DataCommon\SystemDataResourceManager.cs" />
     <Compile Include="DataCommon\TestUtility.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionBasicTests.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.SqlServer.TDS.PreLogin;
+using Microsoft.SqlServer.TDS.Login7;
 using Microsoft.SqlServer.TDS.Servers;
 using Xunit;
 
@@ -384,6 +384,52 @@ namespace Microsoft.Data.SqlClient.Tests
                 using TestTdsServer server = TestTdsServer.StartTestServer(false, false, -5);
             });
 
+        }
+
+        // Test that we send the expected TDS Client Interface Name value with
+        // the LOGIN7 packet.
+        [Fact]
+        public void ConnectionOpen_ClientInterfaceName()
+        {
+            // Peek into the internal ClientInterface class to get the value
+            // we expect to see in the LOGIN packet.
+            var expected =
+                new Func<string>(() =>
+                {
+                    var clientInterfaceType =
+                        typeof(SqlCommand).Assembly
+                        .GetType("Microsoft.Data.SqlClient.ClientInterface");
+                    Assert.NotNull(clientInterfaceType);
+
+                    var nameProperty =
+                        clientInterfaceType.GetProperty(
+                            "Name",
+                            BindingFlags.Public | BindingFlags.Static);
+                    Assert.NotNull(nameProperty);
+
+                    return nameProperty.GetValue(null) as string;
+                })();
+            
+            // Start the test TDS server.
+            using var server = TestTdsServer.StartTestServer();
+            
+            // Assign a delegate to save the Client Interface Name value from
+            // the LOGIN7 packet.
+            string actual = null;
+            server.OnLogin7Validated =
+                (TDSLogin7Token login) =>
+                {
+                    // The test TDS server uses "LibraryName" for the TDS Client
+                    // Interface Name field.
+                    actual = login.LibraryName;
+                };
+
+            // Connect to the test TDS server.
+            using SqlConnection connection = new(server.ConnectionString);
+            connection.Open();
+
+            // Verify that the expected value was sent in the LOGIN packet.
+            Assert.Equal(expected, actual);
         }
 
         [Fact]

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -359,6 +359,21 @@
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="$(SystemSecurityCryptographyPkcsVersion)" />
     <PackageReference Include="Microsoft.Bcl.Cryptography" Version="$(MicrosoftBclCryptographyVersion)" />
   </ItemGroup>
+  <!-- Avoid vulnerabilities in transitive packages. -->
+  <ItemGroup>
+    <!--
+      System.Net.Http 4.3.0:
+
+      https://github.com/advisories/GHSA-7jgj-8wvc-jh57
+    -->
+    <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
+    <!--
+      System.Text.RegularExpressions 4.3.0:
+
+      https://github.com/advisories/GHSA-cmhx-cq75-c4mj
+    -->
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressionsVersion)" />
+  </ItemGroup>
   <ItemGroup>
     <ContentWithTargetPath Condition="'$(TargetGroup)'=='netfx' AND $(ReferenceType)=='Project'" Include="$(BinFolder)$(Configuration).AnyCPU\Microsoft.Data.SqlClient\netfx\$(TargetFramework)\*SNI*.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTDSServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTDSServer.cs
@@ -28,6 +28,16 @@ namespace Microsoft.SqlServer.TDS.Servers
     public class GenericTDSServer : ITDSServer
     {
         /// <summary>
+        /// Delegate to be called when a LOGIN7 request has been received and is
+        /// validated.  This is called before any authentication work is done,
+        /// and before any response is sent.
+        /// </summary>
+        ///
+        public delegate void OnLogin7ValidatedDelegate(
+            TDSLogin7Token login7Token);
+        public OnLogin7ValidatedDelegate OnLogin7Validated { private get; set; }
+
+        /// <summary>
         /// Session counter
         /// </summary>
         private int _sessionCount = 0;
@@ -247,6 +257,9 @@ namespace Microsoft.SqlServer.TDS.Servers
                     }
                 }
             }
+
+            // Pass the packet to our delegate if we have one.
+            OnLogin7Validated?.Invoke(loginRequest);
 
             // Check if SSPI authentication is requested
             if (loginRequest.OptionalFlags2.IntegratedSecurity == TDSLogin7OptionalFlags2IntSecurity.On)

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -71,7 +71,6 @@
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemServiceProcessServiceControllerVersion>6.0.0</SystemServiceProcessServiceControllerVersion>
     <SystemTextEncodingCodePagesVersion>6.0.0</SystemTextEncodingCodePagesVersion>
-    <SystemTextJsonVersion>6.0.11</SystemTextJsonVersion>
     <SystemTextRegularExpressionsVersion>4.3.1</SystemTextRegularExpressionsVersion>
     <XunitVersion>2.6.3</XunitVersion>
     <XunitrunnervisualstudioVersion>2.5.5</XunitrunnervisualstudioVersion>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -66,10 +66,13 @@
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <SystemDataOdbcVersion>6.0.1</SystemDataOdbcVersion>
+    <SystemNetHttpVersion>4.3.4</SystemNetHttpVersion>
     <SystemRuntimeInteropServicesRuntimeInformationVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationVersion>
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemServiceProcessServiceControllerVersion>6.0.0</SystemServiceProcessServiceControllerVersion>
     <SystemTextEncodingCodePagesVersion>6.0.0</SystemTextEncodingCodePagesVersion>
+    <SystemTextJsonVersion>6.0.11</SystemTextJsonVersion>
+    <SystemTextRegularExpressionsVersion>4.3.1</SystemTextRegularExpressionsVersion>
     <XunitVersion>2.6.3</XunitVersion>
     <XunitrunnervisualstudioVersion>2.5.5</XunitrunnervisualstudioVersion>
   </PropertyGroup>


### PR DESCRIPTION
Port of PR #3149 from main to release/6.0:

- Added ClientInterface class that knows how to build a suitable TDS Login ClientInterfaceName value.
- Added tests for ClientInterface.
- Removed unnecessary SQL_PROVIDER_NAME constant.

Spec is here:   https://microsoft.sharepoint-df.com/:w:/t/sqldevx/EZYUHqdnoXhKoQv0kxcM1QUB2V_uTCWN9GHfrDQY2tojmA?e=tf4xco

Additional changes:
- Upgraded a few test dependencies to avoid vulnerabilities.