### PR TITLE
Add try-catch and ensure task exception is set in SqlCommand

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2445,9 +2445,16 @@ namespace Microsoft.Data.SqlClient
                                 _cachedAsyncState.ResetAsyncState();
                             }
 
-                            _activeConnection.GetOpenTdsConnection().DecrementAsyncCount();
+                            try
+                            {
+                                _activeConnection.GetOpenTdsConnection().DecrementAsyncCount();
 
-                            globalCompletion.TrySetException(e);
+                                globalCompletion.TrySetException(e);
+                            }
+                            catch (Exception e2)
+                            {
+                                globalCompletion.TrySetException(e2);
+                            }
                         }
                         else
                         {
@@ -2464,21 +2471,26 @@ namespace Microsoft.Data.SqlClient
                                     TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart), true /*inRetry*/,
                                     asyncWrite);
 
-                                retryTask.ContinueWith(retryTsk =>
-                                {
-                                    if (retryTsk.IsFaulted)
+                                retryTask.ContinueWith(
+                                    static (Task<object> retryTask, object state) =>
                                     {
-                                        globalCompletion.TrySetException(retryTsk.Exception.InnerException);
-                                    }
-                                    else if (retryTsk.IsCanceled)
-                                    {
-                                        globalCompletion.TrySetCanceled();
-                                    }
-                                    else
-                                    {
-                                        globalCompletion.TrySetResult(retryTsk.Result);
-                                    }
-                                }, TaskScheduler.Default);
+                                        TaskCompletionSource<object> completion = (TaskCompletionSource<object>)state;
+                                        if (retryTask.IsFaulted)
+                                        {
+                                            completion.TrySetException(retryTask.Exception.InnerException);
+                                        }
+                                        else if (retryTask.IsCanceled)
+                                        {
+                                            completion.TrySetCanceled();
+                                        }
+                                        else
+                                        {
+                                            completion.TrySetResult(retryTask.Result);
+                                        }
+                                    }, 
+                                    state: globalCompletion,
+                                    TaskScheduler.Default
+                                );
                             }
                             catch (Exception e2)
                             {


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/3067

Adds a try-catch block around getting a connection which can fail. This change ensures that the task completion source that tasks are waiting on is signalled.

Also found a trivial continue that was capturing the tcs so I changed it to static and passed the tcs as state avoiding the lambda capture.