### PR TITLE
Cleanup | SqlDiagnosticListener Classes

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Data.SqlClient
         private static bool _forceRetryableEnclaveQueryExecutionExceptionDuringGenerateEnclavePackage = false;
 #endif
 
-        private static readonly SqlDiagnosticListener s_diagnosticListener = new SqlDiagnosticListener(SqlDiagnosticListener.DiagnosticListenerName);
+        private static readonly SqlDiagnosticListener s_diagnosticListener = new SqlDiagnosticListener();
         private bool _parentOperationStarted = false;
 
         internal static readonly Action<object> s_cancelIgnoreFailure = CancelIgnoreFailureCallback;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Data.SqlClient
         private SqlRetryLogicBaseProvider _retryLogicProvider;
 
         // diagnostics listener
-        private static readonly SqlDiagnosticListener s_diagnosticListener = new SqlDiagnosticListener(SqlDiagnosticListener.DiagnosticListenerName);
+        private static readonly SqlDiagnosticListener s_diagnosticListener = new SqlDiagnosticListener();
 
         // Transient Fault handling flag. This is needed to convey to the downstream mechanism of connection establishment, if Transient Fault handling should be used or not
         // The downstream handling of Connection open is the same for idle connection resiliency. Currently we want to apply transient fault handling only to the connections opened

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.SqlClient
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlTransaction.xml' path='docs/members[@name="SqlTransaction"]/SqlTransaction/*' />
     public sealed partial class SqlTransaction : DbTransaction
     {
-        private static readonly SqlDiagnosticListener s_diagnosticListener = new(SqlDiagnosticListener.DiagnosticListenerName);
+        private static readonly SqlDiagnosticListener s_diagnosticListener = new();
 
         ////////////////////////////////////////////////////////////////////////////////////////
         // PUBLIC METHODS

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/DiagnosticScope.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/DiagnosticScope.netcore.cs
@@ -9,20 +9,27 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Data.SqlClient.Diagnostics
 {
-    internal ref struct DiagnosticScope //: IDisposable //ref structs cannot implement interfaces but the compiler will use pattern matching
+    internal ref struct DiagnosticScope //: IDisposable
     {
         private const int CommandOperation = 1;
         private const int ConnectionOpenOperation = 2;
 
-        private readonly SqlDiagnosticListener _diagnostics;
-        private readonly int _operation;
-        private readonly string _operationName;
-        private readonly Guid _operationId;
         private readonly object _context1;
         private readonly object _context2;
+        private readonly SqlDiagnosticListener _diagnostics;
+        private readonly int _operation;
+        private readonly Guid _operationId;
+        private readonly string _operationName;
+
         private Exception _exception;
 
-        private DiagnosticScope(SqlDiagnosticListener diagnostics, int operation, Guid operationsId, string operationName, object context1, object context2)
+        private DiagnosticScope(
+            SqlDiagnosticListener diagnostics,
+            int operation,
+            Guid operationsId,
+            string operationName,
+            object context1,
+            object context2)
         {
             _diagnostics = diagnostics;
             _operation = operation;
@@ -33,6 +40,19 @@ namespace Microsoft.Data.SqlClient.Diagnostics
             _exception = null;
         }
 
+        public static DiagnosticScope CreateCommandScope(
+            SqlDiagnosticListener diagnostics,
+            SqlCommand command,
+            SqlTransaction transaction,
+            [CallerMemberName]
+            string operationName = "")
+        {
+            Guid operationId = diagnostics.WriteCommandBefore(command, transaction, operationName);
+            return new DiagnosticScope(diagnostics, CommandOperation, operationId, operationName, command, transaction);
+        }
+
+        // Although ref structs do not allow for inheriting from interfaces (< C#13), but the
+        // compiler will know to treat this like an IDisposable (> C# 8)
         public void Dispose()
         {
             switch (_operation)
@@ -40,38 +60,49 @@ namespace Microsoft.Data.SqlClient.Diagnostics
                 case CommandOperation:
                     if (_exception != null)
                     {
-                        _diagnostics.WriteCommandError(_operationId, (SqlCommand)_context1, (SqlTransaction)_context2, _exception, _operationName);
+                        _diagnostics.WriteCommandError(
+                            _operationId,
+                            (SqlCommand)_context1,
+                            (SqlTransaction)_context2,
+                            _exception,
+                            _operationName);
                     }
                     else
                     {
-                        _diagnostics.WriteCommandAfter(_operationId, (SqlCommand)_context1, (SqlTransaction)_context2, _operationName);
+                        _diagnostics.WriteCommandAfter(
+                            _operationId,
+                            (SqlCommand)_context1,
+                            (SqlTransaction)_context2,
+                            _operationName);
                     }
                     break;
 
                 case ConnectionOpenOperation:
                     if (_exception != null)
                     {
-                        _diagnostics.WriteConnectionOpenError(_operationId, (SqlConnection)_context1, _exception, _operationName);
+                        _diagnostics.WriteConnectionOpenError(
+                            _operationId,
+                            (SqlConnection)_context1,
+                            _exception,
+                            _operationName);
                     }
                     else
                     {
-                        _diagnostics.WriteConnectionOpenAfter(_operationId, (SqlConnection)_context1, _operationName);
+                        _diagnostics.WriteConnectionOpenAfter(
+                            _operationId,
+                            (SqlConnection)_context1,
+                            _operationName);
                     }
                     break;
 
-                    // ConnectionCloseOperation is not implemented because it is conditionally emitted and that requires manual calls to the write apis
+                    // ConnectionCloseOperation is not implemented because it is conditionally
+                    // emitted and that requires manual calls to the write apis
             }
         }
 
         public void SetException(Exception ex)
         {
             _exception = ex;
-        }
-
-        public static DiagnosticScope CreateCommandScope(SqlDiagnosticListener diagnostics, SqlCommand command, SqlTransaction transaction, [CallerMemberName] string operationName = "")
-        {
-            Guid operationId = diagnostics.WriteCommandBefore(command, transaction, operationName);
-            return new DiagnosticScope(diagnostics, CommandOperation, operationId, operationName, command, transaction);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/DiagnosticTransactionScope.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/DiagnosticTransactionScope.netcore.cs
@@ -10,22 +10,31 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.Data.SqlClient.Diagnostics
 {
-    internal ref struct DiagnosticTransactionScope //: IDisposable //ref structs cannot implement interfaces but the compiler will use pattern matching
+    internal ref struct DiagnosticTransactionScope //: IDisposable
     {
         public const int TransactionCommit = 1;
         public const int TransactionRollback = 2;
 
+        private readonly SqlConnection _connection;
         private readonly SqlDiagnosticListener _diagnostics;
         private readonly int _operation;
         private readonly Guid _operationId;
         private readonly string _operationName;
         private readonly IsolationLevel _isolationLevel;
-        private readonly SqlConnection _connection;
         private readonly SqlInternalTransaction _transaction;
         private readonly string _transactionName;
+
         private Exception _exception;
 
-        public DiagnosticTransactionScope(SqlDiagnosticListener diagnostics, int operation, Guid operationId, string operationName, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName)
+        public DiagnosticTransactionScope(
+            SqlDiagnosticListener diagnostics,
+            int operation,
+            Guid operationId,
+            string operationName,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            string transactionName)
         {
             _diagnostics = diagnostics;
             _operation = operation;
@@ -38,6 +47,58 @@ namespace Microsoft.Data.SqlClient.Diagnostics
             _exception = null;
         }
 
+        public static DiagnosticTransactionScope CreateTransactionCommitScope(
+            SqlDiagnosticListener diagnostics,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            [CallerMemberName]
+            string operationName = "")
+        {
+            Guid operationId = diagnostics.WriteTransactionCommitBefore(
+                isolationLevel,
+                connection,
+                transaction,
+                operationName);
+            return new DiagnosticTransactionScope(
+                diagnostics,
+                TransactionCommit,
+                operationId,
+                operationName,
+                isolationLevel,
+                connection,
+                transaction,
+                transactionName: null);
+        }
+
+        public static DiagnosticTransactionScope CreateTransactionRollbackScope(
+            SqlDiagnosticListener diagnostics,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            string transactionName,
+            [CallerMemberName]
+            string operationName = "")
+        {
+            Guid operationId = diagnostics.WriteTransactionRollbackBefore(
+                isolationLevel,
+                connection,
+                transaction,
+                transactionName,
+                operationName);
+            return new DiagnosticTransactionScope(
+                diagnostics,
+                TransactionCommit,
+                operationId,
+                operationName,
+                isolationLevel,
+                connection,
+                transaction,
+                transactionName);
+        }
+
+        // Although ref structs do not allow for inheriting from interfaces (< C#13), but the
+        // compiler will know to treat this like an IDisposable (> C# 8)
         public void Dispose()
         {
             switch (_operation)
@@ -45,22 +106,46 @@ namespace Microsoft.Data.SqlClient.Diagnostics
                 case TransactionCommit:
                     if (_exception != null)
                     {
-                        _diagnostics.WriteTransactionCommitError(_operationId, _isolationLevel, _connection, _transaction, _exception, _operationName);
+                        _diagnostics.WriteTransactionCommitError(
+                            _operationId,
+                            _isolationLevel,
+                            _connection,
+                            _transaction,
+                            _exception,
+                            _operationName);
                     }
                     else
                     {
-                        _diagnostics.WriteTransactionCommitAfter(_operationId, _isolationLevel, _connection, _transaction, _operationName);
+                        _diagnostics.WriteTransactionCommitAfter(
+                            _operationId,
+                            _isolationLevel,
+                            _connection,
+                            _transaction,
+                            _operationName);
                     }
                     break;
 
                 case TransactionRollback:
                     if (_exception != null)
                     {
-                        _diagnostics.WriteTransactionRollbackError(_operationId, _isolationLevel, _connection, _transaction, _exception, _transactionName, _operationName);
+                        _diagnostics.WriteTransactionRollbackError(
+                            _operationId,
+                            _isolationLevel,
+                            _connection,
+                            _transaction,
+                            _exception,
+                            _transactionName,
+                            _operationName);
                     }
                     else
                     {
-                        _diagnostics.WriteTransactionRollbackAfter(_operationId, _isolationLevel, _connection, _transaction, _transactionName, _operationName);
+                        _diagnostics.WriteTransactionRollbackAfter(
+                            _operationId,
+                            _isolationLevel,
+                            _connection,
+                            _transaction,
+                            _transactionName,
+                            _operationName);
                     }
                     break;
             }
@@ -69,18 +154,6 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         public void SetException(Exception ex)
         {
             _exception = ex;
-        }
-
-        public static DiagnosticTransactionScope CreateTransactionCommitScope(SqlDiagnosticListener diagnostics, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operationName = "")
-        {
-            Guid operationId = diagnostics.WriteTransactionCommitBefore(isolationLevel, connection, transaction, operationName);
-            return new DiagnosticTransactionScope(diagnostics, TransactionCommit, operationId, operationName, isolationLevel, connection, transaction, null);
-        }
-
-        public static DiagnosticTransactionScope CreateTransactionRollbackScope(SqlDiagnosticListener diagnostics, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName, [CallerMemberName] string operationName = "")
-        {
-            Guid operationId = diagnostics.WriteTransactionRollbackBefore(isolationLevel, connection, transaction, transactionName, operationName);
-            return new DiagnosticTransactionScope(diagnostics, TransactionCommit, operationId, operationName, isolationLevel, connection, transaction, transactionName);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientCommandAfter.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientCommandAfter.netcore.cs
@@ -16,7 +16,14 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientCommandAfter"]/Name/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteCommandAfter";
 
-        internal SqlClientCommandAfter(Guid operationId, string operation, long timestamp, Guid? connectionId, long? transactionId, SqlCommand command, IDictionary statistics)
+        internal SqlClientCommandAfter(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            Guid? connectionId,
+            long? transactionId,
+            SqlCommand command,
+            IDictionary statistics)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientCommandBefore.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientCommandBefore.netcore.cs
@@ -16,7 +16,13 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientCommandBefore"]/SqlClientCommandBefore/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteCommandBefore";
 
-        internal SqlClientCommandBefore(Guid operationId, string operation, long timestamp, Guid? connectionId, long? transactionId, SqlCommand command)
+        internal SqlClientCommandBefore(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            Guid? connectionId,
+            long? transactionId,
+            SqlCommand command)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientCommandError.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientCommandError.netcore.cs
@@ -17,7 +17,14 @@ namespace Microsoft.Data.SqlClient.Diagnostics
 
         public const string Name = "Microsoft.Data.SqlClient.WriteCommandError";
 
-        internal SqlClientCommandError(Guid operationId, string operation, long timestamp, Guid? connectionId, long? transactionId, SqlCommand command, Exception exception)
+        internal SqlClientCommandError(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            Guid? connectionId,
+            long? transactionId,
+            SqlCommand command,
+            Exception exception)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionCloseAfter.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionCloseAfter.netcore.cs
@@ -16,7 +16,13 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientConnectionCloseAfter"]/Name/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteConnectionCloseAfter";
 
-        internal SqlClientConnectionCloseAfter(Guid operationId, string operation, long timestamp, Guid? connectionId, SqlConnection connection, IDictionary statistics)
+        internal SqlClientConnectionCloseAfter(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            Guid? connectionId,
+            SqlConnection connection,
+            IDictionary statistics)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionCloseBefore.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionCloseBefore.netcore.cs
@@ -16,7 +16,13 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientConnectionCloseBefore"]//*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteConnectionCloseBefore";
 
-        internal SqlClientConnectionCloseBefore(Guid operationId, string operation, long timestamp, Guid? connectionId, SqlConnection connection, IDictionary statistics)
+        internal SqlClientConnectionCloseBefore(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            Guid? connectionId,
+            SqlConnection connection,
+            IDictionary statistics)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionCloseError.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionCloseError.netcore.cs
@@ -16,7 +16,14 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientConnectionCloseError"]/Name/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteConnectionCloseError";
 
-        internal SqlClientConnectionCloseError(Guid operationId, string operation, long timestamp, Guid? connectionId, SqlConnection connection, IDictionary statistics, Exception ex)
+        internal SqlClientConnectionCloseError(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            Guid? connectionId,
+            SqlConnection connection,
+            IDictionary statistics,
+            Exception ex)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionOpenAfter.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionOpenAfter.netcore.cs
@@ -16,7 +16,14 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientConnectionOpenAfter"]/Name/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteConnectionOpenAfter";
 
-        internal SqlClientConnectionOpenAfter(Guid operationId, string operation, long timestamp, Guid connectionId, SqlConnection connection, string clientVersion, IDictionary statistics)
+        internal SqlClientConnectionOpenAfter(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            Guid connectionId,
+            SqlConnection connection,
+            string clientVersion,
+            IDictionary statistics)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionOpenBefore.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionOpenBefore.netcore.cs
@@ -16,7 +16,12 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientConnectionOpenBefore"]/Name/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteConnectionOpenBefore";
 
-        internal SqlClientConnectionOpenBefore(Guid operationId, string operation, long timestamp, SqlConnection connection, string clientVersion)
+        internal SqlClientConnectionOpenBefore(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            SqlConnection connection,
+            string clientVersion)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionOpenError.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientConnectionOpenError.netcore.cs
@@ -17,7 +17,14 @@ namespace Microsoft.Data.SqlClient.Diagnostics
 
         public const string Name = "Microsoft.Data.SqlClient.WriteConnectionOpenError";
 
-        internal SqlClientConnectionOpenError(Guid operationId, string operation, long timestamp, Guid connectionId, SqlConnection connection, string clientVersion, Exception exception)
+        internal SqlClientConnectionOpenError(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            Guid connectionId,
+            SqlConnection connection,
+            string clientVersion,
+            Exception exception)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionCommitAfter.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionCommitAfter.netcore.cs
@@ -17,7 +17,13 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientTransactionCommitAfter"]/Name/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteTransactionCommitAfter";
 
-        internal SqlClientTransactionCommitAfter(Guid operationId, string operation, long timestamp, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId)
+        internal SqlClientTransactionCommitAfter(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            long? transactionId)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionCommitBefore.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionCommitBefore.netcore.cs
@@ -17,7 +17,13 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientTransactionCommitBefore"]/Name/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteTransactionCommitBefore";
 
-        internal SqlClientTransactionCommitBefore(Guid operationId, string operation, long timestamp, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId)
+        internal SqlClientTransactionCommitBefore(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            long? transactionId)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionCommitError.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionCommitError.netcore.cs
@@ -17,7 +17,14 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientTransactionCommitError"]/Name/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteTransactionCommitError";
 
-        internal SqlClientTransactionCommitError(Guid operationId, string operation, long timestamp, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, Exception ex)
+        internal SqlClientTransactionCommitError(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            long? transactionId,
+            Exception ex)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionRollbackAfter.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionRollbackAfter.netcore.cs
@@ -17,7 +17,14 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientTransactionRollbackAfter"]/Name/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteTransactionRollbackAfter";
 
-        internal SqlClientTransactionRollbackAfter(Guid operationId, string operation, long timestamp, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, string transactionName)
+        internal SqlClientTransactionRollbackAfter(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            long? transactionId,
+            string transactionName)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionRollbackBefore.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionRollbackBefore.netcore.cs
@@ -17,7 +17,14 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientTransactionRollbackBefore"]/SqlClientTransactionRollbackBefore/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteTransactionRollbackBefore";
 
-        internal SqlClientTransactionRollbackBefore(Guid operationId, string operation, long timestamp, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, string transactionName)
+        internal SqlClientTransactionRollbackBefore(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            long? transactionId,
+            string transactionName)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionRollbackError.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientTransactionRollbackError.netcore.cs
@@ -17,7 +17,15 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientDiagnostic.xml' path='docs/members[@name="SqlClientTransactionRollbackError"]/Name/*'/>
         public const string Name = "Microsoft.Data.SqlClient.WriteTransactionRollbackError";
 
-        internal SqlClientTransactionRollbackError(Guid operationId, string operation, long timestamp, IsolationLevel isolationLevel, SqlConnection connection, long? transactionId, string transactionName, Exception ex)
+        internal SqlClientTransactionRollbackError(
+            Guid operationId,
+            string operation,
+            long timestamp,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            long? transactionId,
+            string transactionName,
+            Exception ex)
         {
             OperationId = operationId;
             Operation = operation;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlDiagnosticListener.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlDiagnosticListener.netcore.cs
@@ -10,362 +10,471 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
-using Microsoft.Data.SqlClient.Diagnostics;
 
 namespace Microsoft.Data.SqlClient.Diagnostics
 {
     internal sealed class SqlDiagnosticListener : DiagnosticListener
     {
-        public const string DiagnosticListenerName = "SqlClientDiagnosticListener";
-
-        public SqlDiagnosticListener(string name) : base(name)
+        public SqlDiagnosticListener() : base("SqlClientDiagnosticListener")
         {
             AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()).Unloading += SqlDiagnosticListener_Unloading;
         }
 
-        public DiagnosticScope CreateCommandScope(SqlCommand command, SqlTransaction transaction, [CallerMemberName] string operationName = "")
+        public DiagnosticScope CreateCommandScope(
+            SqlCommand command,
+            SqlTransaction transaction,
+            [CallerMemberName]
+            string operationName = "")
         {
             return DiagnosticScope.CreateCommandScope(this, command, transaction, operationName);
         }
 
-        public DiagnosticTransactionScope CreateTransactionCommitScope(IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operationName = "")
+        public DiagnosticTransactionScope CreateTransactionCommitScope(
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            [CallerMemberName]
+            string operationName = "")
         {
-            return DiagnosticTransactionScope.CreateTransactionCommitScope(this, isolationLevel, connection, transaction, operationName);
+            return DiagnosticTransactionScope.CreateTransactionCommitScope(
+                this,
+                isolationLevel,
+                connection,
+                transaction,
+                operationName);
         }
 
-        public DiagnosticTransactionScope CreateTransactionRollbackScope(IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName, [CallerMemberName] string operationName = "")
+        public DiagnosticTransactionScope CreateTransactionRollbackScope(
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            string transactionName,
+            [CallerMemberName]
+            string operationName = "")
         {
-            return DiagnosticTransactionScope.CreateTransactionRollbackScope(this, isolationLevel, connection, transaction, transactionName, operationName);
+            return DiagnosticTransactionScope.CreateTransactionRollbackScope(
+                this,
+                isolationLevel,
+                connection,
+                transaction,
+                transactionName,
+                operationName);
         }
 
-        public void WriteCommandAfter(Guid operationId, SqlCommand sqlCommand, SqlTransaction transaction, [CallerMemberName] string operation = "")
+        public void WriteCommandAfter(
+            Guid operationId,
+            SqlCommand sqlCommand,
+            SqlTransaction transaction,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientCommandAfter.Name))
+            if (!IsEnabled(SqlClientCommandAfter.Name))
             {
-                Write(
-                    SqlClientCommandAfter.Name,
-                    new SqlClientCommandAfter(
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        sqlCommand.Connection?.ClientConnectionId,
-                        transaction?.InternalTransaction?.TransactionId,
-                        sqlCommand,
-                        sqlCommand.Statistics?.GetDictionary()
-                    )
-                );
+                return;
             }
+
+            Write(
+                SqlClientCommandAfter.Name,
+                new SqlClientCommandAfter(
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    sqlCommand.Connection?.ClientConnectionId,
+                    transaction?.InternalTransaction?.TransactionId,
+                    sqlCommand,
+                    sqlCommand.Statistics?.GetDictionary()
+                )
+            );
         }
 
-        public Guid WriteCommandBefore(SqlCommand sqlCommand, SqlTransaction transaction, [CallerMemberName] string operation = "")
+        public Guid WriteCommandBefore(
+            SqlCommand sqlCommand,
+            SqlTransaction transaction,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientCommandBefore.Name))
-            {
-                Guid operationId = Guid.NewGuid();
-
-                Write(
-                    SqlClientCommandBefore.Name,
-                    new SqlClientCommandBefore(
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        sqlCommand.Connection?.ClientConnectionId,
-                        transaction?.InternalTransaction?.TransactionId,
-                        sqlCommand
-                    )
-                );
-
-                return operationId;
-            }
-            else
+            if (!IsEnabled(SqlClientCommandBefore.Name))
             {
                 return Guid.Empty;
             }
+
+            Guid operationId = Guid.NewGuid();
+
+            Write(
+                SqlClientCommandBefore.Name,
+                new SqlClientCommandBefore(
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    sqlCommand.Connection?.ClientConnectionId,
+                    transaction?.InternalTransaction?.TransactionId,
+                    sqlCommand
+                )
+            );
+
+            return operationId;
         }
 
-        public void WriteCommandError(Guid operationId, SqlCommand sqlCommand, SqlTransaction transaction, Exception ex, [CallerMemberName] string operation = "")
+        public void WriteCommandError(
+            Guid operationId,
+            SqlCommand sqlCommand,
+            SqlTransaction transaction,
+            Exception ex,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientCommandError.Name))
+            if (!IsEnabled(SqlClientCommandError.Name))
             {
-                Write(
-                    SqlClientCommandError.Name,
-                    new SqlClientCommandError
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        sqlCommand.Connection?.ClientConnectionId,
-                        transaction?.InternalTransaction?.TransactionId,
-                        sqlCommand,
-                        ex
-                    )
-                );
+                return;
             }
+
+            Write(
+                SqlClientCommandError.Name,
+                new SqlClientCommandError
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    sqlCommand.Connection?.ClientConnectionId,
+                    transaction?.InternalTransaction?.TransactionId,
+                    sqlCommand,
+                    ex
+                )
+            );
         }
 
-        public void WriteConnectionCloseAfter(Guid operationId, Guid clientConnectionId, SqlConnection sqlConnection, [CallerMemberName] string operation = "")
+        public void WriteConnectionCloseAfter(
+            Guid operationId,
+            Guid clientConnectionId,
+            SqlConnection sqlConnection,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientConnectionCloseAfter.Name))
+            if (!IsEnabled(SqlClientConnectionCloseAfter.Name))
             {
-                Write(
-                    SqlClientConnectionCloseAfter.Name,
-                    new SqlClientConnectionCloseAfter
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        clientConnectionId,
-                        sqlConnection,
-                        sqlConnection.Statistics?.GetDictionary()
-                    )
-                );
+                return;
             }
+
+            Write(
+                SqlClientConnectionCloseAfter.Name,
+                new SqlClientConnectionCloseAfter
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    clientConnectionId,
+                    sqlConnection,
+                    sqlConnection.Statistics?.GetDictionary()
+                )
+            );
         }
 
         public Guid WriteConnectionCloseBefore(SqlConnection sqlConnection, [CallerMemberName] string operation = "")
         {
-            if (IsEnabled(SqlClientConnectionCloseBefore.Name))
+            if (!IsEnabled(SqlClientConnectionCloseBefore.Name))
             {
-                Guid operationId = Guid.NewGuid();
-
-                Write(
-                    SqlClientConnectionCloseBefore.Name,
-                    new SqlClientConnectionCloseBefore
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        sqlConnection.ClientConnectionId,
-                        sqlConnection,
-                        sqlConnection.Statistics?.GetDictionary()
-                    )
-                );
-
-                return operationId;
-            }
-            else
                 return Guid.Empty;
+            }
+
+            Guid operationId = Guid.NewGuid();
+
+            Write(
+                SqlClientConnectionCloseBefore.Name,
+                new SqlClientConnectionCloseBefore
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    sqlConnection.ClientConnectionId,
+                    sqlConnection,
+                    sqlConnection.Statistics?.GetDictionary()
+                )
+            );
+
+            return operationId;
         }
 
-        public void WriteConnectionCloseError(Guid operationId, Guid clientConnectionId, SqlConnection sqlConnection, Exception ex, [CallerMemberName] string operation = "")
+        public void WriteConnectionCloseError(
+            Guid operationId,
+            Guid clientConnectionId,
+            SqlConnection sqlConnection,
+            Exception ex,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientConnectionCloseError.Name))
+            if (!IsEnabled(SqlClientConnectionCloseError.Name))
             {
-                Write(
-                    SqlClientConnectionCloseError.Name,
-                    new SqlClientConnectionCloseError
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        clientConnectionId,
-                        sqlConnection,
-                        sqlConnection.Statistics?.GetDictionary(),
-                        ex
-                    )
-                );
+                return;
             }
+
+            Write(
+                SqlClientConnectionCloseError.Name,
+                new SqlClientConnectionCloseError
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    clientConnectionId,
+                    sqlConnection,
+                    sqlConnection.Statistics?.GetDictionary(),
+                    ex
+                )
+            );
         }
 
-        public void WriteConnectionOpenAfter(Guid operationId, SqlConnection sqlConnection, [CallerMemberName] string operation = "")
+        public void WriteConnectionOpenAfter(
+            Guid operationId,
+            SqlConnection sqlConnection,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientConnectionOpenAfter.Name))
+            if (!IsEnabled(SqlClientConnectionOpenAfter.Name))
             {
-                Write(
-                    SqlClientConnectionOpenAfter.Name,
-                    new SqlClientConnectionOpenAfter
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        sqlConnection.ClientConnectionId,
-                        sqlConnection,
-                        ThisAssembly.InformationalVersion,
-                        sqlConnection.Statistics?.GetDictionary()
-                    )
-                );
+                return;
             }
+
+            Write(
+                SqlClientConnectionOpenAfter.Name,
+                new SqlClientConnectionOpenAfter
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    sqlConnection.ClientConnectionId,
+                    sqlConnection,
+                    ThisAssembly.InformationalVersion,
+                    sqlConnection.Statistics?.GetDictionary()
+                )
+            );
         }
 
         public Guid WriteConnectionOpenBefore(SqlConnection sqlConnection, [CallerMemberName] string operation = "")
         {
-            if (IsEnabled(SqlClientConnectionOpenBefore.Name))
-            {
-                Guid operationId = Guid.NewGuid();
-
-                Write(
-                    SqlClientConnectionOpenBefore.Name,
-                    new SqlClientConnectionOpenBefore
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        sqlConnection,
-                        ThisAssembly.InformationalVersion
-                    )
-                );
-
-                return operationId;
-            }
-            else
+            if (!IsEnabled(SqlClientConnectionOpenBefore.Name))
             {
                 return Guid.Empty;
             }
+
+            Guid operationId = Guid.NewGuid();
+
+            Write(
+                SqlClientConnectionOpenBefore.Name,
+                new SqlClientConnectionOpenBefore
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    sqlConnection,
+                    ThisAssembly.InformationalVersion
+                )
+            );
+
+            return operationId;
         }
 
-        public void WriteConnectionOpenError(Guid operationId, SqlConnection sqlConnection, Exception ex, [CallerMemberName] string operation = "")
+        public void WriteConnectionOpenError(
+            Guid operationId,
+            SqlConnection sqlConnection,
+            Exception ex,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientConnectionOpenError.Name))
+            if (!IsEnabled(SqlClientConnectionOpenError.Name))
             {
-                Write(
-                    SqlClientConnectionOpenError.Name,
-                    new SqlClientConnectionOpenError
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        sqlConnection.ClientConnectionId,
-                        sqlConnection,
-                        ThisAssembly.InformationalVersion,
-                        ex
-                    )
-                );
+                return;
             }
+
+            Write(
+                SqlClientConnectionOpenError.Name,
+                new SqlClientConnectionOpenError
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    sqlConnection.ClientConnectionId,
+                    sqlConnection,
+                    ThisAssembly.InformationalVersion,
+                    ex
+                )
+            );
         }
 
-        public void WriteTransactionCommitAfter(Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operation = "")
+        public void WriteTransactionCommitAfter(
+            Guid operationId,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientTransactionCommitAfter.Name))
+            if (!IsEnabled(SqlClientTransactionCommitAfter.Name))
             {
-                Write(
-                    SqlClientTransactionCommitAfter.Name,
-                    new SqlClientTransactionCommitAfter
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        isolationLevel,
-                        connection,
-                        transaction?.TransactionId
-                    )
-                );
+                return;
             }
+
+            Write(
+                SqlClientTransactionCommitAfter.Name,
+                new SqlClientTransactionCommitAfter
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    isolationLevel,
+                    connection,
+                    transaction?.TransactionId
+                )
+            );
         }
 
-        public Guid WriteTransactionCommitBefore(IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, [CallerMemberName] string operation = "")
+        public Guid WriteTransactionCommitBefore(
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientTransactionCommitBefore.Name))
-            {
-                Guid operationId = Guid.NewGuid();
-
-                Write(
-                    SqlClientTransactionCommitBefore.Name,
-                    new SqlClientTransactionCommitBefore
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        isolationLevel,
-                        connection,
-                        transaction?.TransactionId
-                    )
-                );
-
-                return operationId;
-            }
-            else
+            if (!IsEnabled(SqlClientTransactionCommitBefore.Name))
             {
                 return Guid.Empty;
             }
+
+            Guid operationId = Guid.NewGuid();
+
+            Write(
+                SqlClientTransactionCommitBefore.Name,
+                new SqlClientTransactionCommitBefore
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    isolationLevel,
+                    connection,
+                    transaction?.TransactionId
+                )
+            );
+
+            return operationId;
         }
 
-        public void WriteTransactionCommitError(Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, Exception ex, [CallerMemberName] string operation = "")
+        public void WriteTransactionCommitError(
+            Guid operationId,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            Exception ex,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientTransactionCommitError.Name))
+            if (!IsEnabled(SqlClientTransactionCommitError.Name))
             {
-                Write(
-                    SqlClientTransactionCommitError.Name,
-                    new SqlClientTransactionCommitError
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        isolationLevel,
-                        connection,
-                        transaction?.TransactionId,
-                        ex
-                    )
-                );
+                return;
             }
+
+            Write(
+                SqlClientTransactionCommitError.Name,
+                new SqlClientTransactionCommitError
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    isolationLevel,
+                    connection,
+                    transaction?.TransactionId,
+                    ex
+                )
+            );
         }
 
-        public void WriteTransactionRollbackAfter(Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName = null, [CallerMemberName] string operation = "")
+        public void WriteTransactionRollbackAfter(
+            Guid operationId,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            string transactionName = null,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientTransactionRollbackAfter.Name))
+            if (!IsEnabled(SqlClientTransactionRollbackAfter.Name))
             {
-                Write(
-                    SqlClientTransactionRollbackAfter.Name,
-                    new SqlClientTransactionRollbackAfter
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        isolationLevel,
-                        connection,
-                        transaction?.TransactionId,
-                        transactionName
-                    )
-                );
+                return;
             }
+
+            Write(
+                SqlClientTransactionRollbackAfter.Name,
+                new SqlClientTransactionRollbackAfter
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    isolationLevel,
+                    connection,
+                    transaction?.TransactionId,
+                    transactionName
+                )
+            );
         }
 
-        public Guid WriteTransactionRollbackBefore(IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, string transactionName = null, [CallerMemberName] string operation = "")
+        public Guid WriteTransactionRollbackBefore(
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            string transactionName = null,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientTransactionRollbackBefore.Name))
-            {
-                Guid operationId = Guid.NewGuid();
-
-                Write(
-                    SqlClientTransactionRollbackBefore.Name,
-                    new SqlClientTransactionRollbackBefore
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        isolationLevel,
-                        connection,
-                        transaction?.TransactionId,
-                        transactionName
-                    )
-                );
-
-                return operationId;
-            }
-            else
+            if (!IsEnabled(SqlClientTransactionRollbackBefore.Name))
             {
                 return Guid.Empty;
             }
+
+            Guid operationId = Guid.NewGuid();
+
+            Write(
+                SqlClientTransactionRollbackBefore.Name,
+                new SqlClientTransactionRollbackBefore
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    isolationLevel,
+                    connection,
+                    transaction?.TransactionId,
+                    transactionName
+                )
+            );
+
+            return operationId;
         }
 
-        public void WriteTransactionRollbackError(Guid operationId, IsolationLevel isolationLevel, SqlConnection connection, SqlInternalTransaction transaction, Exception ex, string transactionName = null, [CallerMemberName] string operation = "")
+        public void WriteTransactionRollbackError(
+            Guid operationId,
+            IsolationLevel isolationLevel,
+            SqlConnection connection,
+            SqlInternalTransaction transaction,
+            Exception ex,
+            string transactionName = null,
+            [CallerMemberName]
+            string operation = "")
         {
-            if (IsEnabled(SqlClientTransactionRollbackError.Name))
+            if (!IsEnabled(SqlClientTransactionRollbackError.Name))
             {
-                Write(
-                    SqlClientTransactionRollbackError.Name,
-                    new SqlClientTransactionRollbackError
-                    (
-                        operationId,
-                        operation,
-                        Stopwatch.GetTimestamp(),
-                        isolationLevel,
-                        connection,
-                        transaction?.TransactionId,
-                        transactionName,
-                        ex
-                    )
-                );
+                return;
             }
+
+            Write(
+                SqlClientTransactionRollbackError.Name,
+                new SqlClientTransactionRollbackError
+                (
+                    operationId,
+                    operation,
+                    Stopwatch.GetTimestamp(),
+                    isolationLevel,
+                    connection,
+                    transaction?.TransactionId,
+                    transactionName,
+                    ex
+                )
+            );
         }
 
         private void SqlDiagnosticListener_Unloading(AssemblyLoadContext obj)


### PR DESCRIPTION
**Description**: Based on the reception of my last cleanup PR, i don't know how this one will be received. This PR just tidies up the SqlDiagnosticListener classes after they were merged. 

* Removing Name - although a name is required to be passed to the DiagnosticListener class on construction, we only ever use the same one, and the class is internal. Thus, it doesn't make a ton of sense to me to expose the name within the project. So, I removed it from the constructor and just pass in the hardcoded name we use. If we end up having multiple names later, we can reinstate this.
* The rest of the changes are just breaking up long lines and some light reordering of member variables.

**Testing**: Once more, no real functional behavior change. Just a bit of tweaks to syntax and a change that doesn't impact anything external (the name thing).