### PR TITLE
Test | Expose internal types to ManualTests

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -33,6 +33,9 @@
     <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFramework)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="ManualTests" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)" />
     <EmbeddedFiles Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
   </ItemGroup>  

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="ManualTests" />
+    <InternalsVisibleTo Include="FunctionalTests" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)" />

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -34,7 +34,6 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="ManualTests" />
-    <InternalsVisibleTo Include="FunctionalTests" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)" />

--- a/src/Microsoft.Data.SqlClient/netfx/src/AssemblyInfo.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ManualTests")]

--- a/src/Microsoft.Data.SqlClient/netfx/src/AssemblyInfo.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/AssemblyInfo.cs
@@ -1,4 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ManualTests")]
-[assembly: InternalsVisibleTo("FunctionalTests")]

--- a/src/Microsoft.Data.SqlClient/netfx/src/AssemblyInfo.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("ManualTests")]
+[assembly: InternalsVisibleTo("FunctionalTests")]

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -856,9 +856,9 @@
     <Compile Include="$(CommonSourceRoot)System\IO\StreamExtensions.netfx.cs">
       <Link>System\IO\StreamExtensions.netfx.cs</Link>
     </Compile>
-    <Compile Include="AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Common\Microsoft\Data\Common\NameValuePermission.cs" />
     <Compile Include="Microsoft\Data\Common\DbConnectionOptions.cs" />
     <Compile Include="Microsoft\Data\Common\DbConnectionString.cs" />

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -856,6 +856,7 @@
     <Compile Include="$(CommonSourceRoot)System\IO\StreamExtensions.netfx.cs">
       <Link>System\IO\StreamExtensions.netfx.cs</Link>
     </Compile>
+    <Compile Include="AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\Microsoft\Data\Common\NameValuePermission.cs" />


### PR DESCRIPTION
Internal types are not accessible outside of their home project. However, they still need to be tested. This PR exposes internal types to the `ManualTests` and `FunctionalTests` projects so that they can be used directly instead of via reflection.

This PR does not update any tests that currently use reflection. Those can be addressed separately as tests are updated or as code health PRs.