### PR TITLE
Improve <LangVersion> selection

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
+    <!--
+      For .NET Framework, we explicitly set the C# language version to 13.  This
+      matches the language version used by the .NET 9 SDK, and provides helpful
+      modern language features.  While this isn't strictly supported by .NET in
+      general, it works well in practice.  There are very few C# language
+      features that depend on SDK APIs, and we avoid them.
+
+      For .NET, we omit this property entirely, which results in the SDK
+      choosing the C# language version that matches the Target Framework.
+
+      Details here:
+
+      https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-versioning
+
+      https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version
+    -->
+    <LangVersion
+      Condition="'$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' == '.NETFramework'">
+      13.0
+    </LangVersion>
+    
     <TargetsWindows Condition="'$(OS)' == 'Windows_NT' AND '$(OSGroup)' == ''">true</TargetsWindows>
     <TargetsWindows Condition="'$(OS)' != 'Windows_NT' AND '$(OSGroup)' == ''">false</TargetsWindows>
     <TargetsWindows Condition="'$(OSGroup)' == 'Windows_NT'">true</TargetsWindows>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,27 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <!--
-      For .NET Framework, we explicitly set the C# language version to 13.  This
-      matches the language version used by the .NET 9 SDK, and provides helpful
-      modern language features.  While this isn't strictly supported by .NET in
-      general, it works well in practice.  There are very few C# language
-      features that depend on SDK APIs, and we avoid them.
-
-      For .NET, we omit this property entirely, which results in the SDK
-      choosing the C# language version that matches the Target Framework.
-
-      Details here:
-
-      https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-versioning
-
-      https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version
-    -->
-    <LangVersion
-      Condition="'$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' == '.NETFramework'">
-      13.0
-    </LangVersion>
-    
     <TargetsWindows Condition="'$(OS)' == 'Windows_NT' AND '$(OSGroup)' == ''">true</TargetsWindows>
     <TargetsWindows Condition="'$(OS)' != 'Windows_NT' AND '$(OSGroup)' == ''">false</TargetsWindows>
     <TargetsWindows Condition="'$(OSGroup)' == 'Windows_NT'">true</TargetsWindows>
@@ -130,5 +109,26 @@
   <!-- Fix GetTargetPath issues - see https://github.com/dotnet/msbuild/issues/4303#issuecomment-482345617 -->
   <PropertyGroup>
     <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
+  </PropertyGroup>
+
+  <!--
+    For non-.NET, we explicitly set the C# language version to 13.  This matches
+    the language version used by the .NET 9 SDK, and provides helpful modern
+    language features.  While this isn't strictly supported by .NET in general,
+    it works well in practice.  There are very few C# language features that
+    depend on SDK APIs, and we avoid them.
+
+    For .NET, we omit this property entirely, which results in the SDK choosing
+    the C# language version that matches the .NET version.
+
+    Details here:
+
+    https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-versioning
+
+    https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version
+  -->
+  <PropertyGroup
+    Condition="'$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' != '.NETCoreApp'">
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Improved the C# language version selection:
- For .NET, let the SDK choose the best language version.
- For everything else (Framework, Standard), explicitly choose C# 13.

I used the `#error version` preprocessor directive to validate that the expected C# version was being used for the MDS projects and the test projects.