### PR TITLE
Merge | SessionHandle.*.cs

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -851,6 +851,9 @@
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\PacketHandle.netcore.Windows.cs">
       <Link>Microsoft\Data\SqlClient\PacketHandle.netcore.Windows.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\SessionHandle.netcore.Windows.cs">
+      <Link>Microsoft\Data\SqlClient\SessionHandle.netcore.Windows.cs</Link>
+    </Compile>
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\SqlColumnEncryptionCngProvider.Windows.cs">
       <Link>Microsoft\Data\SqlClient\SqlColumnEncryptionCngProvider.Windows.cs</Link>
     </Compile>
@@ -870,7 +873,6 @@
       <Link>Microsoft\Data\SqlTypes\SqlFileStream.Windows.cs</Link>
     </Compile>
     
-    <Compile Include="Microsoft\Data\SqlClient\SessionHandle.Windows.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\LocalDB.Windows.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParser.Windows.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParserStateObjectNative.cs" />
@@ -891,9 +893,11 @@
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\PacketHandle.netcore.Unix.cs">
       <Link>Microsoft\Data\SqlClient\PacketHandle.netcore.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\SessionHandle.netcore.Unix.cs">
+      <Link>Microsoft\Data\SqlClient\SessionHandle.netcore.Unix.cs</Link>
+    </Compile>
 
     <Compile Include="Microsoft\Data\Sql\SqlDataSourceEnumerator.Unix.cs" />
-    <Compile Include="Microsoft\Data\SqlClient\SessionHandle.Unix.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\LocalDB.Unix.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlColumnEncryptionCertificateStoreProvider.Unix.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlColumnEncryptionCngProvider.Unix.cs" />

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SessionHandle.netcore.Unix.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SessionHandle.netcore.Unix.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NET
+
 namespace Microsoft.Data.SqlClient
 {
     // this structure is used for transporting packet handle references between the TdsParserStateObject
@@ -18,21 +20,18 @@ namespace Microsoft.Data.SqlClient
         public const int ManagedHandleType = 2;
 
         public readonly SNI.SNIHandle ManagedHandle;
-        public readonly SNIHandle NativeHandle;
-
         public readonly int Type;
 
-        public SessionHandle(SNI.SNIHandle managedHandle, SNIHandle nativeHandle, int type)
+        public SessionHandle(SNI.SNIHandle managedHandle, int type)
         {
             Type = type;
             ManagedHandle = managedHandle;
-            NativeHandle = nativeHandle;
         }
 
-        public bool IsNull => (Type == NativeHandleType) ? NativeHandle is null : ManagedHandle is null;
+        public bool IsNull => ManagedHandle is null;
 
-        public static SessionHandle FromManagedSession(SNI.SNIHandle managedSessionHandle) => new SessionHandle(managedSessionHandle, default, ManagedHandleType);
-
-        public static SessionHandle FromNativeHandle(SNIHandle nativeSessionHandle) => new SessionHandle(default, nativeSessionHandle, NativeHandleType);
+        public static SessionHandle FromManagedSession(SNI.SNIHandle managedSessionHandle) => new SessionHandle(managedSessionHandle, ManagedHandleType);
     }
 }
+
+#endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SessionHandle.netcore.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SessionHandle.netcore.Windows.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NET
+
 namespace Microsoft.Data.SqlClient
 {
     // this structure is used for transporting packet handle references between the TdsParserStateObject
@@ -18,16 +20,23 @@ namespace Microsoft.Data.SqlClient
         public const int ManagedHandleType = 2;
 
         public readonly SNI.SNIHandle ManagedHandle;
+        public readonly SNIHandle NativeHandle;
+
         public readonly int Type;
 
-        public SessionHandle(SNI.SNIHandle managedHandle, int type)
+        public SessionHandle(SNI.SNIHandle managedHandle, SNIHandle nativeHandle, int type)
         {
             Type = type;
             ManagedHandle = managedHandle;
+            NativeHandle = nativeHandle;
         }
 
-        public bool IsNull => ManagedHandle is null;
+        public bool IsNull => (Type == NativeHandleType) ? NativeHandle is null : ManagedHandle is null;
 
-        public static SessionHandle FromManagedSession(SNI.SNIHandle managedSessionHandle) => new SessionHandle(managedSessionHandle, ManagedHandleType);
+        public static SessionHandle FromManagedSession(SNI.SNIHandle managedSessionHandle) => new SessionHandle(managedSessionHandle, default, ManagedHandleType);
+
+        public static SessionHandle FromNativeHandle(SNIHandle nativeSessionHandle) => new SessionHandle(default, nativeSessionHandle, NativeHandleType);
     }
 }
+
+#endif


### PR DESCRIPTION
**Description**: Super duper easy, moving the SessionHandle class implementations from the netcore project to the common project. Classes are now wrapped with #if NET

There's a very small difference between the two files, but as it stands today we don't have the right solution for #if defining the OS. This will be addressed later, once all classes have been merged.

**Testing**: Literally no functional changes. Tests should breeze through unless I goofed on building for Unix.