### PR TITLE
Fix crash when Data Source starts with a comma

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -792,8 +792,19 @@ namespace Microsoft.Data.Common
                 length = foundIndex;
             }
 
-            // check for the instance name
-            foundIndex = dataSource.LastIndexOf('\\', length - 1, length - 1);
+            // Safeguard LastIndexOf call to avoid ArgumentOutOfRangeException when length is 0
+            if (length > 0)
+            {
+                // check for the instance name
+                foundIndex = dataSource.LastIndexOf('\\', length - 1, length - 1);
+            }
+            else
+            {
+                foundIndex = -1;
+            }
+
+
+  
             if (foundIndex > 0)
             {
                 length = foundIndex;

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -1082,6 +1082,18 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal(1, (int)field.GetValue(cn));
         }
 
+
+
+        [Fact]
+        public void ConnectionString_WithOnlyComma_ShouldNotThrow()
+        {
+            SqlConnection cn = new SqlConnection("Data Source=,;Initial Catalog=master;Integrated Security=True");
+            Exception ex = Record.Exception(() => cn.Open());
+
+            Assert.NotNull(ex);
+            Assert.False(ex is ArgumentOutOfRangeException);
+        }
+
         [Theory]
         [InlineData("myserver.database.windows.net")]
         [InlineData("myserver.database.cloudapi.de")]

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionTest.cs
@@ -1085,13 +1085,15 @@ namespace Microsoft.Data.SqlClient.Tests
 
 
         [Fact]
-        public void ConnectionString_WithOnlyComma_ShouldNotThrow()
+        public void ConnectionString_WithOnlyComma()
         {
-            SqlConnection cn = new SqlConnection("Data Source=,;Initial Catalog=master;Integrated Security=True");
-            Exception ex = Record.Exception(() => cn.Open());
+            // Test Case for https://github.com/dotnet/SqlClient/issues/3110
+            // Validates that a single-comma Data Source (e.g., "Data Source=,") no longer causes ArgumentOutOfRangeException
+            // Instead, it should throw a SqlException indicating a connection failure
 
-            Assert.NotNull(ex);
-            Assert.False(ex is ArgumentOutOfRangeException);
+            SqlConnection cn = new SqlConnection("Data Source=,;Initial Catalog=master;Integrated Security=True");
+            Assert.Throws<SqlException>(() => { cn.Open(); });
+
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #3110
this PR fixes a crash in `ADP.IsEndpoint(...)` caused by an unsafe call to `LastIndexOf('\\', length - 1, length - 1)` when the Data Source in the connection string starts with a comma (e.g. `"Data Source=,"`).

When `length == 0`, the method would previously throw an `ArgumentOutOfRangeException`.

---Fix
Added a defensive check to ensure `length > 0` before calling `LastIndexOf`, which prevents invalid index access.

--- Tests

- Added a new unit test: `ConnectionString_WithOnlyComma_ShouldNotThrow`
- The test confirms that the exception is no longer thrown
- Verified the test fails without the fix and passes with it

This is my first open-source contribution — excited to be part of the project! Let me know if you'd like any changes.