### PR TITLE
Revert "Deprecate 'Active Directory Password' authentication mode.

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/ActiveDirectoryAuthenticationProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/ActiveDirectoryAuthenticationProvider.xml
@@ -180,7 +180,7 @@
       <remarks>
         The supported authentication modes with <see cref="T:Microsoft.Data.SqlClient.ActiveDirectoryAuthenticationProvider" /> are:
         <list type="bullet">
-          <item>Active Directory Password (deprecated)</item>
+          <item>Active Directory Password</item>
           <item>Active Directory Integrated</item>
           <item>Active Directory Interactive</item>
           <item>Active Directory Service Principal</item>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlAuthenticationMethod.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlAuthenticationMethod.xml
@@ -12,7 +12,7 @@
       <value>1</value>
     </SqlPassword>
     <ActiveDirectoryPassword>
-      <summary>The authentication method uses Active Directory Password. Use Active Directory Password to connect to a SQL Database using a Microsoft Entra principal name and password. This authentication method is now deprecated, and will be removed in a future release.</summary>
+      <summary>The authentication method uses Active Directory Password. Use Active Directory Password to connect to a SQL Database using a Microsoft Entra principal name and password.</summary>
       <value>2</value>
     </ActiveDirectoryPassword>
     <ActiveDirectoryIntegrated>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml
@@ -1330,9 +1330,9 @@
                 Valid values are:
               </para>
               <list type="bullet">
-                <item><c>Active Directory Password (deprecated)</c></item>
                 <item><c>Active Directory Integrated</c></item>
                 <item><c>Active Directory Interactive</c></item>
+                <item><c>Active Directory Password</c></item>
                 <item><c>Active Directory Service Principal</c></item>
                 <item><c>Active Directory Device Code Flow</c></item>
                 <item><c>Active Directory Managed Identity</c></item>
@@ -1875,7 +1875,7 @@
                         <item>.database.fabric.microsoft.com</item>
                       </list>
                     </item>
-                    <item><c>Authentication</c> is one of the 'Active Directory' authentication types.</item>
+                    <item><c>Authentication</c> is 'Active Directory Password' or 'Active Directory Integrated'</item>
                   </list>
                 </item>
                 <item><c>true</c> in all other cases.</item>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -1642,7 +1642,7 @@
             </list>
           </item>
           <item>
-            <c>Authentication</c> is one of the 'Active Directory' authentication types.
+            <c>Authentication</c> is 'Active Directory Password' or 'Active Directory Integrated'
           </item>
           <item>Otherwise it defaults to <c>true</c>.</item>
         </list>

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -190,7 +190,6 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlAuthenticationMethod.xml' path='docs/members[@name="SqlAuthenticationMethod"]/SqlPassword/*'/>
         SqlPassword = 1,
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlAuthenticationMethod.xml' path='docs/members[@name="SqlAuthenticationMethod"]/ActiveDirectoryPassword/*'/>
-        [System.Obsolete("ActiveDirectoryPassword is deprecated.")]
         ActiveDirectoryPassword = 2,
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlAuthenticationMethod.xml' path='docs/members[@name="SqlAuthenticationMethod"]/ActiveDirectoryIntegrated/*'/>
         ActiveDirectoryIntegrated = 3,

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2001,9 +2001,7 @@ namespace Microsoft.Data.SqlClient
 
             if (connectionOptions != null &&
                 (connectionOptions.Authentication == SqlAuthenticationMethod.SqlPassword ||
-                    #pragma warning disable 0618
                     connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryPassword ||
-                    #pragma warning restore 0618
                     connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryServicePrincipal) &&
                 (!connectionOptions._hasUserIdKeyword || !connectionOptions._hasPasswordKeyword) &&
                 _credential == null)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1329,9 +1329,7 @@ namespace Microsoft.Data.SqlClient
             // If the workflow being used is Active Directory Authentication and server's prelogin response
             // for FEDAUTHREQUIRED option indicates Federated Authentication is required, we have to insert FedAuth Feature Extension
             // in Login7, indicating the intent to use Active Directory Authentication for SQL Server.
-            #pragma warning disable 0618
             if (ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryPassword
-            #pragma warning restore 0618
                 || ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryInteractive
                 || ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow
                 || ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryServicePrincipal
@@ -2488,9 +2486,7 @@ namespace Microsoft.Data.SqlClient
                                 _activeDirectoryAuthTimeoutRetryHelper.CachedToken = _fedAuthToken;
                             }
                             break;
-                        #pragma warning disable 0618
                         case SqlAuthenticationMethod.ActiveDirectoryPassword:
-                        #pragma warning restore 0618
                         case SqlAuthenticationMethod.ActiveDirectoryServicePrincipal:
                             if (_activeDirectoryAuthTimeoutRetryHelper.State == ActiveDirectoryAuthenticationTimeoutRetryState.Retrying)
                             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -8369,9 +8369,7 @@ namespace Microsoft.Data.SqlClient
                         byte workflow = 0x00;
                         switch (fedAuthFeatureData.authentication)
                         {
-                            #pragma warning disable 0618
                             case SqlAuthenticationMethod.ActiveDirectoryPassword:
-                            #pragma warning restore 0618
                                 workflow = TdsEnums.MSALWORKFLOW_ACTIVEDIRECTORYPASSWORD;
                                 break;
                             case SqlAuthenticationMethod.ActiveDirectoryIntegrated:

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -129,7 +129,6 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlAuthenticationMethod.xml' path='docs/members[@name="SqlAuthenticationMethod"]/SqlPassword/*'/>
         SqlPassword = 1,
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlAuthenticationMethod.xml' path='docs/members[@name="SqlAuthenticationMethod"]/ActiveDirectoryPassword/*'/>
-        [System.Obsolete("ActiveDirectoryPassword is deprecated.")]
         ActiveDirectoryPassword = 2,
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlAuthenticationMethod.xml' path='docs/members[@name="SqlAuthenticationMethod"]/ActiveDirectoryIntegrated/*'/>
         ActiveDirectoryIntegrated = 3,

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2058,9 +2058,7 @@ namespace Microsoft.Data.SqlClient
 
             if (connectionOptions != null &&
                 (connectionOptions.Authentication == SqlAuthenticationMethod.SqlPassword ||
-                    #pragma warning disable 0618
                     connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryPassword ||
-                    #pragma warning restore 0618
                     connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryServicePrincipal) &&
                 (!connectionOptions._hasUserIdKeyword || !connectionOptions._hasPasswordKeyword) &&
                 _credential == null)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1402,9 +1402,7 @@ namespace Microsoft.Data.SqlClient
             // If the workflow being used is Active Directory Authentication and server's prelogin response
             // for FEDAUTHREQUIRED option indicates Federated Authentication is required, we have to insert FedAuth Feature Extension
             // in Login7, indicating the intent to use Active Directory Authentication for SQL Server.
-            #pragma warning disable 0618
             if (ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryPassword
-            #pragma warning restore 0618
                 || ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryInteractive
                 || ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryServicePrincipal
                 || ConnectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow
@@ -1806,9 +1804,7 @@ namespace Microsoft.Data.SqlClient
             Boolean isAzureEndPoint = ADP.IsAzureSqlServerEndpoint(connectionOptions.DataSource);
 
             Boolean isFedAuthEnabled = this._accessTokenInBytes != null ||
-                                       #pragma warning disable 0618
                                        connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryPassword ||
-                                       #pragma warning restore 0618
                                        connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryIntegrated ||
                                        connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryInteractive ||
                                        connectionOptions.Authentication == SqlAuthenticationMethod.ActiveDirectoryServicePrincipal ||
@@ -2649,9 +2645,7 @@ namespace Microsoft.Data.SqlClient
                                 _activeDirectoryAuthTimeoutRetryHelper.CachedToken = _fedAuthToken;
                             }
                             break;
-                        #pragma warning disable 0618
                         case SqlAuthenticationMethod.ActiveDirectoryPassword:
-                        #pragma warning restore 0618
                         case SqlAuthenticationMethod.ActiveDirectoryServicePrincipal:
                             if (_activeDirectoryAuthTimeoutRetryHelper.State == ActiveDirectoryAuthenticationTimeoutRetryState.Retrying)
                             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -433,9 +433,7 @@ namespace Microsoft.Data.SqlClient
 
                 switch (authType)
                 {
-                    #pragma warning disable 0618
                     case SqlAuthenticationMethod.ActiveDirectoryPassword:
-                    #pragma warning restore 0618
                         SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.Connect|SEC> Active Directory Password authentication");
                         break;
                     case SqlAuthenticationMethod.ActiveDirectoryIntegrated:
@@ -8560,9 +8558,7 @@ namespace Microsoft.Data.SqlClient
                         byte workflow = 0x00;
                         switch (fedAuthFeatureData.authentication)
                         {
-                            #pragma warning disable 0618
                             case SqlAuthenticationMethod.ActiveDirectoryPassword:
-                            #pragma warning restore 0618
                                 workflow = TdsEnums.MSALWORKFLOW_ACTIVEDIRECTORYPASSWORD;
                                 break;
                             case SqlAuthenticationMethod.ActiveDirectoryIntegrated:

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/DbConnectionStringCommon.cs
@@ -347,7 +347,6 @@ namespace Microsoft.Data.Common
         }
 
         const string SqlPasswordString = "Sql Password";
-        [Obsolete("ActiveDirectoryPassword is deprecated.")]
         const string ActiveDirectoryPasswordString = "Active Directory Password";
         const string ActiveDirectoryIntegratedString = "Active Directory Integrated";
         const string ActiveDirectoryInteractiveString = "Active Directory Interactive";
@@ -406,12 +405,10 @@ namespace Microsoft.Data.Common
                 result = SqlAuthenticationMethod.SqlPassword;
                 isSuccess = true;
             }
-            #pragma warning disable 0618
             else if (StringComparer.InvariantCultureIgnoreCase.Equals(value, ActiveDirectoryPasswordString)
                 || StringComparer.InvariantCultureIgnoreCase.Equals(value, Convert.ToString(SqlAuthenticationMethod.ActiveDirectoryPassword, CultureInfo.InvariantCulture)))
             {
                 result = SqlAuthenticationMethod.ActiveDirectoryPassword;
-            #pragma warning restore 0618
                 isSuccess = true;
             }
             else if (StringComparer.InvariantCultureIgnoreCase.Equals(value, ActiveDirectoryIntegratedString)
@@ -529,9 +526,7 @@ namespace Microsoft.Data.Common
         {
             Debug.Assert(Enum.GetNames(typeof(SqlAuthenticationMethod)).Length == 11, "SqlAuthenticationMethod enum has changed, update needed");
             return value == SqlAuthenticationMethod.SqlPassword
-                #pragma warning disable 0618
                 || value == SqlAuthenticationMethod.ActiveDirectoryPassword
-                #pragma warning restore 0618
                 || value == SqlAuthenticationMethod.ActiveDirectoryIntegrated
                 || value == SqlAuthenticationMethod.ActiveDirectoryInteractive
                 || value == SqlAuthenticationMethod.ActiveDirectoryServicePrincipal
@@ -550,9 +545,7 @@ namespace Microsoft.Data.Common
             return value switch
             {
                 SqlAuthenticationMethod.SqlPassword => SqlPasswordString,
-                #pragma warning disable 0618
                 SqlAuthenticationMethod.ActiveDirectoryPassword => ActiveDirectoryPasswordString,
-                #pragma warning restore 0618
                 SqlAuthenticationMethod.ActiveDirectoryIntegrated => ActiveDirectoryIntegratedString,
                 SqlAuthenticationMethod.ActiveDirectoryInteractive => ActiveDirectoryInteractiveString,
                 SqlAuthenticationMethod.ActiveDirectoryServicePrincipal => ActiveDirectoryServicePrincipalString,

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
@@ -84,9 +84,7 @@ namespace Microsoft.Data.SqlClient
         public override bool IsSupported(SqlAuthenticationMethod authentication)
         {
             return authentication == SqlAuthenticationMethod.ActiveDirectoryIntegrated
-                #pragma warning disable 0618
                 || authentication == SqlAuthenticationMethod.ActiveDirectoryPassword
-                #pragma warning restore 0618
                 || authentication == SqlAuthenticationMethod.ActiveDirectoryInteractive
                 || authentication == SqlAuthenticationMethod.ActiveDirectoryServicePrincipal
                 || authentication == SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow
@@ -240,9 +238,7 @@ namespace Microsoft.Data.SqlClient
                     SqlClientEventSource.Log.TryTraceEvent("AcquireTokenAsync | Acquired access token for Active Directory Integrated auth mode. Expiry Time: {0}", result?.ExpiresOn);
                 }
             }
-            #pragma warning disable 0618
             else if (parameters.AuthenticationMethod == SqlAuthenticationMethod.ActiveDirectoryPassword)
-            #pragma warning restore 0618
             {
                 string pwCacheKey = GetAccountPwCacheKey(parameters);
                 object previousPw = s_accountPwCache.Get(pwCacheKey);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -58,9 +58,7 @@ namespace Microsoft.Data.SqlClient
             {
                 var activeDirectoryAuthProvider = new ActiveDirectoryAuthenticationProvider(instance._applicationClientId);
                 instance.SetProvider(SqlAuthenticationMethod.ActiveDirectoryIntegrated, activeDirectoryAuthProvider);
-                #pragma warning disable 0618
                 instance.SetProvider(SqlAuthenticationMethod.ActiveDirectoryPassword, activeDirectoryAuthProvider);
-                #pragma warning restore 0618
                 instance.SetProvider(SqlAuthenticationMethod.ActiveDirectoryInteractive, activeDirectoryAuthProvider);
                 instance.SetProvider(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal, activeDirectoryAuthProvider);
                 instance.SetProvider(SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow, activeDirectoryAuthProvider);
@@ -232,10 +230,8 @@ namespace Microsoft.Data.SqlClient
             {
                 case ActiveDirectoryIntegrated:
                     return SqlAuthenticationMethod.ActiveDirectoryIntegrated;
-                #pragma warning disable 0618
                 case ActiveDirectoryPassword:
                     return SqlAuthenticationMethod.ActiveDirectoryPassword;
-                #pragma warning restore 0618
                 case ActiveDirectoryInteractive:
                     return SqlAuthenticationMethod.ActiveDirectoryInteractive;
                 case ActiveDirectoryServicePrincipal:

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -1130,7 +1130,6 @@ namespace Microsoft.Data.SqlClient
         SqlPassword,
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlAuthenticationMethod.xml' path='docs/members[@name="SqlAuthenticationMethod"]/ActiveDirectoryPassword/*'/>
-        [Obsolete("ActiveDirectoryPassword is deprecated.")]
         ActiveDirectoryPassword,
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlAuthenticationMethod.xml' path='docs/members[@name="SqlAuthenticationMethod"]/ActiveDirectoryIntegrated/*'/>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlAuthenticationProviderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlAuthenticationProviderTest.cs
@@ -10,9 +10,7 @@ namespace Microsoft.Data.SqlClient.Tests
     {
         [Theory]
         [InlineData(SqlAuthenticationMethod.ActiveDirectoryIntegrated)]
-        #pragma warning disable 0618
         [InlineData(SqlAuthenticationMethod.ActiveDirectoryPassword)]
-        #pragma warning restore 0618
         [InlineData(SqlAuthenticationMethod.ActiveDirectoryInteractive)]
         [InlineData(SqlAuthenticationMethod.ActiveDirectoryServicePrincipal)]
         [InlineData(SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow)]

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/AADConnectionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/AADConnectionTest.cs
@@ -51,9 +51,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             public override bool IsSupported(SqlAuthenticationMethod authenticationMethod)
             {
-                #pragma warning disable 0618
                 return authenticationMethod.Equals(SqlAuthenticationMethod.ActiveDirectoryPassword);
-                #pragma warning restore 0618
             }
         }
 
@@ -260,9 +258,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(nameof(IsAADConnStringsSetup))]
         public static void TestCustomProviderAuthentication()
         {
-            #pragma warning disable 0618
             SqlAuthenticationProvider.SetProvider(SqlAuthenticationMethod.ActiveDirectoryPassword, new CustomSqlAuthenticationProvider(DataTestUtility.ApplicationClientId));
-            #pragma warning restore 0618
             // Connect to Azure DB with password and retrieve user name using custom authentication provider
             using (SqlConnection conn = new SqlConnection(DataTestUtility.AADPasswordConnectionString))
             {
@@ -280,9 +276,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 }
             }
             // Reset to driver internal provider.
-            #pragma warning disable 0618
             SqlAuthenticationProvider.SetProvider(SqlAuthenticationMethod.ActiveDirectoryPassword, new ActiveDirectoryAuthenticationProvider(DataTestUtility.ApplicationClientId));
-            #pragma warning restore 0618
         }
 
         [ConditionalFact(nameof(IsAADConnStringsSetup))]


### PR DESCRIPTION
Revert #3219 for v6.1 - will include it later in v7.0 as marking API obsolete counts as a breaking change.

This reverts commit 325ca56f4e79803374165d6d8106b7a6cd2ea5ee.