### PR TITLE
Revert "Test | Expose internal types to ManualTests"

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -33,9 +33,6 @@
     <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFramework)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
   </PropertyGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="ManualTests" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)" />
     <EmbeddedFiles Include="$(TargetFrameworkMonikerAssemblyAttributesPath)" />
   </ItemGroup>  

--- a/src/Microsoft.Data.SqlClient/netfx/src/AssemblyInfo.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("ManualTests")]

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -869,7 +869,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Common\Microsoft\Data\Common\NameValuePermission.cs" />
     <Compile Include="Microsoft\Data\Common\DbConnectionOptions.cs" />
     <Compile Include="Microsoft\Data\Common\DbConnectionString.cs" />


### PR DESCRIPTION
Reverts dotnet/SqlClient#3239

This change was causing confusion because it's only a partial solution and only works in Visual Studio.
Visual Studio build uses implementation assemblies, which contain internal types.
MSBuild uses the reference assemblies, which don't contain internal types.

We can reapply this change when we've updated our reference assemblies to include internal types.