### PR TITLE
Handle null socket when receiving packets of data

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -841,7 +841,7 @@ namespace Microsoft.Data.SqlClient.SNI
                     else if (timeoutInMilliseconds == -1)
                     {
                         // SqlClient internally represents infinite timeout by -1, and for TcpClient this is translated to a timeout of 0
-                        _socket.ReceiveTimeout = 0;
+                        _socket.ReceiveTimeout = Timeout.Infinite;
                     }
                     else
                     {
@@ -896,7 +896,7 @@ namespace Microsoft.Data.SqlClient.SNI
                 }
                 finally
                 {
-                    // Reset the socket timeout to 0 (infinite) after the receive operation is done
+                    // Reset the socket timeout to -1 (Timeout.Infinite) after the receive operation is done
                     // to avoid blocking the thread in case of a timeout error.
                     _socket.ReceiveTimeout = Timeout.Infinite;
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -840,7 +840,6 @@ namespace Microsoft.Data.SqlClient.SNI
                     }
                     else if (timeoutInMilliseconds == -1)
                     {
-                        // SqlClient internally represents infinite timeout by -1, and for TcpClient this is translated to a timeout of 0
                         _socket.ReceiveTimeout = Timeout.Infinite;
                     }
                     else
@@ -896,7 +895,7 @@ namespace Microsoft.Data.SqlClient.SNI
                 }
                 finally
                 {
-                    // Reset the socket timeout to -1 (Timeout.Infinite) after the receive operation is done
+                    // Reset the socket timeout to Timeout.Infinite after the receive operation is done
                     // to avoid blocking the thread in case of a timeout error.
                     _socket.ReceiveTimeout = Timeout.Infinite;
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -809,17 +809,29 @@ namespace Microsoft.Data.SqlClient.SNI
         }
 
         /// <summary>
-        /// Receive a packet synchronously
+        /// Receives a packet synchronously.
         /// </summary>
-        /// <param name="packet">SNI packet</param>
-        /// <param name="timeoutInMilliseconds">Timeout in Milliseconds</param>
-        /// <returns>SNI error code</returns>
+        /// <param name="packet">The received SNI packet.</param>
+        /// <param name="timeoutInMilliseconds">
+        /// Timeout in milliseconds:
+        /// - If greater than 0, sets the socket's receive timeout to the specified value.
+        /// - If equal to -1, represents an infinite timeout (socket timeout is set to 0).
+        /// - If less than -1 or equal to 0, results in a timeout error.
+        /// </param>
+        /// <returns>SNI error code indicating the result of the operation.</returns>
         public override uint Receive(out SNIPacket packet, int timeoutInMilliseconds)
         {
             SNIPacket errorPacket;
             lock (this)
             {
                 packet = null;
+
+                if (_socket == null)
+                {
+                    SqlClientEventSource.Log.TrySNITraceEvent(nameof(SNITCPHandle), EventType.ERR, "Connection Id {0}, Socket is null.", args0: _connectionId);
+                    return ReportTcpSNIError(0, SNICommon.ConnOpenFailedError, Strings.SNI_ERROR_10);
+                }
+
                 try
                 {
                     if (timeoutInMilliseconds > 0)
@@ -884,7 +896,9 @@ namespace Microsoft.Data.SqlClient.SNI
                 }
                 finally
                 {
-                    _socket.ReceiveTimeout = 0;
+                    // Reset the socket timeout to 0 (infinite) after the receive operation is done
+                    // to avoid blocking the thread in case of a timeout error.
+                    _socket.ReceiveTimeout = Timeout.Infinite;
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -8326,7 +8326,7 @@ namespace System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Socket is null.
         /// </summary>
         internal static string SNI_ERROR_10 {
             get {

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -3805,7 +3805,7 @@
     <value>Associating port with I/O completion mechanism failed</value>
   </data>
   <data name="SNI_ERROR_10" xml:space="preserve">
-    <value />
+    <value>Socket is null</value>
   </data>
   <data name="SNI_ERROR_11" xml:space="preserve">
     <value>Timeout error</value>


### PR DESCRIPTION
This will wrap null socket error in `SqlException` to prevent exception occurring in the finally block.
* Also, using Timeout.Infinite (-1) now that is equivalent to 0 as timeout value.