### PR TITLE
[5.1] CVE-2024-43485 - Update System.Text.Json to 6.0.11

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -7,7 +7,7 @@
     "repositoryName": "SqlClient",
     "codebaseName": "SqlClient",
     "allTools": true,
-    "template": "MSDATA_RevolutionR",
+    "template": "MSDATA_RevolutionR_Overloaded0",
     "language": "csharp",
     "includePathPatterns": "src/Microsoft.Data.SqlClient/*, src/Microsoft.SqlServer.Server/*, tools/*",
     "excludePathPatterns": "src/Microsoft.Data.SqlClient/tests/*"

--- a/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
@@ -46,7 +46,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: MDS_PackageRef_Version
   displayName: 'MDS package version of AKV Provider (build AKV)'
   type: string
-  default: 3.0.0
+  default: 5.1.2
 
 - name: CurrentNetFxVersion
   displayName: 'Lowest supported .NET Framework version (MDS validation)'

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.csproj
@@ -31,16 +31,19 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI">
       <Version>$(MicrosoftDataSqlClientSniVersion)</Version>
       <PrivateAssets>All</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelProtocolsOpenIdConnectVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelProtocolsOpenIdConnectVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -716,17 +716,20 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI">
       <Version>$(MicrosoftDataSqlClientSniVersion)</Version>
       <PrivateAssets>All</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="$(AzureIdentityVersion)" />
     <PackageReference Include="Microsoft.Identity.Client" Version="$(MicrosoftIdentityClientVersion)" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelProtocolsOpenIdConnectVersion)" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="$(MicrosoftIdentityModelJsonWebTokensVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(MicrosoftIdentityModelProtocolsOpenIdConnectVersion)" />
     <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(NetFxSource)tools\targets\GenerateResourceStringsSource.targets" />

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -33,6 +33,7 @@
     <MicrosoftIdentityModelJsonWebTokensVersion>6.35.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>6.0.10</SystemTextJsonVersion>
   </PropertyGroup>
   <!-- NetCore project dependencies -->
   <PropertyGroup>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -32,7 +32,7 @@
     <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>6.35.0</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>
     <MicrosoftIdentityModelJsonWebTokensVersion>6.35.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
-    <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
+    <SystemTextEncodingsWebVersion>6.0.1</SystemTextEncodingsWebVersion>
     <SystemTextJsonVersion>6.0.11</SystemTextJsonVersion>
   </PropertyGroup>
   <!-- NetCore project dependencies -->

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -33,7 +33,7 @@
     <MicrosoftIdentityModelJsonWebTokensVersion>6.35.0</MicrosoftIdentityModelJsonWebTokensVersion>
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemTextEncodingsWebVersion>6.0.0</SystemTextEncodingsWebVersion>
-    <SystemTextJsonVersion>6.0.10</SystemTextJsonVersion>
+    <SystemTextJsonVersion>6.0.11</SystemTextJsonVersion>
   </PropertyGroup>
   <!-- NetCore project dependencies -->
   <PropertyGroup>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -37,7 +37,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
-        <dependency id="System.Text.Json" version="6.0.10" />
+        <dependency id="System.Text.Json" version="6.0.11" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.1" exclude="Compile" />

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -36,7 +36,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
-        <dependency id="System.Text.Encodings.Web" version="6.0.0" />
+        <dependency id="System.Text.Encodings.Web" version="6.0.1" />
         <dependency id="System.Text.Json" version="6.0.11" />
       </group>
       <group targetFramework="net6.0">
@@ -50,7 +50,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Diagnostics.DiagnosticSource" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="6.0.0" exclude="Compile" />
-        <dependency id="System.Text.Encodings.Web" version="6.0.0" />
+        <dependency id="System.Text.Encodings.Web" version="6.0.1" />
         <dependency id="System.Security.Cryptography.Cng" version="5.0.0" />
         <dependency id="System.Security.Principal.Windows" version="5.0.0" exclude="Compile" />
       </group>
@@ -66,7 +66,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="6.0.0" exclude="Compile" />
-        <dependency id="System.Text.Encodings.Web" version="6.0.0" />
+        <dependency id="System.Text.Encodings.Web" version="6.0.1" />
         <dependency id="System.Runtime.Loader" version="4.3.0" />
         <dependency id="System.Security.Cryptography.Cng" version="5.0.0" />
         <dependency id="System.Security.Principal.Windows" version="5.0.0" exclude="Compile" />
@@ -82,7 +82,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.Caching" version="6.0.0" exclude="Compile" />
         <dependency id="System.Text.Encoding.CodePages" version="6.0.0" exclude="Compile" />
-        <dependency id="System.Text.Encodings.Web" version="6.0.0" />
+        <dependency id="System.Text.Encodings.Web" version="6.0.1" />
         <dependency id="System.Runtime.Loader" version="4.3.0" />
         <dependency id="System.Security.Cryptography.Cng" version="5.0.0" />
         <dependency id="System.Security.Principal.Windows" version="5.0.0" exclude="Compile" />

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -37,6 +37,7 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
         <dependency id="System.Configuration.ConfigurationManager" version="6.0.1" exclude="Compile" />
         <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
+        <dependency id="System.Text.Json" version="6.0.10" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="5.1.1" exclude="Compile" />

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -29,21 +29,21 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.4.0,5.0.0)" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.1" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Data.SqlClient" version="3.0.0" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.4.0,5.0.0)" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.1" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Data.SqlClient" version="3.0.0" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.4.0,5.0.0)" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.1" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -27,21 +27,21 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
       <group targetFramework="net462">
         <dependency id="Microsoft.Data.SqlClient" version="[5.1.3,5.2.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
-        <dependency id="System.Text.Encodings.Web" version="6.0.0" />
+        <dependency id="System.Text.Encodings.Web" version="6.0.1" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.4.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Data.SqlClient" version="[5.1.3,5.2.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
-        <dependency id="System.Text.Encodings.Web" version="6.0.0" />
+        <dependency id="System.Text.Encodings.Web" version="6.0.1" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.4.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Data.SqlClient" version="[5.1.3,5.2.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
-        <dependency id="System.Text.Encodings.Web" version="6.0.0" />
+        <dependency id="System.Text.Encodings.Web" version="6.0.1" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.4.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -25,21 +25,21 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
     <tags>sqlclient microsoft.data.sqlclient azurekeyvaultprovider akvprovider alwaysencrypted</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Data.SqlClient" version="3.0.0" />
+        <dependency id="Microsoft.Data.SqlClient" version="[5.1.3,5.2.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.4.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
       <group targetFramework="net6.0">
-        <dependency id="Microsoft.Data.SqlClient" version="3.0.0" />
+        <dependency id="Microsoft.Data.SqlClient" version="[5.1.3,5.2.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.4.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.Data.SqlClient" version="3.0.0" />
+        <dependency id="Microsoft.Data.SqlClient" version="[5.1.3,5.2.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="System.Text.Encodings.Web" version="6.0.0" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.4.0,5.0.0)" />


### PR DESCRIPTION
- Added an explicit dependency on System.Text.Json 6.0.11 to avoid transitive CVE for .NET Framework.
- Reorganized some PackageReference entries to be alphabetically ordered.
- Fixed incorrect Microsoft.Extensions.Caching.Memory version in AKV .nuspec to suppress https://github.com/dotnet/SqlClient/security/dependabot/13
- Fixed incorrect MDS versions in AKV .nuspec.
- Fixed transitive downgrade of System.Text.Encodings.Web.
- Added TSAUpload bug workaround to TSA options config.