### PR TITLE
[5.2] CVE-2024-43483 - Update Microsoft.Extensions.Caching.Memory

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -7,7 +7,7 @@
     "repositoryName": "SqlClient",
     "codebaseName": "SqlClient",
     "allTools": true,
-    "template": "MSDATA_RevolutionR",
+    "template": "MSDATA_RevolutionR_Overloaded0",
     "language": "csharp",
     "includePathPatterns": "src/Microsoft.Data.SqlClient/*, src/Microsoft.SqlServer.Server/*, tools/*",
     "excludePathPatterns": "src/Microsoft.Data.SqlClient/tests/*"

--- a/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
@@ -46,7 +46,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: MDS_PackageRef_Version
   displayName: 'MDS package version of AKV Provider (build AKV)'
   type: string
-  default: 5.1.5
+  default: 5.2.2
 
 - name: CurrentNetFxVersion
   displayName: 'Lowest supported .NET Framework version (MDS validation)'

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -57,7 +57,7 @@
   <PropertyGroup>
     <AzureCoreVersion>[1.38.0,2.0.0)</AzureCoreVersion>
     <AzureSecurityKeyVaultKeysVersion>[4.5.0,5.0.0)</AzureSecurityKeyVaultKeysVersion>
-    <MicrosoftExtensionsCachingMemoryVersion>6.0.1</MicrosoftExtensionsCachingMemoryVersion>
+    <MicrosoftExtensionsCachingMemoryVersion>6.0.3</MicrosoftExtensionsCachingMemoryVersion>
   </PropertyGroup>
   <!-- Test Project Dependencies -->
   <PropertyGroup>

--- a/tools/props/VersionsNet8OrLater.props
+++ b/tools/props/VersionsNet8OrLater.props
@@ -4,6 +4,6 @@
   <PropertyGroup>
     <SystemConfigurationConfigurationManagerVersion>8.0.0</SystemConfigurationConfigurationManagerVersion>
     <SystemRuntimeCachingVersion>8.0.0</SystemRuntimeCachingVersion>
-    <MicrosoftExtensionsCachingMemoryVersion>8.0.0</MicrosoftExtensionsCachingMemoryVersion>
+    <MicrosoftExtensionsCachingMemoryVersion>8.0.1</MicrosoftExtensionsCachingMemoryVersion>
   </PropertyGroup>
 </Project>

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -28,25 +28,25 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
         <dependency id="Microsoft.Data.SqlClient" version="5.1.5" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.1" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Data.SqlClient" version="5.1.5" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.0" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Data.SqlClient" version="5.1.5" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.1" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Microsoft.Data.SqlClient" version="5.1.5" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.1" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -25,25 +25,25 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
     <tags>sqlclient microsoft.data.sqlclient azurekeyvaultprovider akvprovider alwaysencrypted</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Data.SqlClient" version="5.1.5" />
+        <dependency id="Microsoft.Data.SqlClient" version="[5.2.0,5.3.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Data.SqlClient" version="5.1.5" />
+        <dependency id="Microsoft.Data.SqlClient" version="[5.2.0,5.3.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net6.0">
-        <dependency id="Microsoft.Data.SqlClient" version="5.1.5" />
+        <dependency id="Microsoft.Data.SqlClient" version="[5.2.0,5.3.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.Data.SqlClient" version="5.1.5" />
+        <dependency id="Microsoft.Data.SqlClient" version="[5.2.0,5.3.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.3" />


### PR DESCRIPTION
- Addresses https://github.com/dotnet/SqlClient/security/dependabot/13
- Updated MECM to 6.0.3 and 8.0.1 for the appropriate targets.
- Fixed MDS version in AKV .nuspec.
- Added TSAUpload bug workaround to TSA options config.