### PR TITLE
[6.0] CVE-2024-43483 - Update Microsoft.Extensions.Caching.Memory

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -7,7 +7,7 @@
     "repositoryName": "SqlClient",
     "codebaseName": "SqlClient",
     "allTools": true,
-    "template": "MSDATA_RevolutionR",
+    "template": "MSDATA_RevolutionR_Overloaded0",
     "language": "csharp",
     "includePathPatterns": "src/Microsoft.Data.SqlClient/*, src/Microsoft.SqlServer.Server/*, tools/*",
     "excludePathPatterns": "src/Microsoft.Data.SqlClient/tests/*"

--- a/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
@@ -48,7 +48,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: MDS_PackageRef_Version
   displayName: 'MDS package version of AKV Provider (build AKV)'
   type: string
-  default: 5.1.5
+  default: 6.0.1
 
 - name: CurrentNetFxVersion
   displayName: 'Lowest supported .NET Framework version (MDS validation)'

--- a/tools/props/VersionsNet9OrLater.props
+++ b/tools/props/VersionsNet9OrLater.props
@@ -2,9 +2,9 @@
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- NET 9 target framework dependencies -->
   <PropertyGroup>
-    <MicrosoftBclCryptographyVersion>9.0.0</MicrosoftBclCryptographyVersion>
-    <MicrosoftExtensionsCachingMemoryVersion>9.0.0</MicrosoftExtensionsCachingMemoryVersion>
-    <SystemSecurityCryptographyPkcsVersion>9.0.0</SystemSecurityCryptographyPkcsVersion>
-    <SystemConfigurationConfigurationManagerVersion>9.0.0</SystemConfigurationConfigurationManagerVersion>
+    <MicrosoftBclCryptographyVersion>9.0.4</MicrosoftBclCryptographyVersion>
+    <MicrosoftExtensionsCachingMemoryVersion>9.0.4</MicrosoftExtensionsCachingMemoryVersion>
+    <SystemSecurityCryptographyPkcsVersion>9.0.4</SystemSecurityCryptographyPkcsVersion>
+    <SystemConfigurationConfigurationManagerVersion>9.0.4</SystemConfigurationConfigurationManagerVersion>
   </PropertyGroup>
 </Project>

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -54,13 +54,13 @@ When using NuGet 3.x this package requires at least version 3.4.</description>
       <group targetFramework="net9.0">
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.2" exclude="Compile" />
         <dependency id="Azure.Identity" version="1.11.4" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.0" exclude="Compile" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.4" exclude="Compile" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="7.5.0" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="7.5.0" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0"/>
-        <dependency id="System.Configuration.ConfigurationManager" version="9.0.0" exclude="Compile" />
-        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.0"/>
-        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.0"/>
+        <dependency id="System.Configuration.ConfigurationManager" version="9.0.4" exclude="Compile" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.4"/>
+        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.4"/>
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -28,7 +28,7 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
         <dependency id="Microsoft.Data.SqlClient" version="6.0.0" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="6.0.1" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Data.SqlClient" version="6.0.0" />

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -25,22 +25,22 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
     <tags>sqlclient microsoft.data.sqlclient azurekeyvaultprovider akvprovider alwaysencrypted</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Data.SqlClient" version="6.0.0" />
+        <dependency id="Microsoft.Data.SqlClient" version="[6.0.1,6.1.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Data.SqlClient" version="6.0.0" />
+        <dependency id="Microsoft.Data.SqlClient" version="[6.0.1,6.1.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net9.0">
-        <dependency id="Microsoft.Data.SqlClient" version="6.0.0" />
+        <dependency id="Microsoft.Data.SqlClient" version="[6.0.1,6.1.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.0" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.4" />
       </group>
     </dependencies>
     <frameworkAssemblies>


### PR DESCRIPTION
- Addresses https://github.com/dotnet/SqlClient/security/dependabot/13
- Updated AKV .nuspec to declare MECM 8.0.1 for net462, which is what we're actually using.
- Fixed MDS version in AKV .nuspec.
- Bumped .NET 9 dependencies to their latest patch versions.
- Added TSAUpload bug workaround to TSA options config.