### PR TITLE
[5.2] Replace example password with ********

### DIFF
--- a/doc/samples/SqlConnectionStringBuilder.cs
+++ b/doc/samples/SqlConnectionStringBuilder.cs
@@ -21,12 +21,12 @@ class Program
         // connection string, and you can retrieve and
         // modify any of the elements.
         builder.ConnectionString = "server=(local);user id=ab;" +
-            "password= a!Pass113;initial catalog=AdventureWorks";
+            "password=********;initial catalog=AdventureWorks";
 
         // Now that the connection string has been parsed,
         // you can work with individual items.
         Console.WriteLine(builder.Password);
-        builder.Password = "new@1Password";
+        builder.Password = "********";
 
         // You can refer to connection keys using strings, 
         // as well. When you use this technique (the default

--- a/doc/samples/SqlConnectionStringBuilder3.cs
+++ b/doc/samples/SqlConnectionStringBuilder3.cs
@@ -10,7 +10,7 @@ class Program
         try
         {
             string connectString =
-                "Server=(local);Database=AdventureWorks;UID=ab;Pwd= a!Pass@@";
+                "Server=(local);Database=AdventureWorks;UID=ab;Pwd=********";
             Console.WriteLine("Original: " + connectString);
             SqlConnectionStringBuilder builder =
                 new SqlConnectionStringBuilder(connectString);

--- a/doc/samples/SqlConnectionStringBuilder_IntegratedSecurity.cs
+++ b/doc/samples/SqlConnectionStringBuilder_IntegratedSecurity.cs
@@ -10,7 +10,7 @@ class Program
         try
         {
             string connectString =
-                "Data Source=(local);User ID=ab;Password=MyPassword;" +
+                "Data Source=(local);User ID=ab;Password=********;" +
                 "Initial Catalog=AdventureWorks";
 
             SqlConnectionStringBuilder builder =

--- a/doc/samples/SqlConnectionStringBuilder_Remove.cs
+++ b/doc/samples/SqlConnectionStringBuilder_Remove.cs
@@ -10,7 +10,7 @@ class Program
         try
         {
             string connectString =
-                "Data Source=(local);User ID=ab;Password= a1Pass@@11;" +
+                "Data Source=(local);User ID=ab;Password=********;" +
                 "Initial Catalog=AdventureWorks";
 
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectString);

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -851,7 +851,7 @@ Connections are considered the same if they have the same connection string. Dif
  The example displays the following text in the console window:  
   
 ```  
-Original: Data Source=(local);Initial Catalog=AdventureWorks;User ID=ab;Password= a1Pass@@11  
+Original: Data Source=(local);Initial Catalog=AdventureWorks;User ID=ab;Password=********  
 Modified: Data Source=(local);Initial Catalog=AdventureWorks;Integrated Security=True  
 Database = AdventureWorks  
 ```  


### PR DESCRIPTION
Backport of #3286

These example passwords can end up in Microsoft.Data.SqlClient.xml within the released package. The example connection string output looks like real credentials to credential scanners and can cause issues when developers copy build artifacts around.