### PR TITLE
Cleanup of AKV Pipeline After ESRP Changes

### DIFF
--- a/eng/pipelines/akv-official-pipeline.yml
+++ b/eng/pipelines/akv-official-pipeline.yml
@@ -139,7 +139,7 @@ extends:
                         signingAuthAkvName: '$(SigningAuthAkvName)'
                         signingAuthSignCertName: '$(SigningAuthSignCertName)'
                         signingEsrpClientId: '$(SigningEsrpClientId)'
-                        signingEsrpConnectedServiceName: '$(SigningConnectedServiceName)'
+                        signingEsrpConnectedServiceName: '$(SigningEsrpConnectedServiceName)'
                         symbolsAzureSubscription: '$(SymbolsAzureSubscription)'
                         symbolsPublishProjectName: '$(SymbolsPublishProjectName)'
                         symbolsPublishServer: '$(SymbolsPublishServer)'

--- a/eng/pipelines/akv-official-pipeline.yml
+++ b/eng/pipelines/akv-official-pipeline.yml
@@ -38,6 +38,7 @@ parameters:
 variables:
     - template: /eng/pipelines/variables/common-variables.yml@self
     - template: /eng/pipelines/variables/onebranch-variables.yml@self
+    - template: /eng/pipelines/variables/esrp-signing-variables.yml@self
     - template: /eng/pipelines/variables/akv-official-variables.yml@self
 
 resources:
@@ -133,12 +134,12 @@ extends:
                         nugetPackageVersion: '${{ variables.nugetPackageVersion }}'
                         mdsPackageVersion: '${{ variables.mdsPackageVersion }}'
                         publishSymbols: '${{ parameters.publishSymbols }}'
-                        ESRPConnectedServiceName: '$(ESRPConnectedServiceName)'
-                        AppRegistrationClientId: '$(AppRegistrationClientId)'
-                        AppRegistrationTenantId: '$(AppRegistrationTenantId)'
-                        EsrpClientId: '$(EsrpClientId)'
-                        AuthAkvName: '$(AuthAkvName)'
-                        AuthSignCertName: '$(AuthSignCertName)'
+                        signingAppRegistrationClientId: '$(SigningAppRegistrationClientId)'
+                        signingAppRegistrationTenantId: '$(SigningAppRegistrationTenantId)'
+                        signingAuthAkvName: '$(SigningAuthAkvName)'
+                        signingAuthSignCertName: '$(SigningAuthSignCertName)'
+                        signingEsrpClientId: '$(SigningEsrpClientId)'
+                        signingEsrpConnectedServiceName: '$(SigningConnectedServiceName)'
                         symbolsAzureSubscription: '$(SymbolsAzureSubscription)'
                         symbolsPublishProjectName: '$(SymbolsPublishProjectName)'
                         symbolsPublishServer: '$(SymbolsPublishServer)'

--- a/eng/pipelines/jobs/build-akv-official-job.yml
+++ b/eng/pipelines/jobs/build-akv-official-job.yml
@@ -26,22 +26,22 @@ parameters:
     - name: publishSymbols
       type: boolean
 
-    - name: ESRPConnectedServiceName
+    - name: signingAppRegistrationClientId
       type: string
 
-    - name: AppRegistrationClientId
+    - name: signingAppRegistrationTenantId
       type: string
 
-    - name: AppRegistrationTenantId
+    - name: signingAuthAkvName
       type: string
 
-    - name: EsrpClientId
+    - name: signingAuthSignCertName
       type: string
 
-    - name: AuthAkvName
+    - name: signingEsrpClientId
       type: string
 
-    - name: AuthSignCertName
+    - name: signingEsrpConnectedServiceName
       type: string
 
     - name: symbolsAzureSubscription
@@ -108,13 +108,13 @@ jobs:
 
           - template: ../steps/compound-esrp-code-signing-step.yml@self
             parameters:
-                ESRPConnectedServiceName: '${{ parameters.ESRPConnectedServiceName }}'
-                appRegistrationClientId: '${{ parameters.AppRegistrationClientId }}'
-                appRegistrationTenantId: '${{ parameters.AppRegistrationTenantId }}'
-                EsrpClientId: '${{ parameters.EsrpClientId }}'
-                AuthAkvName: '${{ parameters.AuthAkvName }}'
-                AuthSignCertName: '${{ parameters.AuthSignCertName }}'
+                appRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
+                appRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
                 artifactType: 'dll'
+                authAkvName: '${{ parameters.signingAuthAkvName }}'
+                authSignCertName: '${{ parameters.signingAuthSignCertName }}'
+                esrpClientId: '${{ parameters.signingEsrpClientId }}'
+                esrpConnectedServiceName: '${{ parameters.signingEsrpConnectedServiceName }}'
 
           - template: ../steps/compound-nuget-pack-step.yml@self
             parameters:
@@ -127,13 +127,13 @@ jobs:
 
           - template: ../steps/compound-esrp-code-signing-step.yml@self
             parameters:
-                ESRPConnectedServiceName: '${{ parameters.ESRPConnectedServiceName }}'
-                appRegistrationClientId: '${{ parameters.AppRegistrationClientId }}'
-                appRegistrationTenantId: '${{ parameters.AppRegistrationTenantId }}'
-                EsrpClientId: '${{ parameters.EsrpClientId }}'
-                AuthAkvName: '${{ parameters.AuthAkvName }}'
-                AuthSignCertName: '${{ parameters.AuthSignCertName }}'
+                appRegistrationClientId: '${{ parameters.signingAppRegistrationClientId }}'
+                appRegistrationTenantId: '${{ parameters.signingAppRegistrationTenantId }}'
                 artifactType: 'pkg'
+                authAkvName: '${{ parameters.signingAuthAkvName }}'
+                authSignCertName: '${{ parameters.signingAuthSignCertName }}'
+                esrpClientId: '${{ parameters.signingEsrpClientId }}'
+                esrpConnectedServiceName: '${{ parameters.signingEsrpConnectedServiceName }}'
 
           - ${{ if parameters.publishSymbols }}:
             - template: ../steps/compound-publish-symbols-step.yml@self

--- a/eng/pipelines/steps/compound-esrp-code-signing-step.yml
+++ b/eng/pipelines/steps/compound-esrp-code-signing-step.yml
@@ -5,20 +5,15 @@
 #################################################################################
 
 parameters:
-    - name: ESRPConnectedServiceName
-      type: string
-
     - name: appRegistrationClientId
       type: string
 
     - name: appRegistrationTenantId
       type: string
 
-    - name: EsrpClientId
-      type: string
-
-    - # Name of the Azure Key Vault to retrieve ESRP Code Signing certificate from.
-      name: AuthAkvName
+    - # Name of the Azure Key Vault to retrieve certificates from.
+      # note: This has nothing to do with the AKV provider package.
+      name: authAkvName
       type: string
 
     - name: authSignCertName
@@ -30,34 +25,40 @@ parameters:
           - dll
           - pkg
 
+    - name: esrpConnectedServiceName
+      type: string
+
+    - name: esrpClientId
+      type: string
+
 steps:
     - ${{ if eq(parameters.artifactType, 'dll') }}:
         - task: EsrpMalwareScanning@5
           displayName: 'ESRP Malware Scanning Code'
           inputs:
-              ConnectedServiceName: '${{ parameters.ESRPConnectedServiceName }}'
               AppRegistrationClientId: '${{ parameters.appRegistrationClientId }}'
               AppRegistrationTenantId: '${{ parameters.appRegistrationTenantId }}'
-              EsrpClientId: '${{ parameters.EsrpClientId }}'
-              UseMSIAuthentication: true
               CleanupTempStorage: 1
+              ConnectedServiceName: '${{ parameters.esrpConnectedServiceName }}'
+              EsrpClientId: '${{ parameters.esrpClientId }}'
               FolderPath: '$(BUILD_OUTPUT)'
               Pattern: '*.dll'
+              UseMSIAuthentication: true
               VerboseLogin: 1
 
         - task: EsrpCodeSigning@5
           displayName: 'ESRP Signing Code'
           inputs:
-              ConnectedServiceName: '${{ parameters.ESRPConnectedServiceName }}'
               AppRegistrationClientId: '${{ parameters.appRegistrationClientId }}'
               AppRegistrationTenantId: '${{ parameters.appRegistrationTenantId }}'
-              EsrpClientId: '${{ parameters.EsrpClientId }}'
-              UseMSIAuthentication: true
-              AuthAKVName: '${{ parameters.akvName }}'
-              AuthSignCertName: '${{ parameters.AuthSignCertName }}'
+              AuthAKVName: '${{ parameters.authAkvName }}'
+              AuthSignCertName: '${{ parameters.authSignCertName }}'
+              ConnectedServiceName: '${{ parameters.esrpConnectedServiceName }}'
+              EsrpClientId: '${{ parameters.esrpClientId }}'
               FolderPath: '$(BUILD_OUTPUT)'
               Pattern: '*.dll'
               signConfigType: 'inlineSignParams'
+              UseMSIAuthentication: true
               inlineOperation: |
                   [ 
                       {
@@ -102,29 +103,29 @@ steps:
         - task: EsrpMalwareScanning@5
           displayName: 'ESRP Malware Scanning NuGet Package'
           inputs:
-              ConnectedServiceName: '${{ parameters.ESRPConnectedServiceName }}'
               AppRegistrationClientId: '${{ parameters.appRegistrationClientId }}'
               AppRegistrationTenantId: '${{ parameters.appRegistrationTenantId }}'
-              EsrpClientId: '${{ parameters.EsrpClientId }}'
-              UseMSIAuthentication: true
               CleanupTempStorage: 1
+              ConnectedServiceName: '${{ parameters.esrpConnectedServiceName }}'
+              EsrpClientId: '${{ parameters.esrpClientId }}'
               FolderPath: '$(ARTIFACT_PATH)'
               Pattern: '*.*nupkg'
+              UseMSIAuthentication: true
               VerboseLogin: 1
 
         - task: EsrpCodeSigning@5
           displayName: 'ESRP Signing NuGet Package'
           inputs:
-            ConnectedServiceName: '${{ parameters.ESRPConnectedServiceName }}'
             AppRegistrationClientId: '${{ parameters.appRegistrationClientId }}'
             AppRegistrationTenantId: '${{ parameters.appRegistrationTenantId }}'
-            EsrpClientId: '${{ parameters.EsrpClientId }}'
-            UseMSIAuthentication: true
+            ConnectedServiceName: '${{ parameters.esrpConnectedServiceName }}'
+            EsrpClientId: '${{ parameters.esrpClientId }}'
             AuthAKVName: '${{ parameters.akvName }}'
-            AuthSignCertName: '${{ parameters.AuthSignCertName }}'
+            AuthSignCertName: '${{ parameters.authSignCertName }}'
             FolderPath: '$(ARTIFACT_PATH)'
             Pattern: '*.*nupkg'
             signConfigType: 'inlineSignParams'
+            UseMSIAuthentication: true
             inlineOperation: |
                 [ 
                     { 

--- a/eng/pipelines/steps/compound-esrp-code-signing-step.yml
+++ b/eng/pipelines/steps/compound-esrp-code-signing-step.yml
@@ -120,7 +120,7 @@ steps:
             AppRegistrationTenantId: '${{ parameters.appRegistrationTenantId }}'
             ConnectedServiceName: '${{ parameters.esrpConnectedServiceName }}'
             EsrpClientId: '${{ parameters.esrpClientId }}'
-            AuthAKVName: '${{ parameters.akvName }}'
+            AuthAKVName: '${{ parameters.authAkvName }}'
             AuthSignCertName: '${{ parameters.authSignCertName }}'
             FolderPath: '$(ARTIFACT_PATH)'
             Pattern: '*.*nupkg'

--- a/eng/pipelines/variables/akv-official-variables.yml
+++ b/eng/pipelines/variables/akv-official-variables.yml
@@ -7,7 +7,8 @@
 # @TODO: These seem to only really apply to official builds. Name should probably be adjusted to match.
 
 variables:
-      # @TODO: Rename to something more appropriate for symbols
+    # @TODO: If symbols variables are indeed shared between projects and not expected to change
+    #    then they can be removed from this variable group.
     - group: 'akv-variables-v2'
       # SymbolsAzureSubscription
       # SymbolsPublishProjectName

--- a/eng/pipelines/variables/esrp-signing-variables.yml
+++ b/eng/pipelines/variables/esrp-signing-variables.yml
@@ -1,0 +1,17 @@
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+
+# These variables are used for running ESRP signing tasks. All names start with "Signing" to make
+# it clear that these variables are used for signing (as opposed to other msc tasks).
+
+variables:
+    - group: 'esrp-variables-v2'
+      # SigningAppRegistrationClientId
+      # SigningAppRegistrationTenantId
+      # SigningAuthAkvName
+      # SigningAuthSignCertName
+      # SigningEsrpClientId
+      # SigningEsrpConnectedServiceName

--- a/src/Microsoft.Data.SqlClient.sln
+++ b/src/Microsoft.Data.SqlClient.sln
@@ -287,6 +287,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "variables", "variables", "{
 		..\eng\pipelines\variables\akv-official-variables.yml = ..\eng\pipelines\variables\akv-official-variables.yml
 		..\eng\pipelines\variables\common-variables.yml = ..\eng\pipelines\variables\common-variables.yml
 		..\eng\pipelines\variables\onebranch-variables.yml = ..\eng\pipelines\variables\onebranch-variables.yml
+		..\eng\pipelines\variables\esrp-signing-variables.yml = ..\eng\pipelines\variables\esrp-signing-variables.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "jobs", "jobs", "{09352F1D-878F-4F55-8AA2-6E47F1AD37D5}"


### PR DESCRIPTION
**Description**: This PR cleans up the AKV official pipeline after the recent ESRP changes. There's a handful of changes going on here:

* Change parameter naming conventions such that above the level of the signing task, signing parameters have "Signing" prefix - this helps it be obvious the parameters/variables are used for signing (eg, AkvName isn't clear that it is used for signing - AKV could mean any key vault thing, any especially in the AKV provider pipeline it needs clarification)
* Also, enforce naming conventions of camelCase for parameters and PascalCase for variable group variables
* Enforce alphabetical ordering of parameters
* Move variable group to signing-variables-v2 - this helps us have versionable variable groups if we ever need to update the list of variables the pipeline uses.
* Also ensuring that the variable group is pulled into the pipeline - I don't think this was actually tested previously, since the variable group was not being included, and would fail

**Testing**: Build was successful https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=114057&view=results