### PR TITLE
Merge | SqlColumnEncryption*.Unix

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -925,12 +925,18 @@
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\SessionHandle.netcore.Unix.cs">
       <Link>Microsoft\Data\SqlClient\SessionHandle.netcore.Unix.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\SqlColumnEncryptionCertificateStoreProvider.netcore.Unix.cs">
+      <Link>Microsoft\Data\SqlClinet\SqlColumnEncryptionCertificateStoreProvider.netcore.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\SqlColumnEncryptionCngProvider.netcore.Unix.cs">
+      <Link>Microsoft\Data\SqlClinet\SqlColumnEncryptionCngProvider.netcore.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\SqlColumnEncryptionCspProvider.netcore.Unix.cs">
+      <Link>Microsoft\Data\SqlClinet\SqlColumnEncryptionCspProvider.netcore.Unix.cs</Link>
+    </Compile>
 
     <Compile Include="Microsoft\Data\Sql\SqlDataSourceEnumerator.Unix.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SNI\LocalDB.Unix.cs" />
-    <Compile Include="Microsoft\Data\SqlClient\SqlColumnEncryptionCertificateStoreProvider.Unix.cs" />
-    <Compile Include="Microsoft\Data\SqlClient\SqlColumnEncryptionCngProvider.Unix.cs" />
-    <Compile Include="Microsoft\Data\SqlClient\SqlColumnEncryptionCspProvider.Unix.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlFileStream.Unsupported.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParser.Unix.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParserStateObjectFactory.Managed.cs" />

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.netcore.Unix.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.netcore.Unix.cs
@@ -2,35 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NET
+
 using System;
 
 namespace Microsoft.Data.SqlClient
 {
-    /// <summary>
-    /// Provides implementation similar to certificate store provider.
-    /// A CEK encrypted with certificate provider should be decryptable by this provider and vice versa.
-    /// 
-    /// Envolope Format for the encrypted column encryption key  
-    ///           version + keyPathLength + ciphertextLength + keyPath + ciphertext +  signature
-    /// version: A single byte indicating the format version.
-    /// keyPathLength: Length of the keyPath.
-    /// ciphertextLength: ciphertext length
-    /// keyPath: keyPath used to encrypt the column encryption key. This is only used for troubleshooting purposes and is not verified during decryption.
-    /// ciphertext: Encrypted column encryption key
-    /// signature: Signature of the entire byte array. Signature is validated before decrypting the column encryption key.
-    /// </summary>
-    public class SqlColumnEncryptionCngProvider : SqlColumnEncryptionKeyStoreProvider
+    /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/SqlColumnEncryptionCertificateStoreProvider/*' />
+    public class SqlColumnEncryptionCertificateStoreProvider : SqlColumnEncryptionKeyStoreProvider
     {
         /// <summary>
-        /// Name for the CNG key store provider.
+        /// Name for the certificate key store provider.
         /// </summary>
-        public const string ProviderName = @"MSSQL_CNG_STORE";
+        public const string ProviderName = @"MSSQL_CERTIFICATE_STORE";
 
         /// <summary>
-        /// This function uses the asymmetric key specified by the key path
+        /// This function uses a certificate specified by the key path
         /// and decrypts an encrypted CEK with RSA encryption algorithm.
         /// </summary>
-        /// <param name="masterKeyPath">Complete path of an asymmetric key in CNG</param>
+        /// <param name="masterKeyPath">Complete path of a certificate</param>
         /// <param name="encryptionAlgorithm">Asymmetric Key Encryption Algorithm</param>
         /// <param name="encryptedColumnEncryptionKey">Encrypted Column Encryption Key</param>
         /// <returns>Plain text column encryption key</returns>
@@ -40,10 +30,10 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <summary>
-        /// This function uses the asymmetric key specified by the key path
+        /// This function uses a certificate specified by the key path
         /// and encrypts CEK with RSA encryption algorithm.
         /// </summary>
-        /// <param name="masterKeyPath">Complete path of an asymmetric key in AKV</param>
+        /// <param name="masterKeyPath">Complete path of a certificate</param>
         /// <param name="encryptionAlgorithm">Asymmetric Key Encryption Algorithm</param>
         /// <param name="columnEncryptionKey">The plaintext column encryption key</param>
         /// <returns>Encrypted column encryption key</returns>
@@ -53,18 +43,20 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <summary>
-        /// Throws NotSupportedException. In this version of .NET Framework this provider does not support signing column master key metadata.
+        /// This function must be implemented by the corresponding Key Store providers. This function should use an asymmetric key identified by a key path
+        /// and sign the masterkey metadata consisting of (masterKeyPath, allowEnclaveComputations bit, providerName).
         /// </summary>
         /// <param name="masterKeyPath">Complete path of an asymmetric key. Path format is specific to a key store provider.</param>
         /// <param name="allowEnclaveComputations">Boolean indicating whether this key can be sent to trusted enclave</param>
-        /// <returns>Encrypted column encryption key</returns>
+        /// <returns>Signature for master key metadata</returns>
         public override byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
         {
             throw new PlatformNotSupportedException();
         }
 
         /// <summary>
-        /// Throws NotSupportedException. In this version of .NET Framework this provider does not support verifying signatures of column master key metadata.
+        /// This function must be implemented by the corresponding Key Store providers. This function should use an asymmetric key identified by a key path
+        /// and verify the masterkey metadata consisting of (masterKeyPath, allowEnclaveComputations bit, providerName).
         /// </summary>
         /// <param name="masterKeyPath">Complete path of an asymmetric key. Path format is specific to a key store provider.</param>
         /// <param name="allowEnclaveComputations">Boolean indicating whether this key can be sent to trusted enclave</param>
@@ -76,3 +68,5 @@ namespace Microsoft.Data.SqlClient
         }
     }
 }
+
+#endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.netcore.Unix.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.netcore.Unix.cs
@@ -2,13 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NET
+
 using System;
 
 namespace Microsoft.Data.SqlClient
 {
     /// <summary>
     /// Provides implementation similar to certificate store provider.
-    /// A CEK encrypted with certificate store provider should be decryptable by this provider and vice versa.
+    /// A CEK encrypted with certificate provider should be decryptable by this provider and vice versa.
     /// 
     /// Envolope Format for the encrypted column encryption key  
     ///           version + keyPathLength + ciphertextLength + keyPath + ciphertext +  signature
@@ -19,23 +21,22 @@ namespace Microsoft.Data.SqlClient
     /// ciphertext: Encrypted column encryption key
     /// signature: Signature of the entire byte array. Signature is validated before decrypting the column encryption key.
     /// </summary>
-    public class SqlColumnEncryptionCspProvider : SqlColumnEncryptionKeyStoreProvider
+    public class SqlColumnEncryptionCngProvider : SqlColumnEncryptionKeyStoreProvider
     {
         /// <summary>
-        /// Name for the CSP key store provider.
+        /// Name for the CNG key store provider.
         /// </summary>
-        public const string ProviderName = @"MSSQL_CSP_PROVIDER";
+        public const string ProviderName = @"MSSQL_CNG_STORE";
 
         /// <summary>
         /// This function uses the asymmetric key specified by the key path
         /// and decrypts an encrypted CEK with RSA encryption algorithm.
         /// </summary>
-        /// <param name="masterKeyPath">Complete path of an asymmetric key in CSP</param>
+        /// <param name="masterKeyPath">Complete path of an asymmetric key in CNG</param>
         /// <param name="encryptionAlgorithm">Asymmetric Key Encryption Algorithm</param>
         /// <param name="encryptedColumnEncryptionKey">Encrypted Column Encryption Key</param>
         /// <returns>Plain text column encryption key</returns>
-        public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm,
-            byte[] encryptedColumnEncryptionKey)
+        public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
         {
             throw new PlatformNotSupportedException();
         }
@@ -48,8 +49,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="encryptionAlgorithm">Asymmetric Key Encryption Algorithm</param>
         /// <param name="columnEncryptionKey">The plaintext column encryption key</param>
         /// <returns>Encrypted column encryption key</returns>
-        public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm,
-            byte[] columnEncryptionKey)
+        public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
         {
             throw new PlatformNotSupportedException();
         }
@@ -78,3 +78,5 @@ namespace Microsoft.Data.SqlClient
         }
     }
 }
+
+#endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.netcore.Unix.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.netcore.Unix.cs
@@ -2,59 +2,73 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NET
+
 using System;
 
 namespace Microsoft.Data.SqlClient
 {
-    /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/SqlColumnEncryptionCertificateStoreProvider/*' />
-    public class SqlColumnEncryptionCertificateStoreProvider : SqlColumnEncryptionKeyStoreProvider
+    /// <summary>
+    /// Provides implementation similar to certificate store provider.
+    /// A CEK encrypted with certificate store provider should be decryptable by this provider and vice versa.
+    /// 
+    /// Envolope Format for the encrypted column encryption key  
+    ///           version + keyPathLength + ciphertextLength + keyPath + ciphertext +  signature
+    /// version: A single byte indicating the format version.
+    /// keyPathLength: Length of the keyPath.
+    /// ciphertextLength: ciphertext length
+    /// keyPath: keyPath used to encrypt the column encryption key. This is only used for troubleshooting purposes and is not verified during decryption.
+    /// ciphertext: Encrypted column encryption key
+    /// signature: Signature of the entire byte array. Signature is validated before decrypting the column encryption key.
+    /// </summary>
+    public class SqlColumnEncryptionCspProvider : SqlColumnEncryptionKeyStoreProvider
     {
         /// <summary>
-        /// Name for the certificate key store provider.
+        /// Name for the CSP key store provider.
         /// </summary>
-        public const string ProviderName = @"MSSQL_CERTIFICATE_STORE";
+        public const string ProviderName = @"MSSQL_CSP_PROVIDER";
 
         /// <summary>
-        /// This function uses a certificate specified by the key path
+        /// This function uses the asymmetric key specified by the key path
         /// and decrypts an encrypted CEK with RSA encryption algorithm.
         /// </summary>
-        /// <param name="masterKeyPath">Complete path of a certificate</param>
+        /// <param name="masterKeyPath">Complete path of an asymmetric key in CSP</param>
         /// <param name="encryptionAlgorithm">Asymmetric Key Encryption Algorithm</param>
         /// <param name="encryptedColumnEncryptionKey">Encrypted Column Encryption Key</param>
         /// <returns>Plain text column encryption key</returns>
-        public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
+        public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm,
+            byte[] encryptedColumnEncryptionKey)
         {
             throw new PlatformNotSupportedException();
         }
 
         /// <summary>
-        /// This function uses a certificate specified by the key path
+        /// This function uses the asymmetric key specified by the key path
         /// and encrypts CEK with RSA encryption algorithm.
         /// </summary>
-        /// <param name="masterKeyPath">Complete path of a certificate</param>
+        /// <param name="masterKeyPath">Complete path of an asymmetric key in AKV</param>
         /// <param name="encryptionAlgorithm">Asymmetric Key Encryption Algorithm</param>
         /// <param name="columnEncryptionKey">The plaintext column encryption key</param>
         /// <returns>Encrypted column encryption key</returns>
-        public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
+        public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm,
+            byte[] columnEncryptionKey)
         {
             throw new PlatformNotSupportedException();
         }
 
         /// <summary>
-        /// This function must be implemented by the corresponding Key Store providers. This function should use an asymmetric key identified by a key path
-        /// and sign the masterkey metadata consisting of (masterKeyPath, allowEnclaveComputations bit, providerName).
+        /// Throws NotSupportedException. In this version of .NET Framework this provider does not support signing column master key metadata.
         /// </summary>
         /// <param name="masterKeyPath">Complete path of an asymmetric key. Path format is specific to a key store provider.</param>
         /// <param name="allowEnclaveComputations">Boolean indicating whether this key can be sent to trusted enclave</param>
-        /// <returns>Signature for master key metadata</returns>
+        /// <returns>Encrypted column encryption key</returns>
         public override byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
         {
             throw new PlatformNotSupportedException();
         }
 
         /// <summary>
-        /// This function must be implemented by the corresponding Key Store providers. This function should use an asymmetric key identified by a key path
-        /// and verify the masterkey metadata consisting of (masterKeyPath, allowEnclaveComputations bit, providerName).
+        /// Throws NotSupportedException. In this version of .NET Framework this provider does not support verifying signatures of column master key metadata.
         /// </summary>
         /// <param name="masterKeyPath">Complete path of an asymmetric key. Path format is specific to a key store provider.</param>
         /// <param name="allowEnclaveComputations">Boolean indicating whether this key can be sent to trusted enclave</param>
@@ -66,3 +80,5 @@ namespace Microsoft.Data.SqlClient
         }
     }
 }
+
+#endif


### PR DESCRIPTION
**Description**: This is the easiest one so far - literally moving the SqlColumnEncryption*.Unix classes to the common project. The files were wrapped in an `#if NET` to make sure they're only applied to netcore. The suffixes were updated to ".netcore.Unix" - I'm not entirely sure the best way to approach this since the class only applies to Unix, which implicitly means it only applies to netcore.

**Testing**: The files were cut and pasted, there was no code changes.