### PR TITLE
Merge | Port SqlDataSourceConverter, widen test coverage

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -1052,6 +1052,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/DataSource/*'/>
         [System.ComponentModel.DisplayNameAttribute("Data Source")]
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
+        [System.ComponentModel.TypeConverter("Microsoft.Data.SqlClient.SqlConnectionStringBuilder+SqlDataSourceConverter")]
         public string DataSource { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/AttestationProtocol/*' />
         [System.ComponentModel.DisplayNameAttribute("Attestation Protocol")]
@@ -1085,6 +1086,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/FailoverPartner/*'/>
         [System.ComponentModel.DisplayNameAttribute("Failover Partner")]
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
+        [System.ComponentModel.TypeConverter("Microsoft.Data.SqlClient.SqlConnectionStringBuilder+SqlDataSourceConverter")]
         public string FailoverPartner { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/FailoverPartnerSPN/*'/>
         [System.ComponentModel.DisplayNameAttribute("Failover Partner SPN")]

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -1039,6 +1039,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/DataSource/*'/>
         [System.ComponentModel.DisplayNameAttribute("Data Source")]
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
+        [System.ComponentModel.TypeConverter("Microsoft.Data.SqlClient.SqlConnectionStringBuilder+SqlDataSourceConverter")]
         public string DataSource { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/EnclaveAttestationUrl/*'/>
         [System.ComponentModel.DisplayNameAttribute("Enclave Attestation Url")]
@@ -1072,6 +1073,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/FailoverPartner/*'/>
         [System.ComponentModel.DisplayNameAttribute("Failover Partner")]
         [System.ComponentModel.RefreshPropertiesAttribute(System.ComponentModel.RefreshProperties.All)]
+        [System.ComponentModel.TypeConverter("Microsoft.Data.SqlClient.SqlConnectionStringBuilder+SqlDataSourceConverter")]
         public string FailoverPartner { get { throw null; } set { } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnectionStringBuilder.xml' path='docs/members[@name="SqlConnectionStringBuilder"]/FailoverPartnerSPN/*'/>
         [System.ComponentModel.DisplayNameAttribute("Failover Partner SPN")]

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -749,7 +749,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-#if NETFRAMEWORK
         private sealed class SqlDataSourceConverter : StringConverter
         {
             private StandardValuesCollection _standardValues;
@@ -768,10 +767,8 @@ namespace Microsoft.Data.SqlClient
                 {
                     // Get the sources rowset for the SQLOLEDB enumerator
                     DataTable table = SqlClientFactory.Instance.CreateDataSourceEnumerator().GetDataSources();
-                    string ServerName = typeof(System.Data.Sql.SqlDataSourceEnumerator).GetField("ServerName", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null).ToString();
-                    string InstanceName = typeof(System.Data.Sql.SqlDataSourceEnumerator).GetField("InstanceName", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null).ToString();
-                    DataColumn serverName = table.Columns[ServerName];
-                    DataColumn instanceName = table.Columns[InstanceName];
+                    DataColumn serverName = table.Columns[Microsoft.Data.Sql.SqlDataSourceEnumeratorUtil.ServerNameCol];
+                    DataColumn instanceName = table.Columns[Microsoft.Data.Sql.SqlDataSourceEnumeratorUtil.InstanceNameCol];
                     DataRowCollection rows = table.Rows;
 
                     string[] serverNames = new string[rows.Count];
@@ -889,7 +886,7 @@ namespace Microsoft.Data.SqlClient
                 return standardValues;
             }
         }
-#else    
+#if NET
         private static readonly string[] s_notSupportedKeywords = {
             DbConnectionStringKeywords.ConnectionReset,
             DbConnectionStringKeywords.TransactionBinding,
@@ -1194,9 +1191,7 @@ namespace Microsoft.Data.SqlClient
         [ResCategory(StringsHelper.ResourceNames.DataCategory_Source)]
         [ResDescription(StringsHelper.ResourceNames.DbConnectionString_DataSource)]
         [RefreshProperties(RefreshProperties.All)]
-#if NETFRAMEWORK
-        [TypeConverter(typeof(SqlDataSourceConverter))]
-#endif
+        [TypeConverter("Microsoft.Data.SqlClient.SqlConnectionStringBuilder+SqlDataSourceConverter")]
         public string DataSource
         {
             get => _dataSource;
@@ -1378,9 +1373,7 @@ namespace Microsoft.Data.SqlClient
         [ResCategory(StringsHelper.ResourceNames.DataCategory_Source)]
         [ResDescription(StringsHelper.ResourceNames.DbConnectionString_FailoverPartner)]
         [RefreshProperties(RefreshProperties.All)]
-#if NETFRAMEWORK
-        [TypeConverter(typeof(SqlDataSourceConverter))]
-#endif
+        [TypeConverter("Microsoft.Data.SqlClient.SqlConnectionStringBuilder+SqlDataSourceConverter")]
         public string FailoverPartner
         {
             get => _failoverPartner;

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -492,7 +492,7 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Null(result);
         }
 
-        #region SqlConnectionEncryptOptionCoverterTests
+        #region TypeConverter Tests
         [Fact]
         public void ConnectionStringFromJsonTests()
         {
@@ -531,6 +531,81 @@ namespace Microsoft.Data.SqlClient.Tests
         }
 
         [Fact]
+        public void SqlConnectionStringBuilderConverterRoundTrip()
+        {
+            const string SampleConnectionString = "Data Source=localhost;Initial Catalog=master;Integrated Security=True";
+
+            Type instanceDescriptorType = typeof(System.ComponentModel.Design.Serialization.InstanceDescriptor);
+            // Verify that we can use the SqlConnectionStringBuilder's TypeConverter to round-trip a SqlConnectionStringBuilder
+            // to an InstanceDescriptor, then back to another SqlConnectionStringBuilder with the same resultant connection string.
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(SampleConnectionString);
+            TypeConverter converter = TypeDescriptor.GetConverter(typeof(SqlConnectionStringBuilder));
+
+            Assert.NotNull(converter);
+            Assert.True(converter.CanConvertTo(instanceDescriptorType));
+
+            object resultantInstanceDescriptor = converter.ConvertTo(builder, instanceDescriptorType);
+
+            Assert.IsType(instanceDescriptorType, resultantInstanceDescriptor);
+
+            object resultantConnectionStringBuilder = (resultantInstanceDescriptor as System.ComponentModel.Design.Serialization.InstanceDescriptor).Invoke();
+
+            Assert.IsType<SqlConnectionStringBuilder>(resultantConnectionStringBuilder);
+
+            Assert.Equal(builder.ConnectionString, (resultantConnectionStringBuilder as SqlConnectionStringBuilder).ConnectionString);
+        }
+
+        [Fact]
+        public void DataSourceConverterCanConvertFromTest()
+        {
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor dataSourceDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.DataSource), false);
+            TypeConverter converter = dataSourceDescriptor?.Converter;
+
+            Assert.NotNull(dataSourceDescriptor);
+            Assert.NotNull(converter);
+            // Use the converter to determine if can convert from string data type
+            Assert.True(converter.CanConvertFrom(null, typeof(string)), "Expecting to convert from a string type.");
+            // Use the same converter to determine if can convert from int or bool data types
+            Assert.False(converter.CanConvertFrom(null, typeof(int)), "Not expecting to convert from integer type.");
+            Assert.False(converter.CanConvertFrom(null, typeof(bool)), "Not expecting to convert from boolean type.");
+        }
+
+        [Fact]
+        public void FailoverPartnerConverterCanConvertFromTest()
+        {
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor failoverPartnerDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.FailoverPartner), false);
+            TypeConverter converter = failoverPartnerDescriptor?.Converter;
+
+            Assert.NotNull(failoverPartnerDescriptor);
+            Assert.NotNull(converter);
+            // Use the converter to determine if can convert from string data type
+            Assert.True(converter.CanConvertFrom(null, typeof(string)), "Expecting to convert from a string type.");
+            // Use the same converter to determine if can convert from int or bool data types
+            Assert.False(converter.CanConvertFrom(null, typeof(int)), "Not expecting to convert from integer type.");
+            Assert.False(converter.CanConvertFrom(null, typeof(bool)), "Not expecting to convert from boolean type.");
+        }
+
+#if NETFRAMEWORK
+        [Fact]
+        public void NetworkLibraryConverterCanConvertFromTest()
+        {
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor networkLibraryDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.NetworkLibrary), false);
+            TypeConverter converter = networkLibraryDescriptor?.Converter;
+
+            Assert.NotNull(networkLibraryDescriptor);
+            Assert.NotNull(converter);
+            // Use the converter to determine if can convert from string data type
+            Assert.True(converter.CanConvertFrom(null, typeof(string)), "Expecting to convert from a string type.");
+            // Use the same converter to determine if can convert from int or bool data types
+            Assert.False(converter.CanConvertFrom(null, typeof(int)), "Not expecting to convert from integer type.");
+            Assert.False(converter.CanConvertFrom(null, typeof(bool)), "Not expecting to convert from boolean type.");
+        }
+#endif
+
+        [Fact]
         public void SqlConnectionEncryptOptionConverterCanConvertFromTest()
         {
             // Get a converter
@@ -544,17 +619,94 @@ namespace Microsoft.Data.SqlClient.Tests
         }
 
         [Fact]
+        public void DataSourceConverterCanConvertToTest()
+        {
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor dataSourceDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.DataSource), false);
+            TypeConverter converter = dataSourceDescriptor?.Converter;
+
+            Assert.NotNull(dataSourceDescriptor);
+            Assert.NotNull(converter);
+            // Use the converter to check if can convert from string
+            Assert.True(converter.CanConvertTo(null, typeof(string)), "Expecting to convert to a string type.");
+            // Use the same convert to check if can convert to int or bool
+            Assert.False(converter.CanConvertTo(null, typeof(int)), "Not expecting to convert to integer type.");
+            Assert.False(converter.CanConvertTo(null, typeof(bool)), "Not expecting to convert to boolean type.");
+        }
+
+        [Fact]
+        public void FailoverPartnerConverterCanConvertToTest()
+        {
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor failoverPartnerDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.FailoverPartner), false);
+            TypeConverter converter = failoverPartnerDescriptor?.Converter;
+
+            Assert.NotNull(failoverPartnerDescriptor);
+            Assert.NotNull(converter);
+            // Use the converter to check if can convert from string
+            Assert.True(converter.CanConvertTo(null, typeof(string)), "Expecting to convert to a string type.");
+            // Use the same convert to check if can convert to int or bool
+            Assert.False(converter.CanConvertTo(null, typeof(int)), "Not expecting to convert to integer type.");
+            Assert.False(converter.CanConvertTo(null, typeof(bool)), "Not expecting to convert to boolean type.");
+        }
+
+#if NETFRAMEWORK
+        [Fact]
+        public void NetworkLibraryConverterCanConvertToTest()
+        {
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor networkLibraryDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.NetworkLibrary), false);
+            TypeConverter converter = networkLibraryDescriptor?.Converter;
+
+            Assert.NotNull(networkLibraryDescriptor);
+            Assert.NotNull(converter);
+            // Use the converter to check if can convert from string
+            Assert.True(converter.CanConvertTo(null, typeof(string)), "Expecting to convert to a string type.");
+            // Use the same convert to check if can convert to int or bool
+            Assert.False(converter.CanConvertTo(null, typeof(int)), "Not expecting to convert to integer type.");
+            Assert.False(converter.CanConvertTo(null, typeof(bool)), "Not expecting to convert to boolean type.");
+        }
+#endif
+
+        [Fact]
         public void SqlConnectionEncryptOptionConverterCanConvertToTest()
         {
             // Get a converter
             SqlConnectionEncryptOption option = SqlConnectionEncryptOption.Parse("false");
             TypeConverter converter = TypeDescriptor.GetConverter(option.GetType());
-            // Use the converter to check if can convert from stirng
+            // Use the converter to check if can convert from string
             Assert.True(converter.CanConvertTo(null, typeof(string)), "Expecting to convert to a string type.");
             // Use the same convert to check if can convert to int or bool
-            Assert.False(converter.CanConvertTo(null, typeof(int)), "Not expecting to convert from integer type.");
-            Assert.False(converter.CanConvertTo(null, typeof(bool)), "Not expecting to convert from boolean type.");
+            Assert.False(converter.CanConvertTo(null, typeof(int)), "Not expecting to convert to integer type.");
+            Assert.False(converter.CanConvertTo(null, typeof(bool)), "Not expecting to convert to boolean type.");
         }
+
+#if NETFRAMEWORK
+        [Fact]
+        public void NetworkLibraryGetStandardValuesTest()
+        {
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor networkLibraryDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.NetworkLibrary), false);
+            TypeConverter converter = networkLibraryDescriptor?.Converter;
+
+            Assert.NotNull(networkLibraryDescriptor);
+            Assert.NotNull(converter);
+
+            Assert.True(converter.GetStandardValuesSupported());
+            Assert.False(converter.GetStandardValuesExclusive());
+
+            System.Collections.ICollection networkLibraries = converter.GetStandardValues();
+            string[] networkLibraryArray = new string[4];
+
+            Assert.Equal(4, networkLibraries.Count);
+            networkLibraries.CopyTo(networkLibraryArray, 0);
+
+            Assert.NotEqual(-1, Array.IndexOf(networkLibraryArray, "Named Pipes (DBNMPNTW)"));
+            Assert.NotEqual(-1, Array.IndexOf(networkLibraryArray, "Shared Memory (DBMSLPCN)"));
+            Assert.NotEqual(-1, Array.IndexOf(networkLibraryArray, "TCP/IP (DBMSSOCN)"));
+            Assert.NotEqual(-1, Array.IndexOf(networkLibraryArray, "VIA (DBMSGNET)"));
+        }
+#endif
 
         [Fact]
         public void SqlConnectionEncryptOptionConverterConvertFromTest()
@@ -577,6 +729,63 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Throws<ArgumentException>(() => converter.ConvertFrom(true));
         }
 
+#if NETFRAMEWORK
+        [Theory]
+        [InlineData("Named Pipes (DBNMPNTW)", "dbnmpntw")]
+        [InlineData("Shared Memory (DBMSLPCN)", "dbmslpcn")]
+        [InlineData("TCP/IP (DBMSSOCN)", "dbmssocn")]
+        [InlineData("VIA (DBMSGNET)", "dbmsgnet")]
+        public void NetworkLibraryConvertFromValidValueTest(string inputValue, string expectedOutput)
+        {
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor networkLibraryDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.NetworkLibrary), false);
+            TypeConverter converter = networkLibraryDescriptor?.Converter;
+
+            Assert.NotNull(networkLibraryDescriptor);
+            Assert.NotNull(converter);
+
+            // Test case 1: input value as-is
+            object outputValue = converter.ConvertFrom(inputValue);
+
+            Assert.IsType<string>(outputValue);
+            Assert.Equal(expectedOutput, outputValue as string);
+
+            // Test case 2: input value with leading/trailing spaces
+            outputValue = converter.ConvertFrom(" " + inputValue + " ");
+            Assert.IsType<string>(outputValue);
+            Assert.Equal(expectedOutput, outputValue as string);
+
+            // Test case 3: input value with mixed case
+            outputValue = converter.ConvertFrom(inputValue.ToUpper());
+            Assert.IsType<string>(outputValue);
+            Assert.Equal(expectedOutput, outputValue as string);
+        }
+
+        [Fact]
+        public void NetworkLibraryConvertFromInvalidValueTest()
+        {
+            const string InvalidValue = "Sample invalid value";
+
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor networkLibraryDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.NetworkLibrary), false);
+            TypeConverter converter = networkLibraryDescriptor?.Converter;
+
+            Assert.NotNull(networkLibraryDescriptor);
+            Assert.NotNull(converter);
+
+            // Test case 1: input value as-is
+            object outputValue = converter.ConvertFrom(InvalidValue);
+
+            Assert.IsType<string>(outputValue);
+            Assert.Equal(InvalidValue, outputValue as string);
+
+            // Test case 2: input value with leading/trailing spaces
+            outputValue = converter.ConvertFrom(" " + InvalidValue + " ");
+            Assert.IsType<string>(outputValue);
+            Assert.Equal(InvalidValue, outputValue as string);
+        }
+#endif
+
         [Fact]
         public void SqlConnectionEncryptOptionConverterConvertToTest()
         {
@@ -595,6 +804,61 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Throws<ArgumentException>(() => converter.ConvertTo(SqlConnectionEncryptOption.Parse("false"), typeof(int)));
             Assert.Throws<ArgumentException>(() => converter.ConvertTo(SqlConnectionEncryptOption.Parse("false"), typeof(bool)));
         }
+
+#if NETFRAMEWORK
+        [Theory]
+        [InlineData("dbnmpntw", "Named Pipes (DBNMPNTW)")]
+        [InlineData("dbmslpcn", "Shared Memory (DBMSLPCN)")]
+        [InlineData("dbmssocn", "TCP/IP (DBMSSOCN)")]
+        [InlineData("dbmsgnet", "VIA (DBMSGNET)")]
+        public void NetworkLibraryConvertToValidValueTest(string inputValue, string expectedOutput)
+        {
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor networkLibraryDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.NetworkLibrary), false);
+            TypeConverter converter = networkLibraryDescriptor?.Converter;
+
+            Assert.NotNull(networkLibraryDescriptor);
+            Assert.NotNull(converter);
+
+            // Test case 1: input value as-is
+            object outputValue = converter.ConvertTo(inputValue, typeof(string));
+
+            Assert.IsType<string>(outputValue);
+            Assert.Equal(expectedOutput, outputValue as string);
+
+            // Test case 2: input value with leading/trailing spaces
+            outputValue = converter.ConvertTo(" " + inputValue + " ", typeof(string));
+            Assert.IsType<string>(outputValue);
+            Assert.Equal(expectedOutput, outputValue as string);
+
+            // Test case 3: input value with mixed case
+            outputValue = converter.ConvertTo(inputValue.ToUpper(), typeof(string));
+            Assert.IsType<string>(outputValue);
+            Assert.Equal(expectedOutput, outputValue as string);
+        }
+
+        [Fact]
+        public void NetworkLibraryConvertToInvalidValueTest()
+        {
+            const string InvalidValue = " Sample invalid value ";
+
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor networkLibraryDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.NetworkLibrary), false);
+            TypeConverter converter = networkLibraryDescriptor?.Converter;
+
+            Assert.NotNull(networkLibraryDescriptor);
+            Assert.NotNull(converter);
+
+            // In all cases, the output value should be the same as the input value
+            object outputValue = converter.ConvertTo(InvalidValue, typeof(string));
+
+            Assert.IsType<string>(outputValue);
+            Assert.Equal(InvalidValue, outputValue as string);
+
+            // Converting to an invalid type should throw an exception
+            Assert.Throws<NotSupportedException>(() => converter.ConvertTo(InvalidValue, typeof(int)));
+        }
+#endif
 
         internal class UserDbConnectionStringSettings
         {
@@ -643,7 +907,7 @@ namespace Microsoft.Data.SqlClient.Tests
 
             return settingsOut;
         }
-        #endregion
+#endregion
 
         internal void ExecuteConnectionStringTests(string connectionString)
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlDSEnumeratorTest/SqlDataSourceEnumeratorTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlDSEnumeratorTest/SqlDataSourceEnumeratorTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.ServiceProcess;
 using Microsoft.Data.Sql;
@@ -41,6 +42,28 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             // After adding the managed SNI support, this test should have the same result as SqlDataSourceEnumerator_NativeSNI
             Assert.Throws<NotImplementedException>(() => GetDSEnumerator().GetDataSources());
+        }
+
+        // This test validates behavior of SqlDataSourceConverter used to present instance names in PropertyGrid
+        // with the SqlConnectionStringBuilder object presented in the control underneath.
+        [ConditionalFact(nameof(IsEnvironmentAvailable))]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void TestDataSourceConverterGetStandardValues()
+        {
+            PropertyDescriptorCollection csbDescriptor = TypeDescriptor.GetProperties(typeof(SqlConnectionStringBuilder));
+            PropertyDescriptor dataSourceDescriptor = csbDescriptor.Find(nameof(SqlConnectionStringBuilder.DataSource), false);
+            TypeConverter converter = dataSourceDescriptor?.Converter;
+
+            Assert.NotNull(dataSourceDescriptor);
+            Assert.NotNull(converter);
+
+            Assert.True(converter.GetStandardValuesSupported());
+            Assert.False(converter.GetStandardValuesExclusive());
+
+            System.Collections.ICollection dataSources = converter.GetStandardValues();
+            int count = dataSources.Count;
+
+            Assert.InRange(count, 0, 65536);
         }
 
         private SqlDataSourceEnumerator GetDSEnumerator()

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlSchemaInfoTest/SqlSchemaInfoTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlSchemaInfoTest/SqlSchemaInfoTest.cs
@@ -99,16 +99,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connection.ConnectionString);
                 PropertyDescriptorCollection properties = TypeDescriptor.GetProperties(builder);
                 PropertyDescriptor descriptor = properties["InitialCatalog"];
+                DescriptorContext descriptorContext = new DescriptorContext(descriptor, builder);
 
                 DataTestUtility.AssertEqualsWithDescription(
                     "SqlInitialCatalogConverter", descriptor.Converter.GetType().Name,
                     "Unexpected TypeConverter type.");
 
-                Assert.True(descriptor.Converter.GetStandardValuesSupported());
+                Assert.True(descriptor.Converter.GetStandardValuesSupported(descriptorContext));
                 Assert.False(descriptor.Converter.GetStandardValuesExclusive());
 
                 // GetStandardValues of this converter calls GetSchema("DATABASES")
-                var dbNames = descriptor.Converter.GetStandardValues(new DescriptorContext(descriptor, builder));
+                var dbNames = descriptor.Converter.GetStandardValues(descriptorContext);
                 HashSet<string> searchSet = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
                 foreach (string name in dbNames)
                 {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlSchemaInfoTest/SqlSchemaInfoTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlSchemaInfoTest/SqlSchemaInfoTest.cs
@@ -104,6 +104,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     "SqlInitialCatalogConverter", descriptor.Converter.GetType().Name,
                     "Unexpected TypeConverter type.");
 
+                Assert.True(descriptor.Converter.GetStandardValuesSupported());
+                Assert.False(descriptor.Converter.GetStandardValuesExclusive());
+
                 // GetStandardValues of this converter calls GetSchema("DATABASES")
                 var dbNames = descriptor.Converter.GetStandardValues(new DescriptorContext(descriptor, builder));
                 HashSet<string> searchSet = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);


### PR DESCRIPTION
#3243 reminded me that we didn't completely port the TypeConverters for `SqlConnectionStringBuilder`.

This PR makes sure that the WinForms PropertyGrid behaviour is consistent between .NET Core and .NET Framework for the `DataSource` and the `FailoverPartner` properties.

Both this and `NetworkLibraryConverter` also had [very poor](https://app.codecov.io/gh/dotnet/SqlClient/blob/main/src%2FMicrosoft.Data.SqlClient%2Fsrc%2FMicrosoft%2FData%2FSqlClient%2FSqlConnectionStringBuilder.cs#L712) code coverage; I've added tests to broaden this.

I'd appreciate a CI & Codecov run.