### PR TITLE
Merge | Fix/commands null

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBatch.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBatch.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Data.SqlClient
             }
             if (_commands is null) 
             {
-                throw ADP.ArgumentNull(nameof(_commands));
+                throw ADP.InvalidOperation("SqlBatchCommand list has not been initialized.");
             }
             _batchCommand.Connection = Connection;
             _batchCommand.Transaction = Transaction;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBatch.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBatch.cs
@@ -4,6 +4,7 @@
 
 #if NET
 
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -225,7 +226,7 @@ namespace Microsoft.Data.SqlClient
             }
             if (_commands is null) 
             {
-                throw ADP.InvalidOperation("SqlBatchCommand list has not been initialized.");
+                throw ADP.InvalidOperation(StringsHelper.GetString(Strings.ADP_NoSqlBatchCommandList));
             }
             _batchCommand.Connection = Connection;
             _batchCommand.Transaction = Transaction;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBatch.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBatch.cs
@@ -223,6 +223,10 @@ namespace Microsoft.Data.SqlClient
             {
                 throw ADP.ConnectionRequired(nameof(SetupBatchCommandExecute));
             }
+            if (_commands is null) 
+            {
+                throw ADP.ArgumentNull(nameof(_commands));
+            }
             _batchCommand.Connection = Connection;
             _batchCommand.Transaction = Transaction;
             _batchCommand.SetBatchRPCMode(true, _commands.Count);

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -1301,7 +1301,18 @@ namespace System {
                 return ResourceManager.GetString("ADP_NoQuoteChange", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to SqlBatchCommands list has not been initialized..
+        /// </summary>
+        internal static string ADP_NoSqlBatchCommandList
+        {
+            get
+            {
+                return ResourceManager.GetString("ADP_NoSqlBatchCommandList", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The stored procedure &apos;{0}&apos; doesn&apos;t exist..
         /// </summary>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -1303,7 +1303,7 @@ namespace System {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to SqlBatchCommands list has not been initialized..
+        ///   Looks up a localized string similar to SqlBatchCommand list has not been initialized..
         /// </summary>
         internal static string ADP_NoSqlBatchCommandList
         {

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -4740,4 +4740,7 @@
   <data name="ADP_ColumnSchemaMissing1" xml:space="preserve">
     <value>Missing the DataColumn '{0}' for the SourceColumn '{2}'.</value>
   </data>
+  <data name="ADP_NoSqlBatchCommandsList" xml:space="preserve">
+    <value>SqlBatchCommands list has not been initialized.</value>
+  </data>
 </root>

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -4740,7 +4740,7 @@
   <data name="ADP_ColumnSchemaMissing1" xml:space="preserve">
     <value>Missing the DataColumn '{0}' for the SourceColumn '{2}'.</value>
   </data>
-  <data name="ADP_NoSqlBatchCommandsList" xml:space="preserve">
-    <value>SqlBatchCommands list has not been initialized.</value>
+  <data name="ADP_NoSqlBatchCommandList" xml:space="preserve">
+    <value>SqlBatchCommand list has not been initialized.</value>
   </data>
 </root>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Batch/BatchTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Batch/BatchTests.cs
@@ -26,6 +26,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static async Task MissingCommandsThrows()
+        {
+            using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            using (var batch = new SqlBatch { Connection = connection })
+            {
+                connection.Open();
+                await Assert.ThrowsAsync<InvalidOperationException>(() => batch.ExecuteReaderAsync());
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void MissingConnectionThrows()
         {
             using (var batch = new SqlBatch { BatchCommands = { new SqlBatchCommand("SELECT @@SPID") } })


### PR DESCRIPTION
Currently the method is returning **Object reference not set to an instance of an object** when we try to run a batch without commands. This PR returns **SqlBatchCommand list has not been initialized** instead.

I'd appreciate a CI & Test run.