### PR TITLE
Backport 5.1 | Nuget Audit Sources

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -67,8 +67,18 @@
   <PropertyGroup Condition="'$(BuildSimulator)' == 'true'">
     <DefineConstants>$(DefineConstants);ENCLAVE_SIMULATOR</DefineConstants>
   </PropertyGroup>
-
-  <!-- Audit Settings -->
+  
+  <!-- NuGet Audit Settings -->
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <!--
+      ADO does not support audit/vulnerability feeds, so the audit feed is specified (in
+      nuget.config) as nuget.org. OneBranch default network isolation does not allow connections
+      to nuget.org. To avoid this issue, we will disable auditing for official builds, but leave it
+      enabled for local builds.
+      @TODO: If/when auditing is enabled for central feeds services, this can be removed. 
+    -->
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
   <PropertyGroup>
     <NuGetAuditMode>all</NuGetAuditMode>
   </PropertyGroup>


### PR DESCRIPTION
**Description**: This is a simple backport of the Nuget Audit settings from the main branch to the 5.1 branch. There is a slight change from the implementation in main, since technically the `<nugetaudit>` tag does not support the `condition` attribute. The solution is to move it to its own property group. This eliminates an IDE warning when editing the file in an IDE.

Reminder that the reason for disabling auditing on official builds is that the official builds are only allowed to access central feed services (ie, ADO artifacts). The nuget audit by default uses nuget.org. Accessing nuget.org from an official build causes the S360 errors.

**Testing**: Everything still builds locally as expected. I will kick off an official build against this branch to ensure it does not raise a S360 error.
https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=114567