### PR TITLE
Engineering | Nuget Audit Sources Fix

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -72,7 +72,7 @@
   </PropertyGroup>
   
   <!-- NuGet Audit Settings -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
     <!--
       ADO does not support audit/vulnerability feeds, so the audit feed is specified (in
       nuget.config) as nuget.org. OneBranch default network isolation does not allow connections
@@ -80,7 +80,9 @@
       enabled for local builds.
       @TODO: If/when auditing is enabled for central feeds services, this can be removed. 
     -->
-    <NuGetAudit Condition="'$(TF_BUILD)' == 'true'">false</NuGetAudit>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+  <PropertyGroup>
     <NuGetAuditMode>all</NuGetAuditMode>
   </PropertyGroup>
 


### PR DESCRIPTION
**Description**: A small change to the conditional Nuget audit sources in the `Directory.Build.props` file. Nuget audit sources are disabled as part of CI/official builds, but enabled for local builds. However, the way this check was originally implemented was technically incorrectly done. The `<nugetaudit>` technically doesn't allow the `condition` attribute, but msbuild will allow it. However, my IDE gives a warning about it using the attribute incorrectly, so this change moves the condition to a `<propertygroup>` tag that wraps the `<nugetaudit>` tag.

**Testing**: Build runs successfully locally, I will launch an official build against the branch to verify it's official build behavior.
https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=114574&view=results