### PR TITLE
Merge | SqlInternalConnectionTds preparation

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Data.SqlClient
                 opt = new SqlConnectionString(opt, instanceName, userInstance: false, setEnlistValue: null);
                 poolGroupProviderInfo = null; // null so we do not pass to constructor below...
             }
-            return new SqlInternalConnectionTds(identity, opt, key.Credential, poolGroupProviderInfo, "", null, redirectedUserInstance, userOpt, recoverySessionData, applyTransientFaultHandling: applyTransientFaultHandling, key.AccessToken, pool, key.AccessTokenCallback);
+            return new SqlInternalConnectionTds(identity, opt, key.Credential, poolGroupProviderInfo, "", null, redirectedUserInstance, userOpt, recoverySessionData, applyTransientFaultHandling, key.AccessToken, pool, key.AccessTokenCallback);
         }
 
         protected override DbConnectionOptions CreateConnectionOptions(string connectionString, DbConnectionOptions previous)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -879,12 +879,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal override bool IsConnectionAlive(bool throwOnException)
-        {
-            bool isAlive = false;
-            isAlive = _parser._physicalStateObj.IsConnectionAlive(throwOnException);
-            return isAlive;
-        }
+        internal override bool IsConnectionAlive(bool throwOnException) =>
+            _parser._physicalStateObj.IsConnectionAlive(throwOnException);
 
         ////////////////////////////////////////////////////////////////////////////////////////
         // POOLING METHODS

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1246,7 +1246,7 @@ namespace Microsoft.Data.SqlClient
                     _currentSessionData._initialCollation = _currentSessionData._collation;
                     _currentSessionData._initialLanguage = _currentLanguage;
                 }
-                bool isEncrypted = _parser.EncryptionOptions == EncryptionOptions.ON;
+                bool isEncrypted = (_parser.EncryptionOptions & EncryptionOptions.OPTIONS_MASK) == EncryptionOptions.ON;
                 if (_recoverySessionData != null)
                 {
                     if (_recoverySessionData._encrypted != isEncrypted)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2759,6 +2759,7 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS:
                     {
                         SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
+
                         if (data.Length < 1)
                         {
                             SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown version number for GlobalTransactions", ObjectID);
@@ -2772,6 +2773,7 @@ namespace Microsoft.Data.SqlClient
                         }
                         break;
                     }
+
                 case TdsEnums.FEATUREEXT_FEDAUTH:
                     {
                         SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for federated authentication", ObjectID);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2118,7 +2118,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void BreakConnection()
         {
-            var connection = Connection;
+            SqlConnection connection = Connection;
             SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.BreakConnection|RES|CPOOL> {0}, Breaking connection.", ObjectID);
             DoomThisConnection();   // Mark connection as unusable, so it will be destroyed
             if (connection != null)
@@ -2470,7 +2470,7 @@ namespace Microsoft.Data.SqlClient
             // Username to use in error messages.
             string username = null;
 
-            var authProvider = SqlAuthenticationProvider.GetProvider(ConnectionOptions.Authentication);
+            SqlAuthenticationProvider authProvider = SqlAuthenticationProvider.GetProvider(ConnectionOptions.Authentication);
             if (authProvider == null && _accessTokenCallback == null)
                 throw SQL.CannotFindAuthProvider(ConnectionOptions.Authentication.ToString());
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1817,14 +1817,14 @@ namespace Microsoft.Data.SqlClient
                             intervalTimer,
                             withFailover: true
                             );
-                    int routingAttemps = 0;
+                    int routingAttempts = 0;
                     while (RoutingInfo != null)
                     {
-                        if (routingAttemps > _maxNumberOfRedirectRoute)
+                        if (routingAttempts > _maxNumberOfRedirectRoute)
                         {
                             throw SQL.ROR_RecursiveRoutingNotSupported(this, _maxNumberOfRedirectRoute);
                         }
-                        routingAttemps++;
+                        routingAttempts++;
 
                         SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.LoginWithFailover> Routed to {0}", RoutingInfo.ServerName);
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Data.SqlClient
                     opt = new SqlConnectionString(opt, instanceName, false /* user instance=false */, null /* do not modify the Enlist value */);
                     poolGroupProviderInfo = null; // null so we do not pass to constructor below...
                 }
-                result = new SqlInternalConnectionTds(identity, opt, key.Credential, poolGroupProviderInfo, "", null, redirectedUserInstance, userOpt, recoverySessionData, applyTransientFaultHandling: applyTransientFaultHandling, key.AccessToken, pool, key.AccessTokenCallback);
+                result = new SqlInternalConnectionTds(identity, opt, key.Credential, poolGroupProviderInfo, "", null, redirectedUserInstance, userOpt, recoverySessionData, applyTransientFaultHandling, key.AccessToken, pool, key.AccessTokenCallback);
             }
             return result;
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Data.SqlClient
                     opt = new SqlConnectionString(opt, instanceName, false /* user instance=false */, null /* do not modify the Enlist value */);
                     poolGroupProviderInfo = null; // null so we do not pass to constructor below...
                 }
-                result = new SqlInternalConnectionTds(identity, opt, key.Credential, poolGroupProviderInfo, "", null, redirectedUserInstance, userOpt, recoverySessionData, pool, key.AccessToken, applyTransientFaultHandling: applyTransientFaultHandling, key.AccessTokenCallback);
+                result = new SqlInternalConnectionTds(identity, opt, key.Credential, poolGroupProviderInfo, "", null, redirectedUserInstance, userOpt, recoverySessionData, applyTransientFaultHandling: applyTransientFaultHandling, key.AccessToken, pool, key.AccessTokenCallback);
             }
             return result;
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1582,16 +1582,16 @@ namespace Microsoft.Data.SqlClient
 
             ResolveExtendedServerName(serverInfo, !redirectedUserInstance, connectionOptions);
 
-            Boolean disableTnir = ShouldDisableTnir(connectionOptions);
+            bool disableTnir = ShouldDisableTnir(connectionOptions);
 
             long timeoutUnitInterval = 0;
 
-            Boolean isParallel = connectionOptions.MultiSubnetFailover || (connectionOptions.TransparentNetworkIPResolution && !disableTnir);
-
+            bool isParallel = connectionOptions.MultiSubnetFailover || (connectionOptions.TransparentNetworkIPResolution && !disableTnir);
 
             if (isParallel)
             {
                 float failoverTimeoutStep = connectionOptions.MultiSubnetFailover ? ADP.FailoverTimeoutStep : ADP.FailoverTimeoutStepForTnir;
+
                 // Determine unit interval
                 if (timeout.IsInfinite)
                 {
@@ -1613,8 +1613,8 @@ namespace Microsoft.Data.SqlClient
             //  back into the parser for the error cases.
             int attemptNumber = 0;
             TimeoutTimer intervalTimer = null;
-
             TimeoutTimer attemptOneLoginTimeout = timeout;
+
             while (true)
             {
                 Boolean isFirstTransparentAttempt = connectionOptions.TransparentNetworkIPResolution && !disableTnir && attemptNumber == 1;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -475,7 +475,8 @@ namespace Microsoft.Data.SqlClient
                 reconnectSessionData._debugReconnectDataApplied = true;
             }
             try
-            { // use this to help validate this object is only created after the following permission has been previously demanded in the current codepath
+            {
+                // use this to help validate this object is only created after the following permission has been previously demanded in the current codepath
                 if (userConnectionOptions != null)
                 {
                     // As mentioned above, userConnectionOptions may be different to connectionOptions, so we need to demand on the correct connection string
@@ -2907,7 +2908,6 @@ namespace Microsoft.Data.SqlClient
                             }
 #endif
                         }
-
                         break;
                     }
                 case TdsEnums.FEATUREEXT_TCE:
@@ -2937,7 +2937,6 @@ namespace Microsoft.Data.SqlClient
                             // Extract the type of enclave being used by the server.
                             _parser.EnclaveType = Encoding.Unicode.GetString(data, 2, (data.Length - 2));
                         }
-
                         break;
                     }
 
@@ -3029,7 +3028,6 @@ namespace Microsoft.Data.SqlClient
                         // get IPv4 + IPv6 + Port number
                         // not put them in the DNS cache at this point but need to store them somewhere
                         // generate pendingSQLDNSObject and turn on IsSQLDNSRetryEnabled flag
-
                         break;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlInternalConnectionTds : SqlInternalConnection, IDisposable
+    internal sealed class SqlInternalConnectionTds : SqlInternalConnection, IDisposable
     {
         // https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/retry-after#simple-retry-for-errors-with-http-error-codes-500-600
         internal const int MsalHttpRetryStatusCode = 429;
@@ -299,7 +299,7 @@ namespace Microsoft.Data.SqlClient
         // 6. Reading ThreadHasParserLockForClose is thread-safe
         internal class SyncAsyncLock
         {
-            SemaphoreSlim semaphore = new SemaphoreSlim(1);
+            private SemaphoreSlim semaphore = new SemaphoreSlim(1);
 
             internal void Wait(bool canReleaseFromAnyThread)
             {
@@ -656,7 +656,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal SqlInternalTransaction CurrentTransaction
+        internal override SqlInternalTransaction CurrentTransaction
         {
             get
             {
@@ -664,7 +664,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal SqlInternalTransaction AvailableInternalTransaction
+        internal override SqlInternalTransaction AvailableInternalTransaction
         {
             get
             {
@@ -672,8 +672,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-
-        override internal SqlInternalTransaction PendingTransaction
+        internal override SqlInternalTransaction PendingTransaction
         {
             get
             {
@@ -697,7 +696,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool IsLockedForBulkCopy
+        internal override bool IsLockedForBulkCopy
         {
             get
             {
@@ -705,7 +704,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected internal bool IsNonPoolableTransactionRoot
+        internal protected override bool IsNonPoolableTransactionRoot
         {
             get
             {
@@ -713,7 +712,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override internal bool Is2008OrNewer
+        internal override bool Is2008OrNewer
         {
             get
             {
@@ -753,7 +752,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected bool ReadyToPrepareTransaction
+        protected override bool ReadyToPrepareTransaction
         {
             get
             {
@@ -763,7 +762,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override public string ServerVersion
+        public override string ServerVersion
         {
             get
             {
@@ -771,6 +770,7 @@ namespace Microsoft.Data.SqlClient
                        (short)_loginAck.minorVersion, _loginAck.buildNum));
             }
         }
+
         public int ServerProcessId
         {
             get
@@ -806,7 +806,7 @@ namespace Microsoft.Data.SqlClient
         // GENERAL METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
         [SuppressMessage("Microsoft.Globalization", "CA1303:DoNotPassLiteralsAsLocalizedParameters")] // copied from Triaged.cs
-        override protected void ChangeDatabaseInternal(string database)
+        protected override void ChangeDatabaseInternal(string database)
         {
             // MDAC 73598 - add brackets around database
             database = SqlConnection.FixupDatabaseTransactionName(database);
@@ -815,7 +815,7 @@ namespace Microsoft.Data.SqlClient
             _parser.Run(RunBehavior.UntilDone, null, null, null, _parser._physicalStateObj);
         }
 
-        override public void Dispose()
+        public override void Dispose()
         {
             SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionTds.Dispose|ADV> {0} disposing", ObjectID);
             try
@@ -838,7 +838,7 @@ namespace Microsoft.Data.SqlClient
             base.Dispose();
         }
 
-        override internal void ValidateConnectionForExecute(SqlCommand command)
+        internal override void ValidateConnectionForExecute(SqlCommand command)
         {
             TdsParser parser = _parser;
             if ((parser == null) || (parser.State == TdsParserState.Broken) || (parser.State == TdsParserState.Closed))
@@ -946,7 +946,7 @@ namespace Microsoft.Data.SqlClient
         // POOLING METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        override protected void Activate(Transaction transaction)
+        protected override void Activate(Transaction transaction)
         {
             FailoverPermissionDemand(); // Demand for unspecified failover pooled connections
 
@@ -971,7 +971,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected void InternalDeactivate()
+        protected override void InternalDeactivate()
         {
             // When we're deactivated, the user must have called End on all
             // the async commands, or we don't know that we're in a state that
@@ -1044,7 +1044,7 @@ namespace Microsoft.Data.SqlClient
         // LOCAL TRANSACTION METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        override internal void DisconnectTransaction(SqlInternalTransaction internalTransaction)
+        internal override void DisconnectTransaction(SqlInternalTransaction internalTransaction)
         {
             TdsParser parser = Parser;
 
@@ -1059,7 +1059,7 @@ namespace Microsoft.Data.SqlClient
             ExecuteTransaction(transactionRequest, name, iso, null, false);
         }
 
-        override internal void ExecuteTransaction(TransactionRequest transactionRequest, string name, System.Data.IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest)
+        internal override void ExecuteTransaction(TransactionRequest transactionRequest, string name, System.Data.IsolationLevel iso, SqlInternalTransaction internalTransaction, bool isDelegateControlRequest)
         {
             if (IsConnectionDoomed)
             {  // doomed means we can't do anything else...
@@ -1239,20 +1239,20 @@ namespace Microsoft.Data.SqlClient
         // DISTRIBUTED TRANSACTION METHODS
         ////////////////////////////////////////////////////////////////////////////////////////
 
-        override internal void DelegatedTransactionEnded()
+        internal override void DelegatedTransactionEnded()
         {
             // TODO: I don't like the way that this works, but I don't want to rototill the entire pooler to avoid this call.
             base.DelegatedTransactionEnded();
         }
 
-        override protected byte[] GetDTCAddress()
+        protected override byte[] GetDTCAddress()
         {
             byte[] dtcAddress = _parser.GetDTCAddress(ConnectionOptions.ConnectTimeout, _parser.GetSession(this));
             Debug.Assert(dtcAddress != null, "null dtcAddress?");
             return dtcAddress;
         }
 
-        override protected void PropagateTransactionCookie(byte[] cookie)
+        protected override void PropagateTransactionCookie(byte[] cookie)
         {
             _parser.PropagateDistributedTransaction(cookie, ConnectionOptions.ConnectTimeout, _parser._physicalStateObj);
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -463,9 +463,9 @@ namespace Microsoft.Data.SqlClient
                 bool redirectedUserInstance,
                 SqlConnectionString userConnectionOptions = null, // NOTE: userConnectionOptions may be different to connectionOptions if the connection string has been expanded (see SqlConnectionString.Expand)
                 SessionData reconnectSessionData = null,
-                DbConnectionPool pool = null,
-                string accessToken = null,
                 bool applyTransientFaultHandling = false,
+                string accessToken = null,
+                DbConnectionPool pool = null,
                 Func<SqlAuthenticationParameters, CancellationToken,
                 Task<SqlAuthenticationToken>> accessTokenCallback = null) : base(connectionOptions)
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -1961,7 +1961,8 @@ namespace Microsoft.Data.SqlClient
                             _parser.Disconnect();
                         }
 
-                        _parser = new TdsParser(ConnectionOptions.MARS, ConnectionOptions.Asynchronous);
+                        _parser = new TdsParser(ConnectionOptions.MARS, connectionOptions.Asynchronous);
+
                         Debug.Assert(SniContext.Undefined == Parser._physicalStateObj.SniContext, $"SniContext should be Undefined; actual Value: {Parser._physicalStateObj.SniContext}");
 
                         currentServerInfo = new ServerInfo(ConnectionOptions, RoutingInfo, currentServerInfo.ResolvedServerName, currentServerInfo.ServerSPN);
@@ -1970,9 +1971,9 @@ namespace Microsoft.Data.SqlClient
                         _routingDestination = currentServerInfo.UserServerName;
 
                         // restore properties that could be changed by the environment tokens
-                        _currentPacketSize = ConnectionOptions.PacketSize;
+                        _currentPacketSize = connectionOptions.PacketSize;
                         _currentLanguage = _originalLanguage = ConnectionOptions.CurrentLanguage;
-                        CurrentDatabase = _originalDatabase = ConnectionOptions.InitialCatalog;
+                        CurrentDatabase = _originalDatabase = connectionOptions.InitialCatalog;
                         _currentFailoverPartner = null;
                         _instanceName = string.Empty;
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -25,15 +25,15 @@ namespace Microsoft.Data.SqlClient
     internal sealed class SessionStateRecord
     {
         internal bool _recoverable;
-        internal UInt32 _version;
-        internal Int32 _dataLength;
+        internal uint _version;
+        internal int _dataLength;
         internal byte[] _data;
     }
 
     internal sealed class SessionData
     {
         internal const int _maxNumberOfSessionStates = 256;
-        internal UInt32 _tdsVersion;
+        internal uint _tdsVersion;
         internal bool _encrypted;
 
         internal string _database;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -2834,6 +2834,25 @@ namespace Microsoft.Data.SqlClient
                         }
                         break;
                     }
+
+                case TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS:
+                    {
+                        SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
+
+                        if (data.Length < 1)
+                        {
+                            SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown version number for GlobalTransactions", ObjectID);
+                            throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
+                        }
+
+                        IsGlobalTransaction = true;
+                        if (1 == data[0])
+                        {
+                            IsGlobalTransactionsEnabledForServer = true;
+                        }
+                        break;
+                    }
+
                 case TdsEnums.FEATUREEXT_FEDAUTH:
                     {
                         SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for federated authentication", ObjectID);
@@ -2919,24 +2938,6 @@ namespace Microsoft.Data.SqlClient
                             _parser.EnclaveType = Encoding.Unicode.GetString(data, 2, (data.Length - 2));
                         }
 
-                        break;
-                    }
-
-                case TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS:
-                    {
-                        SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ADV> {0}, Received feature extension acknowledgement for GlobalTransactions", ObjectID);
-
-                        if (data.Length < 1)
-                        {
-                            SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.OnFeatureExtAck|ERR> {0}, Unknown version number for GlobalTransactions", ObjectID);
-                            throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
-                        }
-
-                        IsGlobalTransaction = true;
-                        if (1 == data[0])
-                        {
-                            IsGlobalTransactionsEnabledForServer = true;
-                        }
                         break;
                     }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -545,6 +545,7 @@ namespace Microsoft.Data.SqlClient
 
             _parserLock.Wait(canReleaseFromAnyThread: false);
             ThreadHasParserLockForClose = true;   // In case of error, let ourselves know that we already own the parser lock
+
             RuntimeHelpers.PrepareConstrainedRegions();
             try
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -251,7 +251,54 @@ namespace Microsoft.Data.SqlClient
         // If the context is expiring within the next 10 mins, then create a new context, irrespective of if another thread is trying to do the same.
         private static readonly TimeSpan _dbAuthenticationContextUnLockedRefreshTimeSpan = new TimeSpan(hours: 0, minutes: 10, seconds: 00);
 
-        private static HashSet<int> s_transientErrors = new HashSet<int>();
+        // The errors in the transient error set are contained in
+        // https://azure.microsoft.com/en-us/documentation/articles/sql-database-develop-error-messages/#transient-faults-connection-loss-and-other-temporary-errors
+        private static readonly HashSet<int> s_transientErrors = new HashSet<int>
+            {
+            // SQL Error Code: 4060
+            // Cannot open database "%.*ls" requested by the login. The login failed.
+            4060,
+
+            // SQL Error Code: 10928
+            // Resource ID: %d. The %s limit for the database is %d and has been reached.
+            10928,
+
+            // SQL Error Code: 10929
+            // Resource ID: %d. The %s minimum guarantee is %d, maximum limit is %d and the current usage for the database is %d.
+            // However, the server is currently too busy to support requests greater than %d for this database.
+            10929,
+
+            // SQL Error Code: 40197
+            // You will receive this error, when the service is down due to software or hardware upgrades, hardware failures,
+            // or any other failover problems. The error code (%d) embedded within the message of error 40197 provides
+            // additional information about the kind of failure or failover that occurred. Some examples of the error codes are
+            // embedded within the message of error 40197 are 40020, 40143, 40166, and 40540.
+            40197,
+            40020,
+            40143,
+            40166,
+
+            // The service has encountered an error processing your request. Please try again.
+            40540,
+
+            // The service is currently busy. Retry the request after 10 seconds. Incident ID: %ls. Code: %d.
+            40501,
+
+            // Database '%.*ls' on server '%.*ls' is not currently available. Please retry the connection later.
+            // If the problem persists, contact customer support, and provide them the session tracing ID of '%.*ls'.
+            40613,
+
+            // Can not connect to the SQL pool since it is paused. Please resume the SQL pool and try again.
+            42108,
+
+            // The SQL pool is warming up. Please try again.
+            42109
+
+            // Do federation errors deserve to be here ?
+            // Note: Federation errors 10053 and 10054 might also deserve inclusion in your retry logic.
+            // 10053
+            // 10054
+        };
 
         internal SessionData CurrentSessionData
         {
@@ -403,11 +450,6 @@ namespace Microsoft.Data.SqlClient
         private string _routingDestination = null;
         private readonly TimeoutTimer _timeout;
 
-        static SqlInternalConnectionTds()
-        {
-            populateTransientErrors();
-        }
-
         // although the new password is generally not used it must be passed to the ctor
         // the new Login7 packet will always write out the new password (or a length of zero and no bytes if not present)
         //
@@ -557,49 +599,6 @@ namespace Microsoft.Data.SqlClient
             }
             SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.SqlInternalConnectionTds.ctor|ADV> {0}, constructed new TDS internal connection", ObjectID);
         }
-
-        // The errors in the transient error set are contained in
-        // https://azure.microsoft.com/en-us/documentation/articles/sql-database-develop-error-messages/#transient-faults-connection-loss-and-other-temporary-errors
-        private static void populateTransientErrors()
-        {
-            // SQL Error Code: 4060
-            // Cannot open database "%.*ls" requested by the login. The login failed.
-            s_transientErrors.Add(4060);
-            // SQL Error Code: 10928
-            // Resource ID: %d. The %s limit for the database is %d and has been reached.
-            s_transientErrors.Add(10928);
-            // SQL Error Code: 10929
-            // Resource ID: %d. The %s minimum guarantee is %d, maximum limit is %d and the current usage for the database is %d.
-            // However, the server is currently too busy to support requests greater than %d for this database.
-            s_transientErrors.Add(10929);
-            // SQL Error Code: 40197
-            // You will receive this error, when the service is down due to software or hardware upgrades, hardware failures,
-            // or any other failover problems. The error code (%d) embedded within the message of error 40197 provides
-            // additional information about the kind of failure or failover that occurred. Some examples of the error codes are
-            // embedded within the message of error 40197 are 40020, 40143, 40166, and 40540.
-            s_transientErrors.Add(40197);
-            s_transientErrors.Add(40020);
-            s_transientErrors.Add(40143);
-            s_transientErrors.Add(40166);
-            // The service has encountered an error processing your request. Please try again.
-            s_transientErrors.Add(40540);
-            // The service is currently busy. Retry the request after 10 seconds. Incident ID: %ls. Code: %d.
-            s_transientErrors.Add(40501);
-            // Database '%.*ls' on server '%.*ls' is not currently available. Please retry the connection later.
-            // If the problem persists, contact customer support, and provide them the session tracing ID of '%.*ls'.
-            s_transientErrors.Add(40613);
-
-            // Can not connect to the SQL pool since it is paused. Please resume the SQL pool and try again.
-            s_transientErrors.Add(42108);
-
-            // The SQL pool is warming up. Please try again.
-            s_transientErrors.Add(42109);
-            // Do federation errors deserve to be here ?
-            // Note: Federation errors 10053 and 10054 might also deserve inclusion in your retry logic.
-            //transientErrors.Add(10053);
-            //transientErrors.Add(10054);
-        }
-
 
         // Returns true if the Sql error is a transient.
         private bool IsTransientError(SqlException exc)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -106,13 +106,12 @@ namespace Microsoft.Data.SqlClient
     {
         // https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/retry-after#simple-retry-for-errors-with-http-error-codes-500-600
         internal const int MsalHttpRetryStatusCode = 429;
+        // Connection re-route limit
+        internal const int MaxNumberOfRedirectRoute = 10;
 
         // CONNECTION AND STATE VARIABLES
         private readonly SqlConnectionPoolGroupProviderInfo _poolGroupProviderInfo; // will only be null when called for ChangePassword, or creating SSE User Instance
         private TdsParser _parser;
-
-        // Connection re-route limit
-        internal const int _maxNumberOfRedirectRoute = 10;
 
         private SqlLoginAck _loginAck;
         private SqlCredential _credential;
@@ -186,7 +185,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private bool _DNSCachingBeforeRedirect = false;
+        private bool _dnsCachingBeforeRedirect = false;
 
         /// <summary>
         /// Get or set if the control ring send redirect token and feature ext ack with true for DNSCaching
@@ -195,11 +194,11 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                return _DNSCachingBeforeRedirect;
+                return _dnsCachingBeforeRedirect;
             }
             set
             {
-                _DNSCachingBeforeRedirect = value;
+                _dnsCachingBeforeRedirect = value;
             }
         }
 
@@ -1682,9 +1681,9 @@ namespace Microsoft.Data.SqlClient
                     if (RoutingInfo != null)
                     {
                         SqlClientEventSource.Log.TryTraceEvent("<sc.SqlInternalConnectionTds.LoginNoFailover> Routed to {0}", serverInfo.ExtendedServerName);
-                        if (routingAttempts > _maxNumberOfRedirectRoute)
+                        if (routingAttempts > MaxNumberOfRedirectRoute)
                         {
-                            throw SQL.ROR_RecursiveRoutingNotSupported(this, _maxNumberOfRedirectRoute);
+                            throw SQL.ROR_RecursiveRoutingNotSupported(this, MaxNumberOfRedirectRoute);
                         }
 
                         if (timeout.IsExpired)
@@ -1949,9 +1948,9 @@ namespace Microsoft.Data.SqlClient
                     int routingAttempts = 0;
                     while (RoutingInfo != null)
                     {
-                        if (routingAttempts > _maxNumberOfRedirectRoute)
+                        if (routingAttempts > MaxNumberOfRedirectRoute)
                         {
-                            throw SQL.ROR_RecursiveRoutingNotSupported(this, _maxNumberOfRedirectRoute);
+                            throw SQL.ROR_RecursiveRoutingNotSupported(this, MaxNumberOfRedirectRoute);
                         }
                         routingAttempts++;
 
@@ -2779,7 +2778,7 @@ namespace Microsoft.Data.SqlClient
 
         internal void OnFeatureExtAck(int featureId, byte[] data)
         {
-            if (RoutingInfo != null && TdsEnums.FEATUREEXT_SQLDNSCACHING != featureId)
+            if (RoutingInfo != null && featureId != TdsEnums.FEATUREEXT_SQLDNSCACHING)
             {
                 return;
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -22,7 +22,7 @@ using Microsoft.Identity.Client;
 
 namespace Microsoft.Data.SqlClient
 {
-    internal class SessionStateRecord
+    internal sealed class SessionStateRecord
     {
         internal bool _recoverable;
         internal UInt32 _version;
@@ -30,7 +30,7 @@ namespace Microsoft.Data.SqlClient
         internal byte[] _data;
     }
 
-    internal class SessionData
+    internal sealed class SessionData
     {
         internal const int _maxNumberOfSessionStates = 256;
         internal UInt32 _tdsVersion;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -15,12 +14,11 @@ using System.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Transactions;
 using Microsoft.Data.Common;
 using Microsoft.Data.ProviderBase;
 using Microsoft.Data.SqlClient.ConnectionPool;
 using Microsoft.Identity.Client;
-using System.Transactions;
-
 
 namespace Microsoft.Data.SqlClient
 {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -107,12 +107,13 @@ namespace Microsoft.Data.SqlClient
         // https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/retry-after#simple-retry-for-errors-with-http-error-codes-500-600
         internal const int MsalHttpRetryStatusCode = 429;
 
-        // Connection re-route limit
-        internal const int _maxNumberOfRedirectRoute = 10;
-
         // CONNECTION AND STATE VARIABLES
         private readonly SqlConnectionPoolGroupProviderInfo _poolGroupProviderInfo; // will only be null when called for ChangePassword, or creating SSE User Instance
         private TdsParser _parser;
+
+        // Connection re-route limit
+        internal const int _maxNumberOfRedirectRoute = 10;
+
         private SqlLoginAck _loginAck;
         private SqlCredential _credential;
         private FederatedAuthenticationFeatureExtensionData _fedAuthFeatureExtensionData;
@@ -126,7 +127,6 @@ namespace Microsoft.Data.SqlClient
         // Federated Authentication
         // Response obtained from the server for FEDAUTHREQUIRED prelogin option.
         internal bool _fedAuthRequired;
-
         internal bool _federatedAuthenticationRequested;
         internal bool _federatedAuthenticationAcknowledged;
         internal bool _federatedAuthenticationInfoRequested; // Keep this distinct from _federatedAuthenticationRequested, since some fedauth library types may not need more info
@@ -135,7 +135,7 @@ namespace Microsoft.Data.SqlClient
         // The Federated Authentication returned by TryGetFedAuthTokenLocked or GetFedAuthToken.
         SqlFedAuthToken _fedAuthToken = null;
         internal byte[] _accessTokenInBytes;
-        internal readonly Func<SqlAuthenticationParameters, CancellationToken,Task<SqlAuthenticationToken>> _accessTokenCallback;
+        internal readonly Func<SqlAuthenticationParameters, CancellationToken, Task<SqlAuthenticationToken>> _accessTokenCallback;
 
         private readonly ActiveDirectoryAuthenticationTimeoutRetryHelper _activeDirectoryAuthTimeoutRetryHelper;
 
@@ -250,8 +250,6 @@ namespace Microsoft.Data.SqlClient
         // The timespan defining the minimum amount of time the authentication context needs to be valid for re-using the cached context.
         // If the context is expiring within the next 10 mins, then create a new context, irrespective of if another thread is trying to do the same.
         private static readonly TimeSpan _dbAuthenticationContextUnLockedRefreshTimeSpan = new TimeSpan(hours: 0, minutes: 10, seconds: 00);
-
-        private readonly TimeoutTimer _timeout;
 
         private static HashSet<int> transientErrors = new HashSet<int>();
 
@@ -405,6 +403,7 @@ namespace Microsoft.Data.SqlClient
         RoutingInfo _routingInfo = null;
         private Guid _originalClientConnectionId = Guid.Empty;
         private string _routingDestination = null;
+        private readonly TimeoutTimer _timeout;
 
         static SqlInternalConnectionTds()
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserHelperClasses.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Data.SqlClient
         NOT_SUP,
         REQ,
         LOGIN,
-#if NETFRAMEWORK
         OPTIONS_MASK = 0x3f,
+#if NETFRAMEWORK
         CTAIP = 0x40,
         CLIENT_CERT = 0x80,
 #endif


### PR DESCRIPTION
This contains the preparatory work for the merge of SqlInternalConnectionTds. We're working with a smaller code file here, so I've merged every part of the two files which avoids a behavioural change.

This should be easier to review comment-by-comment - it's bulky, but not complex. I'd also appreciate a CI run.

At the end of this, the diff is +43/-80. Remaining differences here are:
* Optimisation: netcore will clear the array of session state when the connection resets, netfx will replace it with a new array.
* netfx will consider four extra error codes from the server to be transient: 40020, 40143, 40166, 40540.
* netfx contains a little context connection support.
* netfx contains support for Transparent Network IP Resolution, while netcore does not.
* netfx supports the Network Library connection string parameter.
* netcore will throw an exception if it receives an ENV_LOGSHIPNODE ENVCHANGE when the connection string's Application Intent is read-only, while netfx will not.
* When getting the federated authentication token, netfx will stop retrying if the next pause between each attempt to acquire a token would cause the connection timeout to be expired.
* netcore supports passing the User ID parameter to MSAL as an initial username; netfx does not.
* Some exception messages are more precise in netfx than they are in netcore.

What should we do with Transparent Network IP Resolution? This functionality doesn't exist in netcore at all - does it need to be ported? If it only exists in netfx for backwards compatibility, should it be made obsolete?

I'd also be interested to know what the right style of exception messages is. If (for example) the connection receives an unexpected session recovery feature extension acknowledgement, which exception message should I merge in favour of?
> Internal connection fatal error. Error state: {ParsingErrorState}, Feature Id: {ID of feature}.

> Internal connection fatal error.

The former is netfx, the latter is netcore. I prefer the detail of netfx, but I imagine netcore changed this for a reason.