### PR TITLE
set NeutralLanguage in AssemblyInfo.props

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -6,7 +6,6 @@
 // New attributes that are designed to work with Microsoft.Data.SqlClient and are publicly documented should be included in future.
 
 [assembly: System.CLSCompliant(true)]
-[assembly: System.Resources.NeutralResourcesLanguageAttribute("en-US")]
 namespace Microsoft.Data
 {
     /// <include file='../../../../doc/snippets/Microsoft.Data/OperationAbortedException.xml' path='docs/members[@name="OperationAbortedException"]/OperationAbortedException/*' />

--- a/tools/props/AssemblyInfo.props
+++ b/tools/props/AssemblyInfo.props
@@ -6,5 +6,6 @@
     <Company>Microsoft Corporation</Company>
     <BaseProduct>Microsoft SqlClient Data Provider</BaseProduct>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
a potential fix for #3324

as described in the linked issue, it was intended to be there in the netfx build but was lost in the sdk csproj conversion

I'm not very familiar with resources, but it seems like it should be emitted for both netfx and net core builds.