### PR TITLE
Bump up revision and prevent apiscan from breaking non-official builds

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
@@ -84,14 +84,22 @@ extends:
     featureFlags:
       WindowsHostVersion: 1ESWindows2022
     globalSdl: # https://aka.ms/obpipelines/sdl
+      tsa:
+        # The OneBranch template will set 'break' to false for the other SDL
+        # tools when TSA is enabled.  This allows TSA to gather the results
+        # and publish them for downstream analysis.
+        enabled: ${{parameters.enableAllSdlTools }}
       apiscan:
-        enabled: ${{ not(parameters['isPreview']) }}
+        enabled: ${{parameters.enableAllSdlTools }}
+        # For non-official builds, the OneBranch template seems to set APIScan's
+        # 'break' to true even when TSA is enabled.  We don't want APIScan to
+        # break non-official builds, so we explicitly set 'break' to false here.
+        ${{ if ne(parameters.oneBranchType, 'Official') }}:
+          break: false
         softwareFolder: $(softwareFolder)
         symbolsFolder: $(symbolsFolder)
         softwarename: Microsoft.Data.SqlClient
         versionNumber: $(AssemblyFileVersion)
-      tsa:
-        enabled: ${{ not(parameters['isPreview']) }} # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.
       codeql:
         compiled:
         enabled: ${{ not(parameters['isPreview']) }}

--- a/eng/pipelines/libraries/common-variables.yml
+++ b/eng/pipelines/libraries/common-variables.yml
@@ -38,7 +38,7 @@ variables:
   - name: Preview
     value: '-preview'
   - name: Revision
-    value: '1'
+    value: '2'
 
   - name: NugetPackageVersion
     value: $(Major).$(Minor).$(Patch)


### PR DESCRIPTION
Port sdl changes from https://github.com/dotnet/SqlClient/pull/3298 to main

Also, bump up revision for next release cycle.