### PR TITLE
Refine handling of moving between replay and continue states

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6500,8 +6500,8 @@ namespace Microsoft.Data.SqlClient
             bytes = null;
             int offset = 0;
             byte[] temp = null;
-            (bool isAvailable, bool isStarting, bool isContinuing) = stateObj.GetSnapshotStatuses();
-            if (isAvailable)
+            (bool canContinue, bool isStarting, bool isContinuing) = stateObj.GetSnapshotStatuses();
+            if (canContinue)
             {
                 if (isContinuing || isStarting)
                 {
@@ -12983,9 +12983,9 @@ namespace Microsoft.Data.SqlClient
             char[] temp = null;
             bool buffIsRented = false;
             int startOffset = 0;
-            (bool isAvailable, bool isStarting, bool isContinuing) = stateObj.GetSnapshotStatuses();
+            (bool canContinue, bool isStarting, bool isContinuing) = stateObj.GetSnapshotStatuses();
 
-            if (isAvailable)
+            if (canContinue)
             {
                 if (isContinuing || isStarting)
                 {
@@ -13004,7 +13004,7 @@ namespace Microsoft.Data.SqlClient
                 length >> 1,
                 stateObj,
                 out length,
-                supportRentedBuff: !isAvailable, // do not use the arraypool if we are going to keep the buffer in the snapshot
+                supportRentedBuff: !canContinue, // do not use the arraypool if we are going to keep the buffer in the snapshot
                 rentedBuff: ref buffIsRented,
                 startOffset,
                 isStarting || isContinuing

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6696,8 +6696,8 @@ namespace Microsoft.Data.SqlClient
             bytes = null;
             int offset = 0;
             byte[] temp = null;
-            (bool isAvailable, bool isStarting, bool isContinuing) = stateObj.GetSnapshotStatuses();
-            if (isAvailable)
+            (bool canContinue, bool isStarting, bool isContinuing) = stateObj.GetSnapshotStatuses();
+            if (canContinue)
             {
                 if (isContinuing || isStarting)
                 {
@@ -13176,9 +13176,9 @@ namespace Microsoft.Data.SqlClient
             char[] temp = null;
             bool buffIsRented = false;
             int startOffset = 0;
-            (bool isAvailable, bool isStarting, bool isContinuing) = stateObj.GetSnapshotStatuses();
+            (bool canContinue, bool isStarting, bool isContinuing) = stateObj.GetSnapshotStatuses();
 
-            if (isAvailable)
+            if (canContinue)
             {
                 if (isContinuing || isStarting)
                 {
@@ -13197,7 +13197,7 @@ namespace Microsoft.Data.SqlClient
                 length >> 1, 
                 stateObj, 
                 out length, 
-                supportRentedBuff: !isAvailable, // do not use the arraypool if we are going to keep the buffer in the snapshot
+                supportRentedBuff: !canContinue, // do not use the arraypool if we are going to keep the buffer in the snapshot
                 rentedBuff: ref buffIsRented, 
                 startOffset, 
                 isStarting || isContinuing

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCachedBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCachedBuffer.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Data.SqlClient
         {
             buffer = null;
 
-            (bool isAvailable, bool isStarting, _) = stateObj.GetSnapshotStatuses();
+            (bool canContinue, bool isStarting, _) = stateObj.GetSnapshotStatuses();
 
             List<byte[]> cachedBytes = null;
-            if (isAvailable)
+            if (canContinue)
             {
                 cachedBytes = stateObj.TryTakeSnapshotStorage() as List<byte[]>;
                 if (isStarting)
@@ -78,10 +78,10 @@ namespace Microsoft.Data.SqlClient
                     byte[] byteArr = new byte[cb];
                     // pass false for the writeDataSizeToSnapshot parameter because we want to only take data
                     // from the current packet and not try to do a continue-capable multi packet read
-                    result = stateObj.TryReadPlpBytes(ref byteArr, 0, cb, out cb, isAvailable, writeDataSizeToSnapshot: false, compatibilityMode: false);
+                    result = stateObj.TryReadPlpBytes(ref byteArr, 0, cb, out cb, canContinue, writeDataSizeToSnapshot: false, compatibilityMode: false);
                     if (result != TdsOperationStatus.Done)
                     {
-                        if (result == TdsOperationStatus.NeedMoreData && isAvailable && cb == byteArr.Length)
+                        if (result == TdsOperationStatus.NeedMoreData && canContinue && cb == byteArr.Length)
                         {
                             // succeeded in getting the data but failed to find the next plp length
                             returnAfterAdd = true;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCachedBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCachedBuffer.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Data.SqlClient
                     byte[] byteArr = new byte[cb];
                     // pass false for the writeDataSizeToSnapshot parameter because we want to only take data
                     // from the current packet and not try to do a continue-capable multi packet read
-                    result = stateObj.TryReadPlpBytes(ref byteArr, 0, cb, out cb, writeDataSizeToSnapshot: false, compatibilityMode: false);
+                    result = stateObj.TryReadPlpBytes(ref byteArr, 0, cb, out cb, isAvailable, writeDataSizeToSnapshot: false, compatibilityMode: false);
                     if (result != TdsOperationStatus.Done)
                     {
                         if (result == TdsOperationStatus.NeedMoreData && isAvailable && cb == byteArr.Length)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2037,14 +2037,15 @@ namespace Microsoft.Data.SqlClient
 
         internal TdsOperationStatus TryReadPlpBytes(ref byte[] buff, int offset, int len, out int totalBytesRead)
         {
+            bool canContinue = false;
             bool isStarting = false;
             bool isContinuing = false;
             bool compatibilityMode = LocalAppContextSwitches.UseCompatibilityAsyncBehaviour;
             if (!compatibilityMode)
             {
-                (_, isStarting, isContinuing) = GetSnapshotStatuses();
+                (canContinue, isStarting, isContinuing) = GetSnapshotStatuses();
             }
-            return TryReadPlpBytes(ref buff, offset, len, out totalBytesRead, isStarting || isContinuing, compatibilityMode);
+            return TryReadPlpBytes(ref buff, offset, len, out totalBytesRead, canContinue, canContinue, compatibilityMode);
         }
         // Reads the requested number of bytes from a plp data stream, or the entire data if
         // requested length is -1 or larger than the actual length of data. First call to this method
@@ -2052,7 +2053,7 @@ namespace Microsoft.Data.SqlClient
         // Returns the actual bytes read.
         // NOTE: This method must be retriable WITHOUT replaying a snapshot
         // Every time you call this method increment the offset and decrease len by the value of totalBytesRead
-        internal TdsOperationStatus TryReadPlpBytes(ref byte[] buff, int offset, int len, out int totalBytesRead, bool writeDataSizeToSnapshot, bool compatibilityMode)
+        internal TdsOperationStatus TryReadPlpBytes(ref byte[] buff, int offset, int len, out int totalBytesRead, bool canContinue, bool writeDataSizeToSnapshot, bool compatibilityMode)
         {
             totalBytesRead = 0;
 
@@ -2077,9 +2078,16 @@ namespace Microsoft.Data.SqlClient
             // If total length is known up front, allocate the whole buffer in one shot instead of realloc'ing and copying over each time
             if (buff == null && _longlen != TdsEnums.SQL_PLP_UNKNOWNLEN)
             {
-                if (writeDataSizeToSnapshot)
+                if (compatibilityMode && _snapshot != null && _snapshotStatus != SnapshotStatus.NotActive)
                 {
-                    // if there is a snapshot and it contains a stored plp buffer take it
+                    // legacy replay path perf optimization
+                    // if there is a snapshot which contains a stored plp buffer take it
+                    // and try to use it if it is the right length
+                    buff = TryTakeSnapshotStorage() as byte[];
+                }
+                else if (writeDataSizeToSnapshot && canContinue && _snapshot != null)
+                {
+                    // if there is a snapshot which it contains a stored plp buffer take it
                     // and try to use it if it is the right length
                     buff = TryTakeSnapshotStorage() as byte[];
                     if (buff != null)
@@ -2088,13 +2096,7 @@ namespace Microsoft.Data.SqlClient
                         totalBytesRead = offset;
                     }
                 }
-                else if (compatibilityMode && _snapshot != null && _snapshotStatus != SnapshotStatus.NotActive)
-                {
-                    // legacy replay path perf optimization
-                    // if there is a snapshot and it contains a stored plp buffer take it
-                    // and try to use it if it is the right length
-                    buff = TryTakeSnapshotStorage() as byte[];
-                }
+
 
                 if ((ulong)(buff?.Length ?? 0) != _longlen)
                 {
@@ -2146,22 +2148,28 @@ namespace Microsoft.Data.SqlClient
                 _longlenleft -= (ulong)bytesRead;
                 if (result != TdsOperationStatus.Done)
                 {
-                    if (writeDataSizeToSnapshot)
-                    {
-                        // a partial read has happened so store the target buffer in the snapshot
-                        // so it can be re-used when another packet arrives and we read again
-                        SetSnapshotStorage(buff);
-                        SetSnapshotDataSize(bytesRead);
-
-                    }
-                    else if (compatibilityMode && _snapshot != null)
+                    if (compatibilityMode && _snapshot != null)
                     {
                         // legacy replay path perf optimization
                         // a partial read has happened so store the target buffer in the snapshot
                         // so it can be re-used when another packet arrives and we read again
                         SetSnapshotStorage(buff);
                     }
+                    else if (canContinue)
+                    {
+                        // a partial read has happened so store the target buffer in the snapshot
+                        // so it can be re-used when another packet arrives and we read again
+                        SetSnapshotStorage(buff);
+                        if (writeDataSizeToSnapshot)
+                        {
+                            SetSnapshotDataSize(bytesRead);
+                        }
+                    }
                     return result;
+                }
+                if (writeDataSizeToSnapshot && canContinue)
+                {
+                    SetSnapshotDataSize(bytesRead);
                 }
 
                 if (_longlenleft == 0)
@@ -2170,19 +2178,19 @@ namespace Microsoft.Data.SqlClient
                     result = TryReadPlpLength(false, out _);
                     if (result != TdsOperationStatus.Done)
                     {
-                        if (writeDataSizeToSnapshot)
-                        {
-                            if (result == TdsOperationStatus.NeedMoreData)
-                            {
-                                SetSnapshotStorage(buff);
-                                SetSnapshotDataSize(bytesRead);
-                            }
-                        } 
-                        else if (compatibilityMode && _snapshot != null)
+                        if (compatibilityMode && _snapshot != null)
                         {
                             // a partial read has happened so store the target buffer in the snapshot
                             // so it can be re-used when another packet arrives and we read again
                             SetSnapshotStorage(buff);
+                        }
+                        else if (canContinue && result == TdsOperationStatus.NeedMoreData)
+                        {
+                            SetSnapshotStorage(buff);
+                            if (writeDataSizeToSnapshot)
+                            {
+                                SetSnapshotDataSize(bytesRead);
+                            }
                         }
                         return result;
                     }
@@ -3455,9 +3463,9 @@ namespace Microsoft.Data.SqlClient
                 _snapshotStatus == TdsParserStateObject.SnapshotStatus.ContinueRunning;
         }
 
-        internal (bool IsAvailable, bool IsStarting, bool IsContinuing) GetSnapshotStatuses()
+        internal (bool CanContinue, bool IsStarting, bool IsContinuing) GetSnapshotStatuses()
         {
-            bool isAvailable = _snapshot != null && _snapshot.ContinueEnabled;
+            bool isAvailable = _snapshot != null && _snapshot.ContinueEnabled && _snapshotStatus != SnapshotStatus.NotActive;
             bool isStarting = false;
             bool isContinuing = false;
             if (isAvailable)
@@ -4018,6 +4026,28 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     Debug.Assert(_stateObj._permitReplayStackTraceToDiffer || prev.Stack == trace, "The stack trace on subsequent replays should be the same");
+                }
+            }
+
+            public int CurrentPacketIndex
+            {
+                get
+                {
+                    int value = -1;
+                    if (_current != null)
+                    {
+                        PacketData current = _firstPacket;
+                        while (current != null)
+                        {
+                            value += 1;
+                            if (current == _current)
+                            {
+                                break;
+                            }
+                            current = current.NextPacket;
+                        } 
+                    }
+                    return value;
                 }
             }
 #endif

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlTypes;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -584,6 +586,60 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         }
                     }
                     return id;
+
+                }
+                finally
+                {
+                    try
+                    {
+                        using (var dropCommand = connection.CreateCommand())
+                        {
+                            dropCommand.CommandText = $"DROP TABLE IF EXISTS [{tableName}]";
+                            dropCommand.ExecuteNonQuery();
+                        }
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static async Task CanReadBinaryData()
+        {
+            const int Size = 20_000;
+
+            byte[] data = Enumerable.Range(0, Size)
+                .Select(i => (byte)(i % 256))
+                .ToArray();
+            string tableName = DataTestUtility.GenerateObjectName();
+
+            using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            {
+                await connection.OpenAsync();
+
+                try
+                {
+                    using (var createCommand = connection.CreateCommand())
+                    {
+                        createCommand.CommandText = $@"
+DROP TABLE IF EXISTS [{tableName}]
+CREATE TABLE [{tableName}] (Id INT IDENTITY(1,1) PRIMARY KEY, Data VARBINARY(MAX));
+INSERT INTO [{tableName}] (Data) VALUES (@data);";
+                        createCommand.Parameters.Add(new SqlParameter("@data", SqlDbType.VarBinary, Size) { Value = data });
+                        await createCommand.ExecuteNonQueryAsync();
+                    }
+
+                    using (var command = connection.CreateCommand())
+                    {
+
+                        command.CommandText = $"SELECT Data FROM [{tableName}]";
+                        command.Parameters.Clear();
+                        var result = (byte[])await command.ExecuteScalarAsync();
+
+                        Debug.Assert(data.SequenceEqual(result));
+                    }
 
                 }
                 finally

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -638,7 +638,7 @@ INSERT INTO [{tableName}] (Data) VALUES (@data);";
                         command.Parameters.Clear();
                         var result = (byte[])await command.ExecuteScalarAsync();
 
-                        Debug.Assert(data.SequenceEqual(result));
+                        Assert.Equal(data, result);
                     }
 
                 }


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/3336

Refines moving between ReplayRunning and ContinueRunning states fixing an issue with varbinary reads.