### PR TITLE
Cleanup | Interop Path Links

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -782,16 +782,16 @@
       <Link>Interop\Windows\Kernel32\Kernel32.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\CreateDisposition.cs">
-      <Link>Interop\Windows\NtDll\Interop\Windows\NtDll\CreateDisposition.cs</Link>
+      <Link>Interop\Windows\NtDll\CreateDisposition.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\CreateOptions.cs">
-      <Link>Interop\Windows\NtDll\Interop\Windows\NtDll\CreateOptions.cs</Link>
+      <Link>Interop\Windows\NtDll\CreateOptions.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\DesiredAccess.cs">
-      <Link>Interop\Windows\NtDll\Interop\Windows\NtDll\DesiredAccess.cs</Link>
+      <Link>Interop\Windows\NtDll\DesiredAccess.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\FileFullEaInformation.cs">
-      <Link>Interop\Windows\NtDll\Interop\Windows\NtDll\FileFullEaInformation.cs</Link>
+      <Link>Interop\Windows\NtDll\FileFullEaInformation.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\ImpersonationLevel.cs">
       <Link>Interop\Windows\NtDll\ImpersonaltionLevel.cs</Link>
@@ -800,16 +800,16 @@
       <Link>Interop\Windows\NtDll\IoStatusBlock.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\NtDll.cs">
-      <Link>Interop\Windows\NtDll\Interop\Windows\NtDll\NtDll.cs</Link>
+      <Link>Interop\Windows\NtDll\NtDll.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\ObjectAttributeFlags.cs">
-      <Link>Interop\Windows\NtDll\Interop\Windows\NtDll\ObjectAttributes.cs</Link>
+      <Link>Interop\Windows\NtDll\ObjectAttributesFlags.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\ObjectAttributes.cs">
-      <Link>Interop\Windows\NtDll\Interop\Windows\NtDll\ObjectAttributes.cs</Link>
+      <Link>Interop\Windows\NtDll\ObjectAttributes.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\SecurityQualityOfService.cs">
-      <Link>Interop\Windows\NtDll\Interop\Windows\NtDll\SecurityQualityOfService.cs</Link>
+      <Link>Interop\Windows\NtDll\SecurityQualityOfService.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\Sni\AuthProviderInfo.cs">
       <Link>Interop\Windows\Sni\AuthProviderInfo.cs</Link>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -803,7 +803,7 @@
       <Link>Interop\Windows\NtDll\NtDll.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\ObjectAttributeFlags.cs">
-      <Link>Interop\Windows\NtDll\ObjectAttributesFlags.cs</Link>
+      <Link>Interop\Windows\NtDll\ObjectAttributeFlags.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\ObjectAttributes.cs">
       <Link>Interop\Windows\NtDll\ObjectAttributes.cs</Link>

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -794,7 +794,7 @@
       <Link>Interop\Windows\NtDll\FileFullEaInformation.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\ImpersonationLevel.cs">
-      <Link>Interop\Windows\NtDll\ImpersonaltionLevel.cs</Link>
+      <Link>Interop\Windows\NtDll\ImpersonationLevel.cs</Link>
     </Compile>
     <Compile Include="$(CommonSourceRoot)\Interop\Windows\NtDll\IoStatusBlock.cs">
       <Link>Interop\Windows\NtDll\IoStatusBlock.cs</Link>


### PR DESCRIPTION
**Description**: Very small 🥔🥔, but it was driving me crazy once I saw it. Basically, some of the interop files in the netcore project had paths that were doubly nested. This PR removes those doubly nested paths.

ie:
`Interop\Windows\NtDll\Interop\Windows\NtDll\file.cs`
becomes 
`Interop\Windows\Ntdll\file.cs`

This also fixes a mistake for ObjectAttributeFlags. Both ObjectAttributes and ObjectAttributeFlags were being linked as "ObjectAttributes". Fixed that as well.