### PR TITLE
APIScan | MSAL `WithClientId` usage

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
@@ -543,31 +543,24 @@ namespace Microsoft.Data.SqlClient
 
         private IPublicClientApplication CreateClientAppInstance(PublicClientAppKey publicClientAppKey)
         {
-            IPublicClientApplication publicClientApplication;
-
-#if NETFRAMEWORK
-            if (_iWin32WindowFunc != null)
+            PublicClientApplicationBuilder builder = PublicClientApplicationBuilder
+                .CreateWithApplicationOptions(new PublicClientApplicationOptions
+                {
+                    ClientId = publicClientAppKey._applicationClientId,
+                    ClientName = DbConnectionStringDefaults.ApplicationName,
+                    ClientVersion = Common.ADP.GetAssemblyVersion().ToString(),
+                    RedirectUri = publicClientAppKey._redirectUri,
+                })
+                .WithAuthority(publicClientAppKey._authority);
+            
+            #if NETFRAMEWORK
+            if (_iWin32WindowFunc is not null)
             {
-                publicClientApplication = PublicClientApplicationBuilder.Create(publicClientAppKey._applicationClientId)
-                .WithAuthority(publicClientAppKey._authority)
-                .WithClientName(DbConnectionStringDefaults.ApplicationName)
-                .WithClientVersion(Common.ADP.GetAssemblyVersion().ToString())
-                .WithRedirectUri(publicClientAppKey._redirectUri)
-                .WithParentActivityOrWindow(_iWin32WindowFunc)
-                .Build();
+                builder.WithParentActivityOrWindow(_iWin32WindowFunc);
             }
-            else
-#endif
-            {
-                publicClientApplication = PublicClientApplicationBuilder.Create(publicClientAppKey._applicationClientId)
-                .WithAuthority(publicClientAppKey._authority)
-                .WithClientName(DbConnectionStringDefaults.ApplicationName)
-                .WithClientVersion(Common.ADP.GetAssemblyVersion().ToString())
-                .WithRedirectUri(publicClientAppKey._redirectUri)
-                .Build();
-            }
+            #endif
 
-            return publicClientApplication;
+            return builder.Build();
         }
 
         private static TokenCredentialData CreateTokenCredentialInstance(TokenCredentialKey tokenCredentialKey, string secret)


### PR DESCRIPTION
**This PR is now officially "optional" - see description for details**

**Description**: APIScan was giving us two major errors - usage of undocumented SNI APIs (which we are working on an exception for) and usage of undocumented MSAL APIs. This PR addresses the latter by replacing usages of undocumented `With*` methods by providing builder constructor with the application options. 

When I went back into the automated builds to check to make sure I got all the undocumented MSAL APIs covered, I discovered the errors were no longer in the APIscan results. As it turns out, the APIs have since been documented and are no longer throwing errors. However, in working out a replacement for the formerly-undocumented methods, I worked out a slightly cleaner implementation. So, this change is completely optional from a APIScan perspective, but I think it still has some small value.

**Testing**: Since this all has to do with AAD, I don't really have the right setup to setup for local testing. Everything still builds, let's see what CI says.