### PR TITLE
APIScan | Fix Builder Mistake

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
@@ -556,7 +556,7 @@ namespace Microsoft.Data.SqlClient
             #if NETFRAMEWORK
             if (_iWin32WindowFunc is not null)
             {
-                builder.WithParentActivityOrWindow(_iWin32WindowFunc);
+                builder = builder.WithParentActivityOrWindow(_iWin32WindowFunc);
             }
             #endif
 


### PR DESCRIPTION
**Description**: Made a mistake when I wrote #3354 - forgot to store the modified builder in the builder variable.

**Testing**: Kinda disappointed it didn't get caught in any CI pathways. Ideally I should write up a test for this specific scenario, but I'm concerned this will be a huge undertaking versus fixing it before it gets released.