### PR TITLE
Merge | Port XEvents activity ID correlation to .NET Core

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -11368,7 +11368,14 @@ namespace Microsoft.Data.SqlClient
 
             const int marsHeaderSize = 18; // 4 + 2 + 8 + 4
 
-            int totalHeaderLength = 4 + marsHeaderSize + notificationHeaderSize;
+            // Header Length (DWORD)
+            // Header Type (ushort)
+            // Trace Data Guid
+            // Trace Data Sequence Number (uint)
+            const int traceHeaderSize = 26;  // 4 + 2 + GUID_SIZE + sizeof(UInt32);
+
+            // TotalLength  - DWORD  - including all headers and lengths, including itself
+            int totalHeaderLength = this.IncludeTraceHeader ? (4 + marsHeaderSize + notificationHeaderSize + traceHeaderSize) : (4 + marsHeaderSize + notificationHeaderSize);
             Debug.Assert(stateObj._outBytesUsed == stateObj._outputHeaderLen, "Output bytes written before total header length");
             // Write total header length
             WriteInt(totalHeaderLength, stateObj);
@@ -11384,6 +11391,15 @@ namespace Microsoft.Data.SqlClient
                 WriteInt(notificationHeaderSize, stateObj);
                 // Write notificaiton header data
                 WriteQueryNotificationHeaderData(notificationRequest, stateObj);
+            }
+
+            if (IncludeTraceHeader)
+            {
+
+                // Write trace header length
+                WriteInt(traceHeaderSize, stateObj);
+                // Write trace header data
+                WriteTraceHeaderData(stateObj);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -11387,6 +11387,7 @@ namespace Microsoft.Data.SqlClient
             if (notificationHeaderSize != 0)
             {
                 // Write notification header length and data
+                // MS-TDS 2.2.5.3.1: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/e168d373-a7b7-41aa-b6ca-25985466a7e0
                 WriteInt(notificationHeaderSize, stateObj);
                 WriteQueryNotificationHeaderData(notificationRequest, stateObj);
             }
@@ -11394,6 +11395,7 @@ namespace Microsoft.Data.SqlClient
             if (IncludeTraceHeader)
             {
                 // Write trace header length and data
+                // MS-TDS 2.2.5.3.3: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/6e9f106b-df6e-4cbe-a6eb-45ceb10c63be
                 WriteInt(TraceHeaderSize, stateObj);
                 WriteTraceHeaderData(stateObj);
             }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -11366,39 +11366,35 @@ namespace Microsoft.Data.SqlClient
 
             int notificationHeaderSize = GetNotificationHeaderSize(notificationRequest);
 
-            const int marsHeaderSize = 18; // 4 + 2 + 8 + 4
+            const int MarsHeaderSize = 18; // 4 + 2 + 8 + 4
 
             // Header Length (DWORD)
             // Header Type (ushort)
             // Trace Data Guid
             // Trace Data Sequence Number (uint)
-            const int traceHeaderSize = 26;  // 4 + 2 + GUID_SIZE + sizeof(UInt32);
+            const int TraceHeaderSize = 26;  // 4 + 2 + sizeof(Guid) + sizeof(uint);
 
             // TotalLength  - DWORD  - including all headers and lengths, including itself
-            int totalHeaderLength = this.IncludeTraceHeader ? (4 + marsHeaderSize + notificationHeaderSize + traceHeaderSize) : (4 + marsHeaderSize + notificationHeaderSize);
+            int totalHeaderLength = IncludeTraceHeader ? (4 + MarsHeaderSize + notificationHeaderSize + TraceHeaderSize) : (4 + MarsHeaderSize + notificationHeaderSize);
             Debug.Assert(stateObj._outBytesUsed == stateObj._outputHeaderLen, "Output bytes written before total header length");
             // Write total header length
             WriteInt(totalHeaderLength, stateObj);
 
-            // Write Mars header length
-            WriteInt(marsHeaderSize, stateObj);
-            // Write Mars header data
+            // Write MARS header length and data
+            WriteInt(MarsHeaderSize, stateObj);
             WriteMarsHeaderData(stateObj, CurrentTransaction);
 
-            if (0 != notificationHeaderSize)
+            if (notificationHeaderSize != 0)
             {
-                // Write Notification header length
+                // Write notification header length and data
                 WriteInt(notificationHeaderSize, stateObj);
-                // Write notificaiton header data
                 WriteQueryNotificationHeaderData(notificationRequest, stateObj);
             }
 
             if (IncludeTraceHeader)
             {
-
-                // Write trace header length
-                WriteInt(traceHeaderSize, stateObj);
-                // Write trace header data
+                // Write trace header length and data
+                WriteInt(TraceHeaderSize, stateObj);
                 WriteTraceHeaderData(stateObj);
             }
         }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -11575,6 +11575,7 @@ namespace Microsoft.Data.SqlClient
             if (notificationHeaderSize != 0)
             {
                 // Write notification header length and data
+                // MS-TDS 2.2.5.3.1: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/e168d373-a7b7-41aa-b6ca-25985466a7e0
                 WriteInt(notificationHeaderSize, stateObj);
                 WriteQueryNotificationHeaderData(notificationRequest, stateObj);
             }
@@ -11582,6 +11583,7 @@ namespace Microsoft.Data.SqlClient
             if (IncludeTraceHeader)
             {
                 // Write trace header length and data
+                // MS-TDS 2.2.5.3.3: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/6e9f106b-df6e-4cbe-a6eb-45ceb10c63be
                 WriteInt(TraceHeaderSize, stateObj);
                 WriteTraceHeaderData(stateObj);
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -11554,39 +11554,35 @@ namespace Microsoft.Data.SqlClient
 
             int notificationHeaderSize = GetNotificationHeaderSize(notificationRequest);
 
-            const int marsHeaderSize = 18; // 4 + 2 + 8 + 4
+            const int MarsHeaderSize = 18; // 4 + 2 + 8 + 4
 
             // Header Length (DWORD)
             // Header Type (ushort)
             // Trace Data Guid
             // Trace Data Sequence Number (uint)
-            const int traceHeaderSize = 26;  // 4 + 2 + GUID_SIZE + sizeof(UInt32);
+            const int TraceHeaderSize = 26;  // 4 + 2 + sizeof(Guid) + sizeof(uint);
 
             // TotalLength  - DWORD  - including all headers and lengths, including itself
-            int totalHeaderLength = this.IncludeTraceHeader ? (4 + marsHeaderSize + notificationHeaderSize + traceHeaderSize) : (4 + marsHeaderSize + notificationHeaderSize);
+            int totalHeaderLength = IncludeTraceHeader ? (4 + MarsHeaderSize + notificationHeaderSize + TraceHeaderSize) : (4 + MarsHeaderSize + notificationHeaderSize);
             Debug.Assert(stateObj._outBytesUsed == stateObj._outputHeaderLen, "Output bytes written before total header length");
             // Write total header length
             WriteInt(totalHeaderLength, stateObj);
 
-            // Write Mars header length
-            WriteInt(marsHeaderSize, stateObj);
-            // Write Mars header data
+            // Write MARS header length and data
+            WriteInt(MarsHeaderSize, stateObj);
             WriteMarsHeaderData(stateObj, CurrentTransaction);
 
-            if (0 != notificationHeaderSize)
+            if (notificationHeaderSize != 0)
             {
-                // Write Notification header length
+                // Write notification header length and data
                 WriteInt(notificationHeaderSize, stateObj);
-                // Write notificaiton header data
                 WriteQueryNotificationHeaderData(notificationRequest, stateObj);
             }
 
             if (IncludeTraceHeader)
             {
-
-                // Write trace header length
-                WriteInt(traceHeaderSize, stateObj);
-                // Write trace header data
+                // Write trace header length and data
+                WriteInt(TraceHeaderSize, stateObj);
                 WriteTraceHeaderData(stateObj);
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -1092,7 +1092,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        public readonly ref struct XEventScope : IDisposable
+        public readonly ref struct XEventScope // : IDisposable
         {
             private readonly SqlConnection _connection;
             private readonly bool _useDatabaseSession;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Principal;
@@ -1027,7 +1028,33 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public class MDSEventListener : BaseEventListener
         {
+            private static Type s_activityCorrelatorType = Type.GetType("Microsoft.Data.Common.ActivityCorrelator, Microsoft.Data.SqlClient");
+            private static PropertyInfo s_currentActivityProperty = s_activityCorrelatorType.GetProperty("Current", BindingFlags.NonPublic | BindingFlags.Static);
+
+            public readonly HashSet<string> ActivityIDs = new();
+
             public override string Name => MDSEventSourceName;
+
+            protected override void OnMatchingEventWritten(EventWrittenEventArgs eventData)
+            {
+                object currentActivity = s_currentActivityProperty.GetValue(null);
+                string activityId = GetActivityId(currentActivity);
+
+                ActivityIDs.Add(activityId);
+            }
+
+            private static string GetActivityId(object currentActivity)
+            {
+                Type activityIdType = currentActivity.GetType();
+                FieldInfo idField = activityIdType.GetField("Id", BindingFlags.NonPublic | BindingFlags.Instance);
+                FieldInfo sequenceField = activityIdType.GetField("Sequence", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                Guid id = (Guid)idField.GetValue(currentActivity);
+                uint sequence = (uint)sequenceField.GetValue(currentActivity);
+
+                // This activity ID format matches the one used in the XEvents trace
+                return string.Format("{0}-{1}", id, sequence).ToUpper();
+            }
         }
 
         public class BaseEventListener : EventListener
@@ -1056,6 +1083,103 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 {
                     IDs.Add(eventData.EventId);
                     EventData.Add(eventData);
+                    OnMatchingEventWritten(eventData);
+                }
+            }
+
+            protected virtual void OnMatchingEventWritten(EventWrittenEventArgs eventData)
+            {
+            }
+        }
+
+        public readonly ref struct XEventScope : IDisposable
+        {
+            private readonly SqlConnection _connection;
+            private readonly bool _useDatabaseSession;
+
+            public string SessionName { get; }
+
+            public XEventScope(SqlConnection connection, string eventSpecification, string targetSpecification)
+            {
+                SessionName = GenerateRandomCharacters("Session");
+                _connection = connection;
+                // SQL Azure only supports database-scoped XEvent sessions
+                _useDatabaseSession = GetSqlServerProperty(connection.ConnectionString, "EngineEdition") == "5";
+
+                SetupXEvent(eventSpecification, targetSpecification);
+            }
+
+            public void Dispose()
+                => DropXEvent();
+
+            public System.Xml.XmlDocument GetEvents()
+            {
+                string xEventQuery = _useDatabaseSession
+                    ? $@"SELECT xet.target_data
+                        FROM sys.dm_xe_database_session_targets AS xet
+                        INNER JOIN sys.dm_xe_database_sessions AS xe
+                           ON (xe.address = xet.event_session_address)
+                        WHERE xe.name = '{SessionName}'"
+                    : $@"SELECT xet.target_data
+                        FROM sys.dm_xe_session_targets AS xet
+                        INNER JOIN sys.dm_xe_sessions AS xe
+                           ON (xe.address = xet.event_session_address)
+                        WHERE xe.name = '{SessionName}'";
+
+                using (SqlCommand command = new SqlCommand(xEventQuery, _connection))
+                {
+                    if (_connection.State == ConnectionState.Closed)
+                    {
+                        _connection.Open();
+                    }
+
+                    string targetData = command.ExecuteScalar() as string;
+                    System.Xml.XmlDocument xmlDocument = new System.Xml.XmlDocument();
+
+                    xmlDocument.LoadXml(targetData);
+                    return xmlDocument;
+                }
+            }
+
+            private void SetupXEvent(string eventSpecification, string targetSpecification)
+            {
+                string sessionLocation = _useDatabaseSession ? "DATABASE" : "SERVER";
+                string xEventCreateAndStartCommandText = $@"CREATE EVENT SESSION [{SessionName}] ON {sessionLocation}
+                        {eventSpecification}
+                        {targetSpecification}
+                        WITH (
+                            MAX_MEMORY=4096 KB,
+                            EVENT_RETENTION_MODE=ALLOW_SINGLE_EVENT_LOSS,
+                            MAX_DISPATCH_LATENCY=30 SECONDS,
+                            MAX_EVENT_SIZE=0 KB,
+                            MEMORY_PARTITION_MODE=NONE,
+                            TRACK_CAUSALITY=ON,
+                            STARTUP_STATE=OFF)
+                            
+                        ALTER EVENT SESSION [{SessionName}] ON {sessionLocation} STATE = START ";
+
+                using (SqlCommand createXEventSession = new SqlCommand(xEventCreateAndStartCommandText, _connection))
+                {
+                    if (_connection.State == ConnectionState.Closed)
+                    {
+                        _connection.Open();
+                    }
+
+                    createXEventSession.ExecuteNonQuery();
+                }
+            }
+
+            private void DropXEvent()
+            {
+                string dropXEventSessionCommand = _useDatabaseSession
+                    ? $"IF EXISTS (select * from sys.dm_xe_database_sessions where name ='{SessionName}')" +
+                        $" DROP EVENT SESSION [{SessionName}] ON DATABASE"
+                    : $"IF EXISTS (select * from sys.dm_xe_sessions where name ='{SessionName}')" +
+                        $" DROP EVENT SESSION [{SessionName}] ON SERVER";
+
+                using (SqlCommand command = new SqlCommand(dropXEventSessionCommand, _connection))
+                {
+                    command.ExecuteNonQuery();
                 }
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -177,6 +177,7 @@
     <Compile Include="ProviderAgnostic\MultipleResultsTest\MultipleResultsTest.cs" />
     <Compile Include="ProviderAgnostic\ReaderTest\ReaderTest.cs" />
     <Compile Include="TracingTests\EventSourceTest.cs" />
+    <Compile Include="TracingTests\XEventsTracingTest.cs" />
     <Compile Include="SQL\AADFedAuthTokenRefreshTest\AADFedAuthTokenRefreshTest.cs" />
     <Compile Include="SQL\ConnectionPoolTest\ConnectionPoolTest.cs" />
     <Compile Include="SQL\ConnectionPoolTest\PoolBlockPeriodTest.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/XEventsTracingTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/XEventsTracingTest.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Xml;
+using System.Xml.XPath;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests
+{
+    public class XEventsTracingTest
+    {
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [InlineData("SELECT @@VERSION", System.Data.CommandType.Text, "sql_statement_starting")]
+        [InlineData("sp_help", System.Data.CommandType.StoredProcedure, "rpc_starting")]
+        public void XEventActivityIDConsistentWithTracing(string query, System.Data.CommandType commandType, string xEvent)
+        {
+            // This test validates that the activity ID recorded in the client-side trace is passed through to the server,
+            // where it can be recorded in an XEvent session. This is documented at:
+            // https://learn.microsoft.com/en-us/sql/relational-databases/native-client/features/accessing-diagnostic-information-in-the-extended-events-log
+
+            using (SqlConnection xEventManagementConnection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            using (DataTestUtility.XEventScope xEventSession = new DataTestUtility.XEventScope(xEventManagementConnection,
+                @"ADD EVENT SQL_STATEMENT_STARTING (ACTION (client_connection_id)),
+                ADD EVENT RPC_STARTING (ACTION (client_connection_id))",
+                "ADD TARGET ring_buffer"))
+            {
+                Guid connectionId;
+                HashSet<string> ids;
+
+                using (DataTestUtility.MDSEventListener TraceListener = new())
+                using (SqlConnection connection = new(DataTestUtility.TCPConnectionString))
+                {
+                    connection.Open();
+                    connectionId = connection.ClientConnectionId;
+
+                    using SqlCommand command = new(query, connection) { CommandType = commandType };
+                    using SqlDataReader reader = command.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        // Flush data
+                    }
+
+                    ids = TraceListener.ActivityIDs;
+                }
+
+                XmlDocument eventList = xEventSession.GetEvents();
+                // Get the associated activity ID from the XEvent session. We expect to see the same ID in the trace as well.
+                string activityId = GetCommandActivityId(query, xEvent, connectionId, eventList);
+
+                Assert.Contains(activityId, ids);
+            }
+        }
+
+        private static string GetCommandActivityId(string commandText, string eventName, Guid connectionId, XmlDocument xEvents)
+        {
+            XPathNavigator xPathRoot = xEvents.CreateNavigator();
+            // The transferred activity ID is attached to the "attach_activity_id_xfer" action within
+            // the "sql_statement_starting" and the "rpc_starting" events.
+            XPathNodeIterator statementStartingQuery = xPathRoot.Select(
+                $"/RingBufferTarget/event[@name='{eventName}'"
+                + $" and action[@name='client_connection_id']/value='{connectionId.ToString().ToUpper()}'"
+                + $" and (data[@name='statement']='{commandText}' or data[@name='object_name']='{commandText}')]");
+
+            Assert.Equal(1, statementStartingQuery.Count);
+            Assert.True(statementStartingQuery.MoveNext());
+
+            XPathNavigator activityIdElement = statementStartingQuery.Current.SelectSingleNode("action[@name='attach_activity_id_xfer']/value");
+            
+            Assert.NotNull(activityIdElement);
+            Assert.NotNull(activityIdElement.Value);
+
+            return activityIdElement.Value;
+        }
+    }
+}


### PR DESCRIPTION
## Description

If tracing was enabled, the netfx version of SqlClient would send the current activity ID to the remote database server. This functionality was part of TdsParser and would be covered by the merge, but it lacked test coverage. I've ported the feature to netcore and added a test.

As a result, it's now possible to enable tracing, then link the activity ID of a SqlCommand to the `attach_activity_id_xfer` value of the appropriate server-side XEvent. The XEvents can then be correlated further within SQL Server. We gain end-to-end trace correlation. In the future, this could be used to link OpenTelemetry spans into SQL Server XEvents.

A fuller description of the feature (albeit one which is described in terms of SQL Server Native Client) is documented [here](https://learn.microsoft.com/en-us/sql/relational-databases/native-client/features/accessing-diagnostic-information-in-the-extended-events-log).

## Issues

Relates to #1261.

## Testing

Added one new functional test. This test enables tracing and XEvents, then runs a simple query or stored procedure and compares the activity ID recorded by the XEvents trace to the activity ID recorded in the SqlClient tracing.