### PR TITLE
Improve async string perf and fix reading chars with initial offset.

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -13088,7 +13088,7 @@ namespace Microsoft.Data.SqlClient
                 ||
                 (buff.Length >= offst + len)
                 ||
-                (buff.Length == (startOffsetByteCount >> 1) + 1),
+                (buff.Length >= (startOffsetByteCount >> 1) + 1),
                 "Invalid length sent to ReadPlpUnicodeChars()!"
             );
             charsLeft = len;
@@ -13152,7 +13152,10 @@ namespace Microsoft.Data.SqlClient
                         }
                         else
                         {
-                            newbuf = new char[offst + charsRead];
+                            // grow by an arbitrary number of packets to avoid needing to reallocate
+                            //  the newbuf on each loop iteration of long packet sequences which causes
+                            //  a performance problem as we spend large amounts of time copying and in gc
+                            newbuf = new char[offst + charsRead + (stateObj.GetPacketSize() * 8)];
                             rentedBuff = false;
                         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -13096,9 +13096,9 @@ namespace Microsoft.Data.SqlClient
             // If total length is known up front, the length isn't specified as unknown 
             // and the caller doesn't pass int.max/2 indicating that it doesn't know the length
             // allocate the whole buffer in one shot instead of realloc'ing and copying over each time
-            if (buff == null && stateObj._longlen != TdsEnums.SQL_PLP_UNKNOWNLEN && len < (int.MaxValue >> 1))
+            if (buff == null && stateObj._longlen != TdsEnums.SQL_PLP_UNKNOWNLEN && stateObj._longlen < (int.MaxValue >> 1))
             {
-                if (supportRentedBuff && len < 1073741824) // 1 Gib
+                if (supportRentedBuff && stateObj._longlen < 1073741824) // 1 Gib
                 {
                     buff = ArrayPool<char>.Shared.Rent((int)Math.Min((int)stateObj._longlen, len));
                     rentedBuff = true;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -13133,8 +13133,7 @@ namespace Microsoft.Data.SqlClient
 
             totalCharsRead = (startOffsetByteCount >> 1);
             charsLeft -= totalCharsRead;
-            offst = totalCharsRead;
-
+            offst += totalCharsRead;
 
             while (charsLeft > 0)
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -13267,7 +13267,7 @@ namespace Microsoft.Data.SqlClient
         {
             int charsRead = 0;
             int charsLeft = 0;
-            
+
             if (stateObj._longlen == 0)
             {
                 Debug.Assert(stateObj._longlenleft == 0);
@@ -13277,11 +13277,11 @@ namespace Microsoft.Data.SqlClient
 
             Debug.Assert((ulong)stateObj._longlen != TdsEnums.SQL_PLP_NULL, "Out of sync plp read request");
             Debug.Assert(
-                (buff == null && offst == 0) 
-                || 
+                (buff == null && offst == 0)
+                ||
                 (buff.Length >= offst + len)
                 ||
-                (buff.Length == (startOffsetByteCount >> 1) + 1), 
+                (buff.Length >= (startOffsetByteCount >> 1) + 1),
                 "Invalid length sent to ReadPlpUnicodeChars()!"
             );
             charsLeft = len;
@@ -13289,9 +13289,9 @@ namespace Microsoft.Data.SqlClient
             // If total length is known up front, the length isn't specified as unknown 
             // and the caller doesn't pass int.max/2 indicating that it doesn't know the length
             // allocate the whole buffer in one shot instead of realloc'ing and copying over each time
-            if (buff == null && stateObj._longlen != TdsEnums.SQL_PLP_UNKNOWNLEN && len < (int.MaxValue >> 1))
+            if (buff == null && stateObj._longlen != TdsEnums.SQL_PLP_UNKNOWNLEN && stateObj._longlen < (int.MaxValue >> 1))
             {
-                if (supportRentedBuff && len < 1073741824) // 1 Gib
+                if (supportRentedBuff && stateObj._longlen < 1073741824) // 1 Gib
                 {
                     buff = ArrayPool<char>.Shared.Rent((int)Math.Min((int)stateObj._longlen, len));
                     rentedBuff = true;
@@ -13327,8 +13327,8 @@ namespace Microsoft.Data.SqlClient
             totalCharsRead = (startOffsetByteCount >> 1);
             charsLeft -= totalCharsRead;
             offst = totalCharsRead;
-            
-            
+
+
             while (charsLeft > 0)
             {
                 if (!partialReadInProgress)
@@ -13345,7 +13345,10 @@ namespace Microsoft.Data.SqlClient
                         }
                         else
                         {
-                            newbuf = new char[offst + charsRead];
+                            // grow by an arbitrary number of packets to avoid needing to reallocate
+                            //  the newbuf on each loop iteration of long packet sequences which causes
+                            //  a performance problem as we spend large amounts of time copying and in gc
+                            newbuf = new char[offst + charsRead + (stateObj.GetPacketSize() * 8)];
                             rentedBuff = false;
                         }
 
@@ -13385,7 +13388,7 @@ namespace Microsoft.Data.SqlClient
                     && (charsLeft > 0)
                 )
                 {
-                    byte b1 = 0; 
+                    byte b1 = 0;
                     byte b2 = 0;
                     if (partialReadInProgress)
                     {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -13326,7 +13326,7 @@ namespace Microsoft.Data.SqlClient
 
             totalCharsRead = (startOffsetByteCount >> 1);
             charsLeft -= totalCharsRead;
-            offst = totalCharsRead;
+            offst += totalCharsRead;
 
 
             while (charsLeft > 0)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -1360,6 +1360,11 @@ namespace Microsoft.Data.SqlClient
             return false;
         }
 
+        internal int GetPacketSize()
+        {
+            return _inBuff.Length;
+        }
+
         ///////////////////////////////////////
         // Buffer read methods - data values //
         ///////////////////////////////////////

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -4027,6 +4027,28 @@ namespace Microsoft.Data.SqlClient
                     Debug.Assert(_stateObj._permitReplayStackTraceToDiffer || prev.Stack == trace, "The stack trace on subsequent replays should be the same");
                 }
             }
+
+            public int CurrentPacketIndex
+            {
+                get
+                {
+                    int value = -1;
+                    if (_current != null)
+                    {
+                        PacketData current = _firstPacket;
+                        while (current != null)
+                        {
+                            value += 1;
+                            if (current == _current)
+                            {
+                                break;
+                            }
+                            current = current.NextPacket;
+                        } 
+                    }
+                    return value;
+                }
+            }
 #endif
             public bool ContinueEnabled => !LocalAppContextSwitches.UseCompatibilityAsyncBehaviour;
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlTypes;
@@ -655,6 +656,94 @@ INSERT INTO [{tableName}] (Data) VALUES (@data);";
                     catch
                     {
                     }
+                }
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        public static async Task CanGetCharsSequentially()
+        {
+            const CommandBehavior commandBehavior = CommandBehavior.SequentialAccess | CommandBehavior.SingleResult;
+            const int length = 32000;
+            const string sqlCharWithArg = "SELECT CONVERT(BIGINT, 1) AS [Id], CONVERT(NVARCHAR(MAX), @input) AS [Value];";
+
+            using (var sqlConnection = new SqlConnection(DataTestUtility.TCPConnectionString))
+            {
+                await sqlConnection.OpenAsync();
+
+                StringBuilder inputBuilder = new StringBuilder(length);
+                Random random = new Random();
+                for (int i = 0; i < length; i++)
+                {
+                    inputBuilder.Append((char)random.Next(0x30, 0x5A));
+                }
+                string input = inputBuilder.ToString();
+
+                using (var sqlCommand = new SqlCommand())
+                {
+                    sqlCommand.Connection = sqlConnection;
+                    sqlCommand.CommandTimeout = 0;
+                    sqlCommand.CommandText = sqlCharWithArg;
+                    sqlCommand.Parameters.Add(new SqlParameter("@input", SqlDbType.NVarChar, -1) { Value = input });
+
+                    using (var sqlReader = await sqlCommand.ExecuteReaderAsync(commandBehavior))
+                    {
+                        if (await sqlReader.ReadAsync())
+                        {
+                            long id = sqlReader.GetInt64(0);
+                            if (id != 1)
+                            {
+                                Assert.Fail("Id not 1");
+                            }
+
+                            var sliced = GetPooledChars(sqlReader, 1, input);
+                            if (!sliced.SequenceEqual(input.ToCharArray()))
+                            {
+                                Assert.Fail("sliced != input");
+                            }
+                        }
+                    }
+                }
+            }
+
+            static char[] GetPooledChars(SqlDataReader sqlDataReader, int ordinal, string input)
+            {
+                var buffer = ArrayPool<char>.Shared.Rent(8192);
+                int offset = 0;
+                while (true)
+                {
+                    int read = (int)sqlDataReader.GetChars(ordinal, offset, buffer, offset, buffer.Length - offset);
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    ReadOnlySpan<char> fetched = buffer.AsSpan(offset, read);
+                    ReadOnlySpan<char> origin = input.AsSpan(offset, read);
+
+                    if (!fetched.Equals(origin, StringComparison.Ordinal))
+                    {
+                        Assert.Fail($"chunk (start:{offset}, for:{read}), is not the same as the input");
+                    }
+
+                    offset += read;
+
+                    if (buffer.Length - offset < 128)
+                    {
+                        buffer = Resize(buffer);
+                    }
+                }
+
+                var sliced = buffer.AsSpan(0, offset).ToArray();
+                ArrayPool<char>.Shared.Return(buffer);
+                return sliced;
+
+                static char[] Resize(char[] buffer)
+                {
+                    var newBuffer = ArrayPool<char>.Shared.Rent(buffer.Length * 2);
+                    Array.Copy(buffer, newBuffer, buffer.Length);
+                    ArrayPool<char>.Shared.Return(buffer);
+                    return newBuffer;
                 }
             }
         }


### PR DESCRIPTION
## Description

For performance related changes see background information in https://github.com/dotnet/SqlClient/issues/3274#issuecomment-2869878530 and the preceeding conversation. Reading a string in async mode was being slower than expected so I investigated. I will annotate each change with an explanation.

## Issues

fixes https://github.com/dotnet/SqlClient/issues/3331
fixes https://github.com/dotnet/SqlClient/issues/3274 

## Testing

Tests have been added which cover both issues that are being fixed.

