### PR TITLE
Fix sequential text reader bug and add covering test

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Data.SqlClient
                         byte[] byteBuffer = PrepareByteBuffer(charsNeeded, out int byteBufferUsed);
 
                         // Permit a 0 byte read in order to advance the reader to the correct column
-                        if ((byteBufferUsed <= byteBuffer.Length) || (byteBuffer.Length == 0))
+                        if (byteBufferUsed <= byteBuffer.Length || byteBuffer.Length == 0)
                         {
                             SqlDataReader reader = _reader;
                             if (reader != null)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Data.SqlClient
                         byte[] byteBuffer = PrepareByteBuffer(charsNeeded, out int byteBufferUsed);
 
                         // Permit a 0 byte read in order to advance the reader to the correct column
-                        if ((byteBufferUsed < byteBuffer.Length) || (byteBuffer.Length == 0))
+                        if ((byteBufferUsed <= byteBuffer.Length) || (byteBuffer.Length == 0))
                         {
                             SqlDataReader reader = _reader;
                             if (reader != null)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -608,6 +608,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static async Task CanReadSequentialDecreasingChunks()
         {
+            // pattern repeat input allows you to more easily identify if chunks are incorrectly
+            //  related to each other by seeing the start and end of sequential chunks and checking
+            //  if they correctly move to the next char while debugging
+            // simply repeating a single char can't tell you where in the string it went wrong.
             const string baseString = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
             StringBuilder inputBuilder = new StringBuilder();
             while (inputBuilder.Length < (64 * 1024))


### PR DESCRIPTION
Fixes #3361 

When using single byte input the test provided triggered a condition where the next read would skip data in available internal buffer because it was exactly, and not less than, the required amount.

/cc @m0a0k0s