### PR TITLE
Enable IL trimming and NativeAOT on AzureKeyVaultProvider

### DIFF
--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
@@ -15,6 +15,8 @@
     <BuildProjectReferences>false</BuildProjectReferences>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <IsTrimmable Condition="'$(TargetGroup)'=='netcoreapp'">true</IsTrimmable>
+    <IsAotCompatible Condition="'$(TargetGroup)'=='netcoreapp'">true</IsAotCompatible>
   </PropertyGroup>
    <!--Generating Strong Name-->
   <PropertyGroup Condition="'$(CDP_BUILD_TYPE)'=='Official'">


### PR DESCRIPTION
## Description

We can safely enable IL trimming and NativeAOT support on the AzureKeyVaultProvider project for the .NET targets. This PR simply sets the `IsTrimmable` and `IsAotCompatible` properties.

This doesn't enable these features on SqlClient itself, and the addon isn't particularly useful on its own - but when the library itself is compatible, the addon isn't going to hold it back.

## Issues

Relates to #1947.

## Testing

The IL trimming and NativeAOT support is mostly flagged by compile-time warnings. A sample application which directly references the DLL runs successfully - I can successfully publish and run the code below.

```csharp
const string AkvPath = "...";
var keyVaultProvider = new SqlColumnEncryptionAzureKeyVaultProvider(new DefaultAzureCredential(true));
var signedCMKM = keyVaultProvider.SignColumnMasterKeyMetadata(AkvPath, false);
var verifiedMetadata = keyVaultProvider.VerifyColumnMasterKeyMetadata(AkvPath, false, signedCMKM);

if (!verifiedMetadata)
    throw new Exception("Signed CMK metadata does not match.");

var cek = new byte[32];
var encryptedCek = keyVaultProvider.EncryptColumnEncryptionKey(AkvPath, "RSA-OAEP", cek);
var decryptedCek = keyVaultProvider.DecryptColumnEncryptionKey(AkvPath, "RSA-OAEP", encryptedCek);

if (!decryptedCek.SequenceEqual(cek))
    throw new Exception("Column encryption key does not roundtrip.");
```

I've not added a unit test - as per dotnet/runtime#97013 this isn't a good way to perform testing.