### PR TITLE
Merge | DbConnectionString

### DIFF
--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -258,6 +258,9 @@
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\Common\ConnectionString\DbConnectionStringSynonyms.cs">
       <Link>Microsoft\Data\Common\ConnectionString\DbConnectionStringSynonyms.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\Common\ConnectionString\DbConnectionString.netfx.cs">
+      <Link>Microsoft\Data\Common\ConnectionString\DbConnectionString.netfx.cs</Link>
+    </Compile>
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\Common\ConnectionString\DbConnectionStringUtilities.cs">
       <Link>Microsoft\Data\Common\ConnectionString\DbConnectionStringUtilities.cs</Link>
     </Compile>
@@ -948,9 +951,7 @@
     <Compile Include="$(CommonSourceRoot)System\IO\StreamExtensions.netfx.cs">
       <Link>System\IO\StreamExtensions.netfx.cs</Link>
     </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Microsoft\Data\Common\DBConnectionString.cs" />
+  
     <Compile Include="Microsoft\Data\SqlClient\SqlBulkCopy.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlClientWrapperSmiStream.cs" />
     <Compile Include="Microsoft\Data\SqlClient\SqlClientWrapperSmiStreamChars.cs" />

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionString.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionString.netfx.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if NETFRAMEWORK
+
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -12,6 +14,8 @@ using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Data.Common
 {
+    // @TODO: Theoretically this class could be replaced with SqlConnectionString.
+    
     [Serializable] // MDAC 83147
     internal sealed class DBConnectionString
     {
@@ -568,3 +572,5 @@ namespace Microsoft.Data.Common
         }
     }
 }
+
+#endif

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionString.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionString.netfx.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Common
     // @TODO: Theoretically this class could be replaced with SqlConnectionString.
     
     [Serializable] // MDAC 83147
-    internal sealed class DBConnectionString
+    internal sealed class DbConnectionString
     {
         // instances of this class are intended to be immutable, i.e readonly
         // used by permission classes so it is much easier to verify correctness
@@ -47,21 +47,21 @@ namespace Microsoft.Data.Common
         readonly private string _encryptedActualConnectionString;
 #pragma warning restore 169
 
-        internal DBConnectionString(string value, string restrictions, KeyRestrictionBehavior behavior, Dictionary<string, string> synonyms, bool useOdbcRules)
+        internal DbConnectionString(string value, string restrictions, KeyRestrictionBehavior behavior, Dictionary<string, string> synonyms, bool useOdbcRules)
             : this(new DbConnectionOptions(value, synonyms), restrictions, behavior, synonyms, false)
         {
             // useOdbcRules is only used to parse the connection string, not to parse restrictions because values don't apply there
             // the hashtable doesn't need clone since it isn't shared with anything else
         }
 
-        internal DBConnectionString(DbConnectionOptions connectionOptions)
+        internal DbConnectionString(DbConnectionOptions connectionOptions)
             : this(connectionOptions, (string)null, KeyRestrictionBehavior.AllowOnly, null, true)
         {
-            // used by DBDataPermission to convert from DbConnectionOptions to DBConnectionString
+            // used by DBDataPermission to convert from DbConnectionOptions to DbConnectionString
             // since backward compatibility requires Everett level classes
         }
 
-        private DBConnectionString(DbConnectionOptions connectionOptions, string restrictions, KeyRestrictionBehavior behavior, Dictionary<string, string> synonyms, bool mustCloneDictionary)
+        private DbConnectionString(DbConnectionOptions connectionOptions, string restrictions, KeyRestrictionBehavior behavior, Dictionary<string, string> synonyms, bool mustCloneDictionary)
         { // used by DBDataPermission
             Debug.Assert(connectionOptions != null, "null connectionOptions");
             switch (behavior)
@@ -117,7 +117,7 @@ namespace Microsoft.Data.Common
             }
         }
 
-        private DBConnectionString(DBConnectionString connectionString, string[] restrictionValues, KeyRestrictionBehavior behavior)
+        private DbConnectionString(DbConnectionString connectionString, string[] restrictionValues, KeyRestrictionBehavior behavior)
         {
             // used by intersect for two equal connection strings with different restrictions
             _encryptedUsersConnectionString = connectionString._encryptedUsersConnectionString;
@@ -194,7 +194,7 @@ namespace Microsoft.Data.Common
             return _parsetable.ContainsKey(keyword);
         }
 
-        internal DBConnectionString Intersect(DBConnectionString entry)
+        internal DbConnectionString Intersect(DbConnectionString entry)
         {
             KeyRestrictionBehavior behavior = _behavior;
             string[] restrictionValues = null;
@@ -286,7 +286,7 @@ namespace Microsoft.Data.Common
             Debug.Assert(!_hasPassword || ContainsKey(DbConnectionStringKeywords.Password) || ContainsKey(DbConnectionStringSynonyms.Pwd), "OnDeserialized password mismatch this");
             Debug.Assert(entry == null || !entry._hasPassword || entry.ContainsKey(DbConnectionStringKeywords.Password) || entry.ContainsKey(DbConnectionStringSynonyms.Pwd), "OnDeserialized password mismatch entry");
 
-            DBConnectionString value = new DBConnectionString(this, restrictionValues, behavior);
+            DbConnectionString value = new DbConnectionString(this, restrictionValues, behavior);
             ValidateCombinedSet(this, value);
             ValidateCombinedSet(entry, value);
 
@@ -294,7 +294,7 @@ namespace Microsoft.Data.Common
         }
 
         [Conditional("DEBUG")]
-        private void ValidateCombinedSet(DBConnectionString componentSet, DBConnectionString combinedSet)
+        private void ValidateCombinedSet(DbConnectionString componentSet, DbConnectionString combinedSet)
         {
             Debug.Assert(combinedSet != null, "The combined connection string should not be null");
             if ((componentSet != null) && (combinedSet._restrictionValues != null) && (componentSet._restrictionValues != null))
@@ -367,7 +367,7 @@ namespace Microsoft.Data.Common
             return (_restrictionValues == null || (0 > Array.BinarySearch(_restrictionValues, key, StringComparer.Ordinal)));
         }
 
-        internal bool IsSupersetOf(DBConnectionString entry)
+        internal bool IsSupersetOf(DbConnectionString entry)
         {
             Debug.Assert(!_hasPassword || ContainsKey(DbConnectionStringKeywords.Password) || ContainsKey(DbConnectionStringSynonyms.Pwd), "OnDeserialized password mismatch this");
             Debug.Assert(!entry._hasPassword || entry.ContainsKey(DbConnectionStringKeywords.Password) || entry.ContainsKey(DbConnectionStringSynonyms.Pwd), "OnDeserialized password mismatch entry");
@@ -477,10 +477,10 @@ namespace Microsoft.Data.Common
             return restrictionValues;
         }
 
-        private static string[] ParseRestrictions(string restrictions, Dictionary<string, string> synonyms)
+        private static string[] ParseRestrictions(string restrictions, IReadOnlyDictionary<string, string> synonyms)
         {
 #if DEBUG
-            SqlClientEventSource.Log.TryAdvancedTraceEvent("<comm.DBConnectionString|INFO|ADV> Restrictions='{0}'", restrictions);
+            SqlClientEventSource.Log.TryAdvancedTraceEvent("<comm.DbConnectionString|INFO|ADV> Restrictions='{0}'", restrictions);
 #endif
             List<string> restrictionValues = new List<string>();
             StringBuilder buffer = new StringBuilder(restrictions.Length);
@@ -496,7 +496,7 @@ namespace Microsoft.Data.Common
                 if (!string.IsNullOrEmpty(keyname))
                 {
 #if DEBUG
-                    SqlClientEventSource.Log.TryAdvancedTraceEvent("<comm.DBConnectionString|INFO|ADV> KeyName='{0}'", keyname);
+                    SqlClientEventSource.Log.TryAdvancedTraceEvent("<comm.DbConnectionString|INFO|ADV> KeyName='{0}'", keyname);
 #endif
                     string realkeyname = synonyms != null ? (string)synonyms[keyname] : keyname; // MDAC 85144
                     if (string.IsNullOrEmpty(realkeyname))

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionString.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionString.netfx.cs
@@ -23,14 +23,6 @@ namespace Microsoft.Data.Common
         // used by permission classes so it is much easier to verify correctness
         // when not worried about the class being modified during execution
 
-        // @TODO: Remove in favor of DbConnectionStringKeywords
-        private static class KEY
-        {
-            internal const string Password = DbConnectionStringKeywords.Password;
-            internal const string PersistSecurityInfo = DbConnectionStringKeywords.PersistSecurityInfo;
-            internal const string Pwd = DbConnectionStringSynonyms.Pwd;
-        };
-
         // this class is serializable with Everett, so ugly field names can't be changed
         readonly private string _encryptedUsersConnectionString;
 
@@ -105,13 +97,13 @@ namespace Microsoft.Data.Common
                 // serialize out with '*' so already knows what we do.  Better this way
                 // than to treat password specially later on which causes problems.
                 const string star = "*";
-                if (_parsetable.ContainsKey(KEY.Password))
+                if (_parsetable.ContainsKey(DbConnectionStringKeywords.Password))
                 {
-                    _parsetable[KEY.Password] = star;
+                    _parsetable[DbConnectionStringKeywords.Password] = star;
                 }
-                if (_parsetable.ContainsKey(KEY.Pwd))
+                if (_parsetable.ContainsKey(DbConnectionStringSynonyms.Pwd))
                 {
-                    _parsetable[KEY.Pwd] = star;
+                    _parsetable[DbConnectionStringSynonyms.Pwd] = star;
                 }
 
                 // replace user's password/pwd value with "*" in the linked list and build a new string
@@ -291,8 +283,8 @@ namespace Microsoft.Data.Common
             }
 
             // verify _hasPassword & _parsetable are in sync between Everett/Whidbey
-            Debug.Assert(!_hasPassword || ContainsKey(KEY.Password) || ContainsKey(KEY.Pwd), "OnDeserialized password mismatch this");
-            Debug.Assert(entry == null || !entry._hasPassword || entry.ContainsKey(KEY.Password) || entry.ContainsKey(KEY.Pwd), "OnDeserialized password mismatch entry");
+            Debug.Assert(!_hasPassword || ContainsKey(DbConnectionStringKeywords.Password) || ContainsKey(DbConnectionStringSynonyms.Pwd), "OnDeserialized password mismatch this");
+            Debug.Assert(entry == null || !entry._hasPassword || entry.ContainsKey(DbConnectionStringKeywords.Password) || entry.ContainsKey(DbConnectionStringSynonyms.Pwd), "OnDeserialized password mismatch entry");
 
             DBConnectionString value = new DBConnectionString(this, restrictionValues, behavior);
             ValidateCombinedSet(this, value);
@@ -377,8 +369,8 @@ namespace Microsoft.Data.Common
 
         internal bool IsSupersetOf(DBConnectionString entry)
         {
-            Debug.Assert(!_hasPassword || ContainsKey(KEY.Password) || ContainsKey(KEY.Pwd), "OnDeserialized password mismatch this");
-            Debug.Assert(!entry._hasPassword || entry.ContainsKey(KEY.Password) || entry.ContainsKey(KEY.Pwd), "OnDeserialized password mismatch entry");
+            Debug.Assert(!_hasPassword || ContainsKey(DbConnectionStringKeywords.Password) || ContainsKey(DbConnectionStringSynonyms.Pwd), "OnDeserialized password mismatch this");
+            Debug.Assert(!entry._hasPassword || entry.ContainsKey(DbConnectionStringKeywords.Password) || entry.ContainsKey(DbConnectionStringSynonyms.Pwd), "OnDeserialized password mismatch entry");
 
             switch (_behavior)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientPermission.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientPermission.netfx.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Data.SqlClient
             if (constr != null)
             {
                 AllowBlankPassword = constr.HasBlankPassword; // MDAC 84563
-                AddPermissionEntry(new DBConnectionString(constr));
+                AddPermissionEntry(new DbConnectionString(constr));
             }
             
             if (constr == null || constr.IsEmpty)
@@ -106,7 +106,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlClientPermission.xml' path='docs/members[@name="SqlClientPermission"]/Add[@name="connectionStringAndrestrictionsStringAndBehavior"]/*' />
         public override void Add(string connectionString, string restrictions, KeyRestrictionBehavior behavior)
         {
-            DBConnectionString constr = new DBConnectionString(connectionString, restrictions, behavior, SqlConnectionString.GetParseSynonyms(), false);
+            DbConnectionString constr = new DbConnectionString(connectionString, restrictions, behavior, SqlConnectionString.GetParseSynonyms(), false);
             AddPermissionEntry(constr);
         }
         
@@ -254,7 +254,7 @@ namespace Microsoft.Data.SqlClient
                     subset = true;
                     if (_keyvalues != null)
                     {
-                        foreach (DBConnectionString kventry in _keyvalues)
+                        foreach (DbConnectionString kventry in _keyvalues)
                         {
                             if (!superset._keyvaluetree.CheckValueForKeyPermit(kventry))
                             {
@@ -293,7 +293,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (_keyvalues != null)
                 {
-                    foreach (DBConnectionString value in _keyvalues)
+                    foreach (DbConnectionString value in _keyvalues)
                     {
                         SecurityElement valueElement = new SecurityElement(XmlStr._add);
                         string tmp;
@@ -342,7 +342,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (_keyvalues != null)
                 {
-                    foreach (DBConnectionString entry in _keyvalues)
+                    foreach (DbConnectionString entry in _keyvalues)
                     {
                         newPermission.AddPermissionEntry(entry);
                     }
@@ -352,7 +352,7 @@ namespace Microsoft.Data.SqlClient
             return newPermission.IsEmpty() ? null : newPermission;
         }
         
-        internal void AddPermissionEntry(DBConnectionString entry)
+        internal void AddPermissionEntry(DbConnectionString entry)
         {
             if (_keyvaluetree == null)
             {
@@ -407,7 +407,7 @@ namespace Microsoft.Data.SqlClient
             private readonly string _value;
 
             // value node with (_restrictions != null) are allowed to match connection strings
-            private DBConnectionString _entry;
+            private DbConnectionString _entry;
 
             private NameValuePermission[] _tree; // with branches
 
@@ -442,7 +442,7 @@ namespace Microsoft.Data.SqlClient
                 _value = keyword;
             }
 
-            private NameValuePermission(string value, DBConnectionString entry)
+            private NameValuePermission(string value, DbConnectionString entry)
             {
                 _value = value;
                 _entry = entry;
@@ -451,9 +451,9 @@ namespace Microsoft.Data.SqlClient
             int IComparable.CompareTo(object other) =>
                 string.CompareOrdinal(_value, ((NameValuePermission)other)._value);
 
-            internal static void AddEntry(NameValuePermission kvtree, ArrayList entries, DBConnectionString entry)
+            internal static void AddEntry(NameValuePermission kvtree, ArrayList entries, DbConnectionString entry)
             {
-                Debug.Assert(entry != null, "null DBConnectionString");
+                Debug.Assert(entry != null, "null DbConnectionString");
 
                 if (entry.KeyChain != null)
                 {
@@ -471,7 +471,7 @@ namespace Microsoft.Data.SqlClient
                         kv = kvtree.CheckKeyForValue(keychain.Value);
                         if (kv == null)
                         {
-                            DBConnectionString insertValue = keychain.Next != null ? null : entry;
+                            DbConnectionString insertValue = keychain.Next != null ? null : entry;
                             kv = new NameValuePermission(keychain.Value, insertValue);
                             kvtree.Add(kv); // add directly into live tree
                             if (insertValue != null)
@@ -500,7 +500,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     // global restrictions
-                    DBConnectionString kentry = kvtree._entry;
+                    DbConnectionString kentry = kvtree._entry;
                     if (kentry != null)
                     {
                         Debug.Assert(entries.Contains(kentry), "entries doesn't contain entry");
@@ -516,7 +516,7 @@ namespace Microsoft.Data.SqlClient
                 }
             }
 
-            internal bool CheckValueForKeyPermit(DBConnectionString parsetable)
+            internal bool CheckValueForKeyPermit(DbConnectionString parsetable)
             {
                 if (parsetable == null)
                 {
@@ -571,7 +571,7 @@ namespace Microsoft.Data.SqlClient
                     // partial chain match, either leaf-node by shorter chain or fail mid-chain if ( _restrictions == null)
                 }
 
-                DBConnectionString entry = _entry;
+                DbConnectionString entry = _entry;
                 if (entry != null)
                 {
                     // also checking !hasMatch is tempting, but wrong


### PR DESCRIPTION
## Description
This merge PR is pretty simple. It moves the DbConnectionString class from the netfx project into the common project. It was originally named DBConnectionString but is now renamed to DbConnectionString to follow naming conventions (after @paulmedynski caused a bunch of merge conflicts fixing broken link to the old name...)

I developed this PR on top of some cleanup work for DbConnectionOptions that I rebased off of. There may be some remnants of those changes in this PR.

## Issues
Continues work on #1261 

## Testing
Class is just being renamed and moved, project still builds, CI should be good to verify.
