### PR TITLE
Fix | PoolGroupProviderInfo Typing

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -33,19 +33,30 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, IDbConnectionPool pool, DbConnection owningConnection)
+        protected override DbConnectionInternal CreateConnection(
+            DbConnectionOptions options,
+            DbConnectionPoolKey poolKey,
+            DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
+            IDbConnectionPool pool,
+            DbConnection owningConnection)
         {
             return CreateConnection(options, poolKey, poolGroupProviderInfo, pool, owningConnection, userOptions: null);
         }
 
-        override protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, IDbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
+        protected override DbConnectionInternal CreateConnection(
+            DbConnectionOptions options,
+            DbConnectionPoolKey poolKey,
+            DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
+            IDbConnectionPool pool,
+            DbConnection owningConnection,
+            DbConnectionOptions userOptions)
         {
             SqlConnectionString opt = (SqlConnectionString)options;
             SqlConnectionPoolKey key = (SqlConnectionPoolKey)poolKey;
             SessionData recoverySessionData = null;
 
             SqlConnection sqlOwningConnection = (SqlConnection)owningConnection;
-            bool applyTransientFaultHandling = sqlOwningConnection != null ? sqlOwningConnection._applyTransientFaultHandling : false;
+            bool applyTransientFaultHandling = sqlOwningConnection?._applyTransientFaultHandling ?? false;
 
             SqlConnectionString userOpt = null;
             if (userOptions != null)
@@ -137,7 +148,20 @@ namespace Microsoft.Data.SqlClient
                 opt = new SqlConnectionString(opt, instanceName, userInstance: false, setEnlistValue: null);
                 poolGroupProviderInfo = null; // null so we do not pass to constructor below...
             }
-            return new SqlInternalConnectionTds(identity, opt, key.Credential, poolGroupProviderInfo, "", null, redirectedUserInstance, userOpt, recoverySessionData, applyTransientFaultHandling, key.AccessToken, pool, key.AccessTokenCallback);
+            return new SqlInternalConnectionTds(
+                identity,
+                opt,
+                key.Credential,
+                poolGroupProviderInfo,
+                newPassword: string.Empty,
+                newSecurePassword: null,
+                redirectedUserInstance,
+                userOpt,
+                recoverySessionData,
+                applyTransientFaultHandling,
+                key.AccessToken,
+                pool,
+                key.AccessTokenCallback);
         }
 
         protected override DbConnectionOptions CreateConnectionOptions(string connectionString, DbConnectionOptions previous)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -138,13 +138,14 @@ namespace Microsoft.Data.SqlClient
                     instanceName,
                     userInstance: false,
                     setEnlistValue: null); // Do not modify the enlist value
+                poolGroupProviderInfo = null;
             }
 
             return new SqlInternalConnectionTds(
                 identity,
                 opt,
                 key.Credential,
-                providerInfo: null,
+                poolGroupProviderInfo,
                 newPassword: string.Empty,
                 newSecurePassword: null,
                 redirectedUserInstance,

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -31,18 +31,30 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, IDbConnectionPool pool, DbConnection owningConnection)
+        protected override DbConnectionInternal CreateConnection(
+            DbConnectionOptions options,
+            DbConnectionPoolKey poolKey,
+            DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
+            IDbConnectionPool pool,
+            DbConnection owningConnection)
         {
             return CreateConnection(options, poolKey, poolGroupProviderInfo, pool, owningConnection, userOptions: null);
         }
 
-        override protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, IDbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
+        protected override DbConnectionInternal CreateConnection(
+            DbConnectionOptions options,
+            DbConnectionPoolKey poolKey,
+            DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
+            IDbConnectionPool pool,
+            DbConnection owningConnection,
+            DbConnectionOptions userOptions)
         {
             SqlConnectionString opt = (SqlConnectionString)options;
             SqlConnectionPoolKey key = (SqlConnectionPoolKey)poolKey;
             SessionData recoverySessionData = null;
+            
             SqlConnection sqlOwningConnection = owningConnection as SqlConnection;
-            bool applyTransientFaultHandling = sqlOwningConnection != null ? sqlOwningConnection._applyTransientFaultHandling : false;
+            bool applyTransientFaultHandling = sqlOwningConnection?._applyTransientFaultHandling ?? false;
 
             SqlConnectionString userOpt = null;
             if (userOptions != null)
@@ -51,7 +63,7 @@ namespace Microsoft.Data.SqlClient
             }
             else if (sqlOwningConnection != null)
             {
-                userOpt = (SqlConnectionString)(sqlOwningConnection.UserConnectionOptions);
+                userOpt = (SqlConnectionString)sqlOwningConnection.UserConnectionOptions;
             }
 
             if (sqlOwningConnection != null)
@@ -164,7 +176,7 @@ namespace Microsoft.Data.SqlClient
             return result;
         }
 
-        override internal DbConnectionPoolProviderInfo CreateConnectionPoolProviderInfo(DbConnectionOptions connectionOptions)
+        internal override DbConnectionPoolProviderInfo CreateConnectionPoolProviderInfo(DbConnectionOptions connectionOptions)
         {
             DbConnectionPoolProviderInfo providerInfo = null;
 
@@ -234,11 +246,11 @@ namespace Microsoft.Data.SqlClient
                                           internalConnection.ServerVersion); //internalConnection.ServerVersionNormalized);
         }
 
-        override internal DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(DbConnectionOptions connectionOptions)
+        internal override DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(
+            DbConnectionOptions connectionOptions)
         {
             return new SqlConnectionPoolGroupProviderInfo((SqlConnectionString)connectionOptions);
         }
-
 
         internal static SqlConnectionString FindSqlConnectionOptions(SqlConnectionPoolKey key)
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlInternalConnectionTds.cs
@@ -457,7 +457,7 @@ namespace Microsoft.Data.SqlClient
                 DbConnectionPoolIdentity identity,
                 SqlConnectionString connectionOptions,
                 SqlCredential credential,
-                object providerInfo,
+                DbConnectionPoolGroupProviderInfo providerInfo,
                 string newPassword,
                 SecureString newSecurePassword,
                 bool redirectedUserInstance,
@@ -467,7 +467,8 @@ namespace Microsoft.Data.SqlClient
                 string accessToken = null,
                 IDbConnectionPool pool = null,
                 Func<SqlAuthenticationParameters, CancellationToken,
-                Task<SqlAuthenticationToken>> accessTokenCallback = null) : base(connectionOptions)
+                Task<SqlAuthenticationToken>> accessTokenCallback = null) 
+            : base(connectionOptions)
         {
 #if DEBUG
             if (reconnectSessionData != null)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionFactory.cs
@@ -91,10 +91,8 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        internal virtual DbConnectionPoolProviderInfo CreateConnectionPoolProviderInfo(DbConnectionOptions connectionOptions)
-        {
-            return null;
-        }
+        internal abstract DbConnectionPoolProviderInfo CreateConnectionPoolProviderInfo(
+            DbConnectionOptions connectionOptions);
 
         protected virtual DbMetaDataFactory CreateMetaDataFactory(DbConnectionInternal internalConnection, out bool cacheMetaDataFactory)
         {
@@ -139,10 +137,8 @@ namespace Microsoft.Data.ProviderBase
             return newConnection;
         }
 
-        internal virtual DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(DbConnectionOptions connectionOptions)
-        {
-            return null;
-        }
+        internal abstract DbConnectionPoolGroupProviderInfo CreateConnectionPoolGroupProviderInfo(
+            DbConnectionOptions connectionOptions);
 
         private Timer CreatePruningTimer() =>
             ADP.UnsafeCreateTimer(
@@ -646,12 +642,23 @@ namespace Microsoft.Data.ProviderBase
             SqlClientEventSource.Metrics.ExitActiveConnectionPoolGroup();
         }
 
-        virtual protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, IDbConnectionPool pool, DbConnection owningConnection, DbConnectionOptions userOptions)
+        protected virtual DbConnectionInternal CreateConnection(
+            DbConnectionOptions options,
+            DbConnectionPoolKey poolKey,
+            DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
+            IDbConnectionPool pool,
+            DbConnection owningConnection,
+            DbConnectionOptions userOptions)
         {
             return CreateConnection(options, poolKey, poolGroupProviderInfo, pool, owningConnection);
         }
 
-        abstract protected DbConnectionInternal CreateConnection(DbConnectionOptions options, DbConnectionPoolKey poolKey, object poolGroupProviderInfo, IDbConnectionPool pool, DbConnection owningConnection);
+        protected abstract DbConnectionInternal CreateConnection(
+            DbConnectionOptions options,
+            DbConnectionPoolKey poolKey,
+            DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
+            IDbConnectionPool pool,
+            DbConnection owningConnection);
 
         abstract protected DbConnectionOptions CreateConnectionOptions(string connectionString, DbConnectionOptions previous);
 


### PR DESCRIPTION
## Description
This PR does two main changes:
1) Reverts a small change in netfx SqlConnectionFactory class from #3393.
    I thought it was a safe change to make, but I neglected to notice that the poolgroupproviderinfo was being passed in from the caller of the method. I noticed this issue while working on merging SqlConnectionFactory, since I made this change on the netfx version but not on the netcore version.
2) Makes SqlConnectionFactory CreateConnection classes have strongly typed poolgroupproviderinfo arguments.
    Not sure why these were always being passed in as object, but they are now being passed in as DbConnectionPoolGroupProviderInfo, which is what they should have been from the beginning.

## Issues
No issue currently correspond to these changes.

## Testing
Well, it still builds. Kinda disappointed the initial issue didn't cause CI failures.
