### PR TITLE
Merge | TdsParser.GetSniErrorDetails

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Unix.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Unix.cs
@@ -22,21 +22,5 @@ namespace Microsoft.Data.SqlClient
         {
             // No - Op
         }
-
-        private SNIErrorDetails GetSniErrorDetails()
-        {
-            SNIErrorDetails details;
-            SniError sniError = SniProxy.Instance.GetLastError();
-            details.sniErrorNumber = sniError.sniError;
-            details.errorMessage = sniError.errorMessage;
-            details.nativeError = sniError.nativeError;
-            details.provider = (int)sniError.provider;
-            details.lineNumber = sniError.lineNumber;
-            details.function = sniError.function;
-            details.exception = sniError.exception;
-            
-            return details;
-        }
-
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Windows.cs
@@ -4,9 +4,6 @@
 
 using System;
 using System.Diagnostics;
-using Interop.Windows.Sni;
-using Microsoft.Data.SqlClient.ManagedSni;
-using SniError = Microsoft.Data.SqlClient.ManagedSni.SniError;
 
 namespace Microsoft.Data.SqlClient
 {
@@ -62,34 +59,5 @@ namespace Microsoft.Data.SqlClient
                 ThrowExceptionAndWarning(_physicalStateObj);
             }
         }
-
-        private SNIErrorDetails GetSniErrorDetails()
-        {
-            SNIErrorDetails details = new SNIErrorDetails();
-
-            if (TdsParserStateObjectFactory.UseManagedSNI)
-            {
-                SniError sniError = SniProxy.Instance.GetLastError();
-                details.sniErrorNumber = sniError.sniError;
-                details.errorMessage = sniError.errorMessage;
-                details.nativeError = sniError.nativeError;
-                details.provider = (int)sniError.provider;
-                details.lineNumber = sniError.lineNumber;
-                details.function = sniError.function;
-                details.exception = sniError.exception;
-            }
-            else
-            {
-                SniNativeWrapper.SniGetLastError(out Interop.Windows.Sni.SniError sniError);
-                details.sniErrorNumber = sniError.sniError;
-                details.errorMessage = sniError.errorMessage;
-                details.nativeError = sniError.nativeError;
-                details.provider = (int)sniError.provider;
-                details.lineNumber = sniError.lineNumber;
-                details.function = sniError.function;
-            }
-            return details;
-        }
-
     }    // tdsparser
 }//namespace

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1450,12 +1450,12 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.ProcessSNIError|ERR> SNIContext must not be None = {0}, _fMARS = {1}, TDS Parser State = {2}", stateObj.DebugOnlyCopyOfSniContext, _fMARS, _state);
 
 #endif
-                SNIErrorDetails details = GetSniErrorDetails();
+                TdsParserStateObject.SniErrorDetails details = stateObj.GetErrorDetails();
 
-                if (details.sniErrorNumber != 0)
+                if (details.SniErrorNumber != 0)
                 {
                     // handle special SNI error codes that are converted into exception which is not a SqlException.
-                    switch (details.sniErrorNumber)
+                    switch (details.SniErrorNumber)
                     {
                         case SniErrors.MultiSubnetFailoverWithMoreThan64IPs:
                             // Connecting with the MultiSubnetFailover connection option to a SQL Server instance configured with more than 64 IP addresses is not supported.
@@ -1476,8 +1476,8 @@ namespace Microsoft.Data.SqlClient
                 }
                 // PInvoke code automatically sets the length of the string for us
                 // So no need to look for \0
-                string errorMessage = details.errorMessage;
-                SqlClientEventSource.Log.TryAdvancedTraceEvent("< sc.TdsParser.ProcessSNIError |ERR|ADV > Error message Detail: {0}", details.errorMessage);
+                string errorMessage = details.ErrorMessage;
+                SqlClientEventSource.Log.TryAdvancedTraceEvent("< sc.TdsParser.ProcessSNIError |ERR|ADV > Error message Detail: {0}", details.ErrorMessage);
 
                 /*  Format SNI errors and add Context Information
                  *
@@ -1494,25 +1494,25 @@ namespace Microsoft.Data.SqlClient
 
                 if (TdsParserStateObjectFactory.UseManagedSNI)
                 {
-                    Debug.Assert(!string.IsNullOrEmpty(details.errorMessage) || details.sniErrorNumber != 0, "Empty error message received from SNI");
-                    SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}, SNI Error Number ={1}", details.errorMessage, details.sniErrorNumber);
+                    Debug.Assert(!string.IsNullOrEmpty(details.ErrorMessage) || details.SniErrorNumber != 0, "Empty error message received from SNI");
+                    SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}, SNI Error Number ={1}", details.ErrorMessage, details.SniErrorNumber);
                 }
                 else
                 {
-                    Debug.Assert(!string.IsNullOrEmpty(details.errorMessage), "Empty error message received from SNI");
-                    SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}", details.errorMessage);
+                    Debug.Assert(!string.IsNullOrEmpty(details.ErrorMessage), "Empty error message received from SNI");
+                    SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}", details.ErrorMessage);
                 }
 
                 string sqlContextInfo = StringsHelper.GetResourceString(stateObj.SniContext.ToString());
-                string providerRid = string.Format("SNI_PN{0}", details.provider);
+                string providerRid = string.Format("SNI_PN{0}", details.Provider);
                 string providerName = StringsHelper.GetResourceString(providerRid);
                 Debug.Assert(!string.IsNullOrEmpty(providerName), $"invalid providerResourceId '{providerRid}'");
-                uint win32ErrorCode = details.nativeError;
+                uint win32ErrorCode = details.NativeError;
 
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > SNI Native Error Code = {0}", win32ErrorCode);
-                if (details.sniErrorNumber == 0)
+                if (details.SniErrorNumber == 0)
                 {
-                    // Provider error. The message from provider is preceeded with non-localizable info from SNI
+                    // Provider error. The message from provider is preceded with non-localizable info from SNI
                     // strip provider info from SNI
                     //
                     int iColon = errorMessage.IndexOf(':');
@@ -1544,7 +1544,7 @@ namespace Microsoft.Data.SqlClient
                     if (TdsParserStateObjectFactory.UseManagedSNI)
                     {
                         // SNI error. Append additional error message info if available and hasn't been included.
-                        string sniLookupMessage = SQL.GetSNIErrorMessage(details.sniErrorNumber);
+                        string sniLookupMessage = SQL.GetSNIErrorMessage(details.SniErrorNumber);
                         errorMessage = (string.IsNullOrEmpty(errorMessage) || errorMessage.Contains(sniLookupMessage))
                                         ? sniLookupMessage
                                         : (sniLookupMessage + ": " + errorMessage);
@@ -1552,25 +1552,25 @@ namespace Microsoft.Data.SqlClient
                     else
                     {
                         // SNI error. Replace the entire message.
-                        errorMessage = SQL.GetSNIErrorMessage(details.sniErrorNumber);
+                        errorMessage = SQL.GetSNIErrorMessage(details.SniErrorNumber);
 
                         // If its a LocalDB error, then nativeError actually contains a LocalDB-specific error code, not a win32 error code
-                        if (details.sniErrorNumber == SniErrors.LocalDBErrorCode)
+                        if (details.SniErrorNumber == SniErrors.LocalDBErrorCode)
                         {
-                            errorMessage += LocalDbApi.GetLocalDbMessage((int)details.nativeError);
+                            errorMessage += LocalDbApi.GetLocalDbMessage((int)details.NativeError);
                             win32ErrorCode = 0;
                         }
                         SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Extracting the latest exception from native SNI. errorMessage: {0}", errorMessage);
                     }
                 }
                 errorMessage = string.Format("{0} (provider: {1}, error: {2} - {3})",
-                    sqlContextInfo, providerName, (int)details.sniErrorNumber, errorMessage);
+                    sqlContextInfo, providerName, (int)details.SniErrorNumber, errorMessage);
 
                 SqlClientEventSource.Log.TryAdvancedTraceErrorEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > SNI Error Message. Native Error = {0}, Line Number ={1}, Function ={2}, Exception ={3}, Server = {4}",
-                    (int)details.nativeError, (int)details.lineNumber, details.function, details.exception, _server);
+                    (int)details.NativeError, (int)details.LineNumber, details.Function, details.Exception, _server);
 
-                return new SqlError(infoNumber: (int)details.nativeError, errorState: 0x00, TdsEnums.FATAL_ERROR_CLASS, _server,
-                    errorMessage, details.function, (int)details.lineNumber, win32ErrorCode: details.nativeError, details.exception);
+                return new SqlError(infoNumber: (int)details.NativeError, errorState: 0x00, TdsEnums.FATAL_ERROR_CLASS, _server,
+                    errorMessage, details.Function, (int)details.LineNumber, win32ErrorCode: details.NativeError, details.Exception);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -392,6 +392,13 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             return 0;
         }
 
+        internal override SniErrorDetails GetErrorDetails()
+        {
+            SniError sniError = SniProxy.Instance.GetLastError();
+
+            return new SniErrorDetails(sniError.errorMessage, sniError.nativeError, sniError.sniError, (int)sniError.provider, sniError.lineNumber, sniError.function, sniError.exception);
+        }
+
         private SniHandle GetSessionSNIHandleHandleOrThrow()
         {
             SniHandle? sessionHandle = _sessionHandle;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectManaged.cs
@@ -396,7 +396,9 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         {
             SniError sniError = SniProxy.Instance.GetLastError();
 
-            return new SniErrorDetails(sniError.errorMessage, sniError.nativeError, sniError.sniError, (int)sniError.provider, sniError.lineNumber, sniError.function, sniError.exception);
+            return new SniErrorDetails(sniError.errorMessage, sniError.nativeError, sniError.sniError,
+                (int)sniError.provider, sniError.lineNumber, sniError.function,
+                sniError.exception);
         }
 
         private SniHandle GetSessionSNIHandleHandleOrThrow()

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -445,7 +445,8 @@ namespace Microsoft.Data.SqlClient
         {
             SniNativeWrapper.SniGetLastError(out SniError sniError);
 
-            return new SniErrorDetails(sniError.errorMessage, sniError.nativeError, sniError.sniError, (int)sniError.provider, sniError.lineNumber, sniError.function);
+            return new SniErrorDetails(sniError.errorMessage, sniError.nativeError, sniError.sniError,
+                (int)sniError.provider, sniError.lineNumber, sniError.function);
         }
 
         internal override void DisposePacketCache()

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -441,6 +441,13 @@ namespace Microsoft.Data.SqlClient
             return returnValue;
         }
 
+        internal override SniErrorDetails GetErrorDetails()
+        {
+            SniNativeWrapper.SniGetLastError(out SniError sniError);
+
+            return new SniErrorDetails(sniError.errorMessage, sniError.nativeError, sniError.sniError, (int)sniError.provider, sniError.lineNumber, sniError.function);
+        }
+
         internal override void DisposePacketCache()
         {
             lock (_writePacketLockObject)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -175,6 +175,13 @@ namespace Microsoft.Data.SqlClient
         internal override uint SetConnectionBufferSize(ref uint unsignedPacketSize)
             => SniNativeWrapper.SniSetInfo(Handle, QueryType.SNI_QUERY_CONN_BUFSIZE, ref unsignedPacketSize);
 
+        internal override SniErrorDetails GetErrorDetails()
+        {
+            SniNativeWrapper.SniGetLastError(out SniError sniError);
+
+            return new SniErrorDetails(sniError.errorMessage, sniError.nativeError, sniError.sniError, (int)sniError.provider, sniError.lineNumber, sniError.function);
+        }
+
         internal override void DisposePacketCache()
         {
             lock (_writePacketLockObject)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -52,6 +52,38 @@ namespace Microsoft.Data.SqlClient
             AttentionReceived = 1 << 5    // NOTE: Received is not volatile as it is only ever accessed\modified by TryRun its callees (i.e. single threaded access)
         }
 
+        internal readonly struct SniErrorDetails
+        {
+            public readonly string ErrorMessage;
+            public readonly uint NativeError;
+            public readonly uint SniErrorNumber;
+            public readonly int Provider;
+            public readonly uint LineNumber;
+            public readonly string Function;
+            public readonly Exception Exception;
+
+            internal SniErrorDetails(string errorMessage, uint nativeError, uint sniErrorNumber, int provider, uint lineNumber, string function, Exception exception)
+            {
+                ErrorMessage = errorMessage;
+                NativeError = nativeError;
+                SniErrorNumber = sniErrorNumber;
+                Provider = provider;
+                LineNumber = lineNumber;
+                Function = function;
+                Exception = exception;
+            }
+
+            internal SniErrorDetails(string errorMessage, uint nativeError, uint sniErrorNumber, int provider, uint lineNumber, string function)
+            {
+                ErrorMessage = errorMessage;
+                NativeError = nativeError;
+                SniErrorNumber = sniErrorNumber;
+                Provider = provider;
+                LineNumber = lineNumber;
+                Function = function;
+            }
+        }
+
         private sealed class TimeoutState
         {
             public const int Stopped = 0;
@@ -520,6 +552,8 @@ namespace Microsoft.Data.SqlClient
         internal abstract uint SetConnectionBufferSize(ref uint unsignedPacketSize);
 
         internal abstract void DisposePacketCache();
+
+        internal abstract SniErrorDetails GetErrorDetails();
 
         internal int GetTimeoutRemaining()
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Data.SqlClient
             public readonly string Function;
             public readonly Exception Exception;
 
-            internal SniErrorDetails(string errorMessage, uint nativeError, uint sniErrorNumber, int provider, uint lineNumber, string function, Exception exception)
+            internal SniErrorDetails(string errorMessage, uint nativeError, uint sniErrorNumber, int provider, uint lineNumber, string function, Exception exception = null)
             {
                 ErrorMessage = errorMessage;
                 NativeError = nativeError;
@@ -71,16 +71,6 @@ namespace Microsoft.Data.SqlClient
                 LineNumber = lineNumber;
                 Function = function;
                 Exception = exception;
-            }
-
-            internal SniErrorDetails(string errorMessage, uint nativeError, uint sniErrorNumber, int provider, uint lineNumber, string function)
-            {
-                ErrorMessage = errorMessage;
-                NativeError = nativeError;
-                SniErrorNumber = sniErrorNumber;
-                Provider = provider;
-                LineNumber = lineNumber;
-                Function = function;
             }
         }
 


### PR DESCRIPTION
## Description

This is a slightly smaller merge, but it's the first of its type.

TdsParser.Windows.cs and TdsParser.Unix.cs have a number of methods which vary in behaviour based upon `TdsParserStateObjectFactory.UseManagedSNI`. This PR handles those methods by moving the method to the `TdsParserStateObject` base class, implementing them in the Native and Managed child classes, then updating the references to use the state object.

Once this process is complete, we'll be able to remove the OS-specific TdsParser files.

## Issues

Contributes to #1261.

## Testing

Unit tests pass locally, but I'd like a CI run please.