### PR TITLE
Improved ADO pipeline and branch configs

### DIFF
--- a/.azuredevops/policies/approvercountpolicy.yml
+++ b/.azuredevops/policies/approvercountpolicy.yml
@@ -1,0 +1,29 @@
+# This file configures the Approver Count Policy Validator status check.  Some
+# settings here are similar to branch policies specified via the Azure DevOps UI
+# that govern how PRs are approved in general.  The settings here dictate how
+# the validator behaves, and it can also prevent PRs from completing.
+#
+# Suggested by Merlinbot (https://sqlclientdrivers.visualstudio.com/ADO.Net/_git/dotnet-sqlclient/pullrequest/4982)
+
+name: approver_count
+description: Approver count policy for dotnet-sqlclient
+resource: repository
+where: 
+configuration:
+  approverCountPolicySettings:
+    isBlocking: true
+    requireMinimumApproverCount: 2
+    creatorVoteCounts: false
+    allowDownvotes: false
+    sourcePushOptions:
+      resetOnSourcePush: true
+      requireVoteOnLastIteration: true
+      requireVoteOnEachIteration: false
+      resetRejectionsOnSourcePush: false
+    blockLastPusherVote: true
+    branchNames:
+    - refs/heads/internal/main
+    - refs/heads/internal/release/6.0
+    - refs/heads/internal/release/5.2
+    - refs/heads/internal/release/5.1
+    displayName: dotnet-sqlclient Approver Count Policy

--- a/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
@@ -82,6 +82,8 @@ extends:
   template: v2/OneBranch.${{parameters.oneBranchType }}.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
   parameters:
     featureFlags:
+      # Suggested by MerlinBot (https://sqlclientdrivers.visualstudio.com/ADO.Net/_git/dotnet-sqlclient/pullrequest/4882)
+      EnableCDPxPAT: false
       WindowsHostVersion: 1ESWindows2022
     globalSdl: # https://aka.ms/obpipelines/sdl
       tsa:


### PR DESCRIPTION
## Description

Our ADO repo had some PRs auto-generated by internal tooling.  These must be applied to GitHub first, and then synced back to ADO.

- Enable the `CDPxPAT` feature on the release pipeline.
- Configure the Approver Count Policy Validator similarly to our overall branch policies.

## Testing

The CI and Release pipelines will validate these changes.