### PR TITLE
Skip unit tests friend assembly designation on official builds

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -33,7 +33,7 @@
   <PropertyGroup>
     <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFramework)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="$(CDP_BUILD_TYPE)!=Official">
     <InternalsVisibleTo Include="UnitTests" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -31,7 +31,7 @@
   <PropertyGroup>
     <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)\$(TargetFramework)','$(GeneratedSourceFileName)'))</TargetFrameworkMonikerAssemblyAttributesPath>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="$(CDP_BUILD_TYPE)!=Official">
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>UnitTests</_Parameter1>
     </AssemblyAttribute>


### PR DESCRIPTION
## Description

In official builds, when assemblies are signed and strong names are generated, friend assembly designations must specify a public key. Unit tests are only run when using project reference, which doesn't apply to official signing pipeline runs which use package reference for tests, so we can skip the friend assembly designation in official builds.

To repro:
- generate a strong name key pair using `sn.exe -k netfxKeypair.snk`
- run the build using: ` $env:CDP_BUILD_TYPE = 'Official'; msbuild -p:AssemblyFileVersion=6.10.25177.2 -t:BuildAllConfigurations -p:GenerateNuget=false -p:SigningKeyPath=C:\Users\mdaigle\SqlClient\netfxKeypair.snk -p:configuration="Release"`

Before:
![image](https://github.com/user-attachments/assets/1cfa9723-dfb1-4a10-8ebf-2f464286b928)

After:
![image](https://github.com/user-attachments/assets/1cfba0c4-6a0e-4984-bf7d-7af8842c9ca5)

## Testing

Existing unit tests should pass when run in project reference mode.

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
