### PR TITLE
Official pipeline tweaks - round 3

### DIFF
--- a/eng/pipelines/common/templates/jobs/validate-signed-package-job.yml
+++ b/eng/pipelines/common/templates/jobs/validate-signed-package-job.yml
@@ -283,8 +283,11 @@ jobs:
     displayName: 'Verify all dlls status are Valid'
 
   - powershell: |
-      # This will check for ProductVersion and FileVersion
-      #  For NetFx we have a different FileVersion, but product versions are all the same some may have and extra numbering at the end. we only check for # first parts
+      # This will check for ProductVersion and FileVersion.
+      #
+      # For NetFx we have a different FileVersion, but product versions are all
+      # the same.  Some may have extra numbering at the end.  We only check for
+      # the first parts.
 
       foreach ( $pVersion in Get-ChildItem *.dll -Path $(extractedNugetPath)  -Recurse | ForEach-Object versioninfo ) 
       {
@@ -329,7 +332,7 @@ jobs:
     displayName: 'Verify "File Version" matches provided pipeline variable "ASSEMBLY_FILE_VERSION" for DLLs'
 
   - powershell: |
-      #Change TestMicrosoftDataSqlClientVersion
+      # Change TestMicrosoftDataSqlClientVersion
 
       [Xml] $versionprops = Get-Content -Path "tools/props/Versions.props" 
       $versionpropspath = "tools\props\Versions.props"
@@ -340,7 +343,7 @@ jobs:
     displayName: 'Modify TestMicrosoftDataSqlClientVersion'
 
   - powershell: |
-      #Change TestMicrosoftDataSqlClientVersion
+      # Check assembly versions.
 
       [Xml] $versionprops = Get-Content -Path "tools/props/Versions.props" 
       $AssemblyFileVersion =  $versionprops.Project.PropertyGroup[0].AssemblyFileVersion

--- a/eng/pipelines/libraries/mds-validation-variables.yml
+++ b/eng/pipelines/libraries/mds-validation-variables.yml
@@ -17,7 +17,7 @@ variables:
   - name: expectedFolderNames
     value: lib,ref,runtimes
   - name: expectedDotnetVersions
-    value: net462,net8.0,net9.0
+    value: netstandard2.0,net462,net8.0,net9.0
   - name: Database
     value: Northwind
   - name: platform

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -4,12 +4,23 @@
   <PropertyGroup>
     <MdsVersionDefault>6.1.0</MdsVersionDefault>
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
+
+    <!--
+      GOTCHA: These two properties must appear in the first <PropertyGroup> in
+      this file due to hardcoded XML processing in:
+
+      eng/pipelines/common/templates/jobs/validate-signed-package-job.yml
+    -->
     <AssemblyFileVersion Condition="'$(AssemblyFileVersion)' == ''">$(MdsVersionDefault).$(BuildNumber)</AssemblyFileVersion>
-    <FileVersion>$(AssemblyFileVersion)</FileVersion>
-    <!-- This Assembly version corresponds to version of Microsoft.Data.SqlClient Assembly. -->
-    <!-- Should only be changed in future when a non-backwards compatible driver is released. -->
-    <!-- Future Assembly Version values shall be Major.Minor.0.0; e.g. 4.0.0.0 -->
+    <!--
+      This sets the version of the Microsoft.Data.SqlClient assembly.  It
+      shoudl only be updated when the major version of the MDS package changes
+      and introduces breaking changes.  Only ever update the major version
+      number.  All other version parts must be set to 0.
+    -->
     <AssemblyVersion>6.0.0.0</AssemblyVersion>
+
+    <FileVersion>$(AssemblyFileVersion)</FileVersion>
     <NugetPackageVersion Condition="'$(NugetPackageVersion)' == ''">$(MdsVersionDefault)-dev</NugetPackageVersion>
     <Version>$(NugetPackageVersion)</Version>
   </PropertyGroup>
@@ -24,6 +35,15 @@
   </PropertyGroup>
   <PropertyGroup>
     <TestAKVProviderVersion>$(NugetPackageVersion)</TestAKVProviderVersion>
+
+    <!--
+      GOTCHA: This property must appear in the last <PropertyGroup> in this file
+      due to hardcoded XML processing in:
+
+      eng/pipelines/common/templates/jobs/validate-signed-package-job.yml
+
+      See the 'Modify TestMicrosoftDataSqlClientVersion' step.
+    -->
     <TestMicrosoftDataSqlClientVersion>$(NugetPackageVersion)</TestMicrosoftDataSqlClientVersion>
   </PropertyGroup>
 </Project>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -14,7 +14,7 @@
     <AssemblyFileVersion Condition="'$(AssemblyFileVersion)' == ''">$(MdsVersionDefault).$(BuildNumber)</AssemblyFileVersion>
     <!--
       This sets the version of the Microsoft.Data.SqlClient assembly.  It
-      shoudl only be updated when the major version of the MDS package changes
+      should only be updated when the major version of the MDS package changes
       and introduces breaking changes.  Only ever update the major version
       number.  All other version parts must be set to 0.
     -->


### PR DESCRIPTION
## Description

Another round of tweaks to get the Official pipeline working:
- Added netstandard2.0 to the list of expected runtimes when validating an Official MDS package.
- Added comments to Versions.props warning of fragile validation logic.
- Improved comments in the validation pipeline job.