### PR TITLE
Tests | Account for MAX_DISPATCH_LATENCY in XEvents tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -1150,7 +1150,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         {eventSpecification}
                         {targetSpecification}
                         WITH (
-                            MAX_MEMORY=4096 KB,
+                            MAX_MEMORY=16 MB,
                             EVENT_RETENTION_MODE=ALLOW_SINGLE_EVENT_LOSS,
                             MAX_DISPATCH_LATENCY={MaxXEventsLatencyS} SECONDS,
                             MAX_EVENT_SIZE=0 KB,

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -1092,6 +1092,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public readonly ref struct XEventScope // : IDisposable
         {
+            private const int MaxXEventsLatencyS = 5;
+
             private readonly SqlConnection _connection;
             private readonly bool _useDatabaseSession;
 
@@ -1126,6 +1128,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                 using (SqlCommand command = new SqlCommand(xEventQuery, _connection))
                 {
+                    Thread.Sleep(MaxXEventsLatencyS * 1000);
+
                     if (_connection.State == ConnectionState.Closed)
                     {
                         _connection.Open();
@@ -1148,7 +1152,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         WITH (
                             MAX_MEMORY=4096 KB,
                             EVENT_RETENTION_MODE=ALLOW_SINGLE_EVENT_LOSS,
-                            MAX_DISPATCH_LATENCY=30 SECONDS,
+                            MAX_DISPATCH_LATENCY={MaxXEventsLatencyS} SECONDS,
                             MAX_EVENT_SIZE=0 KB,
                             MEMORY_PARTITION_MODE=NONE,
                             TRACK_CAUSALITY=ON,


### PR DESCRIPTION
## Description

XEvents are asynchronous, and are written to the target within MAX_DISPATCH_LATENCY seconds. We therefore need to wait that long before querying the target.

## Issues

Fixes #3453.

## Testing

I've run the corresponding test locally ten times while the SQL Server instance is under load, and this seems to work properly.
Could we run the pipeline a few times to prove the reliability please?