### PR TITLE
Fix | Make netfx version of SqlCommand.EndExecuteNonQueryAsync private

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1492,8 +1492,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/EndExecuteNonQueryAsync[@name="IAsyncResult"]/*'/>
-        public int EndExecuteNonQueryAsync(IAsyncResult asyncResult)
+        private int EndExecuteNonQueryAsync(IAsyncResult asyncResult)
         {
             SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.EndExecuteNonQueryAsync | Info | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
             Debug.Assert(!_internalEndExecuteInitiated || _stateObj == null);


### PR DESCRIPTION
## Description
While working on merging SqlCommand, I found this method `EndExecuteNonQueryAsync` that on the netfx side is private, but on the netcore side is public. Normally I'd just assume that netcore has a new public API, but this one seemed fishy since there are `Begin` and `End` methods for the old style async calls, and they normally do not end with `Async`. So digging into it more, I found that there is no public documentation for the method https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlcommand?view=sqlclient-dotnet-core-6.0 . Furthermore, the docs that are linked in the class do not exist (which is surprising it doesn't throw an error...), and the method is not exposed in the ref project. After consulting with @David-Engel the consensus seems to be to make the method private in netcore.

## Issues
Related to #1261 

## Testing
Made one method private, no changes to functionality at all.