### PR TITLE
Cleanup | Remove unused UDT serialization code

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2545,11 +2545,10 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal byte[] GetBytes(object o, out Format format, out int maxSize)
+        internal byte[] GetBytes(object o, out int maxSize)
         {
             SqlUdtInfo attr = GetInfoFromType(o.GetType());
             maxSize = attr.MaxByteSize;
-            format = attr.SerializationFormat;
 
             if (maxSize < -1 || maxSize >= ushort.MaxValue)
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -9903,7 +9903,6 @@ namespace Microsoft.Data.SqlClient
                 {
                     int maxSupportedSize = Is2008OrNewer ? int.MaxValue : short.MaxValue;
                     byte[] udtVal = null;
-                    Format format = Format.Native;
 
                     if (string.IsNullOrEmpty(param.UdtTypeName))
                     {
@@ -9937,7 +9936,7 @@ namespace Microsoft.Data.SqlClient
                         }
                         else
                         {
-                            udtVal = _connHandler.Connection.GetBytes(value, out format, out maxsize);
+                            udtVal = _connHandler.Connection.GetBytes(value, out maxsize);
                         }
 
                         Debug.Assert(udtVal != null, "GetBytes returned null instance. Make sure that it always returns non-null value");

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2458,11 +2458,10 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal byte[] GetBytes(object o, out Format format, out int maxSize)
+        internal byte[] GetBytes(object o, out int maxSize)
         {
             SqlUdtInfo attr = GetInfoFromType(o.GetType());
             maxSize = attr.MaxByteSize;
-            format = attr.SerializationFormat;
 
             if (maxSize < -1 || maxSize >= ushort.MaxValue)
             {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -10090,7 +10090,6 @@ namespace Microsoft.Data.SqlClient
                 {
                     int maxSupportedSize = Is2008OrNewer ? int.MaxValue : short.MaxValue;
                     byte[] udtVal = null;
-                    Format format = Format.Native;
 
                     if (string.IsNullOrEmpty(param.UdtTypeName))
                     {
@@ -10124,7 +10123,7 @@ namespace Microsoft.Data.SqlClient
                         }
                         else
                         {
-                            udtVal = _connHandler.Connection.GetBytes(value, out format, out maxsize);
+                            udtVal = _connHandler.Connection.GetBytes(value, out maxsize);
                         }
 
                         Debug.Assert(udtVal != null, "GetBytes returned null instance. Make sure that it always returns non-null value");

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlNormalizer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlNormalizer.cs
@@ -58,8 +58,6 @@ namespace Microsoft.Data.SqlClient.Server
 #endif
             Type t, bool isTopLevelUdt)
         {
-            _skipNormalize = false;
-
             FieldInfo[] fields = GetFields(t);
 
             _fieldsToNormalize = new FieldInfoEx[fields.Length];
@@ -142,8 +140,6 @@ namespace Microsoft.Data.SqlClient.Server
 
     internal abstract class Normalizer
     {
-        protected bool _skipNormalize;
-
         internal static Normalizer GetNormalizer(
 #if NET
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
@@ -184,7 +180,6 @@ namespace Microsoft.Data.SqlClient.Server
             {
                 throw new Exception(StringsHelper.GetString(Strings.SQL_CannotCreateNormalizer, t.FullName));
             }
-            n._skipNormalize = false;
             return n;
         }
 
@@ -238,20 +233,15 @@ namespace Microsoft.Data.SqlClient.Server
             {
                 b = (byte)sb;
             }
-            if (!_skipNormalize)
-            {
-                b ^= 0x80; //flip the sign bit
-            }
+            b ^= 0x80; //flip the sign bit
             s.WriteByte(b);
         }
 
         internal override void DeNormalize(FieldInfo fi, object recvr, Stream s)
         {
             byte b = (byte)s.ReadByte();
-            if (!_skipNormalize)
-            {
-                b ^= 0x80; //flip the sign bit
-            }
+
+            b ^= 0x80; //flip the sign bit
             sbyte sb;
             unchecked
             {
@@ -285,11 +275,8 @@ namespace Microsoft.Data.SqlClient.Server
         internal override void Normalize(FieldInfo fi, object obj, Stream s)
         {
             byte[] b = BitConverter.GetBytes((short)GetValue(fi, obj));
-            if (!_skipNormalize)
-            {
-                Array.Reverse(b);
-                b[0] ^= 0x80;
-            }
+            Array.Reverse(b);
+            b[0] ^= 0x80;
             s.Write(b, 0, b.Length);
         }
 
@@ -297,11 +284,8 @@ namespace Microsoft.Data.SqlClient.Server
         {
             byte[] b = new byte[2];
             s.ReadExactly(b, 0, b.Length);
-            if (!_skipNormalize)
-            {
-                b[0] ^= 0x80;
-                Array.Reverse(b);
-            }
+            b[0] ^= 0x80;
+            Array.Reverse(b);
             SetValue(fi, recvr, BitConverter.ToInt16(b, 0));
         }
 
@@ -313,10 +297,7 @@ namespace Microsoft.Data.SqlClient.Server
         internal override void Normalize(FieldInfo fi, object obj, Stream s)
         {
             byte[] b = BitConverter.GetBytes((ushort)GetValue(fi, obj));
-            if (!_skipNormalize)
-            {
-                Array.Reverse(b);
-            }
+            Array.Reverse(b);
             s.Write(b, 0, b.Length);
         }
 
@@ -324,10 +305,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             byte[] b = new byte[2];
             s.ReadExactly(b, 0, b.Length);
-            if (!_skipNormalize)
-            {
-                Array.Reverse(b);
-            }
+            Array.Reverse(b);
             SetValue(fi, recvr, BitConverter.ToUInt16(b, 0));
         }
 
@@ -339,11 +317,8 @@ namespace Microsoft.Data.SqlClient.Server
         internal override void Normalize(FieldInfo fi, object obj, Stream s)
         {
             byte[] b = BitConverter.GetBytes((int)GetValue(fi, obj));
-            if (!_skipNormalize)
-            {
-                Array.Reverse(b);
-                b[0] ^= 0x80;
-            }
+            Array.Reverse(b);
+            b[0] ^= 0x80;
             s.Write(b, 0, b.Length);
         }
 
@@ -351,11 +326,8 @@ namespace Microsoft.Data.SqlClient.Server
         {
             byte[] b = new byte[4];
             s.ReadExactly(b, 0, b.Length);
-            if (!_skipNormalize)
-            {
-                b[0] ^= 0x80;
-                Array.Reverse(b);
-            }
+            b[0] ^= 0x80;
+            Array.Reverse(b);
             SetValue(fi, recvr, BitConverter.ToInt32(b, 0));
         }
 
@@ -367,10 +339,7 @@ namespace Microsoft.Data.SqlClient.Server
         internal override void Normalize(FieldInfo fi, object obj, Stream s)
         {
             byte[] b = BitConverter.GetBytes((uint)GetValue(fi, obj));
-            if (!_skipNormalize)
-            {
-                Array.Reverse(b);
-            }
+            Array.Reverse(b);
             s.Write(b, 0, b.Length);
         }
 
@@ -378,10 +347,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             byte[] b = new byte[4];
             s.ReadExactly(b, 0, b.Length);
-            if (!_skipNormalize)
-            {
-                Array.Reverse(b);
-            }
+            Array.Reverse(b);
             SetValue(fi, recvr, BitConverter.ToUInt32(b, 0));
         }
 
@@ -393,11 +359,8 @@ namespace Microsoft.Data.SqlClient.Server
         internal override void Normalize(FieldInfo fi, object obj, Stream s)
         {
             byte[] b = BitConverter.GetBytes((long)GetValue(fi, obj));
-            if (!_skipNormalize)
-            {
-                Array.Reverse(b);
-                b[0] ^= 0x80;
-            }
+            Array.Reverse(b);
+            b[0] ^= 0x80;
             s.Write(b, 0, b.Length);
         }
 
@@ -405,11 +368,8 @@ namespace Microsoft.Data.SqlClient.Server
         {
             byte[] b = new byte[8];
             s.ReadExactly(b, 0, b.Length);
-            if (!_skipNormalize)
-            {
-                b[0] ^= 0x80;
-                Array.Reverse(b);
-            }
+            b[0] ^= 0x80;
+            Array.Reverse(b);
             SetValue(fi, recvr, BitConverter.ToInt64(b, 0));
         }
 
@@ -421,10 +381,7 @@ namespace Microsoft.Data.SqlClient.Server
         internal override void Normalize(FieldInfo fi, object obj, Stream s)
         {
             byte[] b = BitConverter.GetBytes((ulong)GetValue(fi, obj));
-            if (!_skipNormalize)
-            {
-                Array.Reverse(b);
-            }
+            Array.Reverse(b);
             s.Write(b, 0, b.Length);
         }
 
@@ -432,10 +389,7 @@ namespace Microsoft.Data.SqlClient.Server
         {
             byte[] b = new byte[8];
             s.ReadExactly(b, 0, b.Length);
-            if (!_skipNormalize)
-            {
-                Array.Reverse(b);
-            }
+            Array.Reverse(b);
             SetValue(fi, recvr, BitConverter.ToUInt64(b, 0));
         }
 
@@ -448,26 +402,23 @@ namespace Microsoft.Data.SqlClient.Server
         {
             float f = (float)GetValue(fi, obj);
             byte[] b = BitConverter.GetBytes(f);
-            if (!_skipNormalize)
+            Array.Reverse(b);
+            if ((b[0] & 0x80) == 0)
             {
-                Array.Reverse(b);
-                if ((b[0] & 0x80) == 0)
-                {
-                    // This is a positive number.
-                    // Flip the highest bit
-                    b[0] ^= 0x80;
-                }
-                else
-                {
-                    // This is a negative number.
+                // This is a positive number.
+                // Flip the highest bit
+                b[0] ^= 0x80;
+            }
+            else
+            {
+                // This is a negative number.
 
-                    // If all zeroes, means it was a negative zero.
-                    // Treat it same as positive zero, so that
-                    // the normalized key will compare equal.
-                    if (f < 0)
-                    {
-                        FlipAllBits(b);
-                    }
+                // If all zeroes, means it was a negative zero.
+                // Treat it same as positive zero, so that
+                // the normalized key will compare equal.
+                if (f < 0)
+                {
+                    FlipAllBits(b);
                 }
             }
             s.Write(b, 0, b.Length);
@@ -477,21 +428,18 @@ namespace Microsoft.Data.SqlClient.Server
         {
             byte[] b = new byte[4];
             s.ReadExactly(b, 0, b.Length);
-            if (!_skipNormalize)
+            if ((b[0] & 0x80) > 0)
             {
-                if ((b[0] & 0x80) > 0)
-                {
-                    // This is a positive number.
-                    // Flip the highest bit
-                    b[0] ^= 0x80;
-                }
-                else
-                {
-                    // This is a negative number.
-                    FlipAllBits(b);
-                }
-                Array.Reverse(b);
+                // This is a positive number.
+                // Flip the highest bit
+                b[0] ^= 0x80;
             }
+            else
+            {
+                // This is a negative number.
+                FlipAllBits(b);
+            }
+            Array.Reverse(b);
             SetValue(fi, recvr, BitConverter.ToSingle(b, 0));
         }
 
@@ -504,25 +452,22 @@ namespace Microsoft.Data.SqlClient.Server
         {
             double d = (double)GetValue(fi, obj);
             byte[] b = BitConverter.GetBytes(d);
-            if (!_skipNormalize)
+            Array.Reverse(b);
+            if ((b[0] & 0x80) == 0)
             {
-                Array.Reverse(b);
-                if ((b[0] & 0x80) == 0)
+                // This is a positive number.
+                // Flip the highest bit
+                b[0] ^= 0x80;
+            }
+            else
+            {
+                // This is a negative number.
+                if (d < 0)
                 {
-                    // This is a positive number.
-                    // Flip the highest bit
-                    b[0] ^= 0x80;
-                }
-                else
-                {
-                    // This is a negative number.
-                    if (d < 0)
-                    {
-                        // If all zeroes, means it was a negative zero.
-                        // Treat it same as positive zero, so that
-                        // the normalized key will compare equal.
-                        FlipAllBits(b);
-                    }
+                    // If all zeroes, means it was a negative zero.
+                    // Treat it same as positive zero, so that
+                    // the normalized key will compare equal.
+                    FlipAllBits(b);
                 }
             }
             s.Write(b, 0, b.Length);
@@ -532,21 +477,18 @@ namespace Microsoft.Data.SqlClient.Server
         {
             byte[] b = new byte[8];
             s.ReadExactly(b, 0, b.Length);
-            if (!_skipNormalize)
+            if ((b[0] & 0x80) > 0)
             {
-                if ((b[0] & 0x80) > 0)
-                {
-                    // This is a positive number.
-                    // Flip the highest bit
-                    b[0] ^= 0x80;
-                }
-                else
-                {
-                    // This is a negative number.
-                    FlipAllBits(b);
-                }
-                Array.Reverse(b);
+                // This is a positive number.
+                // Flip the highest bit
+                b[0] ^= 0x80;
             }
+            else
+            {
+                // This is a negative number.
+                FlipAllBits(b);
+            }
+            Array.Reverse(b);
             SetValue(fi, recvr, BitConverter.ToDouble(b, 0));
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlNormalizer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlNormalizer.cs
@@ -39,8 +39,6 @@ namespace Microsoft.Data.SqlClient.Server
     {
         private readonly FieldInfoEx[] _fieldsToNormalize;
         private int _size;
-        private readonly byte[] _padBuffer;
-        private readonly object _nullInstance;
 
 #if NETFRAMEWORK
         [System.Security.Permissions.ReflectionPermission(System.Security.Permissions.SecurityAction.Assert, MemberAccess = true)]
@@ -77,8 +75,6 @@ namespace Microsoft.Data.SqlClient.Server
             //sort by offset
             Array.Sort(_fieldsToNormalize);
         }
-
-        internal bool IsNullable => _nullInstance != null;
 
         // Normalize the top-level udt
         internal void NormalizeTopObject(object udt, Stream s) => Normalize(null, udt, s);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlNormalizer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlNormalizer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Data.SqlClient.Server
 #if NET
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
 #endif
-            Type t, bool isTopLevelUdt)
+            Type t)
         {
             FieldInfo[] fields = GetFields(t);
 
@@ -174,7 +174,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
             else if (t.IsValueType)
             {
-                n = new BinaryOrderedUdtNormalizer(t, false);
+                n = new BinaryOrderedUdtNormalizer(t);
             }
             if (n == null)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlSer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlSer.cs
@@ -29,9 +29,6 @@ namespace Microsoft.Data.SqlClient.Server
         // Get the m_size of the serialized stream for this type, in bytes.
         internal static int SizeInBytes(object instance)
         {
-            Type t = instance.GetType();
-
-            _ = GetFormat(t);
             DummyStream stream = new DummyStream();
             Serializer ser = GetSerializer(instance.GetType());
             ser.Serialize(stream, instance);
@@ -49,7 +46,6 @@ namespace Microsoft.Data.SqlClient.Server
 #endif
             Type resultType) => GetSerializer(resultType).Deserialize(s);
 
-        private static Format GetFormat(Type t) => GetUdtAttribute(t).Format;
 
         // Cache the relationship between a type and its serializer.
         // This is expensive to compute since it involves traversing the
@@ -169,7 +165,6 @@ namespace Microsoft.Data.SqlClient.Server
 #endif
             Type t) : base(t)
         {
-            _ = SerializationHelperSql9.GetUdtAttribute(t);
             _normalizer = new BinaryOrderedUdtNormalizer(t);
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlSer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlSer.cs
@@ -50,9 +50,6 @@ namespace Microsoft.Data.SqlClient.Server
         // Cache the relationship between a type and its serializer.
         // This is expensive to compute since it involves traversing the
         // custom attributes of the type using reflection.
-        //
-        // Use a per-thread cache, so that there are no synchronization
-        // issues when accessing cache entries from multiple threads.
         private static ConcurrentDictionary<Type, Serializer> s_types2Serializers;
 
         private static Serializer GetSerializer(

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlSer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlSer.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Data.SqlClient.Server
             Type t) : base(t)
         {
             _ = SerializationHelperSql9.GetUdtAttribute(t);
-            _normalizer = new BinaryOrderedUdtNormalizer(t, true);
+            _normalizer = new BinaryOrderedUdtNormalizer(t);
         }
 
         public override void Serialize(Stream s, object o) => _normalizer.NormalizeTopObject(o, s);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1641,7 +1641,7 @@ namespace Microsoft.Data.SqlClient
                         // in byte[] form.
                         if (!(value is byte[]))
                         {
-                            value = _connection.GetBytes(value, out _, out _);
+                            value = _connection.GetBytes(value, out _);
                             typeChanged = true;
                         }
                         break;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUdtInfo.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUdtInfo.cs
@@ -12,20 +12,12 @@ namespace Microsoft.Data.SqlClient
     internal class SqlUdtInfo
     {
         internal readonly Format SerializationFormat;
-        internal readonly bool IsByteOrdered;
-        internal readonly bool IsFixedLength;
         internal readonly int MaxByteSize;
-        internal readonly string Name;
-        internal readonly string ValidationMethodName;
 
         private SqlUdtInfo(SqlUserDefinedTypeAttribute attr)
         {
             SerializationFormat = attr.Format;
-            IsByteOrdered = attr.IsByteOrdered;
-            IsFixedLength = attr.IsFixedLength;
             MaxByteSize = attr.MaxByteSize;
-            Name = attr.Name;
-            ValidationMethodName = attr.ValidationMethodName;
         }
 
         internal static SqlUdtInfo GetFromType(Type target)


### PR DESCRIPTION
## Description

This sits alongside #3423. Where the earlier PR widens test coverage of the UDT serialization logic, this one simplifies conditions which are constant at runtime. The two primary variables here are `_isTopLevelUdt` and `_skipNormalize`.

`_isTopLevelUdt` is a readonly variable, which is set in the sole `BinaryOrderedUdtNormalizer` constructor to a hardcoded value of `true`. There are then a set of if conditions which test if the variable is false, and which will thus never be called. This PR removes these. The ripple effects of these result in the `_padBuffer` and `_nullInstance` variables never being set (and the `IsNullable` property never being referenced.) These members are also removed.

`_skipNormalize` is another variable, this time defined on the `Normalizer` base class. It is only ever set to `false`, and thus every condition which tests if it is false will succeed. This PR removes the test and runs the code unconditionally.

This accounts for the bulk of the changes. There is one parameter on the constructor to `BinaryOrderedUdtNormalizer` which is never used, a comment which is incorrect, a call to `GetFormat` which discards the result, and several fields on `SqlUdtInfo` which are written to, but never read.

Review of the wider area will highlight some code paths (such as the `Size` property) which remain unused. There are also quirks such as the use of a per-thread type cache, the implementation of the non-generic `IComparable` interface, significant numbers of heap allocations, and likely others. The next set/sets of changes will resolve these, so I've deliberately left these alone to keep this PR focused on the removal of dead code paths.

## Issues

None.

## Testing

All tests pass. I've also tested against the new tests in #3423, and these also pass.