### PR TITLE
Merge | SqlCommand (Part 1)

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -3079,19 +3079,20 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteXmlReaderAsync[@name="default"]/*'/>
-        public Task<XmlReader> ExecuteXmlReaderAsync()
-        {
-            return ExecuteXmlReaderAsync(CancellationToken.None);
-        }
+        public Task<XmlReader> ExecuteXmlReaderAsync() => 
+            ExecuteXmlReaderAsync(CancellationToken.None);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteXmlReaderAsync[@name="CancellationToken"]/*'/>
-        public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken)
-            => IsProviderRetriable ?
-                InternalExecuteXmlReaderWithRetryAsync(cancellationToken) :
-                InternalExecuteXmlReaderAsync(cancellationToken);
+        public Task<XmlReader> ExecuteXmlReaderAsync(CancellationToken cancellationToken) =>
+            IsProviderRetriable
+                ? InternalExecuteXmlReaderWithRetryAsync(cancellationToken)
+                : InternalExecuteXmlReaderAsync(cancellationToken);
 
-        private Task<XmlReader> InternalExecuteXmlReaderWithRetryAsync(CancellationToken cancellationToken)
-            => RetryLogicProvider.ExecuteAsync(this, () => InternalExecuteXmlReaderAsync(cancellationToken), cancellationToken);
+        private Task<XmlReader> InternalExecuteXmlReaderWithRetryAsync(CancellationToken cancellationToken) =>
+            RetryLogicProvider.ExecuteAsync(
+                sender: this,
+                () => InternalExecuteXmlReaderAsync(cancellationToken),
+                cancellationToken);
 
         private Task<XmlReader> InternalExecuteXmlReaderAsync(CancellationToken cancellationToken)
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2769,31 +2769,28 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="default"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync()
-        {
-            return ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
-        }
+        public new Task<SqlDataReader> ExecuteReaderAsync() => 
+            ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="CommandBehavior"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
-        {
-            return ExecuteReaderAsync(behavior, CancellationToken.None);
-        }
+        public new Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior) => 
+            ExecuteReaderAsync(behavior, CancellationToken.None);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="CancellationToken"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
-        {
-            return ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
-        }
+        public new Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken) =>
+            ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="commandBehaviorAndCancellationToken"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
-            => IsProviderRetriable ?
-                InternalExecuteReaderWithRetryAsync(behavior, cancellationToken) :
-                InternalExecuteReaderAsync(behavior, cancellationToken);
+        public new Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) =>
+            IsProviderRetriable
+                ? InternalExecuteReaderWithRetryAsync(behavior, cancellationToken)
+                : InternalExecuteReaderAsync(behavior, cancellationToken);
 
-        private Task<SqlDataReader> InternalExecuteReaderWithRetryAsync(CommandBehavior behavior, CancellationToken cancellationToken)
-            => RetryLogicProvider.ExecuteAsync(this, () => InternalExecuteReaderAsync(behavior, cancellationToken), cancellationToken);
+        private Task<SqlDataReader> InternalExecuteReaderWithRetryAsync(CommandBehavior behavior, CancellationToken cancellationToken) =>
+            RetryLogicProvider.ExecuteAsync(
+                sender: this,
+                () => InternalExecuteReaderAsync(behavior, cancellationToken),
+                cancellationToken);
 
         private Task<SqlDataReader> InternalExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -5554,6 +5554,17 @@ namespace Microsoft.Data.SqlClient
         }
 
 
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Clone/*'/>
+        public SqlCommand Clone()
+        {
+            SqlCommand clone = new SqlCommand(this);
+            SqlClientEventSource.Log.TryTraceEvent("SqlCommand.Clone | API | Object Id {0}, Clone Object Id {1}, Client Connection Id {2}", ObjectID, clone.ObjectID, Connection?.ClientConnectionId);
+            return clone;
+        }
+
+        object ICloneable.Clone() =>
+            Clone();
+
         private Task<T> RegisterForConnectionCloseNotification<T>(Task<T> outerTask)
         {
             SqlConnection connection = _activeConnection;
@@ -7011,17 +7022,6 @@ namespace Microsoft.Data.SqlClient
             {
                 _sqlDep.StartTimer(Notification);
             }
-        }
-
-        object ICloneable.Clone() => Clone();
-
-
-        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Clone/*'/>
-        public SqlCommand Clone()
-        {
-            SqlCommand clone = new SqlCommand(this);
-            SqlClientEventSource.Log.TryTraceEvent("SqlCommand.Clone | API | Object Id {0}, Clone Object Id {1}, Client Connection Id {2}", ObjectID, clone.ObjectID, Connection?.ClientConnectionId);
-            return clone;
         }
 
         private void WriteBeginExecuteEvent()

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2082,13 +2082,16 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteXmlReader[@name="default"]/*'/>
-        public IAsyncResult BeginExecuteReader() => BeginExecuteReader(null, null, CommandBehavior.Default);
+        public IAsyncResult BeginExecuteReader() =>
+            BeginExecuteReader(callback: null, stateObject: null, CommandBehavior.Default);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteXmlReader[@name="AsyncCallbackAndstateObject"]/*'/>
-        public IAsyncResult BeginExecuteReader(AsyncCallback callback, object stateObject) => BeginExecuteReader(callback, stateObject, CommandBehavior.Default);
+        public IAsyncResult BeginExecuteReader(AsyncCallback callback, object stateObject) =>
+            BeginExecuteReader(callback, stateObject, CommandBehavior.Default);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteReader[@name="CommandBehavior"]/*'/>
-        public IAsyncResult BeginExecuteReader(CommandBehavior behavior) => BeginExecuteReader(null, null, behavior);
+        public IAsyncResult BeginExecuteReader(CommandBehavior behavior) =>
+            BeginExecuteReader(callback: null, stateObject: null, behavior);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteReader[@name="AsyncCallbackAndstateObjectAndCommandBehavior"]/*'/>
         public IAsyncResult BeginExecuteReader(AsyncCallback callback, object stateObject, CommandBehavior behavior)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -694,11 +694,13 @@ namespace Microsoft.Data.SqlClient
                 {
                     throw ADP.InvalidCommandTimeout(value);
                 }
+
                 if (value != _commandTimeout)
                 {
                     PropertyChanging();
                     _commandTimeout = value;
                 }
+
                 SqlClientEventSource.Log.TryTraceEvent("SqlCommand.Set_CommandTimeout | API | ObjectId {0}, Command Timeout value {1}, Client Connection Id {2}", ObjectID, value, Connection?.ClientConnectionId);
             }
         }
@@ -749,6 +751,7 @@ namespace Microsoft.Data.SqlClient
                         default:
                             throw ADP.InvalidCommandType(value);
                     }
+
                     SqlClientEventSource.Log.TryTraceEvent("SqlCommand.Set_CommandType | API | ObjectId {0}, Command type value {1}, Client Connection Id {2}", ObjectID, (int)value, Connection?.ClientConnectionId);
                 }
             }
@@ -828,6 +831,7 @@ namespace Microsoft.Data.SqlClient
                     default:
                         throw ADP.InvalidUpdateRowSource(value);
                 }
+
                 SqlClientEventSource.Log.TryTraceEvent("SqlCommand.UpdatedRowSource | API | ObjectId {0}, Updated row source value {1}, Client Connection Id {2}", ObjectID, (int)value, Connection?.ClientConnectionId);
             }
         }
@@ -1793,6 +1797,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
                     WriteBeginExecuteEvent();
+
                     // use the reader to consume metadata
                     SqlDataReader ds = IsProviderRetriable ?
                         RunExecuteReaderWithRetry(CommandBehavior.SequentialAccess, RunBehavior.ReturnImmediately, returnStream: true) :
@@ -1920,9 +1925,7 @@ namespace Microsoft.Data.SqlClient
                         localCompletion,
                         InternalEndExecuteReader,
                         BeginExecuteXmlReaderInternal,
-                        endMethod: nameof(EndExecuteXmlReader)
-                    )
-                )
+                        endMethod: nameof(EndExecuteXmlReader)))
                 {
                     globalCompletion = localCompletion;
                 }
@@ -2306,6 +2309,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
                     WriteBeginExecuteEvent();
+
                     ValidateAsyncCommand(); // Special case - done outside of try/catches to prevent putting a stateObj
                                             // back into pool when we should not.
                 }
@@ -2373,9 +2377,7 @@ namespace Microsoft.Data.SqlClient
                         localCompletion,
                         InternalEndExecuteReader,
                         BeginExecuteReaderInternal,
-                        nameof(EndExecuteReader)
-                    )
-                )
+                        nameof(EndExecuteReader)))
                 {
                     globalCompletion = localCompletion;
                 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2654,13 +2654,16 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteNonQueryAsync[@name="CancellationToken"]/*'/>
-        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
-            => IsProviderRetriable ?
-                InternalExecuteNonQueryWithRetryAsync(cancellationToken) :
-                InternalExecuteNonQueryAsync(cancellationToken);
+        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken) =>
+            IsProviderRetriable
+                ? InternalExecuteNonQueryWithRetryAsync(cancellationToken)
+                : InternalExecuteNonQueryAsync(cancellationToken);
 
-        private Task<int> InternalExecuteNonQueryWithRetryAsync(CancellationToken cancellationToken)
-            => RetryLogicProvider.ExecuteAsync(this, () => InternalExecuteNonQueryAsync(cancellationToken), cancellationToken);
+        private Task<int> InternalExecuteNonQueryWithRetryAsync(CancellationToken cancellationToken) =>
+            RetryLogicProvider.ExecuteAsync(
+                sender: this,
+                () => InternalExecuteNonQueryAsync(cancellationToken),
+                cancellationToken);
 
         private Task<int> InternalExecuteNonQueryAsync(CancellationToken cancellationToken)
         {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -6983,7 +6983,7 @@ namespace Microsoft.Data.SqlClient
         }
 
 
-#if DEBUG
+        #if DEBUG
         internal void CompletePendingReadWithSuccess(bool resetForcePendingReadsToWait)
         {
             var stateObj = _stateObj;
@@ -7025,14 +7025,15 @@ namespace Microsoft.Data.SqlClient
                 }
             }
         }
-#endif
-        internal static void CancelIgnoreFailureCallback(object state)
+        #endif
+
+        private static void CancelIgnoreFailureCallback(object state)
         {
             SqlCommand command = (SqlCommand)state;
             command.CancelIgnoreFailure();
         }
 
-        internal void CancelIgnoreFailure()
+        private void CancelIgnoreFailure()
         {
             // This method is used to route CancellationTokens to the Cancel method.
             // Cancellation is a suggestion, and exceptions should be ignored

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -204,6 +204,7 @@ namespace Microsoft.Data.SqlClient
         // cached metadata
         private _SqlMetaDataSet _cachedMetaData;
 
+        // @TODO: Make properties
         internal ConcurrentDictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave;
         internal bool requiresEnclaveComputations = false;
 
@@ -3897,9 +3898,16 @@ namespace Microsoft.Data.SqlClient
         /// <param name="returnTask"></param>
         /// <param name="asyncWrite"></param>
         /// <param name="usedCache"></param>
-        /// <param name="inRetry"></param>
+        /// <param name="isRetry"></param>
         /// <returns></returns>
-        private void PrepareForTransparentEncryption(bool isAsync, int timeout, TaskCompletionSource<object> completion, out Task returnTask, bool asyncWrite, out bool usedCache, bool inRetry)
+        private void PrepareForTransparentEncryption(
+            bool isAsync,
+            int timeout,
+            TaskCompletionSource<object> completion,
+            out Task returnTask,
+            bool asyncWrite,
+            out bool usedCache,
+            bool isRetry)
         {
             // Fetch reader with input params
             Task fetchInputParameterEncryptionInfoTask = null;
@@ -3919,7 +3927,7 @@ namespace Microsoft.Data.SqlClient
 
             // If we are not in Batch RPC and not already retrying, attempt to fetch the cipher MD for each parameter from the cache.
             // If this succeeds then return immediately, otherwise just fall back to the full crypto MD discovery.
-            if (!_batchRPCMode && !inRetry && (this._parameters != null && this._parameters.Count > 0) && SqlQueryMetadataCache.GetInstance().GetQueryMetadataIfExists(this))
+            if (!_batchRPCMode && !isRetry && (this._parameters != null && this._parameters.Count > 0) && SqlQueryMetadataCache.GetInstance().GetQueryMetadataIfExists(this))
             {
                 usedCache = true;
                 return;
@@ -3949,7 +3957,7 @@ namespace Microsoft.Data.SqlClient
                                                                                                  out describeParameterEncryptionNeeded,
                                                                                                  out fetchInputParameterEncryptionInfoTask,
                                                                                                  out describeParameterEncryptionRpcOriginalRpcMap,
-                                                                                                 inRetry);
+                                                                                                 isRetry);
 
                     Debug.Assert(describeParameterEncryptionNeeded || describeParameterEncryptionDataReader == null,
                         "describeParameterEncryptionDataReader should be null if we don't need to request describe parameter encryption request.");
@@ -3990,7 +3998,7 @@ namespace Microsoft.Data.SqlClient
                             describeParameterEncryptionDataReader,
                             describeParameterEncryptionRpcOriginalRpcMap,
                             describeParameterEncryptionNeeded,
-                            inRetry);
+                            isRetry);
 
                         decrementAsyncCountInFinallyBlock = false;
                     }
@@ -4007,7 +4015,7 @@ namespace Microsoft.Data.SqlClient
                                 describeParameterEncryptionDataReader,
                                 describeParameterEncryptionRpcOriginalRpcMap,
                                 describeParameterEncryptionNeeded,
-                                inRetry);
+                                isRetry);
 
                             decrementAsyncCountInFinallyBlock = false;
                         }
@@ -4017,7 +4025,7 @@ namespace Microsoft.Data.SqlClient
                             ReadDescribeEncryptionParameterResults(
                                 describeParameterEncryptionDataReader,
                                 describeParameterEncryptionRpcOriginalRpcMap,
-                                inRetry);
+                                isRetry);
                         }
 
 #if DEBUG

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Data.SqlClient
         // Prepare
         // Against 7.0 Serve a prepare/unprepare requires an extra roundtrip to the server.
         //
-        // From 8.0 and above  the preparation can be done as part of the command execution.
+        // From 8.0 and above, the preparation can be done as part of the command execution.
 
         private enum EXECTYPE
         {
@@ -254,7 +254,7 @@ namespace Microsoft.Data.SqlClient
 
         internal bool ShouldUseEnclaveBasedWorkflow =>
             (!string.IsNullOrWhiteSpace(_activeConnection.EnclaveAttestationUrl) || Connection.AttestationProtocol == SqlConnectionAttestationProtocol.None) &&
-                    IsColumnEncryptionEnabled;
+                  IsColumnEncryptionEnabled;
 
         /// <summary>
         /// Per-command custom providers. It can be provided by the user and can be set more than once. 
@@ -501,7 +501,6 @@ namespace Microsoft.Data.SqlClient
                 {
                     _transaction = null;
                 }
-
 
                 // Command is no longer prepared on new connection, cleanup prepare status
                 if (IsPrepared)
@@ -1270,7 +1269,8 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteNonQuery[@name="default"]/*'/>
-        public IAsyncResult BeginExecuteNonQuery() => BeginExecuteNonQuery(null, null); // BeginExecuteNonQuery will track ExecutionTime for us
+        public IAsyncResult BeginExecuteNonQuery() =>
+            BeginExecuteNonQuery(null, null);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteNonQuery[@name="AsyncCallbackAndStateObject"]/*'/>
         public IAsyncResult BeginExecuteNonQuery(AsyncCallback callback, object stateObject)
@@ -1364,9 +1364,7 @@ namespace Microsoft.Data.SqlClient
                         localCompletion,
                         InternalEndExecuteNonQuery,
                         BeginExecuteNonQueryInternal,
-                        nameof(EndExecuteNonQuery)
-                    )
-                )
+                        nameof(EndExecuteNonQuery)))
                 {
                     globalCompletion = localCompletion;
                 }
@@ -1425,6 +1423,7 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.TryTraceEvent("SqlCommand.VerifyEndExecuteState | API | ObjectId {0}, Client Connection Id {1}, MARS={2}, AsyncCommandInProgress={3}",
                                                     _activeConnection?.ObjectID, _activeConnection?.ClientConnectionId,
                                                     _activeConnection?.Parser?.MARSOn, _activeConnection?.AsyncCommandInProgress);
+
             if (completionTask.IsCanceled)
             {
                 if (_stateObj != null)
@@ -1689,7 +1688,7 @@ namespace Microsoft.Data.SqlClient
             [CallerMemberName] string methodName = "")
         {
             SqlClientEventSource.Log.TryTraceEvent("SqlCommand.InternalExecuteNonQuery | INFO | ObjectId {0}, Client Connection Id {1}, AsyncCommandInProgress={2}",
-                                                        _activeConnection?.ObjectID, _activeConnection?.ClientConnectionId, _activeConnection?.AsyncCommandInProgress);
+                                                    _activeConnection?.ObjectID, _activeConnection?.ClientConnectionId, _activeConnection?.AsyncCommandInProgress);
             bool isAsync = completion != null;
             usedCache = false;
 
@@ -2185,7 +2184,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal SqlDataReader EndExecuteReaderAsync(IAsyncResult asyncResult)
+        private SqlDataReader EndExecuteReaderAsync(IAsyncResult asyncResult)
         {
             SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.EndExecuteReaderAsync | API | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
             Debug.Assert(!_internalEndExecuteInitiated || _stateObj == null);
@@ -2769,11 +2768,11 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="default"]/*'/>
-        public new Task<SqlDataReader> ExecuteReaderAsync() => 
+        public new Task<SqlDataReader> ExecuteReaderAsync() =>
             ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="CommandBehavior"]/*'/>
-        public new Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior) => 
+        public new Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior) =>
             ExecuteReaderAsync(behavior, CancellationToken.None);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="CancellationToken"]/*'/>
@@ -4225,7 +4224,7 @@ namespace Microsoft.Data.SqlClient
             bool isAsync,
             bool asyncWrite,
             out bool inputParameterEncryptionNeeded,
-            out Task task, 
+            out Task task,
             out ReadOnlyDictionary<_SqlRPC, _SqlRPC> describeParameterEncryptionRpcOriginalRpcMap,
             bool isRetry)
         {
@@ -4387,7 +4386,7 @@ namespace Microsoft.Data.SqlClient
             if (_batchRPCMode)
             {
                 Debug.Assert(originalRpcRequest.systemParamCount > 0,
-                    "originalRpcRequest didn't have at-least 1 parameter in _batchRPCMode, in PrepareDescribeParameterEncryptionRequest.");
+                    "originalRpcRequest didn't have at-least 1 parameter in BatchRPCMode, in PrepareDescribeParameterEncryptionRequest.");
                 text = (string)originalRpcRequest.systemParams[0].Value;
                 //@tsql
                 SqlParameter tsqlParam = describeParameterEncryptionRequest.systemParams[0];
@@ -4723,8 +4722,8 @@ namespace Microsoft.Data.SqlClient
                                     Debug.Assert(_activeConnection != null, @"_activeConnection should not be null");
                                     SqlSecurityUtility.DecryptSymmetricKey(sqlParameter.CipherMetadata, _activeConnection, this);
 
-                                    // This is effective only for _batchRPCMode even though we set it for non-_batchRPCMode also,
-                                    // since for non-_batchRPCMode mode, paramoptions gets thrown away and reconstructed in BuildExecuteSql.
+                                    // This is effective only for BatchRPCMode even though we set it for non-BatchRPCMode also,
+                                    // since for non-BatchRPCMode mode, paramoptions gets thrown away and reconstructed in BuildExecuteSql.
                                     int options = (int)(rpc.userParamMap[index] >> 32);
                                     options |= TdsEnums.RPC_PARAM_ENCRYPTED;
                                     rpc.userParamMap[index] = ((((long)options) << 32) | (long)index);
@@ -5503,6 +5502,7 @@ namespace Microsoft.Data.SqlClient
                 ds.Bind(_stateObj);
                 _stateObj = null;   // the reader now owns this...
                 ds.ResetOptionsString = resetOptionsString;
+
                 // bind this reader to this connection now
                 _activeConnection.AddWeakReference(ds, SqlReferenceCollection.DataReaderTag);
 
@@ -5556,7 +5556,6 @@ namespace Microsoft.Data.SqlClient
                 }
             }
         }
-
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Clone/*'/>
         public SqlCommand Clone()
@@ -6096,8 +6095,8 @@ namespace Microsoft.Data.SqlClient
             rpc.needsFetchParameterEncryptionMetadata = false;
 
             int currentCount = rpc.systemParams?.Length ?? 0;
-            // Make sure there is enough space in the parameters and paramoptions arrays
 
+            // Make sure there is enough space in the parameters and paramoptions arrays
             if (currentCount < systemParamCount)
             {
                 Array.Resize(ref rpc.systemParams, systemParamCount);
@@ -6185,6 +6184,7 @@ namespace Microsoft.Data.SqlClient
 
                     rpc.userParamMap[userParamCount] = ((((long)options) << 32) | (long)index);
                     userParamCount += 1;
+
                     // Must set parameter option bit for LOB_COOKIE if unfilled LazyMat blob
                 }
             }
@@ -7009,7 +7009,7 @@ namespace Microsoft.Data.SqlClient
             // Cancellation is a suggestion, and exceptions should be ignored
             // rather than allowed to be unhandled, as there is no way to route
             // them to the caller.  It would be expected that the error will be
-            // observed anyway from the regular method.  An example is canceling
+            // observed anyway from the regular method.  An example is cancelling
             // an operation on a closed connection.
             try
             {
@@ -7033,6 +7033,12 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.TryBeginExecuteEvent(ObjectID, Connection?.DataSource, Connection?.Database, CommandText, Connection?.ClientConnectionId);
         }
 
+        /// <summary>
+        /// Writes and end execute event in Event Source.
+        /// </summary>
+        /// <param name="success">True if SQL command finished successfully, otherwise false.</param>
+        /// <param name="sqlExceptionNumber">Gets a number that identifies the type of error.</param>
+        /// <param name="synchronous">True if SQL command was executed synchronously, otherwise false.</param>
         private void WriteEndExecuteEvent(bool success, int? sqlExceptionNumber, bool synchronous)
         {
             if (SqlClientEventSource.Log.IsExecutionTraceEnabled())

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -6982,51 +6982,6 @@ namespace Microsoft.Data.SqlClient
             return result;
         }
 
-
-        #if DEBUG
-        internal void CompletePendingReadWithSuccess(bool resetForcePendingReadsToWait)
-        {
-            var stateObj = _stateObj;
-            if (stateObj != null)
-            {
-                stateObj.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
-            }
-            else
-            {
-                var tempCachedAsyncState = cachedAsyncState;
-                if (tempCachedAsyncState != null)
-                {
-                    var reader = tempCachedAsyncState.CachedAsyncReader;
-                    if (reader != null)
-                    {
-                        reader.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
-                    }
-                }
-            }
-        }
-
-        internal void CompletePendingReadWithFailure(int errorCode, bool resetForcePendingReadsToWait)
-        {
-            var stateObj = _stateObj;
-            if (stateObj != null)
-            {
-                stateObj.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
-            }
-            else
-            {
-                var tempCachedAsyncState = _cachedAsyncState;
-                if (tempCachedAsyncState != null)
-                {
-                    var reader = tempCachedAsyncState.CachedAsyncReader;
-                    if (reader != null)
-                    {
-                        reader.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
-                    }
-                }
-            }
-        }
-        #endif
-
         private static void CancelIgnoreFailureCallback(object state)
         {
             SqlCommand command = (SqlCommand)state;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -487,9 +487,11 @@ namespace Microsoft.Data.SqlClient
             {
                 // Don't allow the connection to be changed while in an async operation.
                 if (_activeConnection != value && _activeConnection != null)
-                { // If new value...
+                {
+                    // If new value...
                     if (CachedAsyncState != null && CachedAsyncState.PendingAsyncOperation)
-                    { // If in pending async state, throw.
+                    {
+                        // If in pending async state, throw.
                         throw SQL.CannotModifyPropertyAsyncOperationInProgress();
                     }
                 }
@@ -624,9 +626,11 @@ namespace Microsoft.Data.SqlClient
             {
                 // Don't allow the transaction to be changed while in an async operation.
                 if (_transaction != value && _activeConnection != null)
-                { // If new value...
+                {
+                    // If new value...
                     if (CachedAsyncState.PendingAsyncOperation)
-                    { // If in pending async state, throw
+                    {
+                        // If in pending async state, throw
                         throw SQL.CannotModifyPropertyAsyncOperationInProgress();
                     }
                 }
@@ -867,7 +871,8 @@ namespace Microsoft.Data.SqlClient
         }
 
         private void PropertyChanging()
-        { // also called from SqlParameterCollection
+        {
+            // also called from SqlParameterCollection
             this.IsDirty = true;
         }
 
@@ -1044,7 +1049,8 @@ namespace Microsoft.Data.SqlClient
                     lock (connection)
                     {
                         if (connection != (_activeConnection.InnerConnection as SqlInternalConnectionTds))
-                        { // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
+                        {
+                            // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
                             return;
                         }
 
@@ -1055,7 +1061,8 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         if (!_pendingCancel)
-                        { // Do nothing if already pending.
+                        {
+                            // Do nothing if already pending.
                           // Before attempting actual cancel, set the _pendingCancel flag to false.
                           // This denotes to other thread before obtaining stateObject from the
                           // session pool that there is another thread wishing to cancel.
@@ -3284,14 +3291,17 @@ namespace Microsoft.Data.SqlClient
             if (sproc != null)
             {
                 if (char.IsDigit(sproc[sproc.Length - 1]))
-                { // If last char is a digit, parse.
+                {
+                    // If last char is a digit, parse.
                     int semicolon = sproc.LastIndexOf(';');
                     if (semicolon != -1)
-                    { // If we found a semicolon, obtain the integer.
+                    {
+                        // If we found a semicolon, obtain the integer.
                         string part = sproc.Substring(semicolon + 1);
                         int number = 0;
                         if (int.TryParse(part, out number))
-                        { // No checking, just fail if this doesn't work.
+                        {
+                            // No checking, just fail if this doesn't work.
                             groupNumber = number;
                             sproc = sproc.Substring(0, semicolon);
                         }
@@ -3452,7 +3462,8 @@ namespace Microsoft.Data.SqlClient
             }
 
             if (!string.IsNullOrEmpty(parsedSProc[2]))
-            { // SchemaName is 3rd element in parsed array
+            {
+                // SchemaName is 3rd element in parsed array
                 SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@procedure_schema", SqlDbType.NVarChar, 255));
                 param.Value = UnquoteProcedurePart(parsedSProc[2]);
             }
@@ -5339,7 +5350,8 @@ namespace Microsoft.Data.SqlClient
                 {
                     SqlInternalConnectionTds innerConnectionTds = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
                     if (innerConnectionTds != null)
-                    { // it may be closed
+                    {
+                        // it may be closed
                         innerConnectionTds.DecrementAsyncCount();
                     }
                 }
@@ -5658,7 +5670,8 @@ namespace Microsoft.Data.SqlClient
         private void ValidateAsyncCommand()
         {
             if (CachedAsyncState != null && CachedAsyncState.PendingAsyncOperation)
-            { // Enforce only one pending async execute at a time.
+            {
+                // Enforce only one pending async execute at a time.
                 if (CachedAsyncState.IsActiveConnectionValid(_activeConnection))
                 {
                     throw SQL.PendingBeginXXXExists();

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -5250,7 +5250,7 @@ namespace Microsoft.Data.SqlClient
 
                     if (_execType == EXECTYPE.PREPARED)
                     {
-                        Debug.Assert(this.IsPrepared && ((int)_prepareHandle != -1), "invalid attempt to call sp_execute without a handle!");
+                        Debug.Assert(IsPrepared && _prepareHandle != s_cachedInvalidPrepareHandle, "invalid attempt to call sp_execute without a handle!");
                         rpc = BuildExecute(inSchema);
                     }
                     else if (_execType == EXECTYPE.PREPAREPENDING)
@@ -6316,7 +6316,7 @@ namespace Microsoft.Data.SqlClient
         //
         private _SqlRPC BuildExecute(bool inSchema)
         {
-            Debug.Assert((int)_prepareHandle != -1, "Invalid call to sp_execute without a valid handle!");
+            Debug.Assert(_prepareHandle != s_cachedInvalidPrepareHandle, "Invalid call to sp_execute without a valid handle!");
 
             const int systemParameterCount = 1;
             int userParameterCount = CountSendableParameters(_parameters);
@@ -6346,7 +6346,7 @@ namespace Microsoft.Data.SqlClient
         private void BuildExecuteSql(CommandBehavior behavior, string commandText, SqlParameterCollection parameters, ref _SqlRPC rpc)
         {
 
-            Debug.Assert((int)_prepareHandle == -1, "This command has an existing handle, use sp_execute!");
+            Debug.Assert(_prepareHandle == s_cachedInvalidPrepareHandle, "This command has an existing handle, use sp_execute!");
             Debug.Assert(CommandType.Text == this.CommandType, "invalid use of sp_executesql for stored proc invocation!");
             int systemParamCount;
             SqlParameter sqlParam;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -474,9 +474,8 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Connection/*'/>
-        ///  [
         [DefaultValue(null)]
-        [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
         [ResDescription(StringsHelper.ResourceNames.DbCommand_Connection)]
         new public SqlConnection Connection
         {
@@ -654,7 +653,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/CommandText/*'/>
         [DefaultValue("")]
         [RefreshProperties(RefreshProperties.All)] // MDAC 67707
-        [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
         [ResDescription(StringsHelper.ResourceNames.DbCommand_CommandText)]
         public override string CommandText
         {
@@ -673,12 +672,12 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ColumnEncryptionSetting/*'/>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
         [ResDescription(StringsHelper.ResourceNames.TCE_SqlCommand_ColumnEncryptionSetting)]
         public SqlCommandColumnEncryptionSetting ColumnEncryptionSetting => _columnEncryptionSetting;
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/CommandTimeout/*'/>
-        [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
         [ResDescription(StringsHelper.ResourceNames.DbCommand_CommandTimeout)]
         public override int CommandTimeout
         {
@@ -720,9 +719,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/CommandType/*'/>
-        [DefaultValue(System.Data.CommandType.Text)]
+        [DefaultValue(CommandType.Text)]
         [RefreshProperties(RefreshProperties.All)]
-        [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
         [ResDescription(StringsHelper.ResourceNames.DbCommand_CommandType)]
         public override CommandType CommandType
         {
@@ -752,7 +751,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        // @devnote: By default, the cmd object is visible on the design surface (i.e. VS7 Server Tray)
+        // By default, the cmd object is visible on the design surface (i.e. VS7 Server Tray)
         // to limit the number of components that clutter the design surface,
         // when the DataAdapter design wizard generates the insert/update/delete commands it will
         // set the DesignTimeVisible property to false so that cmds won't appear as individual objects
@@ -760,7 +759,7 @@ namespace Microsoft.Data.SqlClient
         [DefaultValue(true)]
         [DesignOnly(true)]
         [Browsable(false)]
-        [EditorBrowsableAttribute(EditorBrowsableState.Never)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool DesignTimeVisible
         {
             get
@@ -778,7 +777,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Parameters/*'/>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
         [ResDescription(StringsHelper.ResourceNames.DbCommand_Parameters)]
         new public SqlParameterCollection Parameters
         {
@@ -804,8 +803,8 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UpdatedRowSource/*'/>
-        [DefaultValue(System.Data.UpdateRowSource.Both)]
-        [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Update)]
+        [DefaultValue(UpdateRowSource.Both)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Update)]
         [ResDescription(StringsHelper.ResourceNames.DbCommand_UpdatedRowSource)]
         public override UpdateRowSource UpdatedRowSource
         {
@@ -831,7 +830,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/StatementCompleted/*'/>
-        [ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_StatementCompleted)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_StatementCompleted)]
         [ResDescription(StringsHelper.ResourceNames.DbCommand_StatementCompleted)]
         public event StatementCompletedEventHandler StatementCompleted
         {
@@ -2418,8 +2417,7 @@ namespace Microsoft.Data.SqlClient
             TaskCompletionSource<object> localCompletion,
             Func<SqlCommand, IAsyncResult, bool, string, object> endFunc,
             Func<SqlCommand, CommandBehavior, AsyncCallback, object, int, bool, bool, IAsyncResult> retryFunc,
-            string endMethod
-        )
+            string endMethod)
         {
             // We shouldn't be using the cache if we are in retry.
             Debug.Assert(!usedCache || !inRetry);
@@ -2479,7 +2477,7 @@ namespace Microsoft.Data.SqlClient
                         // lock on _stateObj prevents races with close/cancel.
                         lock (_stateObj)
                         {
-                            endFunc(this, tsk, true, endMethod /*inInternal*/);
+                            endFunc(this, tsk, /*isInternal:*/ true, endMethod);
                         }
 
                         globalCompletion.TrySetResult(tsk.Result);
@@ -4325,7 +4323,17 @@ namespace Microsoft.Data.SqlClient
 #endif
 
                 // Execute the RPC.
-                return RunExecuteReaderTds(CommandBehavior.Default, runBehavior: RunBehavior.ReturnImmediately, returnStream: true, isAsync: isAsync, timeout: timeout, task: out task, asyncWrite: asyncWrite, inRetry: false, ds: null, describeParameterEncryptionRequest: true);
+                return RunExecuteReaderTds(
+                    CommandBehavior.Default,
+                    runBehavior: RunBehavior.ReturnImmediately,
+                    returnStream: true,
+                    isAsync: isAsync,
+                    timeout: timeout,
+                    task: out task,
+                    asyncWrite: asyncWrite,
+                    inRetry: false,
+                    ds: null,
+                    describeParameterEncryptionRequest: true);
             }
             else
             {
@@ -4346,7 +4354,14 @@ namespace Microsoft.Data.SqlClient
             return sqlParam;
         }
 
-
+        /// <summary>
+        /// Constructs the sp_describe_parameter_encryption request with the values from the original RPC call.	
+        /// Prototype for &lt;sp_describe_parameter_encryption&gt; is 	
+        /// exec sp_describe_parameter_encryption @tsql=N'[SQL Statement]', @params=N'@p1 varbinary(256)'
+        /// </summary>
+        /// <param name="originalRpcRequest"></param>
+        /// <param name="describeParameterEncryptionRequest"></param>
+        /// <param name="attestationParameters"></param>
         private void PrepareDescribeParameterEncryptionRequest(_SqlRPC originalRpcRequest, ref _SqlRPC describeParameterEncryptionRequest, byte[] attestationParameters = null)
         {
             Debug.Assert(originalRpcRequest != null);
@@ -4459,8 +4474,6 @@ namespace Microsoft.Data.SqlClient
 
                 parameterList = BuildParamList(tdsParser, tempCollection, includeReturnValue: true);
             }
-
-            //@parameters
 
             SqlParameter paramsParam = describeParameterEncryptionRequest.systemParams[1];
             paramsParam.SqlDbType = ((parameterList.Length << 1) <= TdsEnums.TYPE_SIZE_LIMIT) ? SqlDbType.NVarChar : SqlDbType.NText;
@@ -4627,8 +4640,6 @@ namespace Microsoft.Data.SqlClient
                     throw SQL.UnexpectedDescribeParamFormatParameterMetadata();
                 }
 
-
-
                 // Find the RPC command that generated this tce request
                 if (_batchRPCMode)
                 {
@@ -4655,7 +4666,6 @@ namespace Microsoft.Data.SqlClient
                 int receivedMetadataCount = 0;
                 if (!enclaveMetadataExists || ds.NextResult())
                 {
-
                     // Iterate over the parameter names to read the encryption type info
                     while (ds.Read())
                     {
@@ -4667,7 +4677,6 @@ namespace Microsoft.Data.SqlClient
 
                         // When the RPC object gets reused, the parameter array has more parameters that the valid params for the command.
                         // Null is used to indicate the end of the valid part of the array. Refer to GetRPCObject().
-
                         for (int index = 0; index < userParamCount; index++)
                         {
                             SqlParameter sqlParameter = rpc.userParams[index];
@@ -4718,7 +4727,6 @@ namespace Microsoft.Data.SqlClient
 
                 // When the RPC object gets reused, the parameter array has more parameters that the valid params for the command.
                 // Null is used to indicate the end of the valid part of the array. Refer to GetRPCObject().
-
                 if (receivedMetadataCount != userParamCount)
                 {
                     for (int index = 0; index < userParamCount; index++)
@@ -4820,7 +4828,7 @@ namespace Microsoft.Data.SqlClient
                 completion: null,
                 timeout: CommandTimeout,
                 task: out unused,
-                usedCache: out bool _,
+                usedCache: out _,
                 method: method);
             
             Debug.Assert(unused == null, "returned task during synchronous execution");
@@ -6248,7 +6256,6 @@ namespace Microsoft.Data.SqlClient
             // 4-part name 1 + 128 + 1 + 1 + 1 + 128 + 1 + 1 + 1 + 128 + 1 + 1 + 1 + 128 + 1 = 523
             // each char takes 2 bytes. 523 * 2 = 1046
             int commandTextLength = ADP.CharSize * CommandText.Length;
-
             if (commandTextLength <= MaxRPCNameLength)
             {
                 rpc.rpcName = CommandText; // just get the raw command text
@@ -6270,8 +6277,8 @@ namespace Microsoft.Data.SqlClient
         private _SqlRPC BuildExecute(bool inSchema)
         {
             Debug.Assert((int)_prepareHandle != -1, "Invalid call to sp_execute without a valid handle!");
-            const int systemParameterCount = 1;
 
+            const int systemParameterCount = 1;
             int userParameterCount = CountSendableParameters(_parameters);
 
             _SqlRPC rpc = null;
@@ -6466,9 +6473,7 @@ namespace Microsoft.Data.SqlClient
             StringBuilder paramList = new StringBuilder();
             bool fAddSeparator = false;
 
-            int count = 0;
-
-            count = parameters.Count;
+            int count = parameters.Count;
             for (int i = 0; i < count; i++)
             {
                 SqlParameter sqlParam = parameters[i];

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -839,29 +839,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        internal static void CancelIgnoreFailureCallback(object state)
-        {
-            SqlCommand command = (SqlCommand)state;
-            command.CancelIgnoreFailure();
-        }
-
-        internal void CancelIgnoreFailure()
-        {
-            // This method is used to route CancellationTokens to the Cancel method.
-            // Cancellation is a suggestion, and exceptions should be ignored
-            // rather than allowed to be unhandled, as there is no way to route
-            // them to the caller.  It would be expected that the error will be
-            // observed anyway from the regular method.  An example is cancelling
-            // an operation on a closed connection.
-            try
-            {
-                Cancel();
-            }
-            catch (Exception)
-            {
-            }
-        }
-
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UpdatedRowSource/*'/>
         [DefaultValue(UpdateRowSource.Both)]
         [ResCategory(StringsHelper.ResourceNames.DataCategory_Update)]
@@ -7246,7 +7223,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-#if DEBUG
+        #if DEBUG
         internal void CompletePendingReadWithSuccess(bool resetForcePendingReadsToWait)
         {
             var stateObj = _stateObj;
@@ -7288,6 +7265,29 @@ namespace Microsoft.Data.SqlClient
                 }
             }
         }
-#endif
+        #endif
+        
+        private static void CancelIgnoreFailureCallback(object state)
+        {
+            SqlCommand command = (SqlCommand)state;
+            command.CancelIgnoreFailure();
+        }
+
+        private void CancelIgnoreFailure()
+        {
+            // This method is used to route CancellationTokens to the Cancel method.
+            // Cancellation is a suggestion, and exceptions should be ignored
+            // rather than allowed to be unhandled, as there is no way to route
+            // them to the caller.  It would be expected that the error will be
+            // observed anyway from the regular method.  An example is cancelling
+            // an operation on a closed connection.
+            try
+            {
+                Cancel();
+            }
+            catch (Exception)
+            {
+            }
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -7189,7 +7189,30 @@ namespace Microsoft.Data.SqlClient
             }
             return result;
         }
+        
+        private static void CancelIgnoreFailureCallback(object state)
+        {
+            SqlCommand command = (SqlCommand)state;
+            command.CancelIgnoreFailure();
+        }
 
+        private void CancelIgnoreFailure()
+        {
+            // This method is used to route CancellationTokens to the Cancel method.
+            // Cancellation is a suggestion, and exceptions should be ignored
+            // rather than allowed to be unhandled, as there is no way to route
+            // them to the caller.  It would be expected that the error will be
+            // observed anyway from the regular method.  An example is cancelling
+            // an operation on a closed connection.
+            try
+            {
+                Cancel();
+            }
+            catch (Exception)
+            {
+            }
+        }
+        
         private void WriteBeginExecuteEvent()
         {
             SqlClientEventSource.Log.TryBeginExecuteEvent(ObjectID, Connection?.DataSource, Connection?.Database, CommandText, Connection?.ClientConnectionId);
@@ -7220,29 +7243,6 @@ namespace Microsoft.Data.SqlClient
                 int compositeState = successFlag | isSqlExceptionFlag | synchronousFlag;
 
                 SqlClientEventSource.Log.TryEndExecuteEvent(ObjectID, compositeState, sqlExceptionNumber.GetValueOrDefault(), Connection?.ClientConnectionId);
-            }
-        }
-        
-        private static void CancelIgnoreFailureCallback(object state)
-        {
-            SqlCommand command = (SqlCommand)state;
-            command.CancelIgnoreFailure();
-        }
-
-        private void CancelIgnoreFailure()
-        {
-            // This method is used to route CancellationTokens to the Cancel method.
-            // Cancellation is a suggestion, and exceptions should be ignored
-            // rather than allowed to be unhandled, as there is no way to route
-            // them to the caller.  It would be expected that the error will be
-            // observed anyway from the regular method.  An example is cancelling
-            // an operation on a closed connection.
-            try
-            {
-                Cancel();
-            }
-            catch (Exception)
-            {
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -203,6 +203,19 @@ namespace Microsoft.Data.SqlClient
         // cut down on object creation and cache all these
         // cached metadata
         private _SqlMetaDataSet _cachedMetaData;
+        
+        // @TODO: Make properties
+        internal ConcurrentDictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave;
+        internal bool requiresEnclaveComputations = false;
+        
+        private bool ShouldCacheEncryptionMetadata
+        {
+            get
+            {
+                return !requiresEnclaveComputations || _activeConnection.Parser.AreEnclaveRetriesSupported;
+            }
+        }
+        
         internal EnclavePackage enclavePackage = null;
         private SqlEnclaveAttestationParameters enclaveAttestationParameters = null;
         private byte[] customData = null;
@@ -243,15 +256,6 @@ namespace Microsoft.Data.SqlClient
             (!string.IsNullOrWhiteSpace(_activeConnection.EnclaveAttestationUrl) || Connection.AttestationProtocol == SqlConnectionAttestationProtocol.None) &&
                   IsColumnEncryptionEnabled;
 
-        internal ConcurrentDictionary<int, SqlTceCipherInfoEntry> keysToBeSentToEnclave;
-        internal bool requiresEnclaveComputations = false;
-        private bool ShouldCacheEncryptionMetadata
-        {
-            get
-            {
-                return !requiresEnclaveComputations || _activeConnection.Parser.AreEnclaveRetriesSupported;
-            }
-        }
         /// <summary>
         /// Per-command custom providers. It can be provided by the user and can be set more than once. 
         /// </summary> 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2871,14 +2871,17 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private Task<int> InternalExecuteNonQueryWithRetryAsync(CancellationToken cancellationToken)
-            => RetryLogicProvider.ExecuteAsync(this, () => InternalExecuteNonQueryAsync(cancellationToken), cancellationToken);
-
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteNonQueryAsync[@name="CancellationToken"]/*'/>
-        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
-            => IsProviderRetriable ?
-                InternalExecuteNonQueryWithRetryAsync(cancellationToken) :
-                InternalExecuteNonQueryAsync(cancellationToken);
+        public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken) =>
+            IsProviderRetriable
+                ? InternalExecuteNonQueryWithRetryAsync(cancellationToken)
+                : InternalExecuteNonQueryAsync(cancellationToken);
+
+        private Task<int> InternalExecuteNonQueryWithRetryAsync(CancellationToken cancellationToken) =>
+            RetryLogicProvider.ExecuteAsync(
+                sender: this,
+                () => InternalExecuteNonQueryAsync(cancellationToken),
+                cancellationToken);
 
         private Task<int> InternalExecuteNonQueryAsync(CancellationToken cancellationToken)
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -5674,14 +5674,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private void NotifyDependency()
-        {
-            if (_sqlDep != null)
-            {
-                _sqlDep.StartTimer(Notification);
-            }
-        }
-
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Clone/*'/>
         public SqlCommand Clone()
         {
@@ -5690,10 +5682,8 @@ namespace Microsoft.Data.SqlClient
             return clone;
         }
 
-        object ICloneable.Clone()
-        {
-            return Clone();
-        }
+        object ICloneable.Clone() =>
+            Clone();
 
         private Task<T> RegisterForConnectionCloseNotification<T>(Task<T> outterTask)
         {
@@ -7210,6 +7200,14 @@ namespace Microsoft.Data.SqlClient
             }
             catch (Exception)
             {
+            }
+        }
+        
+        private void NotifyDependency()
+        {
+            if (_sqlDep != null)
+            {
+                _sqlDep.StartTimer(Notification);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -2985,32 +2985,29 @@ namespace Microsoft.Data.SqlClient
             );
         }
 
-        private Task<SqlDataReader> InternalExecuteReaderWithRetryAsync(CommandBehavior behavior, CancellationToken cancellationToken)
-            => RetryLogicProvider.ExecuteAsync(this, () => InternalExecuteReaderAsync(behavior, cancellationToken), cancellationToken);
-
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="default"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync()
-            => IsProviderRetriable ?
-                InternalExecuteReaderWithRetryAsync(CommandBehavior.Default, CancellationToken.None) :
-                InternalExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
+        public new Task<SqlDataReader> ExecuteReaderAsync() =>
+            ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="CommandBehavior"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior)
-            => IsProviderRetriable ?
-                InternalExecuteReaderWithRetryAsync(behavior, CancellationToken.None) :
-                InternalExecuteReaderAsync(behavior, CancellationToken.None);
+        public new Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior) =>
+            ExecuteReaderAsync(behavior, CancellationToken.None);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="CancellationToken"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken)
-            => IsProviderRetriable ?
-                InternalExecuteReaderWithRetryAsync(CommandBehavior.Default, cancellationToken) :
-                InternalExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
+        public new Task<SqlDataReader> ExecuteReaderAsync(CancellationToken cancellationToken) =>
+            ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteReaderAsync[@name="commandBehaviorAndCancellationToken"]/*'/>
-        new public Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
-            => IsProviderRetriable ?
-                InternalExecuteReaderWithRetryAsync(behavior, cancellationToken) :
-                InternalExecuteReaderAsync(behavior, cancellationToken);
+        public new Task<SqlDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) =>
+            IsProviderRetriable
+                ? InternalExecuteReaderWithRetryAsync(behavior, cancellationToken)
+                : InternalExecuteReaderAsync(behavior, cancellationToken);
+
+        private Task<SqlDataReader> InternalExecuteReaderWithRetryAsync(CommandBehavior behavior, CancellationToken cancellationToken) =>
+            RetryLogicProvider.ExecuteAsync(
+                sender: this,
+                () => InternalExecuteReaderAsync(behavior, cancellationToken),
+                cancellationToken);
 
         private Task<SqlDataReader> InternalExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -7222,50 +7222,6 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.TryEndExecuteEvent(ObjectID, compositeState, sqlExceptionNumber.GetValueOrDefault(), Connection?.ClientConnectionId);
             }
         }
-
-        #if DEBUG
-        internal void CompletePendingReadWithSuccess(bool resetForcePendingReadsToWait)
-        {
-            var stateObj = _stateObj;
-            if (stateObj != null)
-            {
-                stateObj.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
-            }
-            else
-            {
-                var tempCachedAsyncState = cachedAsyncState;
-                if (tempCachedAsyncState != null)
-                {
-                    var reader = tempCachedAsyncState.CachedAsyncReader;
-                    if (reader != null)
-                    {
-                        reader.CompletePendingReadWithSuccess(resetForcePendingReadsToWait);
-                    }
-                }
-            }
-        }
-
-        internal void CompletePendingReadWithFailure(int errorCode, bool resetForcePendingReadsToWait)
-        {
-            var stateObj = _stateObj;
-            if (stateObj != null)
-            {
-                stateObj.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
-            }
-            else
-            {
-                var tempCachedAsyncState = _cachedAsyncState;
-                if (tempCachedAsyncState != null)
-                {
-                    var reader = tempCachedAsyncState.CachedAsyncReader;
-                    if (reader != null)
-                    {
-                        reader.CompletePendingReadWithFailure(errorCode, resetForcePendingReadsToWait);
-                    }
-                }
-            }
-        }
-        #endif
         
         private static void CancelIgnoreFailureCallback(object state)
         {

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1287,7 +1287,7 @@ namespace Microsoft.Data.SqlClient
             int timeout,
             out bool usedCache,
             bool asyncWrite,
-            bool inRetry,
+            bool isRetry,
             [CallerMemberName] string methodName = "")
         {
             bool innerUsedCache = false;
@@ -1299,7 +1299,7 @@ namespace Microsoft.Data.SqlClient
                     timeout,
                     out innerUsedCache,
                     asyncWrite,
-                    inRetry,
+                    isRetry,
                     methodName));
             usedCache = innerUsedCache;
             return result;
@@ -1333,7 +1333,7 @@ namespace Microsoft.Data.SqlClient
                             CommandTimeout,
                             out _,
                             asyncWrite: false,
-                            inRetry: false);
+                            isRetry: false);
                     }
                     else
                     {
@@ -1366,20 +1366,20 @@ namespace Microsoft.Data.SqlClient
         {
             SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.BeginExecuteNonQuery|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             SqlConnection.ExecutePermission.Demand();
-            return BeginExecuteNonQueryInternal(0, callback, stateObject, 0, inRetry: false);
+            return BeginExecuteNonQueryInternal(0, callback, stateObject, 0, isRetry: false);
         }
 
         private IAsyncResult BeginExecuteNonQueryAsync(AsyncCallback callback, object stateObject)
         {
-            return BeginExecuteNonQueryInternal(0, callback, stateObject, CommandTimeout, inRetry: false, asyncWrite: true);
+            return BeginExecuteNonQueryInternal(0, callback, stateObject, CommandTimeout, isRetry: false, asyncWrite: true);
         }
 
-        private IAsyncResult BeginExecuteNonQueryInternal(CommandBehavior behavior, AsyncCallback callback, object stateObject, int timeout, bool inRetry, bool asyncWrite = false)
+        private IAsyncResult BeginExecuteNonQueryInternal(CommandBehavior behavior, AsyncCallback callback, object stateObject, int timeout, bool isRetry, bool asyncWrite = false)
         {
             TaskCompletionSource<object> globalCompletion = new TaskCompletionSource<object>(stateObject);
             TaskCompletionSource<object> localCompletion = new TaskCompletionSource<object>(stateObject);
 
-            if (!inRetry)
+            if (!isRetry)
             {
                 // Reset _pendingCancel upon entry into any Execute - used to synchronize state
                 // between entry into Execute* API and the thread obtaining the stateObject.
@@ -1392,7 +1392,7 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = null;
             try
             {
-                if (!inRetry)
+                if (!isRetry)
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
                     WriteBeginExecuteEvent();
@@ -1408,7 +1408,7 @@ namespace Microsoft.Data.SqlClient
                         timeout,
                         out usedCache,
                         asyncWrite,
-                        inRetry,
+                        isRetry,
                         methodName: nameof(BeginExecuteNonQuery));
 
                     if (execNQ != null)
@@ -1441,7 +1441,7 @@ namespace Microsoft.Data.SqlClient
                         stateObject,
                         timeout,
                         usedCache,
-                        inRetry,
+                        isRetry,
                         asyncWrite,
                         globalCompletion,
                         localCompletion,
@@ -1795,7 +1795,7 @@ namespace Microsoft.Data.SqlClient
             int timeout,
             out bool usedCache,
             bool asyncWrite = false,
-            bool inRetry = false,
+            bool isRetry = false,
             [CallerMemberName] string methodName = "")
         {
             SqlClientEventSource.Log.TryTraceEvent("SqlCommand.InternalExecuteNonQuery | INFO | ObjectId {0}, Client Connection Id {1}, AsyncCommandInProgress={2}",
@@ -1813,7 +1813,7 @@ namespace Microsoft.Data.SqlClient
                 bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
                 // @devnote: this function may throw for an invalid connection
                 // @devnote: returns false for empty command text
-                if (!inRetry)
+                if (!isRetry)
                 {
                     ValidateCommand(isAsync, methodName);
                 }
@@ -1839,7 +1839,7 @@ namespace Microsoft.Data.SqlClient
                     }
 
                     // We should never get here for a retry since we only have retries for parameters.
-                    Debug.Assert(!inRetry);
+                    Debug.Assert(!isRetry);
 
                     task = RunExecuteNonQueryTds(methodName, isAsync, timeout, asyncWrite);
                 }
@@ -1858,7 +1858,7 @@ namespace Microsoft.Data.SqlClient
                         out task,
                         out usedCache,
                         asyncWrite,
-                        inRetry,
+                        isRetry,
                         methodName);
                     
                     if (reader != null)
@@ -1951,20 +1951,20 @@ namespace Microsoft.Data.SqlClient
         {
             SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.BeginExecuteXmlReader|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
             SqlConnection.ExecutePermission.Demand();
-            return BeginExecuteXmlReaderInternal(CommandBehavior.SequentialAccess, callback, stateObject, 0, inRetry: false);
+            return BeginExecuteXmlReaderInternal(CommandBehavior.SequentialAccess, callback, stateObject, 0, isRetry: false);
         }
 
         private IAsyncResult BeginExecuteXmlReaderAsync(AsyncCallback callback, object stateObject)
         {
-            return BeginExecuteXmlReaderInternal(CommandBehavior.SequentialAccess, callback, stateObject, CommandTimeout, inRetry: false, asyncWrite: true);
+            return BeginExecuteXmlReaderInternal(CommandBehavior.SequentialAccess, callback, stateObject, CommandTimeout, isRetry: false, asyncWrite: true);
         }
 
-        private IAsyncResult BeginExecuteXmlReaderInternal(CommandBehavior behavior, AsyncCallback callback, object stateObject, int timeout, bool inRetry, bool asyncWrite = false)
+        private IAsyncResult BeginExecuteXmlReaderInternal(CommandBehavior behavior, AsyncCallback callback, object stateObject, int timeout, bool isRetry, bool asyncWrite = false)
         {
             TaskCompletionSource<object> globalCompletion = new TaskCompletionSource<object>(stateObject);
             TaskCompletionSource<object> localCompletion = new TaskCompletionSource<object>(stateObject);
 
-            if (!inRetry)
+            if (!isRetry)
             {
                 // Reset _pendingCancel upon entry into any Execute - used to synchronize state
                 // between entry into Execute* API and the thread obtaining the stateObject.
@@ -1977,7 +1977,7 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = null;
             try
             {
-                if (!inRetry)
+                if (!isRetry)
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
                     WriteBeginExecuteEvent();
@@ -1997,7 +1997,7 @@ namespace Microsoft.Data.SqlClient
                         out writeTask,
                         out usedCache,
                         asyncWrite,
-                        inRetry);
+                        isRetry);
                 }
                 catch (Exception e)
                 {
@@ -2029,7 +2029,7 @@ namespace Microsoft.Data.SqlClient
                         stateObject,
                         timeout,
                         usedCache,
-                        inRetry,
+                        isRetry,
                         asyncWrite,
                         globalCompletion,
                         localCompletion,
@@ -2235,7 +2235,7 @@ namespace Microsoft.Data.SqlClient
         {
             SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlCommand.BeginExecuteReader|API|Correlation> ObjectID{0}, behavior={1}, ActivityID {2}", ObjectID, (int)behavior, ActivityCorrelator.Current);
             SqlConnection.ExecutePermission.Demand();
-            return BeginExecuteReaderInternal(behavior, callback, stateObject, 0, inRetry: false);
+            return BeginExecuteReaderInternal(behavior, callback, stateObject, 0, isRetry: false);
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteDbDataReader[@name="CommandBehavior"]/*'/>
@@ -2432,15 +2432,15 @@ namespace Microsoft.Data.SqlClient
 
         private IAsyncResult BeginExecuteReaderAsync(CommandBehavior behavior, AsyncCallback callback, object stateObject)
         {
-            return BeginExecuteReaderInternal(behavior, callback, stateObject, CommandTimeout, inRetry: false, asyncWrite: true);
+            return BeginExecuteReaderInternal(behavior, callback, stateObject, CommandTimeout, isRetry: false, asyncWrite: true);
         }
 
-        private IAsyncResult BeginExecuteReaderInternal(CommandBehavior behavior, AsyncCallback callback, object stateObject, int timeout, bool inRetry, bool asyncWrite = false)
+        private IAsyncResult BeginExecuteReaderInternal(CommandBehavior behavior, AsyncCallback callback, object stateObject, int timeout, bool isRetry, bool asyncWrite = false)
         {
             TaskCompletionSource<object> globalCompletion = new TaskCompletionSource<object>(stateObject);
             TaskCompletionSource<object> localCompletion = new TaskCompletionSource<object>(stateObject);
 
-            if (!inRetry)
+            if (!isRetry)
             {
                 // Reset _pendingCancel upon entry into any Execute - used to synchronize state
                 // between entry into Execute* API and the thread obtaining the stateObject.
@@ -2450,7 +2450,7 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = null;
             try
             {
-                if (!inRetry)
+                if (!isRetry)
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
                     WriteBeginExecuteEvent();
@@ -2473,7 +2473,7 @@ namespace Microsoft.Data.SqlClient
                         out writeTask,
                         out usedCache,
                         asyncWrite,
-                        inRetry,
+                        isRetry,
                         nameof(BeginExecuteReader));
                 }
                 catch (Exception e)
@@ -2506,7 +2506,7 @@ namespace Microsoft.Data.SqlClient
                         stateObject,
                         timeout,
                         usedCache,
-                        inRetry,
+                        isRetry,
                         asyncWrite,
                         globalCompletion,
                         localCompletion,
@@ -2536,7 +2536,7 @@ namespace Microsoft.Data.SqlClient
             object stateObject,
             int timeout,
             bool usedCache,
-            bool inRetry,
+            bool isRetry,
             bool asyncWrite,
             TaskCompletionSource<object> globalCompletion,
             TaskCompletionSource<object> localCompletion,
@@ -2545,11 +2545,11 @@ namespace Microsoft.Data.SqlClient
             string endMethod)
         {
             // We shouldn't be using the cache if we are in retry.
-            Debug.Assert(!usedCache || !inRetry);
+            Debug.Assert(!usedCache || !isRetry);
 
             // If column encryption is enabled and we used the cache, we want to catch any potential exceptions that were caused by the query cache and retry if the error indicates that we should.
             // So, try to read the result of the query before completing the overall task and trigger a retry if appropriate.
-            if ((IsColumnEncryptionEnabled && !inRetry && (usedCache || ShouldUseEnclaveBasedWorkflow))
+            if ((IsColumnEncryptionEnabled && !isRetry && (usedCache || ShouldUseEnclaveBasedWorkflow))
 #if DEBUG
                 || _forceInternalEndQuery
 #endif
@@ -2638,7 +2638,13 @@ namespace Microsoft.Data.SqlClient
                                 {
                                     // Kick off the retry.
                                     _internalEndExecuteInitiated = false;
-                                    Task<object> retryTask = (Task<object>)retryFunc(behavior, null, stateObject, TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart), true/*inRetry*/, asyncWrite);
+                                    Task<object> retryTask = (Task<object>)retryFunc(
+                                        behavior,
+                                        null,
+                                        stateObject,
+                                        TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart),
+                                        /*isRetry:*/ true,
+                                        asyncWrite);
 
                                     retryTask.ContinueWith(
                                         static (Task<object> retryTask, object state) =>
@@ -2965,7 +2971,7 @@ namespace Microsoft.Data.SqlClient
                     beginMethod: static (AsyncCallback callback, object stateObject) =>
                     {
                         ExecuteReaderAsyncCallContext args = (ExecuteReaderAsyncCallContext)stateObject;
-                        return args.Command.BeginExecuteReaderInternal(args.CommandBehavior, callback, stateObject, args.Command.CommandTimeout, inRetry: false, asyncWrite: true);
+                        return args.Command.BeginExecuteReaderInternal(args.CommandBehavior, callback, stateObject, args.Command.CommandTimeout, isRetry: false, asyncWrite: true);
                     },
                     endMethod: static (IAsyncResult asyncResult) =>
                     {
@@ -4878,10 +4884,10 @@ namespace Microsoft.Data.SqlClient
             out Task task,
             out bool usedCache,
             bool asyncWrite = false,
-            bool inRetry = false,
+            bool isRetry = false,
             [CallerMemberName] string method = "")
         {
-            bool async = completion != null;
+            bool isAsync = completion != null;
             usedCache = false;
 
             task = null;
@@ -4897,9 +4903,9 @@ namespace Microsoft.Data.SqlClient
 
             // this function may throw for an invalid connection
             // returns false for empty command text
-            if (!inRetry)
+            if (!isRetry)
             {
-                ValidateCommand(async, method);
+                ValidateCommand(isAsync, method);
             }
 
             CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
@@ -4930,8 +4936,8 @@ namespace Microsoft.Data.SqlClient
                 if (IsColumnEncryptionEnabled)
                 {
                     Task returnTask = null;
-                    PrepareForTransparentEncryption(async, timeout, completion, out returnTask, asyncWrite && async, out usedCache, inRetry);
-                    Debug.Assert(usedCache || (async == (returnTask != null)), @"if we didn't use the cache, returnTask should be null if and only if async is false.");
+                    PrepareForTransparentEncryption(isAsync, timeout, completion, out returnTask, asyncWrite && isAsync, out usedCache, isRetry);
+                    Debug.Assert(usedCache || (isAsync == (returnTask != null)), @"if we didn't use the cache, returnTask should be null if and only if async is false.");
 
                     long firstAttemptStart = ADP.TimerCurrent();
 
@@ -4941,18 +4947,18 @@ namespace Microsoft.Data.SqlClient
                             cmdBehavior,
                             runBehavior,
                             returnStream,
-                            async,
+                            isAsync,
                             timeout,
                             out task,
-                            asyncWrite && async,
-                            isRetry: inRetry,
+                            asyncWrite && isAsync,
+                            isRetry: isRetry,
                             ds: null,
                             describeParameterEncryptionTask: returnTask);
                     }
 
                     catch (EnclaveDelegate.RetryableEnclaveQueryExecutionException)
                     {
-                        if (inRetry)
+                        if (isRetry)
                         {
                             throw;
                         }
@@ -4971,8 +4977,8 @@ namespace Microsoft.Data.SqlClient
                             TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart),
                             out task,
                             out usedCache,
-                            async,
-                            inRetry: true,
+                            isAsync,
+                            isRetry: true,
                             method: method);
                     }
 
@@ -4980,7 +4986,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         // We only want to retry once, so don't retry if we are already in retry.
                         // If we didn't use the cache, we don't want to retry.
-                        if (inRetry || (!usedCache && !ShouldUseEnclaveBasedWorkflow))
+                        if (isRetry || (!usedCache && !ShouldUseEnclaveBasedWorkflow))
                         {
                             throw;
                         }
@@ -5019,15 +5025,15 @@ namespace Microsoft.Data.SqlClient
                                 TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart),
                                 out task,
                                 out usedCache,
-                                async,
-                                inRetry: true,
+                                isAsync,
+                                isRetry: true,
                                 method: method);
                         }
                     }
                 }
                 else
                 {
-                    return RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, async, timeout, out task, asyncWrite && async, isRetry: inRetry);
+                    return RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, isAsync, timeout, out task, asyncWrite && isAsync, isRetry: isRetry);
                 }
             }
             catch (System.OutOfMemoryException e)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -490,9 +490,11 @@ namespace Microsoft.Data.SqlClient
             {
                 // Don't allow the connection to be changed while in an async operation.
                 if (_activeConnection != value && _activeConnection != null)
-                { // If new value...
+                {
+                    // If new value...
                     if (CachedAsyncState != null && CachedAsyncState.PendingAsyncOperation)
-                    { // If in pending async state, throw.
+                    {
+                        // If in pending async state, throw.
                         throw SQL.CannotModifyPropertyAsyncOperationInProgress();
                     }
                 }
@@ -658,9 +660,11 @@ namespace Microsoft.Data.SqlClient
             {
                 // Don't allow the transaction to be changed while in an async operation.
                 if (_transaction != value && _activeConnection != null)
-                { // If new value...
+                {
+                    // If new value...
                     if (CachedAsyncState.PendingAsyncOperation)
-                    { // If in pending async state, throw
+                    {
+                        // If in pending async state, throw
                         throw SQL.CannotModifyPropertyAsyncOperationInProgress();
                     }
                 }
@@ -906,7 +910,8 @@ namespace Microsoft.Data.SqlClient
         }
 
         private void PropertyChanging()
-        { // also called from SqlParameterCollection
+        {
+            // also called from SqlParameterCollection
             this.IsDirty = true;
         }
 
@@ -1112,7 +1117,8 @@ namespace Microsoft.Data.SqlClient
                     lock (connection)
                     {
                         if (connection != (_activeConnection.InnerConnection as SqlInternalConnectionTds))
-                        { // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
+                        {
+                            // make sure the connection held on the active connection is what we have stored in our temp connection variable, if not between getting "connection" and taking the lock, the connection has been closed
                             return;
                         }
 
@@ -1129,7 +1135,8 @@ namespace Microsoft.Data.SqlClient
                             bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
 
                             if (!_pendingCancel)
-                            { // Do nothing if aleady pending.
+                            {
+                                // Do nothing if aleady pending.
                               // Before attempting actual cancel, set the _pendingCancel flag to false.
                               // This denotes to other thread before obtaining stateObject from the
                               // session pool that there is another thread wishing to cancel.
@@ -1747,7 +1754,8 @@ namespace Microsoft.Data.SqlClient
                         }
                     }
                     else
-                    { // otherwise, use a full-fledged execute that can handle params and stored procs
+                    {
+                        // otherwise, use a full-fledged execute that can handle params and stored procs
                         SqlDataReader reader = CompleteAsyncExecuteReader(isInternal);
                         if (reader != null)
                         {
@@ -3314,14 +3322,17 @@ namespace Microsoft.Data.SqlClient
             if (sproc != null)
             {
                 if (char.IsDigit(sproc[sproc.Length - 1]))
-                { // If last char is a digit, parse.
+                {
+                    // If last char is a digit, parse.
                     int semicolon = sproc.LastIndexOf(';');
                     if (semicolon != -1)
-                    { // If we found a semicolon, obtain the integer.
+                    {
+                        // If we found a semicolon, obtain the integer.
                         string part = sproc.Substring(semicolon + 1);
                         int number = 0;
                         if (int.TryParse(part, out number))
-                        { // No checking, just fail if this doesn't work.
+                        {
+                            // No checking, just fail if this doesn't work.
                             groupNumber = number;
                             sproc = sproc.Substring(0, semicolon);
                         }
@@ -3482,7 +3493,8 @@ namespace Microsoft.Data.SqlClient
             }
 
             if (!string.IsNullOrEmpty(parsedSProc[2]))
-            { // SchemaName is 3rd element in parsed array
+            {
+                // SchemaName is 3rd element in parsed array
                 SqlParameter param = paramsCmd.Parameters.Add(new SqlParameter("@procedure_schema", SqlDbType.NVarChar, 255));
                 param.Value = UnquoteProcedurePart(parsedSProc[2]);
             }
@@ -5423,7 +5435,8 @@ namespace Microsoft.Data.SqlClient
                 {
                     SqlInternalConnectionTds innerConnectionTds = (_activeConnection.InnerConnection as SqlInternalConnectionTds);
                     if (innerConnectionTds != null)
-                    { // it may be closed
+                    {
+                        // it may be closed
                         innerConnectionTds.DecrementAsyncCount();
                     }
                 }
@@ -5699,7 +5712,8 @@ namespace Microsoft.Data.SqlClient
         private void ValidateAsyncCommand()
         {
             if (CachedAsyncState.PendingAsyncOperation)
-            { // Enforce only one pending async execute at a time.
+            {
+                // Enforce only one pending async execute at a time.
                 if (CachedAsyncState.IsActiveConnectionValid(_activeConnection))
                 {
                     throw SQL.PendingBeginXXXExists();

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -30,17 +30,15 @@ using System.Collections.Concurrent;
 namespace Microsoft.Data.SqlClient
 {
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/SqlCommand/*'/>
-    [
-    DefaultEvent("RecordsAffected"),
-    ToolboxItem(true),
-    DesignerCategory("")
+    [DefaultEvent("RecordsAffected")]
+    [ToolboxItem(true)]
+    [DesignerCategory("")]
     // TODO: Add designer attribute when Microsoft.VSDesigner.Data.VS.SqlCommandDesigner uses Microsoft.Data.SqlClient
-    ]
     public sealed class SqlCommand : DbCommand, ICloneable
     {
         private static int _objectTypeCount; // EventSource Counter
         private const int MaxRPCNameLength = 1046;
-        internal readonly int ObjectID = System.Threading.Interlocked.Increment(ref _objectTypeCount);
+        internal readonly int ObjectID = Interlocked.Increment(ref _objectTypeCount);
 
         internal sealed class ExecuteReaderAsyncCallContext : AAsyncCallContext<SqlCommand, SqlDataReader, CancellationTokenRegistration>
         {
@@ -291,7 +289,7 @@ namespace Microsoft.Data.SqlClient
             }
             internal bool PendingAsyncOperation
             {
-                get { return (_cachedAsyncResult != null); }
+                get { return _cachedAsyncResult != null; }
             }
             internal string EndMethodName
             {
@@ -474,12 +472,10 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Connection/*' />
-        [
-        DefaultValue(null),
-        ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_Connection),
-        ]
+        /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Connection/*'/>
+        [DefaultValue(null)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResDescription(StringsHelper.ResourceNames.DbCommand_Connection)]
         new public SqlConnection Connection
         {
             get
@@ -532,7 +528,7 @@ namespace Microsoft.Data.SqlClient
                         }
                         catch (Exception)
                         {
-                            // we do not really care about errors in unprepare (may be the old connection went bad)                                        
+                            // we do not really care about errors in unprepare (may be the old connection went bad)
                         }
                         finally
                         {
@@ -571,10 +567,8 @@ namespace Microsoft.Data.SqlClient
         private bool IsProviderRetriable => SqlConfigurableRetryFactory.IsRetriable(RetryLogicProvider);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/RetryLogicProvider/*' />
-        [
-        Browsable(false),
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)
-        ]
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public SqlRetryLogicBaseProvider RetryLogicProvider
         {
             get
@@ -592,11 +586,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/NotificationAutoEnlist/*'/>
-        [
-        DefaultValue(true),
-        ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Notification),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.SqlCommand_NotificationAutoEnlist),
-        ]
+        [DefaultValue(true)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Notification)]
+        [ResDescription(StringsHelper.ResourceNames.SqlCommand_NotificationAutoEnlist)]
         public bool NotificationAutoEnlist
         {
             get
@@ -610,12 +602,10 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Notification/*'/>
-        [
-        Browsable(false),
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden), // MDAC 90471
-        ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Notification),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.SqlCommand_Notification),
-        ]
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] // MDAC 90471
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Notification)]
+        [ResDescription(StringsHelper.ResourceNames.SqlCommand_Notification)]
         public SqlNotificationRequest Notification
         {
             get
@@ -646,11 +636,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Transaction/*'/>
-        [
-        Browsable(false),
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_Transaction),
-        ]
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [ResDescription(StringsHelper.ResourceNames.DbCommand_Transaction)]
         new public SqlTransaction Transaction
         {
             get
@@ -693,12 +681,10 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/CommandText/*'/>
-        [
-        DefaultValue(""),
-        RefreshProperties(RefreshProperties.All), // MDAC 67707
-        ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_CommandText),
-        ]
+        [DefaultValue("")]
+        [RefreshProperties(RefreshProperties.All)] // MDAC 67707
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResDescription(StringsHelper.ResourceNames.DbCommand_CommandText)]
         public override string CommandText
         {
             get => _commandText ?? "";
@@ -715,19 +701,15 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ColumnEncryptionSetting/*'/>
-        [
-        Browsable(false),
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden),
-        ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.TCE_SqlCommand_ColumnEncryptionSetting),
-        ]
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResDescription(StringsHelper.ResourceNames.TCE_SqlCommand_ColumnEncryptionSetting)]
         public SqlCommandColumnEncryptionSetting ColumnEncryptionSetting => _columnEncryptionSetting;
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/CommandTimeout/*'/>
-        [
-        ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_CommandTimeout),
-        ]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResDescription(StringsHelper.ResourceNames.DbCommand_CommandTimeout)]
         public override int CommandTimeout
         {
             get
@@ -769,12 +751,10 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/CommandType/*'/>
-        [
-        DefaultValue(System.Data.CommandType.Text),
-        RefreshProperties(RefreshProperties.All),
-        ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_CommandType),
-        ]
+        [DefaultValue(CommandType.Text)]
+        [RefreshProperties(RefreshProperties.All)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResDescription(StringsHelper.ResourceNames.DbCommand_CommandType)]
         public override CommandType CommandType
         {
             get
@@ -808,12 +788,10 @@ namespace Microsoft.Data.SqlClient
         // when the DataAdapter design wizard generates the insert/update/delete commands it will
         // set the DesignTimeVisible property to false so that cmds won't appear as individual objects
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/DesignTimeVisible/*'/>
-        [
-        DefaultValue(true),
-        DesignOnly(true),
-        Browsable(false),
-        EditorBrowsableAttribute(EditorBrowsableState.Never),
-        ]
+        [DefaultValue(true)]
+        [DesignOnly(true)]
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool DesignTimeVisible
         {
             get
@@ -831,11 +809,9 @@ namespace Microsoft.Data.SqlClient
         public bool EnableOptimizedParameterBinding { get; set; }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/Parameters/*'/>
-        [
-        DesignerSerializationVisibility(DesignerSerializationVisibility.Content),
-        ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Data),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_Parameters),
-        ]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Data)]
+        [ResDescription(StringsHelper.ResourceNames.DbCommand_Parameters)]
         new public SqlParameterCollection Parameters
         {
             get
@@ -883,11 +859,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/UpdatedRowSource/*'/>
-        [
-        DefaultValue(System.Data.UpdateRowSource.Both),
-        ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_Update),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_UpdatedRowSource),
-        ]
+        [DefaultValue(UpdateRowSource.Both)]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_Update)]
+        [ResDescription(StringsHelper.ResourceNames.DbCommand_UpdatedRowSource)]
         public override UpdateRowSource UpdatedRowSource
         {
             get
@@ -911,10 +885,8 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/StatementCompleted/*'/>
-        [
-        ResCategoryAttribute(StringsHelper.ResourceNames.DataCategory_StatementCompleted),
-        ResDescriptionAttribute(StringsHelper.ResourceNames.DbCommand_StatementCompleted),
-        ]
+        [ResCategory(StringsHelper.ResourceNames.DataCategory_StatementCompleted)]
+        [ResDescription(StringsHelper.ResourceNames.DbCommand_StatementCompleted)]
         public event StatementCompletedEventHandler StatementCompleted
         {
             add
@@ -1240,7 +1212,8 @@ namespace Microsoft.Data.SqlClient
         protected override void Dispose(bool disposing)
         {
             if (disposing)
-            { // release managed objects
+            {
+                // release managed objects
                 _cachedMetaData = null;
 
                 // reset async cache information to allow a second async execute
@@ -1564,7 +1537,19 @@ namespace Microsoft.Data.SqlClient
 
                 // When we use query caching for parameter encryption we need to retry on specific errors.
                 // In these cases finalize the call internally and trigger a retry when needed.
-                if (!TriggerInternalEndAndRetryIfNecessary(behavior, stateObject, timeout, usedCache, inRetry, asyncWrite, globalCompletion, localCompletion, InternalEndExecuteNonQuery, BeginExecuteNonQueryInternal, nameof(EndExecuteNonQuery)))
+                if (
+                    !TriggerInternalEndAndRetryIfNecessary(
+                        behavior,
+                        stateObject,
+                        timeout,
+                        usedCache,
+                        inRetry,
+                        asyncWrite,
+                        globalCompletion,
+                        localCompletion,
+                        InternalEndExecuteNonQuery,
+                        BeginExecuteNonQueryInternal,
+                        nameof(EndExecuteNonQuery)))
                 {
                     globalCompletion = localCompletion;
                 }
@@ -2140,7 +2125,19 @@ namespace Microsoft.Data.SqlClient
 
                 // When we use query caching for parameter encryption we need to retry on specific errors.
                 // In these cases finalize the call internally and trigger a retry when needed.
-                if (!TriggerInternalEndAndRetryIfNecessary(behavior, stateObject, timeout, usedCache, inRetry, asyncWrite, globalCompletion, localCompletion, InternalEndExecuteReader, BeginExecuteXmlReaderInternal, nameof(EndExecuteXmlReader)))
+                if (
+                    !TriggerInternalEndAndRetryIfNecessary(
+                        behavior,
+                        stateObject,
+                        timeout,
+                        usedCache,
+                        inRetry,
+                        asyncWrite,
+                        globalCompletion,
+                        localCompletion,
+                        InternalEndExecuteReader,
+                        BeginExecuteXmlReaderInternal,
+                        nameof(EndExecuteXmlReader)))
                 {
                     globalCompletion = localCompletion;
                 }
@@ -2194,10 +2191,7 @@ namespace Microsoft.Data.SqlClient
             {
                 // Similarly, if an exception occurs put the stateObj back into the pool.
                 // and reset async cache information to allow a second async execute
-                if (_cachedAsyncState != null)
-                {
-                    _cachedAsyncState.ResetAsyncState();
-                }
+                _cachedAsyncState?.ResetAsyncState();
                 ReliablePutStateObject();
                 completion.TrySetException(e);
             }
@@ -2254,7 +2248,9 @@ namespace Microsoft.Data.SqlClient
             int? sqlExceptionNumber = null;
             try
             {
-                XmlReader result = CompleteXmlReader(InternalEndExecuteReader(asyncResult, isInternal: false, nameof(EndExecuteXmlReader)), true);
+                XmlReader result = CompleteXmlReader(
+                    InternalEndExecuteReader(asyncResult, isInternal: false,  nameof(EndExecuteXmlReader)),
+                    isAsync: true);
                 success = true;
                 return result;
             }
@@ -2288,7 +2284,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private XmlReader CompleteXmlReader(SqlDataReader ds, bool async = false)
+        private XmlReader CompleteXmlReader(SqlDataReader ds, bool isAsync = false)
         {
             XmlReader xr = null;
 
@@ -2302,7 +2298,7 @@ namespace Microsoft.Data.SqlClient
                 try
                 {
                     SqlStream sqlBuf = new SqlStream(ds, true /*addByteOrderMark*/, (md[0].SqlDbType == SqlDbType.Xml) ? false : true /*process all rows*/);
-                    xr = sqlBuf.ToXmlReader(async);
+                    xr = sqlBuf.ToXmlReader(isAsync);
                 }
                 catch (Exception e)
                 {
@@ -2323,17 +2319,11 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteXmlReader[@name="default"]/*'/>
         [System.Security.Permissions.HostProtectionAttribute(ExternalThreading = true)]
-        public IAsyncResult BeginExecuteReader()
-        {
-            return BeginExecuteReader(null, null, CommandBehavior.Default);
-        }
+        public IAsyncResult BeginExecuteReader() => BeginExecuteReader(null, null, CommandBehavior.Default);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/BeginExecuteXmlReader[@name="AsyncCallbackAndstateObject"]/*'/>
         [System.Security.Permissions.HostProtectionAttribute(ExternalThreading = true)]
-        public IAsyncResult BeginExecuteReader(AsyncCallback callback, object stateObject)
-        {
-            return BeginExecuteReader(callback, stateObject, CommandBehavior.Default);
-        }
+        public IAsyncResult BeginExecuteReader(AsyncCallback callback, object stateObject) => BeginExecuteReader(callback, stateObject, CommandBehavior.Default);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteDbDataReader[@name="CommandBehavior"]/*'/>
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
@@ -2489,7 +2479,10 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 statistics = SqlStatistics.StartTimer(Statistics);
-                SqlDataReader result = InternalEndExecuteReader(asyncResult, isInternal: false, nameof(EndExecuteReader));
+                SqlDataReader result = InternalEndExecuteReader(
+                    asyncResult,
+                    isInternal: false,
+                    nameof(EndExecuteReader));
                 success = true;
                 return result;
             }
@@ -2614,7 +2607,19 @@ namespace Microsoft.Data.SqlClient
 
                 // When we use query caching for parameter encryption we need to retry on specific errors.
                 // In these cases finalize the call internally and trigger a retry when needed.
-                if (!TriggerInternalEndAndRetryIfNecessary(behavior, stateObject, timeout, usedCache, inRetry, asyncWrite, globalCompletion, localCompletion, InternalEndExecuteReader, BeginExecuteReaderInternal, nameof(EndExecuteReader)))
+                if (
+                    !TriggerInternalEndAndRetryIfNecessary(
+                        behavior,
+                        stateObject,
+                        timeout,
+                        usedCache,
+                        inRetry,
+                        asyncWrite,
+                        globalCompletion,
+                        localCompletion,
+                        InternalEndExecuteReader,
+                        BeginExecuteReaderInternal,
+                        nameof(EndExecuteReader)))
                 {
                     globalCompletion = localCompletion;
                 }
@@ -2680,7 +2685,7 @@ namespace Microsoft.Data.SqlClient
                             // lock on _stateObj prevents races with close/cancel.
                             lock (_stateObj)
                             {
-                                endFunc(tsk, true/*inInternal*/, endMethod);
+                                endFunc(tsk, /*isInternal:*/ true, endMethod);
                             }
                             globalCompletion.TrySetResult(tsk.Result);
                         }
@@ -2837,10 +2842,7 @@ namespace Microsoft.Data.SqlClient
             {
                 // Similarly, if an exception occurs put the stateObj back into the pool.
                 // and reset async cache information to allow a second async execute
-                if (_cachedAsyncState != null)
-                {
-                    _cachedAsyncState.ResetAsyncState();
-                }
+                _cachedAsyncState?.ResetAsyncState();
                 ReliablePutStateObject();
                 completion.TrySetException(e);
             }
@@ -3146,61 +3148,62 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     SqlDataReader reader = executeTask.Result;
-                    reader.ReadAsync(cancellationToken).ContinueWith((readTask) =>
-                    {
-                        try
+                    reader.ReadAsync(cancellationToken)
+                        .ContinueWith((Task<bool> readTask) =>
                         {
-                            if (readTask.IsCanceled)
+                            try
                             {
-                                reader.Dispose();
-                                source.SetCanceled();
-                            }
-                            else if (readTask.IsFaulted)
-                            {
-                                reader.Dispose();
-                                source.SetException(readTask.Exception.InnerException);
-                            }
-                            else
-                            {
-                                Exception exception = null;
-                                object result = null;
-                                try
-                                {
-                                    bool more = readTask.Result;
-                                    if (more && reader.FieldCount > 0)
-                                    {
-                                        try
-                                        {
-                                            result = reader.GetValue(0);
-                                        }
-                                        catch (Exception e)
-                                        {
-                                            exception = e;
-                                        }
-                                    }
-                                }
-                                finally
+                                if (readTask.IsCanceled)
                                 {
                                     reader.Dispose();
+                                    source.SetCanceled();
                                 }
-                                if (exception != null)
+                                else if (readTask.IsFaulted)
                                 {
-                                    source.SetException(exception);
+                                    reader.Dispose();
+                                    source.SetException(readTask.Exception.InnerException);
                                 }
                                 else
                                 {
-                                    source.SetResult(result);
+                                    Exception exception = null;
+                                    object result = null;
+                                    try
+                                    {
+                                        bool more = readTask.Result;
+                                        if (more && reader.FieldCount > 0)
+                                        {
+                                            try
+                                            {
+                                                result = reader.GetValue(0);
+                                            }
+                                            catch (Exception e)
+                                            {
+                                                exception = e;
+                                            }
+                                        }
+                                    }
+                                    finally
+                                    {
+                                        reader.Dispose();
+                                    }
+                                    if (exception != null)
+                                    {
+                                        source.SetException(exception);
+                                    }
+                                    else
+                                    {
+                                        source.SetResult(result);
+                                    }
                                 }
                             }
-                        }
-                        catch (Exception e)
-                        {
-                            // exception thrown by Dispose...
-                            source.SetException(e);
-                        }
-                    },
-                    TaskScheduler.Default
-                );
+                            catch (Exception e)
+                            {
+                                // exception thrown by Dispose...
+                                source.SetException(e);
+                            }
+                        },
+                        TaskScheduler.Default
+                    );
                 }
                 return source.Task;
             }, TaskScheduler.Default).Unwrap();
@@ -3507,7 +3510,7 @@ namespace Microsoft.Data.SqlClient
 
             // Use common parser for SqlClient and OleDb - parse into 4 parts - Server, Catalog, Schema, ProcedureName
             string[] parsedSProc = MultipartIdentifier.ParseMultipartIdentifier(CommandText, "[\"", "]\"", Strings.SQL_SqlCommandCommandText, false);
-            if (parsedSProc[3] == null || string.IsNullOrEmpty(parsedSProc[3]))
+            if (string.IsNullOrEmpty(parsedSProc[3]))
             {
                 throw ADP.NoStoredProcedureExists(CommandText);
             }
@@ -3962,7 +3965,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <summary>
         /// Resets the encryption related state of the command object and each of the parameters.
-        /// BatchRPC doesn't need special handling to cleanup the state of each RPC object and its parameters since a new RPC object and 
+        /// BatchRPC doesn't need special handling to cleanup the state of each RPC object and its parameters since a new RPC object and
         /// parameters are generated on every execution.
         /// </summary>
         private void ResetEncryptionState()
@@ -4450,16 +4453,17 @@ namespace Microsoft.Data.SqlClient
 #endif
 
                 // Execute the RPC.
-                return RunExecuteReaderTds(CommandBehavior.Default,
-                                            runBehavior: RunBehavior.ReturnImmediately, // Other RunBehavior modes will skip reading rows.
-                                            returnStream: true,
-                                            async: async,
-                                            timeout: timeout,
-                                            task: out task,
-                                            asyncWrite: asyncWrite,
-                                            inRetry: false,
-                                            ds: null,
-                                            describeParameterEncryptionRequest: true);
+                return RunExecuteReaderTds(
+                    CommandBehavior.Default,
+                    runBehavior: RunBehavior.ReturnImmediately, // Other RunBehavior modes will skip reading rows.
+                    returnStream: true,
+                    async: async,
+                    timeout: timeout,
+                    task: out task,
+                    asyncWrite: asyncWrite,
+                    inRetry: false,
+                    ds: null,
+                    describeParameterEncryptionRequest: true);
             }
             else
             {
@@ -4494,7 +4498,7 @@ namespace Microsoft.Data.SqlClient
 
             // Construct the RPC request for sp_describe_parameter_encryption
             // sp_describe_parameter_encryption always has 2 parameters (stmt, paramlist).
-            //sp_describe_parameter_encryption can have an optional 3rd parameter (attestationParametes), used to identify and execute attestation protocol
+            // sp_describe_parameter_encryption can have an optional 3rd parameter (attestationParameters), used to identify and execute attestation protocol
             GetRPCObject(attestationParameters == null ? 2 : 3, 0, ref describeParameterEncryptionRequest, forSpDescribeParameterEncryption: true);
             describeParameterEncryptionRequest.rpcName = "sp_describe_parameter_encryption";
 
@@ -4861,7 +4865,7 @@ namespace Microsoft.Data.SqlClient
                         SqlParameter sqlParameter = rpc.userParams[index];
                         if (!sqlParameter.HasReceivedMetadata && sqlParameter.Direction != ParameterDirection.ReturnValue)
                         {
-                            // Encryption MD wasn't sent by the server - we expect the metadata to be sent for all the parameters 
+                            // Encryption MD wasn't sent by the server - we expect the metadata to be sent for all the parameters
                             // that were sent in the original sp_describe_parameter_encryption but not necessarily for return values,
                             // since there might be multiple return values but server will only send for one of them.
                             // For parameters that don't need encryption, the encryption type is set to plaintext.
@@ -4947,7 +4951,7 @@ namespace Microsoft.Data.SqlClient
             bool returnStream,
             [CallerMemberName] string method = "")
         {
-            Task unused; // sync execution 
+            Task unused; // sync execution
             SqlDataReader reader = RunExecuteReader(
                 cmdBehavior,
                 runBehavior,
@@ -4962,7 +4966,7 @@ namespace Microsoft.Data.SqlClient
             return reader;
         }
 
-        // task is created in case of pending asynchronous write, returned SqlDataReader should not be utilized until that task is complete 
+        // task is created in case of pending asynchronous write, returned SqlDataReader should not be utilized until that task is complete
         internal SqlDataReader RunExecuteReader(
             CommandBehavior cmdBehavior,
             RunBehavior runBehavior,
@@ -6405,7 +6409,6 @@ namespace Microsoft.Data.SqlClient
             return rpc;
         }
 
-
         //
         // returns true if the parameter is not a return value
         // and it's value is not DBNull (for a nullable parameter)
@@ -6428,7 +6431,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private int CountSendableParameters(SqlParameterCollection parameters)
+        private static int CountSendableParameters(SqlParameterCollection parameters)
         {
             int cParams = 0;
 
@@ -6461,11 +6464,12 @@ namespace Microsoft.Data.SqlClient
             int userParameterCount = CountSendableParameters(parameters);
             GetRPCObject(0, userParameterCount, ref rpc);
 
+            rpc.ProcID = 0;
+
             // TDS Protocol allows rpc name with maximum length of 1046 bytes for ProcName
             // 4-part name 1 + 128 + 1 + 1 + 1 + 128 + 1 + 1 + 1 + 128 + 1 + 1 + 1 + 128 + 1 = 523
             // each char takes 2 bytes. 523 * 2 = 1046
             int commandTextLength = ADP.CharSize * CommandText.Length;
-            rpc.ProcID = 0;
             if (commandTextLength <= MaxRPCNameLength)
             {
                 rpc.rpcName = CommandText; // just get the raw command text
@@ -6500,8 +6504,8 @@ namespace Microsoft.Data.SqlClient
             //@handle
             SqlParameter sqlParam = rpc.systemParams[0];
             sqlParam.SqlDbType = SqlDbType.Int;
-            sqlParam.Value = _prepareHandle;
             sqlParam.Size = 4;
+            sqlParam.Value = _prepareHandle;
             sqlParam.Direction = ParameterDirection.Input;
 
             SetUpRPCParameters(rpc, inSchema, _parameters);
@@ -6629,7 +6633,7 @@ namespace Microsoft.Data.SqlClient
                     parameter = parameters[index];
                     // Possibility of a SQL Injection issue through parameter names and how to construct valid identifier for parameters.
                     // Since the parameters comes from application itself, there should not be a security vulnerability.
-                    // Also since the query is not executed, but only analyzed there is no possibility for elevation of priviledge, but only for 
+                    // Also since the query is not executed, but only analyzed there is no possibility for elevation of privilege, but only for
                     // incorrect results which would only affect the user that attempts the injection.
                     execStatement.Append(' ');
                     SqlParameter.AppendPrefixedParameterName(execStatement, parameter.ParameterName);
@@ -6637,10 +6641,8 @@ namespace Microsoft.Data.SqlClient
                     SqlParameter.AppendPrefixedParameterName(execStatement, parameter.ParameterName);
 
                     // InputOutput and Output parameters need to be marked as such.
-                    if (
-                        parameter.Direction == ParameterDirection.Output ||
-                        parameter.Direction == ParameterDirection.InputOutput
-                    )
+                    if (parameter.Direction == ParameterDirection.Output ||
+                        parameter.Direction == ParameterDirection.InputOutput)
                     {
                         execStatement.AppendFormat(@" OUTPUT");
                     }
@@ -6699,6 +6701,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     paramList.Append(',');
                 }
+
                 SqlParameter.AppendPrefixedParameterName(paramList, sqlParam.ParameterName);
 
                 MetaType mt = sqlParam.InternalMetaType;
@@ -6732,7 +6735,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     // func will change type to that with a 4 byte length if the type has a two
-                    // byte length and a parameter length > than that expressable in 2 bytes
+                    // byte length and a parameter length > than that expressible in 2 bytes
                     mt = sqlParam.ValidateTypeLengths();
                     if ((!mt.IsPlp) && (sqlParam.Direction != ParameterDirection.Output))
                     {
@@ -6770,6 +6773,9 @@ namespace Microsoft.Data.SqlClient
                 }
                 else if (mt.SqlDbType == SqlDbTypeExtensions.Vector)
                 {
+                    // The validate function for SqlParameters would
+                    // have already thrown InvalidCastException if an incompatible
+                    // value is specified for SqlDbType Vector.
                     var sqlVectorProps = (ISqlVector)sqlParam.Value;
                     paramList.Append('(');
                     paramList.Append(sqlVectorProps.Length);
@@ -7070,17 +7076,14 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         private void SetColumnEncryptionSetting(SqlCommandColumnEncryptionSetting newColumnEncryptionSetting)
         {
-            if (!this._wasBatchModeColumnEncryptionSettingSetOnce)
+            if (!_wasBatchModeColumnEncryptionSettingSetOnce)
             {
-                this._columnEncryptionSetting = newColumnEncryptionSetting;
-                this._wasBatchModeColumnEncryptionSettingSetOnce = true;
+                _columnEncryptionSetting = newColumnEncryptionSetting;
+                _wasBatchModeColumnEncryptionSettingSetOnce = true;
             }
-            else
+            else if (_columnEncryptionSetting != newColumnEncryptionSetting)
             {
-                if (this._columnEncryptionSetting != newColumnEncryptionSetting)
-                {
-                    throw SQL.BatchedUpdateColumnEncryptionSettingMismatch();
-                }
+                throw SQL.BatchedUpdateColumnEncryptionSettingMismatch();
             }
         }
 


### PR DESCRIPTION
## Description
This PR is a collection of changes to both SqlCommand implementations to bring them closer together. Although the bulk of SqlCommand is the same, it is a huge class and very hard to reconcile all the differences cleanly. I have no idea what's the best way to handle this merge, so I figure I'll do it in chunks that will be digestible.

In this installment, I've tried to tackle the small differences that are just really annoying to go through. These changes includes:
* Aligning method arguments that are `[CallerMemberName]` and calls to such methods
* Sync formatting for method attributes
* Sync method signatures:
  * TriggerInternalEndAndRetryIfNecessary
  * PrepareForTransparentEncryption
  * TryFetchInputParameterEncryptionInfo
  * ReadDescribeEncryptionParameterResults
  * RunExecuteNonQueryTds
  * RunExecuteReaderTdsWithTransparentParameterEncryption
  * RunExecuteReaderTds
  * OnDone
* Align names
  * KeysToBeSentToEnclave
  * RequiresEnclaveComputations
  * ShouldCacheEncryptionMetadata
* Align visibility
  * CancelIgnoreFailureCallback
  * CancelIgnoreFailure
* Align ordering
  * ExecuteReader methods
  * CancelIgnoreFailureCallback
  * CancelIgnoreFailure
  * Clone, ICloneable.Clone
* Remove unsed debug methods CompletePendingReadWithSuccess CompletePendingReadWithFailure
* Sync method body expression formatting
  * BeginExecuteReader*
  * ExecuteNonQueryAsync*
  * ExecuteReaderAsync*
  * ExecuteXmReaderAsync*
* Sync _prepareHandle type
* Rename CachedAsyncState to AsyncState, change name of property to CachedAsyncState, replace usages of _cachedAsyncState to the property **this could be dangerous**
* Sync async parameters/variables to `isAsync`
* Sync inRetry parameters to `isRetry`
* Sync event/trace/correlation messages to netcore style
* Sync/fix typos, low-risk formatting changes

## Issues


## Testing
Code changes are pretty low stakes syncing between the two implementations. CI should be suitable to vaidate.