### PR TITLE
[6.1] Fix TryReadPlpBytes throws ArgumentException

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -13362,6 +13362,13 @@ namespace Microsoft.Data.SqlClient
                     break;
                 }
             }
+
+            if (writeDataSizeToSnapshot)
+            {
+                stateObj.SetSnapshotStorage(null);
+                stateObj.ClearSnapshotDataSize();
+            }
+
             return TdsOperationStatus.Done;
 
             static int IncrementSnapshotDataSize(TdsParserStateObject stateObj, bool resetting, int previousPacketId, int value)
@@ -13381,7 +13388,7 @@ namespace Microsoft.Data.SqlClient
                         current = 0;
                     }
 
-                    stateObj.SetSnapshotDataSize(current + value);
+                    stateObj.AddSnapshotDataSize(current + value);
 
                     // return new packetid so next time we see this packet we know it isn't new
                     return currentPacketId;
@@ -13389,7 +13396,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     current = stateObj.GetSnapshotDataSize();
-                    stateObj.SetSnapshotDataSize(current + value);
+                    stateObj.AddSnapshotDataSize(current + value);
                     return previousPacketId;
                 }
             }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -13544,6 +13544,13 @@ namespace Microsoft.Data.SqlClient
                     break;
                 }
             }
+
+            if (writeDataSizeToSnapshot)
+            {
+                stateObj.SetSnapshotStorage(null);
+                stateObj.ClearSnapshotDataSize();
+            }
+
             return TdsOperationStatus.Done;
 
             static int IncrementSnapshotDataSize(TdsParserStateObject stateObj, bool resetting, int previousPacketId, int value)
@@ -13563,7 +13570,7 @@ namespace Microsoft.Data.SqlClient
                         current = 0;
                     }
 
-                    stateObj.SetSnapshotDataSize(current + value);
+                    stateObj.AddSnapshotDataSize(current + value);
 
                     // return new packetid so next time we see this packet we know it isn't new
                     return currentPacketId;
@@ -13571,7 +13578,7 @@ namespace Microsoft.Data.SqlClient
                 else
                 {
                     current = stateObj.GetSnapshotDataSize();
-                    stateObj.SetSnapshotDataSize(current + value);
+                    stateObj.AddSnapshotDataSize(current + value);
                     return previousPacketId;
                 }
             }


### PR DESCRIPTION
## Description

Ports #3470 to release/6.1

> In the reproduction shared in https://github.com/dotnet/SqlClient/issues/3463 multiple reads of text fields are ddone in sequence with different lengths until a particular scenario occurs. The situation that causes the error is that a multi-packet text read completes on the third packet of an async operation and the lengths of the text sections in the packets align such that the third packet completes one text read followed by the another text read from the same packet but for a different column.
This hard to reach set of circumstances causes the read logic to see a text read starting in a ContinueReplay state when another read has finished on the same packet and the error is caused by the first completed read leaving behind the data packet byte count used when it completed.

>The fix is much easier than trying to replicate and understand the error. We simply need to clean up the data lengths and buffer when we successfully read a value. I've added this logic to the place where the bug was found and precautionarily to the other place in the codebase that does similar logic (one for bytes, one for chars).

>Creating a test and runs quickly enough to be reliable in the CI is prohibitively difficult. I haven't been able to go anything that needs fewer than 1600 iterations of large text reads. In this case I feel that the fix is obvious enough that existing coverage may be enough.

>This also removes the asserts pointed out as problematic in https://github.com/dotnet/SqlClient/issues/3385 i've reviewed them and they're no longer applicable, they were too stringent for the more relaxed buffer handing used when moving from replay to continue states.

## Issues

fixes https://github.com/dotnet/SqlClient/issues/3463
fixes https://github.com/dotnet/SqlClient/issues/3385
