### PR TITLE
[6.1] Align SqlException Numbers across platforms

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Unix.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Unix.cs
@@ -23,20 +23,18 @@ namespace Microsoft.Data.SqlClient
             // No - Op
         }
 
-        private SNIErrorDetails GetSniErrorDetails()
+        private TdsParserStateObject.SniErrorDetails GetSniErrorDetails()
         {
-            SNIErrorDetails details;
             SniError sniError = SniProxy.Instance.GetLastError();
-            details.sniErrorNumber = sniError.sniError;
-            details.errorMessage = sniError.errorMessage;
-            details.nativeError = sniError.nativeError;
-            details.provider = (int)sniError.provider;
-            details.lineNumber = sniError.lineNumber;
-            details.function = sniError.function;
-            details.exception = sniError.exception;
-            
-            return details;
-        }
 
+            return new(
+                sniError.errorMessage,
+                sniError.nativeError,
+                sniError.sniError,
+                (int)sniError.provider,
+                sniError.lineNumber,
+                sniError.function,
+                sniError.exception);
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1507,7 +1507,7 @@ namespace Microsoft.Data.SqlClient
                 string providerRid = string.Format("SNI_PN{0}", details.provider);
                 string providerName = StringsHelper.GetResourceString(providerRid);
                 Debug.Assert(!string.IsNullOrEmpty(providerName), $"invalid providerResourceId '{providerRid}'");
-                uint win32ErrorCode = details.nativeError;
+                int win32ErrorCode = details.NativeError;
 
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > SNI Native Error Code = {0}", win32ErrorCode);
                 if (details.sniErrorNumber == 0)
@@ -1557,7 +1557,7 @@ namespace Microsoft.Data.SqlClient
                         // If its a LocalDB error, then nativeError actually contains a LocalDB-specific error code, not a win32 error code
                         if (details.sniErrorNumber == SniErrors.LocalDBErrorCode)
                         {
-                            errorMessage += LocalDbApi.GetLocalDbMessage((int)details.nativeError);
+                            errorMessage += LocalDbApi.GetLocalDbMessage(details.NativeError);
                             win32ErrorCode = 0;
                         }
                         SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Extracting the latest exception from native SNI. errorMessage: {0}", errorMessage);
@@ -1567,10 +1567,10 @@ namespace Microsoft.Data.SqlClient
                     sqlContextInfo, providerName, (int)details.sniErrorNumber, errorMessage);
 
                 SqlClientEventSource.Log.TryAdvancedTraceErrorEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > SNI Error Message. Native Error = {0}, Line Number ={1}, Function ={2}, Exception ={3}, Server = {4}",
-                    (int)details.nativeError, (int)details.lineNumber, details.function, details.exception, _server);
+                    details.NativeError, (int)details.LineNumber, details.Function, details.Exception, _server);
 
-                return new SqlError(infoNumber: (int)details.nativeError, errorState: 0x00, TdsEnums.FATAL_ERROR_CLASS, _server,
-                    errorMessage, details.function, (int)details.lineNumber, win32ErrorCode: details.nativeError, details.exception);
+                return new SqlError(infoNumber: details.NativeError, errorState: 0x00, TdsEnums.FATAL_ERROR_CLASS, _server,
+                    errorMessage, details.Function, (int)details.LineNumber, win32ErrorCode: details.NativeError, details.Exception);
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1450,12 +1450,12 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.ProcessSNIError|ERR> SNIContext must not be None = {0}, _fMARS = {1}, TDS Parser State = {2}", stateObj.DebugOnlyCopyOfSniContext, _fMARS, _state);
 
 #endif
-                SNIErrorDetails details = GetSniErrorDetails();
+                TdsParserStateObject.SniErrorDetails details = GetSniErrorDetails();
 
-                if (details.sniErrorNumber != 0)
+                if (details.SniErrorNumber != 0)
                 {
                     // handle special SNI error codes that are converted into exception which is not a SqlException.
-                    switch (details.sniErrorNumber)
+                    switch (details.SniErrorNumber)
                     {
                         case SniErrors.MultiSubnetFailoverWithMoreThan64IPs:
                             // Connecting with the MultiSubnetFailover connection option to a SQL Server instance configured with more than 64 IP addresses is not supported.
@@ -1476,8 +1476,8 @@ namespace Microsoft.Data.SqlClient
                 }
                 // PInvoke code automatically sets the length of the string for us
                 // So no need to look for \0
-                string errorMessage = details.errorMessage;
-                SqlClientEventSource.Log.TryAdvancedTraceEvent("< sc.TdsParser.ProcessSNIError |ERR|ADV > Error message Detail: {0}", details.errorMessage);
+                string errorMessage = details.ErrorMessage;
+                SqlClientEventSource.Log.TryAdvancedTraceEvent("< sc.TdsParser.ProcessSNIError |ERR|ADV > Error message Detail: {0}", details.ErrorMessage);
 
                 /*  Format SNI errors and add Context Information
                  *
@@ -1494,23 +1494,23 @@ namespace Microsoft.Data.SqlClient
 
                 if (TdsParserStateObjectFactory.UseManagedSNI)
                 {
-                    Debug.Assert(!string.IsNullOrEmpty(details.errorMessage) || details.sniErrorNumber != 0, "Empty error message received from SNI");
-                    SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}, SNI Error Number ={1}", details.errorMessage, details.sniErrorNumber);
+                    Debug.Assert(!string.IsNullOrEmpty(details.ErrorMessage) || details.SniErrorNumber != 0, "Empty error message received from SNI");
+                    SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}, SNI Error Number ={1}", details.ErrorMessage, details.SniErrorNumber);
                 }
                 else
                 {
-                    Debug.Assert(!string.IsNullOrEmpty(details.errorMessage), "Empty error message received from SNI");
-                    SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}", details.errorMessage);
+                    Debug.Assert(!string.IsNullOrEmpty(details.ErrorMessage), "Empty error message received from SNI");
+                    SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}", details.ErrorMessage);
                 }
 
                 string sqlContextInfo = StringsHelper.GetResourceString(stateObj.SniContext.ToString());
-                string providerRid = string.Format("SNI_PN{0}", details.provider);
+                string providerRid = string.Format("SNI_PN{0}", details.Provider);
                 string providerName = StringsHelper.GetResourceString(providerRid);
                 Debug.Assert(!string.IsNullOrEmpty(providerName), $"invalid providerResourceId '{providerRid}'");
                 int win32ErrorCode = details.NativeError;
 
                 SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > SNI Native Error Code = {0}", win32ErrorCode);
-                if (details.sniErrorNumber == 0)
+                if (details.SniErrorNumber == 0)
                 {
                     // Provider error. The message from provider is preceeded with non-localizable info from SNI
                     // strip provider info from SNI
@@ -1544,7 +1544,7 @@ namespace Microsoft.Data.SqlClient
                     if (TdsParserStateObjectFactory.UseManagedSNI)
                     {
                         // SNI error. Append additional error message info if available and hasn't been included.
-                        string sniLookupMessage = SQL.GetSNIErrorMessage(details.sniErrorNumber);
+                        string sniLookupMessage = SQL.GetSNIErrorMessage(details.SniErrorNumber);
                         errorMessage = (string.IsNullOrEmpty(errorMessage) || errorMessage.Contains(sniLookupMessage))
                                         ? sniLookupMessage
                                         : (sniLookupMessage + ": " + errorMessage);
@@ -1552,10 +1552,10 @@ namespace Microsoft.Data.SqlClient
                     else
                     {
                         // SNI error. Replace the entire message.
-                        errorMessage = SQL.GetSNIErrorMessage(details.sniErrorNumber);
+                        errorMessage = SQL.GetSNIErrorMessage(details.SniErrorNumber);
 
                         // If its a LocalDB error, then nativeError actually contains a LocalDB-specific error code, not a win32 error code
-                        if (details.sniErrorNumber == SniErrors.LocalDBErrorCode)
+                        if (details.SniErrorNumber == SniErrors.LocalDBErrorCode)
                         {
                             errorMessage += LocalDbApi.GetLocalDbMessage(details.NativeError);
                             win32ErrorCode = 0;
@@ -1564,7 +1564,7 @@ namespace Microsoft.Data.SqlClient
                     }
                 }
                 errorMessage = string.Format("{0} (provider: {1}, error: {2} - {3})",
-                    sqlContextInfo, providerName, (int)details.sniErrorNumber, errorMessage);
+                    sqlContextInfo, providerName, (int)details.SniErrorNumber, errorMessage);
 
                 SqlClientEventSource.Log.TryAdvancedTraceErrorEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > SNI Error Message. Native Error = {0}, Line Number ={1}, Function ={2}, Exception ={3}, Server = {4}",
                     details.NativeError, (int)details.LineNumber, details.Function, details.Exception, _server);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.netcore.cs
@@ -10,17 +10,6 @@ namespace Microsoft.Data.SqlClient
 {
     internal sealed partial class TdsParser
     {
-        internal struct SNIErrorDetails
-        {
-            public string errorMessage;
-            public uint nativeError;
-            public uint sniErrorNumber;
-            public int provider;
-            public uint lineNumber;
-            public string function;
-            public Exception exception;
-        }
-
         internal static void FillGuidBytes(Guid guid, Span<byte> buffer) => guid.TryWriteBytes(buffer);
 
         internal static void FillDoubleBytes(double value, Span<byte> buffer) => BinaryPrimitives.TryWriteInt64LittleEndian(buffer, BitConverter.DoubleToInt64Bits(value));

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1589,7 +1589,7 @@ namespace Microsoft.Data.SqlClient
             string providerRid = string.Format("SNI_PN{0}", (int)details.provider);
             string providerName = StringsHelper.GetString(providerRid);
             Debug.Assert(!string.IsNullOrEmpty(providerName), $"invalid providerResourceId '{providerRid}'");
-            uint win32ErrorCode = details.nativeError;
+            int win32ErrorCode = details.NativeError;
 
             if (details.sniError == 0)
             {
@@ -1627,15 +1627,15 @@ namespace Microsoft.Data.SqlClient
                 // If its a LocalDB error, then nativeError actually contains a LocalDB-specific error code, not a win32 error code
                 if (details.sniError == SniErrors.LocalDBErrorCode)
                 {
-                    errorMessage += LocalDbApi.GetLocalDbMessage((int)details.nativeError);
+                    errorMessage += LocalDbApi.GetLocalDbMessage(details.NativeError);
                     win32ErrorCode = 0;
                 }
             }
             errorMessage = string.Format("{0} (provider: {1}, error: {2} - {3})",
                 sqlContextInfo, providerName, (int)details.sniError, errorMessage);
 
-            return new SqlError((int)details.nativeError, 0x00, TdsEnums.FATAL_ERROR_CLASS,
-                                _server, errorMessage, details.function, (int)details.lineNumber, win32ErrorCode);
+            return new SqlError(details.NativeError, 0x00, TdsEnums.FATAL_ERROR_CLASS,
+                                _server, errorMessage, details.Function, (int)details.LineNumber, win32ErrorCode);
         }
 
         internal void CheckResetConnection(TdsParserStateObject stateObj)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -1589,7 +1589,7 @@ namespace Microsoft.Data.SqlClient
             string providerRid = string.Format("SNI_PN{0}", (int)details.provider);
             string providerName = StringsHelper.GetString(providerRid);
             Debug.Assert(!string.IsNullOrEmpty(providerName), $"invalid providerResourceId '{providerRid}'");
-            int win32ErrorCode = details.NativeError;
+            int win32ErrorCode = details.nativeError;
 
             if (details.sniError == 0)
             {
@@ -1627,15 +1627,15 @@ namespace Microsoft.Data.SqlClient
                 // If its a LocalDB error, then nativeError actually contains a LocalDB-specific error code, not a win32 error code
                 if (details.sniError == SniErrors.LocalDBErrorCode)
                 {
-                    errorMessage += LocalDbApi.GetLocalDbMessage(details.NativeError);
+                    errorMessage += LocalDbApi.GetLocalDbMessage(details.nativeError);
                     win32ErrorCode = 0;
                 }
             }
             errorMessage = string.Format("{0} (provider: {1}, error: {2} - {3})",
                 sqlContextInfo, providerName, (int)details.sniError, errorMessage);
 
-            return new SqlError(details.NativeError, 0x00, TdsEnums.FATAL_ERROR_CLASS,
-                                _server, errorMessage, details.Function, (int)details.LineNumber, win32ErrorCode);
+            return new SqlError(details.nativeError, 0x00, TdsEnums.FATAL_ERROR_CLASS,
+                                _server, errorMessage, details.function, (int)details.lineNumber, win32ErrorCode);
         }
 
         internal void CheckResetConnection(TdsParserStateObject stateObj)

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniError.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniError.cs
@@ -12,7 +12,7 @@ namespace Interop.Windows.Sni
         internal Provider provider;
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 261)]
         internal string errorMessage;
-        internal uint nativeError;
+        internal int nativeError;
         internal uint sniError;
         [MarshalAs(UnmanagedType.LPWStr)]
         internal string fileName;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniCommon.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniCommon.netcore.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         /// <param name="sniError">SNI error code</param>
         /// <param name="errorMessage">Error message</param>
         /// <returns></returns>
-        internal static uint ReportSNIError(SniProviders provider, uint nativeError, uint sniError, string errorMessage)
+        internal static uint ReportSNIError(SniProviders provider, int nativeError, uint sniError, string errorMessage)
         {
             SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniCommon), EventType.ERR, "Provider = {0}, native Error = {1}, SNI Error = {2}, Error Message = {3}", args0: provider, args1: nativeError, args2: sniError, args3: errorMessage);
             return ReportSNIError(new SniError(provider, nativeError, sniError, errorMessage));
@@ -203,7 +203,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
         /// <param name="sniException">SNI Exception</param>
         /// <param name="nativeErrorCode">Native SNI error code</param>
         /// <returns></returns>
-        internal static uint ReportSNIError(SniProviders provider, uint sniError, Exception sniException, uint nativeErrorCode = 0)
+        internal static uint ReportSNIError(SniProviders provider, uint sniError, Exception sniException, int nativeErrorCode = 0)
         {
             SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniCommon), EventType.ERR, "Provider = {0}, SNI Error = {1}, Exception = {2}", args0: provider, args1: sniError, args2: sniException?.Message);
             return ReportSNIError(new SniError(provider, sniError, sniException, nativeErrorCode));

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniNpHandle.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniNpHandle.netcore.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                             packet = null;
                             var e = new Win32Exception();
                             SqlClientEventSource.Log.TrySNITraceEvent(nameof(SniNpHandle), EventType.ERR, "Connection Id {0}, Packet length found 0, Win32 exception raised: {1}", args0: _connectionId, args1: e?.Message);
-                            return ReportErrorAndReleasePacket(errorPacket, (uint)e.NativeErrorCode, 0, e.Message);
+                            return ReportErrorAndReleasePacket(errorPacket, e.NativeErrorCode, 0, e.Message);
                         }
                     }
                     catch (ObjectDisposedException ode)
@@ -413,7 +413,7 @@ namespace Microsoft.Data.SqlClient.ManagedSni
             return SniCommon.ReportSNIError(SniProviders.NP_PROV, SniCommon.InternalExceptionError, sniException);
         }
 
-        private uint ReportErrorAndReleasePacket(SniPacket packet, uint nativeError, uint sniError, string errorMessage)
+        private uint ReportErrorAndReleasePacket(SniPacket packet, int nativeError, uint sniError, string errorMessage)
         {
             if (packet != null)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -424,7 +424,7 @@ namespace Microsoft.Data.SqlClient
             {
                 StringBuilder sb = new StringBuilder(className);
                 sb.Append(".").Append(memberName).Append(" | INFO | SCOPE | Entering Scope {0}");
-                return SNIScopeEnter(sb.ToString());
+                return ScopeEnter(sb.ToString());
             }
             return 0;
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlError.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlError.cs
@@ -33,16 +33,16 @@ namespace Microsoft.Data.SqlClient
         //  to find and invoke the functions, changing the signatures will break many
         //  things elsewhere
 
-        internal SqlError(int infoNumber, byte errorState, byte errorClass, string server, string errorMessage, string procedure, int lineNumber, uint win32ErrorCode, Exception exception = null)
+        internal SqlError(int infoNumber, byte errorState, byte errorClass, string server, string errorMessage, string procedure, int lineNumber, int win32ErrorCode, Exception exception = null)
             : this(infoNumber, errorState, errorClass, server, errorMessage, procedure, lineNumber, win32ErrorCode, exception, -1)
         {
         }
 
-        internal SqlError(int infoNumber, byte errorState, byte errorClass, string server, string errorMessage, string procedure, int lineNumber, uint win32ErrorCode, Exception exception, int batchIndex)
+        internal SqlError(int infoNumber, byte errorState, byte errorClass, string server, string errorMessage, string procedure, int lineNumber, int win32ErrorCode, Exception exception, int batchIndex)
             : this(infoNumber, errorState, errorClass, server, errorMessage, procedure, lineNumber, exception, batchIndex)
         {
             _server = server;
-            _win32ErrorCode = (int)win32ErrorCode;
+            _win32ErrorCode = win32ErrorCode;
         }
 
         internal SqlError(int infoNumber, byte errorState, byte errorClass, string server, string errorMessage, string procedure, int lineNumber, Exception exception = null)
@@ -103,7 +103,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlError.xml' path='docs/members[@name="SqlError"]/LineNumber/*' />
         public int LineNumber => _lineNumber;
 
-        internal int Win32ErrorCode  => _win32ErrorCode;
+        internal int Win32ErrorCode => _win32ErrorCode;
 
         internal Exception Exception => _exception;
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -604,7 +604,7 @@ namespace Microsoft.Data.SqlClient
         public const uint SNI_UNINITIALIZED = unchecked((uint)-1);
         public const uint SNI_SUCCESS = 0;        // The operation completed successfully.
         public const uint SNI_ERROR = 1;          // Error
-        public const uint SNI_WAIT_TIMEOUT = 258;      // The wait operation timed out.
+        public const int SNI_WAIT_TIMEOUT = 258;      // The wait operation timed out.
         public const uint SNI_SUCCESS_IO_PENDING = 997;      // Overlapped I/O operation is in progress.
 
         // Windows Sockets Error Codes

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -52,6 +52,28 @@ namespace Microsoft.Data.SqlClient
             AttentionReceived = 1 << 5    // NOTE: Received is not volatile as it is only ever accessed\modified by TryRun its callees (i.e. single threaded access)
         }
 
+        internal readonly struct SniErrorDetails
+        {
+            public readonly string ErrorMessage;
+            public readonly int NativeError;
+            public readonly uint SniErrorNumber;
+            public readonly int Provider;
+            public readonly uint LineNumber;
+            public readonly string Function;
+            public readonly Exception Exception;
+
+            internal SniErrorDetails(string errorMessage, int nativeError, uint sniErrorNumber, int provider, uint lineNumber, string function, Exception exception = null)
+            {
+                ErrorMessage = errorMessage;
+                NativeError = nativeError;
+                SniErrorNumber = sniErrorNumber;
+                Provider = provider;
+                LineNumber = lineNumber;
+                Function = function;
+                Exception = exception;
+            }
+        }
+
         private sealed class TimeoutState
         {
             public const int Stopped = 0;

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -9678,6 +9678,15 @@ namespace System {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to: The connection attempt timed out.
+        /// </summary>
+        internal static string SQL_ConnectTimeout {
+            get {
+                return ResourceManager.GetString("SQL_ConnectTimeout", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Timeout expired.  The connection has been broken as a result..
         /// </summary>
         internal static string SQL_FatalTimeout {

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -2529,6 +2529,9 @@
   <data name="SQL_AsyncConnectionRequired" xml:space="preserve">
     <value>This command requires an asynchronous connection. Set "Asynchronous Processing=true" in the connection string.</value>
   </data>
+  <data name="SQL_ConnectTimeout" xml:space="preserve">
+    <value>The connection attempt timed out.</value>
+  </data>
   <data name="SQL_FatalTimeout" xml:space="preserve">
     <value>Timeout expired.  The connection has been broken as a result.</value>
   </data>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -45,6 +45,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             "'MSSQL_CERTIFICATE_STORE', 'MSSQL_CNG_STORE', 'MSSQL_CSP_PROVIDER'",
             $"'{NotRequiredProviderName}'");
 
+        private HashSet<string> _cancellationExceptionMessages = new HashSet<string>()
+        {
+            "A severe error occurred on the current command.  The results, if any, should be discarded.\r\nOperation cancelled by user.",
+            "A severe error occurred on the current command.  The results, if any, should be discarded.",
+            "Operation cancelled by user.",
+            "The request failed to run because the batch is aborted, this can be caused by abort signal sent from client, or another request is running in the same session, which makes the session busy.\r\nOperation cancelled by user."
+        };
+
         public ApiShould(PlatformSpecificTestContext context)
         {
             _fixture = context.Fixture;
@@ -1983,18 +1991,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             }
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.Netcoreapp)]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringSetupForAE))]
         [ClassData(typeof(AEConnectionStringProviderWithExecutionMethod))]
-        public void TestSqlCommandCancel(string connection, string value, int number)
+        public void TestSqlCommandCancel(string connection, string value)
         {
             CleanUpTable(connection, _tableName);
 
             string executeMethod = value;
             Assert.True(!string.IsNullOrWhiteSpace(executeMethod), @"executeMethod should not be null or empty");
-
-            int numberOfCancelCalls = number;
-            Assert.True(numberOfCancelCalls >= 0, "numberofCancelCalls should be >=0.");
 
             IList<object> values = GetValues(dataHint: 58);
             Assert.True(values != null && values.Count >= 3, @"values should not be null and count should be >= 3.");
@@ -2007,7 +2011,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             {
                 sqlConnection.Open();
 
-                using (SqlCommand sqlCommand = new SqlCommand($@"SELECT * FROM [{_tableName}] WHERE FirstName = @FirstName AND CustomerId = @CustomerId",
+                // WAITFOR DELAY is present to ensure that the command is always executing by the time the cancellation occurs.
+                // Without this, a command which has completed by the time the cancellation occurs will fail the test. It's last
+                // in the command to ensure that cancellation is tested while row data or metadata is flowing.
+                using (SqlCommand sqlCommand = new SqlCommand($@"SELECT * FROM [{_tableName}] WHERE FirstName = @FirstName AND CustomerId = @CustomerId; WAITFOR DELAY '00:00:00.150'",
                     sqlConnection,
                     transaction: null,
                     columnEncryptionSetting: SqlCommandColumnEncryptionSetting.Enabled))
@@ -2017,29 +2024,50 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
                     CommandHelper.s_sleepDuringTryFetchInputParameterEncryptionInfo?.SetValue(null, true);
 
-                    Thread[] threads = new Thread[2];
+                    Task[] tasks = new Task[2];
+                    ManualResetEventSlim startWorkloadSignal = new ManualResetEventSlim(false);
+                    ManualResetEventSlim workloadCompleteSignal = new ManualResetEventSlim(false);
 
-                    // Invoke ExecuteReader or ExecuteNonQuery in another thread.
+                    /*
+                     * Invoke ExecuteReader or ExecuteNonQuery in another thread.
+                     * Use long-running tasks to create the thread. This enables any failed assertions to propagate, rather than
+                     * allowing the exception to kill the thread and the process.
+                     * These threads should progress in the sequence below:
+                     * 
+                     * Workload Thread                      | Cancel Thread
+                     * ------------------------------------ | -------------
+                     * Start thread                         | Start thread
+                     * Wait for signal                      | -
+                     * -                                    | Set signal for workload start
+                     * Start workload execution             | Loop, cancelling workload until workload complete signal set
+                     * Throw cancellation exception         | -
+                     * Set signal for workload complete     | -
+                     * End thread                           | Finish loop and end thread
+                     */
                     if (executeMethod == @"ExecuteReader")
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteReader));
+                        tasks[0] = new Task(Thread_ExecuteReader,
+                            new TestCommandCancelParams(sqlCommand, _tableName, startWorkloadSignal, workloadCompleteSignal),
+                            TaskCreationOptions.LongRunning);
                     }
                     else
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteNonQuery));
+                        tasks[0] = new Task(Thread_ExecuteNonQuery,
+                            new TestCommandCancelParams(sqlCommand, _tableName, startWorkloadSignal, workloadCompleteSignal),
+                            TaskCreationOptions.LongRunning);
                     }
-
-                    threads[1] = new Thread(new ParameterizedThreadStart(Thread_Cancel));
+                    tasks[1] = new Task(Thread_Cancel,
+                        new TestCommandCancelParams(sqlCommand, _tableName, startWorkloadSignal, workloadCompleteSignal),
+                        TaskCreationOptions.LongRunning);
 
                     // Start the execute thread.
-                    threads[0].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[0].Start();
 
                     // Start the thread which cancels the above command started by the execute thread.
-                    threads[1].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[1].Start();
 
                     // Wait for the threads to finish.
-                    threads[0].Join();
-                    threads[1].Join();
+                    Task.WaitAll(tasks);
 
                     CommandHelper.s_sleepDuringTryFetchInputParameterEncryptionInfo?.SetValue(null, false);
 
@@ -2061,37 +2089,48 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
                     Assert.True(rowsAffected == numberOfRows, "Unexpected number of rows affected as returned by EndExecuteReader.");
 
-                    // Verify the state of the sql command object.
+                    // Verify the state of the sql command object. Also ensure that the exit lock was set (and didn't time out.)
                     VerifySqlCommandStateAfterCompletionOrCancel(sqlCommand);
+                    Assert.True(workloadCompleteSignal.IsSet);
+                    startWorkloadSignal.Reset();
+                    workloadCompleteSignal.Reset();
 
                     CommandHelper.s_sleepDuringRunExecuteReaderTdsForSpDescribeParameterEncryption?.SetValue(null, true);
 
                     // Invoke ExecuteReader or ExecuteNonQuery in another thread.
-                    threads = new Thread[2];
+                    tasks = new Task[2];
                     if (executeMethod == @"ExecuteReader")
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteReader));
+                        tasks[0] = new Task(Thread_ExecuteReader,
+                            new TestCommandCancelParams(sqlCommand, _tableName, startWorkloadSignal, workloadCompleteSignal),
+                            TaskCreationOptions.LongRunning);
                     }
                     else
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteNonQuery));
+                        tasks[0] = new Task(Thread_ExecuteNonQuery,
+                            new TestCommandCancelParams(sqlCommand, _tableName, startWorkloadSignal, workloadCompleteSignal),
+                            TaskCreationOptions.LongRunning);
                     }
-                    threads[1] = new Thread(new ParameterizedThreadStart(Thread_Cancel));
+                    tasks[1] = new Task(Thread_Cancel,
+                        new TestCommandCancelParams(sqlCommand, _tableName, startWorkloadSignal, workloadCompleteSignal),
+                        TaskCreationOptions.LongRunning);
 
                     // Start the execute thread.
-                    threads[0].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[0].Start();
 
                     // Start the thread which cancels the above command started by the execute thread.
-                    threads[1].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[1].Start();
 
                     // Wait for the threads to finish.
-                    threads[0].Join();
-                    threads[1].Join();
+                    Task.WaitAll(tasks);
 
                     CommandHelper.s_sleepDuringRunExecuteReaderTdsForSpDescribeParameterEncryption?.SetValue(null, false);
 
-                    // Verify the state of the sql command object.
+                    // Verify the state of the sql command object. Also ensure that the exit lock was set (and didn't time out.)
                     VerifySqlCommandStateAfterCompletionOrCancel(sqlCommand);
+                    Assert.True(workloadCompleteSignal.IsSet);
+                    startWorkloadSignal.Reset();
+                    workloadCompleteSignal.Reset();
 
                     rowsAffected = 0;
 
@@ -2113,31 +2152,37 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
                     CommandHelper.s_sleepAfterReadDescribeEncryptionParameterResults?.SetValue(null, true);
 
-                    threads = new Thread[2];
+                    tasks = new Task[2];
                     if (executeMethod == @"ExecuteReader")
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteReader));
+                        tasks[0] = new Task(Thread_ExecuteReader,
+                            new TestCommandCancelParams(sqlCommand, _tableName, startWorkloadSignal, workloadCompleteSignal),
+                            TaskCreationOptions.LongRunning);
                     }
                     else
                     {
-                        threads[0] = new Thread(new ParameterizedThreadStart(Thread_ExecuteNonQuery));
+                        tasks[0] = new Task(Thread_ExecuteNonQuery,
+                            new TestCommandCancelParams(sqlCommand, _tableName, startWorkloadSignal, workloadCompleteSignal),
+                            TaskCreationOptions.LongRunning);
                     }
-                    threads[1] = new Thread(new ParameterizedThreadStart(Thread_Cancel));
+                    tasks[1] = new Task(Thread_Cancel,
+                        new TestCommandCancelParams(sqlCommand, _tableName, startWorkloadSignal, workloadCompleteSignal),
+                        TaskCreationOptions.LongRunning);
 
                     // Start the execute thread.
-                    threads[0].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[0].Start();
 
                     // Start the thread which cancels the above command started by the execute thread.
-                    threads[1].Start(new TestCommandCancelParams(sqlCommand, _tableName, numberOfCancelCalls));
+                    tasks[1].Start();
 
                     // Wait for the threads to finish.
-                    threads[0].Join();
-                    threads[1].Join();
+                    Task.WaitAll(tasks);
 
                     CommandHelper.s_sleepAfterReadDescribeEncryptionParameterResults?.SetValue(null, false);
 
-                    // Verify the state of the sql command object.
+                    // Verify the state of the sql command object. Also ensure that the exit lock was set (and didn't time out.)
                     VerifySqlCommandStateAfterCompletionOrCancel(sqlCommand);
+                    Assert.True(workloadCompleteSignal.IsSet);
 
                     rowsAffected = 0;
 
@@ -3130,47 +3175,81 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             Assert.True(rowsAffected == numberOfRows, "Unexpected number of rows affected as returned by EndExecuteReader.");
         }
 
-        private void Thread_ExecuteReader(object cancelCommandTestParamsObject)
+        private void Thread_ExecuteReader(object state)
         {
+            TestCommandCancelParams cancelCommandTestParamsObject = state as TestCommandCancelParams;
+            SqlCommand sqlCommand = cancelCommandTestParamsObject?.SqlCommand;
+            SqlDataReader reader = null;
+
             Assert.True(cancelCommandTestParamsObject != null, @"cancelCommandTestParamsObject should not be null.");
-            SqlCommand sqlCommand = ((TestCommandCancelParams)cancelCommandTestParamsObject).SqlCommand as SqlCommand;
             Assert.True(sqlCommand != null, "sqlCommand should not be null.");
 
-            string.Format(@"SELECT * FROM {0} WHERE FirstName = @FirstName AND CustomerId = @CustomerId", ((TestCommandCancelParams)cancelCommandTestParamsObject).TableName);
-            using (SqlDataReader reader = sqlCommand.ExecuteReader())
+            try
             {
-                while (reader.Read())
+                // Wait for the cancellation thread to open this lock...
+                cancelCommandTestParamsObject.StartWorkloadSignal.Wait();
+
+                Exception ex = Assert.ThrowsAny<Exception>(() =>
                 {
-                    Assert.Throws<InvalidOperationException>(() => sqlCommand.ExecuteReader());
-                }
+                    reader = sqlCommand.ExecuteReader();
+                    while (reader.Read())
+                    { }
+                });
+                Assert.Contains(ex.Message, _cancellationExceptionMessages);
+            }
+            finally
+            {
+                reader?.Dispose();
+                // ...and unlock the cancellation thread once we finish.
+                cancelCommandTestParamsObject.WorkloadCompleteSignal.Set();
             }
         }
 
-        private void Thread_ExecuteNonQuery(object cancelCommandTestParamsObject)
+        private void Thread_ExecuteNonQuery(object state)
         {
+            TestCommandCancelParams cancelCommandTestParamsObject = state as TestCommandCancelParams;
+            SqlCommand sqlCommand = cancelCommandTestParamsObject?.SqlCommand;
+
             Assert.True(cancelCommandTestParamsObject != null, @"cancelCommandTestParamsObject should not be null.");
-            SqlCommand sqlCommand = ((TestCommandCancelParams)cancelCommandTestParamsObject).SqlCommand as SqlCommand;
             Assert.True(sqlCommand != null, "sqlCommand should not be null.");
 
-            string.Format(@"UPDATE {0} SET FirstName = @FirstName WHERE FirstName = @FirstName AND CustomerId = @CustomerId", ((TestCommandCancelParams)cancelCommandTestParamsObject).TableName);
+            try
+            {
+                // Wait for the cancellation thread to open this lock...
+                cancelCommandTestParamsObject.StartWorkloadSignal.Wait();
 
-            Exception ex = Assert.Throws<InvalidOperationException>(() => sqlCommand.ExecuteNonQuery());
-            Assert.Equal(@"Operation cancelled by user.", ex.Message);
+                Exception ex = Assert.ThrowsAny<Exception>(() => sqlCommand.ExecuteNonQuery());
+                Assert.Contains(ex.Message, _cancellationExceptionMessages);
+            }
+            finally
+            {
+                // ...and unlock the cancellation thread once we finish.
+                cancelCommandTestParamsObject.WorkloadCompleteSignal.Set();
+            }
         }
 
-        private void Thread_Cancel(object cancelCommandTestParamsObject)
+        private void Thread_Cancel(object state)
         {
+            TestCommandCancelParams cancelCommandTestParamsObject = state as TestCommandCancelParams;
+            SqlCommand sqlCommand = cancelCommandTestParamsObject?.SqlCommand;
+            int cancellations = 0;
+            System.Diagnostics.Stopwatch cancellationStart = new System.Diagnostics.Stopwatch();
+
             Assert.True(cancelCommandTestParamsObject != null, @"cancelCommandTestParamsObject should not be null.");
-            SqlCommand sqlCommand = ((TestCommandCancelParams)cancelCommandTestParamsObject).SqlCommand as SqlCommand;
             Assert.True(sqlCommand != null, "sqlCommand should not be null.");
 
-            Thread.Sleep(millisecondsTimeout: 500);
+            cancellationStart.Start();
+            cancelCommandTestParamsObject.StartWorkloadSignal.Set();
 
-            // Repeatedly cancel.
-            for (int i = 0; i < ((TestCommandCancelParams)cancelCommandTestParamsObject).NumberofTimesToRunCancel; i++)
+            // Repeatedly cancel until the other thread signals that it's completed execution
+            // (or until the command timeout has passed.)
+            do
             {
                 sqlCommand.Cancel();
-            }
+                cancellations++;
+            } while (!cancelCommandTestParamsObject.WorkloadCompleteSignal.Wait(0)
+                && cancellationStart.ElapsedMilliseconds <= sqlCommand.CommandTimeout);
+            cancellationStart.Stop();
         }
 
         public void Dispose()
@@ -3298,67 +3377,42 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
     internal class TestCommandCancelParams
     {
         /// <summary>
-        /// SqlCommand object.
-        /// </summary>
-        private readonly object _sqlCommand;
-
-        /// <summary>
-        /// Name of the test/works as table name
-        /// </summary>
-        private readonly string _tableName;
-
-        /// <summary>
-        /// number of times to run cancel.
-        /// </summary>
-        private readonly int _numberofCancelCommands;
-
-        /// <summary>
         /// Return the SqlCommand object.
         /// </summary>
-        public object SqlCommand
-        {
-            get
-            {
-                return _sqlCommand;
-            }
-        }
+        public SqlCommand SqlCommand { get; }
 
         /// <summary>
-        /// Return the tablename.
+        /// Return the table name (usually equal to the name of the test.)
         /// </summary>
-        public object TableName
-        {
-            get
-            {
-                return _tableName;
-            }
-        }
+        public string TableName { get; }
 
         /// <summary>
-        /// Return the number of times to run cancel.
+        /// Lock set by the thread cancelling the SqlCommand.
         /// </summary>
-        public int NumberofTimesToRunCancel
-        {
-            get
-            {
-                return _numberofCancelCommands;
-            }
-        }
+        public ManualResetEventSlim StartWorkloadSignal { get; }
+
+        /// <summary>
+        /// Lock set by the thread executing the SqlCommand.
+        /// </summary>
+        public ManualResetEventSlim WorkloadCompleteSignal { get; }
 
         /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="sqlCommand"></param>
         /// <param name="tableName"></param>
-        /// <param name="numberofTimesToCancel"></param>
-        public TestCommandCancelParams(object sqlCommand, string tableName, int numberofTimesToCancel)
+        /// <param name="numberOfTimesToCancel"></param>
+        /// <param name="startWorkloadSignal"></param>
+        /// <param name="workloadCompleteSignal"></param>
+        public TestCommandCancelParams(SqlCommand sqlCommand, string tableName, ManualResetEventSlim startWorkloadSignal, ManualResetEventSlim workloadCompleteSignal)
         {
             Assert.True(sqlCommand != null, "sqlCommand should not be null.");
             Assert.True(!string.IsNullOrWhiteSpace(tableName), "tableName should not be null or empty.");
 
-            _sqlCommand = sqlCommand;
-            _tableName = tableName;
-            _numberofCancelCommands = numberofTimesToCancel;
+            SqlCommand = sqlCommand;
+            TableName = tableName;
+            StartWorkloadSignal = startWorkloadSignal;
+            WorkloadCompleteSignal = workloadCompleteSignal;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -47,10 +47,20 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
         private HashSet<string> _cancellationExceptionMessages = new HashSet<string>()
         {
-            "A severe error occurred on the current command.  The results, if any, should be discarded.\r\nOperation cancelled by user.",
-            "A severe error occurred on the current command.  The results, if any, should be discarded.",
+            "A severe error occurred on the current command.  " +
+            "The results, if any, should be discarded." + Environment.NewLine +
             "Operation cancelled by user.",
-            "The request failed to run because the batch is aborted, this can be caused by abort signal sent from client, or another request is running in the same session, which makes the session busy.\r\nOperation cancelled by user."
+
+            "A severe error occurred on the current command.  " +
+            "The results, if any, should be discarded.",
+
+            "Operation cancelled by user.",
+
+            "The request failed to run because the batch is aborted, " +
+            "this can be caused by abort signal sent from client, " +
+            "or another request is running in the same session, " +
+            "which makes the session busy." + Environment.NewLine +
+            "Operation cancelled by user."
         };
 
         public ApiShould(PlatformSpecificTestContext context)
@@ -3195,7 +3205,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                     while (reader.Read())
                     { }
                 });
-                Assert.Contains(ex.Message, _cancellationExceptionMessages);
+
+                // We don't use Assert.Contains() here because it truncates the
+                // actual and expected strings when outputting a failure.
+                if (!_cancellationExceptionMessages.Contains(ex.Message))
+                {
+                    Assert.Fail(
+                        $"Exception message \"{ex.Message}\" not found in: [\"" +
+                        string.Join("\", \"", _cancellationExceptionMessages) + "\"]");
+                }
             }
             finally
             {
@@ -3219,7 +3237,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                 cancelCommandTestParamsObject.StartWorkloadSignal.Wait();
 
                 Exception ex = Assert.ThrowsAny<Exception>(() => sqlCommand.ExecuteNonQuery());
-                Assert.Contains(ex.Message, _cancellationExceptionMessages);
+
+                // We don't use Assert.Contains() here because it truncates the
+                // actual and expected strings when outputting a failure.
+                if (!_cancellationExceptionMessages.Contains(ex.Message))
+                {
+                    Assert.Fail(
+                        $"Exception message \"{ex.Message}\" not found in: [\"" +
+                        string.Join("\", \"", _cancellationExceptionMessages) + "\"]");
+                }
             }
             finally
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/DatabaseHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/DatabaseHelper.cs
@@ -290,10 +290,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         {
             foreach (string connStrAE in DataTestUtility.AEConnStrings)
             {
-                yield return new object[] { connStrAE, @"ExecuteReader", 1 };
-                yield return new object[] { connStrAE, @"ExecuteReader", 3 };
-                yield return new object[] { connStrAE, @"ExecuteNonQuery", 1 };
-                yield return new object[] { connStrAE, @"ExecuteNonQuery", 3 };
+                yield return new object[] { connStrAE, @"ExecuteReader" };
+                yield return new object[] { connStrAE, @"ExecuteNonQuery" };
             }
         }
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             private static List<ConnectionWorker> s_workerList = new();
             private ManualResetEventSlim _doneEvent = new(false);
             private double _timeElapsed;
-            private Thread _thread;
+            private Task _task;
             private string _connectionString;
             private int _numOfTry;
 
@@ -180,7 +180,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 s_workerList.Add(this);
                 _connectionString = connectionString;
                 _numOfTry = numOfTry;
-                _thread = new Thread(new ThreadStart(SqlConnectionOpen));
+                _task = new Task(SqlConnectionOpen, TaskCreationOptions.LongRunning);
             }
 
             public static List<ConnectionWorker> WorkerList => s_workerList;
@@ -191,7 +191,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 foreach (ConnectionWorker w in s_workerList)
                 {
-                    w._thread.Start();
+                    w._task.Start();
                 }
             }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/MirroringTest/ConnectionOnMirroringTest.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
@@ -28,17 +29,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 builder.ConnectTimeout = 0;
 
                 TestWorker worker = new TestWorker(builder.ConnectionString);
-                Thread childThread = new Thread(() => worker.TestMultipleConnection());
-                childThread.Start();
+                Task childTask = Task.Factory.StartNew(() => worker.TestMultipleConnection(), TaskCreationOptions.LongRunning);
 
                 if (workerCompletedEvent.WaitOne(10000))
                 {
-                    childThread.Join();
+                    childTask.Wait();
                 }
                 else
                 {
-                    // currently Thread.Abort() throws PlatformNotSupportedException in CoreFx.
-                    childThread.Interrupt();
                     throw new Exception("SqlConnection could not open and close successfully in timely manner. Possibly connection hangs.");
                 }
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RandomStressTest/RandomStressTest.cs
@@ -8,6 +8,7 @@ using System.Data;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
@@ -70,8 +71,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 for (int tcount = 0; tcount < ThreadCountDefault; tcount++)
                 {
-                    Thread t = new Thread(TestThread);
-                    t.Start();
+                    _ = Task.Factory.StartNew(TestThread, TaskCreationOptions.LongRunning);
                 }
             }
 


### PR DESCRIPTION
## Description

This is a cherry-pick of 2 PRs and a touch-up commit:
- #2968 
  - This was brought in because some of the changes in #3461 depend on it.
  - This only affects the Manual Tests project, and it will add stability to our CI.
- #3461
  - I had to perform some conflict resolution by accepting the incoming changes in a few places.
  - No manual changes.
- One commit of some manual touch-ups to avoid bringing any other PRs/commits along.

## Issues

#1773