### PR TITLE
[6.1] Suppress xUnit warnings for vector tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/VectorTest/NativeVectorFloat32Tests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/VectorTest/NativeVectorFloat32Tests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsVectorSupported))]
-        [MemberData(nameof(VectorFloat32TestData.GetVectorFloat32TestData), MemberType = typeof(VectorFloat32TestData))]
+        [MemberData(nameof(VectorFloat32TestData.GetVectorFloat32TestData), MemberType = typeof(VectorFloat32TestData), DisableDiscoveryEnumeration = true)]
         public void TestSqlVectorFloat32ParameterInsertionAndReads(
         int pattern,
         object value,
@@ -214,7 +214,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsVectorSupported))]
-        [MemberData(nameof(VectorFloat32TestData.GetVectorFloat32TestData), MemberType = typeof(VectorFloat32TestData))]
+        [MemberData(nameof(VectorFloat32TestData.GetVectorFloat32TestData), MemberType = typeof(VectorFloat32TestData), DisableDiscoveryEnumeration = true)]
         public async Task TestSqlVectorFloat32ParameterInsertionAndReadsAsync(
         int pattern,
         object value,
@@ -248,7 +248,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsVectorSupported))]
-        [MemberData(nameof(VectorFloat32TestData.GetVectorFloat32TestData), MemberType = typeof(VectorFloat32TestData))]
+        [MemberData(nameof(VectorFloat32TestData.GetVectorFloat32TestData), MemberType = typeof(VectorFloat32TestData), DisableDiscoveryEnumeration = true)]
         public void TestStoredProcParamsForVectorFloat32(
         int pattern,
         object value,
@@ -305,7 +305,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsVectorSupported))]
-        [MemberData(nameof(VectorFloat32TestData.GetVectorFloat32TestData), MemberType = typeof(VectorFloat32TestData))]
+        [MemberData(nameof(VectorFloat32TestData.GetVectorFloat32TestData), MemberType = typeof(VectorFloat32TestData), DisableDiscoveryEnumeration = true)]
         public async Task TestStoredProcParamsForVectorFloat32Async(
         int pattern,
         object value,


### PR DESCRIPTION
## Description

Add attribute for suppressing warnings for vector tests of following nature.
They appear while running tests on console. 
```
   /usr/share/dotnet/sdk/9.0.301/Microsoft.TestPlatform.targets(48,5): warning : [xUnit.net 00:00:00.59] ManualTests: Non-serializable data ('System.Object[]') found for 'Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest.NativeVectorFloat32Tests.TestSqlVectorFloat32ParameterInsertionAndReads'; falling back to single test case.
    /usr/share/dotnet/sdk/9.0.301/Microsoft.TestPlatform.targets(48,5): warning : [xUnit.net 00:00:00.59] ManualTests: Non-serializable data ('System.Object[]') found for 'Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest.NativeVectorFloat32Tests.TestSqlVectorFloat32ParameterInsertionAndReadsAsync'; falling back to single test case.
    /usr/share/dotnet/sdk/9.0.301/Microsoft.TestPlatform.targets(48,5): warning : [xUnit.net 00:00:00.59] ManualTests: Non-serializable data ('System.Object[]') found for 'Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest.NativeVectorFloat32Tests.TestStoredProcParamsForVectorFloat32'; falling back to single test case.
    /usr/share/dotnet/sdk/9.0.301/Microsoft.TestPlatform.targets(48,5): warning : [xUnit.net 00:00:00.59] ManualTests: Non-serializable data ('System.Object[]') found for 'Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest.NativeVectorFloat32Tests.TestStoredProcParamsForVectorFloat32Async'; falling back to single test case.
```

## Testing
```
git\SqlClient>dotnet test "src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj" -p:Platform="AnyCPU" -p:Configuration="Debug" -p:TestTargetOS="Windowsnetcoreapp" --no-build -v n --filter "FullyQualifiedName=Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest.NativeVectorFloat32Tests.TestBulkCopyFromSqlTable"
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 9.0.7)
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 8.0.18)
[xUnit.net 00:00:00.07]   Discovering: ManualTests (method display = ClassAndMethod, method display options = None)
[xUnit.net 00:00:00.07]   Discovering: ManualTests (method display = ClassAndMethod, method display options = None)
[xUnit.net 00:00:00.57]   Discovered:  ManualTests (found 1059 test cases)
[xUnit.net 00:00:00.57]   Starting:    ManualTests (parallel test collections = on [20 threads], stop on fail = off)
[xUnit.net 00:00:00.54]   Discovered:  ManualTests (found 1059 test cases)
[xUnit.net 00:00:00.54]   Starting:    ManualTests (parallel test collections = on [20 threads], stop on fail = off)
[xUnit.net 00:00:00.75]   Finished:    ManualTests
[xUnit.net 00:00:00.71]   Finished:    ManualTests
  Microsoft.Data.SqlClient.ManualTesting.Tests test net9.0 succeeded (1.2s)
  Microsoft.Data.SqlClient.ManualTesting.Tests test net8.0 succeeded (1.2s)

Test summary: total: 4, failed: 0, succeeded: 4, skipped: 0, duration: 1.3s
Build succeeded in 1.6s
```
## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
