### PR TITLE
[5.2] Add new trusted AKV URLs for FR and DE

### DIFF
--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Constants.cs
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Constants.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
         /// Azure Key Vault Domain Name
         /// </summary>
         internal static readonly string[] AzureKeyVaultPublicDomainNames =
-        [
+        new string[]
+        {
             // Azure Key Vaults
             "vault.azure.net",                 // Default
             "vault.azure.cn",                  // China
@@ -30,7 +31,7 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
             "managedhsm.cloudapi.eaglex.ic.gov",
             "managedhsm.sovcloud-api.fr",
             "managedhsm.sovcloud-api.de"
-        ];
+        };
 
         /// <summary>
         /// Always Encrypted Parameter names for exec handling

--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Constants.cs
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Constants.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
             "vault.azure.cn",                  // China
             "vault.usgovcloudapi.net",         // US Government
             "vault.microsoftazure.de",         // Azure Germany
-            "vault.cloudapi.microsoft.scloud", // USSec
-            "vault.cloudapi.eaglex.ic.gov",    // USNat
             "vault.sovcloud-api.fr",           // France (Bleu)
             "vault.sovcloud-api.de",           // Germany (Delos)
 
@@ -27,8 +25,6 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
             "managedhsm.azure.cn",
             "managedhsm.usgovcloudapi.net",
             "managedhsm.microsoftazure.de",
-            "managedhsm.cloudapi.microsoft.scloud",
-            "managedhsm.cloudapi.eaglex.ic.gov",
             "managedhsm.sovcloud-api.fr",
             "managedhsm.sovcloud-api.de"
         };

--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Constants.cs
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Constants.cs
@@ -9,16 +9,28 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
         /// <summary>
         /// Azure Key Vault Domain Name
         /// </summary>
-        internal static readonly string[] AzureKeyVaultPublicDomainNames = new string[] {
-            @"vault.azure.net", // default
-            @"vault.azure.cn", // Azure China
-            @"vault.usgovcloudapi.net", // US Government
-            @"vault.microsoftazure.de", // Azure Germany
-            @"managedhsm.azure.net", // public HSM vault
-            @"managedhsm.azure.cn", // Azure China HSM vault
-            @"managedhsm.usgovcloudapi.net", // US Government HSM vault
-            @"managedhsm.microsoftazure.de" // Azure Germany HSM vault
-        };
+        internal static readonly string[] AzureKeyVaultPublicDomainNames =
+        [
+            // Azure Key Vaults
+            "vault.azure.net",                 // Default
+            "vault.azure.cn",                  // China
+            "vault.usgovcloudapi.net",         // US Government
+            "vault.microsoftazure.de",         // Azure Germany
+            "vault.cloudapi.microsoft.scloud", // USSec
+            "vault.cloudapi.eaglex.ic.gov",    // USNat
+            "vault.sovcloud-api.fr",           // France (Bleu)
+            "vault.sovcloud-api.de",           // Germany (Delos)
+
+            // Managed High Security Modules (HSM) Vaults
+            "managedhsm.azure.net",
+            "managedhsm.azure.cn",
+            "managedhsm.usgovcloudapi.net",
+            "managedhsm.microsoftazure.de",
+            "managedhsm.cloudapi.microsoft.scloud",
+            "managedhsm.cloudapi.eaglex.ic.gov",
+            "managedhsm.sovcloud-api.fr",
+            "managedhsm.sovcloud-api.de"
+        ];
 
         /// <summary>
         /// Always Encrypted Parameter names for exec handling

--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Utils.cs
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Utils.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
         internal static ArgumentException InvalidAKVUrl(string masterKeyPath) =>
             new(string.Format(CultureInfo.InvariantCulture, Strings.InvalidAkvUrlTemplate, masterKeyPath), Constants.AeParamMasterKeyPath);
 
-        internal static Exception InvalidAKVUrlTrustedEndpoints(string masterKeyPath, string endpoints) =>
+        internal static ArgumentException InvalidAKVUrlTrustedEndpoints(string masterKeyPath, string endpoints) =>
             new ArgumentException(string.Format(CultureInfo.InvariantCulture, Strings.InvalidAkvKeyPathTrustedTemplate, masterKeyPath, endpoints),
                 Constants.AeParamMasterKeyPath);
     }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ExceptionTestAKVStore.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ExceptionTestAKVStore.cs
@@ -182,7 +182,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             string dummyPathWithOnlyHost = @"https://www.microsoft.com";
             string invalidUrlErrorMessage = $@"Invalid url specified: '{dummyPathWithOnlyHost}'";
             string dummyPathWithInvalidKey = @"https://www.microsoft.vault.azure.com/keys/dummykey/dummykeyid";
-            string invalidTrustedEndpointErrorMessage = $@"Invalid Azure Key Vault key path specified: '{dummyPathWithInvalidKey}'. Valid trusted endpoints: vault.azure.net, vault.azure.cn, vault.usgovcloudapi.net, vault.microsoftazure.de, managedhsm.azure.net, managedhsm.azure.cn, managedhsm.usgovcloudapi.net, managedhsm.microsoftazure.de.\s+\(?Parameter (name: )?'?masterKeyPath('\))?";
 
             Exception ex = Assert.Throws<ArgumentException>(
                 () => fixture.AkvStoreProvider.EncryptColumnEncryptionKey(dummyPathWithOnlyHost, MasterKeyEncAlgo, cek));
@@ -190,7 +189,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
             ex = Assert.Throws<ArgumentException>(
                 () => fixture.AkvStoreProvider.EncryptColumnEncryptionKey(dummyPathWithInvalidKey, MasterKeyEncAlgo, cek));
-            Assert.Matches(invalidTrustedEndpointErrorMessage, ex.Message);
+            Assert.Matches(TrustedUrlsTest.MakeInvalidVaultErrorMessage(dummyPathWithInvalidKey), ex.Message);
 
             ex = Assert.Throws<ArgumentException>(
                  () => fixture.AkvStoreProvider.DecryptColumnEncryptionKey(dummyPathWithOnlyHost, MasterKeyEncAlgo, encryptedCek));
@@ -198,7 +197,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 
             ex = Assert.Throws<ArgumentException>(
                  () => fixture.AkvStoreProvider.DecryptColumnEncryptionKey(dummyPathWithInvalidKey, MasterKeyEncAlgo, encryptedCek));
-            Assert.Matches(invalidTrustedEndpointErrorMessage, ex.Message);
+            Assert.Matches(TrustedUrlsTest.MakeInvalidVaultErrorMessage(dummyPathWithInvalidKey), ex.Message);
         }
 
         [InlineData(true)]

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TrustedUrlsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TrustedUrlsTest.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using Azure.Core;
+using Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted;
+
+public class TrustedUrlsTest
+{
+    private readonly SqlColumnEncryptionAzureKeyVaultProvider _provider;
+    private readonly MethodInfo _method;
+
+    public TrustedUrlsTest()
+    {
+        _provider = new(new SqlClientCustomTokenCredential());
+        
+        var assembly = typeof(SqlColumnEncryptionAzureKeyVaultProvider).Assembly;
+        var clazz = assembly.GetType("Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.SqlColumnEncryptionAzureKeyVaultProvider");
+        _method = clazz.GetMethod(
+            "ValidateNonEmptyAKVPath",
+            System.Reflection.BindingFlags.NonPublic |
+            System.Reflection.BindingFlags.Instance);
+    }
+
+    public const string InvalidVaultKeyPathErrorMessage =
+        @"Invalid Azure Key Vault key path specified: 'https://www.microsoft.com'. " +
+        "Valid trusted endpoints: " +
+        "vault.azure.net, " +
+        "vault.azure.cn, " +
+        "vault.usgovcloudapi.net, " +
+        "vault.microsoftazure.de, " +
+        "vault.cloudapi.microsoft.scloud, " +
+        "vault.cloudapi.eaglex.ic.gov, " +
+        "vault.sovcloud-api.fr, " +
+        "vault.sovcloud-api.de, " +
+        "managedhsm.azure.net, " +
+        "managedhsm.azure.cn, " +
+        "managedhsm.usgovcloudapi.net, " +
+        "managedhsm.microsoftazure.de, " +
+        "managedhsm.cloudapi.microsoft.scloud, " +
+        "managedhsm.cloudapi.eaglex.ic.gov, " +
+        "managedhsm.sovcloud-api.fr, " +
+        "managedhsm.sovcloud-api.de." +
+        @"\s+\(?Parameter (name: )?'?masterKeyPath('\))?";
+
+    private static string MakeUrl(string vault)
+    {
+        return $"https://{vault}/keys/dummykey/dummykeyid";
+    }
+
+    public static string MakeInvalidVaultErrorMessage(string url)
+    {
+        return
+            $"Invalid Azure Key Vault key path specified: '{url}'. " +
+            "Valid trusted endpoints: " +
+            "vault.azure.net, " +
+            "vault.azure.cn, " +
+            "vault.usgovcloudapi.net, " +
+            "vault.microsoftazure.de, " +
+            "vault.cloudapi.microsoft.scloud, " +
+            "vault.cloudapi.eaglex.ic.gov, " +
+            "vault.sovcloud-api.fr, " +
+            "vault.sovcloud-api.de, " +
+            "managedhsm.azure.net, " +
+            "managedhsm.azure.cn, " +
+            "managedhsm.usgovcloudapi.net, " +
+            "managedhsm.microsoftazure.de, " +
+            "managedhsm.cloudapi.microsoft.scloud, " +
+            "managedhsm.cloudapi.eaglex.ic.gov, " +
+            "managedhsm.sovcloud-api.fr, " +
+            "managedhsm.sovcloud-api.de." +
+            @"\s+\(?Parameter (name: )?'?masterKeyPath('\))?";
+    }
+
+    [Theory]
+    [InlineData("www.microsoft.com")]
+    [InlineData("www.microsoft.vault.azure.com")]
+    [InlineData("vault.azure.net.io")]
+    public void InvalidVaults(string vault)
+    {
+        // Test that invalid key paths throw and contain the expected error
+        // message.
+        var url = MakeUrl(vault);
+
+        try
+        {
+            _method.Invoke(_provider, new object[] { url, false });
+        }
+        catch (TargetInvocationException ex)
+        {
+            // Unwrap the exception to get the actual ArgumentException thrown
+            var argEx = ex.InnerException as ArgumentException;
+            Assert.NotNull(argEx);
+            var expected = MakeInvalidVaultErrorMessage(url);
+            Console.WriteLine("Actual:   " + argEx.Message);
+            Console.WriteLine("Expected: " + expected);
+            Assert.Matches(expected, argEx.Message);
+        }
+    }
+
+    [Theory]
+    // Normal vaults.
+    [InlineData("vault.azure.net")]
+    [InlineData("vault.azure.cn")]
+    [InlineData("vault.usgovcloudapi.net")]
+    [InlineData("vault.microsoftazure.de")]
+    [InlineData("vault.cloudapi.microsoft.scloud")]
+    [InlineData("vault.cloudapi.eaglex.ic.gov")]
+    [InlineData("vault.sovcloud-api.fr")]
+    [InlineData("vault.sovcloud-api.de")]
+    // HSM vaults.
+    [InlineData("managedhsm.azure.net")]
+    [InlineData("managedhsm.azure.cn")]
+    [InlineData("managedhsm.usgovcloudapi.net")]
+    [InlineData("managedhsm.microsoftazure.de")]
+    [InlineData("managedhsm.cloudapi.microsoft.scloud")]
+    [InlineData("managedhsm.cloudapi.eaglex.ic.gov")]
+    [InlineData("managedhsm.sovcloud-api.fr")]
+    [InlineData("managedhsm.sovcloud-api.de")]
+    // Vaults with prefixes.
+    [InlineData("foo.bar.vault.microsoftazure.de")]
+    [InlineData("baz.bar.foo.managedhsm.sovcloud-api.fr")]
+    public void ValidVaults(string vault)
+    {
+        // Test that valid vault key paths do not throw exceptions
+        _method.Invoke(_provider, new object[] { MakeUrl(vault), false });
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TrustedUrlsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TrustedUrlsTest.cs
@@ -41,16 +41,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
                 "vault.azure.cn, " +
                 "vault.usgovcloudapi.net, " +
                 "vault.microsoftazure.de, " +
-                "vault.cloudapi.microsoft.scloud, " +
-                "vault.cloudapi.eaglex.ic.gov, " +
                 "vault.sovcloud-api.fr, " +
                 "vault.sovcloud-api.de, " +
                 "managedhsm.azure.net, " +
                 "managedhsm.azure.cn, " +
                 "managedhsm.usgovcloudapi.net, " +
                 "managedhsm.microsoftazure.de, " +
-                "managedhsm.cloudapi.microsoft.scloud, " +
-                "managedhsm.cloudapi.eaglex.ic.gov, " +
                 "managedhsm.sovcloud-api.fr, " +
                 "managedhsm.sovcloud-api.de." +
                 @"\s+\(?Parameter (name: )?'?masterKeyPath('\))?";
@@ -85,8 +81,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         [InlineData("vault.azure.cn")]
         [InlineData("vault.usgovcloudapi.net")]
         [InlineData("vault.microsoftazure.de")]
-        [InlineData("vault.cloudapi.microsoft.scloud")]
-        [InlineData("vault.cloudapi.eaglex.ic.gov")]
         [InlineData("vault.sovcloud-api.fr")]
         [InlineData("vault.sovcloud-api.de")]
         // HSM vaults.
@@ -94,8 +88,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         [InlineData("managedhsm.azure.cn")]
         [InlineData("managedhsm.usgovcloudapi.net")]
         [InlineData("managedhsm.microsoftazure.de")]
-        [InlineData("managedhsm.cloudapi.microsoft.scloud")]
-        [InlineData("managedhsm.cloudapi.eaglex.ic.gov")]
         [InlineData("managedhsm.sovcloud-api.fr")]
         [InlineData("managedhsm.sovcloud-api.de")]
         // Vaults with prefixes.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TrustedUrlsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TrustedUrlsTest.cs
@@ -8,126 +8,103 @@ using Azure.Core;
 using Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider;
 using Xunit;
 
-namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted;
-
-public class TrustedUrlsTest
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 {
-    private readonly SqlColumnEncryptionAzureKeyVaultProvider _provider;
-    private readonly MethodInfo _method;
-
-    public TrustedUrlsTest()
+    public class TrustedUrlsTest
     {
-        _provider = new(new SqlClientCustomTokenCredential());
-        
-        var assembly = typeof(SqlColumnEncryptionAzureKeyVaultProvider).Assembly;
-        var clazz = assembly.GetType("Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.SqlColumnEncryptionAzureKeyVaultProvider");
-        _method = clazz.GetMethod(
-            "ValidateNonEmptyAKVPath",
-            System.Reflection.BindingFlags.NonPublic |
-            System.Reflection.BindingFlags.Instance);
-    }
+        private readonly SqlColumnEncryptionAzureKeyVaultProvider _provider;
+        private readonly MethodInfo _method;
 
-    public const string InvalidVaultKeyPathErrorMessage =
-        @"Invalid Azure Key Vault key path specified: 'https://www.microsoft.com'. " +
-        "Valid trusted endpoints: " +
-        "vault.azure.net, " +
-        "vault.azure.cn, " +
-        "vault.usgovcloudapi.net, " +
-        "vault.microsoftazure.de, " +
-        "vault.cloudapi.microsoft.scloud, " +
-        "vault.cloudapi.eaglex.ic.gov, " +
-        "vault.sovcloud-api.fr, " +
-        "vault.sovcloud-api.de, " +
-        "managedhsm.azure.net, " +
-        "managedhsm.azure.cn, " +
-        "managedhsm.usgovcloudapi.net, " +
-        "managedhsm.microsoftazure.de, " +
-        "managedhsm.cloudapi.microsoft.scloud, " +
-        "managedhsm.cloudapi.eaglex.ic.gov, " +
-        "managedhsm.sovcloud-api.fr, " +
-        "managedhsm.sovcloud-api.de." +
-        @"\s+\(?Parameter (name: )?'?masterKeyPath('\))?";
-
-    private static string MakeUrl(string vault)
-    {
-        return $"https://{vault}/keys/dummykey/dummykeyid";
-    }
-
-    public static string MakeInvalidVaultErrorMessage(string url)
-    {
-        return
-            $"Invalid Azure Key Vault key path specified: '{url}'. " +
-            "Valid trusted endpoints: " +
-            "vault.azure.net, " +
-            "vault.azure.cn, " +
-            "vault.usgovcloudapi.net, " +
-            "vault.microsoftazure.de, " +
-            "vault.cloudapi.microsoft.scloud, " +
-            "vault.cloudapi.eaglex.ic.gov, " +
-            "vault.sovcloud-api.fr, " +
-            "vault.sovcloud-api.de, " +
-            "managedhsm.azure.net, " +
-            "managedhsm.azure.cn, " +
-            "managedhsm.usgovcloudapi.net, " +
-            "managedhsm.microsoftazure.de, " +
-            "managedhsm.cloudapi.microsoft.scloud, " +
-            "managedhsm.cloudapi.eaglex.ic.gov, " +
-            "managedhsm.sovcloud-api.fr, " +
-            "managedhsm.sovcloud-api.de." +
-            @"\s+\(?Parameter (name: )?'?masterKeyPath('\))?";
-    }
-
-    [Theory]
-    [InlineData("www.microsoft.com")]
-    [InlineData("www.microsoft.vault.azure.com")]
-    [InlineData("vault.azure.net.io")]
-    public void InvalidVaults(string vault)
-    {
-        // Test that invalid key paths throw and contain the expected error
-        // message.
-        var url = MakeUrl(vault);
-
-        try
+        public TrustedUrlsTest()
         {
-            _method.Invoke(_provider, new object[] { url, false });
-        }
-        catch (TargetInvocationException ex)
-        {
-            // Unwrap the exception to get the actual ArgumentException thrown
-            var argEx = ex.InnerException as ArgumentException;
-            Assert.NotNull(argEx);
-            var expected = MakeInvalidVaultErrorMessage(url);
-            Console.WriteLine("Actual:   " + argEx.Message);
-            Console.WriteLine("Expected: " + expected);
-            Assert.Matches(expected, argEx.Message);
-        }
-    }
+            _provider = new(new SqlClientCustomTokenCredential());
 
-    [Theory]
-    // Normal vaults.
-    [InlineData("vault.azure.net")]
-    [InlineData("vault.azure.cn")]
-    [InlineData("vault.usgovcloudapi.net")]
-    [InlineData("vault.microsoftazure.de")]
-    [InlineData("vault.cloudapi.microsoft.scloud")]
-    [InlineData("vault.cloudapi.eaglex.ic.gov")]
-    [InlineData("vault.sovcloud-api.fr")]
-    [InlineData("vault.sovcloud-api.de")]
-    // HSM vaults.
-    [InlineData("managedhsm.azure.net")]
-    [InlineData("managedhsm.azure.cn")]
-    [InlineData("managedhsm.usgovcloudapi.net")]
-    [InlineData("managedhsm.microsoftazure.de")]
-    [InlineData("managedhsm.cloudapi.microsoft.scloud")]
-    [InlineData("managedhsm.cloudapi.eaglex.ic.gov")]
-    [InlineData("managedhsm.sovcloud-api.fr")]
-    [InlineData("managedhsm.sovcloud-api.de")]
-    // Vaults with prefixes.
-    [InlineData("foo.bar.vault.microsoftazure.de")]
-    [InlineData("baz.bar.foo.managedhsm.sovcloud-api.fr")]
-    public void ValidVaults(string vault)
-    {
-        // Test that valid vault key paths do not throw exceptions
-        _method.Invoke(_provider, new object[] { MakeUrl(vault), false });
+            var assembly = typeof(SqlColumnEncryptionAzureKeyVaultProvider).Assembly;
+            var clazz = assembly.GetType("Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.SqlColumnEncryptionAzureKeyVaultProvider");
+            _method = clazz.GetMethod(
+                "ValidateNonEmptyAKVPath",
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance);
+        }
+
+        private static string MakeUrl(string vault)
+        {
+            return $"https://{vault}/keys/dummykey/dummykeyid";
+        }
+
+        public static string MakeInvalidVaultErrorMessage(string url)
+        {
+            return
+                $"Invalid Azure Key Vault key path specified: '{url}'. " +
+                "Valid trusted endpoints: " +
+                "vault.azure.net, " +
+                "vault.azure.cn, " +
+                "vault.usgovcloudapi.net, " +
+                "vault.microsoftazure.de, " +
+                "vault.cloudapi.microsoft.scloud, " +
+                "vault.cloudapi.eaglex.ic.gov, " +
+                "vault.sovcloud-api.fr, " +
+                "vault.sovcloud-api.de, " +
+                "managedhsm.azure.net, " +
+                "managedhsm.azure.cn, " +
+                "managedhsm.usgovcloudapi.net, " +
+                "managedhsm.microsoftazure.de, " +
+                "managedhsm.cloudapi.microsoft.scloud, " +
+                "managedhsm.cloudapi.eaglex.ic.gov, " +
+                "managedhsm.sovcloud-api.fr, " +
+                "managedhsm.sovcloud-api.de." +
+                @"\s+\(?Parameter (name: )?'?masterKeyPath('\))?";
+        }
+
+        [Theory]
+        [InlineData("www.microsoft.com")]
+        [InlineData("www.microsoft.vault.azure.com")]
+        [InlineData("vault.azure.net.io")]
+        public void InvalidVaults(string vault)
+        {
+            // Test that invalid key paths throw and contain the expected error
+            // message.
+            var url = MakeUrl(vault);
+
+            try
+            {
+                _method.Invoke(_provider, new object[] { url, false });
+            }
+            catch (TargetInvocationException ex)
+            {
+                // Unwrap the exception to get the actual ArgumentException thrown
+                var argEx = ex.InnerException as ArgumentException;
+                Assert.NotNull(argEx);
+                Assert.Matches(MakeInvalidVaultErrorMessage(url), argEx.Message);
+            }
+        }
+
+        [Theory]
+        // Normal vaults.
+        [InlineData("vault.azure.net")]
+        [InlineData("vault.azure.cn")]
+        [InlineData("vault.usgovcloudapi.net")]
+        [InlineData("vault.microsoftazure.de")]
+        [InlineData("vault.cloudapi.microsoft.scloud")]
+        [InlineData("vault.cloudapi.eaglex.ic.gov")]
+        [InlineData("vault.sovcloud-api.fr")]
+        [InlineData("vault.sovcloud-api.de")]
+        // HSM vaults.
+        [InlineData("managedhsm.azure.net")]
+        [InlineData("managedhsm.azure.cn")]
+        [InlineData("managedhsm.usgovcloudapi.net")]
+        [InlineData("managedhsm.microsoftazure.de")]
+        [InlineData("managedhsm.cloudapi.microsoft.scloud")]
+        [InlineData("managedhsm.cloudapi.eaglex.ic.gov")]
+        [InlineData("managedhsm.sovcloud-api.fr")]
+        [InlineData("managedhsm.sovcloud-api.de")]
+        // Vaults with prefixes.
+        [InlineData("foo.bar.vault.microsoftazure.de")]
+        [InlineData("baz.bar.foo.managedhsm.sovcloud-api.fr")]
+        public void ValidVaults(string vault)
+        {
+            // Test that valid vault key paths do not throw exceptions
+            _method.Invoke(_provider, new object[] { MakeUrl(vault), false });
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -38,20 +38,20 @@
   <ItemGroup Condition="'$(TestSet)' == '' OR '$(TestSet)' == 'AE'">
     <Compile Include="AlwaysEncrypted\AKVTests.cs" />
     <Compile Include="AlwaysEncrypted\AKVUnitTests.cs" />
-    <Compile Include="AlwaysEncrypted\EnclaveAzureDatabaseTests.cs" />
-    <Compile Include="AlwaysEncrypted\ExceptionTestAKVStore.cs" />
-    <Compile Include="AlwaysEncrypted\TestFixtures\Setup\AKVTestTable.cs" />
-    <Compile Include="AlwaysEncrypted\TestFixtures\Setup\AkvColumnMasterKey.cs" />
-    <Compile Include="AlwaysEncrypted\TestFixtures\SQLSetupStrategyAzureKeyVault.cs" />
     <Compile Include="AlwaysEncrypted\ApiShould.cs" />
     <Compile Include="AlwaysEncrypted\BulkCopyAE.cs" />
     <Compile Include="AlwaysEncrypted\BulkCopyAEErrorMessage.cs" />
     <Compile Include="AlwaysEncrypted\End2EndSmokeTests.cs" />
+    <Compile Include="AlwaysEncrypted\ExceptionTestAKVStore.cs" />
     <Compile Include="AlwaysEncrypted\SqlBulkCopyTruncation.cs" />
     <Compile Include="AlwaysEncrypted\SqlNullValues.cs" />
+    <Compile Include="AlwaysEncrypted\TrustedUrlsTest.cs" />
     <Compile Include="AlwaysEncrypted\TestFixtures\DatabaseHelper.cs" />
     <Compile Include="AlwaysEncrypted\TestFixtures\SQLSetupStrategy.cs" />
+    <Compile Include="AlwaysEncrypted\TestFixtures\SQLSetupStrategyAzureKeyVault.cs" />
     <Compile Include="AlwaysEncrypted\TestFixtures\SQLSetupStrategyCertStoreProvider.cs" />
+    <Compile Include="AlwaysEncrypted\TestFixtures\Setup\AKVTestTable.cs" />
+    <Compile Include="AlwaysEncrypted\TestFixtures\Setup\AkvColumnMasterKey.cs" />
     <Compile Include="AlwaysEncrypted\TestFixtures\Setup\ApiTestTable.cs" />
     <Compile Include="AlwaysEncrypted\TestFixtures\Setup\BulkCopyAETestTable.cs" />
     <Compile Include="AlwaysEncrypted\TestFixtures\Setup\BulkCopyAEErrorMessageTestTable.cs" />


### PR DESCRIPTION
Port of #3482 from main to release/5.2

- Added 4 new trusted AKV URLs.
- Fixed existing manual tests and added unit tests.
- Addressed incompatible .NET syntax that isn't supported by C# 9.0.