### PR TITLE
AKV Trusted URL cleanup

### DIFF
--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Constants.cs
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Constants.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
             "vault.azure.cn",                  // China
             "vault.usgovcloudapi.net",         // US Government
             "vault.microsoftazure.de",         // Azure Germany
-            "vault.cloudapi.microsoft.scloud", // USSec
-            "vault.cloudapi.eaglex.ic.gov",    // USNat
             "vault.sovcloud-api.fr",           // France (Bleu)
             "vault.sovcloud-api.de",           // Germany (Delos)
 
@@ -26,8 +24,6 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
             "managedhsm.azure.cn",
             "managedhsm.usgovcloudapi.net",
             "managedhsm.microsoftazure.de",
-            "managedhsm.cloudapi.microsoft.scloud",
-            "managedhsm.cloudapi.eaglex.ic.gov",
             "managedhsm.sovcloud-api.fr",
             "managedhsm.sovcloud-api.de"
         ];

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TrustedUrlsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TrustedUrlsTest.cs
@@ -41,16 +41,12 @@ public class TrustedUrlsTest
             "vault.azure.cn, " +
             "vault.usgovcloudapi.net, " +
             "vault.microsoftazure.de, " +
-            "vault.cloudapi.microsoft.scloud, " +
-            "vault.cloudapi.eaglex.ic.gov, " +
             "vault.sovcloud-api.fr, " +
             "vault.sovcloud-api.de, " +
             "managedhsm.azure.net, " +
             "managedhsm.azure.cn, " +
             "managedhsm.usgovcloudapi.net, " +
             "managedhsm.microsoftazure.de, " +
-            "managedhsm.cloudapi.microsoft.scloud, " +
-            "managedhsm.cloudapi.eaglex.ic.gov, " +
             "managedhsm.sovcloud-api.fr, " +
             "managedhsm.sovcloud-api.de." +
             @"\s+\(?Parameter (name: )?'?masterKeyPath('\))?";
@@ -85,8 +81,6 @@ public class TrustedUrlsTest
     [InlineData("vault.azure.cn")]
     [InlineData("vault.usgovcloudapi.net")]
     [InlineData("vault.microsoftazure.de")]
-    [InlineData("vault.cloudapi.microsoft.scloud")]
-    [InlineData("vault.cloudapi.eaglex.ic.gov")]
     [InlineData("vault.sovcloud-api.fr")]
     [InlineData("vault.sovcloud-api.de")]
     // HSM vaults.
@@ -94,8 +88,6 @@ public class TrustedUrlsTest
     [InlineData("managedhsm.azure.cn")]
     [InlineData("managedhsm.usgovcloudapi.net")]
     [InlineData("managedhsm.microsoftazure.de")]
-    [InlineData("managedhsm.cloudapi.microsoft.scloud")]
-    [InlineData("managedhsm.cloudapi.eaglex.ic.gov")]
     [InlineData("managedhsm.sovcloud-api.fr")]
     [InlineData("managedhsm.sovcloud-api.de")]
     // Vaults with prefixes.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TrustedUrlsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TrustedUrlsTest.cs
@@ -27,27 +27,6 @@ public class TrustedUrlsTest
             System.Reflection.BindingFlags.Instance);
     }
 
-    public const string InvalidVaultKeyPathErrorMessage =
-        @"Invalid Azure Key Vault key path specified: 'https://www.microsoft.com'. " +
-        "Valid trusted endpoints: " +
-        "vault.azure.net, " +
-        "vault.azure.cn, " +
-        "vault.usgovcloudapi.net, " +
-        "vault.microsoftazure.de, " +
-        "vault.cloudapi.microsoft.scloud, " +
-        "vault.cloudapi.eaglex.ic.gov, " +
-        "vault.sovcloud-api.fr, " +
-        "vault.sovcloud-api.de, " +
-        "managedhsm.azure.net, " +
-        "managedhsm.azure.cn, " +
-        "managedhsm.usgovcloudapi.net, " +
-        "managedhsm.microsoftazure.de, " +
-        "managedhsm.cloudapi.microsoft.scloud, " +
-        "managedhsm.cloudapi.eaglex.ic.gov, " +
-        "managedhsm.sovcloud-api.fr, " +
-        "managedhsm.sovcloud-api.de." +
-        @"\s+\(?Parameter (name: )?'?masterKeyPath('\))?";
-
     private static string MakeUrl(string vault)
     {
         return $"https://{vault}/keys/dummykey/dummykeyid";
@@ -96,10 +75,7 @@ public class TrustedUrlsTest
             // Unwrap the exception to get the actual ArgumentException thrown
             var argEx = ex.InnerException as ArgumentException;
             Assert.NotNull(argEx);
-            var expected = MakeInvalidVaultErrorMessage(url);
-            Console.WriteLine("Actual:   " + argEx.Message);
-            Console.WriteLine("Expected: " + expected);
-            Assert.Matches(expected, argEx.Message);
+            Assert.Matches(MakeInvalidVaultErrorMessage(url), argEx.Message);
         }
     }
 


### PR DESCRIPTION
- Removed unnecessary strings and console output from TrustedUrlsTest.
- Removed sensitive vault domains.