### PR TITLE
Fix incorrect snippet description

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
@@ -150,7 +150,7 @@ Next, compile and execute the following:
       </remarks>
       <example>
         <para>
-          The following example creates a <see cref="T:Microsoft.Data.SqlClient.SqlCommand" />, passing in the connection string and command text.
+          The following example creates a <see cref="T:Microsoft.Data.SqlClient.SqlCommand" />, passing in the command text.
         </para>
         <!-- SqlCommand_SqlCommand1 -->
         <code language="c#">


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet-api-docs/issues/11583

Porting to MDS.

> ### Type of issue
> Typo
> 
> ### Description
> The example used for SqlCommand(String) has the following description:
> 
> "The following example creates a SqlCommand, passing in the **connection string and** command text."
> 
> The problem is the lack of a connection string in the example. How should the the connection string be provided in this example? I assume the proper description would be:
> 
> "The following example creates a SqlCommand, passing in the command text."
> 
> ### Page URL
> https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.-ctor?view=net-9.0-pp#system-data-sqlclient-sqlcommand-ctor(system-string)
> 
> ### Content source URL
> https://github.com/dotnet/dotnet-api-docs/blob/main/xml/System.Data.SqlClient/SqlCommand.xml