### PR TITLE
Cleanup | Centralise AppContext switches

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -963,6 +963,11 @@
     
     <Compile Include="Microsoft\Data\SqlClient\TdsParser.Windows.cs" />
     <Compile Include="Microsoft\Data\SqlClient\TdsParserStateObjectNative.cs" />
+
+    <EmbeddedResource Include="$(CommonSourceRoot)Resources\ILLink.Substitutions.Windows.xml">
+      <LogicalName>ILLink.Substitutions.xml</LogicalName>
+      <Link>Resources\ILLink.Substitutions.Windows.xml</Link>
+    </EmbeddedResource>
   </ItemGroup>
 
   <!-- Unix only -->
@@ -1005,6 +1010,11 @@
     </Compile>
 
     <Compile Include="Microsoft\Data\SqlClient\TdsParser.Unix.cs" />
+
+    <EmbeddedResource Include="$(CommonSourceRoot)Resources\ILLink.Substitutions.Unix.xml">
+      <LogicalName>ILLink.Substitutions.xml</LogicalName>
+      <Link>Resources\ILLink.Substitutions.Unix.xml</Link>
+    </EmbeddedResource>
   </ItemGroup>
 
   <!-- Resources -->

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -31,13 +31,6 @@ namespace Microsoft.Data.SqlClient
     [DesignerCategory("")]
     public sealed partial class SqlConnection : DbConnection, ICloneable
     {
-        private enum CultureCheckState : uint
-        {
-            Unknown = 0,
-            Standard = 1,
-            Invariant = 2
-        }
-
         private bool _AsyncCommandInProgress;
 
         // SQLStatistics support
@@ -74,9 +67,6 @@ namespace Microsoft.Data.SqlClient
         // The downstream handling of Connection open is the same for idle connection resiliency. Currently we want to apply transient fault handling only to the connections opened
         // using SqlConnection.Open() method.
         internal bool _applyTransientFaultHandling = false;
-
-        // status of invariant culture environment check
-        private static CultureCheckState _cultureCheckState;
 
         // System column encryption key store providers are added by default
         private static readonly Dictionary<string, SqlColumnEncryptionKeyStoreProvider> s_systemColumnEncryptionKeyStoreProviders
@@ -1956,48 +1946,9 @@ namespace Microsoft.Data.SqlClient
         {
             SqlConnectionString connectionOptions = (SqlConnectionString)ConnectionOptions;
 
-            if (_cultureCheckState != CultureCheckState.Standard)
+            if (LocalAppContextSwitches.GlobalizationInvariantMode)
             {
-                // .NET Core 2.0 and up supports a Globalization Invariant Mode to reduce the size of
-                // required libraries for applications which don't need globalization support. SqlClient
-                // requires those libraries for core functionality and will throw exceptions later if they
-                // are not present. Throwing on open with a meaningful message helps identify the issue.
-                if (_cultureCheckState == CultureCheckState.Unknown)
-                {
-                    // check if invariant state has been set by appcontext switch directly 
-                    if (AppContext.TryGetSwitch("System.Globalization.Invariant", out bool isEnabled) && isEnabled)
-                    {
-                        _cultureCheckState = CultureCheckState.Invariant;
-                    }
-                    else
-                    {
-                        // check if invariant state has been set through environment variables
-                        string envValue = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
-                        if (string.Equals(envValue, bool.TrueString, StringComparison.OrdinalIgnoreCase) || string.Equals(envValue, "1", StringComparison.OrdinalIgnoreCase))
-                        {
-                            _cultureCheckState = CultureCheckState.Invariant;
-                        }
-                        else
-                        {
-                            // if it hasn't been manually set it could still apply if the os doesn't have
-                            //  icu libs installed or is a native binary with icu support trimmed away
-                            // netcore 3.1 to net5 do not throw in attempting to create en-us in inariant mode
-                            // net6 and greater will throw so catch and infer invariant mode from the exception
-                            try
-                            {
-                                _cultureCheckState = CultureInfo.GetCultureInfo("en-US").EnglishName.Contains("Invariant") ? CultureCheckState.Invariant : CultureCheckState.Standard;
-                            }
-                            catch (CultureNotFoundException)
-                            {
-                                _cultureCheckState = CultureCheckState.Invariant;
-                            }
-                        }
-                    }
-                }
-                if (_cultureCheckState == CultureCheckState.Invariant)
-                {
-                    throw SQL.GlobalizationInvariantModeNotSupported();
-                }
+                throw SQL.GlobalizationInvariantModeNotSupported();
             }
 
             _applyTransientFaultHandling = (!overrides.HasFlag(SqlConnectionOverrides.OpenWithoutRetry) && connectionOptions != null && connectionOptions.ConnectRetryCount > 0);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.Windows.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.SqlClient
     {
         internal void PostReadAsyncForMars()
         {
-            if (TdsParserStateObjectFactory.UseManagedSNI)
+            if (LocalAppContextSwitches.UseManagedNetworking)
                 return;
 
             // HACK HACK HACK - for Async only

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -621,7 +621,7 @@ namespace Microsoft.Data.SqlClient
                 // Cache physical stateObj and connection.
                 _pMarsPhysicalConObj = _physicalStateObj;
 
-                if (TdsParserStateObjectFactory.UseManagedSNI)
+                if (LocalAppContextSwitches.UseManagedNetworking)
                     _pMarsPhysicalConObj.IncrementPendingCallbacks();
 
                 uint info = 0;
@@ -1479,7 +1479,7 @@ namespace Microsoft.Data.SqlClient
                  * !=null       | == 0     | replace text left of errorMessage
                  */
 
-                if (TdsParserStateObjectFactory.UseManagedSNI)
+                if (LocalAppContextSwitches.UseManagedNetworking)
                 {
                     Debug.Assert(!string.IsNullOrEmpty(details.ErrorMessage) || details.SniErrorNumber != 0, "Empty error message received from SNI");
                     SqlClientEventSource.Log.TryAdvancedTraceEvent("<sc.TdsParser.ProcessSNIError |ERR|ADV > Empty error message received from SNI. Error Message = {0}, SNI Error Number ={1}", details.ErrorMessage, details.SniErrorNumber);
@@ -1528,7 +1528,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    if (TdsParserStateObjectFactory.UseManagedSNI)
+                    if (LocalAppContextSwitches.UseManagedNetworking)
                     {
                         // SNI error. Append additional error message info if available and hasn't been included.
                         string sniLookupMessage = SQL.GetSNIErrorMessage(details.SniErrorNumber);

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -204,16 +204,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private static bool EnableTruncateSwitch
-        {
-            get
-            {
-                bool value;
-                value = AppContext.TryGetSwitch(enableTruncateSwitch, out value) ? value : false;
-                return value;
-            }
-        }
-
         internal SqlInternalTransaction CurrentTransaction
         {
             get
@@ -7653,7 +7643,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (d.Scale != newScale)
             {
-                bool round = !EnableTruncateSwitch;
+                bool round = !LocalAppContextSwitches.TruncateScaledDecimal;
                 return SqlDecimal.AdjustScale(d, newScale - d.Scale, round);
             }
 
@@ -7666,7 +7656,7 @@ namespace Microsoft.Data.SqlClient
 
             if (newScale != oldScale)
             {
-                bool round = !EnableTruncateSwitch;
+                bool round = !LocalAppContextSwitches.TruncateScaledDecimal;
                 SqlDecimal num = new SqlDecimal(value);
                 num = SqlDecimal.AdjustScale(num, newScale - oldScale, round);
                 return num.Value;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -69,7 +69,6 @@ namespace Microsoft.Data.SqlClient
         // Constants
         private const int constBinBufferSize = 4096; // Size of the buffer used to read input parameter of type Stream
         private const int constTextBufferSize = 4096; // Size of the buffer (in chars) user to read input parameter of type TextReader
-        private const string enableTruncateSwitch = "Switch.Microsoft.Data.SqlClient.TruncateScaledDecimal"; // for applications that need to maintain backwards compatibility with the previous behavior
 
         // State variables
         internal TdsParserState _state = TdsParserState.Closed; // status flag for connection

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -205,16 +205,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private static bool EnableTruncateSwitch
-        {
-            get
-            {
-                bool value;
-                value = AppContext.TryGetSwitch(enableTruncateSwitch, out value) ? value : false;
-                return value;
-            }
-        }
-
         internal SqlInternalTransaction CurrentTransaction
         {
             get
@@ -7849,7 +7839,7 @@ namespace Microsoft.Data.SqlClient
         {
             if (d.Scale != newScale)
             {
-                bool round = !EnableTruncateSwitch;
+                bool round = !LocalAppContextSwitches.TruncateScaledDecimal;
                 return SqlDecimal.AdjustScale(d, newScale - d.Scale, round);
             }
 
@@ -7862,7 +7852,7 @@ namespace Microsoft.Data.SqlClient
 
             if (newScale != oldScale)
             {
-                bool round = !EnableTruncateSwitch;
+                bool round = !LocalAppContextSwitches.TruncateScaledDecimal;
                 SqlDecimal num = new SqlDecimal(value);
                 num = SqlDecimal.AdjustScale(num, newScale - oldScale, round);
                 return num.Value;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -69,7 +69,6 @@ namespace Microsoft.Data.SqlClient
         // Constants
         private const int constBinBufferSize = 4096; // Size of the buffer used to read input parameter of type Stream
         private const int constTextBufferSize = 4096; // Size of the buffer (in chars) user to read input parameter of type TextReader
-        private const string enableTruncateSwitch = "Switch.Microsoft.Data.SqlClient.TruncateScaledDecimal"; // for applications that need to maintain backwards compatibility with the previous behavior
 
         // State variables
         internal TdsParserState _state = TdsParserState.Closed; // status flag for connection

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumerator.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumerator.Windows.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Sql
 #if NETFRAMEWORK
             return SqlDataSourceEnumeratorNativeHelper.GetDataSources();
 #else
-            return SqlClient.TdsParserStateObjectFactory.UseManagedSNI ? SqlDataSourceEnumeratorManagedHelper.GetDataSources() : SqlDataSourceEnumeratorNativeHelper.GetDataSources();
+            return SqlClient.LocalAppContextSwitches.UseManagedNetworking ? SqlDataSourceEnumeratorManagedHelper.GetDataSources() : SqlDataSourceEnumeratorNativeHelper.GetDataSources();
 #endif
         }
     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolIdentity.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolIdentity.Windows.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
 #else
         internal static DbConnectionPoolIdentity GetCurrent()
         {
-            return TdsParserStateObjectFactory.UseManagedSNI ? GetCurrentManaged() : GetCurrentNative();
+            return LocalAppContextSwitches.UseManagedNetworking ? GetCurrentManaged() : GetCurrentNative();
         }
 #endif
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Data.SqlClient
         internal const string UseManagedNetworkingOnWindowsString = "Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows";
 
         private static Tristate s_globalizationInvariantMode;
-        private static Tristate s_useManagedNetworkingOnWindows;
+        private static Tristate s_useManagedNetworking;
 
         /// <summary>
         /// .NET Core 2.0 and up supports Globalization Invariant mode, which reduces the size of the required libraries for
@@ -389,22 +389,22 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (s_useManagedNetworkingOnWindows == Tristate.NotInitialized)
+                if (s_useManagedNetworking == Tristate.NotInitialized)
                 {
                     if (!OperatingSystem.IsWindows())
                     {
-                        s_useManagedNetworkingOnWindows = Tristate.True;
+                        s_useManagedNetworking = Tristate.True;
                     }
                     else if (AppContext.TryGetSwitch(UseManagedNetworkingOnWindowsString, out bool returnedValue) && returnedValue)
                     {
-                        s_useManagedNetworkingOnWindows = Tristate.True;
+                        s_useManagedNetworking = Tristate.True;
                     }
                     else
                     {
-                        s_useManagedNetworkingOnWindows = Tristate.False;
+                        s_useManagedNetworking = Tristate.False;
                     }
                 }
-                return s_useManagedNetworkingOnWindows == Tristate.True;
+                return s_useManagedNetworking == Tristate.True;
             }
         }
 #else

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Data.SqlClient
         private const string UseCompatibilityProcessSniString = @"Switch.Microsoft.Data.SqlClient.UseCompatibilityProcessSni";
         private const string UseCompatibilityAsyncBehaviourString = @"Switch.Microsoft.Data.SqlClient.UseCompatibilityAsyncBehaviour";
         private const string UseConnectionPoolV2String = @"Switch.Microsoft.Data.SqlClient.UseConnectionPoolV2";
+        private const string TruncateScaledDecimalString = @"Switch.Microsoft.Data.SqlClient.TruncateScaledDecimal";
 
         // this field is accessed through reflection in tests and should not be renamed or have the type changed without refactoring NullRow related tests
         private static Tristate s_legacyRowVersionNullBehavior;
@@ -34,6 +35,7 @@ namespace Microsoft.Data.SqlClient
         private static Tristate s_useCompatibilityProcessSni;
         private static Tristate s_useCompatibilityAsyncBehaviour;
         private static Tristate s_useConnectionPoolV2;
+        private static Tristate s_truncateScaledDecimal;
 
 #if NET
         static LocalAppContextSwitches()
@@ -294,6 +296,28 @@ namespace Microsoft.Data.SqlClient
                     }
                 }
                 return s_useConnectionPoolV2 == Tristate.True;
+            }
+        }
+
+        /// <summary>
+        /// When set to true, TdsParser will truncate (rather than round) decimal and SqlDecimal values when scaling them.
+        /// </summary>
+        public static bool TruncateScaledDecimal
+        {
+            get
+            {
+                if (s_truncateScaledDecimal == Tristate.NotInitialized)
+                {
+                    if (AppContext.TryGetSwitch(TruncateScaledDecimalString, out bool returnedValue) && returnedValue)
+                    {
+                        s_truncateScaledDecimal = Tristate.True;
+                    }
+                    else
+                    {
+                        s_truncateScaledDecimal = Tristate.False;
+                    }
+                }
+                return s_truncateScaledDecimal == Tristate.True;
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -3224,7 +3224,7 @@ namespace Microsoft.Data.SqlClient
                     ReadAsyncCallback(IntPtr.Zero, readPacket, 0);
 
                     // Only release packet for Managed SNI as for Native SNI packet is released in finally block.
-                    if (TdsParserStateObjectFactory.UseManagedSNI && readFromNetwork && !IsPacketEmpty(readPacket))
+                    if (LocalAppContextSwitches.UseManagedNetworking && readFromNetwork && !IsPacketEmpty(readPacket))
                     {
                         ReleasePacket(readPacket);
                     }
@@ -3260,7 +3260,7 @@ namespace Microsoft.Data.SqlClient
             }
             finally
             {
-                if (!TdsParserStateObjectFactory.UseManagedSNI)
+                if (!LocalAppContextSwitches.UseManagedNetworking)
                 {
                     if (readFromNetwork && !IsPacketEmpty(readPacket))
                     {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Unix.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Unix.cs
@@ -8,9 +8,6 @@ namespace Microsoft.Data.SqlClient
 {
     internal sealed class TdsParserStateObjectFactory
     {
-
-        public static bool UseManagedSNI => true;
-
         public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
 
         public EncryptionOptions EncryptionOptions => ManagedSni.SniLoadHandle.SingletonInstance.Options;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -42,14 +42,12 @@ namespace Microsoft.Data.SqlClient
 #if NET
             if (LocalAppContextSwitches.UseManagedNetworking)
             {
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | Found AppContext switch '{0}' enabled, managed networking implementation will be used.",
-                    LocalAppContextSwitches.UseManagedNetworkingOnWindowsString);
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | Using managed networking implementation.");
                 return new TdsParserStateObjectManaged(parser);
             }
             else
             {
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | AppContext switch '{0}' not enabled, native networking implementation will be used.",
-                   LocalAppContextSwitches.UseManagedNetworkingOnWindowsString);
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | Using native networking implementation.");
                 return new TdsParserStateObjectNative(parser);
             }
 #else

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObjectFactory.Windows.cs
@@ -13,28 +13,16 @@ namespace Microsoft.Data.SqlClient
     {
         public static readonly TdsParserStateObjectFactory Singleton = new TdsParserStateObjectFactory();
 
-        private const string UseManagedNetworkingOnWindows = "Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows";
-
-#if NET
-        private static bool s_shouldUseManagedSNI;
-
-        // If the appcontext switch is set then Use Managed SNI based on the value. Otherwise Native SNI.dll will be used by default.
-        public static bool UseManagedSNI =>
-            AppContext.TryGetSwitch(UseManagedNetworkingOnWindows, out s_shouldUseManagedSNI) ? s_shouldUseManagedSNI : false;
-#else
-        public const bool UseManagedSNI = false;
-#endif
-
         public EncryptionOptions EncryptionOptions =>
 #if NET
-            UseManagedSNI ? ManagedSni.SniLoadHandle.SingletonInstance.Options : SNILoadHandle.SingletonInstance.Options;
+            LocalAppContextSwitches.UseManagedNetworking ? ManagedSni.SniLoadHandle.SingletonInstance.Options : SNILoadHandle.SingletonInstance.Options;
 #else
             SNILoadHandle.SingletonInstance.Options;
 #endif
 
         public uint SNIStatus =>
 #if NET
-            UseManagedSNI ? ManagedSni.SniLoadHandle.SingletonInstance.Status : SNILoadHandle.SingletonInstance.Status;
+            LocalAppContextSwitches.UseManagedNetworking ? ManagedSni.SniLoadHandle.SingletonInstance.Status : SNILoadHandle.SingletonInstance.Status;
 #else
             SNILoadHandle.SingletonInstance.Status;
 #endif
@@ -44,7 +32,7 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         public bool ClientOSEncryptionSupport =>
 #if NET
-            UseManagedSNI ? ManagedSni.SniLoadHandle.SingletonInstance.ClientOSEncryptionSupport : SNILoadHandle.SingletonInstance.ClientOSEncryptionSupport;
+            LocalAppContextSwitches.UseManagedNetworking ? ManagedSni.SniLoadHandle.SingletonInstance.ClientOSEncryptionSupport : SNILoadHandle.SingletonInstance.ClientOSEncryptionSupport;
 #else
             SNILoadHandle.SingletonInstance.ClientOSEncryptionSupport;
 #endif
@@ -52,16 +40,16 @@ namespace Microsoft.Data.SqlClient
         public TdsParserStateObject CreateTdsParserStateObject(TdsParser parser)
         {
 #if NET
-            if (UseManagedSNI)
+            if (LocalAppContextSwitches.UseManagedNetworking)
             {
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | Found AppContext switch '{0}' enabled, managed networking implementation will be used."
-                   , UseManagedNetworkingOnWindows);
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | Found AppContext switch '{0}' enabled, managed networking implementation will be used.",
+                    LocalAppContextSwitches.UseManagedNetworkingOnWindowsString);
                 return new TdsParserStateObjectManaged(parser);
             }
             else
             {
-                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | AppContext switch '{0}' not enabled, native networking implementation will be used."
-                   , UseManagedNetworkingOnWindows);
+                SqlClientEventSource.Log.TryTraceEvent("TdsParserStateObjectFactory.CreateTdsParserStateObject | Info | AppContext switch '{0}' not enabled, native networking implementation will be used.",
+                   LocalAppContextSwitches.UseManagedNetworkingOnWindowsString);
                 return new TdsParserStateObjectNative(parser);
             }
 #else
@@ -72,7 +60,7 @@ namespace Microsoft.Data.SqlClient
         internal TdsParserStateObject CreateSessionObject(TdsParser tdsParser, TdsParserStateObject _pMarsPhysicalConObj, bool v)
         {
 #if NET
-            if (TdsParserStateObjectFactory.UseManagedSNI)
+            if (LocalAppContextSwitches.UseManagedNetworking)
             {
                 return new TdsParserStateObjectManaged(tdsParser, _pMarsPhysicalConObj, true);
             }

--- a/src/Microsoft.Data.SqlClient/src/Resources/ILLink.Substitutions.Unix.xml
+++ b/src/Microsoft.Data.SqlClient/src/Resources/ILLink.Substitutions.Unix.xml
@@ -1,0 +1,8 @@
+<linker>
+  <assembly fullname="Microsoft.Data.SqlClient">
+    <type fullname="Microsoft.Data.SqlClient.LocalAppContextSwitches">
+      <!-- The Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows switch must always be true on Unix platforms. -->
+      <method signature="System.Boolean get_UseManagedNetworking()" body="stub" value="true" />
+    </type>
+  </assembly>
+</linker>

--- a/src/Microsoft.Data.SqlClient/src/Resources/ILLink.Substitutions.Windows.xml
+++ b/src/Microsoft.Data.SqlClient/src/Resources/ILLink.Substitutions.Windows.xml
@@ -1,0 +1,9 @@
+<linker>
+  <assembly fullname="Microsoft.Data.SqlClient">
+    <type fullname="Microsoft.Data.SqlClient.LocalAppContextSwitches">
+      <!-- Enable the unused SNI to be trimmed based upon the publish-time value of the Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows switch -->
+      <method signature="System.Boolean get_UseManagedNetworking()" body="stub" value="false" feature="Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows" featurevalue="false" />
+      <method signature="System.Boolean get_UseManagedNetworking()" body="stub" value="true" feature="Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows" featurevalue="true" />
+    </type>
+  </assembly>
+</linker>

--- a/src/Microsoft.Data.SqlClient/tests/Common/LocalAppContextSwitchesHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/LocalAppContextSwitchesHelper.cs
@@ -30,7 +30,11 @@ public sealed class LocalAppContextSwitchesHelper : IDisposable
     private readonly PropertyInfo _useCompatibilityProcessSniProperty;
     private readonly PropertyInfo _useCompatibilityAsyncBehaviourProperty;
     private readonly PropertyInfo _useConnectionPoolV2Property;
-    #if NETFRAMEWORK
+    private readonly PropertyInfo _truncateScaledDecimalProperty;
+    #if NET
+    private readonly PropertyInfo _globalizationInvariantModeProperty;
+    private readonly PropertyInfo _useManagedNetworkingProperty;
+    #else
     private readonly PropertyInfo _disableTnirByDefaultProperty;
     #endif
 
@@ -51,7 +55,14 @@ public sealed class LocalAppContextSwitchesHelper : IDisposable
     private readonly Tristate _useCompatibilityAsyncBehaviourOriginal;
     private readonly FieldInfo _useConnectionPoolV2Field;
     private readonly Tristate _useConnectionPoolV2Original;
-    #if NETFRAMEWORK
+    private readonly FieldInfo _truncateScaledDecimalField;
+    private readonly Tristate _truncateScaledDecimalOriginal;
+    #if NET
+    private readonly FieldInfo _globalizationInvariantModeField;
+    private readonly Tristate _globalizationInvariantModeOriginal;
+    private readonly FieldInfo _useManagedNetworkingField;
+    private readonly Tristate _useManagedNetworkingOriginal;
+    #else
     private readonly FieldInfo _disableTnirByDefaultField;
     private readonly Tristate _disableTnirByDefaultOriginal;
     #endif
@@ -140,7 +151,19 @@ public sealed class LocalAppContextSwitchesHelper : IDisposable
             "UseConnectionPoolV2",
             out _useConnectionPoolV2Property);
 
-        #if NETFRAMEWORK
+        InitProperty(
+            "TruncateScaledDecimal",
+            out _truncateScaledDecimalProperty);
+
+        #if NET
+        InitProperty(
+            "GlobalizationInvariantMode",
+            out _globalizationInvariantModeProperty);
+
+        InitProperty(
+            "UseManagedNetworking",
+            out _useManagedNetworkingProperty);
+        #else
         InitProperty(
             "DisableTnirByDefault",
             out _disableTnirByDefaultProperty);
@@ -201,7 +224,22 @@ public sealed class LocalAppContextSwitchesHelper : IDisposable
             out _useConnectionPoolV2Field,
             out _useConnectionPoolV2Original);
 
-        #if NETFRAMEWORK
+        InitField(
+            "s_truncateScaledDecimal",
+            out _truncateScaledDecimalField,
+            out _truncateScaledDecimalOriginal);
+
+        #if NET
+        InitField(
+            "s_globalizationInvariantMode",
+            out _globalizationInvariantModeField,
+            out _globalizationInvariantModeOriginal);
+
+        InitField(
+            "s_useManagedNetworking",
+            out _useManagedNetworkingField,
+            out _useManagedNetworkingOriginal);
+        #else
         InitField(
             "s_disableTnirByDefault",
             out _disableTnirByDefaultField,
@@ -265,7 +303,19 @@ public sealed class LocalAppContextSwitchesHelper : IDisposable
             _useConnectionPoolV2Field,
             _useConnectionPoolV2Original);
 
-        #if NETFRAMEWORK
+        RestoreField(
+            _truncateScaledDecimalField,
+            _truncateScaledDecimalOriginal);
+
+        #if NET
+        RestoreField(
+            _globalizationInvariantModeField,
+            _globalizationInvariantModeOriginal);
+
+        RestoreField(
+            _useManagedNetworkingField,
+            _useManagedNetworkingOriginal);
+        #else
         RestoreField(
             _disableTnirByDefaultField,
             _disableTnirByDefaultOriginal);
@@ -350,7 +400,31 @@ public sealed class LocalAppContextSwitchesHelper : IDisposable
         get => (bool)_useConnectionPoolV2Property.GetValue(null);
     }
 
-    #if NETFRAMEWORK
+    /// <summary>
+    /// Access the LocalAppContextSwitches.TruncateScaledDecimal property.
+    /// </summary>
+    public bool TruncateScaledDecimal
+    {
+        get => (bool)_truncateScaledDecimalProperty.GetValue(null);
+    }
+
+    #if NET
+    /// <summary>
+    /// Access the LocalAppContextSwitches.GlobalizationInvariantMode property.
+    /// </summary>
+    public bool GlobalizationInvariantMode
+    {
+        get => (bool)_globalizationInvariantModeProperty.GetValue(null);
+    }
+
+    /// <summary>
+    /// Access the LocalAppContextSwitches.UseManagedNetworking property.
+    /// </summary>
+    public bool UseManagedNetworking
+    {
+        get => (bool)_useManagedNetworkingProperty.GetValue(null);
+    }
+    #else
     /// <summary>
     /// Access the LocalAppContextSwitches.DisableTnirByDefault property.
     /// </summary>
@@ -443,7 +517,34 @@ public sealed class LocalAppContextSwitchesHelper : IDisposable
         set => SetValue(_useConnectionPoolV2Field, value);
     }
 
-    #if NETFRAMEWORK
+    /// <summary>
+    /// Get or set the LocalAppContextSwitches.TruncateScaledDecimal switch value.
+    /// </summary>
+    public Tristate TruncateScaledDecimalField
+    {
+        get => GetValue(_truncateScaledDecimalField);
+        set => SetValue(_truncateScaledDecimalField, value);
+    }
+
+    #if NET
+    /// <summary>
+    /// Get or set the LocalAppContextSwitches.GlobalizationInvariantMode switch value.
+    /// </summary>
+    public Tristate GlobalizationInvariantModeField
+    {
+        get => GetValue(_globalizationInvariantModeField);
+        set => SetValue(_globalizationInvariantModeField, value);
+    }
+
+    /// <summary>
+    /// Get or set the LocalAppContextSwitches.UseManagedNetworking switch value.
+    /// </summary>
+    public Tristate UseManagedNetworkingField
+    {
+        get => GetValue(_useManagedNetworkingField);
+        set => SetValue(_useManagedNetworkingField, value);
+    }
+    #else
     /// <summary>
     /// Get or set the LocalAppContextSwitches.DisableTnirByDefault switch
     /// value.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/AdjustPrecScaleForBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/AdjustPrecScaleForBulkCopy.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Data;
 using System.Data.SqlTypes;
+using Microsoft.Data.SqlClient.Tests.Common;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests
@@ -14,6 +15,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void RunTest()
         {
+            using LocalAppContextSwitchesHelper appContextSwitches = new();
             SqlDecimal value = BulkCopySqlDecimalToTable(new SqlDecimal(0), 1, 0, 2, 2);
             Assert.Equal("0.00", value.ToString());
 
@@ -27,7 +29,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.Equal("12.3", value.ToString());
 
             value = BulkCopySqlDecimalToTable(new SqlDecimal(123.45), 10, 2, 4, 1);
-            if (AppContext.TryGetSwitch("Switch.Microsoft.Data.SqlClient.TruncateScaledDecimal", out bool switchValue) && switchValue)
+            if (appContextSwitches.TruncateScaledDecimal)
             {
                 Assert.Equal("123.4", value.ToString());
             }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/LocalAppContextSwitchesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/LocalAppContextSwitchesTest.cs
@@ -25,6 +25,7 @@ public class LocalAppContextSwitchesTest
         Assert.False(LocalAppContextSwitches.UseCompatibilityProcessSni);
         Assert.False(LocalAppContextSwitches.UseCompatibilityAsyncBehaviour);
         Assert.False(LocalAppContextSwitches.UseConnectionPoolV2);
+        Assert.False(LocalAppContextSwitches.TruncateScaledDecimal);
         #if NETFRAMEWORK
         Assert.False(LocalAppContextSwitches.DisableTnirByDefault);
         #endif

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/LocalAppContextSwitchesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/LocalAppContextSwitchesTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests;
@@ -26,8 +27,11 @@ public class LocalAppContextSwitchesTest
         Assert.False(LocalAppContextSwitches.UseCompatibilityAsyncBehaviour);
         Assert.False(LocalAppContextSwitches.UseConnectionPoolV2);
         Assert.False(LocalAppContextSwitches.TruncateScaledDecimal);
-        #if NETFRAMEWORK
+#if NETFRAMEWORK
         Assert.False(LocalAppContextSwitches.DisableTnirByDefault);
-        #endif
+        Assert.False(LocalAppContextSwitches.UseManagedNetworking);
+#else
+        Assert.Equal(!OperatingSystem.IsWindows(), LocalAppContextSwitches.UseManagedNetworking);
+#endif
     }
 }


### PR DESCRIPTION
## Description

We try to centralise all access to SqlClient's AppContext switches via the `LocalAppContextSwitches` class. There are currently a few cases where we don't do this though:
* netcore's globalization invariant mode detection lives in SqlConnection
* Switch.Microsoft.Data.SqlClient.TruncateScaledDecimal is handled by TdsParser on both targets
* Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows is handled by TdsParserStateObjectFactory

The first port of call is to relocate all of these to the existing LocalAppContextSwitches class. This slightly helps in the merge of SqlConnection.

I've also added an `ILLink.Substitutions.xml` resource to the output. This is a trimming improvement, and is documented [here](https://github.com/dotnet/runtime/blob/main/docs/tools/illink/data-formats.md). It allows referencing applications to specify a `RuntimeHostConfigurationOption` to set an AppContext switch, which the IL trimmer will reference and remove the entire managed or native SNI. There's a little more work to come on this once trimming is ready.

For comparison purposes, this is modelled in part on CsWinRT:
* [ILLink.Substitutions.xml](https://github.com/microsoft/CsWinRT/blob/master/src/WinRT.Runtime/Configuration/ILLink.Substitutions.xml)
* Underlying [FeatureSwitches](https://github.com/microsoft/CsWinRT/blob/master/src/WinRT.Runtime/Configuration/FeatureSwitches.cs) type
* Usage of [`RuntimeHostConfigurationOption`](https://github.com/microsoft/CsWinRT/blob/master/nuget/Microsoft.Windows.CsWinRT.targets#L339-L374)

I've used sizoscope to verify that I can use RuntimeHostConfigurationOption, publish an application and see the corresponding SNI's types are removed from the output.

## Issues

Partially relates to #1261 and #1942.

## Testing

Unit tests pass locally.