### PR TITLE
CodeQL | RSA Encryption Padding (Part 2?)

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert((dataToSign != null) && (dataToSign.Length != 0));
             Debug.Assert(rsaCngProvider != null);
 
-            return rsaCngProvider.SignData(dataToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            return rsaCngProvider.SignData(dataToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
         }
 
         /// <summary>
@@ -317,7 +317,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert((signature != null) && (signature.Length != 0));
             Debug.Assert(rsaCngProvider != null);
 
-            return rsaCngProvider.VerifyData(dataToVerify, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            return rsaCngProvider.VerifyData(dataToVerify, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
This is a test to see if tests will pass with Pss padding enabled. I don't think it will, but I need to verify.

## Issues
S360 issue for RSA encryption padding scheme.

## Testing
Local tests that should use that codepath tests, so I need a CI run to validate it further
