### PR TITLE
Remove placeholder links from pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,8 @@ High quality descriptions will lead to a smoother review experience.
 
 ## Issues
 
-Link to any relevant issues, bugs, or discussions (e.g., "Closes \#123", "Fixes
-issue \#456").
+Link to any relevant issues, bugs, or discussions (e.g., `Closes #123`, `Fixes
+issue #456`).
 
 ## Testing
 


### PR DESCRIPTION
## Description
The placeholder links in the pr template automatically link many PRs to the unrelated issues 123 and 456. Fix the format so that the examples are preserved, but don't actually hyperlink to the issues. See below for what the changes will look like.

## Issues

Link to any relevant issues, bugs, or discussions (e.g., `Closes #123`, `Fixes
issue #456`").
