### PR TITLE
CodeQL | RSA Padding Scheme (Part 2)

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert((dataToSign != null) && (dataToSign.Length != 0));
             Debug.Assert(rsaCngProvider != null);
 
-            // CodeQL [SM03796] Required for backwards compatibility with existing data and cross-driver compability
+            // CodeQL [SM03796] Required for backwards compatibility with existing data and cross-driver compatability
             return rsaCngProvider.SignData(dataToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         }
 
@@ -318,7 +318,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert((signature != null) && (signature.Length != 0));
             Debug.Assert(rsaCngProvider != null);
 
-            // CodeQL [SM03796] Required for backwards compatibility with existing data and cross-driver compability
+            // CodeQL [SM03796] Required for backwards compatibility with existing data and cross-driver compatability
             return rsaCngProvider.VerifyData(dataToVerify, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.Windows.cs
@@ -301,6 +301,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert((dataToSign != null) && (dataToSign.Length != 0));
             Debug.Assert(rsaCngProvider != null);
 
+            // CodeQL [SM03796] Required for backwards compatibility with existing data and cross-driver compability
             return rsaCngProvider.SignData(dataToSign, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         }
 
@@ -317,6 +318,7 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert((signature != null) && (signature.Length != 0));
             Debug.Assert(rsaCngProvider != null);
 
+            // CodeQL [SM03796] Required for backwards compatibility with existing data and cross-driver compability
             return rsaCngProvider.VerifyData(dataToVerify, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         }
 


### PR DESCRIPTION
## Description
Apparently the is another place in our column encryption provider where we are using an unapproved RSA padding scheme. Although changing the code to use the approved padding scheme would work (see #3495), it would introduce backwards compatability issues with existing encrypted data, as well as cross-driver compatibility issues (as determined by @saurabh500). Thus, the only viable option we have is to suppress the CodeQL issue.

This change will likely have to be backported to the release branches.

## Issues
There's an S360 issue, but that's not accessible from here.

## Testing
Literally just adds a couple special comments, no functional changes whatsoever.