### PR TITLE
[6.1] Update AKV to depend on any MDS 6.x package

### DIFF
--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -25,19 +25,19 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
     <tags>sqlclient microsoft.data.sqlclient azurekeyvaultprovider akvprovider alwaysencrypted</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Data.SqlClient" version="[6.0.1,6.1.0)" />
+        <dependency id="Microsoft.Data.SqlClient" version="[6.0.1,7.0.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Data.SqlClient" version="[6.0.1,6.1.0)" />
+        <dependency id="Microsoft.Data.SqlClient" version="[6.0.1,7.0.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net9.0">
-        <dependency id="Microsoft.Data.SqlClient" version="[6.0.1,6.1.0)" />
+        <dependency id="Microsoft.Data.SqlClient" version="[6.0.1,7.0.0)" />
         <dependency id="Azure.Core" version="[1.38.0,2.0.0)" />
         <dependency id="Azure.Security.KeyVault.Keys" version="[4.5.0,5.0.0)" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.4" />


### PR DESCRIPTION
Port of #3516.

Updated the AKV .nuspec file to declare it depends on any MDS 6.x package. This will make it compatible with the latest MDS 6.1.0 release, and any future MDS 6.x releases.