### PR TITLE
[6.1] Fix API docs

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml
@@ -3606,7 +3606,7 @@ If you call an `Execute` method after calling <xref:Microsoft.Data.SqlClient.Sql
 
 Output parameters (whether prepared or not) must have a user-specified data type. If you specify a variable length data type except vector, you must also specify the maximum <xref:Microsoft.Data.SqlClient.SqlParameter.Size%2A>.
 
-For vector data types, the <xref:Microsoft.Data.SqlClient.SqlParameter.Size%2A> property is ignored. The size of the vector is inferred from the <xref:Microsoft.Data.SqlClient.SqlParameter.Value%2A> of type <xref:Microsoft.Data.SqlTypes.SqlVector%2A>.
+For vector data types, the <xref:Microsoft.Data.SqlClient.SqlParameter.Size%2A> property is ignored. The size of the vector is inferred from the <xref:Microsoft.Data.SqlClient.SqlParameter.Value%2A> of type <xref:Microsoft.Data.SqlTypes.SqlVector&#96;1%2A>.
 
 Prior to Visual Studio 2010, <xref:Microsoft.Data.SqlClient.SqlCommand.Prepare%2A> threw an exception.  Beginning in Visual Studio 2010, this method does not throw an exception.
 

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml
@@ -967,10 +967,10 @@ The <xref:Microsoft.Data.SqlClient.SqlDataReader.GetSchemaTable%2A> method retur
     <GetSqlVector>
       <param name="i"></param>
       <summary>
-        Gets the value of the specified column as a <see cref="T:Microsoft.Data.SqlTypes.SqlVector"/>.
+        Gets the value of the specified column as a <see cref="T:Microsoft.Data.SqlTypes.SqlVector`1"/>.
       </summary>
       <returns>
-        A <see cref="T:Microsoft.Data.SqlTypes.SqlVector"/> object representing the column at the given ordinal.
+        A <see cref="T:Microsoft.Data.SqlTypes.SqlVector`1"/> object representing the column at the given ordinal.
       </returns>
       <exception cref="T:System.ArgumentOutOfRangeException">
         The index passed was outside the range of 0 to <see cref="P:System.Data.DataTableReader.FieldCount" /> - 1
@@ -979,7 +979,7 @@ The <xref:Microsoft.Data.SqlClient.SqlDataReader.GetSchemaTable%2A> method retur
         An attempt was made to read or access columns in a closed <see cref="T:Microsoft.Data.SqlClient.SqlDataReader" />.
       </exception>
       <exception cref="T:System.InvalidCastException">
-        The retrieved data is not compatible with the <see cref="T:Microsoft.Data.SqlTypes.SqlVector" /> type.
+        The retrieved data is not compatible with the <see cref="T:Microsoft.Data.SqlTypes.SqlVector`1" /> type.
       </exception>
       <remarks>
         No conversions are performed; therefore, the data retrieved must already be a vector value, or an exception is generated.


### PR DESCRIPTION
Addresses #3532 

The doc warnings in SqlDataAdapter class are not addressed here, as those methods are missing from generated docs. Following up internally on those warnings.