### PR TITLE
Remove CER

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1411,18 +1411,6 @@ namespace Microsoft.Data.SqlClient
                 CachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteNonQuery), _activeConnection);
                 _stateObj.ReadSni(completion);
             }
-            // Cause of a possible unstable runtime situation on facing with `OutOfMemoryException` and `StackOverflowException` exceptions,
-            // trying to call further functions in the catch of either may fail that should be considered on debuging!
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
             catch (Exception)
             {
                 // Similarly, if an exception occurs put the stateObj back into the pool.
@@ -1967,20 +1955,6 @@ namespace Microsoft.Data.SqlClient
                 // must finish caching information before ReadSni which can activate the callback before returning
                 CachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteXmlReader), _activeConnection);
                 _stateObj.ReadSni(completion);
-            }
-            // Cause of a possible unstable runtime situation on facing with `OutOfMemoryException` and `StackOverflowException` exceptions,
-            // trying to call further functions in the catch of either may fail that should be considered on debuging!
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                completion.TrySetException(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                completion.TrySetException(e);
-                throw;
             }
             catch (Exception e)
             {
@@ -2632,20 +2606,6 @@ namespace Microsoft.Data.SqlClient
                 // must finish caching information before ReadSni which can activate the callback before returning
                 CachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteReader), _activeConnection);
                 _stateObj.ReadSni(completion);
-            }
-            // Cause of a possible unstable runtime situation on facing with `OutOfMemoryException` and `StackOverflowException` exceptions,
-            // trying to call further functions in the catch of either may fail that should be considered on debuging!
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                completion.TrySetException(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                completion.TrySetException(e);
-                throw;
             }
             catch (Exception e)
             {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -4114,9 +4114,7 @@ namespace Microsoft.Data.SqlClient
                     SqlCommand command = (SqlCommand)state;
                     bool processFinallyBlockAsync = true;
                     bool decrementAsyncCountInFinallyBlockAsync = true;
-#if NETFRAMEWORK 
-                    RuntimeHelpers.PrepareConstrainedRegions();
-#endif
+
                     try
                     {
                         // Check for any exceptions on network write, before reading.
@@ -4187,10 +4185,7 @@ namespace Microsoft.Data.SqlClient
             {
                 bool processFinallyBlockAsync = true;
                 bool decrementAsyncCountInFinallyBlockAsync = true;
-
-#if NETFRAMEWORK
-                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
+                
                 try
                 {
                     // Check for any exceptions on network write, before reading.

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1237,34 +1237,11 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = null;
             RepairInnerConnection();
             SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.ChangeDatabase | API | Correlation | Object Id {0}, Activity Id {1}, Database {2}", ObjectID, ActivityCorrelator.Current, database);
-            TdsParser bestEffortCleanupTarget = null;
-
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
+            
             try
             {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
                 statistics = SqlStatistics.StartTimer(Statistics);
                 InnerConnection.ChangeDatabase(database);
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                Abort(e);
-#if NETFRAMEWORK
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-#endif
-                throw;
             }
             finally
             {
@@ -1328,15 +1305,10 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 SqlStatistics statistics = null;
-                TdsParser bestEffortCleanupTarget = null;
                 Exception e = null;
-
-#if NETFRAMEWORK
-                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
+                
                 try
                 {
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
                     statistics = SqlStatistics.StartTimer(Statistics);
 
                     Task reconnectTask = _currentReconnectionTask;
@@ -1361,27 +1333,6 @@ namespace Microsoft.Data.SqlClient
                     {
                         _statistics._closeTimestamp = ADP.TimerCurrent();
                     }
-                }
-                catch (System.OutOfMemoryException ex)
-                {
-                    e = ex;
-                    Abort(ex);
-                    throw;
-                }
-                catch (System.StackOverflowException ex)
-                {
-                    e = ex;
-                    Abort(ex);
-                    throw;
-                }
-                catch (System.Threading.ThreadAbortException ex)
-                {
-                    e = ex;
-                    Abort(ex);
-#if NETFRAMEWORK
-                    SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-#endif
-                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -4641,84 +4641,63 @@ namespace Microsoft.Data.SqlClient
 
         internal void DrainData(TdsParserStateObject stateObj)
         {
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
             try
             {
-                try
+                SqlDataReader.SharedState sharedState = stateObj._readerState;
+                if (sharedState != null && sharedState._dataReady)
                 {
-                    SqlDataReader.SharedState sharedState = stateObj._readerState;
-                    if (sharedState != null && sharedState._dataReady)
+                    _SqlMetaDataSet metadata = stateObj._cleanupMetaData;
+                    if (stateObj._partialHeaderBytesRead > 0)
                     {
-                        _SqlMetaDataSet metadata = stateObj._cleanupMetaData;
-                        if (stateObj._partialHeaderBytesRead > 0)
+                        if (stateObj.TryProcessHeader() != TdsOperationStatus.Done)
                         {
-                            if (stateObj.TryProcessHeader() != TdsOperationStatus.Done)
-                            {
-                                throw SQL.SynchronousCallMayNotPend();
-                            }
+                            throw SQL.SynchronousCallMayNotPend();
                         }
-                        if (0 == sharedState._nextColumnHeaderToRead)
+                    }
+                    if (0 == sharedState._nextColumnHeaderToRead)
+                    {
+                        // i. user called read but didn't fetch anything
+                        if (stateObj.Parser.TrySkipRow(stateObj._cleanupMetaData, stateObj) != TdsOperationStatus.Done)
                         {
-                            // i. user called read but didn't fetch anything
-                            if (stateObj.Parser.TrySkipRow(stateObj._cleanupMetaData, stateObj) != TdsOperationStatus.Done)
-                            {
-                                throw SQL.SynchronousCallMayNotPend();
-                            }
+                            throw SQL.SynchronousCallMayNotPend();
                         }
-                        else
+                    }
+                    else
+                    {
+                        // iia.  if we still have bytes left from a partially read column, skip
+                        if (sharedState._nextColumnDataToRead < sharedState._nextColumnHeaderToRead)
                         {
-                            // iia.  if we still have bytes left from a partially read column, skip
-                            if (sharedState._nextColumnDataToRead < sharedState._nextColumnHeaderToRead)
+                            if ((sharedState._nextColumnHeaderToRead > 0) && (metadata[sharedState._nextColumnHeaderToRead - 1].metaType.IsPlp))
                             {
-                                if ((sharedState._nextColumnHeaderToRead > 0) && (metadata[sharedState._nextColumnHeaderToRead - 1].metaType.IsPlp))
+                                if (stateObj._longlen != 0)
                                 {
-                                    if (stateObj._longlen != 0)
-                                    {
-                                        if (TrySkipPlpValue(ulong.MaxValue, stateObj, out _) != TdsOperationStatus.Done)
-                                        {
-                                            throw SQL.SynchronousCallMayNotPend();
-                                        }
-                                    }
-                                }
-
-                                else if (0 < sharedState._columnDataBytesRemaining)
-                                {
-                                    if (stateObj.TrySkipLongBytes(sharedState._columnDataBytesRemaining) != TdsOperationStatus.Done)
+                                    if (TrySkipPlpValue(ulong.MaxValue, stateObj, out _) != TdsOperationStatus.Done)
                                     {
                                         throw SQL.SynchronousCallMayNotPend();
                                     }
                                 }
                             }
 
-
-                            // Read the remaining values off the wire for this row
-                            if (stateObj.Parser.TrySkipRow(metadata, sharedState._nextColumnHeaderToRead, stateObj) != TdsOperationStatus.Done)
+                            else if (0 < sharedState._columnDataBytesRemaining)
                             {
-                                throw SQL.SynchronousCallMayNotPend();
+                                if (stateObj.TrySkipLongBytes(sharedState._columnDataBytesRemaining) != TdsOperationStatus.Done)
+                                {
+                                    throw SQL.SynchronousCallMayNotPend();
+                                }
                             }
                         }
+
+
+                        // Read the remaining values off the wire for this row
+                        if (stateObj.Parser.TrySkipRow(metadata, sharedState._nextColumnHeaderToRead, stateObj) != TdsOperationStatus.Done)
+                        {
+                            throw SQL.SynchronousCallMayNotPend();
+                        }
                     }
-                    Run(RunBehavior.Clean, null, null, null, stateObj);
                 }
-                catch
-                {
-                    _connHandler.DoomThisConnection();
-                    throw;
-                }
+                Run(RunBehavior.Clean, null, null, null, stateObj);
             }
-            catch (OutOfMemoryException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
-            catch (StackOverflowException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
-            catch (ThreadAbortException)
+            catch
             {
                 _connHandler.DoomThisConnection();
                 throw;
@@ -10214,28 +10193,7 @@ namespace Microsoft.Data.SqlClient
 
         private void TdsExecuteRPC_OnFailure(Exception exc, TdsParserStateObject stateObj)
         {
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-            try
-            {
-                FailureCleanup(stateObj, exc);
-            }
-            catch (OutOfMemoryException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
-            catch (StackOverflowException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
-            catch (ThreadAbortException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
+            FailureCleanup(stateObj, exc);
         }
 
         private void ExecuteFlushTaskCallback(Task tsk, TdsParserStateObject stateObj, TaskCompletionSource<object> completion, bool releaseConnectionLock)
@@ -10247,30 +10205,9 @@ namespace Microsoft.Data.SqlClient
                 {
                     Exception exc = tsk.Exception.InnerException;
 
-#if NETFRAMEWORK
-                    RuntimeHelpers.PrepareConstrainedRegions();
-#endif
                     try
                     {
                         FailureCleanup(stateObj, tsk.Exception);
-                    }
-                    catch (OutOfMemoryException e)
-                    {
-                        _connHandler.DoomThisConnection();
-                        completion.SetException(e);
-                        throw;
-                    }
-                    catch (StackOverflowException e)
-                    {
-                        _connHandler.DoomThisConnection();
-                        completion.SetException(e);
-                        throw;
-                    }
-                    catch (ThreadAbortException e)
-                    {
-                        _connHandler.DoomThisConnection();
-                        completion.SetException(e);
-                        throw;
                     }
                     catch (Exception e)
                     {
@@ -11959,35 +11896,14 @@ namespace Microsoft.Data.SqlClient
 
                 StripPreamble(buffer, ref offset, ref count);
 
-#if NETFRAMEWORK
-                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                try
+                Task task = null;
+                if (count > 0)
                 {
-                    Task task = null;
-                    if (count > 0)
-                    {
-                        _parser.WriteInt(count, _stateObj); // write length of chunk
-                        task = _stateObj.WriteByteArray(buffer, count, offset, canAccumulate: false);
-                    }
+                    _parser.WriteInt(count, _stateObj); // write length of chunk
+                    task = _stateObj.WriteByteArray(buffer, count, offset, canAccumulate: false);
+                }
 
-                    return task ?? Task.CompletedTask;
-                }
-                catch (OutOfMemoryException)
-                {
-                    _parser._connHandler.DoomThisConnection();
-                    throw;
-                }
-                catch (StackOverflowException)
-                {
-                    _parser._connHandler.DoomThisConnection();
-                    throw;
-                }
-                catch (ThreadAbortException)
-                {
-                    _parser._connHandler.DoomThisConnection();
-                    throw;
-                }
+                return task ?? Task.CompletedTask;
             }
 
             internal static void ValidateWriteParameters(byte[] buffer, int offset, int count)

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObject.netcore.cs
@@ -17,17 +17,6 @@ namespace Microsoft.Data.SqlClient
 {
     internal abstract partial class TdsParserStateObject
     {
-        private struct RuntimeHelpers
-        {
-            /// <summary>
-            /// This is a no-op in netcore version. Only needed for merging with netfx codebase.
-            /// </summary>
-            [Conditional("NETFRAMEWORK")]
-            internal static void PrepareConstrainedRegions()
-            {
-            }
-        }
-
         //////////////////
         // Constructors //
         //////////////////
@@ -168,7 +157,6 @@ namespace Microsoft.Data.SqlClient
 
                             PacketHandle syncReadPacket = default;
                             bool readFromNetwork = true;
-                            RuntimeHelpers.PrepareConstrainedRegions();
                             bool shouldDecrement = false;
                             try
                             {
@@ -317,7 +305,6 @@ namespace Microsoft.Data.SqlClient
                 return;
             }
 
-            RuntimeHelpers.PrepareConstrainedRegions();
             bool processFinallyBlock = true;
             try
             {
@@ -711,7 +698,6 @@ namespace Microsoft.Data.SqlClient
 
                 PacketHandle attnPacket = CreateAndSetAttentionPacket();
 
-                RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
                     // Dev11 #344723: SqlClient stress test suspends System_Data!Tcp::ReadSync via a call to SqlDataReader::Close

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -453,16 +453,8 @@ namespace Microsoft.Data.SqlClient
         {
             lock (_writePacketLockObject)
             {
-#if NETFRAMEWORK
-                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                try
-                { }
-                finally
-                {
-                    _writePacketCache.Dispose();
-                    // Do not set _writePacketCache to null, just in case a WriteAsyncCallback completes after this point
-                }
+                _writePacketCache.Dispose();
+                // Do not set _writePacketCache to null, just in case a WriteAsyncCallback completes after this point
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1417,7 +1417,6 @@ namespace Microsoft.Data.SqlClient
             // Read SNI does not have catches for async exceptions, handle here.
             try
             {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
                 // must finish caching information before ReadSni which can activate the callback before returning
                 CachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteNonQuery), _activeConnection);
                 _stateObj.ReadSni(completion);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -307,7 +307,6 @@ namespace Microsoft.Data.SqlClient
                 return (_cachedAsyncConnection == activeConnection && _cachedAsyncCloseCount == activeConnection.CloseCount);
             }
 
-            [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
             internal void ResetAsyncState()
             {
                 SqlClientEventSource.Log.TryTraceEvent("CachedAsyncState.ResetAsyncState | API | ObjectId {0}, Client Connection Id {1}, AsyncCommandInProgress={2}",

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -511,26 +511,10 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (_activeConnection != value && _activeConnection != null)
                     {
-                        RuntimeHelpers.PrepareConstrainedRegions();
                         try
                         {
                             // cleanup
                             Unprepare();
-                        }
-                        catch (System.OutOfMemoryException)
-                        {
-                            _activeConnection.InnerConnection.DoomThisConnection();
-                            throw;
-                        }
-                        catch (System.StackOverflowException)
-                        {
-                            _activeConnection.InnerConnection.DoomThisConnection();
-                            throw;
-                        }
-                        catch (System.Threading.ThreadAbortException)
-                        {
-                            _activeConnection.InnerConnection.DoomThisConnection();
-                            throw;
                         }
                         catch (Exception)
                         {
@@ -952,12 +936,8 @@ namespace Microsoft.Data.SqlClient
                     ValidateCommand(isAsync: false);
 
                     bool processFinallyBlock = true;
-                    TdsParser bestEffortCleanupTarget = null;
-                    RuntimeHelpers.PrepareConstrainedRegions();
                     try
                     {
-                        bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
-
                         // NOTE: The state object isn't actually needed for this, but it is still here for back-compat (since it does a bunch of checks)
                         GetStateObject();
 
@@ -972,26 +952,6 @@ namespace Microsoft.Data.SqlClient
                         }
 
                         InternalPrepare();
-                    }
-                    catch (System.OutOfMemoryException e)
-                    {
-                        processFinallyBlock = false;
-                        _activeConnection.Abort(e);
-                        throw;
-                    }
-                    catch (System.StackOverflowException e)
-                    {
-                        processFinallyBlock = false;
-                        _activeConnection.Abort(e);
-                        throw;
-                    }
-                    catch (System.Threading.ThreadAbortException e)
-                    {
-                        processFinallyBlock = false;
-                        _activeConnection.Abort(e);
-
-                        SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                        throw;
                     }
                     catch (Exception e)
                     {
@@ -1124,52 +1084,29 @@ namespace Microsoft.Data.SqlClient
                             return;
                         }
 
-                        TdsParser bestEffortCleanupTarget = null;
-                        RuntimeHelpers.PrepareConstrainedRegions();
-                        try
+                        if (!_pendingCancel)
                         {
-                            bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
+                            // Do nothing if aleady pending.
+                          // Before attempting actual cancel, set the _pendingCancel flag to false.
+                          // This denotes to other thread before obtaining stateObject from the
+                          // session pool that there is another thread wishing to cancel.
+                          // The period in question is between entering the ExecuteAPI and obtaining
+                          // a stateObject.
+                            _pendingCancel = true;
 
-                            if (!_pendingCancel)
+                            TdsParserStateObject stateObj = _stateObj;
+                            if (stateObj != null)
                             {
-                                // Do nothing if aleady pending.
-                              // Before attempting actual cancel, set the _pendingCancel flag to false.
-                              // This denotes to other thread before obtaining stateObject from the
-                              // session pool that there is another thread wishing to cancel.
-                              // The period in question is between entering the ExecuteAPI and obtaining
-                              // a stateObject.
-                                _pendingCancel = true;
-
-                                TdsParserStateObject stateObj = _stateObj;
-                                if (stateObj != null)
+                                stateObj.Cancel(this);
+                            }
+                            else
+                            {
+                                SqlDataReader reader = connection.FindLiveReader(this);
+                                if (reader != null)
                                 {
-                                    stateObj.Cancel(this);
-                                }
-                                else
-                                {
-                                    SqlDataReader reader = connection.FindLiveReader(this);
-                                    if (reader != null)
-                                    {
-                                        reader.Cancel(this);
-                                    }
+                                    reader.Cancel(this);
                                 }
                             }
-                        }
-                        catch (System.OutOfMemoryException e)
-                        {
-                            _activeConnection.Abort(e);
-                            throw;
-                        }
-                        catch (System.StackOverflowException e)
-                        {
-                            _activeConnection.Abort(e);
-                            throw;
-                        }
-                        catch (System.Threading.ThreadAbortException e)
-                        {
-                            _activeConnection.Abort(e);
-                            SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                            throw;
                         }
                     }
                 }
@@ -1478,30 +1415,12 @@ namespace Microsoft.Data.SqlClient
         private void BeginExecuteNonQueryInternalReadStage(TaskCompletionSource<object> completion)
         {
             // Read SNI does not have catches for async exceptions, handle here.
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
                 bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
                 // must finish caching information before ReadSni which can activate the callback before returning
                 CachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteNonQuery), _activeConnection);
                 _stateObj.ReadSni(completion);
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _activeConnection.Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                throw;
             }
             catch (Exception)
             {
@@ -1697,107 +1616,85 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.TryTraceEvent("SqlCommand.InternalEndExecuteNonQuery | INFO | ObjectId {0}, Client Connection Id {1}, MARS={2}, AsyncCommandInProgress={3}",
                                                     _activeConnection?.ObjectID, _activeConnection?.ClientConnectionId,
                                                     _activeConnection?.Parser?.MARSOn, _activeConnection?.AsyncCommandInProgress);
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
 
+            VerifyEndExecuteState((Task)asyncResult, endMethod);
+            WaitForAsyncResults(asyncResult, isInternal);
+
+            // If column encryption is enabled, also check the state after waiting for the task.
+            // It would be better to do this for all cases, but avoiding for compatibility reasons.
+            if (IsColumnEncryptionEnabled)
+            {
+                VerifyEndExecuteState((Task)asyncResult, endMethod, fullCheckForColumnEncryption: true);
+            }
+
+            bool processFinallyBlock = true;
             try
             {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
-                VerifyEndExecuteState((Task)asyncResult, endMethod);
-                WaitForAsyncResults(asyncResult, isInternal);
-
-                // If column encryption is enabled, also check the state after waiting for the task.
-                // It would be better to do this for all cases, but avoiding for compatibility reasons.
-                if (IsColumnEncryptionEnabled)
+                // If this is not for internal usage, notify the dependency.
+                // If we have already initiated the end internally, the reader should be ready, so just return the rows affected.
+                if (!isInternal)
                 {
-                    VerifyEndExecuteState((Task)asyncResult, endMethod, fullCheckForColumnEncryption: true);
+                    NotifyDependency();
+
+                    if (_internalEndExecuteInitiated)
+                    {
+                        Debug.Assert(_stateObj == null);
+
+                        // Reset the state since we exit early.
+                        CachedAsyncState.ResetAsyncState();
+
+                        return _rowsAffected;
+                    }
                 }
 
-                bool processFinallyBlock = true;
-                try
+                CheckThrowSNIException();
+
+                // only send over SQL Batch command if we are not a stored proc and have no parameters
+                if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
                 {
-                    // If this is not for internal usage, notify the dependency.
-                    // If we have already initiated the end internally, the reader should be ready, so just return the rows affected.
-                    if (!isInternal)
+                    try
                     {
-                        NotifyDependency();
-
-                        if (_internalEndExecuteInitiated)
+                        Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+                        TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out _);
+                        if (result != TdsOperationStatus.Done)
                         {
-                            Debug.Assert(_stateObj == null);
-
-                            // Reset the state since we exit early.
+                            throw SQL.SynchronousCallMayNotPend();
+                        }
+                    }
+                    finally
+                    {
+                        // Don't reset the state for internal End. The user End will do that eventually.
+                        if (!isInternal)
+                        {
                             CachedAsyncState.ResetAsyncState();
-
-                            return _rowsAffected;
-                        }
-                    }
-
-                    CheckThrowSNIException();
-
-                    // only send over SQL Batch command if we are not a stored proc and have no parameters
-                    if ((System.Data.CommandType.Text == this.CommandType) && (0 == GetParameterCount(_parameters)))
-                    {
-                        try
-                        {
-                            Debug.Assert(_stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                            TdsOperationStatus result = _stateObj.Parser.TryRun(RunBehavior.UntilDone, this, null, null, _stateObj, out _);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                throw SQL.SynchronousCallMayNotPend();
-                            }
-                        }
-                        finally
-                        {
-                            // Don't reset the state for internal End. The user End will do that eventually.
-                            if (!isInternal)
-                            {
-                                CachedAsyncState.ResetAsyncState();
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // otherwise, use a full-fledged execute that can handle params and stored procs
-                        SqlDataReader reader = CompleteAsyncExecuteReader(isInternal);
-                        if (reader != null)
-                        {
-                            reader.Close();
                         }
                     }
                 }
-                catch (Exception e)
+                else
                 {
-                    processFinallyBlock = ADP.IsCatchableExceptionType(e);
-                    throw;
-                }
-                finally
-                {
-                    if (processFinallyBlock)
+                    // otherwise, use a full-fledged execute that can handle params and stored procs
+                    SqlDataReader reader = CompleteAsyncExecuteReader(isInternal);
+                    if (reader != null)
                     {
-                        PutStateObject();
+                        reader.Close();
                     }
                 }
+            }
+            catch (Exception e)
+            {
+                processFinallyBlock = ADP.IsCatchableExceptionType(e);
+                throw;
+            }
+            finally
+            {
+                if (processFinallyBlock)
+                {
+                    PutStateObject();
+                }
+            }
 
-                Debug.Assert(_stateObj == null, "non-null state object in EndExecuteNonQuery");
-                return _rowsAffected;
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _activeConnection.Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                throw;
-            }
+            Debug.Assert(_stateObj == null, "non-null state object in EndExecuteNonQuery");
+            return _rowsAffected;
         }
 
         private Task InternalExecuteNonQuery(
@@ -1817,92 +1714,70 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = Statistics;
             _rowsAffected = -1;
 
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
+            // @devnote: this function may throw for an invalid connection
+            // @devnote: returns false for empty command text
+            if (!isRetry)
             {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
-                // @devnote: this function may throw for an invalid connection
-                // @devnote: returns false for empty command text
-                if (!isRetry)
-                {
-                    ValidateCommand(isAsync, methodName);
-                }
-                CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
+                ValidateCommand(isAsync, methodName);
+            }
+            CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
 
-                Task task = null;
+            Task task = null;
 
-                // Always Encrypted generally operates only on parameterized queries. However enclave based Always encrypted also supports unparameterized queries
-                // We skip this block for enclave based always encrypted so that we can make a call to SQL Server to get the encryption information
-                if (!ShouldUseEnclaveBasedWorkflow && !_batchRPCMode && CommandType == CommandType.Text && GetParameterCount(_parameters) == 0)
+            // Always Encrypted generally operates only on parameterized queries. However enclave based Always encrypted also supports unparameterized queries
+            // We skip this block for enclave based always encrypted so that we can make a call to SQL Server to get the encryption information
+            if (!ShouldUseEnclaveBasedWorkflow && !_batchRPCMode && CommandType == CommandType.Text && GetParameterCount(_parameters) == 0)
+            {
+                Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
+                if (statistics != null)
                 {
-                    Debug.Assert(!sendToPipe, "trying to send non-context command to pipe");
-                    if (statistics != null)
+                    if (!IsDirty && IsPrepared)
                     {
-                        if (!IsDirty && IsPrepared)
-                        {
-                            statistics.SafeIncrement(ref statistics._preparedExecs);
-                        }
-                        else
-                        {
-                            statistics.SafeIncrement(ref statistics._unpreparedExecs);
-                        }
+                        statistics.SafeIncrement(ref statistics._preparedExecs);
                     }
-
-                    // We should never get here for a retry since we only have retries for parameters.
-                    Debug.Assert(!isRetry);
-
-                    task = RunExecuteNonQueryTds(methodName, isAsync, timeout, asyncWrite);
-                }
-                else
-                {
-                    // otherwise, use a full-fledged execute that can handle params and stored procs
-                    Debug.Assert(!sendToPipe, "Trying to send non-context command to pipe");
-                    SqlClientEventSource.Log.TryTraceEvent("SqlCommand.InternalExecuteNonQuery | INFO | Object Id {0}, RPC execute method name {1}, isAsync {2}, isRetry {3}", ObjectID, methodName, isAsync, isRetry);
-
-                    SqlDataReader reader = RunExecuteReader(
-                        CommandBehavior.Default,
-                        RunBehavior.UntilDone,
-                        returnStream: false,
-                        completion,
-                        timeout,
-                        out task,
-                        out usedCache,
-                        asyncWrite,
-                        isRetry,
-                        methodName);
-                    
-                    if (reader != null)
+                    else
                     {
-                        if (task != null)
-                        {
-                            task = AsyncHelper.CreateContinuationTask(task, () => reader.Close());
-                        }
-                        else
-                        {
-                            reader.Close();
-                        }
+                        statistics.SafeIncrement(ref statistics._unpreparedExecs);
                     }
                 }
-                Debug.Assert(isAsync || _stateObj == null, "non-null state object in InternalExecuteNonQuery");
-                return task;
+
+                // We should never get here for a retry since we only have retries for parameters.
+                Debug.Assert(!isRetry);
+
+                task = RunExecuteNonQueryTds(methodName, isAsync, timeout, asyncWrite);
             }
-            catch (System.OutOfMemoryException e)
+            else
             {
-                _activeConnection.Abort(e);
-                throw;
+                // otherwise, use a full-fledged execute that can handle params and stored procs
+                Debug.Assert(!sendToPipe, "Trying to send non-context command to pipe");
+                SqlClientEventSource.Log.TryTraceEvent("SqlCommand.InternalExecuteNonQuery | INFO | Object Id {0}, RPC execute method name {1}, isAsync {2}, isRetry {3}", ObjectID, methodName, isAsync, isRetry);
+
+                SqlDataReader reader = RunExecuteReader(
+                    CommandBehavior.Default,
+                    RunBehavior.UntilDone,
+                    returnStream: false,
+                    completion,
+                    timeout,
+                    out task,
+                    out usedCache,
+                    asyncWrite,
+                    isRetry,
+                    methodName);
+
+                if (reader != null)
+                {
+                    if (task != null)
+                    {
+                        task = AsyncHelper.CreateContinuationTask(task, () => reader.Close());
+                    }
+                    else
+                    {
+                        reader.Close();
+                    }
+                }
             }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _activeConnection.Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                throw;
-            }
+            Debug.Assert(isAsync || _stateObj == null, "non-null state object in InternalExecuteNonQuery");
+            return task;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteXmlReader/*'/>
@@ -2075,33 +1950,11 @@ namespace Microsoft.Data.SqlClient
         {
             Debug.Assert(completion != null, "Completion source should not be null");
             // Read SNI does not have catches for async exceptions, handle here.
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
                 // must finish caching information before ReadSni which can activate the callback before returning
                 CachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteXmlReader), _activeConnection);
                 _stateObj.ReadSni(completion);
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                completion.TrySetException(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                completion.TrySetException(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _activeConnection.Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                completion.TrySetException(e);
-                throw;
             }
             catch (Exception e)
             {
@@ -2289,8 +2142,6 @@ namespace Microsoft.Data.SqlClient
             _pendingCancel = false;
 
             SqlStatistics statistics = null;
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
             bool success = false;
             int? sqlExceptionNumber = null;
 
@@ -2299,7 +2150,6 @@ namespace Microsoft.Data.SqlClient
                 try
                 {
                     WriteBeginExecuteEvent();
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
                     statistics = SqlStatistics.StartTimer(Statistics);
                     SqlDataReader result = IsProviderRetriable ?
                         RunExecuteReaderWithRetry(behavior, RunBehavior.ReturnImmediately, returnStream: true) :
@@ -2310,22 +2160,6 @@ namespace Microsoft.Data.SqlClient
                 catch (SqlException e)
                 {
                     sqlExceptionNumber = e.Number;
-                    throw;
-                }
-                catch (System.OutOfMemoryException e)
-                {
-                    _activeConnection.Abort(e);
-                    throw;
-                }
-                catch (System.StackOverflowException e)
-                {
-                    _activeConnection.Abort(e);
-                    throw;
-                }
-                catch (System.Threading.ThreadAbortException e)
-                {
-                    _activeConnection.Abort(e);
-                    SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
                     throw;
                 }
                 finally
@@ -2734,33 +2568,11 @@ namespace Microsoft.Data.SqlClient
             Debug.Assert(completion != null, "CompletionSource should not be null");
             SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlCommand.BeginExecuteReaderInternalReadStage | INFO | Correlation | Object Id {0}, Activity Id {1}, Client Connection Id {2}, Command Text '{3}'", ObjectID, ActivityCorrelator.Current, Connection?.ClientConnectionId, CommandText);
             // Read SNI does not have catches for async exceptions, handle here.
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
                 // must finish caching information before ReadSni which can activate the callback before returning
                 CachedAsyncState.SetActiveConnectionAndResult(completion, nameof(EndExecuteReader), _activeConnection);
                 _stateObj.ReadSni(completion);
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                completion.TrySetException(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                completion.TrySetException(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _activeConnection.Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                completion.TrySetException(e);
-                throw;
             }
             catch (Exception e)
             {
@@ -2789,31 +2601,9 @@ namespace Microsoft.Data.SqlClient
 
             CheckThrowSNIException();
 
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
-                SqlDataReader reader = CompleteAsyncExecuteReader(isInternal);
-                Debug.Assert(_stateObj == null, "non-null state object in InternalEndExecuteReader");
-                return reader;
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _activeConnection.Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                throw;
-            }
+            SqlDataReader reader = CompleteAsyncExecuteReader(isInternal);
+            Debug.Assert(_stateObj == null, "non-null state object in InternalEndExecuteReader");
+            return reader;
         }
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommand.xml' path='docs/members[@name="SqlCommand"]/ExecuteNonQueryAsync[@name="CancellationToken"]/*'/>
@@ -4025,11 +3815,8 @@ namespace Microsoft.Data.SqlClient
             // Used in _batchRPCMode to maintain a map of describe parameter encryption RPC requests (Keys) and their corresponding original RPC requests (Values).
             ReadOnlyDictionary<_SqlRPC, _SqlRPC> describeParameterEncryptionRpcOriginalRpcMap = null;
 
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
                 try
                 {
                     // Fetch the encryption information that applies to any of the input parameters.
@@ -4079,7 +3866,6 @@ namespace Microsoft.Data.SqlClient
                             bool processFinallyBlockAsync = true;
                             bool decrementAsyncCountInFinallyBlockAsync = true;
 
-                            RuntimeHelpers.PrepareConstrainedRegions();
                             try
                             {
                                 // Check for any exceptions on network write, before reading.
@@ -4154,7 +3940,6 @@ namespace Microsoft.Data.SqlClient
                                 bool processFinallyBlockAsync = true;
                                 bool decrementAsyncCountInFinallyBlockAsync = true;
 
-                                RuntimeHelpers.PrepareConstrainedRegions();
                                 try
                                 {
 
@@ -4233,22 +4018,6 @@ namespace Microsoft.Data.SqlClient
                                            describeParameterEncryptionRpcOriginalRpcMap: describeParameterEncryptionRpcOriginalRpcMap,
                                            describeParameterEncryptionDataReader: describeParameterEncryptionDataReader);
                 }
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _activeConnection.Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                throw;
             }
             catch (Exception e)
             {
@@ -4940,59 +4709,102 @@ namespace Microsoft.Data.SqlClient
 
             CheckNotificationStateAndAutoEnlist(); // Only call after validate - requires non null connection!
 
-            TdsParser bestEffortCleanupTarget = null;
             // This section needs to occur AFTER ValidateCommand - otherwise it will AV without a connection.
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
+            SqlStatistics statistics = Statistics;
+            if (statistics != null)
             {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
-                SqlStatistics statistics = Statistics;
-                if (statistics != null)
+                if ((!this.IsDirty && this.IsPrepared && !_hiddenPrepare)
+                    || (this.IsPrepared && _execType == EXECTYPE.PREPAREPENDING))
                 {
-                    if ((!this.IsDirty && this.IsPrepared && !_hiddenPrepare)
-                        || (this.IsPrepared && _execType == EXECTYPE.PREPAREPENDING))
+                    statistics.SafeIncrement(ref statistics._preparedExecs);
+                }
+                else
+                {
+                    statistics.SafeIncrement(ref statistics._unpreparedExecs);
+                }
+            }
+
+            // Reset the encryption related state of the command and its parameters.
+            ResetEncryptionState();
+
+            if (IsColumnEncryptionEnabled)
+            {
+                Task returnTask = null;
+                PrepareForTransparentEncryption(isAsync, timeout, completion, out returnTask, asyncWrite && isAsync, out usedCache, isRetry);
+                Debug.Assert(usedCache || (isAsync == (returnTask != null)), @"if we didn't use the cache, returnTask should be null if and only if async is false.");
+
+                long firstAttemptStart = ADP.TimerCurrent();
+
+                try
+                {
+                    return RunExecuteReaderTdsWithTransparentParameterEncryption(
+                        cmdBehavior,
+                        runBehavior,
+                        returnStream,
+                        isAsync,
+                        timeout,
+                        out task,
+                        asyncWrite && isAsync,
+                        isRetry: isRetry,
+                        ds: null,
+                        describeParameterEncryptionTask: returnTask);
+                }
+
+                catch (EnclaveDelegate.RetryableEnclaveQueryExecutionException)
+                {
+                    if (isRetry)
                     {
-                        statistics.SafeIncrement(ref statistics._preparedExecs);
+                        throw;
+                    }
+
+                    // Retry if the command failed with appropriate error.
+                    // First invalidate the entry from the cache, so that we refresh our encryption MD.
+                    SqlQueryMetadataCache.GetInstance().InvalidateCacheEntry(this);
+
+                    InvalidateEnclaveSession();
+
+                    return RunExecuteReader(
+                        cmdBehavior,
+                        runBehavior,
+                        returnStream,
+                        completion,
+                        TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart),
+                        out task,
+                        out usedCache,
+                        isAsync,
+                        isRetry: true,
+                        method: method);
+                }
+
+                catch (SqlException ex)
+                {
+                    // We only want to retry once, so don't retry if we are already in retry.
+                    // If we didn't use the cache, we don't want to retry.
+                    if (isRetry || (!usedCache && !ShouldUseEnclaveBasedWorkflow))
+                    {
+                        throw;
+                    }
+
+                    bool shouldRetry = false;
+
+                    // Check if we have an error indicating that we can retry.
+                    for (int i = 0; i < ex.Errors.Count; i++)
+                    {
+
+                        if ((usedCache && (ex.Errors[i].Number == TdsEnums.TCE_CONVERSION_ERROR_CLIENT_RETRY)) ||
+                                (ShouldUseEnclaveBasedWorkflow && (ex.Errors[i].Number == TdsEnums.TCE_ENCLAVE_INVALID_SESSION_HANDLE)))
+                        {
+                            shouldRetry = true;
+                            break;
+                        }
+                    }
+
+                    if (!shouldRetry)
+                    {
+                        throw;
                     }
                     else
                     {
-                        statistics.SafeIncrement(ref statistics._unpreparedExecs);
-                    }
-                }
-
-                // Reset the encryption related state of the command and its parameters.
-                ResetEncryptionState();
-
-                if (IsColumnEncryptionEnabled)
-                {
-                    Task returnTask = null;
-                    PrepareForTransparentEncryption(isAsync, timeout, completion, out returnTask, asyncWrite && isAsync, out usedCache, isRetry);
-                    Debug.Assert(usedCache || (isAsync == (returnTask != null)), @"if we didn't use the cache, returnTask should be null if and only if async is false.");
-
-                    long firstAttemptStart = ADP.TimerCurrent();
-
-                    try
-                    {
-                        return RunExecuteReaderTdsWithTransparentParameterEncryption(
-                            cmdBehavior,
-                            runBehavior,
-                            returnStream,
-                            isAsync,
-                            timeout,
-                            out task,
-                            asyncWrite && isAsync,
-                            isRetry: isRetry,
-                            ds: null,
-                            describeParameterEncryptionTask: returnTask);
-                    }
-
-                    catch (EnclaveDelegate.RetryableEnclaveQueryExecutionException)
-                    {
-                        if (isRetry)
-                        {
-                            throw;
-                        }
-
                         // Retry if the command failed with appropriate error.
                         // First invalidate the entry from the cache, so that we refresh our encryption MD.
                         SqlQueryMetadataCache.GetInstance().InvalidateCacheEntry(this);
@@ -5011,76 +4823,11 @@ namespace Microsoft.Data.SqlClient
                             isRetry: true,
                             method: method);
                     }
-
-                    catch (SqlException ex)
-                    {
-                        // We only want to retry once, so don't retry if we are already in retry.
-                        // If we didn't use the cache, we don't want to retry.
-                        if (isRetry || (!usedCache && !ShouldUseEnclaveBasedWorkflow))
-                        {
-                            throw;
-                        }
-
-                        bool shouldRetry = false;
-
-                        // Check if we have an error indicating that we can retry.
-                        for (int i = 0; i < ex.Errors.Count; i++)
-                        {
-
-                            if ((usedCache && (ex.Errors[i].Number == TdsEnums.TCE_CONVERSION_ERROR_CLIENT_RETRY)) ||
-                                    (ShouldUseEnclaveBasedWorkflow && (ex.Errors[i].Number == TdsEnums.TCE_ENCLAVE_INVALID_SESSION_HANDLE)))
-                            {
-                                shouldRetry = true;
-                                break;
-                            }
-                        }
-
-                        if (!shouldRetry)
-                        {
-                            throw;
-                        }
-                        else
-                        {
-                            // Retry if the command failed with appropriate error.
-                            // First invalidate the entry from the cache, so that we refresh our encryption MD.
-                            SqlQueryMetadataCache.GetInstance().InvalidateCacheEntry(this);
-
-                            InvalidateEnclaveSession();
-
-                            return RunExecuteReader(
-                                cmdBehavior,
-                                runBehavior,
-                                returnStream,
-                                completion,
-                                TdsParserStaticMethods.GetRemainingTimeout(timeout, firstAttemptStart),
-                                out task,
-                                out usedCache,
-                                isAsync,
-                                isRetry: true,
-                                method: method);
-                        }
-                    }
-                }
-                else
-                {
-                    return RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, isAsync, timeout, out task, asyncWrite && isAsync, isRetry: isRetry);
                 }
             }
-            catch (System.OutOfMemoryException e)
+            else
             {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _activeConnection.Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                throw;
+                return RunExecuteReaderTds(cmdBehavior, runBehavior, returnStream, isAsync, timeout, out task, asyncWrite && isAsync, isRetry: isRetry);
             }
         }
 
@@ -5674,31 +5421,10 @@ namespace Microsoft.Data.SqlClient
 
             ValidateAsyncCommand();
 
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
-                // close any non MARS dead readers, if applicable, and then throw if still busy.
-                // Throw if we have a live reader on this command
-                _activeConnection.ValidateConnectionForExecute(method, this);
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _activeConnection.Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                throw;
-            }
+            // close any non MARS dead readers, if applicable, and then throw if still busy.
+            // Throw if we have a live reader on this command
+            _activeConnection.ValidateConnectionForExecute(method, this);
+
             // Check to see if the currently set transaction has completed.  If so,
             // null out our local reference.
             if (_transaction != null && _transaction.Connection == null)
@@ -5790,29 +5516,7 @@ namespace Microsoft.Data.SqlClient
 
         private void ReliablePutStateObject()
         {
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_activeConnection);
-                PutStateObject();
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _activeConnection.Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _activeConnection.Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                throw;
-            }
+            PutStateObject();
         }
 
         private void PutStateObject()

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -498,7 +498,6 @@ namespace Microsoft.Data.SqlClient
         internal bool AsyncCommandInProgress
         {
             get => _AsyncCommandInProgress;
-            [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
             set => _AsyncCommandInProgress = value;
         }
 

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1245,30 +1245,11 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = null;
             RepairInnerConnection();
             SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlConnection.ChangeDatabase|API|Correlation> ObjectID{0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
 
             try
             {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
                 statistics = SqlStatistics.StartTimer(Statistics);
                 InnerConnection.ChangeDatabase(database);
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                Abort(e);
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                Abort(e);
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                throw;
             }
             finally
             {
@@ -1315,12 +1296,9 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.TryCorrelationTraceEvent("<sc.SqlConnection.Close|API|Correlation> ObjectID {0}, ActivityID {1}", ObjectID, ActivityCorrelator.Current);
 
                 SqlStatistics statistics = null;
-                TdsParser bestEffortCleanupTarget = null;
 
-                RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
                     statistics = SqlStatistics.StartTimer(Statistics);
 
                     Task reconnectTask = _currentReconnectionTask;
@@ -1345,22 +1323,6 @@ namespace Microsoft.Data.SqlClient
                     {
                         _statistics._closeTimestamp = ADP.TimerCurrent();
                     }
-                }
-                catch (System.OutOfMemoryException ex)
-                {
-                    Abort(ex);
-                    throw;
-                }
-                catch (System.StackOverflowException ex)
-                {
-                    Abort(ex);
-                    throw;
-                }
-                catch (System.Threading.ThreadAbortException ex)
-                {
-                    Abort(ex);
-                    SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                    throw;
                 }
                 finally
                 {
@@ -1436,7 +1398,6 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 SqlStatistics statistics = null;
-                RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
@@ -1709,7 +1670,6 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 SqlStatistics statistics = null;
-                RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
@@ -1791,7 +1751,6 @@ namespace Microsoft.Data.SqlClient
                 try
                 {
                     SqlStatistics statistics = null;
-                    RuntimeHelpers.PrepareConstrainedRegions();
                     try
                     {
                         statistics = SqlStatistics.StartTimer(_parent.Statistics);
@@ -1897,64 +1856,40 @@ namespace Microsoft.Data.SqlClient
 
         private bool TryOpenInner(TaskCompletionSource<DbConnectionInternal> retry)
         {
-            TdsParser bestEffortCleanupTarget = null;
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
+            if (ForceNewConnection)
             {
-                if (ForceNewConnection)
+                if (!InnerConnection.TryReplaceConnection(this, ConnectionFactory, retry, UserConnectionOptions))
                 {
-                    if (!InnerConnection.TryReplaceConnection(this, ConnectionFactory, retry, UserConnectionOptions))
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    if (!InnerConnection.TryOpenConnection(this, ConnectionFactory, retry, UserConnectionOptions))
-                    {
-                        return false;
-                    }
-                }
-                // does not require GC.KeepAlive(this) because of OnStateChange
-
-                // GetBestEffortCleanup must happen AFTER OpenConnection to get the correct target.
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(this);
-
-                var tdsInnerConnection = (SqlInternalConnectionTds)InnerConnection;
-                Debug.Assert(tdsInnerConnection.Parser != null, "Where's the parser?");
-
-                if (!tdsInnerConnection.ConnectionOptions.Pooling)
-                {
-                    // For non-pooled connections, we need to make sure that the finalizer does actually run to avoid leaking SNI handles
-                    GC.ReRegisterForFinalize(this);
-                }
-
-                if (StatisticsEnabled)
-                {
-                    _statistics._openTimestamp = ADP.TimerCurrent();
-                    tdsInnerConnection.Parser.Statistics = _statistics;
-                }
-                else
-                {
-                    tdsInnerConnection.Parser.Statistics = null;
-                    _statistics = null; // in case of previous Open/Close/reset_CollectStats sequence
+                    return false;
                 }
             }
-            catch (System.OutOfMemoryException e)
+            else
             {
-                Abort(e);
-                throw;
+                if (!InnerConnection.TryOpenConnection(this, ConnectionFactory, retry, UserConnectionOptions))
+                {
+                    return false;
+                }
             }
-            catch (System.StackOverflowException e)
+            // does not require GC.KeepAlive(this) because of OnStateChange
+
+            var tdsInnerConnection = (SqlInternalConnectionTds)InnerConnection;
+            Debug.Assert(tdsInnerConnection.Parser != null, "Where's the parser?");
+
+            if (!tdsInnerConnection.ConnectionOptions.Pooling)
             {
-                Abort(e);
-                throw;
+                // For non-pooled connections, we need to make sure that the finalizer does actually run to avoid leaking SNI handles
+                GC.ReRegisterForFinalize(this);
             }
-            catch (System.Threading.ThreadAbortException e)
+
+            if (StatisticsEnabled)
             {
-                Abort(e);
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                throw;
+                _statistics._openTimestamp = ADP.TimerCurrent();
+                tdsInnerConnection.Parser.Statistics = _statistics;
+            }
+            else
+            {
+                tdsInnerConnection.Parser.Statistics = null;
+                _statistics = null; // in case of previous Open/Close/reset_CollectStats sequence
             }
 
             return true;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlConnectionHelper.cs
@@ -170,7 +170,6 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Open->ClosedPreviouslyOpened, and doom the internal connection too...
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         internal void Abort(Exception e)
         {
             DbConnectionInternal innerConnection = _innerConnection;  // Should not cause memory allocation...

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -689,21 +689,16 @@ namespace Microsoft.Data.SqlClient
 
                 IntPtr temp = IntPtr.Zero;
 
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
-                { }
-                finally
+                _pMarsPhysicalConObj.IncrementPendingCallbacks();
+
+                error = SniNativeWrapper.SniReadAsync(_pMarsPhysicalConObj.Handle, ref temp);
+
+                if (temp != IntPtr.Zero)
                 {
-                    _pMarsPhysicalConObj.IncrementPendingCallbacks();
-
-                    error = SniNativeWrapper.SniReadAsync(_pMarsPhysicalConObj.Handle, ref temp);
-
-                    if (temp != IntPtr.Zero)
-                    {
-                        // Be sure to release packet, otherwise it will be leaked by native.
-                        SniNativeWrapper.SniPacketRelease(temp);
-                    }
+                    // Be sure to release packet, otherwise it will be leaked by native.
+                    SniNativeWrapper.SniPacketRelease(temp);
                 }
+
                 Debug.Assert(IntPtr.Zero == temp, "unexpected syncReadPacket without corresponding SNIPacketRelease");
                 if (TdsEnums.SNI_SUCCESS_IO_PENDING != error)
                 {
@@ -4700,87 +4695,68 @@ namespace Microsoft.Data.SqlClient
 
         internal void DrainData(TdsParserStateObject stateObj)
         {
-            RuntimeHelpers.PrepareConstrainedRegions();
             try
             {
-                try
+                SqlDataReader.SharedState sharedState = stateObj._readerState;
+                if (sharedState != null && sharedState._dataReady)
                 {
-                    SqlDataReader.SharedState sharedState = stateObj._readerState;
-                    if (sharedState != null && sharedState._dataReady)
+                    var metadata = stateObj._cleanupMetaData;
+                    if (stateObj._partialHeaderBytesRead > 0)
                     {
-                        var metadata = stateObj._cleanupMetaData;
-                        if (stateObj._partialHeaderBytesRead > 0)
+                        TdsOperationStatus result = stateObj.TryProcessHeader();
+                        if (result != TdsOperationStatus.Done)
                         {
-                            TdsOperationStatus result = stateObj.TryProcessHeader();
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                throw SQL.SynchronousCallMayNotPend();
-                            }
+                            throw SQL.SynchronousCallMayNotPend();
                         }
-                        if (0 == sharedState._nextColumnHeaderToRead)
+                    }
+                    if (0 == sharedState._nextColumnHeaderToRead)
+                    {
+                        // i. user called read but didn't fetch anything
+                        TdsOperationStatus result = stateObj.Parser.TrySkipRow(stateObj._cleanupMetaData, stateObj);
+                        if (result != TdsOperationStatus.Done)
                         {
-                            // i. user called read but didn't fetch anything
-                            TdsOperationStatus result = stateObj.Parser.TrySkipRow(stateObj._cleanupMetaData, stateObj);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                throw SQL.SynchronousCallMayNotPend();
-                            }
+                            throw SQL.SynchronousCallMayNotPend();
                         }
-                        else
+                    }
+                    else
+                    {
+                        // iia.  if we still have bytes left from a partially read column, skip
+                        if (sharedState._nextColumnDataToRead < sharedState._nextColumnHeaderToRead)
                         {
-                            // iia.  if we still have bytes left from a partially read column, skip
-                            if (sharedState._nextColumnDataToRead < sharedState._nextColumnHeaderToRead)
+                            if ((sharedState._nextColumnHeaderToRead > 0) && (metadata[sharedState._nextColumnHeaderToRead - 1].metaType.IsPlp))
                             {
-                                if ((sharedState._nextColumnHeaderToRead > 0) && (metadata[sharedState._nextColumnHeaderToRead - 1].metaType.IsPlp))
+                                if (stateObj._longlen != 0)
                                 {
-                                    if (stateObj._longlen != 0)
-                                    {
-                                        TdsOperationStatus result = TrySkipPlpValue(UInt64.MaxValue, stateObj, out _);
-                                        if (result != TdsOperationStatus.Done)
-                                        {
-                                            throw SQL.SynchronousCallMayNotPend();
-                                        }
-                                    }
-                                }
-
-                                else if (0 < sharedState._columnDataBytesRemaining)
-                                {
-                                    TdsOperationStatus result = stateObj.TrySkipLongBytes(sharedState._columnDataBytesRemaining);
+                                    TdsOperationStatus result = TrySkipPlpValue(UInt64.MaxValue, stateObj, out _);
                                     if (result != TdsOperationStatus.Done)
                                     {
                                         throw SQL.SynchronousCallMayNotPend();
                                     }
                                 }
-
                             }
 
-
-                            // Read the remaining values off the wire for this row
-                            if (stateObj.Parser.TrySkipRow(metadata, sharedState._nextColumnHeaderToRead, stateObj) != TdsOperationStatus.Done)
+                            else if (0 < sharedState._columnDataBytesRemaining)
                             {
-                                throw SQL.SynchronousCallMayNotPend();
+                                TdsOperationStatus result = stateObj.TrySkipLongBytes(sharedState._columnDataBytesRemaining);
+                                if (result != TdsOperationStatus.Done)
+                                {
+                                    throw SQL.SynchronousCallMayNotPend();
+                                }
                             }
+
+                        }
+
+
+                        // Read the remaining values off the wire for this row
+                        if (stateObj.Parser.TrySkipRow(metadata, sharedState._nextColumnHeaderToRead, stateObj) != TdsOperationStatus.Done)
+                        {
+                            throw SQL.SynchronousCallMayNotPend();
                         }
                     }
-                    Run(RunBehavior.Clean, null, null, null, stateObj);
                 }
-                catch
-                {
-                    _connHandler.DoomThisConnection();
-                    throw;
-                }
+                Run(RunBehavior.Clean, null, null, null, stateObj);
             }
-            catch (OutOfMemoryException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
-            catch (StackOverflowException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
-            catch (ThreadAbortException)
+            catch
             {
                 _connHandler.DoomThisConnection();
                 throw;
@@ -10416,26 +10392,7 @@ namespace Microsoft.Data.SqlClient
 
         private void TdsExecuteRPC_OnFailure(Exception exc, TdsParserStateObject stateObj)
         {
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                FailureCleanup(stateObj, exc);
-            }
-            catch (OutOfMemoryException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
-            catch (StackOverflowException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
-            catch (ThreadAbortException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
+            FailureCleanup(stateObj, exc);
         }
 
         private void ExecuteFlushTaskCallback(Task tsk, TdsParserStateObject stateObj, TaskCompletionSource<object> completion, bool releaseConnectionLock)
@@ -10446,29 +10403,9 @@ namespace Microsoft.Data.SqlClient
                 if (tsk.Exception != null)
                 {
                     Exception exc = tsk.Exception.InnerException;
-
-                    RuntimeHelpers.PrepareConstrainedRegions();
                     try
                     {
                         FailureCleanup(stateObj, tsk.Exception);
-                    }
-                    catch (OutOfMemoryException e)
-                    {
-                        _connHandler.DoomThisConnection();
-                        completion.SetException(e);
-                        throw;
-                    }
-                    catch (StackOverflowException e)
-                    {
-                        _connHandler.DoomThisConnection();
-                        completion.SetException(e);
-                        throw;
-                    }
-                    catch (ThreadAbortException e)
-                    {
-                        _connHandler.DoomThisConnection();
-                        completion.SetException(e);
-                        throw;
                     }
                     catch (Exception e)
                     {
@@ -12151,33 +12088,14 @@ namespace Microsoft.Data.SqlClient
 
                 StripPreamble(buffer, ref offset, ref count);
 
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
+                Task task = null;
+                if (count > 0)
                 {
-                    Task task = null;
-                    if (count > 0)
-                    {
-                        _parser.WriteInt(count, _stateObj); // write length of chunk
-                        task = _stateObj.WriteByteArray(buffer, count, offset, canAccumulate: false);
-                    }
+                    _parser.WriteInt(count, _stateObj); // write length of chunk
+                    task = _stateObj.WriteByteArray(buffer, count, offset, canAccumulate: false);
+                }
 
-                    return task ?? Task.CompletedTask;
-                }
-                catch (OutOfMemoryException)
-                {
-                    _parser._connHandler.DoomThisConnection();
-                    throw;
-                }
-                catch (StackOverflowException)
-                {
-                    _parser._connHandler.DoomThisConnection();
-                    throw;
-                }
-                catch (ThreadAbortException)
-                {
-                    _parser._connHandler.DoomThisConnection();
-                    throw;
-                }
+                return task ?? Task.CompletedTask;
             }
 
             internal static void ValidateWriteParameters(byte[] buffer, int offset, int count)

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.netfx.cs
@@ -98,29 +98,10 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        // @TODO: Consider adopting this pattern for all usages of Run and rename to Run.
+        // @TODO: Remove.
         internal bool RunReliably(RunBehavior runBehavior, SqlCommand cmdHandler, SqlDataReader dataStream, BulkCopySimpleResultSet bulkCopyHandler, TdsParserStateObject stateObj)
         {
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-                return Run(runBehavior, cmdHandler, dataStream, bulkCopyHandler, stateObj);
-            }
-            catch (OutOfMemoryException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
-            catch (StackOverflowException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
-            catch (ThreadAbortException)
-            {
-                _connHandler.DoomThisConnection();
-                throw;
-            }
+            return Run(runBehavior, cmdHandler, dataStream, bulkCopyHandler, stateObj);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.netfx.cs
@@ -9,41 +9,6 @@ namespace Microsoft.Data.SqlClient
 {
     internal sealed partial class TdsParser
     {
-        // This is called from a ThreadAbort - ensure that it can be run from a CER Catch
-        internal void BestEffortCleanup()
-        {
-            _state = TdsParserState.Broken;
-
-            var stateObj = _physicalStateObj;
-            if (stateObj != null)
-            {
-                var stateObjHandle = stateObj.Handle;
-                if (stateObjHandle != null)
-                {
-                    stateObjHandle.Dispose();
-                }
-            }
-
-            if (_fMARS)
-            {
-                var sessionPool = _sessionPool;
-                if (sessionPool != null)
-                {
-                    sessionPool.BestEffortCleanup();
-                }
-
-                var marsStateObj = _pMarsPhysicalConObj;
-                if (marsStateObj != null)
-                {
-                    var marsStateObjHandle = marsStateObj.Handle;
-                    if (marsStateObjHandle != null)
-                    {
-                        marsStateObjHandle.Dispose();
-                    }
-                }
-            }
-        }
-
         // Retrieve the IP and port number from native SNI for TCP protocol. The IP information is stored temporarily in the
         // pendingSQLDNSObject but not in the DNS Cache at this point. We only add items to the DNS Cache after we receive the
         // IsSupported flag as true in the feature ext ack from server.

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
@@ -136,7 +136,6 @@ namespace Microsoft.Data.SqlClient
 
         internal uint CheckConnection() => SniNativeWrapper.SniCheckConnection(Handle);
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         internal int DecrementPendingCallbacks(bool release)
         {
             int remaining = Interlocked.Decrement(ref _pendingCallbacks);

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObject.netfx.cs
@@ -173,25 +173,18 @@ namespace Microsoft.Data.SqlClient
                 // here for the callbacks!!!  This only applies to async.  Should be fixed by async fixes for
                 // AD unload/exit.
 
-                // TODO: Make this a BID trace point!
-                RuntimeHelpers.PrepareConstrainedRegions();
-                try
-                { }
-                finally
+                if (packetHandle != null)
                 {
-                    if (packetHandle != null)
-                    {
-                        packetHandle.Dispose();
-                    }
-                    if (asyncAttnPacket != null)
-                    {
-                        asyncAttnPacket.Dispose();
-                    }
-                    if (sessionHandle != null)
-                    {
-                        sessionHandle.Dispose();
-                        DecrementPendingCallbacks(true); // Will dispose of GC handle.
-                    }
+                    packetHandle.Dispose();
+                }
+                if (asyncAttnPacket != null)
+                {
+                    asyncAttnPacket.Dispose();
+                }
+                if (sessionHandle != null)
+                {
+                    sessionHandle.Dispose();
+                    DecrementPendingCallbacks(true); // Will dispose of GC handle.
                 }
             }
 
@@ -260,7 +253,6 @@ namespace Microsoft.Data.SqlClient
 
                             PacketHandle syncReadPacket = default;
                             bool readFromNetwork = true;
-                            RuntimeHelpers.PrepareConstrainedRegions();
                             bool shouldDecrement = false;
                             try
                             {
@@ -371,7 +363,6 @@ namespace Microsoft.Data.SqlClient
                 return;
             }
 
-            RuntimeHelpers.PrepareConstrainedRegions();
             bool processFinallyBlock = true;
             try
             {
@@ -654,14 +645,7 @@ namespace Microsoft.Data.SqlClient
             }
 
             // Async operation completion may be delayed (success pending).
-            RuntimeHelpers.PrepareConstrainedRegions();
-            try
-            {
-            }
-            finally
-            {
-                sniError = WritePacket(packet, sync);
-            }
+            sniError = WritePacket(packet, sync);
 
             if (sniError == TdsEnums.SNI_SUCCESS_IO_PENDING)
             {
@@ -769,7 +753,6 @@ namespace Microsoft.Data.SqlClient
 
                 PacketHandle attnPacket = CreateAndSetAttentionPacket();
 
-                RuntimeHelpers.PrepareConstrainedRegions();
                 try
                 {
                     // Dev11 #344723: SqlClient stress test suspends System_Data!Tcp::ReadSync via a call to SqlDataReader::Close

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -186,16 +186,8 @@ namespace Microsoft.Data.SqlClient
         {
             lock (_writePacketLockObject)
             {
-#if NETFRAMEWORK
-                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                try
-                { }
-                finally
-                {
-                    _writePacketCache.Dispose();
-                    // Do not set _writePacketCache to null, just in case a WriteAsyncCallback completes after this point
-                }
+                _writePacketCache.Dispose();
+                // Do not set _writePacketCache to null, just in case a WriteAsyncCallback completes after this point
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -332,10 +332,7 @@ namespace Microsoft.Data.SqlClient
             bool mustRelease = false;
             bool mustClearBuffer = false;
             IntPtr clearPassword = IntPtr.Zero;
-
-            // provides a guaranteed finally block – without this it isn’t guaranteed – non-
-            // interruptible by fatal exceptions
-            RuntimeHelpers.PrepareConstrainedRegions();
+            
             try
             {
                 unsafe
@@ -348,9 +345,6 @@ namespace Microsoft.Data.SqlClient
                             // SecureString is used
                             if (passwords[i] != null)
                             {
-                                // provides a guaranteed finally block – without this it isn’t
-                                // guaranteed – non-interruptible by fatal exceptions
-                                RuntimeHelpers.PrepareConstrainedRegions();
                                 try
                                 {
                                     // ============================================================

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Sni/SniNativeWrapper.cs
@@ -403,7 +403,6 @@ namespace Microsoft.Data.SqlClient
                 }
 
                 // Make sure that we clear the security sensitive information
-                // data->Initialize() is not safe to call under CER
                 if (mustClearBuffer)
                 {
                     for (int i = 0; i < data.Length; ++i)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -1575,7 +1575,6 @@ namespace Microsoft.Data.Common
             return value;
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         internal static IntPtr IntPtrOffset(IntPtr pbase, int offset)
         {
             if (4 == ADP.s_ptrSize)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -861,9 +861,6 @@ namespace Microsoft.Data.ProviderBase
         /// <summary>
         /// Ensure that this connection cannot be put back into the pool.
         /// </summary>
-        #if NETFRAMEWORK
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-        #endif
         protected internal void DoomThisConnection()
         {
             IsConnectionDoomed = true;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Sql/SqlDataSourceEnumeratorNativeHelper.cs
@@ -37,25 +37,15 @@ namespace Microsoft.Data.Sql
             bool more = true;
             bool failure = false;
             IntPtr handle = ADP.s_ptrZero;
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
             try
             {
                 long s_timeoutTime = TdsParserStaticMethods.GetTimeoutSeconds(ADP.DefaultCommandTimeout);
-#if NETFRAMEWORK
-                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                try
-                { }
-                finally
-                {
-                    handle = SniNativeWrapper.SniServerEnumOpen();
-                    SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {2} returned handle = {3}.",
-                                                           nameof(SqlDataSourceEnumeratorNativeHelper),
-                                                           nameof(GetDataSources),
-                                                           nameof(SniNativeWrapper.SniServerEnumOpen), handle);
-                }
+
+                handle = SniNativeWrapper.SniServerEnumOpen();
+                SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> {2} returned handle = {3}.",
+                                                       nameof(SqlDataSourceEnumeratorNativeHelper),
+                                                       nameof(GetDataSources),
+                                                       nameof(SniNativeWrapper.SniServerEnumOpen), handle);
 
                 if (handle != ADP.s_ptrZero)
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolAuthenticationContext.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolAuthenticationContext.cs
@@ -102,9 +102,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <summary>
         /// Release the lock which was obtained through LockToUpdate.
         /// </summary>
-#if NETFRAMEWORK
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
         internal void ReleaseLockToUpdate()
         {
             int oldValue = Interlocked.CompareExchange(ref _isUpdateInProgress, STATUS_UNLOCKED, STATUS_LOCKED);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
@@ -806,8 +806,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 _resError = e;
 
                 // Make sure the timer starts even if ThreadAbort occurs after setting the ErrorEvent.
-
-                // timer allocation has to be done out of CER block
                 Timer t = new Timer(new TimerCallback(this.ErrorCallback), null, Timeout.Infinite, Timeout.Infinite);
 
                 bool timerIsNotDisposed;
@@ -1619,8 +1617,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 // means, is that we're now responsible for this connection:
                 // it won't get reclaimed if it gets lost.
                 obj.PrePush(owningObject);
-
-                // TODO: Consider using a Cer to ensure that we mark the object for reclaimation in the event something bad happens?
             }
 
             DeactivateObject(obj);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
@@ -811,22 +811,15 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 Timer t = new Timer(new TimerCallback(this.ErrorCallback), null, Timeout.Infinite, Timeout.Infinite);
 
                 bool timerIsNotDisposed;
-#if NETFRAMEWORK
-                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                try
-                { }
-                finally
-                {
-                    _waitHandles.ErrorEvent.Set();
-                    _errorOccurred = true;
+                
+                _waitHandles.ErrorEvent.Set();
+                _errorOccurred = true;
 
-                    // Enable the timer.
-                    // Note that the timer is created to allow periodic invocation. If ThreadAbort occurs in the middle of ErrorCallback,
-                    // the timer will restart. Otherwise, the timer callback (ErrorCallback) destroys the timer after resetting the error to avoid second callback.
-                    _errorTimer = t;
-                    timerIsNotDisposed = t.Change(_errorWait, _errorWait);
-                }
+                // Enable the timer.
+                // Note that the timer is created to allow periodic invocation. If ThreadAbort occurs in the middle of ErrorCallback,
+                // the timer will restart. Otherwise, the timer callback (ErrorCallback) destroys the timer after resetting the error to avoid second callback.
+                _errorTimer = t;
+                timerIsNotDisposed = t.Change(_errorWait, _errorWait);
 
                 Debug.Assert(timerIsNotDisposed, "ErrorCallback timer has been disposed");
 
@@ -1040,22 +1033,10 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             do
             {
                 bool started = false;
-
-#if NETFRAMEWORK
-                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
+                
                 try
                 {
-#if NETFRAMEWORK
-                    RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                    try
-                    { }
-                    finally
-                    {
-                        started = Interlocked.CompareExchange(ref _pendingOpensWaiting, 1, 0) == 0;
-                    }
-
+                    started = Interlocked.CompareExchange(ref _pendingOpensWaiting, 1, 0) == 0;
                     if (!started)
                     {
                         return;
@@ -1081,10 +1062,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                         DbConnectionInternal connection = null;
                         bool timeout = false;
                         Exception caughtException = null;
-
-#if NETFRAMEWORK
-                        RuntimeHelpers.PrepareConstrainedRegions();
-#endif
+                        
                         try
                         {
                             ADP.SetCurrentTransaction(next.Completion.Task.AsyncState as Transaction);
@@ -1095,24 +1073,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                                 onlyOneCheckConnection: false,
                                 next.UserOptions,
                                 out connection);
-                        }
-                        catch (System.OutOfMemoryException)
-                        {
-                            if (connection != null)
-                            { connection.DoomThisConnection(); }
-                            throw;
-                        }
-                        catch (System.StackOverflowException)
-                        {
-                            if (connection != null)
-                            { connection.DoomThisConnection(); }
-                            throw;
-                        }
-                        catch (System.Threading.ThreadAbortException)
-                        {
-                            if (connection != null)
-                            { connection.DoomThisConnection(); }
-                            throw;
                         }
                         catch (Exception e)
                         {
@@ -1228,23 +1188,9 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 do
                 {
                     int waitResult = BOGUS_HANDLE;
-#if NETFRAMEWORK
-                    RuntimeHelpers.PrepareConstrainedRegions();
-#endif
                     try
                     {
-#if NETFRAMEWORK
-                        // We absolutely must have the value of waitResult set, 
-                        // or we may leak the mutex in async abort cases.
-                        RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                        try
-                        {
-                        }
-                        finally
-                        {
-                            waitResult = WaitHandle.WaitAny(_waitHandles.GetHandles(allowCreate), unchecked((int)waitForMultipleObjectsTimeout));
-                        }
+                        waitResult = WaitHandle.WaitAny(_waitHandles.GetHandles(allowCreate), unchecked((int)waitForMultipleObjectsTimeout));
 
                         // From the WaitAny docs: "If more than one object became signaled during
                         // the call, this is the array index of the signaled object with the
@@ -1328,9 +1274,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                                     {
                                         if (_waitHandles.CreationSemaphore.WaitOne(unchecked((int)waitForMultipleObjectsTimeout)))
                                         {
-#if NETFRAMEWORK
-                                            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
                                             try
                                             {
                                                 SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Creating new connection.", Id);
@@ -1559,23 +1502,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                                 return;
                             }
                             int waitResult = BOGUS_HANDLE;
-
-#if NETFRAMEWORK
-                            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
+                            
                             try
                             {
                                 // Obtain creation mutex so we're the only one creating objects
                                 // and we must have the wait result
-#if NETFRAMEWORK
-                                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                                try
-                                { }
-                                finally
-                                {
-                                    waitResult = WaitHandle.WaitAny(_waitHandles.GetHandles(withCreate: true), CreationTimeout);
-                                }
+                                waitResult = WaitHandle.WaitAny(_waitHandles.GetHandles(withCreate: true), CreationTimeout);
                                 if (CREATION_HANDLE == waitResult)
                                 {
                                     DbConnectionInternal newObj;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientMetrics.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientMetrics.cs
@@ -466,7 +466,6 @@ namespace Microsoft.Data.SqlClient.Diagnostics
             }
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         private void RemovePerformanceCounters()
         {
             // ExceptionEventHandler with IsTerminating may be called before

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalDb/LocalDbApi.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalDb/LocalDbApi.Windows.cs
@@ -80,8 +80,6 @@ namespace Microsoft.Data.SqlClient.LocalDb
             {
                 if (s_localDbCreateInstance is null)
                 {
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    
                     lock (s_dllLock)
                     {
                         if (s_localDbCreateInstance is null)
@@ -110,10 +108,6 @@ namespace Microsoft.Data.SqlClient.LocalDb
             {
                 if (s_localDbFormatMessage is null)
                 {
-                    #if NETFRAMEWORK
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    #endif
-                    
                     lock (s_dllLock)
                     {
                         if (s_localDbFormatMessage is null)
@@ -142,10 +136,6 @@ namespace Microsoft.Data.SqlClient.LocalDb
             {
                 if (s_userInstanceDllHandle == IntPtr.Zero)
                 {
-                    #if NETFRAMEWORK
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    #endif
-                    
                     lock (s_dllLock)
                     {
                         if (s_userInstanceDllHandle == IntPtr.Zero)
@@ -187,8 +177,6 @@ namespace Microsoft.Data.SqlClient.LocalDb
             if (s_configurableInstances is null)
             {
                 // load list of instances from configuration, mark them as not created
-                RuntimeHelpers.PrepareConstrainedRegions();
-
                 lock (s_configLock)
                 {
                     if (s_configurableInstances is null)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommandBuilder.cs
@@ -254,34 +254,8 @@ namespace Microsoft.Data.SqlClient
             {
                 throw ADP.ArgumentNull(nameof(command));
             }
-            TdsParser bestEffortCleanupTarget = null;
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-            try
-            {
-                bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(command.Connection);
 
-                command.DeriveParameters();
-            }
-            catch (OutOfMemoryException e)
-            {
-                command?.Connection?.Abort(e);
-                throw;
-            }
-            catch (StackOverflowException e)
-            {
-                command?.Connection?.Abort(e);
-                throw;
-            }
-            catch (ThreadAbortException e)
-            {
-                command?.Connection?.Abort(e);
-#if NETFRAMEWORK
-                SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-#endif
-                throw;
-            }
+            command.DeriveParameters();
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlCommandBuilder.xml' path='docs/members[@name="SqlCommandBuilder"]/GetSchemaTable/*'/>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -263,44 +263,11 @@ namespace Microsoft.Data.SqlClient
                     {
                         throw SQL.PendingBeginXXXExists();
                     }
-
-#if NETFRAMEWORK
-                    RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                    try
+                    
+                    Debug.Assert(_stateObj == null || _stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
+                    if (TryConsumeMetaData() != TdsOperationStatus.Done)
                     {
-                        Debug.Assert(_stateObj == null || _stateObj._syncOverAsync, "Should not attempt pends in a synchronous call");
-                        if (TryConsumeMetaData() != TdsOperationStatus.Done)
-                        {
-                            throw SQL.SynchronousCallMayNotPend();
-                        }
-                    }
-                    catch (System.OutOfMemoryException e)
-                    {
-                        _isClosed = true;
-                        if (_connection != null)
-                        {
-                            _connection.Abort(e);
-                        }
-                        throw;
-                    }
-                    catch (System.StackOverflowException e)
-                    {
-                        _isClosed = true;
-                        if (_connection != null)
-                        {
-                            _connection.Abort(e);
-                        }
-                        throw;
-                    }
-                    catch (System.Threading.ThreadAbortException e)
-                    {
-                        _isClosed = true;
-                        if (_connection != null)
-                        {
-                            _connection.Abort(e);
-                        }
-                        throw;
+                        throw SQL.SynchronousCallMayNotPend();
                     }
                 }
 
@@ -875,43 +842,10 @@ namespace Microsoft.Data.SqlClient
         private void CleanPartialReadReliable()
         {
             AssertReaderState(requireData: true, permitAsync: false);
-
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-            try
-            {
-                TdsOperationStatus result = TryCleanPartialRead();
-                Debug.Assert(result == TdsOperationStatus.Done, "Should not pend on sync call");
-                Debug.Assert(!_sharedState._dataReady, "_dataReady should be cleared");
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
+            
+            TdsOperationStatus result = TryCleanPartialRead();
+            Debug.Assert(result == TdsOperationStatus.Done, "Should not pend on sync call");
+            Debug.Assert(!_sharedState._dataReady, "_dataReady should be cleared");
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Dispose/*' />
@@ -1027,13 +961,9 @@ namespace Microsoft.Data.SqlClient
             TdsParser parser = _parser;
             TdsParserStateObject stateObj = _stateObj;
             bool closeConnection = (IsCommandBehavior(CommandBehavior.CloseConnection));
-            bool aborting = false;
             bool cleanDataFailed = false;
             TdsOperationStatus result;
 
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
             try
             {
                 if ((!_isClosed) && (parser != null) && (stateObj != null) && (stateObj.HasPendingData))
@@ -1091,48 +1021,9 @@ namespace Microsoft.Data.SqlClient
                 RestoreServerSettings(parser, stateObj);
                 return TdsOperationStatus.Done;
             }
-            catch (System.OutOfMemoryException e)
-            {
-                _isClosed = true;
-                aborting = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _isClosed = true;
-                aborting = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _isClosed = true;
-                aborting = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
             finally
             {
-                if (aborting)
-                {
-                    _isClosed = true;
-                    _command = null; // we are done at this point, don't allow navigation to the connection
-                    _connection = null;
-                    _statistics = null;
-                    _stateObj = null;
-                    _parser = null;
-                }
-                else if (closeReader)
+                if (closeReader)
                 {
                     bool wasClosed = _isClosed;
                     _isClosed = true;
@@ -1158,55 +1049,25 @@ namespace Microsoft.Data.SqlClient
                     {
                         Connection.RemoveWeakReference(this);  // This doesn't catch everything -- the connection may be closed, but it prevents dead readers from clogging the collection
                     }
-
-#if NETFRAMEWORK
-                    RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-                    try
+                    
+                    // IsClosed may be true if CloseReaderFromConnection was called - in which case, the session has already been closed
+                    if (!wasClosed && stateObj != null)
                     {
-                        // IsClosed may be true if CloseReaderFromConnection was called - in which case, the session has already been closed
-                        if (!wasClosed && stateObj != null)
+                        if (!cleanDataFailed)
                         {
-                            if (!cleanDataFailed)
+                            stateObj.CloseSession();
+                        }
+                        else
+                        {
+                            if (parser != null)
                             {
-                                stateObj.CloseSession();
-                            }
-                            else
-                            {
-                                if (parser != null)
-                                {
-                                    parser.State = TdsParserState.Broken; // We failed while draining data, so TDS pointer can be between tokens - cannot recover
-                                    parser.PutSession(stateObj);
-                                    parser.Connection.BreakConnection();
-                                }
+                                parser.State = TdsParserState.Broken; // We failed while draining data, so TDS pointer can be between tokens - cannot recover
+                                parser.PutSession(stateObj);
+                                parser.Connection.BreakConnection();
                             }
                         }
-                        // DO NOT USE stateObj after this point - it has been returned to the TdsParser's session pool and potentially handed out to another thread
                     }
-                    catch (System.OutOfMemoryException e)
-                    {
-                        if (_connection != null)
-                        {
-                            _connection.Abort(e);
-                        }
-                        throw;
-                    }
-                    catch (System.StackOverflowException e)
-                    {
-                        if (_connection != null)
-                        {
-                            _connection.Abort(e);
-                        }
-                        throw;
-                    }
-                    catch (System.Threading.ThreadAbortException e)
-                    {
-                        if (_connection != null)
-                        {
-                            _connection.Abort(e);
-                        }
-                        throw;
-                    }
+                    
                     // DO NOT USE stateObj after this point - it has been returned to the TdsParser's session pool and potentially handed out to another thread
 
                     // do not retry here
@@ -1791,265 +1652,232 @@ namespace Microsoft.Data.SqlClient
         {
             remaining = 0;
             TdsOperationStatus result;
+            
+            int cbytes = 0;
+            AssertReaderState(requireData: true, permitAsync: true, columnIndex: i, enforceSequentialAccess: true);
 
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-            try
+            // sequential reading
+            if (IsCommandBehavior(CommandBehavior.SequentialAccess))
             {
-                int cbytes = 0;
-                AssertReaderState(requireData: true, permitAsync: true, columnIndex: i, enforceSequentialAccess: true);
+                Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has an active Stream or TextReader");
 
-                // sequential reading
-                if (IsCommandBehavior(CommandBehavior.SequentialAccess))
+                if (_metaData[i] != null && _metaData[i].cipherMD != null)
                 {
-                    Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has an active Stream or TextReader");
-
-                    if (_metaData[i] != null && _metaData[i].cipherMD != null)
-                    {
-                        throw SQL.SequentialAccessNotSupportedOnEncryptedColumn(_metaData[i].column);
-                    }
-
-                    if (_sharedState._nextColumnHeaderToRead <= i)
-                    {
-                        result = TryReadColumnHeader(i);
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            return result;
-                        }
-                    }
-
-                    // If data is null, ReadColumnHeader sets the data.IsNull bit.
-                    if (_data[i] != null && _data[i].IsNull)
-                    {
-                        throw new SqlNullValueException();
-                    }
-
-                    // If there are an unknown (-1) number of bytes left for a PLP, read its size
-                    if ((-1 == _sharedState._columnDataBytesRemaining) && (_metaData[i].metaType.IsPlp))
-                    {
-                        ulong left;
-                        result = _parser.TryPlpBytesLeft(_stateObj, out left);
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            return result;
-                        }
-                        _sharedState._columnDataBytesRemaining = (long)left;
-                    }
-
-                    if (0 == _sharedState._columnDataBytesRemaining)
-                    {
-                        return TdsOperationStatus.Done; // We've read this column to the end
-                    }
-
-                    // if no buffer is passed in, return the number total of bytes, or -1
-                    if (buffer == null)
-                    {
-                        if (_metaData[i].metaType.IsPlp)
-                        {
-                            remaining = (long)_parser.PlpBytesTotalLength(_stateObj);
-                            return TdsOperationStatus.Done;
-                        }
-                        remaining = _sharedState._columnDataBytesRemaining;
-                        return TdsOperationStatus.Done;
-                    }
-
-                    if (dataIndex < 0)
-                    {
-                        throw ADP.NegativeParameter(nameof(dataIndex));
-                    }
-
-                    if (dataIndex < _columnDataBytesRead)
-                    {
-                        throw ADP.NonSeqByteAccess(dataIndex, _columnDataBytesRead, nameof(GetBytes));
-                    }
-
-                    // if the dataIndex is not equal to bytes read, then we have to skip bytes
-                    long cb = dataIndex - _columnDataBytesRead;
-
-                    // if dataIndex is outside of the data range, return 0
-                    if ((cb > _sharedState._columnDataBytesRemaining) && !_metaData[i].metaType.IsPlp)
-                    {
-                        return TdsOperationStatus.Done;
-                    }
-
-                    // if bad buffer index, throw
-                    if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                    {
-                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
-                    }
-
-                    // if there is not enough room in the buffer for data
-                    if (length + bufferIndex > buffer.Length)
-                    {
-                        throw ADP.InvalidBufferSizeOrIndex(length, bufferIndex);
-                    }
-
-                    if (length < 0)
-                    {
-                        throw ADP.InvalidDataLength(length);
-                    }
-
-                    // Skip if needed
-                    if (cb > 0)
-                    {
-                        if (_metaData[i].metaType.IsPlp)
-                        {
-                            ulong skipped;
-                            result = _parser.TrySkipPlpValue((ulong)cb, _stateObj, out skipped);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                return result;
-                            }
-                            _columnDataBytesRead += (long)skipped;
-                        }
-                        else
-                        {
-                            result = _stateObj.TrySkipLongBytes(cb);
-                            if (result != TdsOperationStatus.Done)
-                            {
-                                return result;
-                            }
-                            _columnDataBytesRead += cb;
-                            _sharedState._columnDataBytesRemaining -= cb;
-                        }
-                    }
-
-                    int bytesRead;
-                    result = TryGetBytesInternalSequential(i, buffer, bufferIndex, length, out bytesRead);
-                    remaining = (int)bytesRead;
-                    return result;
+                    throw SQL.SequentialAccessNotSupportedOnEncryptedColumn(_metaData[i].column);
                 }
 
-                // random access now!
-                // note that since we are caching in an array, and arrays aren't 64 bit ready yet,
-                // we need can cast to int if the dataIndex is in range
+                if (_sharedState._nextColumnHeaderToRead <= i)
+                {
+                    result = TryReadColumnHeader(i);
+                    if (result != TdsOperationStatus.Done)
+                    {
+                        return result;
+                    }
+                }
+
+                // If data is null, ReadColumnHeader sets the data.IsNull bit.
+                if (_data[i] != null && _data[i].IsNull)
+                {
+                    throw new SqlNullValueException();
+                }
+
+                // If there are an unknown (-1) number of bytes left for a PLP, read its size
+                if ((-1 == _sharedState._columnDataBytesRemaining) && (_metaData[i].metaType.IsPlp))
+                {
+                    ulong left;
+                    result = _parser.TryPlpBytesLeft(_stateObj, out left);
+                    if (result != TdsOperationStatus.Done)
+                    {
+                        return result;
+                    }
+                    _sharedState._columnDataBytesRemaining = (long)left;
+                }
+
+                if (0 == _sharedState._columnDataBytesRemaining)
+                {
+                    return TdsOperationStatus.Done; // We've read this column to the end
+                }
+
+                // if no buffer is passed in, return the number total of bytes, or -1
+                if (buffer == null)
+                {
+                    if (_metaData[i].metaType.IsPlp)
+                    {
+                        remaining = (long)_parser.PlpBytesTotalLength(_stateObj);
+                        return TdsOperationStatus.Done;
+                    }
+                    remaining = _sharedState._columnDataBytesRemaining;
+                    return TdsOperationStatus.Done;
+                }
+
                 if (dataIndex < 0)
                 {
                     throw ADP.NegativeParameter(nameof(dataIndex));
                 }
 
-                if (dataIndex > int.MaxValue)
+                if (dataIndex < _columnDataBytesRead)
                 {
-                    throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
+                    throw ADP.NonSeqByteAccess(dataIndex, _columnDataBytesRead, nameof(GetBytes));
                 }
 
-                int ndataIndex = (int)dataIndex;
-                byte[] data;
+                // if the dataIndex is not equal to bytes read, then we have to skip bytes
+                long cb = dataIndex - _columnDataBytesRead;
 
-                // WebData 99342 - in the non-sequential case, we need to support
-                //                 the use of GetBytes on string data columns, but
-                //                 GetSqlBinary isn't supposed to.  What we end up
-                //                 doing isn't exactly pretty, but it does work.
-                if (_metaData[i].metaType.IsBinType)
+                // if dataIndex is outside of the data range, return 0
+                if ((cb > _sharedState._columnDataBytesRemaining) && !_metaData[i].metaType.IsPlp)
                 {
-                    data = GetSqlBinary(i).Value;
+                    return TdsOperationStatus.Done;
                 }
-                else
-                {
-                    Debug.Assert(_metaData[i].metaType.IsLong, "non long type?");
-                    Debug.Assert(_metaData[i].metaType.IsCharType, "non-char type?");
 
-                    SqlString temp = GetSqlString(i);
-                    if (_metaData[i].metaType.IsNCharType)
+                // if bad buffer index, throw
+                if (bufferIndex < 0 || bufferIndex >= buffer.Length)
+                {
+                    throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
+                }
+
+                // if there is not enough room in the buffer for data
+                if (length + bufferIndex > buffer.Length)
+                {
+                    throw ADP.InvalidBufferSizeOrIndex(length, bufferIndex);
+                }
+
+                if (length < 0)
+                {
+                    throw ADP.InvalidDataLength(length);
+                }
+
+                // Skip if needed
+                if (cb > 0)
+                {
+                    if (_metaData[i].metaType.IsPlp)
                     {
-                        data = temp.GetUnicodeBytes();
+                        ulong skipped;
+                        result = _parser.TrySkipPlpValue((ulong)cb, _stateObj, out skipped);
+                        if (result != TdsOperationStatus.Done)
+                        {
+                            return result;
+                        }
+                        _columnDataBytesRead += (long)skipped;
                     }
                     else
                     {
-                        data = temp.GetNonUnicodeBytes();
-                    }
-                }
-
-                cbytes = data.Length;
-
-                // if no buffer is passed in, return the number of characters we have
-                if (buffer == null)
-                {
-                    remaining = cbytes;
-                    return TdsOperationStatus.Done;
-                }
-
-                // if dataIndex is outside of data range, return 0
-                if (ndataIndex < 0 || ndataIndex >= cbytes)
-                {
-                    return TdsOperationStatus.Done;
-                }
-                try
-                {
-                    if (ndataIndex < cbytes)
-                    {
-                        // help the user out in the case where there's less data than requested
-                        if ((ndataIndex + length) > cbytes)
+                        result = _stateObj.TrySkipLongBytes(cb);
+                        if (result != TdsOperationStatus.Done)
                         {
-                            cbytes = cbytes - ndataIndex;
+                            return result;
                         }
-                        else
-                        {
-                            cbytes = length;
-                        }
+                        _columnDataBytesRead += cb;
+                        _sharedState._columnDataBytesRemaining -= cb;
                     }
-
-                    Buffer.BlockCopy(data, ndataIndex, buffer, bufferIndex, cbytes);
                 }
-                catch (Exception e)
+
+                int bytesRead;
+                result = TryGetBytesInternalSequential(i, buffer, bufferIndex, length, out bytesRead);
+                remaining = (int)bytesRead;
+                return result;
+            }
+
+            // random access now!
+            // note that since we are caching in an array, and arrays aren't 64 bit ready yet,
+            // we need can cast to int if the dataIndex is in range
+            if (dataIndex < 0)
+            {
+                throw ADP.NegativeParameter(nameof(dataIndex));
+            }
+
+            if (dataIndex > int.MaxValue)
+            {
+                throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
+            }
+
+            int ndataIndex = (int)dataIndex;
+            byte[] data;
+
+            // WebData 99342 - in the non-sequential case, we need to support
+            //                 the use of GetBytes on string data columns, but
+            //                 GetSqlBinary isn't supposed to.  What we end up
+            //                 doing isn't exactly pretty, but it does work.
+            if (_metaData[i].metaType.IsBinType)
+            {
+                data = GetSqlBinary(i).Value;
+            }
+            else
+            {
+                Debug.Assert(_metaData[i].metaType.IsLong, "non long type?");
+                Debug.Assert(_metaData[i].metaType.IsCharType, "non-char type?");
+
+                SqlString temp = GetSqlString(i);
+                if (_metaData[i].metaType.IsNCharType)
                 {
-                    if (!ADP.IsCatchableExceptionType(e))
-                    {
-                        throw;
-                    }
-                    cbytes = data.Length;
-
-                    if (length < 0)
-                    {
-                        throw ADP.InvalidDataLength(length);
-                    }
-
-                    // if bad buffer index, throw
-                    if (bufferIndex < 0 || bufferIndex >= buffer.Length)
-                    {
-                        throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
-                    }
-
-                    // if there is not enough room in the buffer for data
-                    if (cbytes + bufferIndex > buffer.Length)
-                    {
-                        throw ADP.InvalidBufferSizeOrIndex(cbytes, bufferIndex);
-                    }
-
-                    throw;
+                    data = temp.GetUnicodeBytes();
                 }
+                else
+                {
+                    data = temp.GetNonUnicodeBytes();
+                }
+            }
 
+            cbytes = data.Length;
+
+            // if no buffer is passed in, return the number of characters we have
+            if (buffer == null)
+            {
                 remaining = cbytes;
                 return TdsOperationStatus.Done;
             }
-            catch (System.OutOfMemoryException e)
+
+            // if dataIndex is outside of data range, return 0
+            if (ndataIndex < 0 || ndataIndex >= cbytes)
             {
-                _isClosed = true;
-                if (_connection != null)
+                return TdsOperationStatus.Done;
+            }
+            try
+            {
+                if (ndataIndex < cbytes)
                 {
-                    _connection.Abort(e);
+                    // help the user out in the case where there's less data than requested
+                    if ((ndataIndex + length) > cbytes)
+                    {
+                        cbytes = cbytes - ndataIndex;
+                    }
+                    else
+                    {
+                        cbytes = length;
+                    }
                 }
+
+                Buffer.BlockCopy(data, ndataIndex, buffer, bufferIndex, cbytes);
+            }
+            catch (Exception e)
+            {
+                if (!ADP.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+                cbytes = data.Length;
+
+                if (length < 0)
+                {
+                    throw ADP.InvalidDataLength(length);
+                }
+
+                // if bad buffer index, throw
+                if (bufferIndex < 0 || bufferIndex >= buffer.Length)
+                {
+                    throw ADP.InvalidDestinationBufferIndex(buffer.Length, bufferIndex, nameof(bufferIndex));
+                }
+
+                // if there is not enough room in the buffer for data
+                if (cbytes + bufferIndex > buffer.Length)
+                {
+                    throw ADP.InvalidBufferSizeOrIndex(cbytes, bufferIndex);
+                }
+
                 throw;
             }
-            catch (System.StackOverflowException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
+
+            remaining = cbytes;
+            return TdsOperationStatus.Done;
         }
 
         internal int GetBytesInternalSequential(int i, byte[] buffer, int index, int length, long? timeoutMilliseconds = null)
@@ -2102,78 +1930,45 @@ namespace Microsoft.Data.SqlClient
             bytesRead = 0;
             TdsOperationStatus result;
 
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-            try
+            if ((_sharedState._columnDataBytesRemaining == 0) || (length == 0))
             {
-                if ((_sharedState._columnDataBytesRemaining == 0) || (length == 0))
+                // No data left or nothing requested, return 0
+                bytesRead = 0;
+                return TdsOperationStatus.Done;
+            }
+            else
+            {
+                // if plp columns, do partial reads. Don't read the entire value in one shot.
+                if (_metaData[i].metaType.IsPlp)
                 {
-                    // No data left or nothing requested, return 0
-                    bytesRead = 0;
+                    // Read in data
+                    result = _stateObj.TryReadPlpBytes(ref buffer, index, length, out bytesRead);
+                    _columnDataBytesRead += bytesRead;
+                    if (result != TdsOperationStatus.Done)
+                    {
+                        return result;
+                    }
+
+                    // Query for number of bytes left
+                    ulong left;
+                    result = _parser.TryPlpBytesLeft(_stateObj, out left);
+                    if (result != TdsOperationStatus.Done)
+                    {
+                        _sharedState._columnDataBytesRemaining = -1;
+                        return result;
+                    }
+                    _sharedState._columnDataBytesRemaining = (long)left;
                     return TdsOperationStatus.Done;
                 }
                 else
                 {
-                    // if plp columns, do partial reads. Don't read the entire value in one shot.
-                    if (_metaData[i].metaType.IsPlp)
-                    {
-                        // Read in data
-                        result = _stateObj.TryReadPlpBytes(ref buffer, index, length, out bytesRead);
-                        _columnDataBytesRead += bytesRead;
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            return result;
-                        }
-
-                        // Query for number of bytes left
-                        ulong left;
-                        result = _parser.TryPlpBytesLeft(_stateObj, out left);
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            _sharedState._columnDataBytesRemaining = -1;
-                            return result;
-                        }
-                        _sharedState._columnDataBytesRemaining = (long)left;
-                        return TdsOperationStatus.Done;
-                    }
-                    else
-                    {
-                        // Read data (not exceeding the total amount of data available)
-                        int bytesToRead = (int)Math.Min((long)length, _sharedState._columnDataBytesRemaining);
-                        result = _stateObj.TryReadByteArray(buffer.AsSpan(index), bytesToRead, out bytesRead);
-                        _columnDataBytesRead += bytesRead;
-                        _sharedState._columnDataBytesRemaining -= bytesRead;
-                        return result;
-                    }
+                    // Read data (not exceeding the total amount of data available)
+                    int bytesToRead = (int)Math.Min((long)length, _sharedState._columnDataBytesRemaining);
+                    result = _stateObj.TryReadByteArray(buffer.AsSpan(index), bytesToRead, out bytesRead);
+                    _columnDataBytesRead += bytesRead;
+                    _sharedState._columnDataBytesRemaining -= bytesRead;
+                    return result;
                 }
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
             }
         }
 
@@ -2446,126 +2241,93 @@ namespace Microsoft.Data.SqlClient
 
         private long GetCharsFromPlpData(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
         {
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-            try
+            long cch;
+
+            AssertReaderState(requireData: true, permitAsync: false, columnIndex: i, enforceSequentialAccess: true);
+            Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has active Stream or TextReader");
+            // don't allow get bytes on non-long or non-binary columns
+            Debug.Assert(_metaData[i].metaType.IsPlp, "GetCharsFromPlpData called on a non-plp column!");
+            // Must be sequential reading
+            Debug.Assert(IsCommandBehavior(CommandBehavior.SequentialAccess), "GetCharsFromPlpData called for non-Sequential access");
+
+            if (!_metaData[i].metaType.IsCharType)
             {
-                long cch;
+                throw SQL.NonCharColumn(_metaData[i].column);
+            }
 
-                AssertReaderState(requireData: true, permitAsync: false, columnIndex: i, enforceSequentialAccess: true);
-                Debug.Assert(!HasActiveStreamOrTextReaderOnColumn(i), "Column has active Stream or TextReader");
-                // don't allow get bytes on non-long or non-binary columns
-                Debug.Assert(_metaData[i].metaType.IsPlp, "GetCharsFromPlpData called on a non-plp column!");
-                // Must be sequential reading
-                Debug.Assert(IsCommandBehavior(CommandBehavior.SequentialAccess), "GetCharsFromPlpData called for non-Sequential access");
+            if (_sharedState._nextColumnHeaderToRead <= i)
+            {
+                ReadColumnHeader(i);
+            }
 
-                if (!_metaData[i].metaType.IsCharType)
-                {
-                    throw SQL.NonCharColumn(_metaData[i].column);
-                }
+            // If data is null, ReadColumnHeader sets the data.IsNull bit.
+            if (_data[i] != null && _data[i].IsNull)
+            {
+                throw new SqlNullValueException();
+            }
 
-                if (_sharedState._nextColumnHeaderToRead <= i)
-                {
-                    ReadColumnHeader(i);
-                }
+            if (dataIndex < _columnDataCharsRead)
+            {
+                // Don't allow re-read of same chars in sequential access mode
+                throw ADP.NonSeqByteAccess(dataIndex, _columnDataCharsRead, nameof(GetChars));
+            }
 
-                // If data is null, ReadColumnHeader sets the data.IsNull bit.
-                if (_data[i] != null && _data[i].IsNull)
-                {
-                    throw new SqlNullValueException();
-                }
+            // If we start reading the new column, either dataIndex is 0 or
+            // _columnDataCharsRead is 0 and dataIndex > _columnDataCharsRead is true below.
+            // In both cases we will clean decoder
+            if (dataIndex == 0)
+            {
+                _stateObj._plpdecoder = null;
+            }
 
-                if (dataIndex < _columnDataCharsRead)
-                {
-                    // Don't allow re-read of same chars in sequential access mode
-                    throw ADP.NonSeqByteAccess(dataIndex, _columnDataCharsRead, nameof(GetChars));
-                }
+            bool isUnicode = _metaData[i].metaType.IsNCharType;
 
-                // If we start reading the new column, either dataIndex is 0 or
-                // _columnDataCharsRead is 0 and dataIndex > _columnDataCharsRead is true below.
-                // In both cases we will clean decoder
-                if (dataIndex == 0)
-                {
-                    _stateObj._plpdecoder = null;
-                }
-
-                bool isUnicode = _metaData[i].metaType.IsNCharType;
-
-                // If there are an unknown (-1) number of bytes left for a PLP, read its size
-                if (-1 == _sharedState._columnDataBytesRemaining)
-                {
-                    _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
-                }
-
-                if (0 == _sharedState._columnDataBytesRemaining)
-                {
-                    _stateObj._plpdecoder = null;
-                    return 0; // We've read this column to the end
-                }
-
-                // if no buffer is passed in, return the total number of characters or -1
-                if (buffer == null)
-                {
-                    cch = (long)_parser.PlpBytesTotalLength(_stateObj);
-                    return (isUnicode && (cch > 0)) ? cch >> 1 : cch;
-                }
-                if (dataIndex > _columnDataCharsRead)
-                {
-                    // Skip chars
-
-                    // Clean decoder state: we do not reset it, but destroy to ensure
-                    // that we do not start decoding the column with decoder from the old one
-                    _stateObj._plpdecoder = null;
-                    cch = dataIndex - _columnDataCharsRead;
-                    cch = isUnicode ? (cch << 1) : cch;
-                    cch = (long)_parser.SkipPlpValue((ulong)(cch), _stateObj);
-                    _columnDataBytesRead += cch;
-                    _columnDataCharsRead += (isUnicode && (cch > 0)) ? cch >> 1 : cch;
-                }
-                cch = length;
-
-                if (isUnicode)
-                {
-                    cch = (long)_parser.ReadPlpUnicodeChars(ref buffer, bufferIndex, length, _stateObj);
-                    _columnDataBytesRead += (cch << 1);
-                }
-                else
-                {
-                    cch = (long)_parser.ReadPlpAnsiChars(ref buffer, bufferIndex, length, _metaData[i], _stateObj);
-                    _columnDataBytesRead += cch << 1;
-                }
-                _columnDataCharsRead += cch;
+            // If there are an unknown (-1) number of bytes left for a PLP, read its size
+            if (-1 == _sharedState._columnDataBytesRemaining)
+            {
                 _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
-                return cch;
             }
-            catch (System.OutOfMemoryException e)
+
+            if (0 == _sharedState._columnDataBytesRemaining)
             {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
+                _stateObj._plpdecoder = null;
+                return 0; // We've read this column to the end
             }
-            catch (System.StackOverflowException e)
+
+            // if no buffer is passed in, return the total number of characters or -1
+            if (buffer == null)
             {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
+                cch = (long)_parser.PlpBytesTotalLength(_stateObj);
+                return (isUnicode && (cch > 0)) ? cch >> 1 : cch;
             }
-            catch (System.Threading.ThreadAbortException e)
+            if (dataIndex > _columnDataCharsRead)
             {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
+                // Skip chars
+
+                // Clean decoder state: we do not reset it, but destroy to ensure
+                // that we do not start decoding the column with decoder from the old one
+                _stateObj._plpdecoder = null;
+                cch = dataIndex - _columnDataCharsRead;
+                cch = isUnicode ? (cch << 1) : cch;
+                cch = (long)_parser.SkipPlpValue((ulong)(cch), _stateObj);
+                _columnDataBytesRead += cch;
+                _columnDataCharsRead += (isUnicode && (cch > 0)) ? cch >> 1 : cch;
             }
+            cch = length;
+
+            if (isUnicode)
+            {
+                cch = (long)_parser.ReadPlpUnicodeChars(ref buffer, bufferIndex, length, _stateObj);
+                _columnDataBytesRead += (cch << 1);
+            }
+            else
+            {
+                cch = (long)_parser.ReadPlpAnsiChars(ref buffer, bufferIndex, length, _metaData[i], _stateObj);
+                _columnDataBytesRead += cch << 1;
+            }
+            _columnDataCharsRead += cch;
+            _sharedState._columnDataBytesRemaining = (long)_parser.PlpBytesLeft(_stateObj);
+            return cch;
         }
 
         internal long GetStreamingXmlChars(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
@@ -3724,10 +3486,6 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = null;
             using (TryEventScope.Create("SqlDataReader.NextResult | API | Object Id {0}", ObjectID))
             {
-#if NETFRAMEWORK
-                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-
                 try
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
@@ -3863,33 +3621,6 @@ namespace Microsoft.Data.SqlClient
                     more = success;
                     return TdsOperationStatus.Done;
                 }
-                catch (System.OutOfMemoryException e)
-                {
-                    _isClosed = true;
-                    if (_connection != null)
-                    {
-                        _connection.Abort(e);
-                    }
-                    throw;
-                }
-                catch (System.StackOverflowException e)
-                {
-                    _isClosed = true;
-                    if (_connection != null)
-                    {
-                        _connection.Abort(e);
-                    }
-                    throw;
-                }
-                catch (System.Threading.ThreadAbortException e)
-                {
-                    _isClosed = true;
-                    if (_connection != null)
-                    {
-                        _connection.Abort(e);
-                    }
-                    throw;
-                }
                 finally
                 {
                     SqlStatistics.StopTimer(statistics);
@@ -3924,10 +3655,6 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = null;
             using (TryEventScope.Create("SqlDataReader.TryReadInternal | API | Object Id {0}", ObjectID))
             {
-#if NETFRAMEWORK
-                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-
                 try
                 {
                     TdsOperationStatus result;
@@ -4087,36 +3814,6 @@ namespace Microsoft.Data.SqlClient
 
                     return TdsOperationStatus.Done;
                 }
-                catch (OutOfMemoryException e)
-                {
-                    _isClosed = true;
-                    SqlConnection con = _connection;
-                    if (con != null)
-                    {
-                        con.Abort(e);
-                    }
-                    throw;
-                }
-                catch (StackOverflowException e)
-                {
-                    _isClosed = true;
-                    SqlConnection con = _connection;
-                    if (con != null)
-                    {
-                        con.Abort(e);
-                    }
-                    throw;
-                }
-                catch (System.Threading.ThreadAbortException e)
-                {
-                    _isClosed = true;
-                    SqlConnection con = _connection;
-                    if (con != null)
-                    {
-                        con.Abort(e);
-                    }
-                    throw;
-                }
                 finally
                 {
                     SqlStatistics.StopTimer(statistics);
@@ -4143,54 +3840,21 @@ namespace Microsoft.Data.SqlClient
         {
             CheckDataIsReady(columnIndex: i, permitAsync: true, allowPartiallyReadColumn: allowPartiallyReadColumn, methodName: null);
 
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-            try
-            {
-                Debug.Assert(_sharedState._nextColumnHeaderToRead <= _metaData.Length, "_sharedState._nextColumnHeaderToRead too large");
-                Debug.Assert(_sharedState._nextColumnDataToRead <= _metaData.Length, "_sharedState._nextColumnDataToRead too large");
+            Debug.Assert(_sharedState._nextColumnHeaderToRead <= _metaData.Length, "_sharedState._nextColumnHeaderToRead too large");
+            Debug.Assert(_sharedState._nextColumnDataToRead <= _metaData.Length, "_sharedState._nextColumnDataToRead too large");
 
-                if (setTimeout)
-                {
-                    SetTimeout(_defaultTimeoutMilliseconds);
-                }
+            if (setTimeout)
+            {
+                SetTimeout(_defaultTimeoutMilliseconds);
+            }
 
-                TdsOperationStatus result = TryReadColumnInternal(i, readHeaderOnly: false, forStreaming: forStreaming);
-                if (result != TdsOperationStatus.Done)
-                {
-                    return result;
-                }
+            TdsOperationStatus result = TryReadColumnInternal(i, readHeaderOnly: false, forStreaming: forStreaming);
+            if (result != TdsOperationStatus.Done)
+            {
+                return result;
+            }
 
-                Debug.Assert(_data[i] != null, " data buffer is null?");
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
+            Debug.Assert(_data[i] != null, " data buffer is null?");
 
             return TdsOperationStatus.Done;
         }
@@ -4233,41 +3897,8 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.InvalidRead();
             }
-
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-            try
-            {
-                return TryReadColumnInternal(i, readHeaderOnly: true);
-            }
-            catch (System.OutOfMemoryException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.StackOverflowException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
-            catch (System.Threading.ThreadAbortException e)
-            {
-                _isClosed = true;
-                if (_connection != null)
-                {
-                    _connection.Abort(e);
-                }
-                throw;
-            }
+            
+            return TryReadColumnInternal(i, readHeaderOnly: true);
         }
 
         internal TdsOperationStatus TryReadColumnInternal(int i, bool readHeaderOnly = false, bool forStreaming = false)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -611,9 +611,7 @@ namespace Microsoft.Data.SqlClient
                             string database = null;
                             string service = null;
                             bool appDomainStart = false;
-#if NETFRAMEWORK
-                            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
+
                             try
                             { // CER to ensure that if Start succeeds we add to hash completing setup.
                               // Start using process wide default service/queue & database from connection string.
@@ -749,9 +747,7 @@ namespace Microsoft.Data.SqlClient
                             if (useDefaults)
                             {
                                 bool appDomainStop = false;
-#if NETFRAMEWORK
-                                RuntimeHelpers.PrepareConstrainedRegions();
-#endif
+
                                 try
                                 { // CER to ensure that if Stop succeeds we remove from hash completing teardown.
                                   // Start using process wide default service/queue & database from connection string.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependency.cs
@@ -613,7 +613,7 @@ namespace Microsoft.Data.SqlClient
                             bool appDomainStart = false;
 
                             try
-                            { // CER to ensure that if Start succeeds we add to hash completing setup.
+                            {
                               // Start using process wide default service/queue & database from connection string.
                                 result = s_processDispatcher.StartWithDefault(
                                     connectionString,
@@ -749,7 +749,7 @@ namespace Microsoft.Data.SqlClient
                                 bool appDomainStop = false;
 
                                 try
-                                { // CER to ensure that if Stop succeeds we remove from hash completing teardown.
+                                {
                                   // Start using process wide default service/queue & database from connection string.
                                     result = s_processDispatcher.Stop(
                                         connectionString,

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyListener.cs
@@ -691,7 +691,6 @@ internal class SqlDependencyProcessDispatcher : MarshalByRefObject
                             if (_hashHelper.Identity != null)
                             { // Only impersonate if Integrated Security.
                                 WindowsImpersonationContext context = null;
-                                RuntimeHelpers.PrepareConstrainedRegions(); // CER for context.Undo.
                                 try
                                 {
                                     context = _windowsIdentity.Impersonate();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalConnection.cs
@@ -633,30 +633,5 @@ namespace Microsoft.Data.SqlClient
         abstract protected void PropagateTransactionCookie(byte[] transactionCookie);
 
         abstract internal void ValidateConnectionForExecute(SqlCommand command);
-
-        static internal TdsParser GetBestEffortCleanupTarget(SqlConnection connection)
-        {
-            if (connection != null)
-            {
-                SqlInternalConnectionTds innerConnection = (connection.InnerConnection as SqlInternalConnectionTds);
-                if (innerConnection != null)
-                {
-                    return innerConnection.Parser;
-                }
-            }
-
-            return null;
-        }
-
-#if NETFRAMEWORK
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-        static internal void BestEffortCleanup(TdsParser target)
-        {
-            if (target != null)
-            {
-                target.BestEffortCleanup();
-            }
-        }
-#endif
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlTransaction.cs
@@ -106,41 +106,15 @@ namespace Microsoft.Data.SqlClient
                     ObjectId,
                     ActivityCorrelator.Current,
                     Connection?.ClientConnectionId);
-
-                #if NETFRAMEWORK
-                TdsParser bestEffortCleanupTarget = null;
-                RuntimeHelpers.PrepareConstrainedRegions();
-                #endif
+                
                 try
                 {
-                    #if NETFRAMEWORK
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                    #endif
-
                     statistics = SqlStatistics.StartTimer(Statistics);
 
                     _isFromApi = true;
 
                     InternalTransaction.Commit();
                 }
-                #if NETFRAMEWORK
-                catch (OutOfMemoryException e)
-                {
-                    _connection.Abort(e);
-                    throw;
-                }
-                catch (StackOverflowException e)
-                {
-                    _connection.Abort(e);
-                    throw;
-                }
-                catch (ThreadAbortException e)
-                {
-                    _connection.Abort(e);
-                    SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                    throw;
-                }
-                #endif
                 catch (SqlException ex)
                 {
                     #if NET
@@ -176,40 +150,9 @@ namespace Microsoft.Data.SqlClient
         {
             if (disposing)
             {
-                #if NETFRAMEWORK
-                TdsParser bestEffortCleanupTarget = null;
-                RuntimeHelpers.PrepareConstrainedRegions();
-                #endif
-                try
+                if (!IsZombied && !Is2005PartialZombie)
                 {
-                    #if NETFRAMEWORK
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                    #endif
-
-                    if (!IsZombied && !Is2005PartialZombie)
-                    {
-                        InternalTransaction.Dispose();
-                    }
-                }
-                catch (OutOfMemoryException e)
-                {
-                    _connection.Abort(e);
-                    throw;
-                }
-                catch (StackOverflowException e)
-                {
-                    _connection.Abort(e);
-                    throw;
-                }
-                catch (ThreadAbortException e)
-                {
-                    _connection.Abort(e);
-
-                    #if NETFRAMEWORK
-                    SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                    #endif
-
-                    throw;
+                    InternalTransaction.Dispose();
                 }
             }
 
@@ -248,40 +191,16 @@ namespace Microsoft.Data.SqlClient
                         ObjectId,
                         ActivityCorrelator.Current,
                         Connection?.ClientConnectionId);
-
-                    #if NETFRAMEWORK
-                    TdsParser bestEffortCleanupTarget = null;
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    #endif
+                    
                     try
                     {
-                        #if NETFRAMEWORK
-                        bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                        #endif
 
                         statistics = SqlStatistics.StartTimer(Statistics);
 
                         _isFromApi = true;
                         InternalTransaction.Rollback();
                     }
-                    #if NETFRAMEWORK
-                    catch (OutOfMemoryException e)
-                    {
-                        _connection.Abort(e);
-                        throw;
-                    }
-                    catch (StackOverflowException e)
-                    {
-                        _connection.Abort(e);
-                        throw;
-                    }
-                    catch (ThreadAbortException e)
-                    {
-                        _connection.Abort(e);
-                        SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                        throw;
-                    }
-                    #else
+                    #if NET
                     catch (Exception ex)
                     {
                         diagnosticScope.SetException(ex);
@@ -327,40 +246,14 @@ namespace Microsoft.Data.SqlClient
             using (eventScopeEnter)
             {
                 SqlStatistics statistics = null;
-
-                #if NETFRAMEWORK
-                TdsParser bestEffortCleanupTarget = null;
-                RuntimeHelpers.PrepareConstrainedRegions();
-                #endif
                 try
                 {
-                    #if NETFRAMEWORK
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                    #endif
-
                     statistics = SqlStatistics.StartTimer(Statistics);
 
                     _isFromApi = true;
                     InternalTransaction.Rollback(transactionName);
                 }
-                #if NETFRAMEWORK
-                catch (OutOfMemoryException e)
-                {
-                    _connection.Abort(e);
-                    throw;
-                }
-                catch (StackOverflowException e)
-                {
-                    _connection.Abort(e);
-                    throw;
-                }
-                catch (ThreadAbortException e)
-                {
-                    _connection.Abort(e);
-                    SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                    throw;
-                }
-                #else
+                #if NET
                 catch (Exception ex)
                 {
                     diagnosticScope.SetException(ex);
@@ -391,42 +284,12 @@ namespace Microsoft.Data.SqlClient
             SqlStatistics statistics = null;
             using (TryEventScope.Create("SqlTransaction.Save | API | Object Id {0} | Save Point Name '{1}'", ObjectId, savePointName))
             {
-                #if NETFRAMEWORK
-                TdsParser bestEffortCleanupTarget = null;
-                RuntimeHelpers.PrepareConstrainedRegions();
-                #endif
                 try
                 {
-                    #if NETFRAMEWORK
-                    bestEffortCleanupTarget = SqlInternalConnection.GetBestEffortCleanupTarget(_connection);
-                    #endif
-
                     statistics = SqlStatistics.StartTimer(Statistics);
 
                     InternalTransaction.Save(savePointName);
                 }
-                #if NETFRAMEWORK
-                catch (OutOfMemoryException e)
-                {
-                    _connection.Abort(e);
-                    throw;
-                }
-                catch (StackOverflowException e)
-                {
-                    _connection.Abort(e);
-                    throw;
-                }
-                catch (ThreadAbortException e)
-                {
-                    _connection.Abort(e);
-
-                    #if NETFRAMEWORK
-                    SqlInternalConnection.BestEffortCleanup(bestEffortCleanupTarget);
-                    #endif
-
-                    throw;
-                }
-                #endif
                 finally
                 {
                     SqlStatistics.StopTimer(statistics);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -180,49 +180,9 @@ namespace Microsoft.Data.SqlClient
 #if NETFRAMEWORK
                         if (connectionToDoom != null || connectionToAbort != null)
                         {
-                            RuntimeHelpers.PrepareConstrainedRegions();
                             try
                             {
                                 onSuccess();
-                            }
-                            catch (System.OutOfMemoryException e)
-                            {
-                                if (connectionToDoom != null)
-                                {
-                                    connectionToDoom.DoomThisConnection();
-                                }
-                                else
-                                {
-                                    connectionToAbort.Abort(e);
-                                }
-                                completion.SetException(e);
-                                throw;
-                            }
-                            catch (System.StackOverflowException e)
-                            {
-                                if (connectionToDoom != null)
-                                {
-                                    connectionToDoom.DoomThisConnection();
-                                }
-                                else
-                                {
-                                    connectionToAbort.Abort(e);
-                                }
-                                completion.SetException(e);
-                                throw;
-                            }
-                            catch (System.Threading.ThreadAbortException e)
-                            {
-                                if (connectionToDoom != null)
-                                {
-                                    connectionToDoom.DoomThisConnection();
-                                }
-                                else
-                                {
-                                    connectionToAbort.Abort(e);
-                                }
-                                completion.SetException(e);
-                                throw;
                             }
                             catch (Exception e)
                             {
@@ -312,51 +272,9 @@ namespace Microsoft.Data.SqlClient
                     }
                     else if (connectionToDoom != null || connectionToAbort != null)
                     {
-#if NETFRAMEWORK
-                        RuntimeHelpers.PrepareConstrainedRegions();
-#endif
                         try
                         {
                             onSuccess(state2);
-                        }
-                        catch (System.OutOfMemoryException e)
-                        {
-                            if (connectionToDoom != null)
-                            {
-                                connectionToDoom.DoomThisConnection();
-                            }
-                            else
-                            {
-                                connectionToAbort.Abort(e);
-                            }
-                            completion.SetException(e);
-                            throw;
-                        }
-                        catch (System.StackOverflowException e)
-                        {
-                            if (connectionToDoom != null)
-                            {
-                                connectionToDoom.DoomThisConnection();
-                            }
-                            else
-                            {
-                                connectionToAbort.Abort(e);
-                            }
-                            completion.SetException(e);
-                            throw;
-                        }
-                        catch (System.Threading.ThreadAbortException e)
-                        {
-                            if (connectionToDoom != null)
-                            {
-                                connectionToDoom.DoomThisConnection();
-                            }
-                            else
-                            {
-                                connectionToAbort.Abort(e);
-                            }
-                            completion.SetException(e);
-                            throw;
                         }
                         catch (Exception e)
                         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.Windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.Windows.cs
@@ -158,57 +158,49 @@ namespace Microsoft.Data.SqlClient
             string hostNameInCertificate)
             : base(IntPtr.Zero, true)
         {
-#if NETFRAMEWORK
-            RuntimeHelpers.PrepareConstrainedRegions();
-#endif
-            try
-            { }
-            finally
-            {
-                _fSync = fSync;
-                instanceName = new byte[256]; // Size as specified by netlibs.
-                // Option ignoreSniOpenTimeout is no longer available
-                //if (ignoreSniOpenTimeout)
-                //{
-                //    // UNDONE: ITEM12001110 (DB Mirroring Reconnect) Old behavior of not truly honoring timeout presevered 
-                //    //  for non-failover scenarios to avoid breaking changes as part of a QFE.  Consider fixing timeout
-                //    //  handling in next full release and removing ignoreSniOpenTimeout parameter.
-                //    timeout = Timeout.Infinite; // -1 == native SNIOPEN_TIMEOUT_VALUE / INFINITE
-                //}
+            _fSync = fSync;
+            instanceName = new byte[256]; // Size as specified by netlibs.
+            // Option ignoreSniOpenTimeout is no longer available
+            //if (ignoreSniOpenTimeout)
+            //{
+            //    // UNDONE: ITEM12001110 (DB Mirroring Reconnect) Old behavior of not truly honoring timeout presevered
+            //    //  for non-failover scenarios to avoid breaking changes as part of a QFE.  Consider fixing timeout
+            //    //  handling in next full release and removing ignoreSniOpenTimeout parameter.
+            //    timeout = Timeout.Infinite; // -1 == native SNIOPEN_TIMEOUT_VALUE / INFINITE
+            //}
 
-                #if NETFRAMEWORK
-                int transparentNetworkResolutionStateNo = (int)transparentNetworkResolutionState;
-                _status = SniNativeWrapper.SniOpenSyncEx(
-                    myInfo,
-                    serverName,
-                    ref base.handle,
-                    ref spn,
-                    instanceName,
-                    flushCache,
-                    fSync,
-                    timeout,
-                    fParallel,
-                    transparentNetworkResolutionStateNo,
-                    totalTimeout,
-                    ipPreference,
-                    cachedDNSInfo,
-                    hostNameInCertificate);
-                #else
-                _status = SniNativeWrapper.SniOpenSyncEx(
-                    myInfo,
-                    serverName,
-                    ref base.handle,
-                    ref spn,
-                    instanceName,
-                    flushCache,
-                    fSync,
-                    timeout,
-                    fParallel,
-                    ipPreference,
-                    cachedDNSInfo,
-                    hostNameInCertificate);
-                #endif
-            }
+            #if NETFRAMEWORK
+            int transparentNetworkResolutionStateNo = (int)transparentNetworkResolutionState;
+            _status = SniNativeWrapper.SniOpenSyncEx(
+                myInfo,
+                serverName,
+                ref base.handle,
+                ref spn,
+                instanceName,
+                flushCache,
+                fSync,
+                timeout,
+                fParallel,
+                transparentNetworkResolutionStateNo,
+                totalTimeout,
+                ipPreference,
+                cachedDNSInfo,
+                hostNameInCertificate);
+            #else
+            _status = SniNativeWrapper.SniOpenSyncEx(
+                myInfo,
+                serverName,
+                ref base.handle,
+                ref spn,
+                instanceName,
+                flushCache,
+                fSync,
+                timeout,
+                fParallel,
+                ipPreference,
+                cachedDNSInfo,
+                hostNameInCertificate);
+            #endif
         }
 
         // constructs SNI Handle for MARS session

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSessionPool.cs
@@ -217,7 +217,6 @@ namespace Microsoft.Data.SqlClient
         }
 
 #if NETFRAMEWORK
-        // This is called from a ThreadAbort - ensure that it can be run from a CER Catch
         internal void BestEffortCleanup()
         {
             for (int i = 0; i < _cache.Count; i++)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -923,9 +923,6 @@ namespace Microsoft.Data.SqlClient
             Parser.PutSession(this);
         }
 
-#if NETFRAMEWORK
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-#endif
         internal int IncrementPendingCallbacks()
         {
             int remaining = Interlocked.Increment(ref _pendingCallbacks);


### PR DESCRIPTION
## Description
This is a fairly major change. 

https://learn.microsoft.com/en-us/dotnet/framework/performance/constrained-execution-regions#code-not-permitted-in-cers

For the longest time, and especially as part of this common project merge, we have maintained these Constrained Execution Regions as part of our netfx implementation. However, they've been a major pain to work around, since they involve try/catch/finally structures that aren't needed in netcore, or catching exceptions that are never expected to be caught in netcore. There have been several approaches brought forward to conditionally include the CER structures - some better than others. While working on the SqlCommand merge, I suggested another approach that moves the CER structure to a helper (see #3514). This uncovered a major limitation on CER blocks - that function pointers/delegates cannot be used (see link above).

This prompted a bit more research, and it appears that our codebase is riddled with code that cannot be called from a CER block. Since .NET 2.0, CER has been a guideline instead of a hard rule, and CER execution has become best-effort rather than guaranteed, and as a result much more permissive in what can be prepared/executed. Even with obvious issues in the code, CI has passed for ages, and no users have complained of faults arising from CER failures. As such, the question arises - **do we even need CER anymore?** The answer to this, so far, seems to be **no**.

So, in this PR, I searched the codebase for instances of `PrepareConstrainedRegion` and just removed the entire try/catch/finally structure where possible.

Here's some examples of places where we're doing unapproved things inside CER blocks:

* `SqlCommand.InternalExecuteNonQuery`
  * Called from `SqlCommand.ExecuteNonQuery`
  * Calls `RunExecuteNonQueryTds` which contains a lambda being called on timeout (among others)
* `SqlCommand.ExecuteReader`
  * Explicitly allocates the reader inside the constrained execution region 
  * Uses lambdas all over
* `SqlConnection.InternalOpenAsync`
  * Called from `SqlConnection.OpenAsync`
  * Uses function pointer in retry callback
* `TdsParserStateObject.ReadSniError`
  * Calls `TdsParserStateObject.ProcessSniPacket` which explicitly allocates a byte array

This PR is best viewed with whitespace changes ignored

## Issues
Will make remaining work for #1261 easier

## Testing
Project still builds, CI will hopefully be sufficient for validation of behavior.