### PR TITLE
Disable packet multiplexing design by default

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,7 @@
     </ItemGroup>
     <!-- NetFx and NetCore project dependencies -->
     <ItemGroup>
-        <PackageVersion Include="Azure.Identity" Version="1.13.2" />
+        <PackageVersion Include="Azure.Identity" Version="1.14.2" />
         <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.7.1" />
         <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.7.1" />
         <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,7 @@
     </ItemGroup>
     <!-- NetFx and NetCore project dependencies -->
     <ItemGroup>
-        <PackageVersion Include="Azure.Identity" Version="1.14.2" />
+        <PackageVersion Include="Azure.Identity" Version="1.13.2" />
         <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.7.1" />
         <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.7.1" />
         <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -67,11 +67,11 @@ namespace Microsoft.Data.SqlClient
 #endif
 
         /// <summary>
-        /// In TdsParser the ProcessSni function changed significantly when the packet
+        /// In TdsParser, the ProcessSni function changed significantly when the packet
         /// multiplexing code needed for high speed multi-packet column values was added.
-        /// The switch is enabled by default and retains the old ProcessSni design.
-        /// Use this switch to enable experimental design that uses the new ProcessSni
-        /// behavior using the packet multiplexer.
+        /// When this switch is set to true (the default), the old ProcessSni design is used.
+        /// When this switch is set to false, the new experimental ProcessSni behavior using
+        /// the packet multiplexer is enabled.
         /// </summary>
         public static bool UseCompatibilityProcessSni
         {
@@ -95,12 +95,12 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <summary>
-        /// In TdsParser the async multi-packet column value fetch behaviour is capable of
-        /// using a continue snapshot state in addition to the original replay from start
-        /// logic.
-        /// This switch disables use of the continue snapshot state and is enabled by default. This switch will always
-        /// return true if <see cref="UseCompatibilityProcessSni"/> is enabled because the 
-        /// continue state is not stable without the multiplexer.
+        /// In TdsParser, the async multi-packet column value fetch behavior can use a continue snapshot state
+        /// for improved efficiency. When this switch is enabled (the default), the driver preserves the legacy
+        /// compatibility behavior, which does not use the continue snapshot state. When disabled, the new behavior
+        /// using the continue snapshot state is enabled. This switch will always return true if
+        /// <see cref="UseCompatibilityProcessSni"/> is enabled, because the continue state is not stable without
+        /// the multiplexer.
         /// </summary>
         public static bool UseCompatibilityAsyncBehaviour
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -69,8 +69,9 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// In TdsParser the ProcessSni function changed significantly when the packet
         /// multiplexing code needed for high speed multi-packet column values was added.
-        /// In case of compatibility problems this switch will change TdsParser to use
-        /// the previous version of the function.
+        /// The switch is enabled by default and retains the old ProcessSni design.
+        /// Use this switch to enable experimental design that uses the new ProcessSni
+        /// behavior using the packet multiplexer.
         /// </summary>
         public static bool UseCompatibilityProcessSni
         {
@@ -78,7 +79,9 @@ namespace Microsoft.Data.SqlClient
             {
                 if (s_useCompatibilityProcessSni == Tristate.NotInitialized)
                 {
-                    if (AppContext.TryGetSwitch(UseCompatibilityProcessSniString, out bool returnedValue) && returnedValue)
+                    // Check if the switch has been set by the AppContext switch directly
+                    // If it has not been set, we default to true.
+                    if (!AppContext.TryGetSwitch(UseCompatibilityProcessSniString, out bool returnedValue) || returnedValue)
                     {
                         s_useCompatibilityProcessSni = Tristate.True;
                     }
@@ -95,7 +98,7 @@ namespace Microsoft.Data.SqlClient
         /// In TdsParser the async multi-packet column value fetch behaviour is capable of
         /// using a continue snapshot state in addition to the original replay from start
         /// logic.
-        /// This switch disables use of the continue snapshot state. This switch will always
+        /// This switch disables use of the continue snapshot state and is enabled by default. This switch will always
         /// return true if <see cref="UseCompatibilityProcessSni"/> is enabled because the 
         /// continue state is not stable without the multiplexer.
         /// </summary>
@@ -114,7 +117,7 @@ namespace Microsoft.Data.SqlClient
 
                 if (s_useCompatibilityAsyncBehaviour == Tristate.NotInitialized)
                 {
-                    if (AppContext.TryGetSwitch(UseCompatibilityAsyncBehaviourString, out bool returnedValue) && returnedValue)
+                    if (!AppContext.TryGetSwitch(UseCompatibilityAsyncBehaviourString, out bool returnedValue) || returnedValue)
                     {
                         s_useCompatibilityAsyncBehaviour = Tristate.True;
                     }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/MultiplexerTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/MultiplexerTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.SqlClient.Tests
                 {
                     return foundValue;
                 }
-                return false;
+                return true; // Default to true if the switch is not set
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/LocalAppContextSwitchesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/LocalAppContextSwitchesTest.cs
@@ -23,8 +23,8 @@ public class LocalAppContextSwitchesTest
         Assert.False(LocalAppContextSwitches.MakeReadAsyncBlocking);
         Assert.True(LocalAppContextSwitches.UseMinimumLoginTimeout);
         Assert.True(LocalAppContextSwitches.LegacyVarTimeZeroScaleBehaviour);
-        Assert.False(LocalAppContextSwitches.UseCompatibilityProcessSni);
-        Assert.False(LocalAppContextSwitches.UseCompatibilityAsyncBehaviour);
+        Assert.True(LocalAppContextSwitches.UseCompatibilityProcessSni);
+        Assert.True(LocalAppContextSwitches.UseCompatibilityAsyncBehaviour);
         Assert.False(LocalAppContextSwitches.UseConnectionPoolV2);
         Assert.False(LocalAppContextSwitches.TruncateScaledDecimal);
 #if NETFRAMEWORK


### PR DESCRIPTION
## Description

Enables below App Context switches by default until packet multiplexing is ready for production use.

`Switch.Microsoft.Data.SqlClient.UseCompatibilityProcessSni`
`Switch.Microsoft.Data.SqlClient.UseCompatibilityAsyncBehaviour`

## Issues

Addresses #3519 

Potentially also #3536 #3529 (waiting for confirmation)

_(TODO: Backport to release/6.1 on merge)_