### PR TITLE
Temporarily Disable Enclave Testing

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -366,36 +366,37 @@ stages:
             LocalDbAppName: $(LocalDbAppName)
             LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
 
-        ${{ if eq(variables['system.pullRequest.isFork'], 'False') }}: # only run enclave jobs if the password is available
-          windows_enclave_sql:
-            pool: ADO-CI-AE-1ES-Pool
-            images: 
-              Win22_Enclave_Sql19: ADO-MMS22-SQL19
-            TargetFrameworks: ${{parameters.targetFrameworks }}
-            netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
-            buildPlatforms: ${{parameters.buildPlatforms }}
-            testSets: [AE]
-            useManagedSNI: ${{parameters.useManagedSNI }}
-            codeCovTargetFrameworks: ${{parameters.codeCovTargetFrameworks }}
-            configSqlFor: enclave
-            operatingSystem: Windows
-            configProperties:
-              # config.json properties
-              TCPConnectionStringHGSVBS: $(SQL_TCP_CONN_STRING_HGSVBS)
-              TCPConnectionStringNoneVBS: $(SQL_TCP_CONN_STRING_NoneVBS)
-              TCPConnectionStringAASSGX: $(SQL_TCP_CONN_STRING_AASSGX)
-              EnclaveEnabled: true
-              AADAuthorityURL: $(AADAuthorityURL)
-              AADServicePrincipalId: $(AADServicePrincipalId)
-              ${{ if eq(variables['system.pullRequest.isFork'], 'False') }}:
-                AADServicePrincipalSecret: $(AADServicePrincipalSecret)
-              AzureKeyVaultUrl: $(AzureKeyVaultUrl)
-              AzureKeyVaultTenantId: $(AzureKeyVaultTenantId)
-              SupportsIntegratedSecurity: $(SupportsIntegratedSecurity)
-              UserManagedIdentityClientId: $(UserManagedIdentityClientId)
-              AliasName: $(SQLAliasName)            
-              LocalDbAppName: $(LocalDbAppName)
-              LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
+# Enclave tests disabled as on 2025-08-05 due to azure capacity issues. Reenable once instances are available again.
+#        ${{ if eq(variables['system.pullRequest.isFork'], 'False') }}: # only run enclave jobs if the password is available
+#          windows_enclave_sql:
+#            pool: ADO-CI-AE-1ES-Pool
+#            images:
+#              Win22_Enclave_Sql19: ADO-MMS22-SQL19
+#            TargetFrameworks: ${{parameters.targetFrameworks }}
+#            netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
+#            buildPlatforms: ${{parameters.buildPlatforms }}
+#            testSets: [AE]
+#            useManagedSNI: ${{parameters.useManagedSNI }}
+#            codeCovTargetFrameworks: ${{parameters.codeCovTargetFrameworks }}
+#            configSqlFor: enclave
+#            operatingSystem: Windows
+#            configProperties:
+#              # config.json properties
+#              TCPConnectionStringHGSVBS: $(SQL_TCP_CONN_STRING_HGSVBS)
+#              TCPConnectionStringNoneVBS: $(SQL_TCP_CONN_STRING_NoneVBS)
+#              TCPConnectionStringAASSGX: $(SQL_TCP_CONN_STRING_AASSGX)
+#              EnclaveEnabled: true
+#              AADAuthorityURL: $(AADAuthorityURL)
+#              AADServicePrincipalId: $(AADServicePrincipalId)
+#              ${{ if eq(variables['system.pullRequest.isFork'], 'False') }}:
+#                AADServicePrincipalSecret: $(AADServicePrincipalSecret)
+#              AzureKeyVaultUrl: $(AzureKeyVaultUrl)
+#              AzureKeyVaultTenantId: $(AzureKeyVaultTenantId)
+#              SupportsIntegratedSecurity: $(SupportsIntegratedSecurity)
+#              UserManagedIdentityClientId: $(UserManagedIdentityClientId)
+#              AliasName: $(SQLAliasName)
+#              LocalDbAppName: $(LocalDbAppName)
+#              LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
 
     # self hosted SQL Server on Linux
         linux_sql_19_22:
@@ -452,34 +453,35 @@ stages:
             LocalDbAppName: $(LocalDbAppName)
             LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
 
-        ${{ if eq(variables['system.pullRequest.isFork'], 'False') }}: # only run enclave jobs if the password is available
-          linux_enclave_sql:
-            pool: ADO-CI-AE-1ES-Pool
-            images:
-              Ubuntu20_Enclave_Sql19: ADO-UB20-Sql22
-            TargetFrameworks: ${{parameters.targetFrameworksLinux }}
-            netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
-            buildPlatforms: [AnyCPU]
-            testSets: [AE]
-            useManagedSNI: [true]
-            codeCovTargetFrameworks: ${{parameters.codeCovTargetFrameworks }}
-            configSqlFor: enclave
-            operatingSystem: Linux
-            configProperties:
-              # config.json properties
-              TCPConnectionStringHGSVBS: $(SQL_TCP_CONN_STRING_HGSVBS)
-              TCPConnectionStringNoneVBS: $(SQL_TCP_CONN_STRING_NoneVBS)
-              TCPConnectionStringAASSGX: $(SQL_TCP_CONN_STRING_AASSGX)
-              EnclaveEnabled: true
-              AADServicePrincipalId: $(AADServicePrincipalId)
-              ${{ if eq(variables['system.pullRequest.isFork'], 'False') }}:
-                AADServicePrincipalSecret: $(AADServicePrincipalSecret)
-              AzureKeyVaultUrl: $(AzureKeyVaultUrl)
-              AzureKeyVaultTenantId: $(AzureKeyVaultTenantId)
-              SupportsIntegratedSecurity: false
-              UserManagedIdentityClientId: $(UserManagedIdentityClientId)
-              LocalDbAppName: $(LocalDbAppName)
-              LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
+# Enclave tests disabled as on 2025-08-05 due to azure capacity issues. Reenable once instances are available again.
+#        ${{ if eq(variables['system.pullRequest.isFork'], 'False') }}: # only run enclave jobs if the password is available
+#          linux_enclave_sql:
+#            pool: ADO-CI-AE-1ES-Pool
+#            images:
+#              Ubuntu20_Enclave_Sql19: ADO-UB20-Sql22
+#            TargetFrameworks: ${{parameters.targetFrameworksLinux }}
+#            netcoreVersionTestUtils: ${{parameters.netcoreVersionTestUtils }}
+#            buildPlatforms: [AnyCPU]
+#            testSets: [AE]
+#            useManagedSNI: [true]
+#            codeCovTargetFrameworks: ${{parameters.codeCovTargetFrameworks }}
+#            configSqlFor: enclave
+#            operatingSystem: Linux
+#            configProperties:
+#              # config.json properties
+#              TCPConnectionStringHGSVBS: $(SQL_TCP_CONN_STRING_HGSVBS)
+#              TCPConnectionStringNoneVBS: $(SQL_TCP_CONN_STRING_NoneVBS)
+#              TCPConnectionStringAASSGX: $(SQL_TCP_CONN_STRING_AASSGX)
+#              EnclaveEnabled: true
+#              AADServicePrincipalId: $(AADServicePrincipalId)
+#              ${{ if eq(variables['system.pullRequest.isFork'], 'False') }}:
+#                AADServicePrincipalSecret: $(AADServicePrincipalSecret)
+#              AzureKeyVaultUrl: $(AzureKeyVaultUrl)
+#              AzureKeyVaultTenantId: $(AzureKeyVaultTenantId)
+#              SupportsIntegratedSecurity: false
+#              UserManagedIdentityClientId: $(UserManagedIdentityClientId)
+#              LocalDbAppName: $(LocalDbAppName)
+#              LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
 
         # Self hosted SQL Server on Mac
         mac_sql_22:


### PR DESCRIPTION
## Description
Due to Azure capacity constraints, our enclave environments for testing have been deallocated. Since this completely blocks all PRs going through, and standing up new environments in new regions will take a lot more work (and we have very pressing issues to resolve ASAP), this PR disables enclave testing. It is temporary, hence just commenting out the configurations to run.

## Issues
N/A but it is an issue we're painfully aware of.

## Testing
This only affects CI, so CI should be the validation we need.