### PR TITLE
[6.1] Add CodeQL suppression for DefaultAzureCredential and fix macOS CI failures

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ActiveDirectoryAuthenticationProvider.cs
@@ -582,7 +582,28 @@ namespace Microsoft.Data.SqlClient
                     defaultAzureCredentialOptions.WorkloadIdentityClientId = tokenCredentialKey._clientId;
                 }
 
-                return new TokenCredentialData(new DefaultAzureCredential(defaultAzureCredentialOptions), GetHash(secret));
+                // SqlClient is a library and provides support to acquire access
+                // token using 'DefaultAzureCredential' on user demand when they
+                // specify 'Authentication = Active Directory Default' in
+                // connection string.
+                //
+                // Default Azure Credential is instantiated by the calling
+                // application when using "Active Directory Default"
+                // authentication code to connect to Azure SQL instance.
+                // SqlClient is a library, doesn't instantiate the credential
+                // without running application instructions.
+                //
+                // Note that CodeQL suppression support can only detect
+                // suppression comments that appear immediately above the
+                // flagged statement, or appended to the end of the statement.
+                // Multi-line justifications are not supported.
+                //
+                // https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-semmle#guidance-on-suppressions
+                //
+                // CodeQL [SM05137] See above for justification.
+                DefaultAzureCredential cred = new(defaultAzureCredentialOptions);
+
+                return new TokenCredentialData(cred, GetHash(secret));
             }
 
             TokenCredentialOptions tokenCredentialOptions = new() { AuthorityHost = new Uri(tokenCredentialKey._authority) };

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniTcpHandle.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniTcpHandle.netcore.cs
@@ -953,9 +953,30 @@ namespace Microsoft.Data.SqlClient.ManagedSni
                 }
                 finally
                 {
-                    // Reset the socket timeout to Timeout.Infinite after the receive operation is done
-                    // to avoid blocking the thread in case of a timeout error.
-                    _socket.ReceiveTimeout = Timeout.Infinite;
+                    const int resetTimeout = Timeout.Infinite;
+
+                    try
+                    {
+                        // Reset the socket timeout to Timeout.Infinite after
+                        // the receive operation is done to avoid blocking the
+                        // thread in case of a timeout error.
+                        _socket.ReceiveTimeout = resetTimeout;
+
+                    }
+                    catch (SocketException ex)
+                    {
+                        // We sometimes see setting the ReceiveTimeout fail
+                        // on macOS. There's isn't much we can do about it
+                        // though, so just log and move on.
+                        SqlClientEventSource.Log.TrySNITraceEvent(
+                            nameof(SniTcpHandle),
+                            EventType.ERR,
+                            "Connection Id {0}, Failed to reset socket " +
+                            "receive timeout to {1}: {2}",
+                            _connectionId,
+                            resetTimeout,
+                            ex.Message);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Port of #3542.

- Adjusted CodeQL suppression to meet the strict requirements of where it may appear relative to the flagged code.
- Adding catch for macOS socket error to log and ignore.