### PR TITLE
Add Stress Tests to CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ indent_size = 4
 [*.{json,jsonc}]
 indent_size = 2
 
+[*.{yml,yaml}]
+indent_size = 2
+
 # C# files
 [*.cs]
 # New line preferences

--- a/eng/pipelines/common/templates/steps/configure-sql-server-linux-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-linux-step.yml
@@ -3,6 +3,11 @@
 # The .NET Foundation licenses this file to you under the MIT license.          #
 # See the LICENSE file in the project root for more information.                #
 #################################################################################
+
+# This step configures an existing SQL Server running on the local Linux host.
+# For example, our 1ES Hosted Pool has images like ADO-UB20-SQL22 that come with
+# SQL Server 2022 pre-installed and running.
+
 parameters:
   - name: password
     type: string

--- a/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
@@ -3,6 +3,10 @@
 # The .NET Foundation licenses this file to you under the MIT license.          #
 # See the LICENSE file in the project root for more information.                #
 #################################################################################
+
+# This step installs the latest SQL Server 2022 onto the macOS host and
+# configures it for use.
+
 parameters:
   - name: password
     type: string
@@ -13,7 +17,7 @@ parameters:
     default: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
 steps:
-# Linux only steps
+# macOS only steps
 - bash: |
     # The "user" pipeline variable conflicts with homebrew, causing errors during install. Set it back to the pipeline user.
     USER=`whoami`

--- a/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
@@ -3,6 +3,11 @@
 # The .NET Foundation licenses this file to you under the MIT license.          #
 # See the LICENSE file in the project root for more information.                #
 #################################################################################
+
+# This step configures an existing SQL Server running on the local Windows host.
+# For example, our 1ES Hosted Pool has images like ADO-MMS22-SQL22 that come
+# with SQL Server 2022 pre-installed and running.
+
 parameters:
 # Windows only parameters
   - name: instanceName
@@ -63,7 +68,7 @@ parameters:
     default: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 steps:
-# windows only steps
+# Windows only steps
 - powershell: |
     try
     {

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -65,6 +65,13 @@ parameters:
     - Project
     - Package
 
+- name: buildConfiguration
+  displayName: 'Build Configuration'
+  default: Release
+  values:
+    - Release
+    - Debug
+
 - name: defaultPoolName
   type: string
   default: $(ci_var_defaultPoolName)
@@ -84,6 +91,7 @@ stages:
     jobs:
     - template: common/templates/jobs/ci-build-nugets-job.yml@self
       parameters:
+        configuration: ${{ parameters.buildConfiguration }}
         artifactName: $(artifactName)
         ${{if ne(parameters.SNIVersion, '')}}:
           prebuildSteps:
@@ -92,6 +100,15 @@ stages:
                 SNIVersion: ${{parameters.SNIVersion}}
                 SNIValidationFeed: ${{parameters.SNIValidationFeed}}
 
+  - template: stages/stress-tests-ci-stage.yml@self
+    parameters:
+      buildConfiguration: ${{ parameters.buildConfiguration }}
+      dependsOn: [build_nugets]
+      pipelineArtifactName: $(artifactName)
+      mdsPackageVersion: $(NugetPackageVersion)
+      ${{ if eq(parameters.debug, 'true') }}:
+        verbosity: 'detailed'
+    
   - template: common/templates/stages/ci-run-tests-stage.yml@self
     parameters:
       debug: ${{ parameters.debug }}
@@ -139,7 +156,6 @@ stages:
       testConfigurations:
         windows_sql_19_x64: # configuration name
           pool: ${{parameters.defaultPoolName }} # pool name
-          hostedPool: false # whether the pool is hosted or not
           images: # list of images to run tests on
             Win22_Sql19: ADO-MMS22-SQL19 # stage display name: image name from the pool
           TargetFrameworks: ${{parameters.targetFrameworks }} #[net462, net8.0] # list of target frameworks to run
@@ -181,7 +197,6 @@ stages:
 
         windows_sql_19_x86: # configuration name
           pool: ${{parameters.defaultPoolName }} # pool name
-          hostedPool: false # whether the pool is hosted or not
           images: # list of images to run tests on
             Win22_Sql19_x86: ADO-MMS22-SQL19 # stage display name: image name from the pool
           TargetFrameworks: [net8.0] #[net462, net8.0] # list of target frameworks to run

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -76,6 +76,11 @@ parameters:
   type: string
   default: $(ci_var_defaultPoolName)
 
+- name: enableStressTests
+  displayName: Enable Stress Tests
+  type: boolean
+  default: false
+
 variables:
   - template: libraries/ci-build-variables.yml@self
   
@@ -100,14 +105,15 @@ stages:
                 SNIVersion: ${{parameters.SNIVersion}}
                 SNIValidationFeed: ${{parameters.SNIValidationFeed}}
 
-  - template: stages/stress-tests-ci-stage.yml@self
-    parameters:
-      buildConfiguration: ${{ parameters.buildConfiguration }}
-      dependsOn: [build_nugets]
-      pipelineArtifactName: $(artifactName)
-      mdsPackageVersion: $(NugetPackageVersion)
-      ${{ if eq(parameters.debug, 'true') }}:
-        verbosity: 'detailed'
+  - ${{ if eq(parameters.enableStressTests, true) }}:
+    - template: stages/stress-tests-ci-stage.yml@self
+      parameters:
+        buildConfiguration: ${{ parameters.buildConfiguration }}
+        dependsOn: [build_nugets]
+        pipelineArtifactName: $(artifactName)
+        mdsPackageVersion: $(NugetPackageVersion)
+        ${{ if eq(parameters.debug, 'true') }}:
+          verbosity: 'detailed'
     
   - template: common/templates/stages/ci-run-tests-stage.yml@self
     parameters:

--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -88,6 +88,11 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     - Release
     - Debug
 
+- name: enableStressTests
+  displayName: Enable Stress Tests
+  type: boolean
+  default: false
+
 extends:
   template: dotnet-sqlclient-ci-core.yml@self
   parameters:
@@ -100,3 +105,4 @@ extends:
     codeCovTargetFrameworks: ${{ parameters.codeCovTargetFrameworks }}
     buildType: ${{ parameters.buildType }}
     buildConfiguration: ${{ parameters.buildConfiguration }}
+    enableStressTests: ${{ parameters.enableStressTests }}

--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -81,6 +81,13 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     - Project
     - Package
 
+- name: buildConfiguration
+  displayName: 'Build Configuration'
+  default: Release
+  values:
+    - Release
+    - Debug
+
 extends:
   template: dotnet-sqlclient-ci-core.yml@self
   parameters:
@@ -92,3 +99,4 @@ extends:
     useManagedSNI: ${{ parameters.useManagedSNI }}
     codeCovTargetFrameworks: ${{ parameters.codeCovTargetFrameworks }}
     buildType: ${{ parameters.buildType }}
+    buildConfiguration: ${{ parameters.buildConfiguration }}

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -73,6 +73,13 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     - Project
     - Package
 
+- name: buildConfiguration
+  displayName: 'Build Configuration'
+  default: Release
+  values:
+    - Release
+    - Debug
+
 extends:
   template: dotnet-sqlclient-ci-core.yml@self
   parameters:
@@ -84,3 +91,4 @@ extends:
     useManagedSNI: ${{ parameters.useManagedSNI }}
     codeCovTargetFrameworks: ${{ parameters.codeCovTargetFrameworks }}
     buildType: ${{ parameters.buildType }}
+    buildConfiguration: ${{ parameters.buildConfiguration }}

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -80,6 +80,11 @@ parameters: # parameters are shown up in ADO UI in a build queue time
     - Release
     - Debug
 
+- name: enableStressTests
+  displayName: Enable Stress Tests
+  type: boolean
+  default: false
+
 extends:
   template: dotnet-sqlclient-ci-core.yml@self
   parameters:
@@ -92,3 +97,4 @@ extends:
     codeCovTargetFrameworks: ${{ parameters.codeCovTargetFrameworks }}
     buildType: ${{ parameters.buildType }}
     buildConfiguration: ${{ parameters.buildConfiguration }}
+    enableStressTests: ${{ parameters.enableStressTests }}

--- a/eng/pipelines/jobs/stress-tests-ci-job.yml
+++ b/eng/pipelines/jobs/stress-tests-ci-job.yml
@@ -1,0 +1,214 @@
+################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET
+# Foundation licenses this file to you under the MIT license.  See the LICENSE
+# file in the project root for more information.
+################################################################################
+
+# This stage builds and runs stress tests against an MDS NuGet package available
+# as a pipeline artifact.
+#
+# The stress tests are located here:
+#
+#   src/Microsoft.Data.SqlClient/tests/StressTests
+#
+# This template defines a job named 'run_stress_tests_job_<suffix>' that can be
+# depended on by downstream jobs.
+
+parameters:
+  # The suffix to append to the job name.
+  - name: jobNameSuffix
+    type: string
+    default: ''
+
+  # The prefix to prepend to the job's display name:
+  #
+  #   [<prefix>] Run Stress Tests
+  #
+  - name: displayNamePrefix
+    type: string
+    default: ''
+
+  # The name of the Azure Pipelines pool to use.
+  - name: poolName
+    type: string
+    default: ''
+
+  # The pool VM image to use.
+  - name: vmImage
+    type: string
+    default: ''
+
+  # The pipeline step to run to configure SQL Server.
+  #
+  # This step is expected to require no parameters.  It must configure a SQL
+  # Server instance listening on localhost for SQL auth via the 'sa' user with
+  # the pipeline variable $(Password) as the password.
+  - name: sqlSetupStep
+    type: string
+    default: ''
+
+  # The name of the pipeline artifact to download that contains the MDS package
+  # to stress test.
+  - name: pipelineArtifactName
+    type: string
+    default: ''
+
+  # The solution file to restore/build.
+  - name: solution
+    type: string
+    default: ''
+
+  # The test project to run.
+  - name: testProject
+    type: string
+    default: ''
+
+  # dotnet CLI arguments for the restore step.
+  - name: restoreArguments
+    type: string
+    default: ''
+
+  # dotnet CLI arguments for the build and run steps.
+  - name: buildArguments
+    type: string
+    default: ''
+
+  # The list of .NET runtimes to test against.
+  - name: netTestRuntimes
+    type: object
+    default: []
+
+  # The list of .NET Framework runtimes to test against.
+  - name: netFrameworkTestRuntimes
+    type: object
+    default: []
+
+  # The stress test config file contents to write to the config file.
+  #
+  # This should point to the SQL Server configured via the sqlSetupStep
+  # parameter, with user 'sa' and password of $(Password).
+  - name: configContent
+    type: string
+    default: ''
+
+jobs:
+- job: run_stress_tests_job_${{ parameters.jobNameSuffix }}
+  displayName: '[${{ parameters.displayNamePrefix }}] Run Stress Tests'
+  pool:
+    name: ${{ parameters.poolName }}
+    ${{ if eq(parameters.poolName, 'Azure Pipelines') }}:
+      vmImage: ${{ parameters.vmImage }}
+    ${{ else }}:
+      demands:
+        - imageOverride -equals ${{ parameters.vmImage }}
+
+  variables:
+    # Stress test command-line arguments.
+    - name: testArguments
+      value: -a SqlClient.Stress.Tests -console
+
+    # Explicitly unset the $PLATFORM environment variable that is set by the
+    # 'ADO Build properties' Library in the ADO SqlClientDrivers public project.
+    # This is defined with a non-standard Platform of 'AnyCPU', and will fail
+    # the builds if left defined.  The stress tests solution does not require
+    # any specific Platform, and so its solution file doesn't support any
+    # non-standard platforms.
+    #
+    # Note that Azure Pipelines will inject this variable as PLATFORM into the
+    # environment of all tasks in this job.
+    #
+    # See:
+    #   https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch
+    #
+    - name: Platform
+      value: ''
+
+    # Do the same for $CONFIGURATION since we explicitly set it using our
+    # 'buildConfiguration' parameter, and we don't want the environment to
+    # override us.
+    - name: Configuration
+      value: ''
+
+  steps:
+
+  # Install the .NET 9.0 SDK.
+  - task: UseDotNet@2
+    displayName: Install .NET 9.0 SDK
+    inputs:
+      packageType: sdk
+      version: 9.x
+
+  # Install the .NET 8.0 runtime.
+  - task: UseDotNet@2
+    displayName: Install .NET 8.0 Runtime
+    inputs:
+      packageType: runtime
+      version: 8.x
+
+  # Download the pipeline artifact that contains the MDS package to test.
+  - task: DownloadPipelineArtifact@2
+    displayName: Download Pipeline Artifact
+    inputs:
+      artifactName: ${{ parameters.pipelineArtifactName }}
+      # The stress tests solution has a NuGet.config file that configures
+      # sources to look in this packages/ directory.
+      targetPath: $(Build.SourcesDirectory)/packages
+
+  # Setup the local SQL Server.
+  - template: ${{ parameters.sqlSetupStep }}@self
+
+  # We use the 'custom' command because the DotNetCoreCLI@2 task doesn't support
+  # all of our argument combinations for the different build steps.
+
+  # Restore the solution.
+  - task: DotNetCoreCLI@2
+    displayName: Restore Solution
+    inputs:
+      command: custom
+      custom: restore
+      projects: ${{ parameters.solution }}
+      arguments: ${{ parameters.restoreArguments }}
+
+  # Build the solution.
+  - task: DotNetCoreCLI@2
+    displayName: Build Solution
+    inputs:
+      command: custom
+      custom: build
+      projects: ${{ parameters.solution }}
+      arguments: ${{ parameters.buildArguments }} --no-restore
+
+  # Write the config file.
+  - task: PowerShell@2
+    displayName: Write Config File
+    inputs:
+      pwsh: true
+      targetType: inline
+      script: |
+        # Capture the multi-line JSON content into a variable.
+        $content = @"
+        ${{ parameters.configContent }}
+        "@
+
+        # Write the JSON content to the config file.
+        $content | Out-File -FilePath "config.json"
+
+  # Run the stress tests for each .NET runtime.
+  - ${{ each runtime in parameters.netTestRuntimes }}:
+    - task: DotNetCoreCLI@2
+      displayName: Test [${{runtime}}]
+      inputs:
+        command: custom
+        custom: run
+        projects: ${{ parameters.testProject }}
+        arguments: ${{ parameters.buildArguments }} --no-build -f ${{runtime}} -e STRESS_CONFIG_FILE=config.json -- $(testArguments)
+
+  # Run the stress tests for each .NET Framework runtime.
+  - ${{ each runtime in parameters.netFrameworkTestRuntimes }}:
+    - task: DotNetCoreCLI@2
+      displayName: Test [${{runtime}}]
+      inputs:
+        command: custom
+        custom: run
+        projects: ${{ parameters.testProject }}
+        arguments: ${{ parameters.buildArguments }} --no-build -f ${{runtime}} -e STRESS_CONFIG_FILE=config.json -- $(testArguments)

--- a/eng/pipelines/stages/stress-tests-ci-stage.yml
+++ b/eng/pipelines/stages/stress-tests-ci-stage.yml
@@ -1,0 +1,191 @@
+################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET
+# Foundation licenses this file to you under the MIT license.  See the LICENSE
+# file in the project root for more information.
+################################################################################
+
+# This stage builds and runs stress tests against an MDS NuGet package available
+# as a pipeline artifact.
+#
+# The stress tests are located here:
+#
+#   src/Microsoft.Data.SqlClient/tests/StressTests
+#
+# All tests use a localhost SQL Server configured for SQL auth via the 'sa' user
+# and password of '$(Password)'.  The $(Password) variable is defined in the ADO
+# Library "ADO Test Configuration properties", brought in by
+# common/templates/libraries/ci-build-variables.yml.
+#
+# This template defines a stage named 'run_stress_tests_stage' that can be
+# depended on by downstream stages.
+
+parameters:
+  # The type of build to produce (Release or Debug)
+  - name: buildConfiguration
+    displayName: Build Configuration
+    type: string
+    default: Release
+    values:
+    - Release
+    - Debug
+
+  # The names of any stages this stage depends on, for example the stages
+  # that publish the MDS package artifacts we will test.
+  - name: dependsOn
+    displayName: Depends On Stages
+    type: object
+    default: []
+
+  # The name of the pipeline artifact to download that contains the MDS package
+  # to stress test.
+  - name: pipelineArtifactName
+    displayName: Pipeline Artifact Name
+    type: string
+    default: Artifacts
+
+  # The MDS package version to stress test.  This version must be available in
+  # one of the configured NuGet sources.
+  - name: mdsPackageVersion
+    displayName: MDS Package Version
+    type: string
+    default: ''
+
+  # The list of .NET runtimes to test against.
+  - name: netTestRuntimes
+    displayName: .NET Test Runtimes
+    type: object
+    default: [net8.0, net9.0]
+
+  # The list of .NET Framework runtimes to test against.
+  - name: netFrameworkTestRuntimes
+    displayName: .NET Framework Test Runtimes
+    type: object
+    default: [net462, net47, net471, net472, net48, net481]
+
+  # The verbosity level for the dotnet CLI commands.
+  - name: verbosity
+    displayName: Dotnet CLI verbosity
+    type: string
+    default: normal
+    values:
+    - quiet
+    - minimal
+    - normal
+    - detailed
+    - diagnostic
+
+stages:
+  - stage: run_stress_tests_stage
+    displayName: Run Stress Tests
+    dependsOn: ${{ parameters.dependsOn }}
+
+    variables:
+      # The directory where dotnet artifacts will be staged.  Not to be
+      # confused with pipeline artifact.
+      - name: dotnetArtifactsDir
+        value: $(Build.StagingDirectory)/dotnetArtifacts
+
+      # The solution file to use for all dotnet CLI commands.
+      - name: solution
+        value: src/Microsoft.Data.SqlClient/tests/StressTests/StressTests.slnx
+
+      # The stress test project to run.
+      - name: testProject
+        value: src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Runner/SqlClient.Stress.Runner.csproj
+
+      # dotnet CLI arguments common to all commands.
+      - name: commonArguments
+        value: >-
+          --verbosity ${{parameters.verbosity}}
+          --artifacts-path $(dotnetArtifactsDir)
+          -p:MdsPackageVersion=${{parameters.mdsPackageVersion}}
+
+      # dotnet CLI arguments for build/run commands.
+      - name: buildArguments
+        value: >-
+          $(commonArguments)
+          --configuration ${{parameters.buildConfiguration}}
+
+      # The contents of the config file to use for all tests.  We will write
+      # this to a JSON file for each test job, and then point to it via the
+      # STRESS_CONFIG_FILE environment variable.
+      - name: ConfigContent
+        value: |
+          [
+            {
+              "name": "Azure SQL",
+              "type": "SqlServer",
+              "isDefault": true,
+              "dataSource": "localhost",
+              "user": "sa",
+              "password": "$(Password)",
+              "supportsWindowsAuthentication": false,
+              "isLocal": false,
+              "disableMultiSubnetFailover": true,
+              "disableNamedPipes": true,
+              "encrypt": false
+            }
+          ]
+
+    jobs:
+
+    # --------------------------------------------------------------------------
+    # Build and test on Linux.
+
+    - template: ../jobs/stress-tests-ci-job.yml@self
+      parameters:
+        jobNameSuffix: linux
+        displayNamePrefix: Linux
+        poolName: $(ci_var_defaultPoolName)
+        vmImage: ADO-UB20-SQL22
+        sqlSetupStep: /eng/pipelines/common/templates/steps/configure-sql-server-linux-step.yml
+        pipelineArtifactName: ${{ parameters.pipelineArtifactName }}
+        solution: $(solution)
+        testProject: $(testProject)
+        restoreArguments: $(commonArguments)
+        buildArguments: $(buildArguments)
+        netTestRuntimes: ${{ parameters.netTestRuntimes }}
+        configContent: $(ConfigContent)
+
+    # --------------------------------------------------------------------------
+    # Build and test on Windows
+
+    - template: ../jobs/stress-tests-ci-job.yml
+      parameters:
+        jobNameSuffix: windows
+        displayNamePrefix: Win
+        poolName: $(ci_var_defaultPoolName)
+        # The Windows images include a suitable .NET Framework runtime, so we
+        # don't have to install one explicitly.
+        vmImage: ADO-MMS22-SQL22
+        sqlSetupStep: /eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
+        pipelineArtifactName: ${{ parameters.pipelineArtifactName }}
+        solution: $(solution)
+        testProject: $(testProject)
+        restoreArguments: $(commonArguments)
+        buildArguments: $(buildArguments)
+        netTestRuntimes: ${{ parameters.netTestRuntimes }}
+        # Note that we include the .NET Framework runtimes for test runs on
+        # Windows.
+        netFrameworkTestRuntimes: ${{ parameters.netFrameworkTestRuntimes }}
+        configContent: $(ConfigContent)
+
+    # --------------------------------------------------------------------------
+    # Build and test on macOS.
+
+    - template: ../jobs/stress-tests-ci-job.yml
+      parameters:
+        jobNameSuffix: macos
+        displayNamePrefix: macOS
+        # We don't have any 1ES Hosted Pool images for macOS, so we use a
+        # generic one from Azure Pipelines.
+        poolName: Azure Pipelines
+        vmImage: macos-latest
+        sqlSetupStep: /eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
+        pipelineArtifactName: ${{ parameters.pipelineArtifactName }}
+        solution: $(solution)
+        testProject: $(testProject)
+        restoreArguments: $(commonArguments)
+        buildArguments: $(buildArguments)
+        netTestRuntimes: ${{ parameters.netTestRuntimes }}
+        configContent: $(ConfigContent)

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/Directory.Build.props
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/Directory.Build.props
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Empty to inhibit searching up the directory tree. -->
+  <!-- We purposely do not include any parent Directory.Build.props files. -->
+
+  <!-- Properties common to all projects in this solution. -->
+  <PropertyGroup>
+    <!-- Target all frameworks that MDS supports. -->
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0;net9.0</TargetFrameworks>
+
+    <!--
+      Use the latest C# language version, regardless of what a particular
+      target framework claims to support.
+    -->
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/Directory.Packages.props
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/Directory.Packages.props
@@ -1,14 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!-- We purposely do not include any parent Directory.Packages.props files. -->
+
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   
+  <!--
+    If the $(MdsPackageVersion) property is set, typically for CI builds, use
+    that as the MDS version.  Otherwise, use a specific nuget.org published
+    version.
+  -->
+  <Choose>
+    <When Condition="'$(MdsPackageVersion)' != ''">
+      <PropertyGroup>
+        <MdsVersion>$(MdsPackageVersion)</MdsVersion>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <!-- <MdsVersion>5.1.7</MdsVersion> -->
+        <!-- <MdsVersion>5.2.3</MdsVersion> -->
+        <!-- <MdsVersion>6.0.1</MdsVersion> -->
+        <!-- <MdsVersion>6.0.2</MdsVersion> -->
+        <!-- <MdsVersion>6.1.0-preview1.25120.4</MdsVersion> -->
+        <MdsVersion>6.1.0-preview2.25178.5</MdsVersion>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
   <ItemGroup>
-    <!-- <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" /> -->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.0-preview2.25178.5" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="$(MdsVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/IMonitorLoader/IMonitorLoader.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/IMonitorLoader/IMonitorLoader.csproj
@@ -2,7 +2,5 @@
   <PropertyGroup>
     <RootNamespace>Monitoring</RootNamespace>
     <AssemblyName>Monitoring</AssemblyName>
-    <TargetFrameworks>net481;net9.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/NuGet.config
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/NuGet.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--
+      During development or CI runs, the MDS package being tested may only be
+      available locally.
+
+      This directory must exist before dotnet restore will succeed.  Building
+      and packing MDS will create it.
+    -->
+    <add key="local" value="../../../../packages/" />
+  </packageSources>
+</configuration>

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/Readme.md
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/Readme.md
@@ -9,7 +9,7 @@ This is a console application targeting all frameworks supported by MDS,
 currently:
 
 - .NET 8.0
-- .NET T9.0
+- .NET 9.0
 - .NET Framework 4.6.2
 - .NET Framework 4.7
 - .NET Framework 4.7.1

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/Readme.md
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/Readme.md
@@ -1,16 +1,30 @@
 # Microsoft.Data.SqlClient Stress Test
 
 This Stress testing application for `Microsoft.Data.SqlClient` is under progress.
-This project intends to help finding a certain level of effectiveness under unfavorable conditions, and verifying the mode of failures.
-This is a console application with targeting frameworks `.Net Framework 4.8.1`, `.NET 9.0` under driver's supported operating systems and SQL Servers.
+
+This project intends to help finding a certain level of effectiveness under
+unfavorable conditions, and verifying the mode of failures.
+
+This is a console application targeting all frameworks supported by MDS,
+currently:
+
+- .NET 8.0
+- .NET T9.0
+- .NET Framework 4.6.2
+- .NET Framework 4.7
+- .NET Framework 4.7.1
+- .NET Framework 4.7.2
+- .NET Framework 4.8
+- .NET Framework 4.8.1
 
 ## Purpose of application for developers
 
-Define fuzz tests for all new features/APIs in the driver and to be run before every GA release.
+Define fuzz tests for all new features/APIs in the driver and to be run before
+every GA release.
 
 ## Pre-Requisites
 
-Required in StressTest.config:
+Required in the config file:
 
 |Field|Values|Description|
 |-|-|-|
@@ -18,7 +32,6 @@ Required in StressTest.config:
 |`type`|`SqlServer`|Only `SqlServer` is acceptable.|
 |`isDefault`|`true`, `false`|If there is a source node with `isDefault=true`, this node is returned.|
 |`dataSource`||SQL Server data source name.|
-|`database`||Targeting database name in the SQL Server.|
 |`user`||User Id to connect the server.|
 |`password`||Paired password with the user.|
 |`supportsWindowsAuthentication`|`true`, `false`|Tries to use integrated security in connection string mixed with SQL Server authentication if it set to `true` by applying the randomization.|
@@ -27,49 +40,66 @@ Required in StressTest.config:
 |`disableNamedPipes`|`true`, `false`|`true` means the connections will create just using tcp protocol.|
 |`encrypt`|`true`, `false`|Assigns the encrypt property of the connection strings.|
 
+Note: The database user must have permission to create and drop databases.
+Each execution of the stress tests will create a database with a name like:
+
+- `StressTests-<GUID>`
+
+The database will be dropped as a best effort once testing is complete.  This
+allows for multiple test runs to execute in parallel against the same database
+server without colliding.
+
 ## Adding new Tests
 
 - [ToDo]
 
 ## Building the application
 
-To build the application we need to run the command:
+To build the application using the `StressTests.slnx` solution:
 
 ```bash
-dotnet build <-f|--framework <FRAMEWORK>> [-c|--configuration <Release|Debug>]
+dotnet build [-c|--configuration <Release|Debug>]
 ```
 
-The path should be pointing to SqlClient.Stress.Runner.csproj file.
-
 ```bash
-# Builds the application for the Client Os in `Debug` Configuration for `AnyCpu` platform.
-# All supported target frameworks, .NET Framework  (NetFx) and .NET Core drivers are built by default (as supported by Client OS).
+# Builds the application for the Client Os in `Debug` Configuration for `AnyCpu`
+# platform.
+#
+# All supported target frameworks are built by default.
 
-> dotnet build
+$ dotnet build
 ```
 
 ```bash
 # Build the application for .Net framework 4.8.1 with `Debug` configuration.
 
-> dotnet build -f net481
+$ dotnet build -f net481
 ```
 
 ```bash
 # Build the application for .Net 9.0 with `Release` configuration.
 
-> dotnet build -f net9.0 -c Release
+$ dotnet build -f net9.0 -c Release
 ```
 
 ```bash
 # Cleans all build directories
 
-> dotnet clean
+$ dotnet clean
 ```
 
 ## Running tests
 
-After building the application, find the built folder with target framework and run the `stresstest.exe` file with required arguments.
-Find the result in a log file inside the `logs` folder besides the command prompt.
+After building the application, find the built folder with target framework and
+run the `stresstest.exe` file with required arguments.
+
+Find the result in a log file inside the `logs` folder besides the command
+prompt.
+
+You may specify the config file by supplying an environment variable that
+points to the file:
+
+- `STRESS_CONFIG_FILE=/path/to/my/config.jsonc`
 
 ## Command prompt
 
@@ -81,10 +111,13 @@ directory (i.e. the same directory this readme file is in).
 $ cd /home/paul/dev/SqlClient/src/Microsoft.Data.SqlClient/tests/StressTests
 
 # Via dotnet run CLI:
-$ dotnet run -no-build -f net9.0 --project SqlClient.Stress.Runner/SqlClient.Stress.Runner.csproj -- -a SqlClient.Stress.Tests
+$ dotnet run --no-build -f net9.0 --project SqlClient.Stress.Runner/SqlClient.Stress.Runner.csproj -- -a SqlClient.Stress.Tests
 
 # Via dotnet CLI:
 $ dotnet SqlClient.Stress.Runner/bin/Debug/net9.0/stresstest.dll -a SqlClient.Stress.Tests
+
+# With a specific config file and all output to console:
+$ dotnet run --no-build -f net9.0 --project SqlClient.Stress.Runner/SqlClient.Stress.Runner.csproj -e STRESS_CONFIG_FILE=/path/to/config.jsonc -- -a SqlClient.Stress.Tests -console
 ```
 
 ```powershell
@@ -92,10 +125,13 @@ $ dotnet SqlClient.Stress.Runner/bin/Debug/net9.0/stresstest.dll -a SqlClient.St
 > cd \dev\SqlClient\src\Microsoft.Data.SqlClient\tests\StressTests
 
 # Via dotnet run CLI:
-$ dotnet run -no-build -f net9.0 --project SqlClient.Stress.Runner\SqlClient.Stress.Runner.csproj -- -a SqlClient.Stress.Tests
+> dotnet run --no-build -f net9.0 --project SqlClient.Stress.Runner\SqlClient.Stress.Runner.csproj -- -a SqlClient.Stress.Tests
 
 # Via executable:
 > .\SqlClient.Stress.Runner\bin\Debug\net481\stresstest.exe -a SqlClient.Stress.Tests
+
+# With a specific config file and all output to console:
+> dotnet run --no-build -f net9.0 --project SqlClient.Stress.Runner\SqlClient.Stress.Runner.csproj -e STRESS_CONFIG_FILE=c:\path\to\config.jsonc -- -a SqlClient.Stress.Tests -console
 ```
 
 ## Supported arguments
@@ -109,6 +145,7 @@ $ dotnet run -no-build -f net9.0 --project SqlClient.Stress.Runner\SqlClient.Str
 |-override|&lt;name&gt; &lt;value&gt;|Override the value of a test property.|
 |-test|&lt;name1;name2&gt;|Run specific test(s).|
 |-debug||Print process ID in the beginning and wait for Enter (to give your time to attach the debugger).|
+|-console||Emit all output to the console instead of a log file.|
 |-exceptionThreshold|&lt;n&gt;|An optional limit on exceptions which will be caught. When reached, test will halt.|
 |-monitorenabled|true, false|True or False to enable monitoring. Default is false [not implemented]|
 |-randomSeed||Enables setting of the random number generator used internally. This serves both the purpose of helping to improve reproducibility and making it deterministic from Chess's perspective for a given schedule. Default is 0.|
@@ -116,62 +153,72 @@ $ dotnet run -no-build -f net9.0 --project SqlClient.Stress.Runner\SqlClient.Str
 |-printMethodName||Print tests' title in console window|
 |-deadlockdetection|true, false|True or False to enable deadlock detection. Default is `false`.|
 
-```bash
-# Run the application for a built target framework and all discovered tests without debugger attached.
+```powershell
+# Run the application for a built target framework and all discovered tests
+# without debugger attached.
 
 > .\stresstest.exe -a SqlClient.Stress.Tests -all
 ```
 
-```bash
-# Run the application for a built target framework and all discovered tests without debugger attached and shows the test methods' names.
+```powershell
+# Run the application for a built target framework and all discovered tests
+# without debugger attached and shows the test methods' names.
 
 > .\stresstest.exe -a SqlClient.Stress.Tests -all -printMethodName 
 ```
 
-```bash
-# Run the application for a built target framework and all discovered tests and will wait for debugger to be attached.
+```powershell
+# Run the application for a built target framework and all discovered tests and
+# will wait for debugger to be attached.
 
 > .\stresstest.exe -a SqlClient.Stress.Tests -all -debug 
 ```
 
-```bash
-# Run the application for a built target framework and "TestExecuteXmlReaderAsyncCancellation" test without debugger attached.
+```powershell
+# Run the application for a built target framework and
+# "TestExecuteXmlReaderAsyncCancellation" test without debugger attached.
 
 > .\stresstest.exe -a SqlClient.Stress.Tests -test TestExecuteXmlReaderAsyncCancellation
 ```
 
-```bash
-# Run the application for a built target framework and "TestExecuteXmlReaderAsyncCancellation" test without debugger attached.
+```powershell
+# Run the application for a built target framework and
+# "TestExecuteXmlReaderAsyncCancellation" test without debugger attached.
 
 > .\stresstest.exe -a SqlClient.Stress.Tests -test TestExecuteXmlReaderAsyncCancellation
 ```
 
-```bash
-# Run the application for a built target framework and all discovered tests without debugger attached for 10 seconds.
+```powershell
+# Run the application for a built target framework and all discovered tests
+# without debugger attached for 10 seconds.
 
 > .\stresstest.exe -a SqlClient.Stress.Tests -all -duration 10
 ```
 
-```bash
-# Run the application for a built target framework and all discovered tests without debugger attached with 5 threads.
+```powershell
+# Run the application for a built target framework and all discovered tests
+# without debugger attached with 5 threads.
 
 > .\stresstest.exe -a SqlClient.Stress.Tests -all -threads 5
 ```
 
-```bash
-# Run the application for a built target framework and all discovered tests without debugger attached and dead lock detection process.
+```powershell
+# Run the application for a built target framework and all discovered tests
+# without debugger attached and dead lock detection process.
 
 > .\stresstest.exe -a SqlClient.Stress.Tests -all -deadlockdetection true
 ```
 
-```bash
-# Run the application for a built target framework and all discovered tests without debugger attached with overriding the weight property with value 15.
+```powershell
+# Run the application for a built target framework and all discovered tests
+# without debugger attached with overriding the weight property with value 15.
 
 > .\stresstest.exe -a SqlClient.Stress.Tests -all -override Weight 15
 ```
 
-```bash
-# Run the application for a built target framework and all discovered tests without debugger attached with injecting random seed of 5.
+```powershell
+# Run the application for a built target framework and all discovered tests
+# without debugger attached with injecting random seed of 5.
 
 > .\stresstest.exe -a SqlClient.Stress.Tests -all -randomSeed 5
 ```

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Common/SqlClient.Stress.Common.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Common/SqlClient.Stress.Common.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net481;net9.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
+  <!-- All properties are inherited from Directory.Build.props. -->
 
 </Project>

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Framework/DataStressFactory.cs
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Framework/DataStressFactory.cs
@@ -418,7 +418,7 @@ namespace Stress.Data
                 cmdText.Append(";").Append(GetRandomSessionModificationStatement(rnd));
             }
 
-            com.CommandText = cmdText.ToString(); ;
+            com.CommandText = cmdText.ToString();
             return com;
         }
 
@@ -946,6 +946,9 @@ namespace Stress.Data
             }
             TableMetadataList = null;
         }
+
+        public abstract void CreateDatabase(DataSource source);
+        public abstract void DropDatabase(DataSource source);
 
         #endregion
     }

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Framework/DataTestGroup.cs
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Framework/DataTestGroup.cs
@@ -96,6 +96,8 @@ namespace Stress.Data
         [GlobalTestSetup]
         public virtual void GlobalTestSetup()
         {
+            Console.WriteLine("DataTestGroup.GlobalTestSetup(): Starting...");
+
             // Preconditions - ensure this setup is only called once
             DataStressErrors.Assert(string.IsNullOrEmpty(s_scenario), "Scenario was already set");
             DataStressErrors.Assert(s_source == null, "Source was already set");
@@ -118,12 +120,22 @@ namespace Stress.Data
 
             // Set m_factory
             s_factory = CreateFactory(ref s_scenario, ref s_source);
+
+            Console.WriteLine($"GlobalTestSetup factory created:");
+            Console.WriteLine($"  Scenario: {s_scenario}");
+            Console.WriteLine($"  Factory:  {s_factory.GetType().Name}");
+            Console.WriteLine($"  Source:");
+            s_source.Emit(4);
+
+            s_factory.CreateDatabase(s_source);
             s_factory.InitializeSharedData(s_source);
 
             // Postconditions
             DataStressErrors.Assert(!string.IsNullOrEmpty(s_scenario), "Scenario was not set");
             DataStressErrors.Assert(s_source != null, "Source was not set");
             DataStressErrors.Assert(s_factory != null, "Factory was not set");
+
+            Console.WriteLine("DataTestGroup.GlobalTestSetup(): Finished");
         }
 
         /// <summary>
@@ -134,11 +146,16 @@ namespace Stress.Data
         [GlobalTestCleanup]
         public virtual void GlobalTestCleanup()
         {
+            Console.WriteLine("DataTestGroup.GlobalTestCleanup(): Starting...");
+
             s_factory.CleanupSharedData();
+            s_factory.DropDatabase(s_source);
             s_source = null;
             s_scenario = null;
             s_factory.Dispose();
             s_factory = null;
+
+            Console.WriteLine("DataTestGroup.GlobalTestCleanup(): Finished");
         }
 
 

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Framework/SqlClient.Stress.Framework.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Framework/SqlClient.Stress.Framework.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <RootNamespace>Stress.Data</RootNamespace>
-    <TargetFrameworks>net481;net9.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,12 +10,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SqlClient.Stress.Common\SqlClient.Stress.Common.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="StressTest.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Framework/StressTests.config.jsonc
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Framework/StressTests.config.jsonc
@@ -1,0 +1,19 @@
+// Sample config file for the Stress Tests app.
+[
+  // Each array element is a "data source" object.
+  {
+    "name": "My Favourite SQL Server",
+    "type": "SqlServer",
+    "isDefault": true,
+    "dataSource": "127.0.0.1,1433",
+    "entraIdUser": "",
+    "entraIdPassword": "",
+    "user": "sa",
+    "password": "",
+    "supportsWindowsAuthentication": false,
+    "isLocal": false,
+    "disableMultiSubnetFailover": true,
+    "disableNamedPipes": true,
+    "encrypt": false
+  }
+]

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Framework/StressTests.config.xml
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Framework/StressTests.config.xml
@@ -7,7 +7,6 @@
         type="SqlServer"
         isDefault="true"
         dataSource="127.0.0.1,1433"
-        database="master"
         user="sa"
         password=""
         supportsWindowsAuthentication="false"

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Runner/SqlClient.Stress.Runner.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Runner/SqlClient.Stress.Runner.csproj
@@ -3,9 +3,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>stresstest</AssemblyName>
-    <TargetFrameworks>net481;net9.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\IMonitorLoader\IMonitorLoader.csproj" />

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Tests/SqlClient.Stress.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Tests/SqlClient.Stress.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <RootNamespace>Stress.Data.SqlClient</RootNamespace>
-    <TargetFrameworks>net481;net9.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Tests/SqlClientStressFactory.cs
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Tests/SqlClientStressFactory.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Data.SqlClient;
 using Microsoft.Test.Data.SqlClient;
@@ -272,10 +273,18 @@ namespace Stress.Data.SqlClient
                 using SqlCommand command = connection.CreateCommand();
                 command.CommandText =
                     $"select session_id from sys.dm_exec_sessions where database_id = DB_ID('{database}')";
-                using var reader = command.ExecuteReader();
-                while (reader.Read())
+
+                List<short> sessionIds = new();
                 {
-                    var sessionId = reader.GetInt16(0);
+                    using var reader = command.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        sessionIds.Add(reader.GetInt16(0));
+                    }
+                }
+
+                foreach (var sessionId in sessionIds)
+                {
                     using var killCommand = connection.CreateCommand();
                     killCommand.CommandText = $"kill {sessionId}";
                     Console.WriteLine($"  Killing session {sessionId}...");

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Tests/SqlClientStressFactory.cs
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Tests/SqlClientStressFactory.cs
@@ -74,8 +74,6 @@ namespace Stress.Data.SqlClient
             }
         }
 
-
-
         internal void Terminate()
         {
             if (_multiSubnetSetupHelper != null)
@@ -94,10 +92,16 @@ namespace Stress.Data.SqlClient
             get { return false; }
         }
 
-
         public override string CreateBaseConnectionString(Random rnd, ConnectionStringOptions options)
         {
+            return CreateBaseConnectionStringBuilder(rnd, options).ToString();
+        }
+
+        private SqlConnectionStringBuilder CreateBaseConnectionStringBuilder(
+            Random rnd, ConnectionStringOptions options)
+        {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder();
+            builder.ApplicationName = "StressTests";
 
             switch (_scenario)
             {
@@ -124,6 +128,12 @@ namespace Stress.Data.SqlClient
             if (integratedSecurity)
             {
                 builder.IntegratedSecurity = true;
+            }
+            else if (_source.EntraIdUser.Length != 0)
+            {
+                builder.Authentication = SqlAuthenticationMethod.ActiveDirectoryPassword;
+                builder.UserID = _source.EntraIdUser;
+                builder.Password = _source.EntraIdPassword;
             }
             else
             {
@@ -212,7 +222,7 @@ namespace Stress.Data.SqlClient
             builder.TrustServerCertificate = true;
 
             builder.MaxPoolSize = 1000;
-            return builder.ToString();
+            return builder;
         }
 
         protected override int GetNumDifferentApplicationNames()
@@ -221,6 +231,67 @@ namespace Stress.Data.SqlClient
             // to also have many different application names. Getting connections from many different pools is not interesting to test
             // because it reduces the amount of multithreadedness within each pool.
             return 1;
+        }
+
+        public override void CreateDatabase(DataSource source)
+        {
+            var database = (source as SqlServerDataSource).Database;
+
+            Console.WriteLine($"Creating database [{database}]...");
+
+            var builder = CreateBaseConnectionStringBuilder(
+                null, ConnectionStringOptions.DisableMultiSubnetFailover);
+            builder.InitialCatalog = "master";
+
+            using SqlConnection connection = new(builder.ToString());
+            connection.Open();
+
+            using SqlCommand command = connection.CreateCommand();
+            command.CommandText = $"create database [{database}]";
+            command.ExecuteNonQuery();
+
+            Console.WriteLine($"Created database [{database}]");
+        }
+
+        public override void DropDatabase(DataSource source)
+        {
+            var database = (source as SqlServerDataSource).Database;
+
+            Console.WriteLine($"Dropping database [{database}]...");
+
+            var builder = CreateBaseConnectionStringBuilder(
+                null, ConnectionStringOptions.DisableMultiSubnetFailover);
+            builder.InitialCatalog = "master";
+
+            using SqlConnection connection = new(builder.ToString());
+            connection.Open();
+
+            // Kill all connections currently using the database so we can drop
+            // it.
+            {
+                using SqlCommand command = connection.CreateCommand();
+                command.CommandText =
+                    $"select session_id from sys.dm_exec_sessions where database_id = DB_ID('{database}')";
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    var sessionId = reader.GetInt16(0);
+                    using var killCommand = connection.CreateCommand();
+                    killCommand.CommandText = $"kill {sessionId}";
+                    Console.WriteLine($"  Killing session {sessionId}...");
+                    killCommand.ExecuteNonQuery();
+                    Console.WriteLine($"  Killed session {sessionId}");
+                }
+            }
+
+            // Drop the database.
+            {
+                using SqlCommand command = connection.CreateCommand();
+                command.CommandText = $"drop database [{database}]";
+                command.ExecuteNonQuery();
+            }
+
+            Console.WriteLine($"Dropped database [{database}]");
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Tests/SqlClientTestGroup.cs
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Tests/SqlClientTestGroup.cs
@@ -76,19 +76,27 @@ namespace Stress.Data.SqlClient
 
         public override void GlobalTestSetup()
         {
+            Console.WriteLine("SqlClientTestGroup.GlobalTestSetup(): Starting...");
+
             base.GlobalTestSetup();
 
             s_clearAllPoolsThread = new Thread(ClearAllPoolsThreadFunc);
             s_clearAllPoolsThread.Start();
 
             // set the notification options for SqlNotificationRequest tests
-            s_notificationOptions = "service=StressNotifications;local database=" + ((SqlServerDataSource)Source).Database;
+            var source = Source as SqlServerDataSource;
+            s_notificationOptions = "service=StressNotifications;local database=" + source.Database;
 
-            s_sqlDependencyConnString = Factory.CreateBaseConnectionString(null, DataStressFactory.ConnectionStringOptions.DisableMultiSubnetFailover);
+            s_sqlDependencyConnString = Factory.CreateBaseConnectionString(
+                null, DataStressFactory.ConnectionStringOptions.DisableMultiSubnetFailover);
+
+            Console.WriteLine("SqlClientTestGroup.GlobalTestSetup(): Finished");
         }
 
         public override void GlobalTestCleanup()
         {
+            Console.WriteLine("SqlClientTestGroup.GlobalTestCleanup(): Starting...");
+
             s_clearAllPoolsThreadStop.Set();
             s_clearAllPoolsThread.Join();
 
@@ -99,6 +107,8 @@ namespace Stress.Data.SqlClient
             }
 
             base.GlobalTestCleanup();
+
+            Console.WriteLine("SqlClientTestGroup.GlobalTestCleanup(): Finished");
         }
 
         public override void GlobalExceptionHandler(Exception e)

--- a/tools/targets/GenerateThisAssemblyCs.targets
+++ b/tools/targets/GenerateThisAssemblyCs.targets
@@ -14,6 +14,7 @@ namespace System
 internal static class ThisAssembly
 {
 internal const string InformationalVersion = "$(AssemblyFileVersion)"%3B
+internal const string NuGetPackageVersion = "$(Version)"%3B
 }
 }
       </ThisAssemblyCsContents>


### PR DESCRIPTION
## Description

Adding stress tests runs to CI.  These will use 1ES images for Windows and Linux, and Azure Pipelines macos-latest for macOS.  All tests run against a locally installed SQL Server using SQL auth.

CI pipelines disable stress tests by default.  You can manually run the pipelines with stress tests enabled.