### PR TITLE
[6.1] Vector ref assembly fixes and enable vector and json tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Data.SqlTypes
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlVector.xml' path='docs/members[@name="SqlVector"]/IsNull/*' />
         public bool IsNull => throw null;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlVector.xml' path='docs/members[@name="SqlVector"]/Null/*' />
-        public static SqlVector<T> Null => throw null;
+        public static SqlVector<T>? Null => throw null;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlVector.xml' path='docs/members[@name="SqlVector"]/Length/*' />
         public int Length { get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlVector.xml' path='docs/members[@name="SqlVector"]/Memory/*' />

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.cs
@@ -2425,7 +2425,7 @@ namespace Microsoft.Data.SqlTypes
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlVector.xml' path='docs/members[@name="SqlVector"]/IsNull/*' />
         public bool IsNull => throw null;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlVector.xml' path='docs/members[@name="SqlVector"]/Null/*' />
-        public static SqlVector<T> Null => throw null;
+        public static SqlVector<T>? Null => throw null;
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlVector.xml' path='docs/members[@name="SqlVector"]/Length/*' />
         public int Length { get { throw null; } }
         /// <include file='../../../../doc/snippets/Microsoft.Data.SqlTypes/SqlVector.xml' path='docs/members[@name="SqlVector"]/Memory/*' />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -92,11 +92,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         //SQL Server EngineEdition
         private static string s_sqlServerEngineEdition;
 
+        // Currently, only Azure SQL supports vectors and JSON.
+        // Our CI images with specific SQL Server versions lag
+        // behind with vector and JSON support.
         // JSON Column type
-        public static readonly bool IsJsonSupported = false;
-
+        public static readonly bool IsJsonSupported = !IsNotAzureServer();
         // VECTOR column type
-        public static readonly bool IsVectorSupported = false;
+        public static readonly bool IsVectorSupported = !IsNotAzureServer();
 
         // Azure Synapse EngineEditionId == 6
         // More could be read at https://learn.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql?view=sql-server-ver16#propertyname

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTesting.Tests.csproj
@@ -185,6 +185,9 @@
     <Compile Include="SQL\DataSourceParserTest\DataSourceParserTest.cs" />
     <Compile Include="SQL\InstanceNameTest\InstanceNameTest.cs" />
     <Compile Include="SQL\IntegratedAuthenticationTest\IntegratedAuthenticationTest.cs" />
+    <Compile Include="SQL\JsonTest\JsonBulkCopyTest.cs" />
+    <Compile Include="SQL\JsonTest\JsonStreamTest.cs" />
+    <Compile Include="SQL\JsonTest\JsonTest.cs" />
     <Compile Include="SQL\KerberosTests\KerberosTest.cs" />
     <Compile Include="SQL\KerberosTests\KerberosTicketManager\KerberosTicketManager.cs" />
     <Compile Include="SQL\LocalDBTest\LocalDBTest.cs" />
@@ -213,6 +216,9 @@
     <Compile Include="SQL\UdtTest\UdtTest2.cs" />
     <Compile Include="SQL\UdtTest\UdtTestHelpers.cs" />
     <Compile Include="SQL\Utf8SupportTest\Utf8SupportTest.cs" />
+    <Compile Include="SQL\VectorTest\VectorTypeBackwardCompatibilityTests.cs" />
+    <Compile Include="SQL\VectorTest\NativeVectorFloat32Tests.cs" />
+    <Compile Include="SQL\VectorTest\VectorAPIValidationTest.cs" />
     <Compile Include="SQL\WeakRefTest\WeakRefTest.cs" />
     <Compile Include="SQL\WeakRefTestYukonSpecific\WeakRefTestYukonSpecific.cs" />
     <Compile Include="SQL\ParameterTest\DateTimeVariantTest.cs" />
@@ -294,11 +300,6 @@
     <Compile Include="SQL\Common\SystemDataInternals\TdsParserStateObjectHelper.cs" />
     <Compile Include="SQL\ConnectionTestWithSSLCert\CertificateTest.cs" />
     <Compile Include="SQL\ConnectionTestWithSSLCert\CertificateTestWithTdsServer.cs" />
-    <Compile Include="SQL\JsonTest\JsonBulkCopyTest.cs" />
-    <Compile Include="SQL\JsonTest\JsonStreamTest.cs" />
-    <Compile Include="SQL\JsonTest\JsonTest.cs" />
-    <Compile Include="SQL\VectorTest\VectorTypeBackwardCompatibilityTests.cs" />
-    <Compile Include="SQL\VectorTest\NativeVectorFloat32Tests.cs" />
     <Compile Include="SQL\SqlCommand\SqlCommandStoredProcTest.cs" />
     <Compile Include="TracingTests\TestTdsServer.cs" />
     <Compile Include="XUnitAssemblyAttributes.cs" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/VectorTest/VectorAPIValidationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/VectorTest/VectorAPIValidationTest.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Data.SqlTypes;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest
+{
+    public sealed class VectorAPIValidationTest
+    {
+        // We need this testcase to validate ref assembly for vector APIs
+        // Unit tests are covered under SqlVectorTest.cs
+        [Fact]
+        public void VectorAPITest()
+        {
+            // Validate that SqlVector<float> is a valid type and has valid SqlDbType
+            Assert.True(typeof(SqlVector<float>).IsValueType, "SqlVector<float> should be a value type.");
+            Assert.Equal(36, (int)SqlDbTypeExtensions.Vector);
+
+            // Validate ctor1 with float[] : public SqlVector(System.ReadOnlyMemory<T> memory) { }
+            var vector = new SqlVector<float>(VectorFloat32TestData.testData);
+            Assert.Equal(VectorFloat32TestData.testData, vector.Memory.ToArray());
+            Assert.Equal(3, vector.Length);
+
+            // Validate ctor2 with ReadOnlyMemory<T> : public SqlVector(ReadOnlyMemory<T> memory) { }
+            vector = new SqlVector<float>(new ReadOnlyMemory<float>(VectorFloat32TestData.testData));
+            Assert.Equal(VectorFloat32TestData.testData, vector.Memory.ToArray());
+            Assert.Equal(3, vector.Length);
+
+            //Validate IsNull property
+            Assert.False(vector.IsNull, "IsNull should be false for non-null vector.");
+
+            // Validate Null property returns null
+            Assert.Null(SqlVector<float>.Null);
+
+            //Validate length property
+            Assert.Equal(3, vector.Length);
+
+            // Validate CreateNull method
+            vector = SqlVector<float>.CreateNull(5);
+            Assert.True(vector.IsNull);
+            Assert.Equal(5, vector.Length);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Ports #3521 and enable vector and json test coverage through port of #3559.

## Testing
Adds a testcase for validation of ref assembly APIs for SqlVector.

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
