### PR TITLE
Set next MDS version number to 7.0.0

### DIFF
--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="Current" DefaultTargets="Build"
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MdsVersionDefault>6.1.0</MdsVersionDefault>
+    <MdsVersionDefault>7.0.0</MdsVersionDefault>
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
 
     <!--

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -18,7 +18,7 @@
       and introduces breaking changes.  Only ever update the major version
       number.  All other version parts must be set to 0.
     -->
-    <AssemblyVersion>6.0.0.0</AssemblyVersion>
+    <AssemblyVersion>7.0.0.0</AssemblyVersion>
 
     <FileVersion>$(AssemblyFileVersion)</FileVersion>
     <NugetPackageVersion Condition="'$(NugetPackageVersion)' == ''">$(MdsVersionDefault)-dev</NugetPackageVersion>


### PR DESCRIPTION
## Description

Updated the default MDS version number to 7.0.0 in anticipation of the next MDS major release.