### PR TITLE
[6.1] AKV Provider Strong Name Signing

### DIFF
--- a/eng/pipelines/jobs/build-akv-official-job.yml
+++ b/eng/pipelines/jobs/build-akv-official-job.yml
@@ -91,6 +91,7 @@ jobs:
                 assemblyFileVersion: '${{ parameters.assemblyFileVersion }}'
                 buildConfiguration: '${{ parameters.buildConfiguration }}'
                 mdsPackageVersion: '${{ parameters.mdsPackageVersion }}'
+                signingKeyPath: '$(Agent.TempDirectory)/netfxKeypair.snk'
                 
           - ${{ each targetFramework in parameters.targetFrameworks }}:  
               - template: ../steps/compound-extract-akv-apiscan-files-step.yml
@@ -105,6 +106,7 @@ jobs:
             parameters:
                 buildConfiguration: '${{ parameters.buildConfiguration }}'
                 mdsPackageVersion: '${{ parameters.mdsPackageVersion }}'
+                signingKeyPath: '$(Agent.TempDirectory)/netfxKeypair.snk'
 
           - template: ../steps/compound-esrp-code-signing-step.yml@self
             parameters:

--- a/eng/pipelines/steps/compound-build-akv-step.yml
+++ b/eng/pipelines/steps/compound-build-akv-step.yml
@@ -19,6 +19,9 @@ parameters:
     - name: mdsPackageVersion
       type: string
 
+    - name: signingKeyPath
+      type: string
+
 steps:
     - task: DownloadSecureFile@1
       displayName: 'Download Signing Key'
@@ -38,6 +41,14 @@ steps:
           packageType: 'runtime'
           version: '8.x'
 
+    # @TODO: TEMPORARY DIAGNOSTICS
+    - task: CopyFiles@2
+      displayName: 'DIAG: Copy SNK'
+      inputs:
+        contents: '*.snk'
+        sourceFolder: '$(Agent.TempDirectory)'
+        targetFolder: '$(ARTIFACT_PATH)/diag'
+
     - task: MSBuild@1
       displayName: 'Build.proj - BuildAkv'
       inputs:
@@ -48,7 +59,7 @@ steps:
               -p:AssemblyFileVersion=${{ parameters.assemblyFileVersion }}
               -p:NugetPackageVersion=${{ parameters.mdsPackageVersion }}
               -p:ReferenceType=Package
-              -p:SigningKeyPath=$(Agent.TempDirectory)/netfxKeypair.snk
+              -p:SigningKeyPath=${{ parameters.signingKeyPath }}
               
     - script: tree /a /f $(BUILD_OUTPUT)
       displayName: Output Build Output Tree

--- a/eng/pipelines/steps/compound-build-akv-step.yml
+++ b/eng/pipelines/steps/compound-build-akv-step.yml
@@ -41,14 +41,6 @@ steps:
           packageType: 'runtime'
           version: '8.x'
 
-    # @TODO: TEMPORARY DIAGNOSTICS
-    - task: CopyFiles@2
-      displayName: 'DIAG: Copy SNK'
-      inputs:
-        contents: '*.snk'
-        sourceFolder: '$(Agent.TempDirectory)'
-        targetFolder: '$(ARTIFACT_PATH)/diag'
-
     - task: MSBuild@1
       displayName: 'Build.proj - BuildAkv'
       inputs:

--- a/eng/pipelines/steps/roslyn-analyzers-akv-step.yml
+++ b/eng/pipelines/steps/roslyn-analyzers-akv-step.yml
@@ -4,9 +4,13 @@
 # See the LICENSE file in the project root for more information.                #
 #################################################################################
 
-# @TODO: This can probably be made generic and pass in the command lines for msbuild
-#        BUT, they should be kept separate by now as we rebuild build.proj in parallel, we won't
-#        affect >1 project at a time.
+# NOTE: Because Roslyn analyzers run with the build process, this step must happen within our
+#   build in order to generate logs that Guardian/SDL can consume. HOWEVER - this step will rebuild
+#   the project and overwrite any previously build output! Therefore, the command line params in
+#   this step and the build step must be the same to avoid packaging invalid binaries!
+#   There is a way to avoid using this task and have analyzers run during the main build, but this
+#   task will ensure we are using the latest analyzers as per SDL.
+#   For more info, please see: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-mohanb/security-integration/guardian-wiki/sdl-azdo-extension/roslyn-analyzers-build-task
 
 parameters:
     - name: buildConfiguration
@@ -14,6 +18,8 @@ parameters:
 
     - name: mdsPackageVersion
       type: string
+
+    - name: signingKeyPath
 
 steps:
     - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
@@ -27,5 +33,6 @@ steps:
               -p:Configuration=${{ parameters.buildConfiguration }}
               -p:NugetPackageVersion=${{ parameters.mdsPackageVersion }}
               -p:ReferenceType=Package
+              -p:SigningKeyPath=${{ parameters.signingKeyPath }}
           msBuildVersion: 17.0
           setupCommandLinePicker: vs2022

--- a/eng/pipelines/steps/roslyn-analyzers-akv-step.yml
+++ b/eng/pipelines/steps/roslyn-analyzers-akv-step.yml
@@ -20,6 +20,7 @@ parameters:
       type: string
 
     - name: signingKeyPath
+      type: string
 
 steps:
     - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3

--- a/eng/pipelines/variables/akv-official-variables.yml
+++ b/eng/pipelines/variables/akv-official-variables.yml
@@ -30,7 +30,7 @@ variables:
     - name: versionMinor
       value: '1'
     - name: versionPatch
-      value: '1'
+      value: '2'
     - name: versionPreview
       value: '-preview1'
 

--- a/src/Microsoft.Data.SqlClient.sln
+++ b/src/Microsoft.Data.SqlClient.sln
@@ -287,6 +287,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "variables", "variables", "{
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "jobs", "jobs", "{09352F1D-878F-4F55-8AA2-6E47F1AD37D5}"
+	ProjectSection(SolutionItems) = preProject
+		..\eng\pipelines\jobs\build-akv-official-job.yml = ..\eng\pipelines\jobs\build-akv-official-job.yml
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "steps", "steps", "{AD738BD4-6A02-4B88-8F93-FBBBA49A74C8}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
@@ -18,14 +18,14 @@
     <IsTrimmable Condition="'$(TargetGroup)'=='netcoreapp'">true</IsTrimmable>
     <IsAotCompatible Condition="'$(TargetGroup)'=='netcoreapp'">true</IsAotCompatible>
   </PropertyGroup>
+
   <!--Generating Strong Name-->
-  <PropertyGroup Condition="'$(CDP_BUILD_TYPE)'=='Official'">
+  <PropertyGroup Condition="'$(CDP_BUILD_TYPE)'=='Official' Or '$(CDP_BUILD_TYPE)'=='Buddy'">
     <SignAssembly>true</SignAssembly>
     <KeyFile>$(SigningKeyPath)</KeyFile>
-  </PropertyGroup>
-  <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
   <PropertyGroup>
     <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(GeneratedSourceFileName)'))</TargetFrameworkMonikerAssemblyAttributesPath>
   </PropertyGroup>


### PR DESCRIPTION
## Description
Addressing a high-priority issue where official builds of AKV provider are not strong name signed. This was a mistake in the new official pipeline, where the signing key path was not being provided to the Roslyn analyzer step of the official build job. Because the Roslyn analyzer step rebuilds the project (and replaces the build output), if this step does not perform signing, it will replace the strong name signed binaries with unsigned binaries.

This PR fixes this by 1) adding the signing key path variable to the Roslyn analyzer build arguments, and 2) factors out the signing key path to an argument to the main build and Roslyn analyzer steps.

## Issues
Not sure if there is an issue that can be linked. But there's definitely an IcM about it.

## Testing
See this build: https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=123216&view=results
CI will still need to pass since it tweaks the signing behavior on non-official builds.