### PR TITLE
Fix Debug Assertion in Connection Pool Due to Double Deactivation

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -513,14 +513,16 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        internal void DeactivateConnection()
+        internal void DeactivateConnection(bool callDecrement=true)
         {
             // Internal method called from the connection pooler so we don't expose
             // the Deactivate method publicly.
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionInternal.DeactivateConnection|RES|INFO|CPOOL> {0}, Deactivating", ObjectID);
 
             #if DEBUG
-            int activateCount = Interlocked.Decrement(ref _activateCount);
+            int activateCount = _activateCount;
+            if(callDecrement)
+                activateCount = Interlocked.Decrement(ref _activateCount);
             Debug.Assert(activateCount == 0, "activated multiple times?");
             #endif
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
@@ -1628,7 +1628,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             Debug.Assert(obj != null, "null pooledObject?");
             Debug.Assert(obj.EnlistedTransaction == null, "pooledObject is still enlisted?");
 
-            obj.DeactivateConnection();
+            obj.DeactivateConnection(false);
 
             // called by the transacted connection pool , once it's removed the
             // connection from it's list.  We put the connection back in general

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
@@ -1628,7 +1628,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             Debug.Assert(obj != null, "null pooledObject?");
             Debug.Assert(obj.EnlistedTransaction == null, "pooledObject is still enlisted?");
 
-            obj.DeactivateConnection(false);
+            obj.DeactivateConnection();
 
             // called by the transacted connection pool , once it's removed the
             // connection from it's list.  We put the connection back in general


### PR DESCRIPTION
Problem:
During execution of the test TestAutoEnlistment_TxScopeComplete and TestAutoEnlistment_TxScopeNonComplete in Debug mode,a debug assertion fails on CoreCLR: 
```Method Debug.Fail failed with 'activated multiple times?```

This occurs inside the DeactivateConnection method when returning a connection to the pool after a transaction completes.This assertion failure indicates that the internal _activateCount was already 0 when decrement was attempted again, deactivating the connection more than once.

Root Cause:
In the TransactionEnded function, after a transaction completes, the connection involved is returned to the general pool via:

```Pool.PutObjectFromTransactedPool(transactedObject);```

During this process, DeactivateConnection() is called again. However, the connection had already been deactivated earlier as part of the transaction's enlistment cleanup.This results in DeactivateConnection() being called twice without a corresponding call to ActivateConnection() in between, which causes _activateCount to decrement to -1, triggering the debug assertion.

Fix:
We prevent the second DeactivateConnection to decrement the _activateCount counter, by passing the parameter "false" to DeactivateConnection.

cc: @uweigand @giritrivedi @saitama951


