### PR TITLE
[DRAFT] Add Debug CI runs

### DIFF
--- a/eng/pipelines/common/templates/jobs/build-signed-package-job.yml
+++ b/eng/pipelines/common/templates/jobs/build-signed-package-job.yml
@@ -65,3 +65,4 @@ jobs:
     parameters:
       publishSymbols: ${{ parameters['PublishSymbols'] }}
       symbolsArtifactName: mds_symbols_$(System.TeamProject)_$(Build.Repository.Name)_$(Build.SourceBranchName)_$(NuGetPackageVersion)_$(System.TimelineId)
+      buildConfiguration: Release

--- a/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
@@ -20,9 +20,12 @@ parameters:
     type: string
     default: $(Platform)
   
-  - name: configuration
+  - name: buildConfiguration
     type: string
-    default: $(Configuration)
+    default: Debug
+    values:
+      - Debug
+      - Release
 
   - name: prebuildSteps
     type: stepList
@@ -47,14 +50,14 @@ jobs:
   - template: ../steps/ci-project-build-step.yml@self
     parameters:
       platform: ${{ parameters.platform }}
-      configuration: ${{ parameters.configuration }}
+      buildConfiguration: ${{ parameters.buildConfiguration }}
       operatingSystem: Windows
       build: all
 
   - template: ../steps/generate-nuget-package-step.yml@self
     parameters:
       NugetPackageVersion: $(NugetPackageVersion)
-      configuration: $(Configuration)
+      buildConfiguration: ${{ parameters.buildConfiguration }}
       nuspecPath: 'tools/specs/Microsoft.Data.SqlClient.nuspec'
       OutputDirectory: $(packagePath)
       generateSymbolsPackage: false
@@ -63,7 +66,7 @@ jobs:
   - template: ../steps/generate-nuget-package-step.yml@self
     parameters:
       NugetPackageVersion: $(NugetPackageVersion)
-      configuration: $(Configuration)
+      buildConfiguration: ${{ parameters.buildConfiguration }}
       nuspecPath: 'tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec'
       OutputDirectory: $(packagePath)
       generateSymbolsPackage: false

--- a/eng/pipelines/common/templates/steps/build-all-configurations-signed-dlls-step.yml
+++ b/eng/pipelines/common/templates/steps/build-all-configurations-signed-dlls-step.yml
@@ -8,9 +8,12 @@ parameters:
     type: string
     default: $(AssemblyFileVersion)
   
-  - name: Configuration
+  - name: buildConfiguration
     type: string
-    default: '$(Configuration)'
+    default: Debug
+    values:
+      - Debug
+      - Release
 
   - name: packageRefMdsVersion
     type: string
@@ -46,5 +49,5 @@ steps:
     displayName: 'BuildAllConfigurations using build.proj'
     inputs:
       solution: '**/build.proj'
-      configuration: '${{parameters.Configuration }}'
+      configuration: '${{parameters.buildConfiguration }}'
       msbuildArguments: '-p:AssemblyFileVersion=${{parameters.AssemblyFileVersion }} -t:BuildAllConfigurations -p:GenerateNuget=false -p:SigningKeyPath=$(Agent.TempDirectory)\netfxKeypair.snk'

--- a/eng/pipelines/common/templates/steps/build-all-tests-step.yml
+++ b/eng/pipelines/common/templates/steps/build-all-tests-step.yml
@@ -15,9 +15,12 @@ parameters:
     type: string
     default: $(Platform)
   
-  - name: configuration
+  - name: buildConfiguration
     type: string
-    default: '$(Configuration)'
+    default: Debug
+    values:
+      - Debug
+      - Release
 
   - name: referenceType
     default: Package
@@ -39,7 +42,7 @@ steps:
     inputs:
       solution: build.proj
       platform: '${{parameters.platform }}'
-      configuration: '${{parameters.configuration }}'
+      configuration: '${{parameters.buildConfiguration }}'
       msbuildArguments: '-t:BuildTestsNetFx -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }}'
 
 # - ${{else if contains(parameters.targetFramework, 'netstandard')}}: # .NET Standard
@@ -48,7 +51,7 @@ steps:
 #     inputs:
 #       solution: build.proj
 #       platform: '${{parameters.platform }}'
-#       configuration: '${{parameters.configuration }}'
+#       configuration: '${{parameters.buildConfiguration }}'
 #       msbuildArguments: '-t:BuildTestsNetCore -p:ReferenceType=NetStandard -p:TargetNetStandardVersion=${{parameters.targetNetStandardVersion }} -p:TF=${{parameters.targetFramework }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }}'
 #     condition: and(succeeded(), not(startsWith(variables['TF'], 'net4')), startsWith(variables['TargetNetStandardVersion'], 'netstandard'))
 
@@ -58,7 +61,7 @@ steps:
     inputs:
       solution: build.proj
       platform: '${{parameters.platform }}'
-      configuration: '${{parameters.configuration }}'
+      configuration: '${{parameters.buildConfiguration }}'
       msbuildArguments: '-t:BuildTestsNetCore -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }}'
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
@@ -69,7 +72,7 @@ steps:
       command: custom
       projects: build.proj
       custom: msbuild
-      arguments: '-t:BuildTestsNetCore -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }} -p:OSGroup=${{parameters.OSGroup }} -p:platform=${{parameters.platform }} -p:Configuration=${{parameters.configuration }}'
+      arguments: '-t:BuildTestsNetCore -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }} -p:OSGroup=${{parameters.OSGroup }} -p:platform=${{parameters.platform }} -p:Configuration=${{parameters.buildConfiguration }}'
       verbosityRestore: Detailed
       verbosityPack: Detailed
     condition: and(succeeded(), ne(variables['Agent.OS'], 'Windows_NT'))

--- a/eng/pipelines/common/templates/steps/build-and-run-tests-netcore-step.yml
+++ b/eng/pipelines/common/templates/steps/build-and-run-tests-netcore-step.yml
@@ -8,9 +8,12 @@ parameters:
     type: string
     default: $(TargetNetCoreVersion)
 
-  - name: configuration
+  - name: buildConfiguration
     type: string
-    default: $(Configuration)
+    default: Debug
+    values:
+      - Debug
+      - Release
 
   - name: referenceType
     default: Project
@@ -55,14 +58,14 @@ steps:
   inputs:
     solution: build.proj
     msbuildArchitecture: x64
-    msbuildArguments: '-p:Configuration=${{parameters.configuration }} -t:BuildAKVNetCore -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }}'
+    msbuildArguments: '-p:Configuration=${{parameters.buildConfiguration }} -t:BuildAKVNetCore -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }}'
 
 - task: MSBuild@1
   displayName: 'MSBuild Build Tests for ${{parameters.TargetNetCoreVersion }}'
   inputs:
     solution: build.proj
     msbuildArchitecture: x64
-    msbuildArguments: '-t:BuildTestsNetCore -p:ReferenceType=${{parameters.referenceType }} -p:TargetNetCoreVersion=${{parameters.TargetNetCoreVersion }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} -p:Configuration=${{parameters.configuration }}'
+    msbuildArguments: '-t:BuildTestsNetCore -p:ReferenceType=${{parameters.referenceType }} -p:TargetNetCoreVersion=${{parameters.TargetNetCoreVersion }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} -p:Configuration=${{parameters.buildConfiguration }}'
 
 # Don't run unit tests using package reference. Unit tests are only run using project reference.
 
@@ -71,12 +74,12 @@ steps:
   inputs:
     command: test
     projects: 'src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.FunctionalTests.csproj'
-    arguments: '-p:Platform=${{parameters.platform }} -p:TestTargetOS="${{parameters.TestTargetOS }}" -p:TargetNetCoreVersion=${{parameters.TargetNetCoreVersion }}  -p:ReferenceType=${{parameters.referenceType }} -p:Configuration=${{parameters.configuration }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests"'
+    arguments: '-p:Platform=${{parameters.platform }} -p:TestTargetOS="${{parameters.TestTargetOS }}" -p:TargetNetCoreVersion=${{parameters.TargetNetCoreVersion }}  -p:ReferenceType=${{parameters.referenceType }} -p:Configuration=${{parameters.buildConfiguration }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} --no-build -v n --filter "category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests"'
 
 - task: DotNetCoreCLI@2
   displayName: 'Run Manual Tests for ${{parameters.TargetNetCoreVersion }}'
   inputs:
     command: test
     projects: 'src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj'
-    arguments: '-p:Platform=${{parameters.platform }} -p:TestTargetOS="${{parameters.TestTargetOS }}" -p:TargetNetCoreVersion=${{parameters.TargetNetCoreVersion }} -p:ReferenceType=${{parameters.referenceType }} -p:Configuration=${{parameters.configuration }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} --no-build -v n --filter  category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests  --collect "Code Coverage"'
+    arguments: '-p:Platform=${{parameters.platform }} -p:TestTargetOS="${{parameters.TestTargetOS }}" -p:TargetNetCoreVersion=${{parameters.TargetNetCoreVersion }} -p:ReferenceType=${{parameters.referenceType }} -p:Configuration=${{parameters.buildConfiguration }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} --no-build -v n --filter  category!=nonnetcoreapptests&category!=failing&category!=nonwindowstests  --collect "Code Coverage"'
   retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}

--- a/eng/pipelines/common/templates/steps/build-and-run-tests-netfx-step.yml
+++ b/eng/pipelines/common/templates/steps/build-and-run-tests-netfx-step.yml
@@ -8,9 +8,12 @@ parameters:
     type: string
     default: $(TargetNetFxVersion)
 
-  - name: configuration
+  - name: buildConfiguration
     type: string
-    default: $(Configuration)
+    default: Debug
+    values:
+      - Debug
+      - Release
 
   - name: referenceType
     default: Project
@@ -55,13 +58,13 @@ steps:
   inputs:
     solution: build.proj
     msbuildArchitecture: x64
-    msbuildArguments: '-p:Configuration=${{parameters.configuration }} -t:BuildAKVNetFx -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }}'
+    msbuildArguments: '-p:Configuration=${{parameters.buildConfiguration }} -t:BuildAKVNetFx -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }}'
 
 - task: MSBuild@1
   displayName: 'MSBuild Build Tests for ${{parameters.TargetNetFxVersion }}'
   inputs:
     solution: build.proj
-    msbuildArguments: ' -t:BuildTestsNetFx -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} -p:TargetNetFxVersion=${{parameters.TargetNetFxVersion }} -p:Configuration=${{parameters.configuration }} -p:Platform=${{parameters.platform }}'
+    msbuildArguments: ' -t:BuildTestsNetFx -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} -p:TargetNetFxVersion=${{parameters.TargetNetFxVersion }} -p:Configuration=${{parameters.buildConfiguration }} -p:Platform=${{parameters.platform }}'
     
 # Don't run unit tests using package reference. Unit tests are only run using project reference.
 
@@ -70,12 +73,12 @@ steps:
   inputs:
     command: test
     projects: 'src\Microsoft.Data.SqlClient\tests\FunctionalTests\Microsoft.Data.SqlClient.FunctionalTests.csproj'
-    arguments: '-p:Platform=${{parameters.platform }} -p:TestTargetOS="${{parameters.TestTargetOS }}" -p:TargetNetFxVersion=${{parameters.TargetNetFxVersion }} -p:ReferenceType=${{parameters.referenceType }} -p:Configuration=${{parameters.configuration }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" --collect "Code Coverage"'
+    arguments: '-p:Platform=${{parameters.platform }} -p:TestTargetOS="${{parameters.TestTargetOS }}" -p:TargetNetFxVersion=${{parameters.TargetNetFxVersion }} -p:ReferenceType=${{parameters.referenceType }} -p:Configuration=${{parameters.buildConfiguration }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" --collect "Code Coverage"'
 
 - task: DotNetCoreCLI@2
   displayName: 'Run Manual Tests for ${{parameters.TargetNetFxVersion }}'
   inputs:
     command: test
     projects: 'src\Microsoft.Data.SqlClient\tests\ManualTests\Microsoft.Data.SqlClient.ManualTesting.Tests.csproj'
-    arguments: '-p:Platform=${{parameters.platform }} -p:TestTargetOS="${{parameters.TestTargetOS }}" -p:TargetNetFxVersion=${{parameters.TargetNetFxVersion }} -p:ReferenceType=${{parameters.referenceType }} -p:Configuration=${{parameters.configuration }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" --collect "Code Coverage"'
+    arguments: '-p:Platform=${{parameters.platform }} -p:TestTargetOS="${{parameters.TestTargetOS }}" -p:TargetNetFxVersion=${{parameters.TargetNetFxVersion }} -p:ReferenceType=${{parameters.referenceType }} -p:Configuration=${{parameters.buildConfiguration }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.NugetPackageVersion }} --no-build -v n --filter "category!=nonnetfxtests&category!=failing&category!=nonwindowstests" --collect "Code Coverage"'
   retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}

--- a/eng/pipelines/common/templates/steps/ci-project-build-step.yml
+++ b/eng/pipelines/common/templates/steps/ci-project-build-step.yml
@@ -8,10 +8,13 @@ parameters:
     type: string
     default: $(Platform)
   
-  - name: configuration
+  - name: buildConfiguration
     type: string
-    default: $(Configuration)
-  
+    default: Debug
+    values:
+      - Debug
+      - Release
+
   - name: buildNumber
     type: string
     default: $(BuildNumber)
@@ -64,7 +67,7 @@ steps:
           solution: build.proj
           msbuildArchitecture: x64
           platform: '${{ parameters.platform }}'
-          configuration: '${{ parameters.configuration }}'
+          configuration: '${{ parameters.buildConfiguration }}'
           msbuildArguments: '-t:BuildAllConfigurations -p:GenerateDocumentationFile=false -p:GenerateNuGet=false -p:BuildNumber=${{ parameters.buildNumber }}'
           clean: true
 
@@ -76,7 +79,7 @@ steps:
           solution: build.proj
           msbuildArchitecture: x64
           platform: '${{ parameters.platform }}'
-          configuration: '${{ parameters.configuration }}'
+          configuration: '${{ parameters.buildConfiguration }}'
           msbuildArguments: '-t:BuildAllConfigurations -p:GenerateNuGet=false -p:BuildNumber=${{ parameters.buildNumber }}'
           clean: true
 
@@ -88,7 +91,7 @@ steps:
         solution: build.proj
         msbuildArchitecture: x64
         platform: '${{ parameters.platform }}'
-        configuration: '${{ parameters.configuration }}'
+        configuration: '${{ parameters.buildConfiguration }}'
         msbuildArguments: '-t:BuildAKVNetFx -p:BuildNumber=${{ parameters.buildNumber }}'
 
     - task: MSBuild@1
@@ -98,7 +101,7 @@ steps:
         solution: build.proj
         msbuildArchitecture: x64
         platform: '${{ parameters.platform }}'
-        configuration: '${{ parameters.configuration }}'
+        configuration: '${{ parameters.buildConfiguration }}'
         msbuildArguments: '-t:BuildAKVNetCoreAllOS -p:BuildNumber=${{ parameters.buildNumber }}'
 
 - ${{ if or(eq(parameters.operatingSystem, 'Linux'), eq(parameters.operatingSystem, 'MacOS'), eq(parameters.operatingSystem, 'deferedToRuntime')) }}:
@@ -109,7 +112,7 @@ steps:
       command: custom
       projects: build.proj
       custom: msbuild
-      arguments: '-t:BuildAll -p:TestEnabled=true -p:GenerateDocumentationFile=false -p:configuration=${{ parameters.configuration }}'
+      arguments: '-t:BuildAll -p:TestEnabled=true -p:GenerateDocumentationFile=false -p:configuration=${{ parameters.buildConfiguration }}'
       verbosityRestore: Detailed
       verbosityPack: Detailed
     retryCountOnTaskFailure: 1

--- a/eng/pipelines/common/templates/steps/copy-dlls-for-test-step.yml
+++ b/eng/pipelines/common/templates/steps/copy-dlls-for-test-step.yml
@@ -4,9 +4,12 @@
 # See the LICENSE file in the project root for more information.                #
 #################################################################################
 parameters:
-  - name: Configuration
+  - name: buildConfiguration
     type: string
-    default: '$(Configuration)'
+    default: Debug
+    values:
+      - Debug
+      - Release
 
   - name: symbolsFolder
     type: string
@@ -56,11 +59,11 @@ steps:
         
         if ($tf.StartsWith('net4'))
         {
-          Copy-Item "artifacts\${{parameters.referenceType }}\bin\Windows_NT\${{parameters.Configuration }}.AnyCPU\Microsoft.Data.SqlClient\netfx\$tf\Microsoft.Data.SqlClient.dll" "$software\win\$tf" -recurse
+          Copy-Item "artifacts\${{parameters.referenceType }}\bin\Windows_NT\${{parameters.buildConfiguration }}.AnyCPU\Microsoft.Data.SqlClient\netfx\$tf\Microsoft.Data.SqlClient.dll" "$software\win\$tf" -recurse
         }
         else
         {
-          Copy-Item "artifacts\${{parameters.referenceType }}\bin\Windows_NT\${{parameters.Configuration }}.AnyCPU\Microsoft.Data.SqlClient\netcore\$tf\Microsoft.Data.SqlClient.dll" "$software\win\$tf" -recurse
+          Copy-Item "artifacts\${{parameters.referenceType }}\bin\Windows_NT\${{parameters.buildConfiguration }}.AnyCPU\Microsoft.Data.SqlClient\netcore\$tf\Microsoft.Data.SqlClient.dll" "$software\win\$tf" -recurse
         }
         
         $symbols = '${{parameters.symbolsFolder}}'

--- a/eng/pipelines/common/templates/steps/generate-nuget-package-step.yml
+++ b/eng/pipelines/common/templates/steps/generate-nuget-package-step.yml
@@ -16,9 +16,12 @@ parameters:
     type: string
     default: '$(Build.SourcesDirectory)/packages'
 
-  - name: Configuration
+  - name: buildConfiguration
     type: string
-    default: '$(Configuration)'
+    default: Debug
+    values:
+      - Debug
+      - Release
 
   - name: generateSymbolsPackage
     type: boolean
@@ -55,6 +58,6 @@ steps:
   inputs:
     command: custom
     ${{ if parameters.generateSymbolsPackage }}:
-      arguments: 'pack -Symbols -SymbolPackageFormat snupkg ${{parameters.nuspecPath}} -Version ${{parameters.NugetPackageVersion}} -OutputDirectory ${{parameters.OutputDirectory}} -properties "COMMITID=$(CommitHead);Configuration=${{parameters.Configuration}};ReferenceType=${{parameters.referenceType}}"'
+      arguments: 'pack -Symbols -SymbolPackageFormat snupkg ${{parameters.nuspecPath}} -Version ${{parameters.NugetPackageVersion}} -OutputDirectory ${{parameters.OutputDirectory}} -properties "COMMITID=$(CommitHead);Configuration=${{parameters.buildConfiguration}};ReferenceType=${{parameters.referenceType}}"'
     ${{else }}:
-      arguments: 'pack ${{parameters.nuspecPath}} -Version ${{parameters.NugetPackageVersion}} -OutputDirectory ${{parameters.OutputDirectory}} -properties "COMMITID=$(CommitHead);Configuration=${{parameters.Configuration}};ReferenceType=${{parameters.referenceType}}"'
+      arguments: 'pack ${{parameters.nuspecPath}} -Version ${{parameters.NugetPackageVersion}} -OutputDirectory ${{parameters.OutputDirectory}} -properties "COMMITID=$(CommitHead);Configuration=${{parameters.buildConfiguration}};ReferenceType=${{parameters.referenceType}}"'

--- a/eng/pipelines/common/templates/steps/publish-symbols-step.yml
+++ b/eng/pipelines/common/templates/steps/publish-symbols-step.yml
@@ -47,6 +47,13 @@ parameters:
     - MDS
     - MSS
 
+  - name: buildConfiguration
+    type: string
+    default: Debug
+    values:
+      - Debug
+      - Release
+
 steps:
 - powershell: 'Write-Host "##vso[task.setvariable variable=ArtifactServices.Symbol.AccountName;]${{parameters.SymAccount}}"'
   displayName: 'Update Symbol.AccountName with ${{parameters.SymAccount}}'
@@ -58,8 +65,8 @@ steps:
     inputs:
       SymbolsFolder: '$(Build.SourcesDirectory)\artifacts\${{parameters.referenceType }}\bin'
       SearchPattern: |
-        Windows_NT/$(Configuration).AnyCPU/**/Microsoft.Data.SqlClient.pdb
-        Unix/$(Configuration).AnyCPU/**/Microsoft.Data.SqlClient.pdb
+        Windows_NT/${{ parameters.buildConfiguration }}.AnyCPU/**/Microsoft.Data.SqlClient.pdb
+        Unix/${{ parameters.buildConfiguration }}.AnyCPU/**/Microsoft.Data.SqlClient.pdb
       IndexSources: false
       SymbolServerType: TeamServices
       SymbolsMaximumWaitTime: 60

--- a/eng/pipelines/common/templates/steps/publish-test-results-step.yml
+++ b/eng/pipelines/common/templates/steps/publish-test-results-step.yml
@@ -15,9 +15,12 @@ parameters:
     type: string
     default: $(Platform)
 
-  - name: configuration
+  - name: buildConfiguration
     type: string
-    default: '$(Configuration)'
+    default: Debug
+    values:
+      - Debug
+      - Release
   
   - name: operatingSystem
     type: string
@@ -29,7 +32,7 @@ steps:
     testResultsFormat: VSTest
     mergeTestResults: true
     buildPlatform: '${{parameters.platform }}'
-    buildConfiguration: '${{parameters.configuration }}'
+    buildConfiguration: '${{parameters.buildConfiguration }}'
     ${{ if eq(parameters.operatingSystem, 'Windows') }}:
       testResultsFiles: 'TestResults/*.trx'
       testRunTitle: 'Windows Tests'

--- a/eng/pipelines/common/templates/steps/run-all-tests-step.yml
+++ b/eng/pipelines/common/templates/steps/run-all-tests-step.yml
@@ -19,9 +19,12 @@ parameters:
     type: string
     default: $(Platform)
   
-  - name: configuration
+  - name: buildConfiguration
     type: string
-    default: '$(Configuration)'
+    default: Debug
+    values:
+      - Debug
+      - Release
 
   - name: referenceType
     default: Package
@@ -60,7 +63,7 @@ steps:
         solution: build.proj
         msbuildArchitecture: ${{parameters.msbuildArchitecture }}
         platform: '${{parameters.platform }}'
-        configuration: '${{parameters.configuration }}'
+        configuration: '${{parameters.buildConfiguration }}'
         ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:   
           msbuildArguments: '-t:RunUnitTests -p:TF=${{parameters.targetFramework }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }}'
         ${{ else }}: # x86
@@ -74,7 +77,7 @@ steps:
       solution: build.proj
       msbuildArchitecture: ${{parameters.msbuildArchitecture }}
       platform: '${{parameters.platform }}'
-      configuration: '${{parameters.configuration }}'
+      configuration: '${{parameters.buildConfiguration }}'
       ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:      
         msbuildArguments: '-t:RunFunctionalTests -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }}'
       ${{ else }}: # x86
@@ -88,7 +91,7 @@ steps:
       solution: build.proj
       msbuildArchitecture: ${{parameters.msbuildArchitecture }}
       platform: '${{parameters.platform }}'
-      configuration: '${{parameters.configuration }}'
+      configuration: '${{parameters.buildConfiguration }}'
       ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
         msbuildArguments: '-t:RunManualTests -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }}'
       ${{ else }}: # x86
@@ -104,7 +107,7 @@ steps:
         command: custom
         projects: build.proj
         custom: msbuild
-        arguments: '-t:RunUnitTests -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }} -p:platform=${{parameters.platform }} -p:Configuration=${{parameters.configuration }}'
+        arguments: '-t:RunUnitTests -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }} -p:platform=${{parameters.platform }} -p:Configuration=${{parameters.buildConfiguration }}'
         verbosityRestore: Detailed
         verbosityPack: Detailed
       retryCountOnTaskFailure: 1
@@ -116,7 +119,7 @@ steps:
       command: custom
       projects: build.proj
       custom: msbuild
-      arguments: '-t:RunFunctionalTests -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }} -p:platform=${{parameters.platform }} -p:Configuration=${{parameters.configuration }}'
+      arguments: '-t:RunFunctionalTests -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }} -p:platform=${{parameters.platform }} -p:Configuration=${{parameters.buildConfiguration }}'
       verbosityRestore: Detailed
       verbosityPack: Detailed
     retryCountOnTaskFailure: 1
@@ -128,7 +131,7 @@ steps:
       command: custom
       projects: build.proj
       custom: msbuild
-      arguments: '-t:RunManualTests -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }} -p:platform=${{parameters.platform }} -p:Configuration=${{parameters.configuration }}'
+      arguments: '-t:RunManualTests -p:TF=${{parameters.targetFramework }} -p:TestSet=${{parameters.testSet }} -p:ReferenceType=${{parameters.referenceType }} -p:TestMicrosoftDataSqlClientVersion=${{parameters.nugetPackageVersion }} -p:platform=${{parameters.platform }} -p:Configuration=${{parameters.buildConfiguration }}'
       verbosityRestore: Detailed
       verbosityPack: Detailed
     retryCountOnTaskFailure: 2

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -67,10 +67,11 @@ parameters:
 
 - name: buildConfiguration
   displayName: 'Build Configuration'
-  default: Release
+  type: string
+  default: Debug
   values:
-    - Release
     - Debug
+    - Release
 
 - name: defaultPoolName
   type: string
@@ -96,7 +97,7 @@ stages:
     jobs:
     - template: common/templates/jobs/ci-build-nugets-job.yml@self
       parameters:
-        configuration: ${{ parameters.buildConfiguration }}
+        buildConfiguration: ${{ parameters.buildConfiguration }}
         artifactName: $(artifactName)
         ${{if ne(parameters.SNIVersion, '')}}:
           prebuildSteps:

--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -83,10 +83,11 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 
 - name: buildConfiguration
   displayName: 'Build Configuration'
-  default: Release
+  type: string
+  default: Debug
   values:
-    - Release
     - Debug
+    - Release
 
 - name: enableStressTests
   displayName: Enable Stress Tests

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -75,10 +75,11 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 
 - name: buildConfiguration
   displayName: 'Build Configuration'
-  default: Release
+  type: string
+  default: Debug
   values:
-    - Release
     - Debug
+    - Release
 
 - name: enableStressTests
   displayName: Enable Stress Tests

--- a/eng/pipelines/jobs/build-akv-official-job.yml
+++ b/eng/pipelines/jobs/build-akv-official-job.yml
@@ -16,6 +16,9 @@ parameters:
 
     - name: buildConfiguration
       type: string
+      values:
+        - Debug
+        - Release
 
     - name: nugetPackageVersion
       type: string

--- a/eng/pipelines/libraries/common-variables.yml
+++ b/eng/pipelines/libraries/common-variables.yml
@@ -13,8 +13,6 @@ variables:
     # AuthAKVName
     # AuthSignCertName
 
-  - name: Configuration
-    value: Release
   - name: CommitHead
     value: '' # the value will be extracted from the repo's head  
   - name: REPOROOT

--- a/eng/pipelines/stages/stress-tests-ci-stage.yml
+++ b/eng/pipelines/stages/stress-tests-ci-stage.yml
@@ -20,14 +20,14 @@
 # depended on by downstream stages.
 
 parameters:
-  # The type of build to produce (Release or Debug)
+  # The type of build to produce (Debug or Release)
   - name: buildConfiguration
     displayName: Build Configuration
     type: string
-    default: Release
+    default: Debug
     values:
-    - Release
-    - Debug
+      - Debug
+      - Release
 
   # The names of any stages this stage depends on, for example the stages
   # that publish the MDS package artifacts we will test.

--- a/eng/pipelines/steps/compound-build-akv-step.yml
+++ b/eng/pipelines/steps/compound-build-akv-step.yml
@@ -15,6 +15,9 @@ parameters:
 
     - name: buildConfiguration
       type: string
+      values:
+        - Debug
+        - Release
 
     - name: mdsPackageVersion
       type: string

--- a/eng/pipelines/steps/compound-nuget-pack-step.yml
+++ b/eng/pipelines/steps/compound-nuget-pack-step.yml
@@ -7,6 +7,9 @@
 parameters:
     - name: buildConfiguration
       type: string
+      values:
+        - Debug
+        - Release
 
     - name: generateSymbolsPackage
       type: boolean

--- a/eng/pipelines/steps/roslyn-analyzers-akv-step.yml
+++ b/eng/pipelines/steps/roslyn-analyzers-akv-step.yml
@@ -11,6 +11,9 @@
 parameters:
     - name: buildConfiguration
       type: string
+      values:
+        - Debug
+        - Release
 
     - name: mdsPackageVersion
       type: string

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Config.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Data.SqlClient.TestUtilities
         public bool IsJsonSupported = false;
         public static Config Load(string configPath = @"config.json")
         {
+            configPath = Environment.GetEnvironmentVariable("MDS_TEST_CONFIG") ?? configPath;
+
             try
             {
                 using (StreamReader r = new StreamReader(configPath))


### PR DESCRIPTION
## Description

- Changed default build configuration from Release to Debug for CI-SqlClient[-Package] pipelines.
- Plumbed 'builConfiguration' template parameter down through all of the pipeline YML files.
- Removed the pipeline variable $(Configuration) in favour of buildConfiguration parameter.
- Added environment variable override for unit test config file.

I will also be changing how the triggered and scheculed pipelines run, defaulting them to Release so we continue to get coverage there as well.

## Testing

- The CI-SqlClient and CI-SqlClient-Package runs will now be Debug.
- There will likely be new top-level pipelines for main-commit triggers and schedules, that build/run in Release mode.