### PR TITLE
[6.1] Backport mac server name fix

### DIFF
--- a/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
@@ -73,8 +73,17 @@ parameters:
       - Project
       - Package
 
+  # The timeout, in minutes, for this job.
+  - name: timeout
+    type: string
+    default: 90
+
 jobs:
 - job: ${{ format('{0}', coalesce(parameters.jobDisplayName, parameters.image, 'unknown_image')) }}
+
+  # Some of our tests take longer than the default 60 minutes to run on some
+  # OSes and configurations.
+  timeoutInMinutes: ${{ parameters.timeout }}
 
   pool:
     name: '${{ parameters.poolName }}'

--- a/eng/pipelines/common/templates/jobs/run-tests-package-reference-job.yml
+++ b/eng/pipelines/common/templates/jobs/run-tests-package-reference-job.yml
@@ -20,11 +20,21 @@ parameters:
   - name: isPreview
     type: boolean
 
+  # The timeout, in minutes, for this job.
+  - name: timeout
+    type: string
+    default: 90
+
 jobs:
 - job: run_tests_package_reference
   displayName: 'Run tests with package reference'
   ${{ if ne(parameters.dependsOn, 'empty')}}:
     dependsOn: '${{parameters.dependsOn }}'
+
+  # Some of our tests take longer than the default 60 minutes to run on some
+  # OSes and configurations.
+  timeoutInMinutes: ${{ parameters.timeout }}
+
   pool:
     type: windows  # read more about custom job pool types at https://aka.ms/obpipelines/yaml/jobs
     isCustom: true

--- a/eng/pipelines/common/templates/stages/ci-run-tests-stage.yml
+++ b/eng/pipelines/common/templates/stages/ci-run-tests-stage.yml
@@ -30,6 +30,11 @@ parameters:
     type: jobList
     default: []
 
+  # The timeout, in minutes, for each test job.
+  - name: testsTimeout
+    type: string
+    default: 90
+
 stages:
 - ${{ each config in parameters.testConfigurations }}:
   - ${{ each image in config.value.images }}:
@@ -47,6 +52,7 @@ stages:
                 parameters:
                   debug: ${{ parameters.debug }}
                   buildType: ${{ parameters.buildType }}
+                  timeout: ${{ parameters.testsTimeout }}
                   poolName: ${{ config.value.pool }}
                   hostedPool: ${{ eq(config.value.hostedPool, true) }}
                   image: ${{ image.value }}
@@ -72,6 +78,7 @@ stages:
                   parameters:
                     debug: ${{ parameters.debug }}
                     buildType: ${{ parameters.buildType }}
+                    timeout: ${{ parameters.testsTimeout }}
                     poolName: ${{ config.value.pool }}
                     hostedPool: ${{ eq(config.value.hostedPool, true) }}
                     image: ${{ image.value }}

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -81,6 +81,11 @@ parameters:
   type: boolean
   default: false
 
+# The timeout, in minutes, for each test job.
+- name: testsTimeout
+  type: string
+  default: 90
+
 variables:
   - template: libraries/ci-build-variables.yml@self
   
@@ -119,6 +124,7 @@ stages:
     parameters:
       debug: ${{ parameters.debug }}
       buildType: ${{ parameters.buildType }}
+      testsTimeout: ${{ parameters.testsTimeout }}
       ${{ if eq(parameters.buildType, 'Package') }}:
         dependsOn: build_nugets
 

--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -93,6 +93,12 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   type: boolean
   default: false
 
+# The timeout, in minutes, for each test job.
+- name: testsTimeout
+  displayName: 'Tests timeout (in minutes)'
+  type: string
+  default: 90
+
 extends:
   template: dotnet-sqlclient-ci-core.yml@self
   parameters:
@@ -106,3 +112,4 @@ extends:
     buildType: ${{ parameters.buildType }}
     buildConfiguration: ${{ parameters.buildConfiguration }}
     enableStressTests: ${{ parameters.enableStressTests }}
+    testsTimeout: ${{ parameters.testsTimeout }}

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -85,6 +85,12 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   type: boolean
   default: false
 
+# The timeout, in minutes, for each test job.
+- name: testsTimeout
+  displayName: 'Tests timeout (in minutes)'
+  type: string
+  default: 90
+
 extends:
   template: dotnet-sqlclient-ci-core.yml@self
   parameters:
@@ -98,3 +104,4 @@ extends:
     buildType: ${{ parameters.buildType }}
     buildConfiguration: ${{ parameters.buildConfiguration }}
     enableStressTests: ${{ parameters.enableStressTests }}
+    testsTimeout: ${{ parameters.testsTimeout }}

--- a/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
@@ -62,6 +62,12 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   type: boolean
   default: false
 
+# The timeout, in minutes, for each test job.
+- name: testsTimeout
+  displayName: 'Tests timeout (in minutes)'
+  type: string
+  default: 90
+
 variables:
   - template: /eng/pipelines/libraries/variables.yml@self
   - name: packageFolderName
@@ -161,6 +167,7 @@ extends:
         parameters:
           packageFolderName: $(packageFolderName)
           isPreview: ${{ parameters['isPreview'] }}
+          timeout: ${{ parameters.testsTimeout }}
           downloadPackageStep:
             download: current
             artifact: $(packageFolderName)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -587,7 +587,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// </summary>
         /// <param name="prefix">Add the prefix to the generate string.</param>
         /// <param name="withBracket">Database name must be pass with brackets by default.</param>
-        /// <returns>Unique name by considering the Sql Server naming rules.</returns>
+        /// <returns>Unique name by considering the Sql Server naming rules, never longer than 96 characters.</returns>
         public static string GetUniqueNameForSqlServer(string prefix, bool withBracket = true)
         {
             string extendedPrefix = string.Format(
@@ -597,10 +597,21 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 Environment.MachineName,
                 DateTime.Now.ToString("yyyy_MM_dd", CultureInfo.InvariantCulture));
             string name = GetUniqueName(extendedPrefix, withBracket);
-            if (name.Length > 128)
+
+            // Truncate to no more than 96 characters.
+            const int maxLen = 96;
+            if (name.Length > maxLen)
             {
-                throw new ArgumentOutOfRangeException("the name is too long - SQL Server names are limited to 128");
+                if (withBracket)
+                {
+                    name = name.Substring(0, maxLen - 1) + ']';
+                }
+                else
+                {
+                    name = name.Substring(0, maxLen);
+                }
             }
+
             return name;
         }
 


### PR DESCRIPTION
## Description

- Backported part of #3494 and all of #3591:
  - Added configurable test jobs timeout, defaulting to 90 minutes.
  - Reduced generated database names to 96 chars to try to fix macOS test failures.
