### PR TITLE
Fix unique db object name issues

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/ApiShould.cs
@@ -166,8 +166,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             const string firstColumnName = @"firstColumn";
             const string secondColumnName = @"secondColumn";
             const string thirdColumnName = @"thirdColumn";
-            string inputProcedureName = DataTestUtility.GetUniqueName("InputProc").ToString();
-            string outputProcedureName = DataTestUtility.GetUniqueName("OutputProc").ToString();
+            string inputProcedureName = DataTestUtility.GetShortName("InputProc").ToString();
+            string outputProcedureName = DataTestUtility.GetShortName("OutputProc").ToString();
             const int charColumnSize = 100;
             const int decimalColumnPrecision = 10;
             const int decimalColumnScale = 4;
@@ -722,7 +722,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         [ClassData(typeof(AEConnectionStringProvider))]
         public async Task TestExecuteReaderAsyncWithLargeQuery(string connectionString)
         {
-            string randomName = DataTestUtility.GetUniqueName(Guid.NewGuid().ToString().Replace("-", ""), false);
+            string randomName = DataTestUtility.GetShortName(Guid.NewGuid().ToString().Replace("-", ""), false);
             if (randomName.Length > 50)
             {
                 randomName = randomName.Substring(0, 50);
@@ -912,8 +912,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             using SqlCommand sqlCommand = new("", sqlConnection, transaction: null,
                 columnEncryptionSetting: SqlCommandColumnEncryptionSetting.Enabled);
 
-            string procWithoutParams = DataTestUtility.GetUniqueName("EnclaveWithoutParams", withBracket: false);
-            string procWithParam = DataTestUtility.GetUniqueName("EnclaveWithParams", withBracket: false);
+            string procWithoutParams = DataTestUtility.GetShortName("EnclaveWithoutParams", withBracket: false);
+            string procWithParam = DataTestUtility.GetShortName("EnclaveWithParams", withBracket: false);
 
             try
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CspProviderExt.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CspProviderExt.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         [MemberData(nameof(TestEncryptDecryptWithCsp_Data))]
         public void TestEncryptDecryptWithCsp(string connectionString, string providerName, int providerType)
         {
-            string keyIdentifier = DataTestUtility.GetUniqueNameForSqlServer("CSP");
+            string keyIdentifier = DataTestUtility.GetLongName("CSP");
             CspParameters namedCspParameters = new CspParameters(providerType, providerName, keyIdentifier);
             using SQLSetupStrategyCspProvider sqlSetupStrategyCsp = new SQLSetupStrategyCspProvider(namedCspParameters);
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -660,7 +660,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// 
         /// <param name="suffix">
         /// The suffix to use when generating the unique name, truncated to at
-        /// most 18 characters.
+        /// most 32 characters.
         /// </param>
         /// 
         /// <param name="withBracket">
@@ -685,9 +685,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             name.Append(GetGuidParts());
             name.Append('-');
 
-            if (suffix.Length > 18)
+            if (suffix.Length > 32)
             {
-                suffix = suffix[0..18];
+                suffix = suffix[0..32];
             }
 
             suffix =

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -578,7 +578,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// Generate a short unique database object name, whose maximum length
         /// is 30 characters, with the format:
         ///
-        ///   <GUID-Parts>-<Suffix>
+        ///   <GUID-Parts>_<Suffix>
         ///
         /// The GUID Parts will be the characters from the 1st and 4th blocks
         /// from a traditional string representation, as shown here:
@@ -604,7 +604,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// When true, the entire generated name will be enclosed in square
         /// brackets, for example:
         /// 
-        ///   [7ff01cb811f0-MySuffix]
+        ///   [7ff01cb811f0_MySuffix]
         /// </param>
         /// 
         /// <returns>
@@ -620,7 +620,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
 
             name.Append(GetGuidParts());
-            name.Append('-');
+            name.Append('_');
 
             int maxSuffixLength = withBracket ? 16 : 18;
             if (suffix.Length > maxSuffixLength)
@@ -641,7 +641,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// Generate a long unique database object name, whose maximum length is
         /// 96 characters, with the format:
         /// 
-        ///   <GUID-Parts>-<Suffix>-<UserName>-<MachineName>
+        ///   <GUID-Parts>_<Suffix>_<UserName>_<MachineName>
         ///
         /// The GUID Parts will be the characters from the 1st and 4th blocks
         /// from a traditional string representation, as shown here:
@@ -667,7 +667,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// When true, the entire generated name will be enclosed in square
         /// brackets, for example:
         /// 
-        ///   [7ff01cb811f0-MySuffix-test_user-ci_agent_machine_name]
+        ///   [7ff01cb811f0_MySuffix_test_user_ci_agent_machine_name]
         /// </param>
         /// 
         /// <returns>
@@ -683,7 +683,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
 
             name.Append(GetGuidParts());
-            name.Append('-');
+            name.Append('_');
 
             if (suffix.Length > 32)
             {
@@ -691,8 +691,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
 
             suffix =
-              suffix + '-' +
-              Environment.UserName + '-' +
+              suffix + '_' +
+              Environment.UserName + '_' +
               Environment.MachineName;
 
             int maxSuffixLength = withBracket ? 82 : 84;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -671,7 +671,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// </param>
         /// 
         /// <returns>
-        /// A unique database object name, no more than 30 characters long.
+        /// A unique database object name, no more than 96 characters long.
         /// </returns>
         public static string GetLongName(string suffix, bool withBracket = true)
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             get
             {
-                SqlConnectionStringBuilder builder = new (TCPConnectionString);
+                SqlConnectionStringBuilder builder = new(TCPConnectionString);
                 return builder.Authentication == SqlAuthenticationMethod.SqlPassword || builder.Authentication == SqlAuthenticationMethod.NotSpecified;
             }
         }
@@ -571,7 +571,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             var guid = Guid.NewGuid().ToString();
             // GOTCHA: The slice operator is inclusive of the start index and
             // exclusive of the end index!
-            return guid[0..8] + guid[19..23];
+            return guid.Substring(0, 8) + guid.Substring(19, 4);
         }
 
         /// <summary>
@@ -625,7 +625,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             int maxSuffixLength = withBracket ? 16 : 18;
             if (suffix.Length > maxSuffixLength)
             {
-                suffix = suffix[0..maxSuffixLength];
+                suffix = suffix.Substring(0, maxSuffixLength);
             }
             name.Append(suffix);
 
@@ -687,7 +687,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             if (suffix.Length > 32)
             {
-                suffix = suffix[0..32];
+                suffix = suffix.Substring(0, 32);
             }
 
             suffix =
@@ -698,7 +698,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             int maxSuffixLength = withBracket ? 82 : 84;
             if (suffix.Length > maxSuffixLength)
             {
-                suffix = suffix[0..maxSuffixLength];
+                suffix = suffix.Substring(0, maxSuffixLength);
             }
 
             name.Append(suffix);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -600,7 +600,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// withBracket is true.
         ///
         /// This should not contain any characters that cannot be used in
-        /// database object names.
+        /// database object names.  See:
+        /// 
+        /// https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver17#rules-for-regular-identifiers
         /// </param>
         /// 
         /// <param name="withBracket">
@@ -637,8 +639,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 name.Append(']');
             }
 
-            System.Console.WriteLine($"Generated short name \"{name.ToString()}\"");
-
             return name.ToString();
         }
 
@@ -670,7 +670,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// most 32 characters.
         ///
         /// This should not contain any characters that cannot be used in
-        /// database object names.
+        /// database object names.  See:
+        /// 
+        /// https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver17#rules-for-regular-identifiers
         /// </param>
         /// 
         /// <param name="withBracket">
@@ -722,8 +724,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             {
                 name.Append(']');
             }
-
-            System.Console.WriteLine($"Generated long name \"{name.ToString()}\"");
 
             return name.ToString();
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/ProviderAgnostic/ReaderTest/ReaderTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string connectionString = DataTestUtility.TCPConnectionString;
 
-            string tempTable = DataTestUtility.GetUniqueNameForSqlServer("table");
+            string tempTable = DataTestUtility.GetLongName("table");
 
             DbProviderFactory provider = SqlClientFactory.Instance;
             try
@@ -275,7 +275,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static void SqlDataReader_SqlBuffer_GetFieldValue()
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("SqlBuffer_GetFieldValue");
+            string tableName = DataTestUtility.GetLongName("SqlBuffer_GetFieldValue");
             DateTimeOffset dtoffset = DateTimeOffset.Now;
             DateTime dt = DateTime.Now;
             //Exclude the millisecond because of rounding at some points by SQL Server.
@@ -374,7 +374,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static async Task SqlDataReader_SqlBuffer_GetFieldValue_Async()
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("SqlBuffer_GetFieldValue_Async");
+            string tableName = DataTestUtility.GetLongName("SqlBuffer_GetFieldValue_Async");
             DateTimeOffset dtoffset = DateTimeOffset.Now;
             DateTime dt = DateTime.Now;
             //Exclude the millisecond because of rounding at some points by SQL Server.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AdapterTest/AdapterTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AdapterTest/AdapterTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public AdapterTest()
         {
             // create random name for temp tables
-            _tempTable = DataTestUtility.GetUniqueName("AdapterTest");
+            _tempTable = DataTestUtility.GetShortName("AdapterTest");
             _tempTable = _tempTable.Replace('-', '_');
 
             _randomGuid = Guid.NewGuid().ToString();
@@ -555,7 +555,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public void ParameterTest_InOut()
         {
-            string procName = DataTestUtility.GetUniqueName("P");
+            string procName = DataTestUtility.GetShortName("P");
             // input, output
             string spCreateInOut =
                 "CREATE PROCEDURE " + procName + " @in int, @inout int OUTPUT, @out nvarchar(8) OUTPUT " +
@@ -836,13 +836,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public void UpdateRefreshTest()
         {
-            string identTableName = DataTestUtility.GetUniqueName("ID_");
+            string identTableName = DataTestUtility.GetShortName("ID_");
             string createIdentTable =
                 $"CREATE TABLE {identTableName} (id int IDENTITY," +
                 "LastName nvarchar(50) NULL," +
                 "Firstname nvarchar(50) NULL)";
 
-            string spName = DataTestUtility.GetUniqueName("sp_insert", withBracket: false);
+            string spName = DataTestUtility.GetShortName("sp_insert", withBracket: false);
             string spCreateInsert =
                 $"CREATE PROCEDURE {spName}" +
                 "(@FirstName nvarchar(50), @LastName nvarchar(50), @id int OUTPUT) " +
@@ -1155,7 +1155,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public void AutoGenErrorTest()
         {
-            string identTableName = DataTestUtility.GetUniqueName("ID_");
+            string identTableName = DataTestUtility.GetShortName("ID_");
             string createIdentTable =
                 $"CREATE TABLE {identTableName} (id int IDENTITY," +
                 "LastName nvarchar(50) NULL," +

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectivityTests/ConnectivityTest.cs
@@ -393,7 +393,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             SqlConnectionStringBuilder connectionStringBuilder = new(DataTestUtility.TCPConnectionString)
             {
-                InitialCatalog = DataTestUtility.GetUniqueNameForSqlServer("DoesNotExist", false),
+                InitialCatalog = DataTestUtility.GetLongName("DoesNotExist", false),
                 Pooling = false,
                 ConnectTimeout = 15,
                 ConnectRetryCount = 3

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataClassificationTest/DataClassificationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataClassificationTest/DataClassificationTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsSupportedDataClassification))]
         public static void TestDataClassificationResultSetRank()
         {
-            s_tableName = DataTestUtility.GetUniqueNameForSqlServer("DC");
+            s_tableName = DataTestUtility.GetLongName("DC");
             using (SqlConnection sqlConnection = new SqlConnection(DataTestUtility.TCPConnectionString))
             using (SqlCommand sqlCommand = sqlConnection.CreateCommand())
             {
@@ -41,7 +41,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsSupportedDataClassification))]
         public static void TestDataClassificationResultSet()
         {
-            s_tableName = DataTestUtility.GetUniqueNameForSqlServer("DC");
+            s_tableName = DataTestUtility.GetLongName("DC");
             using (SqlConnection sqlConnection = new SqlConnection(DataTestUtility.TCPConnectionString))
             using (SqlCommand sqlCommand = sqlConnection.CreateCommand())
             {
@@ -232,7 +232,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             data.Rows.Add(Guid.NewGuid(), "Company 2", "sample2@contoso.com", 1);
             data.Rows.Add(Guid.NewGuid(), "Company 3", "sample3@contoso.com", 1);
 
-            var tableName = DataTestUtility.GetUniqueNameForSqlServer("DC");
+            var tableName = DataTestUtility.GetLongName("DC");
 
             using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [InlineData("Georgian_Modern_Sort_CI_AS")]
         public static void CollatedDataReaderTest(string collation)
         {
-            string dbName = DataTestUtility.GetUniqueName("CollationTest", false);
+            string dbName = DataTestUtility.GetShortName("CollationTest", false);
 
             SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString)
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             byte[] inputData = null;
             byte[] outputData = null;
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("data");
+            string tableName = DataTestUtility.GetLongName("data");
 
             using (SqlConnection connection = new(connectionString))
             {
@@ -556,7 +556,7 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
 
         private static void TimestampRead(string connectionString)
         {
-            string tempTable = DataTestUtility.GetUniqueNameForSqlServer("##Temp");
+            string tempTable = DataTestUtility.GetLongName("##Temp");
             tempTable = tempTable.Replace('-', '_');
 
             using (SqlConnection conn = new SqlConnection(connectionString))
@@ -1062,7 +1062,7 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
 
         private static void NumericRead(string connectionString)
         {
-            string tempTable = DataTestUtility.GetUniqueNameForSqlServer("##Temp");
+            string tempTable = DataTestUtility.GetLongName("##Temp");
             tempTable = tempTable.Replace('-', '_');
 
             using (SqlConnection conn = new SqlConnection(connectionString))
@@ -1892,8 +1892,8 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
 
         private static void VariantCollationsTest(string connectionString)
         {
-            string dbName = DataTestUtility.GetUniqueName("JPN");
-            string tableName = DataTestUtility.GetUniqueName("T");
+            string dbName = DataTestUtility.GetShortName("JPN");
+            string tableName = DataTestUtility.GetShortName("T");
 
             using (SqlConnection connection = new SqlConnection(connectionString))
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonBulkCopyTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonBulkCopyTest.cs
@@ -14,10 +14,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.JsonTest
     public class JsonBulkCopyTest
     {
         private readonly ITestOutputHelper _output;
-        private static readonly string _generatedJsonFile = DataTestUtility.GetUniqueName("randomRecords");
-        private static readonly string _outputFile = DataTestUtility.GetUniqueName("serverResults");
-        private static readonly string _sourceTableName = DataTestUtility.GetUniqueName("jsonBulkCopySrcTable", true);
-        private static readonly string _destinationTableName = DataTestUtility.GetUniqueName("jsonBulkCopyDestTable", true);
+        private static readonly string _generatedJsonFile = DataTestUtility.GetShortName("randomRecords");
+        private static readonly string _outputFile = DataTestUtility.GetShortName("serverResults");
+        private static readonly string _sourceTableName = DataTestUtility.GetShortName("jsonBulkCopySrcTable", true);
+        private static readonly string _destinationTableName = DataTestUtility.GetShortName("jsonBulkCopyDestTable", true);
 
         public JsonBulkCopyTest(ITestOutputHelper output)
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonStreamTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonStreamTest.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     public  class JsonStreamTest
     {
         private readonly ITestOutputHelper _output;
-        private static readonly string _jsonFile = DataTestUtility.GetUniqueName("randomRecords") + ".json";
-        private static readonly string _outputFile = DataTestUtility.GetUniqueName("serverRecords") + ".json";
+        private static readonly string _jsonFile = DataTestUtility.GetShortName("randomRecords") + ".json";
+        private static readonly string _outputFile = DataTestUtility.GetShortName("serverRecords") + ".json";
 
         public JsonStreamTest(ITestOutputHelper output)
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "TestSimpleParameter_Type";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string procName = DataTestUtility.GetUniqueNameForSqlServer("paramProc1");
+            string procName = DataTestUtility.GetLongName("paramProc1");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -115,7 +115,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "TestSimpleParameter_Variant";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string procName = DataTestUtility.GetUniqueNameForSqlServer("paramProc2");
+            string procName = DataTestUtility.GetLongName("paramProc2");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -153,7 +153,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "TestSqlDataRecordParameterToTVP_Type";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string tvpTypeName = DataTestUtility.GetUniqueNameForSqlServer("tvpType");
+            string tvpTypeName = DataTestUtility.GetLongName("tvpType");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -200,7 +200,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "TestSqlDataRecordParameterToTVP_Variant";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string tvpTypeName = DataTestUtility.GetUniqueNameForSqlServer("tvpVariant");
+            string tvpTypeName = DataTestUtility.GetLongName("tvpVariant");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -245,7 +245,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "TestSqlDataReaderParameterToTVP_Type";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string tvpTypeName = DataTestUtility.GetUniqueNameForSqlServer("tvpType");
+            string tvpTypeName = DataTestUtility.GetLongName("tvpType");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -295,7 +295,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "TestSqlDataReaderParameterToTVP_Variant";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string tvpTypeName = DataTestUtility.GetUniqueNameForSqlServer("tvpVariant");
+            string tvpTypeName = DataTestUtility.GetLongName("tvpVariant");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -347,10 +347,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "TestSqlDataReader_TVP_Type";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string tvpTypeName = DataTestUtility.GetUniqueNameForSqlServer("tvpType");
-            string InputTableName = DataTestUtility.GetUniqueNameForSqlServer("InputTable");
-            string OutputTableName = DataTestUtility.GetUniqueNameForSqlServer("OutputTable");
-            string ProcName = DataTestUtility.GetUniqueNameForSqlServer("spTVPProc");
+            string tvpTypeName = DataTestUtility.GetLongName("tvpType");
+            string InputTableName = DataTestUtility.GetLongName("InputTable");
+            string OutputTableName = DataTestUtility.GetLongName("OutputTable");
+            string ProcName = DataTestUtility.GetLongName("spTVPProc");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -428,10 +428,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "TestSqlDataReader_TVP_Variant";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string tvpTypeName = DataTestUtility.GetUniqueNameForSqlServer("tvpVariant_DRdrTVPVar");
-            string InputTableName = DataTestUtility.GetUniqueNameForSqlServer("InputTable");
-            string OutputTableName = DataTestUtility.GetUniqueNameForSqlServer("OutputTable");
-            string ProcName = DataTestUtility.GetUniqueNameForSqlServer("spTVPProc_DRdrTVPVar");
+            string tvpTypeName = DataTestUtility.GetLongName("tvpVariant_DRdrTVPVar");
+            string InputTableName = DataTestUtility.GetLongName("InputTable");
+            string OutputTableName = DataTestUtility.GetLongName("OutputTable");
+            string ProcName = DataTestUtility.GetLongName("spTVPProc_DRdrTVPVar");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -512,8 +512,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "TestSimpleDataReader_Type";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string inputTable = DataTestUtility.GetUniqueNameForSqlServer("inputTable");
-            string procName = DataTestUtility.GetUniqueNameForSqlServer("paramProc3");
+            string inputTable = DataTestUtility.GetLongName("inputTable");
+            string procName = DataTestUtility.GetLongName("paramProc3");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -568,8 +568,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "TestSimpleDataReader_Variant";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string inputTable = DataTestUtility.GetUniqueNameForSqlServer("inputTable");
-            string procName = DataTestUtility.GetUniqueNameForSqlServer("paramProc4");
+            string inputTable = DataTestUtility.GetLongName("inputTable");
+            string procName = DataTestUtility.GetLongName("paramProc4");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -624,8 +624,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "SqlBulkCopySqlDataReader_Type";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string bulkCopySrcTableName = DataTestUtility.GetUniqueNameForSqlServer("bulkSrcTable");
-            string bulkCopyTableName = DataTestUtility.GetUniqueNameForSqlServer("bulkDestTable");
+            string bulkCopySrcTableName = DataTestUtility.GetLongName("bulkSrcTable");
+            string bulkCopyTableName = DataTestUtility.GetLongName("bulkDestTable");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -698,8 +698,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "SqlBulkCopySqlDataReader_Variant";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string bulkCopySrcTableName = DataTestUtility.GetUniqueNameForSqlServer("bulkSrcTable");
-            string bulkCopyTableName = DataTestUtility.GetUniqueNameForSqlServer("bulkDestTable");
+            string bulkCopySrcTableName = DataTestUtility.GetLongName("bulkSrcTable");
+            string bulkCopyTableName = DataTestUtility.GetLongName("bulkDestTable");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -776,7 +776,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "SqlBulkCopyDataTable_Type";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string bulkCopyTableName = DataTestUtility.GetUniqueNameForSqlServer("bulkDestType");
+            string bulkCopyTableName = DataTestUtility.GetLongName("bulkDestType");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -836,7 +836,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "SqlBulkCopyDataTable_Variant";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string bulkCopyTableName = DataTestUtility.GetUniqueNameForSqlServer("bulkDestVariant");
+            string bulkCopyTableName = DataTestUtility.GetLongName("bulkDestVariant");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -886,7 +886,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "SqlBulkCopyDataRow_Type";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string bulkCopyTableName = DataTestUtility.GetUniqueNameForSqlServer("bulkDestType");
+            string bulkCopyTableName = DataTestUtility.GetLongName("bulkDestType");
             try
             {
                 using SqlConnection conn = new(s_connStr);
@@ -941,7 +941,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             string tag = "SqlBulkCopyDataRow_Variant";
             DisplayHeader(tag, paramValue, expectedBaseTypeName);
-            string bulkCopyTableName = DataTestUtility.GetUniqueNameForSqlServer("bulkDestVariant");
+            string bulkCopyTableName = DataTestUtility.GetLongName("bulkDestVariant");
             try
             {
                 using SqlConnection conn = new(s_connStr);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static void Test_Copy_SqlParameter()
         {
             using var conn = new SqlConnection(s_connString);
-            string cTableName = DataTestUtility.GetUniqueNameForSqlServer("#tmp");
+            string cTableName = DataTestUtility.GetLongName("#tmp");
             try
             {
                 // Create tmp table
@@ -262,9 +262,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             };
 
             using SqlConnection connection = new(builder.ConnectionString);
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Table");
-            string procName = DataTestUtility.GetUniqueNameForSqlServer("Proc");
-            string typeName = DataTestUtility.GetUniqueName("Type");
+            string tableName = DataTestUtility.GetLongName("Table");
+            string procName = DataTestUtility.GetLongName("Proc");
+            string typeName = DataTestUtility.GetShortName("Type");
             try
             {
                 connection.Open();
@@ -343,8 +343,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             };
             
             using SqlConnection connection = new(builder.ConnectionString);
-            string procName = DataTestUtility.GetUniqueNameForSqlServer("Proc");
-            string typeName = DataTestUtility.GetUniqueName("Type");
+            string procName = DataTestUtility.GetLongName("Proc");
+            string typeName = DataTestUtility.GetShortName("Type");
             try
             {
                 connection.Open();
@@ -403,8 +403,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static void TestDateOnlyTVPDataTable_CommandSP()
         {
-            string tableTypeName = "[dbo]." + DataTestUtility.GetUniqueNameForSqlServer("UDTTTestDateOnlyTVP");
-            string spName = DataTestUtility.GetUniqueNameForSqlServer("spTestDateOnlyTVP");
+            string tableTypeName = "[dbo]." + DataTestUtility.GetLongName("UDTTTestDateOnlyTVP");
+            string spName = DataTestUtility.GetLongName("spTestDateOnlyTVP");
             SqlConnection connection = new(s_connString);
             try
             {
@@ -451,8 +451,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static void TestDateOnlyTVPSqlDataRecord_CommandSP()
         {
-            string tableTypeName = "[dbo]." + DataTestUtility.GetUniqueNameForSqlServer("UDTTTestDateOnlySqlDataRecordTVP");
-            string spName = DataTestUtility.GetUniqueNameForSqlServer("spTestDateOnlySqlDataRecordTVP");
+            string tableTypeName = "[dbo]." + DataTestUtility.GetLongName("UDTTTestDateOnlySqlDataRecordTVP");
+            string spName = DataTestUtility.GetLongName("spTestDateOnlySqlDataRecordTVP");
             SqlConnection connection = new(s_connString);
             try
             {
@@ -574,7 +574,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             using LocalAppContextSwitchesHelper appContextSwitchesHelper = new();
 
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("TestDecimalParameterCMD");
+            string tableName = DataTestUtility.GetLongName("TestDecimalParameterCMD");
             using SqlConnection connection = InitialDatabaseTable(connectionString, tableName);
             try
             {
@@ -609,7 +609,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             using LocalAppContextSwitchesHelper appContextSwitchesHelper = new();
 
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("TestDecimalParameterBC");
+            string tableName = DataTestUtility.GetLongName("TestDecimalParameterBC");
             using SqlConnection connection = InitialDatabaseTable(connectionString, tableName);
             try
             {
@@ -645,9 +645,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             using LocalAppContextSwitchesHelper appContextSwitchesHelper = new();
 
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("TestDecimalParameterBC");
-            string tableTypeName = DataTestUtility.GetUniqueNameForSqlServer("UDTTTestDecimalParameterBC");
-            string spName = DataTestUtility.GetUniqueNameForSqlServer("spTestDecimalParameterBC");
+            string tableName = DataTestUtility.GetLongName("TestDecimalParameterBC");
+            string tableTypeName = DataTestUtility.GetLongName("UDTTTestDecimalParameterBC");
+            string spName = DataTestUtility.GetLongName("spTestDecimalParameterBC");
             using SqlConnection connection = InitialDatabaseUDTT(connectionString, tableName, tableTypeName, spName);
             try
             {
@@ -932,7 +932,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             int firstInput = 12;
 
-            string sprocName = DataTestUtility.GetUniqueName("P");
+            string sprocName = DataTestUtility.GetShortName("P");
             // input, output
             string createSprocQuery =
                 "CREATE PROCEDURE " + sprocName + " @in int " +

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SqlAdapterUpdateBatch.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SqlAdapterUpdateBatch.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public void SqlAdapterTest()
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Adapter");
+            string tableName = DataTestUtility.GetLongName("Adapter");
             string tableNameNoBrackets = tableName.Substring(1, tableName.Length - 2);
             try
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SqlVariantParam.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/SqlVariantParam.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// </summary>
         private static void SendVariantBulkCopy(object paramValue, string expectedTypeName, string expectedBaseTypeName)
         {
-            string bulkCopyTableName = DataTestUtility.GetUniqueNameForSqlServer("bulkDest");
+            string bulkCopyTableName = DataTestUtility.GetLongName("bulkDest");
 
             // Fetch reader using type.
             using SqlDataReader dr = GetReaderForVariant(paramValue, false);
@@ -194,7 +194,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// </summary>
         private static void SendVariantTvp(object paramValue, string expectedTypeName, string expectedBaseTypeName)
         {
-            string tvpTypeName = DataTestUtility.GetUniqueNameForSqlServer("tvpVariant");
+            string tvpTypeName = DataTestUtility.GetLongName("tvpVariant");
 
             using SqlConnection connTvp = new(s_connStr);
             connTvp.Open();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public void DropDatabaseWithActiveConnection(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int currentRetries = 0;
-            string database = DataTestUtility.GetUniqueNameForSqlServer($"RetryLogic_{provider.RetryLogic.RetryIntervalEnumerator.GetType().Name}", false);
+            string database = DataTestUtility.GetLongName($"RetryLogic_{provider.RetryLogic.RetryIntervalEnumerator.GetType().Name}", false);
             var builder = new SqlConnectionStringBuilder(cnnString)
             {
                 InitialCatalog = database,
@@ -330,7 +330,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public void UpdateALockedTable(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int currentRetries = 0;
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Region");
+            string tableName = DataTestUtility.GetLongName("Region");
             string fieldName = "RegionDescription";
 
             using (var cnn1 = new SqlConnection(cnnString))

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public void CreateDatabaseWhileTryingToConnect(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int currentRetries = 0;
-            string database = DataTestUtility.GetUniqueNameForSqlServer($"RetryLogic_{provider.RetryLogic.RetryIntervalEnumerator.GetType().Name}", false);
+            string database = DataTestUtility.GetLongName($"RetryLogic_{provider.RetryLogic.RetryIntervalEnumerator.GetType().Name}", false);
             var builder = new SqlConnectionStringBuilder(cnnString)
             {
                 InitialCatalog = database,

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/AdjustPrecScaleForBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/AdjustPrecScaleForBulkCopy.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         private static SqlDecimal BulkCopySqlDecimalToTable(SqlDecimal decimalValue, int sourcePrecision, int sourceScale, int targetPrecision, int targetScale)
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Table");
+            string tableName = DataTestUtility.GetLongName("Table");
             string connectionString = DataTestUtility.TCPConnectionString;
 
             SqlDecimal resultValue;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/AzureDistributedTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/AzureDistributedTransaction.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     public class AzureDistributedTransaction
     {
         private static readonly string s_connectionString = DataTestUtility.TCPConnectionString;
-        private static readonly string s_tableName = DataTestUtility.GetUniqueNameForSqlServer("Azure");
+        private static readonly string s_tableName = DataTestUtility.GetLongName("Azure");
         private static readonly string s_createTableCmd = $"CREATE TABLE {s_tableName} (NAME NVARCHAR(40), AGE INT)";
         private static readonly string s_sqlBulkCopyCmd = "SELECT * FROM(VALUES ('Fuller', 33), ('Davon', 49)) AS q (FirstName, Age)";
         private static readonly int s_commandTimeout = 30;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyWidenNullInexactNumerics.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyWidenNullInexactNumerics.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     {
         public static void Test(string sourceDatabaseConnectionString, string destinationDatabaseConnectionString)
         {
-            string sourceTableName = DataTestUtility.GetUniqueNameForSqlServer("BCP_SRC");
-            string destTableName = DataTestUtility.GetUniqueNameForSqlServer("BCP_DST");
+            string sourceTableName = DataTestUtility.GetLongName("BCP_SRC");
+            string destTableName = DataTestUtility.GetLongName("BCP_DST");
 
             // this test copies float and real inexact numeric types into decimal targets using bulk copy to check that the widening of the type succeeds.
             using (var sourceConnection = new SqlConnection(sourceDatabaseConnectionString))

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/DataConversionErrorMessageTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/DataConversionErrorMessageTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             srcConstr = DataTestUtility.TCPConnectionString;
 
             Connection = new SqlConnection(srcConstr);
-            TableName = DataTestUtility.GetUniqueNameForSqlServer("SqlBulkCopyTest_CopyStringToIntTest_");
+            TableName = DataTestUtility.GetLongName("SqlBulkCopyTest_CopyStringToIntTest_");
             InitialTable(Connection, TableName);
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/TestBulkCopyWithUTF8.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/TestBulkCopyWithUTF8.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     /// </summary>
     public sealed class TestBulkCopyWithUtf8 : IDisposable
     {
-        private static string s_sourceTable = DataTestUtility.GetUniqueName("SourceTableForUTF8Data");
-        private static string s_destinationTable = DataTestUtility.GetUniqueName("DestinationTableForUTF8Data");
+        private static string s_sourceTable = DataTestUtility.GetShortName("SourceTableForUTF8Data");
+        private static string s_destinationTable = DataTestUtility.GetShortName("DestinationTableForUTF8Data");
         private static string s_testValue = "test";
         private static byte[] s_testValueInUtf8Bytes = new byte[] { 0x74, 0x65, 0x73, 0x74 };
         private static readonly string s_insertQuery = $"INSERT INTO {s_sourceTable} VALUES('{s_testValue}')";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/WriteToServerTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/WriteToServerTest.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     public class WriteToServerTest
     {
         private readonly string _connectionString = null;
-        private readonly string _tableName1 = DataTestUtility.GetUniqueName("Bulk1");
-        private readonly string _tableName2 = DataTestUtility.GetUniqueName("Bulk2");
+        private readonly string _tableName1 = DataTestUtility.GetShortName("Bulk1");
+        private readonly string _tableName2 = DataTestUtility.GetShortName("Bulk2");
 
         public WriteToServerTest()
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCompletedTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandCompletedTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static void VerifyStatmentCompletedCalled()
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("stmt");
+            string tableName = DataTestUtility.GetLongName("stmt");
 
             using (var conn = new SqlConnection(s_connStr))
             using (var cmd = conn.CreateCommand())

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandSetTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlCommand/SqlCommandSetTest.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public void TestByteArrayParameters()
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("CMD");
-            string procName = DataTestUtility.GetUniqueNameForSqlServer("CMD");
+            string tableName = DataTestUtility.GetLongName("CMD");
+            string procName = DataTestUtility.GetLongName("CMD");
             byte[] bArray = new byte[] { 1, 2, 3 };
 
             using (var connection = new SqlConnection(DataTestUtility.TCPConnectionString))

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlFileStreamTest/SqlFileStreamTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlFileStreamTest/SqlFileStreamTest.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         fileStreamDir += "\\";
                     }
 
-                    string dbName = DataTestUtility.GetUniqueName("FS", false);
+                    string dbName = DataTestUtility.GetShortName("FS", false);
                     string createDBQuery = @$"CREATE DATABASE [{dbName}]
                                          ON PRIMARY
                                           (NAME = PhotoLibrary_data,
@@ -266,7 +266,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private static string SetupTable(string connString)
         {
             // Generate random table name
-            string tempTable = DataTestUtility.GetUniqueNameForSqlServer("fs");
+            string tempTable = DataTestUtility.GetLongName("fs");
             // Create table
             string createTable = $"CREATE TABLE {tempTable} (EmployeeId INT  NOT NULL  PRIMARY KEY, Photo VARBINARY(MAX) FILESTREAM  NULL, RowGuid UNIQUEIDENTIFIER NOT NULL ROWGUIDCOL UNIQUE DEFAULT NEWID() ) ";
             ExecuteNonQueryCommand(createTable, connString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/SqlServerTypesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/SqlServerTypesTest.cs
@@ -408,7 +408,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public static void TestSqlServerTypesInsertAndRead()
         {
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("Type");
+            string tableName = DataTestUtility.GetLongName("Type");
             string allTypesSQL = @$"
                     if not exists (select * from sysobjects where name='{tableName}' and xtype='U')
                     Begin

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UdtBulkCopyTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UdtBulkCopyTest.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             _connStr = (new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString) { InitialCatalog = DataTestUtility.UdtTestDbName }).ConnectionString;
             SqlConnection conn = new SqlConnection(_connStr);
 
-            string cities = DataTestUtility.GetUniqueNameForSqlServer("UdtBulkCopy_cities");
-            string customers = DataTestUtility.GetUniqueNameForSqlServer("UdtBulkCopy_customers");
-            string circles = DataTestUtility.GetUniqueNameForSqlServer("UdtBulkCopy_circles");
+            string cities = DataTestUtility.GetLongName("UdtBulkCopy_cities");
+            string customers = DataTestUtility.GetLongName("UdtBulkCopy_customers");
+            string circles = DataTestUtility.GetLongName("UdtBulkCopy_circles");
 
             conn.Open();
             try

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UdtDateTimeOffsetTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UdtDateTimeOffsetTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     public class UdtDateTimeOffsetTest
     {
         private readonly string _connectionString = null;
-        private readonly string _udtTableType = DataTestUtility.GetUniqueNameForSqlServer("DataTimeOffsetTableType");
+        private readonly string _udtTableType = DataTestUtility.GetLongName("DataTimeOffsetTableType");
         private readonly ITestOutputHelper _testOutputHelper;
 
         public UdtDateTimeOffsetTest(ITestOutputHelper testOutputHelper)
@@ -87,7 +87,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
             for (int scale = fromScale; scale <= toScale; scale++)
             {
-                string tvpTypeName = DataTestUtility.GetUniqueNameForSqlServer("tvpType"); // Need a unique name per scale, else we get errors. See https://github.com/dotnet/SqlClient/issues/3011
+                string tvpTypeName = DataTestUtility.GetLongName("tvpType"); // Need a unique name per scale, else we get errors. See https://github.com/dotnet/SqlClient/issues/3011
 
                 DateTimeOffset dateTimeOffset = new DateTimeOffset(2024, 1, 1, 23, 59, 59, TimeSpan.Zero);
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UdtTest2.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/UdtTest2.cs
@@ -84,8 +84,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsUdtTestDatabasePresent), nameof(DataTestUtility.AreConnStringsSetup))]
         public void UDTParams_Invalid2()
         {
-            string spInsertCustomer = DataTestUtility.GetUniqueNameForSqlServer("spUdtTest2_InsertCustomer");
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("UdtTest2");
+            string spInsertCustomer = DataTestUtility.GetLongName("spUdtTest2_InsertCustomer");
+            string tableName = DataTestUtility.GetLongName("UdtTest2");
 
             using (SqlConnection conn = new SqlConnection(_connStr))
             using (SqlCommand cmd = conn.CreateCommand())
@@ -143,8 +143,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsUdtTestDatabasePresent), nameof(DataTestUtility.AreConnStringsSetup))]
         public void UDTParams_TypedNull()
         {
-            string spInsertCustomer = DataTestUtility.GetUniqueNameForSqlServer("spUdtTest2_InsertCustomer");
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("UdtTest2_Customer");
+            string spInsertCustomer = DataTestUtility.GetLongName("spUdtTest2_InsertCustomer");
+            string tableName = DataTestUtility.GetLongName("UdtTest2_Customer");
 
             using (SqlConnection conn = new SqlConnection(_connStr))
             using (SqlCommand cmd = conn.CreateCommand())
@@ -188,8 +188,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsUdtTestDatabasePresent), nameof(DataTestUtility.AreConnStringsSetup))]
         public void UDTParams_NullInput()
         {
-            string spInsertCustomer = DataTestUtility.GetUniqueNameForSqlServer("spUdtTest2_InsertCustomer");
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("UdtTest2_Customer");
+            string spInsertCustomer = DataTestUtility.GetLongName("spUdtTest2_InsertCustomer");
+            string tableName = DataTestUtility.GetLongName("UdtTest2_Customer");
 
             using (SqlConnection conn = new SqlConnection(_connStr))
             using (SqlCommand cmd = conn.CreateCommand())
@@ -232,8 +232,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsUdtTestDatabasePresent), nameof(DataTestUtility.AreConnStringsSetup))]
         public void UDTParams_InputOutput()
         {
-            string spInsertCity = DataTestUtility.GetUniqueNameForSqlServer("spUdtTest2_InsertCity");
-            string tableName = DataTestUtility.GetUniqueNameForSqlServer("UdtTest2");
+            string spInsertCity = DataTestUtility.GetLongName("spUdtTest2_InsertCity");
+            string tableName = DataTestUtility.GetLongName("UdtTest2");
 
             using (SqlConnection conn = new SqlConnection(_connStr))
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Utf8SupportTest/Utf8SupportTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/Utf8SupportTest/Utf8SupportTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static void UTF8databaseTest()
         {
             const string letters = @"!\#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f€\u0081‚ƒ„…†‡ˆ‰Š‹Œ\u008dŽ\u008f\u0090‘’“”•–—˜™š›œ\u009džŸ ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ";
-            string dbName = DataTestUtility.GetUniqueNameForSqlServer("UTF8databaseTest", false);
+            string dbName = DataTestUtility.GetLongName("UTF8databaseTest", false);
             string tblName = "Table1";
 
             SqlConnectionStringBuilder builder = new(DataTestUtility.TCPConnectionString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/VectorTest/NativeVectorFloat32Tests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/VectorTest/NativeVectorFloat32Tests.cs
@@ -57,15 +57,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest
     {
         private readonly ITestOutputHelper _output;
         private static readonly string s_connectionString = ManualTesting.Tests.DataTestUtility.TCPConnectionString;
-        private static readonly string s_tableName = DataTestUtility.GetUniqueName("VectorTestTable");
-        private static readonly string s_bulkCopySrcTableName = DataTestUtility.GetUniqueName("VectorBulkCopyTestTable");
+        private static readonly string s_tableName = DataTestUtility.GetShortName("VectorTestTable");
+        private static readonly string s_bulkCopySrcTableName = DataTestUtility.GetShortName("VectorBulkCopyTestTable");
         private static readonly string s_bulkCopySrcTableDef = $@"(Id INT PRIMARY KEY IDENTITY, VectorData vector(3) NULL)";
         private static readonly string s_tableDefinition = $@"(Id INT PRIMARY KEY IDENTITY, VectorData vector(3) NULL)";
         private static readonly string s_selectCmdString = $"SELECT VectorData FROM {s_tableName} ORDER BY Id DESC";
         private static readonly string s_insertCmdString = $"INSERT INTO {s_tableName} (VectorData) VALUES (@VectorData)";
         private static readonly string s_vectorParamName = $"@VectorData";
         private static readonly string s_outputVectorParamName = $"@OutputVectorData";
-        private static readonly string s_storedProcName = DataTestUtility.GetUniqueName("VectorsAsVarcharSp");
+        private static readonly string s_storedProcName = DataTestUtility.GetShortName("VectorsAsVarcharSp");
         private static readonly string s_storedProcBody = $@"
                 {s_vectorParamName} vector(3),   -- Input: Serialized float[] as JSON string
                 {s_outputVectorParamName} vector(3) OUTPUT  -- Output: Echoed back from latest inserted row

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/VectorTest/VectorTypeBackwardCompatibilityTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/VectorTest/VectorTypeBackwardCompatibilityTests.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest
     {
         private readonly ITestOutputHelper _output;
         private static readonly string s_connectionString = ManualTesting.Tests.DataTestUtility.TCPConnectionString;
-        private static readonly string s_tableName = DataTestUtility.GetUniqueName("VectorTestTable");
-        private static readonly string s_bulkCopySrcTableName = DataTestUtility.GetUniqueName("VectorBulkCopyTestTable");
+        private static readonly string s_tableName = DataTestUtility.GetShortName("VectorTestTable");
+        private static readonly string s_bulkCopySrcTableName = DataTestUtility.GetShortName("VectorBulkCopyTestTable");
         private static readonly string s_bulkCopySrcTableDef = $@"(Id INT PRIMARY KEY IDENTITY, VectorData varchar(max) NULL)";
         private static readonly string s_tableDefinition = $@"(Id INT PRIMARY KEY IDENTITY, VectorData vector(3) NULL)";
         private static readonly string s_selectCmdString = $"SELECT VectorData FROM {s_tableName} ORDER BY Id DESC";
         private static readonly string s_insertCmdString = $"INSERT INTO {s_tableName} (VectorData) VALUES (@VectorData)";
         private static readonly string s_vectorParamName = $"@VectorData";
-        private static readonly string s_storedProcName = DataTestUtility.GetUniqueName("VectorsAsVarcharSp");
+        private static readonly string s_storedProcName = DataTestUtility.GetShortName("VectorsAsVarcharSp");
         private static readonly string s_storedProcBody = $@"
                 @InputVectorJson VARCHAR(MAX),   -- Input: Serialized float[] as JSON string
                 @OutputVectorJson VARCHAR(MAX) OUTPUT  -- Output: Echoed back from latest inserted row


### PR DESCRIPTION
## Description

- Fixed the unique name generators to:
  - Keep max lengths to 30 and 96 characters respectively.
  - Ensure sufficient uniqueness even when truncation occurs.
