### PR TITLE
[5.] Backport mac server name fix

### DIFF
--- a/eng/pipelines/common/templates/jobs/run-tests-package-reference-job.yml
+++ b/eng/pipelines/common/templates/jobs/run-tests-package-reference-job.yml
@@ -17,11 +17,21 @@ parameters:
     type: string
     default: empty
 
+  # The timeout, in minutes, for this job.
+  - name: timeout
+    type: string
+    default: 90
+
 jobs:
 - job: run_tests_package_reference
   displayName: 'Run tests with package reference'
   ${{ if ne(parameters.dependsOn, 'empty')}}:
     dependsOn: '${{parameters.dependsOn }}'
+
+  # Some of our tests take longer than the default 60 minutes to run on some
+  # OSes and configurations.
+  timeoutInMinutes: ${{ parameters.timeout }}
+
   pool:
     type: windows  # read more about custom job pool types at https://aka.ms/obpipelines/yaml/jobs
     isCustom: true

--- a/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
@@ -65,6 +65,12 @@ parameters: # parameters are shown up in ADO UI in a build queue time
   - NonOfficial
   - Official
 
+# The timeout, in minutes, for each test job.
+- name: testsTimeout
+  displayName: 'Tests timeout (in minutes)'
+  type: string
+  default: 90
+
 variables:
   - template: /eng/pipelines/libraries/variables.yml@self
   - name: packageFolderName
@@ -164,6 +170,7 @@ extends:
       - template: eng/pipelines/common/templates/jobs/run-tests-package-reference-job.yml@self
         parameters:
           packageFolderName: $(packageFolderName)
+          timeout: ${{ parameters.testsTimeout }}
           downloadPackageStep:
             download: current
             artifact: $(packageFolderName)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -573,7 +573,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// </summary>
         /// <param name="prefix">Add the prefix to the generate string.</param>
         /// <param name="withBracket">Database name must be pass with brackets by default.</param>
-        /// <returns>Unique name by considering the Sql Server naming rules.</returns>
+        /// <returns>Unique name by considering the Sql Server naming rules, never longer than 96 characters.</returns>
         public static string GetUniqueNameForSqlServer(string prefix, bool withBracket = true)
         {
             string extendedPrefix = string.Format(
@@ -583,10 +583,21 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 Environment.MachineName,
                 DateTime.Now.ToString("yyyy_MM_dd", CultureInfo.InvariantCulture));
             string name = GetUniqueName(extendedPrefix, withBracket);
-            if (name.Length > 128)
+
+            // Truncate to no more than 96 characters.
+            const int maxLen = 96;
+            if (name.Length > maxLen)
             {
-                throw new ArgumentOutOfRangeException("the name is too long - SQL Server names are limited to 128");
+                if (withBracket)
+                {
+                    name = name.Substring(0, maxLen - 1) + ']';
+                }
+                else
+                {
+                    name = name.Substring(0, maxLen);
+                }
             }
+
             return name;
         }
 


### PR DESCRIPTION
## Description

- Backported part of #3494 and #3591:
  - Added configurable test jobs timeout, defaulting to 90 minutes.
  - Reduced generated database names to 96 chars to try to fix macOS test failures.
