### PR TITLE
Add continue request usage

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6447,7 +6447,7 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.SQLVECTOR:
                     // Vector data is read as non-plp binary value.
                     // This is same as reading varbinary(8000).
-                    result = stateObj.TryReadByteArrayWithContinue(length, out b);
+                    result = stateObj.TryReadByteArrayWithContinue(length, isPlp: false, out b);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6377,25 +6377,10 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.SQLVARBINARY:
                 case TdsEnums.SQLIMAGE:
                     byte[] b = null;
-
-                    // If varbinary(max), we only read the first chunk here, expecting the caller to read the rest
-                    if (isPlp)
+                    result = stateObj.TryReadByteArrayWithContinue(length, isPlp, out b);
+                    if (result != TdsOperationStatus.Done)
                     {
-                        // If we are given -1 for length, then we read the entire value,
-                        // otherwise only the requested amount, usually first chunk.
-                        result = stateObj.TryReadPlpBytes(ref b, 0, length, out _);
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            return result;
-                        }
-                    }
-                    else
-                    {
-                        result = stateObj.TryReadByteArrayWithContinue(length, out b);
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            return result;
-                        }
+                        return result;
                     }
 
                     if (md.isEncrypted
@@ -6790,7 +6775,7 @@ namespace Microsoft.Data.SqlClient
                         // Note: Better not come here with plp data!!
                         Debug.Assert(length <= TdsEnums.MAXSIZE);
                         byte[] b = new byte[length];
-                        result = stateObj.TryReadByteArray(b, length);
+                        result = stateObj.TryReadByteArrayWithContinue(length, isPlp: false, out b);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -6541,24 +6541,10 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.SQLIMAGE:
                     byte[] b = null;
 
-                    // If varbinary(max), we only read the first chunk here, expecting the caller to read the rest
-                    if (isPlp)
+                    result = stateObj.TryReadByteArrayWithContinue(length, isPlp, out b);
+                    if (result != TdsOperationStatus.Done)
                     {
-                        // If we are given -1 for length, then we read the entire value,
-                        // otherwise only the requested amount, usually first chunk.
-                        result = stateObj.TryReadPlpBytes(ref b, 0, length, out _);
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            return result;
-                        }
-                    }
-                    else
-                    {
-                        result = stateObj.TryReadByteArrayWithContinue(length, out b);
-                        if (result != TdsOperationStatus.Done)
-                        {
-                            return result;
-                        }
+                        return result;
                     }
 
                     if (md.isEncrypted
@@ -6625,7 +6611,7 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.SQLVECTOR:
                     // Vector data is read as non-plp binary value.
                     // This is same as reading varbinary(8000).
-                    result = stateObj.TryReadByteArrayWithContinue(length, out b);
+                    result = stateObj.TryReadByteArrayWithContinue(length, isPlp: false, out b);
                     if (result != TdsOperationStatus.Done)
                     {
                         return result;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCachedBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCachedBuffer.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Data.SqlClient
         {
             buffer = null;
 
+            stateObj.RequestContinue(true);
             (bool canContinue, bool isStarting, bool isContinuing) = stateObj.GetSnapshotStatuses();
 
             List<byte[]> cachedBytes = null;
@@ -81,13 +82,17 @@ namespace Microsoft.Data.SqlClient
                     result = stateObj.TryReadPlpBytes(ref byteArr, 0, cb, out cb, canContinue, writeDataSizeToSnapshot: false, compatibilityMode: false);
                     if (result != TdsOperationStatus.Done)
                     {
-                        if (result == TdsOperationStatus.NeedMoreData && canContinue && cb == byteArr.Length && (isContinuing || !isStarting))
+                        if (result == TdsOperationStatus.NeedMoreData && canContinue && cb == byteArr.Length)
                         {
                             // succeeded in getting the data but failed to find the next plp length
                             returnAfterAdd = true;
                         }
                         else
                         {
+                            if (canContinue)
+                            {
+                                stateObj.SetSnapshotStorage(cachedBytes);
+                            }
                             return result;
                         }
                     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -1560,17 +1560,13 @@ namespace Microsoft.Data.SqlClient
             return TdsOperationStatus.Done;
         }
 
-        internal TdsOperationStatus TryReadByteArrayWithContinue(int length, out byte[] value)
-        {
-            return TryReadByteArrayWithContinue(length, false, out value);
-        }
         internal TdsOperationStatus TryReadByteArrayWithContinue(int length, bool isPlp, out byte[] value)
         {
             Debug.Assert(_syncOverAsync || !_asyncReadWithoutSnapshot, "This method is not safe to call when doing sync over async");
 
             byte[] buf = null;
             RequestContinue(true);
-            (bool canContinue, bool isStarting, bool isContinuing) = GetSnapshotStatuses();
+            (bool canContinue, bool _, bool isContinuing) = GetSnapshotStatuses();
 
             if (isPlp)
             {
@@ -1973,7 +1969,7 @@ namespace Microsoft.Data.SqlClient
 
             if (((_inBytesUsed + cBytes) > _inBytesRead) || (_inBytesPacket < cBytes))
             {
-                TdsOperationStatus result = TryReadByteArrayWithContinue(cBytes, out buf);
+                TdsOperationStatus result = TryReadByteArrayWithContinue(cBytes, isPlp: false, out buf);
                 if (result != TdsOperationStatus.Done)
                 {
                     value = null;


### PR DESCRIPTION
Builds on the stable base provided by https://github.com/dotnet/SqlClient/pull/3534 and adds the optional async-continue capability back in. It is optional, it is not on by default in this build. To use it you must set a switch: `AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseCompatibilityAsyncBehaviour", false);` this will use the new multiplexer and async-continue support already defaults to enabled.

This changes the way that continue is used from the original implementation. Originally continue was always available which proved to cause problems with routes through the code that did not expect to be able to fail causing lost context. This new approach runs as if continue is disabled until a function is called which explicitly requests continue mode to be enabled. The only functions that can do this are the ones that read multi-packet string or binary data. The request is cleared when the read completes so it cannot affect other reads from the same packet.

## Benchmark results:
All Reads were 10 Mib of data.
### BinaryRead
| Method      | UseContinue | Mean        | Error     | StdDev    | Gen0      | Gen1      | Gen2      | Allocated |
|------------ |------------ |------------:|----------:|----------:|----------:|----------:|----------:|----------:|
| **Async**       | **False**       | **5,840.26 ms** | **94.748 ms** | **88.627 ms** | **2000.0000** | **1000.0000** | **1000.0000** |  **40.81 MB** |
| StreamAsync | False       |    46.91 ms |  0.925 ms |  1.692 ms | 3083.3333 | 1833.3333 | 1833.3333 |   51.8 MB |
| Sync        | False       |    26.87 ms |  0.534 ms |  1.042 ms | 1562.5000 |  906.2500 |  906.2500 |  30.73 MB |
| **Async**       | **True**        |    **50.78 ms** |  **1.003 ms** |  **1.561 ms** | **2181.8182** | **2090.9091** |  **909.0909** |  **40.82 MB** |
| StreamAsync | True        |    58.23 ms |  1.114 ms |  2.469 ms | 2888.8889 | 1666.6667 | 1666.6667 |   51.8 MB |
| Sync        | True        |    26.50 ms |  0.509 ms |  0.522 ms | 1562.5000 |  906.2500 |  906.2500 |  30.73 MB |

### StringRead

| Method | UseContinue | Mean        | Error      | StdDev     | Gen0      | Gen1      | Gen2     | Allocated |
|------- |------------ |------------:|-----------:|-----------:|----------:|----------:|---------:|----------:|
| **Async**  | **False**       | **5,832.31 ms** | **114.512 ms** | **191.324 ms** | **1000.0000** |         **-** |        **-** |   **50.8 MB** |
| Sync   | False       |    34.32 ms |   0.686 ms |   1.026 ms | 1000.0000 |  400.0000 | 400.0000 |  40.72 MB |
| **Async**  | **True**        |    **66.26 ms** |   **0.960 ms** |   **1.895 ms** | **1625.0000** | **1500.0000** | **375.0000** |  **50.81 MB** |
| Sync   | True        |    35.14 ms |   0.694 ms |   1.215 ms | 1000.0000 |  400.0000 | 400.0000 |  40.72 MB |

### XmlRead
 Method | UseContinue | Mean          | Error        | StdDev       | Gen0          | Gen1          | Gen2         | Allocated    |
------- |------------ |--------------:|-------------:|-------------:|--------------:|--------------:|-------------:|-------------:|
 **Sync**   | **False**       |      **92.20 ms** |     **1.334 ms** |     **1.183 ms** |     **3166.6667** |     **3000.0000** |    **1000.0000** |     **38.57 MB** |
 Async  | False       | 182,897.65 ms | 3,447.733 ms | 5,053.643 ms | 31360000.0000 | 31012000.0000 | 9640000.0000 | 360347.15 MB |
 **Sync**   | **True**        |      **89.87 ms** |     **0.803 ms** |     **0.712 ms** |     **3166.6667** |     **3000.0000** |    **1000.0000** |     **38.57 MB** |
 Async  | True        |     128.25 ms |     2.192 ms |     3.213 ms |     4800.0000 |     4600.0000 |    1400.0000 |     56.39 MB |

Here are the benchmark files that I used to get these numbers. You'll need connection strings and to generate a random 10Mib xml files from somewhere on the web. [Benchmarks.zip](https://github.com/user-attachments/files/22232851/Benchmarks.zip)
The async xml numbers are pretty unbelievable. If you replicate or improve the benches it would be good to get perf corroboration.

@ErikEJ this will be the build you'll want to test and then possible make available to people, as discussed on the previous PR.
@edwardneal if you have the resources could you run your fantastic test suite against this version and see if you can identify any new bugs?
@dotnet/sqlclientdevteam can you run CI please.
