### PR TITLE
[7.0] Fix package dependency versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -158,23 +158,13 @@ dotnet_code_quality.CA2100.excluded_type_names_with_derived_types = Microsoft.Da
 dotnet_diagnostic.xUnit1031.severity=none
 dotnet_diagnostic.xUnit1030.severity=none
 
-[*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
-indent_size = 2
-
-# Xml build files
-[*.builds]
-indent_size = 2
-
 # Xml files
-[*.{xml,stylecop,resx,ruleset}]
-indent_size = 2
-
-# Xml config files
-[*.{props,targets,config,nuspec}]
+[*.{xml,csproj,stylecop,resx,ruleset,props,targets,config,nuspec}]
 indent_size = 2
 
 # Shell scripts
 [*.sh]
 end_of_line = lf
+
 [*.{cmd, bat}]
 end_of_line = crlf

--- a/eng/pipelines/common/templates/steps/publish-symbols-step.yml
+++ b/eng/pipelines/common/templates/steps/publish-symbols-step.yml
@@ -12,7 +12,6 @@ parameters:
 
   - name: publishSymbols
     type: string
-    default: '$(PublishSymbols)'
 
   - name: symbolsVersion
     type: string

--- a/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
@@ -38,7 +38,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: 'debug'
   displayName: 'Enable debug output'
   type: boolean
-  default: true
+  default: false
 
 - name: publishSymbols
   displayName: 'Publish symbols'

--- a/eng/pipelines/steps/compound-nuget-pack-step.yml
+++ b/eng/pipelines/steps/compound-nuget-pack-step.yml
@@ -44,7 +44,7 @@ steps:
                     -SymbolPackageFormat snupkg
                     -Version ${{ parameters.packageVersion }}
                     -OutputDirectory ${{ parameters.outputDirectory }}
-                    -Properties "COMMITID=$(Build.SourceVersion);Configuration=${{ parameters.buildConfiguration }};ReferenceType=${{ parameters.referenceType }}"
+                    -Properties "COMMITID=$(Build.SourceVersion);Configuration=${{ parameters.buildConfiguration }};ReferenceType=${{ parameters.referenceType }};NoWarn=NU5128"
     - ${{ else }}:
           - task: NuGetCommand@2
             displayName: 'Generate NuGet Package'
@@ -55,5 +55,4 @@ steps:
                     ${{ parameters.nuspecPath }}
                     -Version ${{ parameters.packageVersion }}
                     -OutputDirectory ${{ parameters.outputDirectory }}
-                    -Properties "COMMITID=$(Build.SourceVersion);Configuration=${{ parameters.buildConfiguration }};ReferenceType=${{ parameters.referenceType }}"
-
+                    -Properties "COMMITID=$(Build.SourceVersion);Configuration=${{ parameters.buildConfiguration }};ReferenceType=${{ parameters.referenceType }};NoWarn=NU5128"

--- a/eng/pipelines/steps/compound-nuget-pack-step.yml
+++ b/eng/pipelines/steps/compound-nuget-pack-step.yml
@@ -44,7 +44,7 @@ steps:
                     -SymbolPackageFormat snupkg
                     -Version ${{ parameters.packageVersion }}
                     -OutputDirectory ${{ parameters.outputDirectory }}
-                    -Properties "COMMITID=$(Build.SourceVersion);Configuration=${{ parameters.buildConfiguration }};ReferenceType=${{ parameters.referenceType }};NoWarn=NU5128"
+                    -Properties "COMMITID=$(Build.SourceVersion);Configuration=${{ parameters.buildConfiguration }};ReferenceType=${{ parameters.referenceType }}"
     - ${{ else }}:
           - task: NuGetCommand@2
             displayName: 'Generate NuGet Package'
@@ -55,4 +55,4 @@ steps:
                     ${{ parameters.nuspecPath }}
                     -Version ${{ parameters.packageVersion }}
                     -OutputDirectory ${{ parameters.outputDirectory }}
-                    -Properties "COMMITID=$(Build.SourceVersion);Configuration=${{ parameters.buildConfiguration }};ReferenceType=${{ parameters.referenceType }};NoWarn=NU5128"
+                    -Properties "COMMITID=$(Build.SourceVersion);Configuration=${{ parameters.buildConfiguration }};ReferenceType=${{ parameters.referenceType }}"

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,71 +1,114 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    </PropertyGroup>
-    <!-- NetFx project dependencies -->
-    <ItemGroup>
-        <PackageVersion Include="Microsoft.Data.SqlClient.SNI" Version="6.0.2" />
-        <PackageVersion Include="System.Buffers" Version="4.5.1" />
-        <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-        <PackageVersion Include="System.Memory" Version="4.5.5" />
-        <PackageVersion Include="System.Data.Common" Version="4.3.0" />
-        <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
-        <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
-    </ItemGroup>
-    <!-- NetFx and NetCore project dependencies -->
-    <ItemGroup>
-        <PackageVersion Include="Azure.Identity" Version="1.14.2" />
-        <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.7.1" />
-        <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.7.1" />
-        <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    </ItemGroup>
-    <!-- NetCore project dependencies -->
-    <ItemGroup>
-        <PackageVersion Include="Microsoft.Data.SqlClient.SNI.runtime" Version="6.0.2" />
-        <PackageVersion Include="Microsoft.SqlServer.Server" Version="1.0.0" />
-    </ItemGroup>
-    <!-- AKV Provider project dependencies -->
-    <ItemGroup>
-        <PackageVersion Include="Azure.Core" Version="[1.47.1,2.0.0)" />
-        <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="[4.7.0,5.0.0)" />
-    </ItemGroup>
-    <!-- Test Project Dependencies -->
-    <ItemGroup>
-        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-        <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-        <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25164.6" />
-        <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25164.6" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="172.76.0" />
-        <PackageVersion Include="Microsoft.SqlServer.Types" Version="160.1000.6" />
-        <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
-        <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
-        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageVersion Include="System.Data.Odbc" Version="8.0.1" />
-        <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
-        <PackageVersion Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
-        <PackageVersion Include="System.Text.Encoding.CodePages" Version="6.0.0" />
-        <PackageVersion Include="xunit" Version="2.9.2" />
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-        <PackageVersion Include="xunit.runner.console" Version="2.9.2" />
-    </ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  
+  <!-- ===================================================================== -->
+  <!-- Shared Dependencies -->
 
-    <!-- Target framework specific dependencies -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="9.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.5" />
-        <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.5" />
-        <PackageVersion Include="System.Text.Json" Version="9.0.5" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
-        <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
-        <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
-        <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-    </ItemGroup>
+  <!-- Published -->
+  <ItemGroup>
+    <!-- MDS and AKV -->
+    <PackageVersion Include="Azure.Core" Version="1.47.1" />
+  </ItemGroup>
+
+  <!-- Published - Target Framework Specific Dependencies -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <!-- MDS and AKV -->
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
+    <!-- MDS and AKV -->
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+  </ItemGroup>
+
+  <!-- Internal -->
+  <ItemGroup>
+    <!-- MDS and AKV Tests -->
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
+    <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="10.0.0-beta.25164.6" />
+    <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="10.0.0-beta.25164.6" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="172.76.0" />
+    <PackageVersion Include="Microsoft.SqlServer.Types" Version="160.1000.6" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="System.Data.Odbc" Version="8.0.1" />
+    <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageVersion Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.runner.console" Version="2.9.2" />
+  </ItemGroup>
+
+  <!-- Internal - Target Framework Specific Dependencies -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <!-- MDS and AKV Tests -->
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
+    <!-- MDS and AKV Tests -->
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+  </ItemGroup>
+
+  <!-- ===================================================================== -->
+  <!-- MDS Dependencies -->
+
+  <!-- Common Dependencies (.NET and .NET Framework) -->
+  <ItemGroup>
+    <PackageVersion Include="Azure.Identity" Version="1.14.2" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.7.1" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.7.1" />
+    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+  </ItemGroup>
+
+  <!-- Common Target Framework Specific Dependencies -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.5" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.5" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
+    <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+  <!-- .NET Dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Data.SqlClient.SNI.runtime" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.SqlServer.Server" Version="1.0.0" />
+  </ItemGroup>
+
+  <!-- .NET Framework Dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Data.SqlClient.SNI" Version="6.0.2" />
+    <PackageVersion Include="System.Buffers" Version="4.5.1" />
+    <PackageVersion Include="System.Data.Common" Version="4.3.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <PackageVersion Include="System.ValueTuple" Version="4.6.1" />
+  </ItemGroup>
+
+  <!-- =================================================================== -->
+  <!-- AKV Dependencies -->
+
+  <ItemGroup>
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
+  </ItemGroup>
+
+  <!-- =================================================================== -->
+  <!-- MSS Dependencies -->
+
+  <!-- None -->
+
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -69,14 +69,12 @@
   <!-- Common Target Framework Specific Dependencies -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="9.0.5" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.5" />
     <PackageVersion Include="System.Text.Json" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
     <PackageVersion Include="Microsoft.Bcl.Cryptography" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />

--- a/tools/specs/Microsoft.Data.SqlClient.nuspec
+++ b/tools/specs/Microsoft.Data.SqlClient.nuspec
@@ -39,6 +39,7 @@
         <dependency id="System.Buffers" version="4.5.1" />
         <dependency id="System.Data.Common" version="4.3.0" />
         <dependency id="System.Diagnostics.DiagnosticSource" version="8.0.1" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
         <dependency id="System.Security.Cryptography.Pkcs" version="8.0.1" />
         <dependency id="System.Text.Encodings.Web" version="8.0.0" />
         <dependency id="System.Text.Json" version="8.0.5" />
@@ -53,33 +54,36 @@
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="7.7.1" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0" />
         <dependency id="System.Configuration.ConfigurationManager" version="8.0.1" exclude="Compile" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
         <dependency id="System.Security.Cryptography.Pkcs" version="8.0.1" />
         <dependency id="System.Text.Json" version="8.0.5" />
       </group>
       <group targetFramework="net9.0">
         <dependency id="Azure.Core" version="1.47.1" />
         <dependency id="Azure.Identity" version="1.14.2" />
-        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.4" />
+        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.5" />
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.2" exclude="Compile" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.4" exclude="Compile" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.5" exclude="Compile" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="7.7.1" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="7.7.1" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0" />
-        <dependency id="System.Configuration.ConfigurationManager" version="9.0.4" exclude="Compile" />
-        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.4" />
+        <dependency id="System.Configuration.ConfigurationManager" version="9.0.5" exclude="Compile" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.5" />
         <dependency id="System.Text.Json" version="9.0.5" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="Azure.Core" version="1.47.1" />
         <dependency id="Azure.Identity" version="1.14.2" />
-        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.4" />
+        <dependency id="Microsoft.Bcl.Cryptography" version="9.0.5" />
         <dependency id="Microsoft.Data.SqlClient.SNI.runtime" version="6.0.2" exclude="Compile" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.4" exclude="Compile" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.5" exclude="Compile" />
         <dependency id="Microsoft.IdentityModel.JsonWebTokens" version="7.7.1" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="7.7.1" />
         <dependency id="Microsoft.SqlServer.Server" version="1.0.0" />
-        <dependency id="System.Configuration.ConfigurationManager" version="9.0.4" exclude="Compile" />
-        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.4" />
+        <dependency id="System.Configuration.ConfigurationManager" version="9.0.5" exclude="Compile" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" />
+        <dependency id="System.Security.Cryptography.Pkcs" version="9.0.5" />
         <dependency id="System.Text.Json" version="9.0.5" />
       </group>
     </dependencies>

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -31,13 +31,13 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Data.SqlClient" version="(6,7.0]" />
+        <dependency id="Microsoft.Data.SqlClient" version="(6.2,7.1)" />
         <dependency id="Azure.Core" version="1.47.1" />
         <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net9.0">
-        <dependency id="Microsoft.Data.SqlClient" version="(6,7.0]" />
+        <dependency id="Microsoft.Data.SqlClient" version="(6.2,7.1)" />
         <dependency id="Azure.Core" version="1.47.1" />
         <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.5" />

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -25,22 +25,22 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
     <tags>sqlclient microsoft.data.sqlclient azurekeyvaultprovider akvprovider alwaysencrypted</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Data.SqlClient" version="[6.1.1,7.0.0)" />
-        <dependency id="Azure.Core" version="[1.47.1,2.0.0)" />
-        <dependency id="Azure.Security.KeyVault.Keys" version="[4.7.0,5.0.0)" />
+        <dependency id="Microsoft.Data.SqlClient" version="7.0.*" />
+        <dependency id="Azure.Core" version="1.47.1" />
+        <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Data.SqlClient" version="[6.1.1,7.0.0)" />
-        <dependency id="Azure.Core" version="[1.47.1,2.0.0)" />
-        <dependency id="Azure.Security.KeyVault.Keys" version="[4.7.0,5.0.0)" />
+        <dependency id="Microsoft.Data.SqlClient" version="7.0.*" />
+        <dependency id="Azure.Core" version="1.47.1" />
+        <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net9.0">
-        <dependency id="Microsoft.Data.SqlClient" version="[6.1.1,7.0.0)" />
-        <dependency id="Azure.Core" version="[1.47.1,2.0.0)" />
-        <dependency id="Azure.Security.KeyVault.Keys" version="[4.7.0,5.0.0)" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.4" />
+        <dependency id="Microsoft.Data.SqlClient" version="7.0.*" />
+        <dependency id="Azure.Core" version="1.47.1" />
+        <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.5" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -69,14 +69,12 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
 
     <file src="..\..\..\artifacts\$ReferenceType$\bin\AnyOS\$Configuration$.AnyCPU\AzureKeyVaultProvider\net8.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.xml" target="lib\net8.0\" exclude="" />
 
-    <file src="..\..\..\artifacts\$ReferenceType$\bin\AnyOS\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.dll" target="lib\net9.0\" exclude="" />
-    <file src="..\..\..\artifacts\$ReferenceType$\bin\Windows_NT\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.dll" target="runtimes\win\lib\net9.0\" exclude="" />
-    <file src="..\..\..\artifacts\$ReferenceType$\bin\Unix\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.dll" target="runtimes\unix\lib\net9.0\" exclude="" />
+    <!--
+      GOTCHA: Even though we target .NET 9.0 and build DLLs for it, we do not
+      publish them!  AKV doesn't actually use any .NET 9.0 specific features,
+      so we don't need to publish DLLs.  Apps targeting .NET 9.0 will happily
+      use the AKV .NET 8.0 DLLs.
+    -->
 
-    <file src="..\..\..\artifacts\$ReferenceType$\bin\AnyOS\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.pdb" target="lib\net9.0\" exclude="" />
-    <file src="..\..\..\artifacts\$ReferenceType$\bin\Windows_NT\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.pdb" target="runtimes\win\lib\net9.0\" exclude="" />
-    <file src="..\..\..\artifacts\$ReferenceType$\bin\Unix\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.pdb" target="runtimes\unix\lib\net9.0\" exclude="" />
-
-    <file src="..\..\..\artifacts\$ReferenceType$\bin\AnyOS\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.xml" target="lib\net9.0\" exclude="" />
   </files>
 </package>

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -25,7 +25,7 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
     <tags>sqlclient microsoft.data.sqlclient azurekeyvaultprovider akvprovider alwaysencrypted</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Data.SqlClient" version="(6.2,7.0.0]" />
+        <dependency id="Microsoft.Data.SqlClient" version="(6.2,7.1)" />
         <dependency id="Azure.Core" version="1.47.1" />
         <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -36,12 +36,6 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
         <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
-      <group targetFramework="net9.0">
-        <dependency id="Microsoft.Data.SqlClient" version="(6.2,7.1)" />
-        <dependency id="Azure.Core" version="1.47.1" />
-        <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
-        <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.5" />
-      </group>
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="mscorlib" targetFramework="net462" />

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -25,19 +25,19 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
     <tags>sqlclient microsoft.data.sqlclient azurekeyvaultprovider akvprovider alwaysencrypted</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Data.SqlClient" version="7.0.*" />
+        <dependency id="Microsoft.Data.SqlClient" version="(6.2,7.0.0]" />
         <dependency id="Azure.Core" version="1.47.1" />
         <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Data.SqlClient" version="7.0.*" />
+        <dependency id="Microsoft.Data.SqlClient" version="(6,7.0]" />
         <dependency id="Azure.Core" version="1.47.1" />
         <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net9.0">
-        <dependency id="Microsoft.Data.SqlClient" version="7.0.*" />
+        <dependency id="Microsoft.Data.SqlClient" version="(6,7.0]" />
         <dependency id="Azure.Core" version="1.47.1" />
         <dependency id="Azure.Security.KeyVault.Keys" version="4.7.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.5" />
@@ -68,5 +68,15 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
     <file src="..\..\..\artifacts\$ReferenceType$\bin\Unix\$Configuration$.AnyCPU\AzureKeyVaultProvider\net8.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.pdb" target="runtimes\unix\lib\net8.0\" exclude="" />
 
     <file src="..\..\..\artifacts\$ReferenceType$\bin\AnyOS\$Configuration$.AnyCPU\AzureKeyVaultProvider\net8.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.xml" target="lib\net8.0\" exclude="" />
-    </files>
+
+    <file src="..\..\..\artifacts\$ReferenceType$\bin\AnyOS\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.dll" target="lib\net9.0\" exclude="" />
+    <file src="..\..\..\artifacts\$ReferenceType$\bin\Windows_NT\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.dll" target="runtimes\win\lib\net9.0\" exclude="" />
+    <file src="..\..\..\artifacts\$ReferenceType$\bin\Unix\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.dll" target="runtimes\unix\lib\net9.0\" exclude="" />
+
+    <file src="..\..\..\artifacts\$ReferenceType$\bin\AnyOS\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.pdb" target="lib\net9.0\" exclude="" />
+    <file src="..\..\..\artifacts\$ReferenceType$\bin\Windows_NT\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.pdb" target="runtimes\win\lib\net9.0\" exclude="" />
+    <file src="..\..\..\artifacts\$ReferenceType$\bin\Unix\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.pdb" target="runtimes\unix\lib\net9.0\" exclude="" />
+
+    <file src="..\..\..\artifacts\$ReferenceType$\bin\AnyOS\$Configuration$.AnyCPU\AzureKeyVaultProvider\net9.0\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.xml" target="lib\net9.0\" exclude="" />
+  </files>
 </package>

--- a/tools/targets/add-ons/GenerateAKVProviderNugetPackage.targets
+++ b/tools/targets/add-ons/GenerateAKVProviderNugetPackage.targets
@@ -7,6 +7,6 @@
     <Message Text="Setting NugetPackageVersion to $(NugetPackageVersion)" />
     <Exec Command="powershell.exe -NonInteractive -executionpolicy Unrestricted ^
       -command &quot;&amp;$(ToolsDir)scripts\downloadLatestNuget.ps1 -nugetDestPath '$(NuGetRoot)'&quot;" />
-    <Exec Command="$(NuGetCmd) pack $(ToolsDir)specs\add-ons\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec -Version $(NugetPackageVersion) -Symbols -SymbolPackageFormat snupkg -OutputDirectory $(PackagesDir) -properties Configuration=$(Configuration);ReferenceType=$(ReferenceType)" />
+    <Exec Command="$(NuGetCmd) pack $(ToolsDir)specs\add-ons\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec -Version $(NugetPackageVersion) -Symbols -SymbolPackageFormat snupkg -OutputDirectory $(PackagesDir) -properties Configuration=$(Configuration);ReferenceType=$(ReferenceType);NoWarn=NU5128" />
   </Target>
 </Project>

--- a/tools/targets/add-ons/GenerateAKVProviderNugetPackage.targets
+++ b/tools/targets/add-ons/GenerateAKVProviderNugetPackage.targets
@@ -7,6 +7,6 @@
     <Message Text="Setting NugetPackageVersion to $(NugetPackageVersion)" />
     <Exec Command="powershell.exe -NonInteractive -executionpolicy Unrestricted ^
       -command &quot;&amp;$(ToolsDir)scripts\downloadLatestNuget.ps1 -nugetDestPath '$(NuGetRoot)'&quot;" />
-    <Exec Command="$(NuGetCmd) pack $(ToolsDir)specs\add-ons\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec -Version $(NugetPackageVersion) -Symbols -SymbolPackageFormat snupkg -OutputDirectory $(PackagesDir) -properties Configuration=$(Configuration);ReferenceType=$(ReferenceType);NoWarn=NU5128" />
+    <Exec Command="$(NuGetCmd) pack $(ToolsDir)specs\add-ons\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec -Version $(NugetPackageVersion) -Symbols -SymbolPackageFormat snupkg -OutputDirectory $(PackagesDir) -properties Configuration=$(Configuration);ReferenceType=$(ReferenceType)" />
   </Target>
 </Project>

--- a/tools/targets/add-ons/GenerateAKVProviderNugetPackage.targets
+++ b/tools/targets/add-ons/GenerateAKVProviderNugetPackage.targets
@@ -7,6 +7,6 @@
     <Message Text="Setting NugetPackageVersion to $(NugetPackageVersion)" />
     <Exec Command="powershell.exe -NonInteractive -executionpolicy Unrestricted ^
       -command &quot;&amp;$(ToolsDir)scripts\downloadLatestNuget.ps1 -nugetDestPath '$(NuGetRoot)'&quot;" />
-    <Exec Command="$(NuGetCmd) pack $(ToolsDir)specs\add-ons\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec -Version $(NugetPackageVersion) -Symbols -SymbolPackageFormat snupkg -OutputDirectory $(PackagesDir) -properties Configuration=$(Configuration);" />
+    <Exec Command="$(NuGetCmd) pack $(ToolsDir)specs\add-ons\Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec -Version $(NugetPackageVersion) -Symbols -SymbolPackageFormat snupkg -OutputDirectory $(PackagesDir) -properties Configuration=$(Configuration);ReferenceType=$(ReferenceType)" />
   </Target>
 </Project>


### PR DESCRIPTION
## Description

Once again, our actual and advertised MDS and AKV package dependencies have diverged.  This cleans them up to be current, accurate, and consistent.  I re-arranged the `Directory.Packages.props` file to indicate where/why packages are used.

I also managed to find a dependency version notation for AKV's .nuspec that allows it to be compatible with all MDS 7.0.x versions, including preview releases.

The `GenerateAKVProviderNugetPackage` wasn't working, so I fixed that as well.

I made some official pipeline tweaks as well after deleting some unused/obsolete pipeline variables.

## Testing

Tested restoring MDS and AKV packages in a test project using their pre-release versioning to prove that NuGet is happy.
