### PR TITLE
Fix | Improve error handling when creating performance counters

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientMetrics.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientMetrics.cs
@@ -493,25 +493,25 @@ namespace Microsoft.Data.SqlClient.Diagnostics
 
         private PerformanceCounter? CreatePerformanceCounter(string counterName, PerformanceCounterType counterType)
         {
-            PerformanceCounter? instance = null;
-
             _instanceName ??= GetInstanceName();
             try
             {
-                instance = new PerformanceCounter();
+                PerformanceCounter instance = new();
                 instance.CategoryName = PerformanceCounterCategoryName;
                 instance.CounterName = counterName;
                 instance.InstanceName = _instanceName;
                 instance.InstanceLifetime = PerformanceCounterInstanceLifetime.Process;
                 instance.ReadOnly = false;
                 instance.RawValue = 0;  // make sure we start out at zero
+
+                return instance;
             }
             catch (InvalidOperationException e)
             {
                 ADP.TraceExceptionWithoutRethrow(e);
-            }
 
-            return instance;
+                return null;
+            }
         }
 
         // SxS: this method uses GetCurrentProcessId to construct the instance name.


### PR DESCRIPTION
## Description

This may need to be backported to 6.1.

#3251 refactored DbConnectionPoolCounters (a netfx-specific class) into a platform-independent SqlClientMetrics class. While the performance counter creation logic remained the same, I introduced a bug in the exception handling.

https://github.com/dotnet/SqlClient/blob/c12134ad0cc9fb9051fe35e416ec81c28182f254/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionPoolCounters.netfx.cs#L104-L122

In the original logic, if an InvalidOperationException was thrown then the exception handler ran before assigning a value to the class' performance counter. In the refactored logic, the counter was returned anyway.

The net effect of this is that if a performance counter failed to initialise (such as if the ".NET Data Provider for SqlServer" provider wasn't present) then it'd be returned in an uninitialised state. The next attempt to increment the counter would try to initialise it again, failing again.

## Issues

Fixes #3595.

## Testing

I don't think there's a way to add a non-intrusive automatic test, but a manual test works properly.

To break this, I ran:
`unlodctr ".NET Data Provider for SqlServer"`
main currently fails with an InvalidOperationException, and it's resolved by running:
`lodctr "C:\Windows\INF\.NET Data Provider for SqlServer\_dataperfcounters_shared12_neutral.ini"`

After this fix, the performance counters now silently fail (and tracing records the error while initializing.)

