### PR TITLE
Tests | Active Issues (Part 3)

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/LocalDBTest/LocalDBTest.cs
@@ -92,25 +92,22 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         #region NamedPipeTests
 
-        [Fact]
-        [ActiveIssue("20245")] //pending pipeline configuration
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
         public static void SqlLocalDbNamedPipeConnectionTest()
         {
             ConnectionTest(s_localDbNamedPipeConnectionString);
         }
 
-        [Fact]
-        [ActiveIssue("20245")] //pending pipeline configuration
-        public static void LocalDBNamedPipeEncryptionNotSupportedTest()
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
+        public static void LocalDbNamedPipeEncryptionNotSupportedTest()
         {
             // Encryption is not supported by SQL Local DB.
             // But connection should succeed as encryption is disabled by driver.
             ConnectionWithEncryptionTest(s_localDbNamedPipeConnectionString);
         }
 
-        [Fact]
-        [ActiveIssue("20245")] //pending pipeline configuration
-        public static void LocalDBNamepipeMarsTest()
+        [ConditionalFact(nameof(IsLocalDBEnvironmentSet))]
+        public static void LocalDbNamedPipeMarsTest()
         {
             ConnectionWithMarsTest(s_localDbNamedPipeConnectionString);
         }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/TvpTest.cs
@@ -53,34 +53,42 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
-        [ActiveIssue("5531")]
-        public void TestPacketNumberWraparound()
+        public async Task TestPacketNumberWraparound()
         {
-            // this test uses a specifically crafted sql record enumerator and data to put the TdsParserStateObject.WritePacket(byte,bool)
-            // into a state where it can't differentiate between a packet in the middle of a large packet-set after a byte counter wraparound
-            // and the first packet of the connection and in doing so trips over a check for packet length from the input which has been 
-            // forced to tell it that there is no output buffer space left, this causes an uncancellable infinite loop
+            // This test uses a specifically crafted SQL record enumerator and data to put the
+            // TdsParserStateObject.WritePacket(byte,bool) into a state where it can't
+            // differentiate between a packet in the middle of a large packet-set after a byte
+            // counter wraparound and the first packet of the connection and in doing so trips over
+            // a check for packet length from the input which has been forced to tell it that there
+            // is no output buffer space left, this causes an uncancellable infinite loop.
+            //
+            // If the enumerator is completely read to the end then the bug is no longer present
+            // and the packet creation task returns, if the timeout occurs it is probable (but not
+            // absolute) that the write operation is stuck.
 
-            // if the enumerator is completely read to the end then the bug is no longer present and the packet creation task returns,
-            // if the timeout occurs it is probable (but not absolute) that the write is stuck
-
+            // Arrange
             var enumerator = new WraparoundRowEnumerator(1000000);
+            using var cancellationTokenSource = new CancellationTokenSource();
 
+            // Act
             Stopwatch stopwatch = new();
             stopwatch.Start();
-            int returned = Task.WaitAny(
-                Task.Factory.StartNew(
-                    () => RunPacketNumberWraparound(enumerator),
-                    TaskCreationOptions.DenyChildAttach | TaskCreationOptions.LongRunning
-                ),
-                Task.Delay(TimeSpan.FromSeconds(60))
-            );
+
+            Task actionTask = Task.Factory.StartNew(
+                async () => await RunPacketNumberWraparound(enumerator, cancellationTokenSource.Token),
+                TaskCreationOptions.DenyChildAttach | TaskCreationOptions.LongRunning);
+            Task timeoutTask = Task.Delay(TimeSpan.FromSeconds(60), cancellationTokenSource.Token);
+            await Task.WhenAny(actionTask, timeoutTask);
+
             stopwatch.Stop();
-            if (enumerator.MaxCount != enumerator.Count)
-            {
-                Console.WriteLine($"enumerator.Count={enumerator.Count}, enumerator.MaxCount={enumerator.MaxCount}, elapsed={stopwatch.Elapsed.TotalSeconds}");
-            }
-            Assert.True(enumerator.MaxCount == enumerator.Count);
+            cancellationTokenSource.Cancel();
+
+            // Assert
+            Assert.True(
+                enumerator.MaxCount == enumerator.Count,
+                $"enumerator.Count={enumerator.Count}, " +
+                $"enumerator.MaxCount={enumerator.MaxCount}, " +
+                $"elapsed={stopwatch.Elapsed}");
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
@@ -688,23 +696,27 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        private static async Task RunPacketNumberWraparound(WraparoundRowEnumerator enumerator)
+        private static async Task RunPacketNumberWraparound(
+            WraparoundRowEnumerator enumerator,
+            CancellationToken cancellationToken)
         {
             using var connection = new SqlConnection(DataTestUtility.TCPConnectionString);
-            using var cmd = new SqlCommand("unimportant")
-            {
-                CommandType = CommandType.StoredProcedure,
-                Connection = connection,
-            };
-            await cmd.Connection.OpenAsync();
-            cmd.Parameters.Add(new SqlParameter("@rows", SqlDbType.Structured)
+            await connection.OpenAsync(cancellationToken);
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandType = CommandType.StoredProcedure;
+            cmd.CommandText = "unimportant";
+
+            var parameter = new SqlParameter("@rows", SqlDbType.Structured)
             {
                 TypeName = "unimportant",
-                Value = enumerator,
-            });
+                Value = enumerator
+            };
+            cmd.Parameters.Add(parameter);
+
             try
             {
-                await cmd.ExecuteNonQueryAsync();
+                await cmd.ExecuteNonQueryAsync(cancellationToken);
             }
             catch (Exception)
             {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
@@ -175,11 +175,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     yield return new object[] { cnn[0], item[0] };
         }
 
-        public static IEnumerable<object[]> GetConnectionAndRetryStrategyLockedTable(int numberOfRetries)
-        {
-            return GetConnectionAndRetryStrategy(numberOfRetries, TimeSpan.FromMilliseconds(100), FilterSqlStatements.None, null);
-        }
-
         public static IEnumerable<int> GetDefaultTransientErrorCodes(params int[] additionalCodes)
         {
             var transientErrorCodes = new HashSet<int>(s_defaultTransientErrors);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
@@ -175,11 +175,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     yield return new object[] { cnn[0], item[0] };
         }
 
-        public static IEnumerable<object[]> GetConnectionAndRetryStrategyInvalidCatalog(int numberOfRetries)
-        {
-            return GetConnectionAndRetryStrategy(numberOfRetries, TimeSpan.FromSeconds(1), FilterSqlStatements.None, null, 250, true);
-        }
-
         public static IEnumerable<object[]> GetConnectionAndRetryStrategyInvalidCommand(int numberOfRetries)
         {
             return GetConnectionAndRetryStrategy(numberOfRetries, TimeSpan.FromMilliseconds(100), FilterSqlStatements.None, null);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
@@ -175,12 +175,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     yield return new object[] { cnn[0], item[0] };
         }
 
-        //40613:    Database '%.*ls' on server '%.*ls' is not currently available. Please retry the connection later. If the problem persists, contact customer support, and provide them the session tracing ID of '%.*ls'.
-        public static IEnumerable<object[]> GetConnectionAndRetryStrategyLongRunner(int numberOfRetries)
-        {
-            return GetConnectionAndRetryStrategy(numberOfRetries, TimeSpan.FromSeconds(120), FilterSqlStatements.None, null, 20 * 1000);
-        }
-
         public static IEnumerable<object[]> GetConnectionAndRetryStrategyDropDB(int numberOfRetries)
         {
             List<int> faults = s_defaultTransientErrors.ToList();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             int numberOfRetries,
             TimeSpan maxInterval,
             TimeSpan? deltaTime = null,
-            IEnumerable<int> transientErrors = null,
+            IEnumerable<int> transientErrorCodes = null,
             FilterSqlStatements unauthorizedStatements = FilterSqlStatements.None)
         {
             var option = new SqlRetryLogicOption
@@ -91,7 +91,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 NumberOfTries = numberOfRetries,
                 DeltaTime = deltaTime ?? TimeSpan.FromMilliseconds(10),
                 MaxTimeInterval = maxInterval,
-                TransientErrors = transientErrors ?? s_defaultTransientErrors,
+                TransientErrors = transientErrorCodes ?? s_defaultTransientErrors,
                 AuthorizedSqlCondition = RetryPreConditon(unauthorizedStatements)
             };
 
@@ -173,11 +173,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             foreach (var item in GetRetryStrategies(option))
                 foreach (var cnn in GetConnectionStrings())
                     yield return new object[] { cnn[0], item[0] };
-        }
-
-        public static IEnumerable<object[]> GetConnectionAndRetryStrategyFilterDMLStatements(int numberOfRetries)
-        {
-            return GetConnectionAndRetryStrategy(numberOfRetries, TimeSpan.FromMilliseconds(100), FilterSqlStatements.DML, new int[] { 207, 102, 2812 });
         }
 
         //40613:    Database '%.*ls' on server '%.*ls' is not currently available. Please retry the connection later. If the problem persists, contact customer support, and provide them the session tracing ID of '%.*ls'.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
@@ -208,12 +208,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return GetConnectionAndRetryStrategy(numberOfRetries, TimeSpan.FromMilliseconds(100), FilterSqlStatements.None, null);
         }
 
-        public static IEnumerable<object[]> GetNoneRetriableCondition()
-        {
-            yield return new object[] { DataTestUtility.TCPConnectionString, null };
-            yield return new object[] { DataTestUtility.TCPConnectionString, SqlConfigurableRetryFactory.CreateNoneRetryProvider() };
-        }
-
         private static IEnumerable<object[]> GetRetryStrategies(SqlRetryLogicOption retryLogicOption)
         {
             yield return new object[] { SqlConfigurableRetryFactory.CreateExponentialRetryProvider(retryLogicOption) };

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
@@ -175,16 +175,20 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     yield return new object[] { cnn[0], item[0] };
         }
 
-        public static IEnumerable<object[]> GetConnectionAndRetryStrategyDropDB(int numberOfRetries)
-        {
-            List<int> faults = s_defaultTransientErrors.ToList();
-            faults.Add(3702);    // Cannot drop database because it is currently in use.
-            return GetConnectionAndRetryStrategy(numberOfRetries, TimeSpan.FromMilliseconds(2000), FilterSqlStatements.None, faults, 500);
-        }
-
         public static IEnumerable<object[]> GetConnectionAndRetryStrategyLockedTable(int numberOfRetries)
         {
             return GetConnectionAndRetryStrategy(numberOfRetries, TimeSpan.FromMilliseconds(100), FilterSqlStatements.None, null);
+        }
+
+        public static IEnumerable<int> GetDefaultTransientErrorCodes(params int[] additionalCodes)
+        {
+            var transientErrorCodes = new HashSet<int>(s_defaultTransientErrors);
+            foreach (int additionalCode in additionalCodes)
+            {
+                transientErrorCodes.Add(additionalCode);
+            }
+
+            return transientErrorCodes;
         }
 
         private static IEnumerable<object[]> GetRetryStrategies(SqlRetryLogicOption retryLogicOption)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/RetryLogicTestHelper.cs
@@ -175,11 +175,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     yield return new object[] { cnn[0], item[0] };
         }
 
-        public static IEnumerable<object[]> GetConnectionAndRetryStrategyInvalidCommand(int numberOfRetries)
-        {
-            return GetConnectionAndRetryStrategy(numberOfRetries, TimeSpan.FromMilliseconds(100), FilterSqlStatements.None, null);
-        }
-
         public static IEnumerable<object[]> GetConnectionAndRetryStrategyFilterDMLStatements(int numberOfRetries)
         {
             return GetConnectionAndRetryStrategy(numberOfRetries, TimeSpan.FromMilliseconds(100), FilterSqlStatements.DML, new int[] { 207, 102, 2812 });

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 numberOfRetries: 2,
                 maxInterval: TimeSpan.FromMilliseconds(100),
                 transientErrorCodes: [102, 207, 2812],
-                unauthorizedStatements: FilterSqlStatements.DML);
+                unauthorizedStatementRegex: RetryLogicTestHelper.FilterDmlStatements);
 
         // Synapse: Msg 103010, Level 16, State 1, Line 1 | Parse error at line: 1, column: 1: Incorrect syntax near 'command'
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.AreConnStringsSetup))]

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
@@ -135,9 +135,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> RetryExecuteWithTransactionScope_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 5,
+                maxInterval: TimeSpan.FromMilliseconds(100));
+
         [ActiveIssue("14588")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCommand), parameters: new object[] { 5 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(RetryExecuteWithTransactionScope_Data), DisableDiscoveryEnumeration = true)]
         public void RetryExecuteWithTransScope(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int numberOfTries = provider.RetryLogic.NumberOfTries;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
@@ -151,7 +151,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 numberOfRetries: 5,
                 maxInterval: TimeSpan.FromMilliseconds(100));
 
-        [ActiveIssue("14588")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(RetryExecuteWithTransactionScope_Data), DisableDiscoveryEnumeration = true)]
         public void RetryExecuteWithTransScope(string cnnString, SqlRetryLogicBaseProvider provider)
@@ -296,7 +295,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 deltaTime: TimeSpan.FromMilliseconds(500),
                 transientErrorCodes: RetryLogicTestHelper.GetDefaultTransientErrorCodes(3702));
 
-        [ActiveIssue("14325")]
         // avoid creating a new database in Azure
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(DropDatabaseWithActiveConnection_Data), DisableDiscoveryEnumeration = true)]

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
@@ -289,10 +289,17 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> DropDatabaseWithActiveConnection_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 5,
+                maxInterval: TimeSpan.FromSeconds(2),
+                deltaTime: TimeSpan.FromMilliseconds(500),
+                transientErrorCodes: RetryLogicTestHelper.GetDefaultTransientErrorCodes(3702));
+
         [ActiveIssue("14325")]
         // avoid creating a new database in Azure
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyDropDB), parameters: new object[] { 5 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(DropDatabaseWithActiveConnection_Data), DisableDiscoveryEnumeration = true)]
         public void DropDatabaseWithActiveConnection(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int currentRetries = 0;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
@@ -358,11 +358,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> UpdateLockedTable_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 10,
+                maxInterval: TimeSpan.FromMilliseconds(100));
+
         // In Managed SNI by Named pipe connection, SqlCommand doesn't respect timeout. "ActiveIssue 12167"
         // Synapse: Does not support WAITFOR DELAY.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotUsingManagedSNIOnWindows), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyLockedTable), parameters: new object[] { 10 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
-        public void UpdateALockedTable(string cnnString, SqlRetryLogicBaseProvider provider)
+        [MemberData(nameof(UpdateLockedTable_Data), DisableDiscoveryEnumeration = true)]
+        public void UpdateLockedTable(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int currentRetries = 0;
             string tableName = DataTestUtility.GetLongName("Region");

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
@@ -45,8 +45,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         #region Sync
+
+        public static TheoryData<string, SqlRetryLogicBaseProvider> RetryExecuteFail_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 2,
+                maxInterval: TimeSpan.FromMilliseconds(100));
+
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCommand), parameters: new object[] { 2 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(RetryExecuteFail_Data), DisableDiscoveryEnumeration = true)]
         public void RetryExecuteFail(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int numberOfTries = provider.RetryLogic.NumberOfTries;
@@ -90,8 +96,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> RetryExecuteCancel_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 2,
+                maxInterval: TimeSpan.FromMilliseconds(100));
+
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCommand), parameters: new object[] { 2 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(RetryExecuteCancel_Data), DisableDiscoveryEnumeration = true)]
         public void RetryExecuteCancel(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int numberOfTries = provider.RetryLogic.NumberOfTries;
@@ -176,10 +187,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> RetryExecuteWithTransaction_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 5,
+                maxInterval: TimeSpan.FromMilliseconds(100));
+
         // Synapse: 111214;An attempt to complete a transaction has failed. No corresponding transaction found.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCommand), parameters: new object[] { 5 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
-        public void RetryExecuteWithTrans(string cnnString, SqlRetryLogicBaseProvider provider)
+        [MemberData(nameof(RetryExecuteWithTransaction_Data), DisableDiscoveryEnumeration = true)]
+        public void RetryExecuteWithTransaction(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int numberOfTries = provider.RetryLogic.NumberOfTries;
             int cancelAfterRetries = numberOfTries + 1;
@@ -424,8 +440,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         #endregion
 
         #region Async
+
+        public static TheoryData<string, SqlRetryLogicBaseProvider> RetryExecuteAsyncFail_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 2,
+                maxInterval: TimeSpan.FromMilliseconds(100));
+
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCommand), parameters: new object[] { 2 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(RetryExecuteAsyncFail_Data), DisableDiscoveryEnumeration = true)]
         public async Task RetryExecuteAsyncFail(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int numberOfTries = provider.RetryLogic.NumberOfTries;
@@ -489,8 +511,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> RetryExecuteAsyncCancel_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 2,
+                maxInterval: TimeSpan.FromMilliseconds(100));
+
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCommand), parameters: new object[] { 2 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(RetryExecuteAsyncCancel_Data), DisableDiscoveryEnumeration = true)]
         public async Task RetryExecuteAsyncCancel(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int numberOfTries = provider.RetryLogic.NumberOfTries;
@@ -556,8 +583,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         #endregion
 
         #region Concurrent
+
+        public static TheoryData<string, SqlRetryLogicBaseProvider> ConcurrentExecution_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 2,
+                maxInterval: TimeSpan.FromMilliseconds(100));
+
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCommand), parameters: new object[] { 2 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(ConcurrentExecution_Data), DisableDiscoveryEnumeration = true)]
         public void ConcurrentExecution(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             string query = "SELECT bad command";
@@ -573,8 +606,13 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> ConcurrentExecutionAsync_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 2,
+                maxInterval: TimeSpan.FromMilliseconds(100));
+
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCommand), parameters: new object[] { 2 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(ConcurrentExecutionAsync_Data), DisableDiscoveryEnumeration = true)]
         public async Task ConcurrentExecutionAsync(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             string query = "SELECT bad command";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlCommandReliabilityTest.cs
@@ -382,8 +382,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> NoneRetriableExecuteFail_Data =>
+            RetryLogicTestHelper.GetNonRetriableCases();
+
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetNoneRetriableCondition), MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(NoneRetriableExecuteFail_Data), DisableDiscoveryEnumeration = true)]
         public void NoneRetriableExecuteFail(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             string query = "SELECT bad command";

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConfigurationManagerReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConfigurationManagerReliabilityTest.cs
@@ -48,7 +48,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             s_commandCRLTest.RetryExecuteFail(TcpCnnString, cmdProvider);
             if (DataTestUtility.IsNotAzureSynapse())
             {
-                s_commandCRLTest.RetryExecuteUnauthorizedSqlStatementDML(TcpCnnString, cmdProvider);
+                // @TODO: Why are we calling a test from another test?
+                s_commandCRLTest.RetryExecuteUnauthorizedSqlStatementDml(TcpCnnString, cmdProvider);
             }
         }
         #endregion

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 maxInterval: TimeSpan.FromSeconds(10),
                 deltaTime: TimeSpan.FromSeconds(1));
 
-        [ActiveIssue("14590", TestPlatforms.Windows)]
         // avoid creating a new database in Azure
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(CreateDatabaseWhileTryingToConnect_Data), DisableDiscoveryEnumeration = true)]
@@ -125,7 +124,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 maxInterval: TimeSpan.FromSeconds(1),
                 deltaTime: TimeSpan.FromMilliseconds(250));
 
-        [ActiveIssue("25147")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConcurrentExecution_Data), DisableDiscoveryEnumeration = true)]
         public void ConcurrentExecution(string cnnString, SqlRetryLogicBaseProvider provider)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
@@ -133,8 +133,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.Equal(numberOfTries * concurrentExecution, retriesCount + concurrentExecution);
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> DefaultOpenWithoutRetry_Data =>
+            RetryLogicTestHelper.GetNonRetriableCases();
+
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetNoneRetriableCondition), MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(DefaultOpenWithoutRetry_Data), DisableDiscoveryEnumeration = true)]
         public void DefaultOpenWithoutRetry(string connectionString, SqlRetryLogicBaseProvider cnnProvider)
         {
             var cnnString = new SqlConnectionStringBuilder(connectionString)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
@@ -64,10 +64,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> CreateDatabaseWhileTryingToConnect_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 10,
+                maxInterval: TimeSpan.FromSeconds(10),
+                deltaTime: TimeSpan.FromSeconds(1));
+
         [ActiveIssue("14590", TestPlatforms.Windows)]
         // avoid creating a new database in Azure
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyLongRunner), parameters: new object[] { 10 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(CreateDatabaseWhileTryingToConnect_Data), DisableDiscoveryEnumeration = true)]
         public void CreateDatabaseWhileTryingToConnect(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int currentRetries = 0;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         // Test relies on error 4060 for automatic retry, which is not reliable when using Azure or AAD auth
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionCancelRetryOpenAsyncInvalidCatalog_Data), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(ConnectionCancelRetryOpenInvalidCatalog_Data), DisableDiscoveryEnumeration = true)]
         public void ConnectionCancelRetryOpenInvalidCatalog(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int cancelAfterRetries = provider.RetryLogic.NumberOfTries - 1;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/RetryLogic/SqlConnectionReliabilityTest.cs
@@ -16,9 +16,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private readonly string _cancelErrMsgPattern = RetryLogicTestHelper.s_cancelErrMsgPattern;
 
         #region Sync
+
+        public static TheoryData<string, SqlRetryLogicBaseProvider> ConnectionRetryOpenInvalidCatalogFailed_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 2,
+                maxInterval: TimeSpan.FromSeconds(1),
+                deltaTime: TimeSpan.FromMilliseconds(250));
+
         // Test relies on error 4060 for automatic retry, which is not reliable when using Azure or AAD auth
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCatalog), parameters: new object[] { 2 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(ConnectionRetryOpenInvalidCatalogFailed_Data), DisableDiscoveryEnumeration = true)]
         public void ConnectionRetryOpenInvalidCatalogFailed(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int numberOfTries = provider.RetryLogic.NumberOfTries;
@@ -34,9 +41,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> ConnectionCancelRetryOpenInvalidCatalog_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 2,
+                maxInterval: TimeSpan.FromSeconds(1),
+                deltaTime: TimeSpan.FromMilliseconds(250));
+
         // Test relies on error 4060 for automatic retry, which is not reliable when using Azure or AAD auth
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCatalog), parameters: new object[] { 2 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(ConnectionCancelRetryOpenAsyncInvalidCatalog_Data), DisableDiscoveryEnumeration = true)]
         public void ConnectionCancelRetryOpenInvalidCatalog(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int cancelAfterRetries = provider.RetryLogic.NumberOfTries - 1;
@@ -100,9 +113,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.True(currentRetries > 0);
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> ConcurrentExecution_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 2,
+                maxInterval: TimeSpan.FromSeconds(1),
+                deltaTime: TimeSpan.FromMilliseconds(250));
+
         [ActiveIssue("25147")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCatalog), parameters: new object[] { 2 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(ConcurrentExecution_Data), DisableDiscoveryEnumeration = true)]
         public void ConcurrentExecution(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int numberOfTries = provider.RetryLogic.NumberOfTries;
@@ -160,9 +179,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         #endregion
 
         #region Async
+
+        public static TheoryData<string, SqlRetryLogicBaseProvider> ConnectionRetryOpenAsyncInvalidCatalogFailed_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 5,
+                maxInterval: TimeSpan.FromSeconds(1),
+                deltaTime: TimeSpan.FromMilliseconds(250));
+
         // Test relies on error 4060 for automatic retry, which is not reliable when using Azure or AAD auth
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCatalog), parameters: new object[] { 5 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(ConnectionRetryOpenAsyncInvalidCatalogFailed_Data), DisableDiscoveryEnumeration = true)]
         public async Task ConnectionRetryOpenAsyncInvalidCatalogFailed(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int numberOfTries = provider.RetryLogic.NumberOfTries;
@@ -178,9 +204,15 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        public static TheoryData<string, SqlRetryLogicBaseProvider> ConnectionCancelRetryOpenAsyncInvalidCatalog_Data =>
+            RetryLogicTestHelper.GetConnectionStringAndRetryProviders(
+                numberOfRetries: 2,
+                maxInterval: TimeSpan.FromSeconds(1),
+                deltaTime: TimeSpan.FromMilliseconds(250));
+
         // Test relies on error 4060 for automatic retry, which is not returned when using AAD auth
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.TcpConnectionStringDoesNotUseAadAuth))]
-        [MemberData(nameof(RetryLogicTestHelper.GetConnectionAndRetryStrategyInvalidCatalog), parameters: new object[] { 2 }, MemberType = typeof(RetryLogicTestHelper), DisableDiscoveryEnumeration = true)]
+        [MemberData(nameof(ConnectionCancelRetryOpenAsyncInvalidCatalog_Data), DisableDiscoveryEnumeration = true)]
         public async Task ConnectionCancelRetryOpenAsyncInvalidCatalog(string cnnString, SqlRetryLogicBaseProvider provider)
         {
             int numberOfTries = provider.RetryLogic.NumberOfTries;


### PR DESCRIPTION
## Description
In this installment of cleaning up `[ActiveIssue]` tests, I focus mostly on the reliability tests, including upgrading the test cases to use `TheoryData` over a network of object arrays. Here's the tests that were re-enabled:

* Microsoft.Data.SqlClient.ManualTests
  * LocalDBTest
    * SqlLocalDbNamedPipeConnectionTest
    * LocalDbNamedPipeEncryptionNotSupported
    * LocalDbNamedPipeMarsTest
  * SqlCommandReliabilityTest - Test cases rewritten to use strongly typed TheoryData and member data from properties instead of method calls
    * DropDatabaseWithActiveConnection
    * RetryExecuteWithTransScope
  * SqlConnectionReliabilityTest - Test cases rewritten to use strongly typed TheoryData and member data from properties instead of method calls
    * CreateDatabaseWhileTryingToConnect
    * "ConcurrentExecution" (of what? who knows.)
  * TvpTest
    * TestPacketNumberWraparound - Rewritten to be properly async/await, with improved timeout, and cancellation of the test action if the timeout expires

## Issues
Continuation of work from #3624

## Testing
Tests all pass locally! It's possible these will fail in CI, but we won't know until we try :)
