### PR TITLE
Enable PR and scheduled builds for 6.0

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -22,7 +22,7 @@ trigger:
 
 schedules:
 - cron: '0 5 * * Fri'
-  displayName: Weekly Thursday 10:00 PM (UTC - 7) Build
+  displayName: Weekly Friday 5:00 AM (UTC) / Thursday 10:00 PM (UTC - 7) Build
   branches:
     include:
     - internal/release/6.0

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -9,8 +9,8 @@ trigger:
   batch: true
   branches:
     include:
-    - main
-    - internal/main
+    - release/6.0
+    - internal/release/6.0
   paths:
     include:
     - src
@@ -21,11 +21,11 @@ trigger:
     - Nuget.config
 
 schedules:
-- cron: '0 5 * * Thu'
-  displayName: Weekly Wednesday 10:00 PM (UTC - 7) Build
+- cron: '0 5 * * Fri'
+  displayName: Weekly Thursday 10:00 PM (UTC - 7) Build
   branches:
     include:
-    - internal/main
+    - internal/release/6.0
   always: true
 
 parameters: # parameters are shown up in ADO UI in a build queue time


### PR DESCRIPTION
## Description

Enables CI builds for PRs against release/6.0 and internal/release/6.0.
Enables weekly scheduled build for internal/release/6.0 branch (internal pipelines only).
