### PR TITLE
Merge | Enable SqlClientDiagnosticListener in SqlCommand on .NET Framework

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.netcore.cs
@@ -62,10 +62,6 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         private static bool _forceRetryableEnclaveQueryExecutionExceptionDuringGenerateEnclavePackage = false;
 #endif
-
-        private static readonly SqlDiagnosticListener s_diagnosticListener = new SqlDiagnosticListener();
-        private bool _parentOperationStarted = false;
-
         internal static readonly Action<object> s_cancelIgnoreFailure = CancelIgnoreFailureCallback;
 
         private _SqlRPC[] _rpcArrayOf1 = null;                // Used for RPC executes

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.NonQuery.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.NonQuery.cs
@@ -84,9 +84,7 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
             
-            #if NET
             using var diagnosticScope = s_diagnosticListener.CreateCommandScope(this, _transaction);
-            #endif
 
             using var eventScope = TryEventScope.Create($"SqlCommand.ExecuteNonQuery | API | Object Id {ObjectID}");
             SqlClientEventSource.Log.TryCorrelationTraceEvent(
@@ -128,9 +126,7 @@ namespace Microsoft.Data.SqlClient
             }
             catch (Exception ex)
             {
-                #if NET
                 diagnosticScope.SetException(ex);
-                #endif
 
                 if (ex is SqlException sqlException)
                 {
@@ -326,26 +322,20 @@ namespace Microsoft.Data.SqlClient
             {
                 Exception e = task.Exception?.InnerException;
                 
-                #if NET
                 s_diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
-                #endif
                 
                 source.SetException(e);
             }
             else if (task.IsCanceled)
             {
-                #if NET
                 s_diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
-                #endif
                 
                 source.SetCanceled();
             }
             else
             {
                 // Task successful
-                #if NET
                 s_diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
-                #endif
                 
                 source.SetResult(task.Result);
             }
@@ -652,11 +642,7 @@ namespace Microsoft.Data.SqlClient
                 $"Client Connection Id {_activeConnection?.ClientConnectionId}, " +
                 $"Command Text '{CommandText}'");
             
-            #if NET
             Guid operationId = s_diagnosticListener.WriteCommandBefore(this, _transaction);
-            #else
-            Guid operationId = Guid.Empty;
-            #endif
             
             // Connection can be used as state in RegisterForConnectionCloseNotification continuation
             // to avoid an allocation so use it as the state value if possible but it can be changed if
@@ -715,9 +701,7 @@ namespace Microsoft.Data.SqlClient
             }
             catch (Exception e)
             {
-                #if NET
                 s_diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
-                #endif
                 
                 source.SetException(e);
                 context.Dispose();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Reader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Reader.cs
@@ -109,10 +109,8 @@ namespace Microsoft.Data.SqlClient
             _pendingCancel = false;
 
             // @TODO: Do we want to use a command scope here like nonquery and xml? or is operation id ok?
-            #if NET
             Guid operationId = s_diagnosticListener.WriteCommandBefore(this, _transaction);
             Exception e = null;
-            #endif
 
             using var eventScope = TryEventScope.Create($"SqlCommand.ExecuteReader | API | Object Id {ObjectID}");
             // @TODO: Do we want to have a correlation trace event here like nonquery and xml?
@@ -136,9 +134,7 @@ namespace Microsoft.Data.SqlClient
             // @TODO: CER Exception Handling was removed here (see GH#3581)
             catch (Exception ex)
             {
-                #if NET
                 e = ex;
-                #endif
 
                 if (ex is SqlException sqlException)
                 {
@@ -152,7 +148,6 @@ namespace Microsoft.Data.SqlClient
                 SqlStatistics.StopTimer(statistics);
                 WriteEndExecuteEvent(success, sqlExceptionNumber, synchronous: true);
 
-                #if NET
                 if (e is not null)
                 {
                     s_diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
@@ -161,7 +156,6 @@ namespace Microsoft.Data.SqlClient
                 {
                     s_diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                 }
-                #endif
             }
         }
 
@@ -573,23 +567,19 @@ namespace Microsoft.Data.SqlClient
             {
                 Exception e = task.Exception.InnerException;
 
-                #if NET
                 if (!_parentOperationStarted)
                 {
                     s_diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                 }
-                #endif
 
                 source.SetException(e);
             }
             else
             {
-                #if NET
                 if (!_parentOperationStarted)
                 {
                     s_diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
                 }
-                #endif
 
                 if (task.IsCanceled)
                 {
@@ -940,13 +930,7 @@ namespace Microsoft.Data.SqlClient
                 $"Client Connection Id {_activeConnection?.ClientConnectionId}, " +
                 $"Command Text '{CommandText}'");
 
-            Guid operationId = Guid.Empty;
-            #if NET
-            if (!_parentOperationStarted)
-            {
-                operationId = s_diagnosticListener.WriteCommandBefore(this, _transaction);
-            }
-            #endif
+            Guid operationId = !_parentOperationStarted ? s_diagnosticListener.WriteCommandBefore(this, _transaction) : Guid.Empty;
 
             // Connection can be used as state in RegisterForConnectionCloseNotification
             // continuation to avoid an allocation so use it as the state value if possible, but it
@@ -1015,12 +999,10 @@ namespace Microsoft.Data.SqlClient
             }
             catch (Exception e)
             {
-                #if NET
                 if (!_parentOperationStarted)
                 {
                     s_diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
                 }
-                #endif
 
                 source.SetException(e);
                 context?.Dispose();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Scalar.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Scalar.cs
@@ -28,9 +28,7 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
             
-            #if NET
             using var diagnosticScope = s_diagnosticListener.CreateCommandScope(this, _transaction);
-            #endif
 
             using var eventScope = TryEventScope.Create($"SqlCommand.ExecuteScalar | API | Object Id {ObjectID}");
             SqlClientEventSource.Log.TryCorrelationTraceEvent(
@@ -60,9 +58,7 @@ namespace Microsoft.Data.SqlClient
             }
             catch (Exception ex)
             {
-                #if NET
                 diagnosticScope.SetException(ex);
-                #endif
 
                 if (ex is SqlException sqlException)
                 {
@@ -233,10 +229,8 @@ namespace Microsoft.Data.SqlClient
                 $"Client Connection Id {_activeConnection?.ClientConnectionId}, " +
                 $"Command Text '{CommandText}'");
 
-            #if NET
             Guid operationId = s_diagnosticListener.WriteCommandBefore(this, _transaction);
             _parentOperationStarted = true;
-            #endif
 
             // @TODO: Use continue with state? This would be a good candidate for rewriting async/await
             return ExecuteReaderAsync(cancellationToken).ContinueWith(executeTask =>
@@ -249,13 +243,11 @@ namespace Microsoft.Data.SqlClient
                 }
                 else if (executeTask.IsFaulted)
                 {
-                    #if NET
                     s_diagnosticListener.WriteCommandError(
                         operationId,
                         this,
                         _transaction,
                         executeTask.Exception.InnerException);
-                    #endif
                     
                     source.SetException(executeTask.Exception.InnerException);
                 }
@@ -279,13 +271,11 @@ namespace Microsoft.Data.SqlClient
                             {
                                 reader.Dispose();
                                 
-                                #if NET
                                 s_diagnosticListener.WriteCommandError(
                                     operationId,
                                     this,
                                     _transaction,
                                     readTask.Exception.InnerException);
-                                #endif
                                 
                                 source.SetException(readTask.Exception.InnerException);
                             }
@@ -316,17 +306,13 @@ namespace Microsoft.Data.SqlClient
 
                                 if (exception is not null)
                                 {
-                                    #if NET
                                     s_diagnosticListener.WriteCommandError(operationId, this, _transaction, exception);
-                                    #endif
                                     
                                     source.SetException(exception);
                                 }
                                 else
                                 {
-                                    #if NET
                                     s_diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
-                                    #endif
                                     
                                     source.SetResult(result);
                                 }
@@ -341,9 +327,7 @@ namespace Microsoft.Data.SqlClient
                     TaskScheduler.Default);
                 }
 
-                #if NET
                 _parentOperationStarted = false;
-                #endif
                 
                 return source.Task;
             },

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Xml.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Xml.cs
@@ -86,9 +86,7 @@ namespace Microsoft.Data.SqlClient
             // between entry into Execute* API and the thread obtaining the stateObject.
             _pendingCancel = false;
             
-            #if NET
             using var diagnosticScope = s_diagnosticListener.CreateCommandScope(this, _transaction);
-            #endif
 
             using var eventScope = TryEventScope.Create($"SqlCommand.ExecuteXmlReader | API | Object Id {ObjectID}");
             SqlClientEventSource.Log.TryCorrelationTraceEvent(
@@ -116,9 +114,7 @@ namespace Microsoft.Data.SqlClient
             }
             catch (Exception ex)
             {
-                #if NET
                 diagnosticScope.SetException(ex);
-                #endif
 
                 if (ex is SqlException sqlException)
                 {
@@ -365,25 +361,19 @@ namespace Microsoft.Data.SqlClient
             {
                 Exception e = task.Exception?.InnerException;
                 
-                #if NET
                 s_diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
-                #endif
                 
                 source.SetException(e);
             }
             else if (task.IsCanceled)
             {
-                #if NET
                 s_diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
-                #endif
                 
                 source.SetCanceled();
             }
             else
             {
-                #if NET
                 s_diagnosticListener.WriteCommandAfter(operationId, this, _transaction);
-                #endif
                 
                 source.SetResult(task.Result);
             }
@@ -475,11 +465,7 @@ namespace Microsoft.Data.SqlClient
                 $"Client Connection Id {_activeConnection?.ClientConnectionId}, " +
                 $"Command Text '{CommandText}'");
             
-            #if NET
             Guid operationId = s_diagnosticListener.WriteCommandBefore(this, _transaction);
-            #else
-            Guid operationId = Guid.Empty;
-            #endif
             
             // Connection can be used as state in RegisterForConnectionCloseNotification continuation
             // to avoid an allocation so use it as the state value if possible but it can be changed if
@@ -547,9 +533,7 @@ namespace Microsoft.Data.SqlClient
             }
             catch (Exception e) 
             {
-                #if NET
                 s_diagnosticListener.WriteCommandError(operationId, this, _transaction, e);
-                #endif
                 
                 source.SetException(e);
             }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/DiagnosticTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/DiagnosticTest.cs
@@ -25,6 +25,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
     {
         private const string BadConnectionString = "data source = bad; initial catalog = bad; integrated security = true; connection timeout = 1;";
 
+        private const string WriteCommandBefore = "Microsoft.Data.SqlClient.WriteCommandBefore";
+        private const string WriteCommandAfter = "Microsoft.Data.SqlClient.WriteCommandAfter";
+        private const string WriteCommandError = "Microsoft.Data.SqlClient.WriteCommandError";
+        private const string WriteConnectionOpenBefore = "Microsoft.Data.SqlClient.WriteConnectionOpenBefore";
+        private const string WriteConnectionOpenAfter = "Microsoft.Data.SqlClient.WriteConnectionOpenAfter";
+        private const string WriteConnectionOpenError = "Microsoft.Data.SqlClient.WriteConnectionOpenError";
+        private const string WriteConnectionCloseBefore = "Microsoft.Data.SqlClient.WriteConnectionCloseBefore";
+        private const string WriteConnectionCloseAfter = "Microsoft.Data.SqlClient.WriteConnectionCloseAfter";
+        private const string WriteConnectionCloseError = "Microsoft.Data.SqlClient.WriteConnectionCloseError";
+
         [Fact]
         public void ExecuteScalarTest()
         {
@@ -41,7 +51,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         conn.Open();
                         cmd.ExecuteScalar();
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -62,7 +72,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         conn.Open();
                         Assert.Throws<SqlException>(() => cmd.ExecuteScalar());
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandError, WriteConnectionCloseBefore, WriteConnectionCloseAfter]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -83,7 +93,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         conn.Open();
                         cmd.ExecuteNonQuery();
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -107,7 +117,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                         Assert.Throws<SqlException>(() => cmd.ExecuteNonQuery());
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandError, WriteConnectionCloseBefore, WriteConnectionCloseAfter]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -132,7 +142,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             // Read until end.
                         }
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -154,7 +164,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         // @TODO: TestTdsServer should not throw on ExecuteReader, it should throw on reader.Read
                         Assert.Throws<SqlException>(() => cmd.ExecuteReader());
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandError, WriteConnectionCloseBefore, WriteConnectionCloseAfter]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -179,7 +189,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             // Read to end
                         }
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -206,7 +216,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             // Read to end
                         }
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -228,7 +238,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         // @TODO: TestTdsServer should not throw on ExecuteXmlReader, should throw on reader.Read
                         Assert.Throws<SqlException>(() => cmd.ExecuteXmlReader());
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandError, WriteConnectionCloseBefore, WriteConnectionCloseAfter]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -254,7 +264,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         conn.Open();
                         await cmd.ExecuteScalarAsync();
                     }
-                }).Wait();
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]).Wait();
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -280,7 +290,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         conn.Open();
                         await Assert.ThrowsAsync<SqlException>(() => cmd.ExecuteScalarAsync());
                     }
-                }).Wait();
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandError, WriteConnectionCloseBefore, WriteConnectionCloseAfter]).Wait();
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -306,7 +316,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         conn.Open();
                         await cmd.ExecuteNonQueryAsync();
                     }
-                }).Wait();
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]).Wait();
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -332,7 +342,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         conn.Open();
                         await Assert.ThrowsAsync<SqlException>(() => cmd.ExecuteNonQueryAsync());
                     }
-                }).Wait();
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandError, WriteConnectionCloseBefore, WriteConnectionCloseAfter]).Wait();
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -362,7 +372,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             // Read to end
                         }
                     }
-                }).Wait();
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]).Wait();
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -389,7 +399,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         // @TODO: TestTdsServer should not throw on ExecuteReader, should throw on reader.Read
                         await Assert.ThrowsAsync<SqlException>(() => cmd.ExecuteReaderAsync());
                     }
-                }).Wait();
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandError, WriteConnectionCloseBefore, WriteConnectionCloseAfter]).Wait();
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -421,7 +431,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                             // Read to end
                         }
                     }
-                }).Wait();
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]).Wait();
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -449,11 +459,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         // @TODO: Since this test uses a real database connection, the exception is
                         //     thrown during reader.Read. (ie, TestTdsServer does not obey proper
                         //     exception behavior)
+                        // NB: As a result of the exception being thrown during reader.Read, 
+                        // cmd.ExecuteXmlReaderAsync returns successfully. This means that we receive
+                        // a WriteCommandAfter event rather than WriteCommandError.
                         await conn.OpenAsync();
                         XmlReader reader = await cmd.ExecuteXmlReaderAsync();
                         await Assert.ThrowsAsync<SqlException>(() => reader.ReadAsync());
                     }
-                }).Wait();
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteCommandBefore, WriteCommandAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]).Wait();
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -469,7 +482,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     {
                         sqlConnection.Open();
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -485,7 +498,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     {
                         Assert.Throws<SqlException>(() => sqlConnection.Open());
                     }
-                });
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenError]);
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -505,7 +518,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     {
                         await sqlConnection.OpenAsync();
                     }
-                }).Wait();
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenAfter, WriteConnectionCloseBefore, WriteConnectionCloseAfter]).Wait();
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
@@ -525,12 +538,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     {
                         await Assert.ThrowsAsync<SqlException>(() => sqlConnection.OpenAsync());
                     }
-                }).Wait();
+                }, [WriteConnectionOpenBefore, WriteConnectionOpenError]).Wait();
                 return RemoteExecutor.SuccessExitCode;
             }).Dispose();
         }
 
-        private static void CollectStatisticsDiagnostics(Action<string> sqlOperation, [CallerMemberName] string methodName = "")
+        private static void CollectStatisticsDiagnostics(Action<string> sqlOperation, string[] expectedDiagnostics, [CallerMemberName] string methodName = "")
         {
             bool statsLogged = false;
             bool operationHasError = false;
@@ -738,6 +751,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     Assert.True(statsLogged);
 
                     diagnosticListenerObserver.Disable();
+                    foreach (string expected in expectedDiagnostics)
+                    {
+                        Assert.True(diagnosticListenerObserver.HasReceivedDiagnostic(expected), $"Missing diagnostic '{expected}'");
+                    }
 
                     Console.WriteLine(string.Format("Test: {0} Listeners Disabled", methodName));
                 }
@@ -746,7 +763,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Console.WriteLine(string.Format("Test: {0} Listeners Disposed Successfully", methodName));
         }
 
-        private static async Task CollectStatisticsDiagnosticsAsync(Func<string, Task> sqlOperation, [CallerMemberName] string methodName = "")
+        private static async Task CollectStatisticsDiagnosticsAsync(Func<string, Task> sqlOperation, string[] expectedDiagnostics, [CallerMemberName] string methodName = "")
         {
             bool statsLogged = false;
             bool operationHasError = false;
@@ -936,6 +953,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     Assert.True(statsLogged);
 
                     diagnosticListenerObserver.Disable();
+                    foreach (string expected in expectedDiagnostics)
+                    {
+                        Assert.True(diagnosticListenerObserver.HasReceivedDiagnostic(expected), $"Missing diagnostic '{expected}'");
+                    }
 
                     Console.WriteLine(string.Format("Test: {0} Listeners Disabled", methodName));
                 }


### PR DESCRIPTION
## Description

This picks up where #3493 left off. Now that the SqlCommand methods with instrumentation have been merged, I've enabled the SqlClientDiagnosticListener functionality on the class.

I also noticed that tests in the DiagnosticTest class were passing unexpectedly, so dug a little deeper. These tests currently verify that the diagnostics we receive have a valid structure, but don't verify that we receive all of the diagnostics we expect to. I've modified the test to tighten this logic and explicitly specify the diagnostics we expect each scenario to receive.

@benrr101 I think we've passed the point where I'm likely to generate merge conflicts, but I'm happy to re-merge if you think that's likely.

## Issues

Contributes to #1261.

## Testing

Automated tests pass (even with the stricter validation.) Could someone run CI please?