### PR TITLE
Add PR Debug pipelines

### DIFF
--- a/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
@@ -21,9 +21,11 @@ pr:
   branches:
     include:
     # GitHub repo branch targets that will trigger PR validation builds.
-    - dev/*
-    - feat/*
-    - main
+    # TODO: Temporarily restricting to my ci-debug branches only.
+    - dev/paul/ci-debug-*
+    # - dev/*
+    # - feat/*
+    # - main
 
   paths:
     include:

--- a/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
@@ -21,9 +21,11 @@ pr:
   branches:
     include:
     # GitHub repo branch targets that will trigger PR validation builds.
-    - dev/*
-    - feat/*
-    - main
+    # TODO: Temporarily restricting to my ci-debug branches only.
+    - dev/paul/ci-debug-*
+    # - dev/*
+    # - feat/*
+    # - main
 
   paths:
     include:


### PR DESCRIPTION
Azure DevOps (1ES Start Right) doesn't permit creation of new pipelines in the UI unless the YAML files exist on the default branch (which IMO is a [bug](https://github.com/1ES-microsoft/Start-Right/issues/46)).  This PR adds 2 new YAML pipeline files that will be used to setup PR validation runs in Debug mode.

Initially, these PR runs will trigger only for `dev/paul/ci-debug*` branches.  This will allow me to complete #3589 and get the new pipelines working without disturbing anyone else.