### PR TITLE
Performance | Use lower-allocation AE primitives in SqlColumnEncryptionCertificateStoreProvider

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncrypted/ColumnMasterKeyMetadata.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncrypted/ColumnMasterKeyMetadata.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted;
 /// This takes ownership of the RSA instance supplied to it, disposing of it when Dispose is called.
 /// </para>
 /// </remarks>
-internal readonly ref struct ColumnMasterKeyMetadata // : IDisposable
+internal readonly ref struct ColumnMasterKeyMetadata : IDisposable
 {
     private static readonly HashAlgorithmName s_hashAlgorithm = HashAlgorithmName.SHA256;
 
@@ -49,7 +49,6 @@ internal readonly ref struct ColumnMasterKeyMetadata // : IDisposable
 #endif
     private readonly RSA _rsa;
 
-    // @TODO: SqlColumnEncryptionCertificateStoreProvider.SignMasterKeyMetadata and .VerifyMasterKeyMetadata should use this type.
     /// <summary>
     /// Represents metadata associated with a column master key, including its cryptographic hash, path, provider name,
     /// and enclave computation settings.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncrypted/EncryptedColumnEncryptionKeyParameters.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncrypted/EncryptedColumnEncryptionKeyParameters.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Data.SqlClient.AlwaysEncrypted;
 /// This takes ownership of the RSA instance supplied to it, disposing of it when Dispose is called.
 /// </para>
 /// </remarks>
-internal readonly ref struct EncryptedColumnEncryptionKeyParameters // : IDisposable
+internal readonly ref struct EncryptedColumnEncryptionKeyParameters : IDisposable
 {
     private const byte AlgorithmVersion = 0x01;
 
@@ -64,7 +64,6 @@ internal readonly ref struct EncryptedColumnEncryptionKeyParameters // : IDispos
     private readonly string _keyType;
     private readonly string _keyPathReference;
 
-    // @TODO: SqlColumnEncryptionCertificateStoreProvider, SqlColumnEncryptionCngProvider and SqlColumnEncryptionCspProvider should use this type.
     /// <summary>
     /// Initializes a new instance of the <see cref="EncryptedColumnEncryptionKeyParameters"/> struct with the specified
     /// RSA key, key path, key type, and key path reference.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.cs
@@ -3,10 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
+using Microsoft.Data.SqlClient.AlwaysEncrypted;
+
+#nullable enable
 
 namespace Microsoft.Data.SqlClient
 {
@@ -16,7 +18,7 @@ namespace Microsoft.Data.SqlClient
         // Constants
         //
         // Assumption: Certificate Locations (LocalMachine & CurrentUser), Certificate Store name "My"
-        // Certificate provider name (CertificateStore) dont need to be localized.
+        // Certificate provider name (CertificateStore) don't need to be localized.
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/ProviderName/*' />
         public const string ProviderName = @"MSSQL_CERTIFICATE_STORE";
@@ -37,12 +39,12 @@ namespace Microsoft.Data.SqlClient
         internal const string RSAEncryptionAlgorithmWithOAEP = @"RSA_OAEP";
 
         /// <summary>
-        /// LocalMachine certificate store location. Valid certificate locations are LocalMachine and CurrentUser.
+        /// LocalMachine certificate store location. Valid certificate locations are LocalMachine (on Windows) and CurrentUser.
         /// </summary>
         private const string CertLocationLocalMachine = @"LocalMachine";
 
         /// <summary>
-        /// CurrentUser certificate store location. Valid certificate locations are LocalMachine and CurrentUser.
+        /// CurrentUser certificate store location. Valid certificate locations are LocalMachine (on Windows) and CurrentUser.
         /// </summary>
         private const string CertLocationCurrentUser = @"CurrentUser";
 
@@ -52,247 +54,12 @@ namespace Microsoft.Data.SqlClient
         private const string MyCertificateStore = @"My";
 
         /// <summary>
-        /// Hashing algorithm used for signing
+        /// Gets a string array containing valid certificate locations.
         /// </summary>
-        private const string HashingAlgorithm = @"SHA256";
-
-        /// <summary>
-        /// Algorithm version
-        /// </summary>
-        private readonly byte[] _version = new byte[] { 0x01 };
-
-        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/DecryptColumnEncryptionKey/*' />
-        public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
-        {
-            // Validate the input parameters
-            ValidateNonEmptyCertificatePath(masterKeyPath, isSystemOp: true);
-
-            if (encryptedColumnEncryptionKey == null)
-            {
-                throw SQL.NullEncryptedColumnEncryptionKey();
-            }
-            else if (0 == encryptedColumnEncryptionKey.Length)
-            {
-                throw SQL.EmptyEncryptedColumnEncryptionKey();
-            }
-
-            // Validate encryptionAlgorithm
-            ValidateEncryptionAlgorithm(encryptionAlgorithm, isSystemOp: true);
-
-            // Validate key path length
-            ValidateCertificatePathLength(masterKeyPath, isSystemOp: true);
-
-            // Parse the path and get the X509 cert
-            RSA rsaPrivateKey = GetCertificatePrivateKeyByPath(masterKeyPath, isSystemOp: true);
-            
-            int keySizeInBytes= rsaPrivateKey.KeySize / 8;
-
-            // Validate and decrypt the EncryptedColumnEncryptionKey
-            // Format is 
-            //           version + keyPathLength + ciphertextLength + keyPath + ciphertext +  signature
-            //
-            // keyPath is present in the encrypted column encryption key for identifying the original source of the asymmetric key pair and 
-            // we will not validate it against the data contained in the CMK metadata (masterKeyPath).
-
-            // Validate the version byte
-            if (encryptedColumnEncryptionKey[0] != _version[0])
-            {
-                throw SQL.InvalidAlgorithmVersionInEncryptedCEK(encryptedColumnEncryptionKey[0], _version[0]);
-            }
-
-            // Get key path length
-            int currentIndex = _version.Length;
-            short keyPathLength = BitConverter.ToInt16(encryptedColumnEncryptionKey, currentIndex);
-            currentIndex += sizeof(short);
-
-            // Get ciphertext length
-            int cipherTextLength = BitConverter.ToInt16(encryptedColumnEncryptionKey, currentIndex);
-            currentIndex += sizeof(short);
-
-            // Skip KeyPath
-            // KeyPath exists only for troubleshooting purposes and doesnt need validation.
-            currentIndex += keyPathLength;
-
-            // validate the ciphertext length
-            if (cipherTextLength != keySizeInBytes)
-            {
-                throw SQL.InvalidCiphertextLengthInEncryptedCEKCertificate(cipherTextLength, keySizeInBytes, masterKeyPath);
-            }
-
-            // Validate the signature length
-            // Signature length should be same as the key side for RSA PKCSv1.5
-            int signatureLength = encryptedColumnEncryptionKey.Length - currentIndex - cipherTextLength;
-            if (signatureLength != keySizeInBytes)
-            {
-                throw SQL.InvalidSignatureInEncryptedCEKCertificate(signatureLength, keySizeInBytes, masterKeyPath);
-            }
-
-            // Get ciphertext
-            byte[] cipherText = new byte[cipherTextLength];
-            Buffer.BlockCopy(encryptedColumnEncryptionKey, currentIndex, cipherText, 0, cipherText.Length);
-            currentIndex += cipherTextLength;
-
-            // Get signature
-            byte[] signature = new byte[signatureLength];
-            Buffer.BlockCopy(encryptedColumnEncryptionKey, currentIndex, signature, 0, signature.Length);
-
-            // Compute the hash to validate the signature
-            byte[] hash;
-            using (SHA256 sha256 = SHA256.Create())
-            {
-                sha256.TransformFinalBlock(encryptedColumnEncryptionKey, 0, encryptedColumnEncryptionKey.Length - signature.Length);
-                hash = sha256.Hash;
-            }
-
-            Debug.Assert(hash != null, @"hash should not be null while decrypting encrypted column encryption key.");
-
-            // Validate the signature
-            if (!RSAVerifySignature(hash, signature, rsaPrivateKey))
-            {
-                throw SQL.InvalidCertificateSignature(masterKeyPath);
-            }
-
-            // Decrypt the CEK
-            return RSADecrypt(cipherText, rsaPrivateKey);
-        }
-
-        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/EncryptColumnEncryptionKey/*' />
-        public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
-        {
-            // Validate the input parameters
-            ValidateNonEmptyCertificatePath(masterKeyPath, isSystemOp: false);
-            if (columnEncryptionKey == null)
-            {
-                throw SQL.NullColumnEncryptionKey();
-            }
-            else if (0 == columnEncryptionKey.Length)
-            {
-                throw SQL.EmptyColumnEncryptionKey();
-            }
-
-            // Validate encryptionAlgorithm
-            ValidateEncryptionAlgorithm(encryptionAlgorithm, isSystemOp: false);
-
-            // Validate masterKeyPath Length
-            ValidateCertificatePathLength(masterKeyPath, isSystemOp: false);
-
-            // Parse the certificate path and get the X509 cert
-            RSA rsaPrivateKey = GetCertificatePrivateKeyByPath(masterKeyPath, isSystemOp: false);
-            
-            int keySizeInBytes = rsaPrivateKey.KeySize / 8;
-
-            // Construct the encryptedColumnEncryptionKey
-            // Format is 
-            //          version + keyPathLength + ciphertextLength + ciphertext + keyPath + signature
-            //
-            // We currently only support one version
-            byte[] version = new byte[] { _version[0] };
-
-            // Get the Unicode encoded bytes of culture invariant lower case masterKeyPath
-            byte[] masterKeyPathBytes = Encoding.Unicode.GetBytes(masterKeyPath.ToLowerInvariant());
-            byte[] keyPathLength = BitConverter.GetBytes((short)masterKeyPathBytes.Length);
-
-            // Encrypt the plain text
-            byte[] cipherText = RSAEncrypt(columnEncryptionKey, rsaPrivateKey);
-            byte[] cipherTextLength = BitConverter.GetBytes((short)cipherText.Length);
-            Debug.Assert(cipherText.Length == keySizeInBytes, @"cipherText length does not match the RSA key size");
-
-            // Compute hash
-            // SHA-2-256(version + keyPathLength + ciphertextLength + keyPath + ciphertext) 
-            byte[] hash;
-            using (SHA256 sha256 = SHA256.Create())
-            {
-                sha256.TransformBlock(version, 0, version.Length, version, 0);
-                sha256.TransformBlock(keyPathLength, 0, keyPathLength.Length, keyPathLength, 0);
-                sha256.TransformBlock(cipherTextLength, 0, cipherTextLength.Length, cipherTextLength, 0);
-                sha256.TransformBlock(masterKeyPathBytes, 0, masterKeyPathBytes.Length, masterKeyPathBytes, 0);
-                sha256.TransformFinalBlock(cipherText, 0, cipherText.Length);
-                hash = sha256.Hash;
-            }
-
-            // Sign the hash
-            byte[] signedHash = RSASignHashedData(hash, rsaPrivateKey);
-            Debug.Assert(signedHash.Length == keySizeInBytes, @"signed hash length does not match the RSA key size");
-            Debug.Assert(RSAVerifySignature(hash, signedHash, rsaPrivateKey), @"Invalid signature of the encrypted column encryption key computed.");
-
-            // Construct the encrypted column encryption key
-            // EncryptedColumnEncryptionKey = version + keyPathLength + ciphertextLength + keyPath + ciphertext +  signature
-            int encryptedColumnEncryptionKeyLength = version.Length + cipherTextLength.Length + keyPathLength.Length + cipherText.Length + masterKeyPathBytes.Length + signedHash.Length;
-            byte[] encryptedColumnEncryptionKey = new byte[encryptedColumnEncryptionKeyLength];
-
-            // Copy version byte
-            int currentIndex = 0;
-            Buffer.BlockCopy(version, 0, encryptedColumnEncryptionKey, currentIndex, version.Length);
-            currentIndex += version.Length;
-
-            // Copy key path length
-            Buffer.BlockCopy(keyPathLength, 0, encryptedColumnEncryptionKey, currentIndex, keyPathLength.Length);
-            currentIndex += keyPathLength.Length;
-
-            // Copy ciphertext length
-            Buffer.BlockCopy(cipherTextLength, 0, encryptedColumnEncryptionKey, currentIndex, cipherTextLength.Length);
-            currentIndex += cipherTextLength.Length;
-
-            // Copy key path
-            Buffer.BlockCopy(masterKeyPathBytes, 0, encryptedColumnEncryptionKey, currentIndex, masterKeyPathBytes.Length);
-            currentIndex += masterKeyPathBytes.Length;
-
-            // Copy ciphertext
-            Buffer.BlockCopy(cipherText, 0, encryptedColumnEncryptionKey, currentIndex, cipherText.Length);
-            currentIndex += cipherText.Length;
-
-            // copy the signature
-            Buffer.BlockCopy(signedHash, 0, encryptedColumnEncryptionKey, currentIndex, signedHash.Length);
-
-            return encryptedColumnEncryptionKey;
-        }
-
-        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/SignColumnMasterKeyMetadata/*' />
-        public override byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
-        {
-            byte[] hash = ComputeMasterKeyMetadataHash(masterKeyPath, allowEnclaveComputations, isSystemOp: false);
-
-            // Parse the certificate path and get the X509 cert
-            RSA rsaPrivateKey = GetCertificatePrivateKeyByPath(masterKeyPath, isSystemOp: false);
-
-            byte[] signature = RSASignHashedData(hash, rsaPrivateKey);
-
-            return signature;
-        }
-
-        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/VerifyColumnMasterKeyMetadata/*' />
-        public override bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
-        {
-            byte[] hash = ComputeMasterKeyMetadataHash(masterKeyPath, allowEnclaveComputations, isSystemOp: true);
-
-            // Parse the certificate path and get the X509 cert
-            RSA rsaPrivateKey = GetCertificatePrivateKeyByPath(masterKeyPath, isSystemOp: true);
-
-            // Validate the signature
-            return RSAVerifySignature(hash, signature, rsaPrivateKey);
-        }
-
-        private byte[] ComputeMasterKeyMetadataHash(string masterKeyPath, bool allowEnclaveComputations, bool isSystemOp)
-        {
-            // Validate the input parameters
-            ValidateNonEmptyCertificatePath(masterKeyPath, isSystemOp);
-
-            // Validate masterKeyPath Length
-            ValidateCertificatePathLength(masterKeyPath, isSystemOp);
-
-            string masterkeyMetadata = ProviderName + masterKeyPath + allowEnclaveComputations;
-            masterkeyMetadata = masterkeyMetadata.ToLowerInvariant();
-            byte[] masterkeyMetadataBytes = Encoding.Unicode.GetBytes(masterkeyMetadata.ToLowerInvariant());
-
-            // Compute hash 
-            byte[] hash;
-            using (SHA256 sha256 = SHA256.Create())
-            {
-                sha256.TransformFinalBlock(masterkeyMetadataBytes, 0, masterkeyMetadataBytes.Length);
-                hash = sha256.Hash;
-            }
-            return hash;
-        }
+        private static string[] ValidCertificateLocations =>
+            Environment.OSVersion.Platform == PlatformID.Win32NT
+                ? [CertLocationLocalMachine, CertLocationCurrentUser]
+                : [CertLocationCurrentUser];
 
         /// <summary>
         /// This function validates that the encryption algorithm is RSA_OAEP and if it is not,
@@ -300,27 +67,35 @@ namespace Microsoft.Data.SqlClient
         /// </summary>
         /// <param name="encryptionAlgorithm">Asymmetric key encryption algorithm</param>
         /// <param name="isSystemOp"></param>
-        private void ValidateEncryptionAlgorithm(string encryptionAlgorithm, bool isSystemOp)
+        private static void ValidateEncryptionAlgorithm([NotNull] string? encryptionAlgorithm, bool isSystemOp)
         {
             // This validates that the encryption algorithm is RSA_OAEP
-            if (encryptionAlgorithm == null)
+            if (encryptionAlgorithm is null)
             {
                 throw SQL.NullKeyEncryptionAlgorithm(isSystemOp);
             }
 
-            if (string.Equals(encryptionAlgorithm, RSAEncryptionAlgorithmWithOAEP, StringComparison.OrdinalIgnoreCase) != true)
+            if (!string.Equals(encryptionAlgorithm, RSAEncryptionAlgorithmWithOAEP, StringComparison.OrdinalIgnoreCase))
             {
                 throw SQL.InvalidKeyEncryptionAlgorithm(encryptionAlgorithm, RSAEncryptionAlgorithmWithOAEP, isSystemOp);
             }
         }
 
         /// <summary>
-        /// Certificate path length has to fit in two bytes, so check its value against Int16.MaxValue
+        /// Checks if the certificate path is Empty, Null or larger than short.MaxValue characters (and raises exception if they are).
         /// </summary>
-        /// <param name="masterKeyPath"></param>
-        /// <param name="isSystemOp"></param>
-        private void ValidateCertificatePathLength(string masterKeyPath, bool isSystemOp)
+        private static void ValidateCertificatePathLength([NotNull] string? masterKeyPath, bool isSystemOp)
         {
+            if (masterKeyPath is null)
+            {
+                throw SQL.NullCertificatePath(ValidCertificateLocations, isSystemOp);
+            }
+
+            if (string.IsNullOrWhiteSpace(masterKeyPath))
+            {
+                throw SQL.InvalidCertificatePath(masterKeyPath, ValidCertificateLocations, isSystemOp);
+            }
+
             if (masterKeyPath.Length >= short.MaxValue)
             {
                 throw SQL.LargeCertificatePathLength(masterKeyPath.Length, short.MaxValue, isSystemOp);
@@ -328,100 +103,106 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <summary>
-        /// Gets a string array containing Valid certificate locations.
-        /// </summary>
-        private string[] GetValidCertificateLocations()
-        {
-            return Environment.OSVersion.Platform == PlatformID.Win32NT
-                ? new string[2] { CertLocationLocalMachine, CertLocationCurrentUser }
-                : new string[1] { CertLocationCurrentUser };
-        }
-
-        /// <summary>
-        /// Checks if the certificate path is Empty or Null (and raises exception if they are).
-        /// </summary>
-        private void ValidateNonEmptyCertificatePath(string masterKeyPath, bool isSystemOp)
-        {
-            if (string.IsNullOrWhiteSpace(masterKeyPath))
-            {
-                if (masterKeyPath == null)
-                {
-                    throw SQL.NullCertificatePath(GetValidCertificateLocations(), isSystemOp);
-                }
-                else
-                {
-                    throw SQL.InvalidCertificatePath(masterKeyPath, GetValidCertificateLocations(), isSystemOp);
-                }
-            }
-        }
-
-        /// <summary>
         /// Parses the given certificate path, searches in certificate store and returns a matching certificate's private key
         /// </summary>
         /// <param name="keyPath">
-        /// Certificate key path. Format of the path is [LocalMachine|CurrentUser]/[storename]/thumbprint
+        /// Certificate key path. Format of the path is [LocalMachine|CurrentUser]/[StoreName]/Thumbprint
         /// </param>
         /// <param name="isSystemOp"></param>
         /// <returns>Returns the private key of the certificate identified by the certificate path</returns>
-        private RSA GetCertificatePrivateKeyByPath(string keyPath, bool isSystemOp)
+        private static RSA GetCertificatePrivateKeyByPath(string keyPath, bool isSystemOp)
         {
-            Debug.Assert(!string.IsNullOrEmpty(keyPath));
-
-            // Assign default values for omitted fields
-            StoreLocation storeLocation = StoreLocation.LocalMachine; // Default to Local Machine
-            StoreName storeName = StoreName.My;
-            string[] certParts = keyPath.Split('/');
+            StoreLocation storeLocation;
+            StoreName storeName;
+            ReadOnlySpan<char> keyPathSpan = keyPath.AsSpan();
+            int firstSeparator = keyPathSpan.IndexOf('/');
+            ReadOnlySpan<char> trailingFirstSeparator = firstSeparator == -1 ? default : keyPathSpan.Slice(firstSeparator + 1);
+            int secondSeparator = firstSeparator == -1 ? -1 : trailingFirstSeparator.IndexOf('/');
+            ReadOnlySpan<char> trailingSecondSeparator = secondSeparator == -1 ? default : trailingFirstSeparator.Slice(secondSeparator + 1);
+            int subsequentSeparators = secondSeparator == -1 ? -1 : trailingSecondSeparator.IndexOf('/');
 
             // Validate certificate path
             // Certificate path should only contain 3 parts (Certificate Location, Certificate Store Name and Thumbprint)
-            if (certParts.Length > 3)
+            // We know there are more than three parts if there are three or more separators
+            if (subsequentSeparators != -1)
             {
-                throw SQL.InvalidCertificatePath(keyPath, GetValidCertificateLocations(), isSystemOp);
+                throw SQL.InvalidCertificatePath(keyPath, ValidCertificateLocations, isSystemOp);
+            }
+
+            ReadOnlySpan<char> storeLocationSpan = default;
+            ReadOnlySpan<char> storeNameSpan = default;
+            ReadOnlySpan<char> thumbprintSpan;
+
+            // Extract the store location where the cert is stored. This can be in one of the following formats:
+            // * [Location]/[StoreName]/[Thumbprint] (firstSeparator and secondSeparator are not -1)
+            // * [StoreName]/[Thumbprint] (firstSeparator is not -1, secondSeparator is -1)
+            // * [Thumbprint] (general case)
+            if (secondSeparator != -1)
+            {
+                // There are two separators (and thus, three parts)
+                storeLocationSpan = keyPathSpan.Slice(0, firstSeparator);
+                storeNameSpan = trailingFirstSeparator.Slice(0, secondSeparator);
+                thumbprintSpan = trailingSecondSeparator;
+            }
+            else if (firstSeparator != -1)
+            {
+                storeNameSpan = keyPathSpan.Slice(0, firstSeparator);
+                thumbprintSpan = trailingFirstSeparator;
+            }
+            else
+            {
+                thumbprintSpan = keyPathSpan;
             }
 
             // Extract the store location where the cert is stored
-            if (certParts.Length > 2)
+            if (storeLocationSpan.IsEmpty
+                && Environment.OSVersion.Platform == PlatformID.Win32NT)
             {
-                if (string.Equals(certParts[0], CertLocationLocalMachine, StringComparison.OrdinalIgnoreCase) == true
-                    && Environment.OSVersion.Platform == PlatformID.Win32NT)
-                {
-                    storeLocation = StoreLocation.LocalMachine;
-                }
-                else if (string.Equals(certParts[0], CertLocationCurrentUser, StringComparison.OrdinalIgnoreCase) == true)
-                {
-                    storeLocation = StoreLocation.CurrentUser;
-                }
-                else
-                {
-                    // throw an invalid certificate location exception
-                    throw SQL.InvalidCertificateLocation(certParts[0], keyPath, GetValidCertificateLocations(), isSystemOp);
-                }
+                // Default to Local Machine on Windows. Non-Windows platforms only support CurrentUser
+                storeLocation = StoreLocation.LocalMachine;
+            }
+            else if (storeLocationSpan.Equals(CertLocationLocalMachine.AsSpan(), StringComparison.OrdinalIgnoreCase)
+                && Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                storeLocation = StoreLocation.LocalMachine;
+            }
+            else if (storeLocationSpan.Equals(CertLocationCurrentUser.AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                storeLocation = StoreLocation.CurrentUser;
+            }
+            else
+            {
+                // Throw an invalid certificate location exception
+                throw SQL.InvalidCertificateLocation(storeLocationSpan.ToString(), keyPath, ValidCertificateLocations, isSystemOp);
             }
 
             // Parse the certificate store name
-            if (certParts.Length > 1)
+            if (storeNameSpan.IsEmpty)
             {
-                if (string.Equals(certParts[certParts.Length - 2], MyCertificateStore, StringComparison.OrdinalIgnoreCase) == true)
-                {
-                    storeName = StoreName.My;
-                }
-                else
-                {
-                    // We only support storing them in My certificate store
-                    throw SQL.InvalidCertificateStore(certParts[certParts.Length - 2], keyPath, MyCertificateStore, isSystemOp);
-                }
+                // Default to My certificate store
+                storeName = StoreName.My;
+            }
+            else if (storeNameSpan.Equals(MyCertificateStore.AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                storeName = StoreName.My;
+            }
+            else
+            {
+                // We only support storing them in My certificate store
+                throw SQL.InvalidCertificateStore(storeNameSpan.ToString(), keyPath, MyCertificateStore, isSystemOp);
             }
 
-            // Get thumpbrint
-            string thumbprint = certParts[certParts.Length - 1];
-            if (string.IsNullOrEmpty(thumbprint))
+            // Get thumbprint
+            if (thumbprintSpan.IsEmpty)
             {
                 // An empty thumbprint specified
                 throw SQL.EmptyCertificateThumbprint(keyPath, isSystemOp);
             }
-
-            // Find the certificate and return
-            return GetCertificatePrivateKey(storeLocation, storeName, keyPath, thumbprint, isSystemOp);
+            else
+            {
+                // Find the certificate and return
+                return GetCertificatePrivateKey(storeLocation, storeName, keyPath, thumbprintSpan, isSystemOp);
+            }
         }
 
         /// <summary>
@@ -433,7 +214,7 @@ namespace Microsoft.Data.SqlClient
         /// <param name="thumbprint">Certificate thumbprint</param>
         /// <param name="isSystemOp"></param>
         /// <returns>Matching certificate's private key</returns>
-        private static RSA GetCertificatePrivateKey(StoreLocation storeLocation, StoreName storeName, string masterKeyPath, string thumbprint, bool isSystemOp)
+        private static RSA GetCertificatePrivateKey(StoreLocation storeLocation, StoreName storeName, string masterKeyPath, ReadOnlySpan<char> thumbprint, bool isSystemOp)
         {
             // Open specified certificate store
             using X509Store certificateStore = new(storeName, storeLocation);
@@ -442,13 +223,13 @@ namespace Microsoft.Data.SqlClient
             // Search for the specified certificate
             X509Certificate2Collection matchingCertificates =
                         certificateStore.Certificates.Find(X509FindType.FindByThumbprint,
-                        thumbprint,
+                        thumbprint.ToString(),
                         false);
 
             // Throw an exception if a cert with the specified thumbprint is not found
             if (matchingCertificates == null || matchingCertificates.Count == 0)
             {
-                throw SQL.CertificateNotFound(thumbprint, storeName.ToString(), storeLocation.ToString(), isSystemOp);
+                throw SQL.CertificateNotFound(thumbprint.ToString(), storeName.ToString(), storeLocation.ToString(), isSystemOp);
             }
 
             using X509Certificate2 certificate = matchingCertificates[0];
@@ -458,78 +239,87 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.CertificateWithNoPrivateKey(masterKeyPath, isSystemOp);
             }
 
-            // Return the matching certificate's private key
+            // Return the matching certificate's private key. Throw an exception if the private key is not RSA
             return certificate.GetRSAPrivateKey()
                 ?? throw SQL.CertificateWithNoPrivateKey(masterKeyPath, isSystemOp);
         }
 
-        /// <summary>
-        /// Encrypt the text using specified RSA key.
-        /// </summary>
-        /// <param name="plainText">Text to encrypt.</param>
-        /// <param name="rsa">RSA key.</param>
-        /// <returns>Returns an encrypted blob or throws an exception if there are any errors.</returns>
-        private byte[] RSAEncrypt(byte[] plainText, RSA rsa)
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/DecryptColumnEncryptionKey/*' />
+        public override byte[] DecryptColumnEncryptionKey(string? masterKeyPath, string? encryptionAlgorithm, byte[]? encryptedColumnEncryptionKey)
         {
-            Debug.Assert(plainText != null);
-            
-            // CodeQL [SM03796] Required for an external standard: Always Encrypted only supports encrypting column encryption keys with RSA_OAEP(SHA1) (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
-            return rsa.Encrypt(plainText, RSAEncryptionPadding.OaepSHA1);
+            // Validate the input parameters
+            ValidateCertificatePathLength(masterKeyPath, isSystemOp: true);
+
+            if (encryptedColumnEncryptionKey is null)
+            {
+                throw SQL.NullEncryptedColumnEncryptionKey();
+            }
+            else if (encryptedColumnEncryptionKey.Length == 0)
+            {
+                throw SQL.EmptyEncryptedColumnEncryptionKey();
+            }
+
+            // Validate encryptionAlgorithm
+            ValidateEncryptionAlgorithm(encryptionAlgorithm, isSystemOp: true);
+
+            // Parse the path and get the X509 cert
+            RSA rsaPrivateKey = GetCertificatePrivateKeyByPath(masterKeyPath, isSystemOp: true);
+            using EncryptedColumnEncryptionKeyParameters cekHandler = new(rsaPrivateKey, masterKeyPath, MasterKeyType, KeyPathReference);
+
+            return cekHandler.Decrypt(encryptedColumnEncryptionKey);
         }
 
-        /// <summary>
-        /// Decrypt the data using specified RSA key.
-        /// </summary>
-        /// <param name="cipherText">Text to decrypt.</param>
-        /// <param name="rsa">RSA key.</param>
-        /// <returns>Returns a decrypted blob or throws an exception if there are any errors.</returns>
-        private byte[] RSADecrypt(byte[] cipherText, RSA rsa)
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/EncryptColumnEncryptionKey/*' />
+        public override byte[] EncryptColumnEncryptionKey(string? masterKeyPath, string? encryptionAlgorithm, byte[]? columnEncryptionKey)
         {
-            Debug.Assert((cipherText != null) && (cipherText.Length != 0));
-            
-            // CodeQL [SM03796] Required for an external standard: Always Encrypted only supports encrypting column encryption keys with RSA_OAEP(SHA1) (https://learn.microsoft.com/en-us/sql/t-sql/statements/create-column-encryption-key-transact-sql?view=sql-server-ver16)
-            return rsa.Decrypt(cipherText, RSAEncryptionPadding.OaepSHA1);
+            // Validate the input parameters
+            ValidateCertificatePathLength(masterKeyPath, isSystemOp: false);
+            if (columnEncryptionKey is null)
+            {
+                throw SQL.NullColumnEncryptionKey();
+            }
+            else if (columnEncryptionKey.Length == 0)
+            {
+                throw SQL.EmptyColumnEncryptionKey();
+            }
+
+            // Validate encryptionAlgorithm
+            ValidateEncryptionAlgorithm(encryptionAlgorithm, isSystemOp: false);
+
+            // Parse the certificate path and get the X509 cert
+            RSA rsaPrivateKey = GetCertificatePrivateKeyByPath(masterKeyPath, isSystemOp: false);
+
+            using EncryptedColumnEncryptionKeyParameters cekBuilder = new(rsaPrivateKey, masterKeyPath, MasterKeyType, KeyPathReference);
+
+            return cekBuilder.Encrypt(columnEncryptionKey);
         }
 
-        /// <summary>
-        /// Generates signature based on RSA PKCS#v1.5 scheme using a specified RSA key. 
-        /// </summary>
-        /// <param name="dataToSign">Text to sign.</param>
-        /// <param name="rsa">RSA key.</param>
-        /// <returns>Signature</returns>
-        private byte[] RSASignHashedData(byte[] dataToSign, RSA rsa)
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/SignColumnMasterKeyMetadata/*' />
+        public override byte[] SignColumnMasterKeyMetadata(string? masterKeyPath, bool allowEnclaveComputations)
         {
-            Debug.Assert((dataToSign != null) && (dataToSign.Length != 0));
+            // Validate the input parameters
+            ValidateCertificatePathLength(masterKeyPath, isSystemOp: false);
 
-            // Prepare RSAPKCS1SignatureFormatter for signing the passed in hash
-            RSAPKCS1SignatureFormatter rsaFormatter = new RSAPKCS1SignatureFormatter(rsa);
-            //Set the hash algorithm to SHA256.
-            rsaFormatter.SetHashAlgorithm(HashingAlgorithm);
+            // Parse the certificate path and get the X509 cert
+            RSA rsaPrivateKey = GetCertificatePrivateKeyByPath(masterKeyPath, isSystemOp: false);
 
-            //Create a signature for HashValue and return it. 
-            return rsaFormatter.CreateSignature(dataToSign);
+            using ColumnMasterKeyMetadata cmkSigner = new(rsaPrivateKey, masterKeyPath, ProviderName, allowEnclaveComputations);
+
+            return cmkSigner.Sign();
         }
 
-        /// <summary>
-        /// Verifies the given RSA PKCSv1.5 signature.
-        /// </summary>
-        /// <param name="dataToVerify"></param>
-        /// <param name="signature"></param>
-        /// <param name="rsa"></param>
-        /// <returns>true if signature is valid, false if it is not valid</returns>
-        private bool RSAVerifySignature(byte[] dataToVerify, byte[] signature, RSA rsa)
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCertificateStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionCertificateStoreProvider"]/VerifyColumnMasterKeyMetadata/*' />
+        public override bool VerifyColumnMasterKeyMetadata(string? masterKeyPath, bool allowEnclaveComputations, byte[] signature)
         {
-            Debug.Assert((dataToVerify != null) && (dataToVerify.Length != 0));
-            Debug.Assert((signature != null) && (signature.Length != 0));
+            // Validate the input parameters
+            ValidateCertificatePathLength(masterKeyPath, isSystemOp: false);
 
-            // Prepare RSAPKCS1SignatureFormatter for signing the passed in hash
-            RSAPKCS1SignatureDeformatter rsaDeFormatter = new RSAPKCS1SignatureDeformatter(rsa);
+            // Parse the certificate path and get the X509 cert
+            RSA rsaPrivateKey = GetCertificatePrivateKeyByPath(masterKeyPath, isSystemOp: true);
 
-            //Set the hash algorithm to SHA256.
-            rsaDeFormatter.SetHashAlgorithm(HashingAlgorithm);
+            using ColumnMasterKeyMetadata cmkVerifier = new(rsaPrivateKey, masterKeyPath, ProviderName, allowEnclaveComputations);
 
-            //Create a signature for HashValue and return it. 
-            return rsaDeFormatter.VerifySignature(dataToVerify, signature);
+            return cmkVerifier.Verify(signature);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -1783,29 +1783,14 @@ namespace Microsoft.Data.SqlClient
             return ADP.Argument(StringsHelper.GetString(Strings.TCE_InvalidCiphertextLengthInEncryptedCEK, actual, expected, keyType, masterKeyPath, keyPathReference), TdsEnums.TCE_PARAM_ENCRYPTED_CEK);
         }
 
-        internal static Exception InvalidCiphertextLengthInEncryptedCEKCertificate(int actual, int expected, string certificateName)
-        {
-            return ADP.Argument(StringsHelper.GetString(Strings.TCE_InvalidCiphertextLengthInEncryptedCEKCertificate, actual, expected, certificateName), TdsEnums.TCE_PARAM_ENCRYPTED_CEK);
-        }
-
         internal static Exception InvalidSignatureInEncryptedCEK(string keyType, string keyPathReference, int actual, int expected, string masterKeyPath)
         {
             return ADP.Argument(StringsHelper.GetString(Strings.TCE_InvalidSignatureInEncryptedCEK, actual, expected, keyType, masterKeyPath, keyPathReference), TdsEnums.TCE_PARAM_ENCRYPTED_CEK);
         }
 
-        internal static Exception InvalidSignatureInEncryptedCEKCertificate(int actual, int expected, string masterKeyPath)
-        {
-            return ADP.Argument(StringsHelper.GetString(Strings.TCE_InvalidSignatureInEncryptedCEKCertificate, actual, expected, masterKeyPath), TdsEnums.TCE_PARAM_ENCRYPTED_CEK);
-        }
-
         internal static Exception InvalidSignature(string masterKeyPath, string keyType)
         {
             return ADP.Argument(StringsHelper.GetString(Strings.TCE_InvalidSignature, keyType, masterKeyPath), TdsEnums.TCE_PARAM_ENCRYPTED_CEK);
-        }
-
-        internal static Exception InvalidCertificateSignature(string certificatePath)
-        {
-            return ADP.Argument(StringsHelper.GetString(Strings.TCE_InvalidCertificateSignature, certificatePath), TdsEnums.TCE_PARAM_ENCRYPTED_CEK);
         }
 
         internal static Exception CertificateWithNoPrivateKey(string keyPath, bool isSystemOp)

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -12656,15 +12656,6 @@ namespace System {
                 return ResourceManager.GetString("TCE_InvalidCertificatePathSysErr_Unix", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The specified encrypted column encryption key signature does not match the signature computed with the column master key (certificate) in &apos;{0}&apos;. The encrypted column encryption key may be corrupt, or the specified path may be incorrect..
-        /// </summary>
-        internal static string TCE_InvalidCertificateSignature {
-            get {
-                return ResourceManager.GetString("TCE_InvalidCertificateSignature", resourceCulture);
-            }
-        }
         
         /// <summary>
         ///   Looks up a localized string similar to Invalid certificate store &apos;{0}&apos; specified in certificate path &apos;{1}&apos;. Expected value: &apos;{2}&apos;..
@@ -12690,15 +12681,6 @@ namespace System {
         internal static string TCE_InvalidCiphertextLengthInEncryptedCEK {
             get {
                 return ResourceManager.GetString("TCE_InvalidCiphertextLengthInEncryptedCEK", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The specified encrypted column encryption key&apos;s ciphertext length: {0} does not match the ciphertext length: {1} when using column master key (certificate) in &apos;{2}&apos;. The encrypted column encryption key may be corrupt, or the specified certificate path may be incorrect..
-        /// </summary>
-        internal static string TCE_InvalidCiphertextLengthInEncryptedCEKCertificate {
-            get {
-                return ResourceManager.GetString("TCE_InvalidCiphertextLengthInEncryptedCEKCertificate", resourceCulture);
             }
         }
         
@@ -12906,15 +12888,6 @@ namespace System {
         internal static string TCE_InvalidSignatureInEncryptedCEK {
             get {
                 return ResourceManager.GetString("TCE_InvalidSignatureInEncryptedCEK", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The specified encrypted column encryption key&apos;s signature length: {0} does not match the signature length: {1} when using column master key (certificate) in &apos;{2}&apos;. The encrypted column encryption key may be corrupt, or the specified certificate path may be incorrect..
-        /// </summary>
-        internal static string TCE_InvalidSignatureInEncryptedCEKCertificate {
-            get {
-                return ResourceManager.GetString("TCE_InvalidSignatureInEncryptedCEKCertificate", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -4077,20 +4077,11 @@
   <data name="TCE_InvalidCiphertextLengthInEncryptedCEK" xml:space="preserve">
     <value>The specified encrypted column encryption key's ciphertext length: {0} does not match the ciphertext length: {1} when using column master key ({2}) in '{3}'. The encrypted column encryption key may be corrupt, or the specified {4} path may be incorrect.</value>
   </data>
-  <data name="TCE_InvalidCiphertextLengthInEncryptedCEKCertificate" xml:space="preserve">
-    <value>The specified encrypted column encryption key's ciphertext length: {0} does not match the ciphertext length: {1} when using column master key (certificate) in '{2}'. The encrypted column encryption key may be corrupt, or the specified certificate path may be incorrect.</value>
-  </data>
   <data name="TCE_InvalidSignatureInEncryptedCEK" xml:space="preserve">
     <value>The specified encrypted column encryption key's signature length: {0} does not match the signature length: {1} when using column master key ({2}) in '{3}'. The encrypted column encryption key may be corrupt, or the specified {4} path may be incorrect.</value>
   </data>
-  <data name="TCE_InvalidSignatureInEncryptedCEKCertificate" xml:space="preserve">
-    <value>The specified encrypted column encryption key's signature length: {0} does not match the signature length: {1} when using column master key (certificate) in '{2}'. The encrypted column encryption key may be corrupt, or the specified certificate path may be incorrect.</value>
-  </data>
   <data name="TCE_InvalidSignature" xml:space="preserve">
     <value>The specified encrypted column encryption key signature does not match the signature computed with the column master key ({0}) in '{1}'. The encrypted column encryption key may be corrupt, or the specified path may be incorrect.</value>
-  </data>
-  <data name="TCE_InvalidCertificateSignature" xml:space="preserve">
-    <value>The specified encrypted column encryption key signature does not match the signature computed with the column master key (certificate) in '{0}'. The encrypted column encryption key may be corrupt, or the specified path may be incorrect.</value>
   </data>
   <data name="TCE_CertificateWithNoPrivateKey" xml:space="preserve">
     <value>Certificate specified in key path '{0}' does not have a private key to encrypt a column encryption key. Verify the certificate is imported correctly.</value>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CoreCryptoTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CoreCryptoTests.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Microsoft.Data.SqlClient;
-using System.Diagnostics;
+using Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
@@ -49,6 +50,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         public void TestRsaCryptoWithNativeBaseline()
         {
+            SqlColumnEncryptionCertificateStoreProvider rsaProvider = new();
+
             // Initialize the reader for resource text file which has the native code generated baseline.
             CryptoNativeBaselineReader cryptoNativeBaselineReader = new CryptoNativeBaselineReader();
 
@@ -64,23 +67,48 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             byte[] rsaKeyPair = cryptoParametersListForTest[0].RsaKeyPair;
             byte[] rsaPfx = cryptoParametersListForTest[1].RsaKeyPair;
 
-            // For each crypto vector, run the test to compare the output generated through sqlclient's code and the native code.
-            foreach (CryptoVector cryptoParameter in cryptoParametersListForTest)
+            // Convert the PFX into a certificate and install it into the local user's certificate store.
+            // We can only do this cross-platform on the CurrentUser store, which matches the baseline data we have.
+            Debug.Assert(rsaPfx != null && rsaPfx.Length > 0);
+
+            X509Store store = null;
+            bool addedToStore = false;
+#if NET9_0_OR_GREATER
+            using X509Certificate2 x509 = X509CertificateLoader.LoadPkcs12(rsaPfx, @"P@zzw0rD!SqlvN3x+");
+#else
+            using X509Certificate2 x509 = new(rsaPfx, @"P@zzw0rD!SqlvN3x+");
+#endif
+            Debug.Assert(x509.HasPrivateKey);
+
+            try
             {
-                if (cryptoParameter.CryptNativeTestVectorTypeVal == CryptNativeTestVectorType.Rsa)
+                store = new(StoreName.My, StoreLocation.CurrentUser);
+                store.Open(OpenFlags.ReadWrite);
+
+                store.Add(x509);
+                addedToStore = true;
+
+                // For each crypto vector, run the test to compare the output generated through sqlclient's code and the native code.
+                foreach (CryptoVector cryptoParameter in cryptoParametersListForTest)
                 {
-                    // Verify that we are using the right padding scheme for RSA encryption
-                    byte[] plaintext = CertificateUtility.DecryptRsaDirectly(rsaPfx, cryptoParameter.CiphertextCek, @"Test");
-                    Assert.True(cryptoParameter.PlaintextCek.SequenceEqual(plaintext), "Plaintext CEK Value does not match with the native code baseline.");
+                    if (cryptoParameter.CryptNativeTestVectorTypeVal == CryptNativeTestVectorType.Rsa)
+                    {
+                        Debug.Assert(cryptoParameter.PathCek != null && cryptoParameter.PathCek.StartsWith("CurrentUser/My"));
 
-                    // Verify that the signed blob is conforming to our envelope (SHA-256, PKCS 1 padding)
-                    bool signatureVerified = CertificateUtility.VerifyRsaSignatureDirectly(cryptoParameter.HashedCek, cryptoParameter.SignedCek, rsaPfx);
-                    Assert.True(signatureVerified, "Plaintext CEK signature scheme does not match with the native code baseline.");
-
-                    //// TODO:  Programmatically install the in-memory PFX into the right store (based on path) & use the public API
-                    //plaintext = Utility.VerifyRsaSignature(cryptoParameter.PathCek, cryptoParameter.FinalcellCek, rsaPfx);
-                    //CError.Compare(cryptoParameter.PlaintextCek.SequenceEqual(plaintext), "Plaintext CEK Value does not match with the native code baseline (end to end).");
+                        // Decrypt the supplied final cell CEK, and ensure that the plaintext CEK value matches the native code baseline.
+                        byte[] plaintext = rsaProvider.DecryptColumnEncryptionKey(cryptoParameter.PathCek, "RSA_OAEP", cryptoParameter.FinalcellCek);
+                        Assert.Equal(cryptoParameter.PlaintextCek, plaintext);
+                    }
                 }
+            }
+            finally
+            {
+                if (addedToStore)
+                {
+                    store.Remove(x509);
+                }
+
+                store?.Dispose();
             }
         }
 


### PR DESCRIPTION
## Description

This is my final PR in this set of changes to this area, picking up where #3612 left off. Benchmarks for this PR are located in #3554.

The previous PR used the AlwaysEncrypted primitives in `SqlColumnEncryptionCspProvider` and `SqlColumnEncryptionCngProvider`. This one introduces them to `SqlColumnEncryptionCertificateStoreProvider`.

While verifying this, I also noticed that the `TestRsaCryptoWithNativeBaseline` test was calling private methods using reflection, but that there was a TODO item in the test to use the public API surface instead. I've done this.

## Issues

PR 1/3: #3554.
PR 2/3: #3612.
PR 3/3: this one.

## Testing

As in the previous PR, automated tests pass. I also created an AE-enabled table in SSMS which used a certificate store-based master key and confirmed that I was able to query it and insert records into it.