### PR TITLE
[6.1] Cleanup semaphore holder

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
@@ -1320,10 +1320,10 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
 
                                     if (onlyOneCheckConnection)
                                     {
+                                        bool obtained = false;
 #if NETFRAMEWORK
                                         RuntimeHelpers.PrepareConstrainedRegions();
 #endif
-                                        bool obtained = false;
                                         try
                                         {
                                             obtained = _waitHandles.CreationSemaphore.WaitOne(unchecked((int)waitForMultipleObjectsTimeout));


### PR DESCRIPTION
Additional change to https://github.com/dotnet/SqlClient/pull/3653

Managing Semaphores with Disposable pattern may not be a good idea for .NET Framework applications (within CER enabled blocks). Reverting this change, to prevent any side effects.