### PR TITLE
Introduce Async API counterparts for AE base class

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
@@ -24,7 +24,7 @@
         Decrypts the specified encrypted value of a column encryption key. The encrypted value is expected to be encrypted using the column master key with the specified key path and using the specified algorithm.
       </summary>
       <returns>
-        Returns <see cref="T:System.Byte" /> array representing the decrypted column encryption key.
+        Returns <see cref="T:System.Byte[]" /> array representing the decrypted column encryption key.
       </returns>
     </DecryptColumnEncryptionKey>
     <DecryptColumnEncryptionKeyAsync>
@@ -41,7 +41,7 @@
         Decrypts the specified encrypted value of a column encryption key asynchronously. The encrypted value is expected to be encrypted using the column master key with the specified key path and using the specified algorithm.
       </summary>
       <returns>
-        Returns a task that returns <see cref="T:System.Byte" /> array representing the decrypted column encryption key on completion.
+        Returns a task that returns <see cref="T:System.Byte[]" /> array representing the decrypted column encryption key on completion.
       </returns>
     </DecryptColumnEncryptionKeyAsync>
     <EncryptColumnEncryptionKey>
@@ -58,7 +58,7 @@
         Encrypts a column encryption key using the column master key with the specified key path and using the specified algorithm.
       </summary>
       <returns>
-        Returns <see cref="T:System.Byte" /> array representing the encrypted column encryption key.
+        Returns <see cref="T:System.Byte[]" /> array representing the encrypted column encryption key.
       </returns>
     </EncryptColumnEncryptionKey>
     <EncryptColumnEncryptionKeyAsync>
@@ -75,7 +75,7 @@
         Encrypts a column encryption key asynchronously using the column master key with the specified key path and using the specified algorithm.
       </summary>
       <returns>
-        Returns a task that returns <see cref="T:System.Byte" /> array representing the encrypted column encryption key on completion.
+        Returns a task that returns <see cref="T:System.Byte[]" /> array representing the encrypted column encryption key on completion.
       </returns>
     </EncryptColumnEncryptionKeyAsync>
     <SignColumnMasterKeyMetadata>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
@@ -24,9 +24,26 @@
         Decrypts the specified encrypted value of a column encryption key. The encrypted value is expected to be encrypted using the column master key with the specified key path and using the specified algorithm.
       </summary>
       <returns>
-        Returns <see cref="T:System.Byte" />. The decrypted column encryption key.
+        Returns <see cref="T:System.Byte" /> array representing the decrypted column encryption key.
       </returns>
     </DecryptColumnEncryptionKey>
+    <DecryptColumnEncryptionKeyAsync>
+      <param name="masterKeyPath">
+        The master key path.
+      </param>
+      <param name="encryptionAlgorithm">
+        The encryption algorithm.
+      </param>
+      <param name="encryptedColumnEncryptionKey">
+        The encrypted column encryption key.
+      </param>
+      <summary>
+        Decrypts the specified encrypted value of a column encryption key asynchronously. The encrypted value is expected to be encrypted using the column master key with the specified key path and using the specified algorithm.
+      </summary>
+      <returns>
+        Returns a task that returns <see cref="T:System.Byte" /> array representing the decrypted column encryption key on completion.
+      </returns>
+    </DecryptColumnEncryptionKeyAsync>
     <EncryptColumnEncryptionKey>
       <param name="masterKeyPath">
         The master key path.
@@ -41,9 +58,26 @@
         Encrypts a column encryption key using the column master key with the specified key path and using the specified algorithm.
       </summary>
       <returns>
-        Returns <see cref="T:System.Byte" />. The encrypted column encryption key.
+        Returns <see cref="T:System.Byte" /> array representing the encrypted column encryption key.
       </returns>
     </EncryptColumnEncryptionKey>
+    <EncryptColumnEncryptionKeyAsync>
+      <param name="masterKeyPath">
+        The master key path.
+      </param>
+      <param name="encryptionAlgorithm">
+        The encryption algorithm.
+      </param>
+      <param name="columnEncryptionKey">
+        The plaintext column encryption key.
+      </param>
+      <summary>
+        Encrypts a column encryption key asynchronously using the column master key with the specified key path and using the specified algorithm.
+      </summary>
+      <returns>
+        Returns a task that returns <see cref="T:System.Byte" /> array representing the encrypted column encryption key on completion.
+      </returns>
+    </EncryptColumnEncryptionKeyAsync>
     <SignColumnMasterKeyMetadata>
       <param name="masterKeyPath">
         The column master key path.
@@ -55,7 +89,7 @@
         When implemented in a derived class, digitally signs the column master key metadata with the column master key referenced by the <paramref name="masterKeyPath" /> parameter. The input values used to generate the signature should be the specified values of the <paramref name="masterKeyPath" /> and <paramref name="allowEnclaveComputations" /> parameters.
       </summary>
       <returns>
-        The signature of the column master key metadata.
+        Returns the signature of the column master key metadata.
       </returns>
       <remarks>
         <para>
@@ -69,6 +103,31 @@
         In all cases.
       </exception>
     </SignColumnMasterKeyMetadata>
+    <SignColumnMasterKeyMetadataAsync>
+      <param name="masterKeyPath">
+        The column master key path.
+      </param>
+      <param name="allowEnclaveComputations">
+        <see langword="true" /> to indicate that the column master key supports enclave computations; otherwise, <see langword="false" />.
+      </param>
+      <summary>
+        When implemented in a derived class, asynchronously digitally signs the column master key metadata with the column master key referenced by the <paramref name="masterKeyPath" /> parameter. The input values used to generate the signature should be the specified values of the <paramref name="masterKeyPath" /> and <paramref name="allowEnclaveComputations" /> parameters.
+      </summary>
+      <returns>
+        Returns a task that returns the signature of the column master key metadata on completion.
+      </returns>
+      <remarks>
+        <para>
+          To ensure that the <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" /> method doesn't break applications that rely on an old API, it throws a <see cref="T:System.NotImplementedException" /> exception by default.
+        </para>
+        <para>
+          The <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" /> method will be used by client tools that generate Column Master Keys (CMK) for customers. <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" /> must be implemented by the corresponding key store providers that wish to use enclaves with <see href="https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-database-engine">Always Encrypted</see>.
+        </para>
+      </remarks>
+      <exception cref="T:System.NotImplementedException">
+        In all cases.
+      </exception>
+    </SignColumnMasterKeyMetadataAsync>
     <VerifyColumnMasterKeyMetadata>
       <param name="masterKeyPath">
         The column master key path.
@@ -86,6 +145,23 @@
         When implemented in a derived class, the method is expected to return true if the specified signature is valid, or false if the specified signature is not valid. The default implementation throws `NotImplementedException`.
       </returns>
     </VerifyColumnMasterKeyMetadata>
+    <VerifyColumnMasterKeyMetadataAsync>
+      <param name="masterKeyPath">
+        The column master key path.
+      </param>
+      <param name="allowEnclaveComputations">
+        Indicates whether the column master key supports enclave computations.
+      </param>
+      <param name="signature">
+        The signature of the column master key metadata.
+      </param>
+      <summary>
+        When implemented in a derived class, this method is expected to verify the specified signature is valid for the column master key with the specified key path and the specified enclave behavior asynchronously. The default implementation throws `NotImplementedException`.
+      </summary>
+      <returns>
+        When implemented in a derived class, the method is expected to return true if the specified signature is valid, or false if the specified signature is not valid. The default implementation throws `NotImplementedException`.
+      </returns>
+    </VerifyColumnMasterKeyMetadataAsync>
     <ColumnEncryptionKeyCacheTtl>
       <summary>
         Gets or sets the lifespan of the decrypted column encryption key in the cache. Once the timespan has elapsed, the decrypted column encryption key is discarded and must be revalidated.

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
@@ -30,7 +30,8 @@
         The encrypted column encryption key.
       </param>
       <returns>
-        Returns the decrypted column encryption key as a byte array.
+        Returns a <see cref="T:System.Byte[]" /> representing the decrypted
+        column encryption key.
       </returns>
     </DecryptColumnEncryptionKey>
     <DecryptColumnEncryptionKeyAsync>
@@ -56,26 +57,51 @@
         A token to cancel the asynchronous operation.
       </param>
       <returns>
-        A task that, when completed, returns the decrypted column encryption
-        key as a byte array.
+        A task that returns a <see cref="T:System.Byte[]" /> representing
+        the decrypted column encryption key on completion.
       </returns>
       <remarks>
         <para>
-          The default implementation calls the synchronous
+          The default implementation first checks the
+          <paramref name="cancellationToken" /> and returns a canceled task
+          if cancellation has been requested. Otherwise, it calls the
+          synchronous
           <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.DecryptColumnEncryptionKey(System.String,System.String,System.Byte[])" />
           method and wraps the result in a completed task. If the synchronous
           method throws, the exception is caught and a faulted task is
           returned rather than throwing synchronously.
         </para>
         <para>
-          The <paramref name="cancellationToken" /> parameter is not observed
-          by the default implementation. Derived classes that perform I/O
-          (such as calls to Azure Key Vault) should override this method with
-          a truly asynchronous implementation that honors the cancellation
-          token.
+          Derived classes that perform I/O (such as calls to Azure Key Vault)
+          should override this method with a truly asynchronous
+          implementation that honors the cancellation token.
         </para>
       </remarks>
     </DecryptColumnEncryptionKeyAsync>
+    <DecryptColumnEncryptionKeyAsyncNoCancellation>
+      <summary>
+        Asynchronously decrypts the specified encrypted value of a column
+        encryption key. The encrypted value is expected to be encrypted using
+        the column master key with the specified key path and using the
+        specified algorithm.
+      </summary>
+      <param name="masterKeyPath">
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
+      </param>
+      <param name="encryptionAlgorithm">
+        The encryption algorithm name. For example,
+        <c>RSA_OAEP</c>.
+      </param>
+      <param name="encryptedColumnEncryptionKey">
+        The encrypted column encryption key.
+      </param>
+      <returns>
+        A task that returns a <see cref="T:System.Byte[]" /> representing
+        the decrypted column encryption key on completion.
+      </returns>
+    </DecryptColumnEncryptionKeyAsyncNoCancellation>
     <EncryptColumnEncryptionKey>
       <summary>
         Encrypts a column encryption key using the column master key with
@@ -94,7 +120,8 @@
         The column encryption key to encrypt.
       </param>
       <returns>
-        Returns the encrypted column encryption key as a byte array.
+        Returns a <see cref="T:System.Byte[]" /> representing the encrypted
+        column encryption key.
       </returns>
     </EncryptColumnEncryptionKey>
     <EncryptColumnEncryptionKeyAsync>
@@ -119,26 +146,50 @@
         A token to cancel the asynchronous operation.
       </param>
       <returns>
-        A task that, when completed, returns the encrypted column encryption
-        key as a byte array.
+        A task that returns a <see cref="T:System.Byte[]" /> representing
+        the encrypted column encryption key on completion.
       </returns>
       <remarks>
         <para>
-          The default implementation calls the synchronous
+          The default implementation first checks the
+          <paramref name="cancellationToken" /> and returns a canceled task
+          if cancellation has been requested. Otherwise, it calls the
+          synchronous
           <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.EncryptColumnEncryptionKey(System.String,System.String,System.Byte[])" />
           method and wraps the result in a completed task. If the synchronous
           method throws, the exception is caught and a faulted task is
           returned rather than throwing synchronously.
         </para>
         <para>
-          The <paramref name="cancellationToken" /> parameter is not observed
-          by the default implementation. Derived classes that perform I/O
-          (such as calls to Azure Key Vault) should override this method with
-          a truly asynchronous implementation that honors the cancellation
-          token.
+          Derived classes that perform I/O (such as calls to Azure Key Vault)
+          should override this method with a truly asynchronous
+          implementation that honors the cancellation token.
         </para>
       </remarks>
     </EncryptColumnEncryptionKeyAsync>
+    <EncryptColumnEncryptionKeyAsyncNoCancellation>
+      <summary>
+        Asynchronously encrypts a column encryption key using the column
+        master key with the specified key path and using the specified
+        algorithm.
+      </summary>
+      <param name="masterKeyPath">
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
+      </param>
+      <param name="encryptionAlgorithm">
+        The encryption algorithm name. For example,
+        <c>RSA_OAEP</c>.
+      </param>
+      <param name="columnEncryptionKey">
+        The column encryption key to encrypt.
+      </param>
+      <returns>
+        A task that returns a <see cref="T:System.Byte[]" /> representing
+        the encrypted column encryption key on completion.
+      </returns>
+    </EncryptColumnEncryptionKeyAsyncNoCancellation>
     <SignColumnMasterKeyMetadata>
       <summary>
         When implemented in a derived class, signs the column master key
@@ -190,12 +241,15 @@
         A token to cancel the asynchronous operation.
       </param>
       <returns>
-        A task that, when completed, returns the signature of the column
-        master key metadata as a byte array.
+        A task that, when completed, returns a <see cref="T:System.Byte[]" />
+        representing the signature of the column master key metadata.
       </returns>
       <remarks>
         <para>
-          The default implementation calls the synchronous
+          The default implementation first checks the
+          <paramref name="cancellationToken" /> and returns a canceled task
+          if cancellation has been requested. Otherwise, it calls the
+          synchronous
           <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" />
           method, which throws a
           <see cref="T:System.NotImplementedException" /> by default. In
@@ -204,10 +258,9 @@
           throwing synchronously.
         </para>
         <para>
-          The <paramref name="cancellationToken" /> parameter is not observed
-          by the default implementation. Derived classes that perform I/O
-          should override this method with a truly asynchronous
-          implementation that honors the cancellation token.
+          Derived classes that perform I/O should override this method with
+          a truly asynchronous implementation that honors the cancellation
+          token.
         </para>
         <para>
           Key store providers that wish to use enclaves with
@@ -217,6 +270,27 @@
         </para>
       </remarks>
     </SignColumnMasterKeyMetadataAsync>
+    <SignColumnMasterKeyMetadataAsyncNoCancellation>
+      <summary>
+        When implemented in a derived class, asynchronously signs the column
+        master key metadata with the column master key referenced by the
+        <paramref name="masterKeyPath" /> parameter.
+      </summary>
+      <param name="masterKeyPath">
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
+      </param>
+      <param name="allowEnclaveComputations">
+        <see langword="true" /> to indicate that the column master key
+        supports enclave computations; otherwise,
+        <see langword="false" />.
+      </param>
+      <returns>
+        A task that, when completed, returns a <see cref="T:System.Byte[]" />
+        representing the signature of the column master key metadata.
+      </returns>
+    </SignColumnMasterKeyMetadataAsyncNoCancellation>
     <VerifyColumnMasterKeyMetadata>
       <summary>
         When implemented in a derived class, this method is expected to
@@ -275,7 +349,10 @@
       </returns>
       <remarks>
         <para>
-          The default implementation calls the synchronous
+          The default implementation first checks the
+          <paramref name="cancellationToken" /> and returns a canceled task
+          if cancellation has been requested. Otherwise, it calls the
+          synchronous
           <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.VerifyColumnMasterKeyMetadata(System.String,System.Boolean,System.Byte[])" />
           method, which throws a
           <see cref="T:System.NotImplementedException" /> by default. In
@@ -284,13 +361,36 @@
           throwing synchronously.
         </para>
         <para>
-          The <paramref name="cancellationToken" /> parameter is not observed
-          by the default implementation. Derived classes that perform I/O
-          should override this method with a truly asynchronous
-          implementation that honors the cancellation token.
+          Derived classes that perform I/O should override this method with
+          a truly asynchronous implementation that honors the cancellation
+          token.
         </para>
       </remarks>
     </VerifyColumnMasterKeyMetadataAsync>
+    <VerifyColumnMasterKeyMetadataAsyncNoCancellation>
+      <summary>
+        When implemented in a derived class, asynchronously verifies the
+        specified signature is valid for the column master key with the
+        specified key path and the specified enclave behavior.
+      </summary>
+      <param name="masterKeyPath">
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
+      </param>
+      <param name="allowEnclaveComputations">
+        Indicates whether the column master key supports enclave
+        computations.
+      </param>
+      <param name="signature">
+        The signature of the column master key metadata.
+      </param>
+      <returns>
+        A task that, when completed, returns <see langword="true" /> if the
+        specified signature is valid, or <see langword="false" /> if it is
+        not valid.
+      </returns>
+    </VerifyColumnMasterKeyMetadataAsyncNoCancellation>
     <ColumnEncryptionKeyCacheTtl>
       <summary>
         Gets or sets the lifespan of the decrypted column encryption key in the cache. Once the timespan has elapsed, the decrypted column encryption key is discarded and must be revalidated.

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
@@ -37,6 +37,9 @@
       <param name="encryptedColumnEncryptionKey">
         The encrypted column encryption key.
       </param>
+      <param name="cancellationToken">
+        A token to cancel the asynchronous operation.
+      </param>
       <summary>
         Decrypts the specified encrypted value of a column encryption key asynchronously. The encrypted value is expected to be encrypted using the column master key with the specified key path and using the specified algorithm.
       </summary>
@@ -70,6 +73,9 @@
       </param>
       <param name="columnEncryptionKey">
         The plaintext column encryption key.
+      </param>
+      <param name="cancellationToken">
+        A token to cancel the asynchronous operation.
       </param>
       <summary>
         Encrypts a column encryption key asynchronously using the column master key with the specified key path and using the specified algorithm.
@@ -110,6 +116,9 @@
       <param name="allowEnclaveComputations">
         <see langword="true" /> to indicate that the column master key supports enclave computations; otherwise, <see langword="false" />.
       </param>
+      <param name="cancellationToken">
+        A token to cancel the asynchronous operation.
+      </param>
       <summary>
         When implemented in a derived class, asynchronously digitally signs the column master key metadata with the column master key referenced by the <paramref name="masterKeyPath" /> parameter. The input values used to generate the signature should be the specified values of the <paramref name="masterKeyPath" /> and <paramref name="allowEnclaveComputations" /> parameters.
       </summary>
@@ -118,15 +127,12 @@
       </returns>
       <remarks>
         <para>
-          To ensure that the <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" /> method doesn't break applications that rely on an old API, it throws a <see cref="T:System.NotImplementedException" /> exception by default.
+          The default implementation calls the synchronous <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" /> method, which throws a <see cref="T:System.NotImplementedException" /> by default. In this case, the returned task will be faulted with <see cref="T:System.NotImplementedException" />.
         </para>
         <para>
-          The <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" /> method will be used by client tools that generate Column Master Keys (CMK) for customers. <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" /> must be implemented by the corresponding key store providers that wish to use enclaves with <see href="https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-database-engine">Always Encrypted</see>.
+          Key store providers that wish to use enclaves with <see href="https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-database-engine">Always Encrypted</see> should override this method with a truly asynchronous implementation when the signing operation involves I/O.
         </para>
       </remarks>
-      <exception cref="T:System.NotImplementedException">
-        In all cases.
-      </exception>
     </SignColumnMasterKeyMetadataAsync>
     <VerifyColumnMasterKeyMetadata>
       <param name="masterKeyPath">
@@ -155,11 +161,14 @@
       <param name="signature">
         The signature of the column master key metadata.
       </param>
+      <param name="cancellationToken">
+        A token to cancel the asynchronous operation.
+      </param>
       <summary>
-        When implemented in a derived class, this method is expected to verify the specified signature is valid for the column master key with the specified key path and the specified enclave behavior asynchronously. The default implementation throws `NotImplementedException`.
+        When implemented in a derived class, this method is expected to verify the specified signature is valid for the column master key with the specified key path and the specified enclave behavior asynchronously. The default implementation returns a faulted task with <see cref="T:System.NotImplementedException" />.
       </summary>
       <returns>
-        When implemented in a derived class, the method is expected to return true if the specified signature is valid, or false if the specified signature is not valid. The default implementation throws `NotImplementedException`.
+        A task that, when completed, returns <see langword="true" /> if the specified signature is valid, or <see langword="false" /> if it is not valid.
       </returns>
     </VerifyColumnMasterKeyMetadataAsync>
     <ColumnEncryptionKeyCacheTtl>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
@@ -78,30 +78,6 @@
         </para>
       </remarks>
     </DecryptColumnEncryptionKeyAsync>
-    <DecryptColumnEncryptionKeyAsyncNoCancellation>
-      <summary>
-        Asynchronously decrypts the specified encrypted value of a column
-        encryption key. The encrypted value is expected to be encrypted using
-        the column master key with the specified key path and using the
-        specified algorithm.
-      </summary>
-      <param name="masterKeyPath">
-        The column master key path. The path format is specific to the key
-        store provider implementation (e.g. a thumbprint for the certificate
-        store, or a key identifier URL for Azure Key Vault).
-      </param>
-      <param name="encryptionAlgorithm">
-        The encryption algorithm name. For example,
-        <c>RSA_OAEP</c>.
-      </param>
-      <param name="encryptedColumnEncryptionKey">
-        The encrypted column encryption key.
-      </param>
-      <returns>
-        A task that returns a <see cref="T:System.Byte[]" /> representing
-        the decrypted column encryption key on completion.
-      </returns>
-    </DecryptColumnEncryptionKeyAsyncNoCancellation>
     <EncryptColumnEncryptionKey>
       <summary>
         Encrypts a column encryption key using the column master key with
@@ -167,29 +143,6 @@
         </para>
       </remarks>
     </EncryptColumnEncryptionKeyAsync>
-    <EncryptColumnEncryptionKeyAsyncNoCancellation>
-      <summary>
-        Asynchronously encrypts a column encryption key using the column
-        master key with the specified key path and using the specified
-        algorithm.
-      </summary>
-      <param name="masterKeyPath">
-        The column master key path. The path format is specific to the key
-        store provider implementation (e.g. a thumbprint for the certificate
-        store, or a key identifier URL for Azure Key Vault).
-      </param>
-      <param name="encryptionAlgorithm">
-        The encryption algorithm name. For example,
-        <c>RSA_OAEP</c>.
-      </param>
-      <param name="columnEncryptionKey">
-        The column encryption key to encrypt.
-      </param>
-      <returns>
-        A task that returns a <see cref="T:System.Byte[]" /> representing
-        the encrypted column encryption key on completion.
-      </returns>
-    </EncryptColumnEncryptionKeyAsyncNoCancellation>
     <SignColumnMasterKeyMetadata>
       <summary>
         When implemented in a derived class, signs the column master key
@@ -276,30 +229,6 @@
         </para>
       </remarks>
     </SignColumnMasterKeyMetadataAsync>
-    <SignColumnMasterKeyMetadataAsyncNoCancellation>
-      <summary>
-        When implemented in a derived class, asynchronously signs the column
-        master key metadata with the column master key referenced by the
-        <paramref name="masterKeyPath" /> parameter.
-      </summary>
-      <param name="masterKeyPath">
-        The column master key path. The path format is specific to the key
-        store provider implementation (e.g. a thumbprint for the certificate
-        store, or a key identifier URL for Azure Key Vault).
-      </param>
-      <param name="allowEnclaveComputations">
-        <see langword="true" /> to indicate that the column master key
-        supports enclave computations; otherwise,
-        <see langword="false" />. When <see langword="true" />, the
-        generated signature covers the enclave-enabled property so that
-        the metadata can later be verified for enclave use.
-      </param>
-      <returns>
-        A task that, when completed, returns a <see cref="T:System.Byte[]" />
-        representing the signature of the column master key metadata. The
-        signature format is provider-specific.
-      </returns>
-    </SignColumnMasterKeyMetadataAsyncNoCancellation>
     <VerifyColumnMasterKeyMetadata>
       <summary>
         When implemented in a derived class, this method is expected to
@@ -384,34 +313,6 @@
         </para>
       </remarks>
     </VerifyColumnMasterKeyMetadataAsync>
-    <VerifyColumnMasterKeyMetadataAsyncNoCancellation>
-      <summary>
-        When implemented in a derived class, asynchronously verifies the
-        specified signature is valid for the column master key with the
-        specified key path and the specified enclave behavior.
-      </summary>
-      <param name="masterKeyPath">
-        The column master key path. The path format is specific to the key
-        store provider implementation (e.g. a thumbprint for the certificate
-        store, or a key identifier URL for Azure Key Vault).
-      </param>
-      <param name="allowEnclaveComputations">
-        Indicates whether the column master key supports enclave
-        computations. This value must match what was passed to
-        <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" />
-        when the signature was generated.
-      </param>
-      <param name="signature">
-        The signature to verify, as previously returned by
-        <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" />.
-        The format is provider-specific.
-      </param>
-      <returns>
-        A task that, when completed, returns <see langword="true" /> if the
-        specified signature is valid, or <see langword="false" /> if it is
-        not valid.
-      </returns>
-    </VerifyColumnMasterKeyMetadataAsyncNoCancellation>
     <ColumnEncryptionKeyCacheTtl>
       <summary>
         Gets or sets the lifespan of the decrypted column encryption key in the cache. Once the timespan has elapsed, the decrypted column encryption key is discarded and must be revalidated.

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
@@ -11,28 +11,43 @@
       </summary>
     </ctor>
     <DecryptColumnEncryptionKey>
+      <summary>
+        Decrypts the specified encrypted value of a column encryption key.
+        The encrypted value is expected to be encrypted using the column
+        master key with the specified key path and using the specified
+        algorithm.
+      </summary>
       <param name="masterKeyPath">
-        The master key path.
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
       </param>
       <param name="encryptionAlgorithm">
-        The encryption algorithm.
+        The encryption algorithm name. For example,
+        <c>RSA_OAEP</c>.
       </param>
       <param name="encryptedColumnEncryptionKey">
         The encrypted column encryption key.
       </param>
-      <summary>
-        Decrypts the specified encrypted value of a column encryption key. The encrypted value is expected to be encrypted using the column master key with the specified key path and using the specified algorithm.
-      </summary>
       <returns>
-        Returns <see cref="T:System.Byte[]" /> array representing the decrypted column encryption key.
+        Returns the decrypted column encryption key as a byte array.
       </returns>
     </DecryptColumnEncryptionKey>
     <DecryptColumnEncryptionKeyAsync>
+      <summary>
+        Asynchronously decrypts the specified encrypted value of a column
+        encryption key. The encrypted value is expected to be encrypted using
+        the column master key with the specified key path and using the
+        specified algorithm.
+      </summary>
       <param name="masterKeyPath">
-        The master key path.
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
       </param>
       <param name="encryptionAlgorithm">
-        The encryption algorithm.
+        The encryption algorithm name. For example,
+        <c>RSA_OAEP</c>.
       </param>
       <param name="encryptedColumnEncryptionKey">
         The encrypted column encryption key.
@@ -40,76 +55,106 @@
       <param name="cancellationToken">
         A token to cancel the asynchronous operation.
       </param>
-      <summary>
-        Decrypts the specified encrypted value of a column encryption key asynchronously. The encrypted value is expected to be encrypted using the column master key with the specified key path and using the specified algorithm.
-      </summary>
       <returns>
-        Returns a task that returns <see cref="T:System.Byte[]" /> array representing the decrypted column encryption key on completion.
+        A task that, when completed, returns the decrypted column encryption
+        key as a byte array.
       </returns>
       <remarks>
         <para>
-          The default implementation calls the synchronous <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.DecryptColumnEncryptionKey(System.String,System.String,System.Byte[])" /> method and wraps the result in a completed task. If the synchronous method throws, the exception is caught and a faulted task is returned rather than throwing synchronously.
+          The default implementation calls the synchronous
+          <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.DecryptColumnEncryptionKey(System.String,System.String,System.Byte[])" />
+          method and wraps the result in a completed task. If the synchronous
+          method throws, the exception is caught and a faulted task is
+          returned rather than throwing synchronously.
         </para>
         <para>
-          The <paramref name="cancellationToken" /> parameter is not observed by the default implementation. Derived classes that perform I/O (such as calls to Azure Key Vault) should override this method with a truly asynchronous implementation that honors the cancellation token.
+          The <paramref name="cancellationToken" /> parameter is not observed
+          by the default implementation. Derived classes that perform I/O
+          (such as calls to Azure Key Vault) should override this method with
+          a truly asynchronous implementation that honors the cancellation
+          token.
         </para>
       </remarks>
     </DecryptColumnEncryptionKeyAsync>
     <EncryptColumnEncryptionKey>
+      <summary>
+        Encrypts a column encryption key using the column master key with
+        the specified key path and using the specified algorithm.
+      </summary>
       <param name="masterKeyPath">
-        The master key path.
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
       </param>
       <param name="encryptionAlgorithm">
-        The encryption algorithm.
+        The encryption algorithm name. For example,
+        <c>RSA_OAEP</c>.
       </param>
       <param name="columnEncryptionKey">
-        The plaintext column encryption key.
+        The column encryption key to encrypt.
       </param>
-      <summary>
-        Encrypts a column encryption key using the column master key with the specified key path and using the specified algorithm.
-      </summary>
       <returns>
-        Returns <see cref="T:System.Byte[]" /> array representing the encrypted column encryption key.
+        Returns the encrypted column encryption key as a byte array.
       </returns>
     </EncryptColumnEncryptionKey>
     <EncryptColumnEncryptionKeyAsync>
+      <summary>
+        Asynchronously encrypts a column encryption key using the column
+        master key with the specified key path and using the specified
+        algorithm.
+      </summary>
       <param name="masterKeyPath">
-        The master key path.
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
       </param>
       <param name="encryptionAlgorithm">
-        The encryption algorithm.
+        The encryption algorithm name. For example,
+        <c>RSA_OAEP</c>.
       </param>
       <param name="columnEncryptionKey">
-        The plaintext column encryption key.
+        The column encryption key to encrypt.
       </param>
       <param name="cancellationToken">
         A token to cancel the asynchronous operation.
       </param>
-      <summary>
-        Encrypts a column encryption key asynchronously using the column master key with the specified key path and using the specified algorithm.
-      </summary>
       <returns>
-        Returns a task that returns <see cref="T:System.Byte[]" /> array representing the encrypted column encryption key on completion.
+        A task that, when completed, returns the encrypted column encryption
+        key as a byte array.
       </returns>
       <remarks>
         <para>
-          The default implementation calls the synchronous <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.EncryptColumnEncryptionKey(System.String,System.String,System.Byte[])" /> method and wraps the result in a completed task. If the synchronous method throws, the exception is caught and a faulted task is returned rather than throwing synchronously.
+          The default implementation calls the synchronous
+          <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.EncryptColumnEncryptionKey(System.String,System.String,System.Byte[])" />
+          method and wraps the result in a completed task. If the synchronous
+          method throws, the exception is caught and a faulted task is
+          returned rather than throwing synchronously.
         </para>
         <para>
-          The <paramref name="cancellationToken" /> parameter is not observed by the default implementation. Derived classes that perform I/O (such as calls to Azure Key Vault) should override this method with a truly asynchronous implementation that honors the cancellation token.
+          The <paramref name="cancellationToken" /> parameter is not observed
+          by the default implementation. Derived classes that perform I/O
+          (such as calls to Azure Key Vault) should override this method with
+          a truly asynchronous implementation that honors the cancellation
+          token.
         </para>
       </remarks>
     </EncryptColumnEncryptionKeyAsync>
     <SignColumnMasterKeyMetadata>
+      <summary>
+        When implemented in a derived class, signs the column master key
+        metadata with the column master key referenced by the
+        <paramref name="masterKeyPath" /> parameter.
+      </summary>
       <param name="masterKeyPath">
-        The column master key path.
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
       </param>
       <param name="allowEnclaveComputations">
-        <see langword="true" /> to indicate that the column master key supports enclave computations; otherwise, <see langword="false" />.
+        <see langword="true" /> to indicate that the column master key
+        supports enclave computations; otherwise,
+        <see langword="false" />.
       </param>
-      <summary>
-        When implemented in a derived class, digitally signs the column master key metadata with the column master key referenced by the <paramref name="masterKeyPath" /> parameter. The input values used to generate the signature should be the specified values of the <paramref name="masterKeyPath" /> and <paramref name="allowEnclaveComputations" /> parameters.
-      </summary>
       <returns>
         Returns the signature of the column master key metadata.
       </returns>
@@ -126,56 +171,96 @@
       </exception>
     </SignColumnMasterKeyMetadata>
     <SignColumnMasterKeyMetadataAsync>
+      <summary>
+        When implemented in a derived class, asynchronously signs the column
+        master key metadata with the column master key referenced by the
+        <paramref name="masterKeyPath" /> parameter.
+      </summary>
       <param name="masterKeyPath">
-        The column master key path.
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
       </param>
       <param name="allowEnclaveComputations">
-        <see langword="true" /> to indicate that the column master key supports enclave computations; otherwise, <see langword="false" />.
+        <see langword="true" /> to indicate that the column master key
+        supports enclave computations; otherwise,
+        <see langword="false" />.
       </param>
       <param name="cancellationToken">
         A token to cancel the asynchronous operation.
       </param>
-      <summary>
-        When implemented in a derived class, asynchronously digitally signs the column master key metadata with the column master key referenced by the <paramref name="masterKeyPath" /> parameter. The input values used to generate the signature should be the specified values of the <paramref name="masterKeyPath" /> and <paramref name="allowEnclaveComputations" /> parameters.
-      </summary>
       <returns>
-        Returns a task that returns the signature of the column master key metadata on completion.
+        A task that, when completed, returns the signature of the column
+        master key metadata as a byte array.
       </returns>
       <remarks>
         <para>
-          The default implementation calls the synchronous <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" /> method, which throws a <see cref="T:System.NotImplementedException" /> by default. In this case, the returned task will be faulted with <see cref="T:System.NotImplementedException" /> rather than throwing synchronously.
+          The default implementation calls the synchronous
+          <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" />
+          method, which throws a
+          <see cref="T:System.NotImplementedException" /> by default. In
+          this case, the returned task will be faulted with
+          <see cref="T:System.NotImplementedException" /> rather than
+          throwing synchronously.
         </para>
         <para>
-          The <paramref name="cancellationToken" /> parameter is not observed by the default implementation. Derived classes that perform I/O should override this method with a truly asynchronous implementation that honors the cancellation token.
+          The <paramref name="cancellationToken" /> parameter is not observed
+          by the default implementation. Derived classes that perform I/O
+          should override this method with a truly asynchronous
+          implementation that honors the cancellation token.
         </para>
         <para>
-          Key store providers that wish to use enclaves with <see href="https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-database-engine">Always Encrypted</see> should override this method with a truly asynchronous implementation when the signing operation involves I/O.
+          Key store providers that wish to use enclaves with
+          <see href="https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-database-engine">Always Encrypted</see>
+          should override this method with a truly asynchronous
+          implementation when the signing operation involves I/O.
         </para>
       </remarks>
     </SignColumnMasterKeyMetadataAsync>
     <VerifyColumnMasterKeyMetadata>
+      <summary>
+        When implemented in a derived class, this method is expected to
+        verify the specified signature is valid for the column master key
+        with the specified key path and the specified enclave behavior. The
+        default implementation throws
+        <see cref="T:System.NotImplementedException" />.
+      </summary>
       <param name="masterKeyPath">
-        The column master key path.
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
       </param>
       <param name="allowEnclaveComputations">
-        Indicates whether the column master key supports enclave computations.
+        Indicates whether the column master key supports enclave
+        computations.
       </param>
       <param name="signature">
         The signature of the column master key metadata.
       </param>
-      <summary>
-        When implemented in a derived class, this method is expected to verify the specified signature is valid for the column master key with the specified key path and the specified enclave behavior. The default implementation throws `NotImplementedException`.
-      </summary>
       <returns>
-        When implemented in a derived class, the method is expected to return true if the specified signature is valid, or false if the specified signature is not valid. The default implementation throws `NotImplementedException`.
+        When implemented in a derived class, the method is expected to
+        return <see langword="true" /> if the specified signature is valid,
+        or <see langword="false" /> if the specified signature is not valid.
+        The default implementation throws
+        <see cref="T:System.NotImplementedException" />.
       </returns>
     </VerifyColumnMasterKeyMetadata>
     <VerifyColumnMasterKeyMetadataAsync>
+      <summary>
+        When implemented in a derived class, asynchronously verifies the
+        specified signature is valid for the column master key with the
+        specified key path and the specified enclave behavior. The default
+        implementation returns a faulted task with
+        <see cref="T:System.NotImplementedException" />.
+      </summary>
       <param name="masterKeyPath">
-        The column master key path.
+        The column master key path. The path format is specific to the key
+        store provider implementation (e.g. a thumbprint for the certificate
+        store, or a key identifier URL for Azure Key Vault).
       </param>
       <param name="allowEnclaveComputations">
-        Indicates whether the column master key supports enclave computations.
+        Indicates whether the column master key supports enclave
+        computations.
       </param>
       <param name="signature">
         The signature of the column master key metadata.
@@ -183,18 +268,26 @@
       <param name="cancellationToken">
         A token to cancel the asynchronous operation.
       </param>
-      <summary>
-        When implemented in a derived class, this method is expected to verify the specified signature is valid for the column master key with the specified key path and the specified enclave behavior asynchronously. The default implementation returns a faulted task with <see cref="T:System.NotImplementedException" />.
-      </summary>
       <returns>
-        A task that, when completed, returns <see langword="true" /> if the specified signature is valid, or <see langword="false" /> if it is not valid.
+        A task that, when completed, returns <see langword="true" /> if the
+        specified signature is valid, or <see langword="false" /> if it is
+        not valid.
       </returns>
       <remarks>
         <para>
-          The default implementation calls the synchronous <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.VerifyColumnMasterKeyMetadata(System.String,System.Boolean,System.Byte[])" /> method, which throws a <see cref="T:System.NotImplementedException" /> by default. In this case, the returned task will be faulted with <see cref="T:System.NotImplementedException" /> rather than throwing synchronously.
+          The default implementation calls the synchronous
+          <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.VerifyColumnMasterKeyMetadata(System.String,System.Boolean,System.Byte[])" />
+          method, which throws a
+          <see cref="T:System.NotImplementedException" /> by default. In
+          this case, the returned task will be faulted with
+          <see cref="T:System.NotImplementedException" /> rather than
+          throwing synchronously.
         </para>
         <para>
-          The <paramref name="cancellationToken" /> parameter is not observed by the default implementation. Derived classes that perform I/O should override this method with a truly asynchronous implementation that honors the cancellation token.
+          The <paramref name="cancellationToken" /> parameter is not observed
+          by the default implementation. Derived classes that perform I/O
+          should override this method with a truly asynchronous
+          implementation that honors the cancellation token.
         </para>
       </remarks>
     </VerifyColumnMasterKeyMetadataAsync>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
@@ -46,6 +46,14 @@
       <returns>
         Returns a task that returns <see cref="T:System.Byte[]" /> array representing the decrypted column encryption key on completion.
       </returns>
+      <remarks>
+        <para>
+          The default implementation calls the synchronous <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.DecryptColumnEncryptionKey(System.String,System.String,System.Byte[])" /> method and wraps the result in a completed task. If the synchronous method throws, the exception is caught and a faulted task is returned rather than throwing synchronously.
+        </para>
+        <para>
+          The <paramref name="cancellationToken" /> parameter is not observed by the default implementation. Derived classes that perform I/O (such as calls to Azure Key Vault) should override this method with a truly asynchronous implementation that honors the cancellation token.
+        </para>
+      </remarks>
     </DecryptColumnEncryptionKeyAsync>
     <EncryptColumnEncryptionKey>
       <param name="masterKeyPath">
@@ -83,6 +91,14 @@
       <returns>
         Returns a task that returns <see cref="T:System.Byte[]" /> array representing the encrypted column encryption key on completion.
       </returns>
+      <remarks>
+        <para>
+          The default implementation calls the synchronous <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.EncryptColumnEncryptionKey(System.String,System.String,System.Byte[])" /> method and wraps the result in a completed task. If the synchronous method throws, the exception is caught and a faulted task is returned rather than throwing synchronously.
+        </para>
+        <para>
+          The <paramref name="cancellationToken" /> parameter is not observed by the default implementation. Derived classes that perform I/O (such as calls to Azure Key Vault) should override this method with a truly asynchronous implementation that honors the cancellation token.
+        </para>
+      </remarks>
     </EncryptColumnEncryptionKeyAsync>
     <SignColumnMasterKeyMetadata>
       <param name="masterKeyPath">
@@ -127,7 +143,10 @@
       </returns>
       <remarks>
         <para>
-          The default implementation calls the synchronous <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" /> method, which throws a <see cref="T:System.NotImplementedException" /> by default. In this case, the returned task will be faulted with <see cref="T:System.NotImplementedException" />.
+          The default implementation calls the synchronous <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" /> method, which throws a <see cref="T:System.NotImplementedException" /> by default. In this case, the returned task will be faulted with <see cref="T:System.NotImplementedException" /> rather than throwing synchronously.
+        </para>
+        <para>
+          The <paramref name="cancellationToken" /> parameter is not observed by the default implementation. Derived classes that perform I/O should override this method with a truly asynchronous implementation that honors the cancellation token.
         </para>
         <para>
           Key store providers that wish to use enclaves with <see href="https://learn.microsoft.com/sql/relational-databases/security/encryption/always-encrypted-database-engine">Always Encrypted</see> should override this method with a truly asynchronous implementation when the signing operation involves I/O.
@@ -170,6 +189,14 @@
       <returns>
         A task that, when completed, returns <see langword="true" /> if the specified signature is valid, or <see langword="false" /> if it is not valid.
       </returns>
+      <remarks>
+        <para>
+          The default implementation calls the synchronous <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.VerifyColumnMasterKeyMetadata(System.String,System.Boolean,System.Byte[])" /> method, which throws a <see cref="T:System.NotImplementedException" /> by default. In this case, the returned task will be faulted with <see cref="T:System.NotImplementedException" /> rather than throwing synchronously.
+        </para>
+        <para>
+          The <paramref name="cancellationToken" /> parameter is not observed by the default implementation. Derived classes that perform I/O should override this method with a truly asynchronous implementation that honors the cancellation token.
+        </para>
+      </remarks>
     </VerifyColumnMasterKeyMetadataAsync>
     <ColumnEncryptionKeyCacheTtl>
       <summary>

--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml
@@ -204,10 +204,13 @@
       <param name="allowEnclaveComputations">
         <see langword="true" /> to indicate that the column master key
         supports enclave computations; otherwise,
-        <see langword="false" />.
+        <see langword="false" />. When <see langword="true" />, the
+        generated signature covers the enclave-enabled property so that
+        the metadata can later be verified for enclave use.
       </param>
       <returns>
-        Returns the signature of the column master key metadata.
+        Returns the signature of the column master key metadata. The format
+        is provider-specific.
       </returns>
       <remarks>
         <para>
@@ -235,14 +238,17 @@
       <param name="allowEnclaveComputations">
         <see langword="true" /> to indicate that the column master key
         supports enclave computations; otherwise,
-        <see langword="false" />.
+        <see langword="false" />. When <see langword="true" />, the
+        generated signature covers the enclave-enabled property so that
+        the metadata can later be verified for enclave use.
       </param>
       <param name="cancellationToken">
         A token to cancel the asynchronous operation.
       </param>
       <returns>
         A task that, when completed, returns a <see cref="T:System.Byte[]" />
-        representing the signature of the column master key metadata.
+        representing the signature of the column master key metadata. The
+        signature format is provider-specific.
       </returns>
       <remarks>
         <para>
@@ -284,11 +290,14 @@
       <param name="allowEnclaveComputations">
         <see langword="true" /> to indicate that the column master key
         supports enclave computations; otherwise,
-        <see langword="false" />.
+        <see langword="false" />. When <see langword="true" />, the
+        generated signature covers the enclave-enabled property so that
+        the metadata can later be verified for enclave use.
       </param>
       <returns>
         A task that, when completed, returns a <see cref="T:System.Byte[]" />
-        representing the signature of the column master key metadata.
+        representing the signature of the column master key metadata. The
+        signature format is provider-specific.
       </returns>
     </SignColumnMasterKeyMetadataAsyncNoCancellation>
     <VerifyColumnMasterKeyMetadata>
@@ -306,10 +315,14 @@
       </param>
       <param name="allowEnclaveComputations">
         Indicates whether the column master key supports enclave
-        computations.
+        computations. This value must match what was passed to
+        <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" />
+        when the signature was generated.
       </param>
       <param name="signature">
-        The signature of the column master key metadata.
+        The signature to verify, as previously returned by
+        <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" />.
+        The format is provider-specific.
       </param>
       <returns>
         When implemented in a derived class, the method is expected to
@@ -334,10 +347,14 @@
       </param>
       <param name="allowEnclaveComputations">
         Indicates whether the column master key supports enclave
-        computations.
+        computations. This value must match what was passed to
+        <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" />
+        when the signature was generated.
       </param>
       <param name="signature">
-        The signature of the column master key metadata.
+        The signature to verify, as previously returned by
+        <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" />.
+        The format is provider-specific.
       </param>
       <param name="cancellationToken">
         A token to cancel the asynchronous operation.
@@ -380,10 +397,14 @@
       </param>
       <param name="allowEnclaveComputations">
         Indicates whether the column master key supports enclave
-        computations.
+        computations. This value must match what was passed to
+        <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" />
+        when the signature was generated.
       </param>
       <param name="signature">
-        The signature of the column master key metadata.
+        The signature to verify, as previously returned by
+        <see cref="M:Microsoft.Data.SqlClient.SqlColumnEncryptionKeyStoreProvider.SignColumnMasterKeyMetadata(System.String,System.Boolean)" />.
+        The format is provider-specific.
       </param>
       <returns>
         A task that, when completed, returns <see langword="true" /> if the

--- a/specs/002-async-always-encrypted/spec.md
+++ b/specs/002-async-always-encrypted/spec.md
@@ -1,0 +1,423 @@
+# Feature Specification: Async-Friendly Always Encrypted Support
+
+**Issue**: [#3672](https://github.com/dotnet/SqlClient/issues/3672)  
+**Feature Branch**: `dev/cheena/async-ae`  
+**Created**: 2026-05-13  
+**Status**: Draft  
+**Milestone**: 7.1.0-preview2  
+
+## Summary
+
+Eliminate sync-over-async in Always Encrypted (AE) code paths by adding async counterparts to all provider base classes and implementations, then rewiring async execution paths in SqlCommand to use them. Currently, async operations like `ExecuteReaderAsync` block ThreadPool threads when AE is enabled because all key decryption, signature verification, and enclave attestation calls are synchronous — including HTTP calls to Azure Key Vault and attestation services.
+
+## User Scenarios & Testing
+
+### User Story 1 — Async Key Decryption with Azure Key Vault
+
+As an application developer using Always Encrypted with Azure Key Vault, I want `ExecuteReaderAsync` to perform column encryption key (CEK) decryption asynchronously via the Azure Key Vault SDK, so that my async code paths do not block ThreadPool threads waiting for HTTP responses from Azure Key Vault.
+
+**Independent Test**: Execute `ExecuteReaderAsync` against a table with encrypted columns using AKV-managed keys, and verify that no ThreadPool thread is blocked during CEK decryption.
+
+**Acceptance Scenarios**:
+
+1. **Given** a table with AE-encrypted columns and AKV-stored Column Master Key (CMK), **When** `ExecuteReaderAsync` is called, **Then** the CEK decryption calls `CryptographyClient.UnwrapKeyAsync()` instead of the sync `UnwrapKey()`.
+2. **Given** a `CancellationToken` passed to `ExecuteReaderAsync`, **When** the token is cancelled during AKV key decryption, **Then** the operation is cancelled and a `TaskCanceledException` is thrown.
+3. **Given** a custom `SqlColumnEncryptionKeyStoreProvider` that does NOT override async methods, **When** `ExecuteReaderAsync` is called, **Then** the default base class fallback wraps the sync method in `Task.FromResult` and the operation completes successfully (backward compatible).
+
+---
+
+### User Story 2 — Async Enclave Attestation
+
+As an application developer using Always Encrypted with secure enclaves, I want enclave attestation (Azure Attestation or HGS) to be performed asynchronously, so that HTTP calls to attestation services do not block my async query execution path.
+
+**Independent Test**: Execute an enclave-enabled query via `ExecuteReaderAsync` with Azure Attestation and verify that the OpenID configuration fetch and JWT validation are performed asynchronously.
+
+**Acceptance Scenarios**:
+
+1. **Given** an enclave-enabled query using Azure Attestation, **When** `ExecuteReaderAsync` is called, **Then** `ConfigurationManager<OpenIdConnectConfiguration>.GetConfigurationAsync()` is used instead of the sync variant.
+2. **Given** an enclave-enabled query using HGS attestation, **When** `ExecuteReaderAsync` is called, **Then** the HTTP call to the HGS signing certificates endpoint uses `await HttpClient.GetStreamAsync()` instead of `.Result`.
+
+---
+
+### User Story 3 — Sync Path Preservation
+
+As an application developer using synchronous APIs (`ExecuteReader`, `ExecuteNonQuery`, etc.) with Always Encrypted, I want the existing behavior to remain exactly the same, so that this feature introduces zero regressions in sync code paths.
+
+**Independent Test**: Run the full existing AE test suite using sync APIs and verify all tests pass with no behavioral changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** any sync API call with AE-encrypted parameters, **When** the call is executed, **Then** the sync code path uses the existing sync provider methods with no changes.
+
+---
+
+### User Story 4 — Custom Key Store Provider Backward Compatibility
+
+As a third-party developer who has implemented a custom `SqlColumnEncryptionKeyStoreProvider`, I want the new async methods in the base class to have a safe default implementation, so that my existing provider continues to work without modification.
+
+**Independent Test**: Register a custom provider that only overrides the abstract sync methods and verify it works correctly in both sync and async query paths.
+
+**Acceptance Scenarios**:
+
+1. **Given** a custom provider that only implements sync `DecryptColumnEncryptionKey`, **When** `DecryptColumnEncryptionKeyAsync` is called, **Then** the base class default wraps the sync call in `Task.FromResult` and returns successfully.
+2. **Given** a custom provider whose sync method throws an exception, **When** the async variant is called, **Then** the returned Task is faulted (not a synchronous throw).
+
+---
+
+### Edge Cases
+
+- **Cache hit for CEK**: If the decrypted CEK is already cached in `SqlSymmetricKeyCache`, the async path MUST return immediately from cache without invoking the provider. Under the check-release-fetch-relock pattern (Decision 7), cache hits are detected while the semaphore is held and returned before the lock is released — this is the fast path.
+- **Mixed sync/async provider calls on same `SemaphoreSlim`**: Mixing `.Wait()` and `.WaitAsync()` on the same `SemaphoreSlim` instance is safe per .NET documentation. Sync callers continue using `.Wait()`; async callers use `.WaitAsync()`. Do NOT change the sync path to use `.WaitAsync().GetAwaiter().GetResult()` — that pattern deadlocks under a synchronization context.
+- **CancellationToken in default fallback**: The default base class implementation wraps sync methods and ignores `CancellationToken` since sync calls are not cancellable. Document this behavior.
+- **Multiple encrypted parameters serialized by lock**: When a query has N encrypted parameters, `DecryptSymmetricKeyAsync` is called N times. Under the old lock-during-I/O pattern, these would serialize on `_cacheLock`. Under the check-release-fetch-relock pattern (Decision 7), cache misses proceed concurrently with no lock held during I/O.
+- **Concurrent cache misses for same key**: Two threads may both miss the cache and each independently fetch the same key from AKV. The last write wins (idempotent). This is an accepted trade-off; see FR-014 for optional deduplication.
+- **Enclave session cache hit**: If an enclave session already exists in cache, the async path should return from cache without performing attestation.
+- **Provider `EncryptColumnEncryptionKeyAsync`**: While decrypt is the hot path (used on every query), encrypt is used by tooling (SSMS, SqlPackage). Still needs async support for completeness.
+- **`ColumnEncryptionKeyCacheTtl` mutation in `SqlSymmetricKeyCache`**: The existing sync code sets `provider.ColumnEncryptionKeyCacheTtl = new TimeSpan(0)` while the semaphore is held. In the async version, this property mutation must remain inside the semaphore-held section to avoid a race with concurrent async callers on the same provider instance.
+
+## Design Decisions
+
+### Decision 1: `Task<T>` over `ValueTask<T>` for Public APIs
+
+**Chosen**: `Task<T>`
+
+**Rationale**: Public virtual methods that consumers override. The primary beneficiary (AKV) always allocates a Task due to HTTP I/O. `ValueTask<T>` has stricter usage rules (single await, no caching) that would be error-prone for third-party implementers. `Task<T>` is the safer, simpler contract for public extensibility.
+
+### Decision 2: `CancellationToken` on All Async Methods
+
+**Chosen**: Add `CancellationToken cancellationToken = default` to all 4 new async methods.
+
+**Rationale**: Standard .NET async API pattern. Critical for AKV timeout scenarios where HTTP calls may hang. Omitting it would require a breaking API change later. Since PR #3673 hasn't shipped, now is the time.
+
+### Decision 3: Certificate/CNG/CSP Providers Keep Default Fallback
+
+**Chosen**: No async overrides for `SqlColumnEncryptionCertificateStoreProvider`, `SqlColumnEncryptionCngProvider`, or `SqlColumnEncryptionCspProvider`.
+
+**Rationale**: These providers perform local crypto (X509Store, CNG keys, CSP registry) — CPU-bound operations that don't benefit from async. The base class `Task.FromResult` fallback is appropriate. Avoids unnecessary code complexity.
+
+### Decision 4: Enclave Provider Uses Tuples Instead of `out` Parameters
+
+**Chosen**: Async enclave methods return tuples (e.g., `Task<(SqlEnclaveSession, long, byte[], int)>`) instead of using `out` parameters.
+
+**Rationale**: C# async methods cannot have `out` parameters. `SqlColumnEncryptionEnclaveProvider` is **internal**, so the API change has no public surface impact.
+
+### Decision 5: Sync Methods Remain Unchanged
+
+**Chosen**: All existing sync methods are preserved as-is. New async methods are added alongside them.
+
+**Rationale**: Zero behavioral change for sync callers. The `isAsync` flag already used throughout SqlCommand determines which path is taken.
+
+### Decision 6: `ConfigureAwait(false)` Required on All `await` in Library Code
+
+**Chosen**: Every `await` expression in implementation code (all phases) MUST use `.ConfigureAwait(false)`.
+
+**Rationale**: SqlClient is a library, not an application. If `ConfigureAwait(false)` is omitted, the `await` continuation is scheduled back onto the caller's `SynchronizationContext`. In app models that have a synchronization context (ASP.NET Framework, WPF, WinForms), any code that calls async methods with `.Result` or `.Wait()` (common in app code calling library APIs) will deadlock. This is a required invariant for all library async code in the .NET ecosystem. Applies to Phases 2, 3, 4, and 5.
+
+### Decision 7: Lock-During-I/O Must Use Check-Release-Fetch-Relock Pattern
+
+**Chosen**: In all async code paths, the `SemaphoreSlim` MUST be released before performing I/O (HTTP calls to AKV, Azure Attestation, HGS), then re-acquired to update the cache.
+
+**Rationale**: Three existing `SemaphoreSlim` sites hold their lock for the full duration of I/O:
+
+- `SqlSymmetricKeyCache._cacheLock` — static singleton, held during `DecryptColumnEncryptionKey`
+- `AzureSqlKeyCryptographer._keyDictionarySemaphore` — held during AKV key fetch
+- `SqlColumnEncryptionAzureKeyVaultProvider._cacheSemaphore` — held during CEK decrypt
+
+Simply swapping `.Wait()` to `.WaitAsync()` does not fix the problem. The lock is still held during HTTP I/O, which serializes all concurrent requests through a single thread gate — the opposite of what async is intended to achieve. `_cacheLock` in `SqlSymmetricKeyCache` is a **static field shared across all connections**, making this especially severe.
+
+**Required pattern** for all three sites:
+
+```csharp
+await semaphore.WaitAsync(ct).ConfigureAwait(false);
+try
+{
+    if (cache.TryGetValue(key, out var cached))
+        return cached;
+}
+finally { semaphore.Release(); }  // release BEFORE any I/O
+
+var value = await FetchAsync(key, ct).ConfigureAwait(false);
+
+await semaphore.WaitAsync(ct).ConfigureAwait(false);
+try { cache.Set(key, value); }
+finally { semaphore.Release(); }
+return value;
+```
+
+> **Important**: The first acquire MUST be wrapped in `try/finally` to guarantee semaphore release if `TryGetValue` or any cache-inspection code throws unexpectedly.
+
+Two threads may independently fetch the same key on a concurrent miss; the second write is idempotent (same decrypted value). This is acceptable and already implicitly assumed by the existing comment in `SqlSymmetricKeyCache`: "first one wins."
+
+### Decision 8: `IMemoryCache` Has No `GetOrCreateAsync` — Use Explicit `TryGetValue`/`Set`
+
+**Chosen**: All async paths that currently call `IMemoryCache.GetOrCreate(key, Func<T>)` MUST be decomposed to `TryGetValue` + async compute + `Set`.
+
+**Rationale**: `Microsoft.Extensions.Caching.Memory.IMemoryCache` does not provide a `GetOrCreateAsync(key, Func<Task<T>>)` overload. Using `GetOrCreate` with a sync factory in an async context either blocks (sync-over-async) or requires wrapping the cache call in `Task.Run`. The correct pattern is explicit decomposition, allowing the async factory to run free of any cache lock.
+
+**Affected sites**: `SqlColumnEncryptionAzureKeyVaultProvider.GetOrCreateColumnEncryptionKey`. Note: `GetOrCreateSignatureVerificationResult` is purely sync (CPU-bound RSA verify) and can stay as-is for async paths.
+
+### Decision 9: `DecryptSymmetricKeyAsync` Returns a Tuple Instead of `out` Parameters
+
+**Chosen**: `SqlSecurityUtility.DecryptSymmetricKeyAsync` returns `Task<(SqlClientSymmetricKey Key, SqlEncryptionKeyInfo KeyInfoChosen)>` instead of using `out` parameters.
+
+**Rationale**: The existing sync signature `void DecryptSymmetricKey(entry, out SqlClientSymmetricKey key, out SqlEncryptionKeyInfo keyInfo, ...)` cannot have an async counterpart because C# async methods cannot have `out` parameters. This is consistent with Decision 4 for enclave provider APIs.
+
+### Decision 10: `GetParameterEncryptionDataReaderAsync` Becomes a True `async Task` Method
+
+**Chosen**: `GetParameterEncryptionDataReaderAsync` in Phase 5 MUST be refactored to a proper `async Task` method signature, not retain the current `Task.Run(() => { ... })` structure.
+
+**Rationale**: The current implementation wraps the entire CEK decryption pipeline inside `Task.Run`, which consumes a ThreadPool thread for the duration of AKV HTTP I/O. This is the primary sync-over-async bottleneck (SC-001 and SC-003). The replacement must be a genuine `async Task` with `await` at each I/O boundary. Similarly, the sync `GetParameterEncryptionDataReader` uses the `AsyncHelper.ContinueTaskWithState` callback pattern; Phase 5 should not extend this pattern — the async path should use clean `async/await`.
+
+## Requirements
+
+### Functional Requirements
+
+**FR-001**: System MUST add `virtual async` counterparts for `DecryptColumnEncryptionKey`, `EncryptColumnEncryptionKey`, `SignColumnMasterKeyMetadata`, and `VerifyColumnMasterKeyMetadata` to the public `SqlColumnEncryptionKeyStoreProvider` base class.
+
+**FR-002**: All new async public methods MUST accept `CancellationToken cancellationToken = default` as a parameter.
+
+**FR-003**: Default implementations of async methods in the base class MUST wrap the sync counterpart via `Task.FromResult`, and MUST return faulted Tasks (not throw synchronously) when the sync method throws.
+
+**FR-004**: `SqlColumnEncryptionAzureKeyVaultProvider` MUST override all 4 async methods with truly async implementations using Azure SDK async APIs (`UnwrapKeyAsync`, `WrapKeyAsync`, `SignDataAsync`, `VerifyDataAsync`, `GetKeyAsync`).
+
+**FR-005**: `SqlColumnEncryptionAzureKeyVaultProvider` async methods MUST propagate `CancellationToken` to underlying Azure SDK calls.
+
+**FR-006**: System MUST add internal async counterparts to enclave provider base class and all implementations (`NoneAttestationEnclaveProvider`, `AzureAttestationEnclaveProvider`, `HostGuardianServiceEnclaveProvider`).
+
+**FR-007**: Enclave providers with HTTP I/O (Azure Attestation, HGS) MUST implement truly async attestation flows.
+
+**FR-008**: System MUST add async counterparts to intermediate utility methods: `SqlSecurityUtility.DecryptSymmetricKeyAsync`, `SqlSecurityUtility.VerifyColumnMasterKeySignatureAsync`, `SqlSymmetricKeyCache.GetKeyAsync`. `DecryptSymmetricKeyAsync` MUST return `Task<(SqlClientSymmetricKey Key, SqlEncryptionKeyInfo KeyInfoChosen)>` (per Decision 9, replacing `out` parameters). `CancellationToken` MUST be threaded through from each async utility method to the provider async call.
+
+**FR-009**: `SqlCommand` async execution paths MUST use async AE methods when `isAsync=true`, eliminating `Task.Run` wrappers and sync-over-async patterns in `GetParameterEncryptionDataReaderAsync` and related methods. `GetParameterEncryptionDataReaderAsync` MUST be converted to a true `async Task` method (per Decision 10), not retain the `Task.Run` wrapper.
+
+**FR-010**: System MUST NOT change any existing sync code paths or behavior.
+
+**FR-011**: All new public APIs MUST be declared in the reference assembly at `src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs`.
+
+**FR-012**: All async paths involving `SemaphoreSlim` cache locks MUST implement the check-release-fetch-relock pattern (per Decision 7). Simply replacing `.Wait()` with `.WaitAsync()` while holding the semaphore during I/O is **not** acceptable. Affected: `SqlSymmetricKeyCache._cacheLock`, `AzureSqlKeyCryptographer._keyDictionarySemaphore`, `SqlColumnEncryptionAzureKeyVaultProvider._cacheSemaphore`.
+
+**FR-013**: Every `await` expression in async implementation code (Phases 2–5) MUST use `.ConfigureAwait(false)` per Decision 6. This is a hard correctness requirement, not a style preference.
+
+**FR-014**: Async cache-miss paths MUST tolerate concurrent fetches for the same key without deadlocking or throwing. When multiple threads concurrently miss the same cache entry and independently fetch the key, the last write MUST win silently (idempotent cache insert). The implementation MAY additionally deduplicate in-flight requests via a `ConcurrentDictionary<key, Task<value>>` pattern to avoid redundant AKV HTTP calls under load, though this is not required for correctness.
+
+**FR-015**: If any async operation in Phase 3 must run before `EnclaveSessionCache.CreateSession` stores a session, the `lock(enclaveCacheLock)` statement in `EnclaveSessionCache` MUST be replaced with a `SemaphoreSlim`, because `lock` statements cannot span `await` expressions. Operations that are purely synchronous (key derivation from already-available material) may remain inside a `lock`.
+
+### Key Entities
+
+- **`SqlColumnEncryptionKeyStoreProvider`** (public abstract class): Base class for all column encryption key store providers. Gains 4 new virtual async methods.
+- **`SqlColumnEncryptionAzureKeyVaultProvider`** (public class, separate package): The only built-in provider that benefits from truly async — every operation is HTTP I/O to Azure Key Vault.
+- **`AzureSqlKeyCryptographer`** (internal class, AKV package): Wrapper around Azure SDK `CryptographyClient`/`KeyClient`. Gets async counterparts for `AddKey`, `UnwrapKey`, `WrapKey`, `SignData`, `VerifyData`.
+- **`SqlColumnEncryptionEnclaveProvider`** (internal abstract class): Base class for enclave providers. Gains 4 internal abstract async methods with tuple returns.
+- **`EnclaveDelegate`** (internal sealed class): Dispatcher that routes enclave calls to the correct provider. Gets async dispatcher methods.
+- **`SqlSecurityUtility`** (internal static class): Orchestrator for encryption/decryption operations. Gets `DecryptSymmetricKeyAsync`, `VerifyColumnMasterKeySignatureAsync`.
+- **`SqlSymmetricKeyCache`** (internal sealed class, singleton): Global cache for decrypted column encryption keys. Gets `GetKeyAsync` with async cache locking.
+
+## Implementation Phases
+
+### Phase 1: Base Class API Design (PR #3673 — in progress)
+
+#### Depends on: nothing
+
+Add 4 virtual async methods to `SqlColumnEncryptionKeyStoreProvider` with `CancellationToken`, update ref assemblies and XML docs.
+
+**Files:**
+
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs`
+- `src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs`
+- `doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml`
+
+### Phase 2: Key Store Provider Implementations
+
+*Depends on: Phase 1. Parallel with Phase 3.*
+
+#### 2A. AzureKeyVaultProvider (truly async)
+
+- `src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/AzureSqlKeyCryptographer.cs` — Add `AddKeyAsync`, `UnwrapKeyAsync`, `WrapKeyAsync`, `SignDataAsync`, `VerifyDataAsync` using Azure SDK async APIs. `AddKeyAsync` MUST apply the check-release-fetch-relock pattern to `_keyDictionarySemaphore` (per Decision 7 and FR-012) — the semaphore must be released before calling `KeyClient.GetKeyAsync()` over HTTP
+- `src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/SqlColumnEncryptionAzureKeyVaultProvider.cs` — Override all 4 async methods; convert `_cacheSemaphore.Wait()` to the **check-release-fetch-relock pattern** in async paths (per Decision 7 and FR-012):
+  - `GetOrCreateColumnEncryptionKey` cannot use `IMemoryCache.GetOrCreate` with a sync factory in the async path — replace with explicit `TryGetValue` + async compute + `Set` (per Decision 8 and FR-012)
+  - All `await` MUST use `.ConfigureAwait(false)` (per Decision 6 and FR-013)
+
+**Async key-unwrap flow** for `DecryptColumnEncryptionKeyAsync`:
+
+1. `await _cacheSemaphore.WaitAsync(ct).ConfigureAwait(false)`
+2. If cache hit: release semaphore, return cached value
+3. If cache miss: release semaphore immediately
+4. `await KeyCryptographer.UnwrapKeyAsync(..., ct).ConfigureAwait(false)`  ← I/O happens lock-free
+5. `await _cacheSemaphore.WaitAsync(ct).ConfigureAwait(false)`, then cache the result, release
+
+#### 2B-2D. CertificateStore, CNG, CSP Providers
+
+- No changes — default base class fallback is sufficient for local crypto operations
+
+### Phase 3: Enclave Provider Async APIs
+
+*Depends on: nothing. Parallel with Phase 2.*
+
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.cs` — 4 internal abstract async methods
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs` — `GetEnclaveSessionHelperAsync()`
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveSessionCache.cs` — Audit `lock(enclaveCacheLock)`: if any async operation must execute before `CreateSession` stores a session, replace `lock` with `SemaphoreSlim` per FR-015; cache-only paths (no `await` inside) may retain `lock`
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs` — Sync wrappers (no real I/O)
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs` — Truly async (`ConfigurationManager.GetConfigurationAsync()`)
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs` — Abstract `MakeRequestAsync`, `VerifyAttestationInfoAsync`, `GetSigningCertificateAsync`
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs` — Truly async (`HttpClient.GetStreamAsync` without `.Result`)
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.Crypto.cs` — Async dispatcher methods
+
+All `await` in all files above MUST use `.ConfigureAwait(false)` per FR-013.
+
+### Phase 4: Async Utility Layer
+
+#### Depends on: Phase 1. (Phase 2 required for AKV end-to-end testing but not for compilation.)
+
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs`:
+  - `DecryptSymmetricKeyAsync` — returns `Task<(SqlClientSymmetricKey Key, SqlEncryptionKeyInfo KeyInfoChosen)>` per Decision 9 (replaces `out` parameters); accepts and propagates `CancellationToken`
+  - `GetKeyFromLocalProvidersAsync` — internal async counterpart; accepts and propagates `CancellationToken`
+  - `VerifyColumnMasterKeySignatureAsync` — accepts and propagates `CancellationToken`
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs`:
+  - `GetKeyAsync` — implements check-release-fetch-relock pattern per Decision 7 (FR-012); `_cacheLock` is **static**, making the lock-during-I/O problem especially severe for concurrency; accepts and propagates `CancellationToken` to `provider.DecryptColumnEncryptionKeyAsync`
+
+All `await` in all files above MUST use `.ConfigureAwait(false)` per FR-013.
+
+> **Note**: Phases 1–4 deliver async infrastructure but provide no end-to-end benefit until Phase 5 ships. The `SqlCommand` async path (`GetParameterEncryptionDataReaderAsync`) still uses `Task.Run` wrapping sync calls until Phase 5. SC-001 and SC-003 are only achieved after Phase 5.
+
+### Phase 5: Async Call-Site Integration
+
+*Depends on: Phase 4.*
+
+- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs`:
+  1. `ReadDescribeEncryptionParameterResultsKeysAsync` → `VerifyColumnMasterKeySignatureAsync()`
+  2. `ReadDescribeEncryptionParameterResultsMetadataAsync` → `DecryptSymmetricKeyAsync()` (**highest impact**); consume the `(Key, KeyInfoChosen)` tuple result per Decision 9
+  3. `ReadDescribeEncryptionParameterResultsAsync` → orchestrates above
+  4. **Refactor `GetParameterEncryptionDataReaderAsync` into a true `async Task` method** (per Decision 10): remove the `Task.Run(() => { ... })` wrapper entirely; the method must `await` each I/O step directly. Do NOT extend the `AsyncHelper.ContinueTaskWithState` callback pattern used by the sync counterpart — the async path should use clean `async/await`.
+  5. `TryFetchInputParameterEncryptionInfoAsync` → `EnclaveDelegate.GetEnclaveSessionAsync()`, `GetAttestationParametersAsync()`
+
+All `await` in all files above MUST use `.ConfigureAwait(false)` per FR-013.
+
+### Phase 6: Testing & Documentation
+
+*Spans all phases.*
+
+**Unit Tests** (`src/Microsoft.Data.SqlClient/tests/UnitTests/`):
+
+- Default async fallback behavior
+- CancellationToken propagation
+- Faulted Task exception behavior
+
+**Static Analysis (CI gate)**:
+
+- Run a Roslyn analyzer or `grep`-based CI check to verify every `await` in `Microsoft.Data.SqlClient` and `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider` assemblies uses `.ConfigureAwait(false)`. A single missed instance can cause production deadlocks in ASP.NET Framework / WPF / WinForms hosts. This MUST be enforced in CI, not left to manual review.
+
+**Functional Tests** (`src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/`):
+
+- Extend `DummyKeyStoreProvider` with async overrides
+- Test async methods on `SqlColumnEncryptionKeyStoreProvider`
+
+**Manual/Integration Tests** (`src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/`):
+
+- AKV async decrypt/encrypt end-to-end
+- Enclave session creation async (Azure Attestation, HGS)
+- End-to-end async query with encrypted parameters
+
+**Documentation**:
+
+- `doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml`
+- `doc/samples/` — Async AE usage sample code
+
+## New Public API Surface
+
+### SqlColumnEncryptionKeyStoreProvider (4 new virtual methods)
+
+```csharp
+public abstract class SqlColumnEncryptionKeyStoreProvider
+{
+    // Existing abstract methods (unchanged)
+    public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
+    public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
+
+    // Existing virtual methods (unchanged)
+    public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations);
+    public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature);
+    public virtual TimeSpan? ColumnEncryptionKeyCacheTtl { get; set; }
+
+    // NEW async virtual methods
+    public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(
+        string masterKeyPath,
+        string encryptionAlgorithm,
+        byte[] encryptedColumnEncryptionKey,
+        CancellationToken cancellationToken = default);
+
+    public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(
+        string masterKeyPath,
+        string encryptionAlgorithm,
+        byte[] columnEncryptionKey,
+        CancellationToken cancellationToken = default);
+
+    public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(
+        string masterKeyPath,
+        bool allowEnclaveComputations,
+        CancellationToken cancellationToken = default);
+
+    public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(
+        string masterKeyPath,
+        bool allowEnclaveComputations,
+        byte[] signature,
+        CancellationToken cancellationToken = default);
+}
+```
+
+### SqlColumnEncryptionAzureKeyVaultProvider (4 new override methods)
+
+```csharp
+public class SqlColumnEncryptionAzureKeyVaultProvider : SqlColumnEncryptionKeyStoreProvider
+{
+    // NEW async overrides (truly async via Azure SDK)
+    public override Task<byte[]> DecryptColumnEncryptionKeyAsync(
+        string masterKeyPath, string encryptionAlgorithm,
+        byte[] encryptedColumnEncryptionKey,
+        CancellationToken cancellationToken = default);
+
+    public override Task<byte[]> EncryptColumnEncryptionKeyAsync(
+        string masterKeyPath, string encryptionAlgorithm,
+        byte[] columnEncryptionKey,
+        CancellationToken cancellationToken = default);
+
+    public override Task<byte[]> SignColumnMasterKeyMetadataAsync(
+        string masterKeyPath, bool allowEnclaveComputations,
+        CancellationToken cancellationToken = default);
+
+    public override Task<bool> VerifyColumnMasterKeyMetadataAsync(
+        string masterKeyPath, bool allowEnclaveComputations,
+        byte[] signature,
+        CancellationToken cancellationToken = default);
+}
+```
+
+## Success Criteria
+
+**SC-001**: After implementation, `ExecuteReaderAsync` with AE-encrypted columns and AKV keys MUST NOT block any ThreadPool thread on HTTP I/O (verifiable via diagnostic tracing or async call stack inspection).
+
+**SC-002**: All existing AE tests (unit, functional, manual) pass unchanged — zero regressions in sync code paths.
+
+**SC-003**: `Task.Run` is no longer used in `GetParameterEncryptionDataReaderAsync` for AE operations.
+
+**SC-004**: `CancellationToken` is properly propagated from `SqlCommand` async methods through to Azure SDK calls.
+
+**SC-005**: Custom third-party `SqlColumnEncryptionKeyStoreProvider` implementations that only implement sync methods continue to work in both sync and async query paths.
+
+## Assumptions
+
+- Azure SDK (`Azure.Security.KeyVault.Keys.Cryptography`) async methods (`UnwrapKeyAsync`, `WrapKeyAsync`, etc.) are stable and production-ready.
+- `SemaphoreSlim` supports mixed `.Wait()` / `.WaitAsync()` usage on the same instance (per .NET documentation).
+- `SqlColumnEncryptionEnclaveProvider` is internal and can have its API changed freely.
+- The existing `isAsync` flag pattern in `SqlCommand` is the correct mechanism for choosing sync vs async AE paths.
+- `HostGuardianServiceEnclaveProvider.MakeRequest()` currently calls `HttpClient.GetStreamAsync().Result` internally (hidden sync-over-async), which the async version should simply `await`.
+- PR #3673 has not shipped, so adding `CancellationToken` to the base class methods is a non-breaking change.
+- Certificate/CNG/CSP providers perform local crypto that does not benefit from async; `Task.FromResult` wrapping is sufficient.
+
+## Further Considerations
+
+1. **`ConfigureAwait(false)` enforcement**: Consider adding a Roslyn analyzer rule to flag missing `ConfigureAwait(false)` in this assembly, similar to how `ConfigureAwaitAnalyzer` can be applied. This would prevent regressions as new async code is added.
+2. **Third-party provider migration**: Document guidance for custom provider authors on how to override the new async methods for providers that do real I/O. Specifically: they should use `.ConfigureAwait(false)`, implement proper cancellation support, and not hold locks during I/O.
+3. **Performance benchmarking**: After Phase 5, benchmark async AE queries against sync baseline to quantify ThreadPool thread savings and latency improvements under load.
+4. **In-flight request deduplication (optional optimization)**: If high concurrency with cold-cache scenarios is observed in benchmarks, consider a `ConcurrentDictionary<string, Task<byte[]>>` for in-flight AKV requests (per FR-014) so concurrent misses for the same key share a single HTTP call rather than each making an independent one.
+5. **`GetOrCreateSignatureVerificationResult` in AKV provider**: `_columnMasterKeyMetadataSignatureVerificationCache.GetOrCreate` for CMK signature verification uses a sync factory (CPU-bound RSA). This is acceptable for async paths since RSA verification is fast and non-blocking; no async variant is needed here.
+6. **`ValueTask<T>` for internal cache-hit fast paths**: Decision 1 correctly uses `Task<T>` for public virtual APIs (safer for third-party implementers). However, internal methods like `SqlSymmetricKeyCache.GetKeyAsync` have a high cache-hit rate where the result is returned synchronously from `MemoryCache`. Using `ValueTask<T>` for these internal methods would avoid a `Task` allocation on the fast path. This is a P2 optimization that can be adopted later without API impact since these methods are internal.

--- a/specs/002-async-always-encrypted/spec.md
+++ b/specs/002-async-always-encrypted/spec.md
@@ -85,9 +85,9 @@ As a third-party developer who has implemented a custom `SqlColumnEncryptionKeyS
 
 ### Decision 2: `CancellationToken` on All Async Methods
 
-**Chosen**: Add `CancellationToken cancellationToken = default` to all 4 new async methods.
+**Chosen**: Provide two overloads per async method: a `virtual` overload accepting an explicit `CancellationToken` parameter, and a non-virtual convenience overload (without `CancellationToken`) that delegates to the first passing `CancellationToken.None`. The default implementation checks the token for cancellation before invoking the synchronous method.
 
-**Rationale**: Standard .NET async API pattern. Critical for AKV timeout scenarios where HTTP calls may hang. Omitting it would require a breaking API change later. Since PR #3673 hasn't shipped, now is the time.
+**Rationale**: This follows the standard .NET library overload pattern for async APIs. It is critical for AKV timeout scenarios where HTTP calls may hang. The explicit token overload allows derived classes to honor cancellation. Since PR #3673 hasn't shipped, now is the time.
 
 ### Decision 3: Certificate/CNG/CSP Providers Keep Default Fallback
 
@@ -174,7 +174,7 @@ Two threads may independently fetch the same key on a concurrent miss; the secon
 
 **FR-001**: System MUST add `virtual async` counterparts for `DecryptColumnEncryptionKey`, `EncryptColumnEncryptionKey`, `SignColumnMasterKeyMetadata`, and `VerifyColumnMasterKeyMetadata` to the public `SqlColumnEncryptionKeyStoreProvider` base class.
 
-**FR-002**: All new async public methods MUST accept `CancellationToken cancellationToken = default` as a parameter.
+**FR-002**: All new async public methods MUST provide two overloads: one accepting `CancellationToken cancellationToken` (virtual, overridable) and one without (non-virtual, delegates to the first with `CancellationToken.None`). The default implementation MUST check the token for cancellation before executing the synchronous fallback.
 
 **FR-003**: Default implementations of async methods in the base class MUST wrap the sync counterpart via `Task.FromResult`, and MUST return faulted Tasks (not throw synchronously) when the sync method throws.
 

--- a/specs/002-async-always-encrypted/spec.md
+++ b/specs/002-async-always-encrypted/spec.md
@@ -54,9 +54,9 @@ Custom providers that only implement sync `DecryptColumnEncryptionKey` continue 
 
 Public virtual methods use `Task<T>`, not `ValueTask<T>`. The primary beneficiary (AKV) always allocates a Task due to HTTP I/O. `ValueTask<T>` has stricter usage rules that would be error-prone for third-party implementers.
 
-### 2. Two Overloads Per Async Method
+### 2. `CancellationToken` with Default Value
 
-Each async method provides: a `virtual` overload accepting `CancellationToken` (overridable), and a non-virtual convenience overload that delegates with `CancellationToken.None`. Follows the standard .NET library pattern.
+Each async method accepts a `CancellationToken cancellationToken = default` parameter. This is a single `virtual` overload — callers can omit the token for convenience, and derived classes override a single method. The default implementation checks the token for cancellation before invoking the synchronous method.
 
 ### 3. Certificate/CNG/CSP Providers Keep Default Fallback
 
@@ -120,7 +120,7 @@ Remove the `Task.Run(() => { ... })` wrapper entirely. The method must `await` e
 | ID | Requirement |
 |----|-------------|
 | FR-001 | Add `virtual` async counterparts for `DecryptColumnEncryptionKey`, `EncryptColumnEncryptionKey`, `SignColumnMasterKeyMetadata`, and `VerifyColumnMasterKeyMetadata` to `SqlColumnEncryptionKeyStoreProvider`. |
-| FR-002 | Each async method provides two overloads: `virtual` with `CancellationToken` + non-virtual without. Default checks token before sync fallback. |
+| FR-002 | Each async method accepts `CancellationToken cancellationToken = default` as a single virtual overload. Default checks token before sync fallback. |
 | FR-003 | Default async implementations wrap sync via `Task.FromResult`; return faulted Tasks (not synchronous throws) on exception. |
 | FR-004 | `SqlColumnEncryptionAzureKeyVaultProvider` overrides all 4 async methods with truly async Azure SDK calls. |
 | FR-005 | AKV provider propagates `CancellationToken` to all Azure SDK calls. |
@@ -139,7 +139,7 @@ Remove the `Task.Run(() => { ... })` wrapper entirely. The method must `await` e
 
 | Entity | Scope | Changes |
 |--------|-------|---------|
-| `SqlColumnEncryptionKeyStoreProvider` | public abstract | +4 virtual async methods, +4 non-virtual convenience overloads |
+| `SqlColumnEncryptionKeyStoreProvider` | public abstract | +4 virtual async methods with `CancellationToken = default` |
 | `SqlColumnEncryptionAzureKeyVaultProvider` | public (separate package) | Overrides all 4 async methods with Azure SDK async calls |
 | `AzureSqlKeyCryptographer` | internal (AKV package) | +async counterparts for `AddKey`, `UnwrapKey`, `WrapKey`, `SignData`, `VerifyData` |
 | `SqlColumnEncryptionEnclaveProvider` | internal abstract | +4 abstract async methods with tuple returns |
@@ -242,17 +242,11 @@ public abstract class SqlColumnEncryptionKeyStoreProvider
     public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature);
     public virtual TimeSpan? ColumnEncryptionKeyCacheTtl { get; set; }
 
-    // NEW: Async with CancellationToken (virtual, overridable)
-    public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken);
-    public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, CancellationToken cancellationToken);
-    public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, CancellationToken cancellationToken);
-    public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, CancellationToken cancellationToken);
-
-    // NEW: Convenience overloads (non-virtual, delegate with CancellationToken.None)
-    public Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
-    public Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
-    public Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations);
-    public Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature);
+    // NEW: Async with optional CancellationToken (virtual, overridable)
+    public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken = default);
+    public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, CancellationToken cancellationToken = default);
+    public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, CancellationToken cancellationToken = default);
+    public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, CancellationToken cancellationToken = default);
 }
 ```
 
@@ -262,10 +256,10 @@ public abstract class SqlColumnEncryptionKeyStoreProvider
 public class SqlColumnEncryptionAzureKeyVaultProvider : SqlColumnEncryptionKeyStoreProvider
 {
     // Overrides — truly async via Azure SDK
-    public override Task<byte[]> DecryptColumnEncryptionKeyAsync(..., CancellationToken cancellationToken);
-    public override Task<byte[]> EncryptColumnEncryptionKeyAsync(..., CancellationToken cancellationToken);
-    public override Task<byte[]> SignColumnMasterKeyMetadataAsync(..., CancellationToken cancellationToken);
-    public override Task<bool> VerifyColumnMasterKeyMetadataAsync(..., CancellationToken cancellationToken);
+    public override Task<byte[]> DecryptColumnEncryptionKeyAsync(..., CancellationToken cancellationToken = default);
+    public override Task<byte[]> EncryptColumnEncryptionKeyAsync(..., CancellationToken cancellationToken = default);
+    public override Task<byte[]> SignColumnMasterKeyMetadataAsync(..., CancellationToken cancellationToken = default);
+    public override Task<bool> VerifyColumnMasterKeyMetadataAsync(..., CancellationToken cancellationToken = default);
 }
 ```
 

--- a/specs/002-async-always-encrypted/spec.md
+++ b/specs/002-async-always-encrypted/spec.md
@@ -16,116 +16,79 @@ Eliminate sync-over-async in Always Encrypted (AE) code paths by adding async co
 
 As an application developer using Always Encrypted with Azure Key Vault, I want `ExecuteReaderAsync` to perform column encryption key (CEK) decryption asynchronously via the Azure Key Vault SDK, so that my async code paths do not block ThreadPool threads waiting for HTTP responses from Azure Key Vault.
 
-**Independent Test**: Execute `ExecuteReaderAsync` against a table with encrypted columns using AKV-managed keys, and verify that no ThreadPool thread is blocked during CEK decryption.
-
 **Acceptance Scenarios**:
 
-1. **Given** a table with AE-encrypted columns and AKV-stored Column Master Key (CMK), **When** `ExecuteReaderAsync` is called, **Then** the CEK decryption calls `CryptographyClient.UnwrapKeyAsync()` instead of the sync `UnwrapKey()`.
+1. **Given** a table with AE-encrypted columns and AKV-stored CMK, **When** `ExecuteReaderAsync` is called, **Then** CEK decryption calls `CryptographyClient.UnwrapKeyAsync()` instead of the sync `UnwrapKey()`.
 2. **Given** a `CancellationToken` passed to `ExecuteReaderAsync`, **When** the token is cancelled during AKV key decryption, **Then** the operation is cancelled and a `TaskCanceledException` is thrown.
-3. **Given** a custom `SqlColumnEncryptionKeyStoreProvider` that does NOT override async methods, **When** `ExecuteReaderAsync` is called, **Then** the default base class fallback wraps the sync method in `Task.FromResult` and the operation completes successfully (backward compatible).
-
----
+3. **Given** a custom provider that does NOT override async methods, **When** `ExecuteReaderAsync` is called, **Then** the base class fallback wraps the sync method in `Task.FromResult` and completes successfully.
 
 ### User Story 2 — Async Enclave Attestation
 
-As an application developer using Always Encrypted with secure enclaves, I want enclave attestation (Azure Attestation or HGS) to be performed asynchronously, so that HTTP calls to attestation services do not block my async query execution path.
-
-**Independent Test**: Execute an enclave-enabled query via `ExecuteReaderAsync` with Azure Attestation and verify that the OpenID configuration fetch and JWT validation are performed asynchronously.
+As an application developer using Always Encrypted with secure enclaves, I want enclave attestation to be performed asynchronously, so that HTTP calls to attestation services do not block my async query execution path.
 
 **Acceptance Scenarios**:
 
-1. **Given** an enclave-enabled query using Azure Attestation, **When** `ExecuteReaderAsync` is called, **Then** `ConfigurationManager<OpenIdConnectConfiguration>.GetConfigurationAsync()` is used instead of the sync variant.
-2. **Given** an enclave-enabled query using HGS attestation, **When** `ExecuteReaderAsync` is called, **Then** the HTTP call to the HGS signing certificates endpoint uses `await HttpClient.GetStreamAsync()` instead of `.Result`.
-
----
+1. **Given** an enclave-enabled query using Azure Attestation, **When** `ExecuteReaderAsync` is called, **Then** `ConfigurationManager<OpenIdConnectConfiguration>.GetConfigurationAsync()` is used.
+2. **Given** an enclave-enabled query using HGS attestation, **When** `ExecuteReaderAsync` is called, **Then** the HTTP call uses `await HttpClient.GetStreamAsync()` instead of `.Result`.
 
 ### User Story 3 — Sync Path Preservation
 
-As an application developer using synchronous APIs (`ExecuteReader`, `ExecuteNonQuery`, etc.) with Always Encrypted, I want the existing behavior to remain exactly the same, so that this feature introduces zero regressions in sync code paths.
+All existing sync methods are preserved as-is. The `isAsync` flag in `SqlCommand` determines which path is taken. Zero behavioral change for sync callers.
 
-**Independent Test**: Run the full existing AE test suite using sync APIs and verify all tests pass with no behavioral changes.
+### User Story 4 — Custom Provider Backward Compatibility
 
-**Acceptance Scenarios**:
-
-1. **Given** any sync API call with AE-encrypted parameters, **When** the call is executed, **Then** the sync code path uses the existing sync provider methods with no changes.
-
----
-
-### User Story 4 — Custom Key Store Provider Backward Compatibility
-
-As a third-party developer who has implemented a custom `SqlColumnEncryptionKeyStoreProvider`, I want the new async methods in the base class to have a safe default implementation, so that my existing provider continues to work without modification.
-
-**Independent Test**: Register a custom provider that only overrides the abstract sync methods and verify it works correctly in both sync and async query paths.
-
-**Acceptance Scenarios**:
-
-1. **Given** a custom provider that only implements sync `DecryptColumnEncryptionKey`, **When** `DecryptColumnEncryptionKeyAsync` is called, **Then** the base class default wraps the sync call in `Task.FromResult` and returns successfully.
-2. **Given** a custom provider whose sync method throws an exception, **When** the async variant is called, **Then** the returned Task is faulted (not a synchronous throw).
-
----
+Custom providers that only implement sync `DecryptColumnEncryptionKey` continue to work. The base class default wraps the sync call in `Task.FromResult`. If the sync method throws, the returned Task is faulted (not a synchronous throw).
 
 ### Edge Cases
 
-- **Cache hit for CEK**: If the decrypted CEK is already cached in `SqlSymmetricKeyCache`, the async path MUST return immediately from cache without invoking the provider. Under the check-release-fetch-relock pattern (Decision 7), cache hits are detected while the semaphore is held and returned before the lock is released — this is the fast path.
-- **Mixed sync/async provider calls on same `SemaphoreSlim`**: Mixing `.Wait()` and `.WaitAsync()` on the same `SemaphoreSlim` instance is safe per .NET documentation. Sync callers continue using `.Wait()`; async callers use `.WaitAsync()`. Do NOT change the sync path to use `.WaitAsync().GetAwaiter().GetResult()` — that pattern deadlocks under a synchronization context.
-- **CancellationToken in default fallback**: The default base class implementation wraps sync methods and ignores `CancellationToken` since sync calls are not cancellable. Document this behavior.
-- **Multiple encrypted parameters serialized by lock**: When a query has N encrypted parameters, `DecryptSymmetricKeyAsync` is called N times. Under the old lock-during-I/O pattern, these would serialize on `_cacheLock`. Under the check-release-fetch-relock pattern (Decision 7), cache misses proceed concurrently with no lock held during I/O.
-- **Concurrent cache misses for same key**: Two threads may both miss the cache and each independently fetch the same key from AKV. The last write wins (idempotent). This is an accepted trade-off; see FR-014 for optional deduplication.
-- **Enclave session cache hit**: If an enclave session already exists in cache, the async path should return from cache without performing attestation.
-- **Provider `EncryptColumnEncryptionKeyAsync`**: While decrypt is the hot path (used on every query), encrypt is used by tooling (SSMS, SqlPackage). Still needs async support for completeness.
-- **`ColumnEncryptionKeyCacheTtl` mutation in `SqlSymmetricKeyCache`**: The existing sync code sets `provider.ColumnEncryptionKeyCacheTtl = new TimeSpan(0)` while the semaphore is held. In the async version, this property mutation must remain inside the semaphore-held section to avoid a race with concurrent async callers on the same provider instance.
+- **Cache hit for CEK**: Async path returns immediately from cache without invoking the provider.
+- **Mixed sync/async on `SemaphoreSlim`**: For sites still using `SemaphoreSlim` (non-`IMemoryCache` caches), mixing `.Wait()` and `.WaitAsync()` is safe per .NET docs. For `IMemoryCache`-backed caches, the async path uses `GetOrCreateAsync` and does not need `SemaphoreSlim`.
+- **CancellationToken in default fallback**: The base class wraps sync methods and checks the token before invocation; sync calls themselves are not cancellable.
+- **Concurrent cache misses**: Two threads may independently fetch the same key. Last write wins (idempotent). See FR-014 for optional deduplication.
+- **Enclave session cache hit**: Returns from cache without performing attestation.
+- **`ColumnEncryptionKeyCacheTtl` mutation**: Property mutation must remain inside the semaphore-held section in `SqlSymmetricKeyCache` to avoid races.
 
 ## Design Decisions
 
-### Decision 1: `Task<T>` over `ValueTask<T>` for Public APIs
+### 1. `Task<T>` for Public APIs
 
-**Chosen**: `Task<T>`
+Public virtual methods use `Task<T>`, not `ValueTask<T>`. The primary beneficiary (AKV) always allocates a Task due to HTTP I/O. `ValueTask<T>` has stricter usage rules that would be error-prone for third-party implementers.
 
-**Rationale**: Public virtual methods that consumers override. The primary beneficiary (AKV) always allocates a Task due to HTTP I/O. `ValueTask<T>` has stricter usage rules (single await, no caching) that would be error-prone for third-party implementers. `Task<T>` is the safer, simpler contract for public extensibility.
+### 2. Two Overloads Per Async Method
 
-### Decision 2: `CancellationToken` on All Async Methods
+Each async method provides: a `virtual` overload accepting `CancellationToken` (overridable), and a non-virtual convenience overload that delegates with `CancellationToken.None`. Follows the standard .NET library pattern.
 
-**Chosen**: Provide two overloads per async method: a `virtual` overload accepting an explicit `CancellationToken` parameter, and a non-virtual convenience overload (without `CancellationToken`) that delegates to the first passing `CancellationToken.None`. The default implementation checks the token for cancellation before invoking the synchronous method.
+### 3. Certificate/CNG/CSP Providers Keep Default Fallback
 
-**Rationale**: This follows the standard .NET library overload pattern for async APIs. It is critical for AKV timeout scenarios where HTTP calls may hang. The explicit token overload allows derived classes to honor cancellation. Since PR #3673 hasn't shipped, now is the time.
+No async overrides — these perform local crypto (CPU-bound) that doesn't benefit from async. The base class `Task.FromResult` fallback is sufficient.
 
-### Decision 3: Certificate/CNG/CSP Providers Keep Default Fallback
+### 4. Async Methods Return Tuples Instead of `out` Parameters
 
-**Chosen**: No async overrides for `SqlColumnEncryptionCertificateStoreProvider`, `SqlColumnEncryptionCngProvider`, or `SqlColumnEncryptionCspProvider`.
+C# async methods cannot have `out` parameters. Internal enclave methods return tuples (e.g., `Task<(SqlEnclaveSession, long, byte[], int)>`). `SqlSecurityUtility.DecryptSymmetricKeyAsync` returns `Task<(SqlClientSymmetricKey Key, SqlEncryptionKeyInfo KeyInfoChosen)>`.
 
-**Rationale**: These providers perform local crypto (X509Store, CNG keys, CSP registry) — CPU-bound operations that don't benefit from async. The base class `Task.FromResult` fallback is appropriate. Avoids unnecessary code complexity.
+### 5. `ConfigureAwait(false)` on Every `await`
 
-### Decision 4: Enclave Provider Uses Tuples Instead of `out` Parameters
+Every `await` in library code MUST use `.ConfigureAwait(false)`. Omission causes deadlocks in ASP.NET Framework, WPF, and WinForms hosts. This is a hard correctness requirement enforced in CI.
 
-**Chosen**: Async enclave methods return tuples (e.g., `Task<(SqlEnclaveSession, long, byte[], int)>`) instead of using `out` parameters.
+### 6. `MemoryCache.GetOrCreateAsync` for Async Cache Patterns
 
-**Rationale**: C# async methods cannot have `out` parameters. `SqlColumnEncryptionEnclaveProvider` is **internal**, so the API change has no public surface impact.
+**API**: [`CacheExtensions.GetOrCreateAsync<TItem>(IMemoryCache, Object, Func<ICacheEntry, Task<TItem>>)`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.getorcreateasync?view=net-10.0-pp)
 
-### Decision 5: Sync Methods Remain Unchanged
+For `IMemoryCache`-backed caches, use `GetOrCreateAsync` with an async factory delegate instead of `SemaphoreSlim` + manual `TryGetValue`/`Set`. This eliminates lock-during-I/O without requiring the check-release-fetch-relock pattern.
 
-**Chosen**: All existing sync methods are preserved as-is. New async methods are added alongside them.
+```csharp
+var result = await _cache.GetOrCreateAsync(cacheKey, async entry =>
+{
+    entry.SlidingExpiration = _columnEncryptionKeyCacheTtl;
+    return await provider.DecryptColumnEncryptionKeyAsync(
+        masterKeyPath, algorithm, encryptedKey, ct)
+        .ConfigureAwait(false);
+}).ConfigureAwait(false);
+```
 
-**Rationale**: Zero behavioral change for sync callers. The `isAsync` flag already used throughout SqlCommand determines which path is taken.
+**Affected**: `SqlColumnEncryptionAzureKeyVaultProvider._columnEncryptionKeyCache`
 
-### Decision 6: `ConfigureAwait(false)` Required on All `await` in Library Code
-
-**Chosen**: Every `await` expression in implementation code (all phases) MUST use `.ConfigureAwait(false)`.
-
-**Rationale**: SqlClient is a library, not an application. If `ConfigureAwait(false)` is omitted, the `await` continuation is scheduled back onto the caller's `SynchronizationContext`. In app models that have a synchronization context (ASP.NET Framework, WPF, WinForms), any code that calls async methods with `.Result` or `.Wait()` (common in app code calling library APIs) will deadlock. This is a required invariant for all library async code in the .NET ecosystem. Applies to Phases 2, 3, 4, and 5.
-
-### Decision 7: Lock-During-I/O Must Use Check-Release-Fetch-Relock Pattern
-
-**Chosen**: In all async code paths, the `SemaphoreSlim` MUST be released before performing I/O (HTTP calls to AKV, Azure Attestation, HGS), then re-acquired to update the cache.
-
-**Rationale**: Three existing `SemaphoreSlim` sites hold their lock for the full duration of I/O:
-
-- `SqlSymmetricKeyCache._cacheLock` — static singleton, held during `DecryptColumnEncryptionKey`
-- `AzureSqlKeyCryptographer._keyDictionarySemaphore` — held during AKV key fetch
-- `SqlColumnEncryptionAzureKeyVaultProvider._cacheSemaphore` — held during CEK decrypt
-
-Simply swapping `.Wait()` to `.WaitAsync()` does not fix the problem. The lock is still held during HTTP I/O, which serializes all concurrent requests through a single thread gate — the opposite of what async is intended to achieve. `_cacheLock` in `SqlSymmetricKeyCache` is a **static field shared across all connections**, making this especially severe.
-
-**Required pattern** for all three sites:
+For sites NOT using `IMemoryCache` (custom `Dictionary`/`ConcurrentDictionary` caches), use the check-release-fetch-relock pattern with `SemaphoreSlim`:
 
 ```csharp
 await semaphore.WaitAsync(ct).ConfigureAwait(false);
@@ -134,7 +97,7 @@ try
     if (cache.TryGetValue(key, out var cached))
         return cached;
 }
-finally { semaphore.Release(); }  // release BEFORE any I/O
+finally { semaphore.Release(); }  // release BEFORE I/O
 
 var value = await FetchAsync(key, ct).ConfigureAwait(false);
 
@@ -144,84 +107,55 @@ finally { semaphore.Release(); }
 return value;
 ```
 
-> **Important**: The first acquire MUST be wrapped in `try/finally` to guarantee semaphore release if `TryGetValue` or any cache-inspection code throws unexpectedly.
+**Affected**: `SqlSymmetricKeyCache._cacheLock`, `AzureSqlKeyCryptographer._keyDictionarySemaphore`
 
-Two threads may independently fetch the same key on a concurrent miss; the second write is idempotent (same decrypted value). This is acceptable and already implicitly assumed by the existing comment in `SqlSymmetricKeyCache`: "first one wins."
+### 7. `GetParameterEncryptionDataReaderAsync` Must Be True `async Task`
 
-### Decision 8: `IMemoryCache` Has No `GetOrCreateAsync` — Use Explicit `TryGetValue`/`Set`
-
-**Chosen**: All async paths that currently call `IMemoryCache.GetOrCreate(key, Func<T>)` MUST be decomposed to `TryGetValue` + async compute + `Set`.
-
-**Rationale**: `Microsoft.Extensions.Caching.Memory.IMemoryCache` does not provide a `GetOrCreateAsync(key, Func<Task<T>>)` overload. Using `GetOrCreate` with a sync factory in an async context either blocks (sync-over-async) or requires wrapping the cache call in `Task.Run`. The correct pattern is explicit decomposition, allowing the async factory to run free of any cache lock.
-
-**Affected sites**: `SqlColumnEncryptionAzureKeyVaultProvider.GetOrCreateColumnEncryptionKey`. Note: `GetOrCreateSignatureVerificationResult` is purely sync (CPU-bound RSA verify) and can stay as-is for async paths.
-
-### Decision 9: `DecryptSymmetricKeyAsync` Returns a Tuple Instead of `out` Parameters
-
-**Chosen**: `SqlSecurityUtility.DecryptSymmetricKeyAsync` returns `Task<(SqlClientSymmetricKey Key, SqlEncryptionKeyInfo KeyInfoChosen)>` instead of using `out` parameters.
-
-**Rationale**: The existing sync signature `void DecryptSymmetricKey(entry, out SqlClientSymmetricKey key, out SqlEncryptionKeyInfo keyInfo, ...)` cannot have an async counterpart because C# async methods cannot have `out` parameters. This is consistent with Decision 4 for enclave provider APIs.
-
-### Decision 10: `GetParameterEncryptionDataReaderAsync` Becomes a True `async Task` Method
-
-**Chosen**: `GetParameterEncryptionDataReaderAsync` in Phase 5 MUST be refactored to a proper `async Task` method signature, not retain the current `Task.Run(() => { ... })` structure.
-
-**Rationale**: The current implementation wraps the entire CEK decryption pipeline inside `Task.Run`, which consumes a ThreadPool thread for the duration of AKV HTTP I/O. This is the primary sync-over-async bottleneck (SC-001 and SC-003). The replacement must be a genuine `async Task` with `await` at each I/O boundary. Similarly, the sync `GetParameterEncryptionDataReader` uses the `AsyncHelper.ContinueTaskWithState` callback pattern; Phase 5 should not extend this pattern — the async path should use clean `async/await`.
+Remove the `Task.Run(() => { ... })` wrapper entirely. The method must `await` each I/O step directly using clean `async/await`, not the `AsyncHelper.ContinueTaskWithState` callback pattern.
 
 ## Requirements
 
 ### Functional Requirements
 
-**FR-001**: System MUST add `virtual async` counterparts for `DecryptColumnEncryptionKey`, `EncryptColumnEncryptionKey`, `SignColumnMasterKeyMetadata`, and `VerifyColumnMasterKeyMetadata` to the public `SqlColumnEncryptionKeyStoreProvider` base class.
-
-**FR-002**: All new async public methods MUST provide two overloads: one accepting `CancellationToken cancellationToken` (virtual, overridable) and one without (non-virtual, delegates to the first with `CancellationToken.None`). The default implementation MUST check the token for cancellation before executing the synchronous fallback.
-
-**FR-003**: Default implementations of async methods in the base class MUST wrap the sync counterpart via `Task.FromResult`, and MUST return faulted Tasks (not throw synchronously) when the sync method throws.
-
-**FR-004**: `SqlColumnEncryptionAzureKeyVaultProvider` MUST override all 4 async methods with truly async implementations using Azure SDK async APIs (`UnwrapKeyAsync`, `WrapKeyAsync`, `SignDataAsync`, `VerifyDataAsync`, `GetKeyAsync`).
-
-**FR-005**: `SqlColumnEncryptionAzureKeyVaultProvider` async methods MUST propagate `CancellationToken` to underlying Azure SDK calls.
-
-**FR-006**: System MUST add internal async counterparts to enclave provider base class and all implementations (`NoneAttestationEnclaveProvider`, `AzureAttestationEnclaveProvider`, `HostGuardianServiceEnclaveProvider`).
-
-**FR-007**: Enclave providers with HTTP I/O (Azure Attestation, HGS) MUST implement truly async attestation flows.
-
-**FR-008**: System MUST add async counterparts to intermediate utility methods: `SqlSecurityUtility.DecryptSymmetricKeyAsync`, `SqlSecurityUtility.VerifyColumnMasterKeySignatureAsync`, `SqlSymmetricKeyCache.GetKeyAsync`. `DecryptSymmetricKeyAsync` MUST return `Task<(SqlClientSymmetricKey Key, SqlEncryptionKeyInfo KeyInfoChosen)>` (per Decision 9, replacing `out` parameters). `CancellationToken` MUST be threaded through from each async utility method to the provider async call.
-
-**FR-009**: `SqlCommand` async execution paths MUST use async AE methods when `isAsync=true`, eliminating `Task.Run` wrappers and sync-over-async patterns in `GetParameterEncryptionDataReaderAsync` and related methods. `GetParameterEncryptionDataReaderAsync` MUST be converted to a true `async Task` method (per Decision 10), not retain the `Task.Run` wrapper.
-
-**FR-010**: System MUST NOT change any existing sync code paths or behavior.
-
-**FR-011**: All new public APIs MUST be declared in the reference assembly at `src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs`.
-
-**FR-012**: All async paths involving `SemaphoreSlim` cache locks MUST implement the check-release-fetch-relock pattern (per Decision 7). Simply replacing `.Wait()` with `.WaitAsync()` while holding the semaphore during I/O is **not** acceptable. Affected: `SqlSymmetricKeyCache._cacheLock`, `AzureSqlKeyCryptographer._keyDictionarySemaphore`, `SqlColumnEncryptionAzureKeyVaultProvider._cacheSemaphore`.
-
-**FR-013**: Every `await` expression in async implementation code (Phases 2–5) MUST use `.ConfigureAwait(false)` per Decision 6. This is a hard correctness requirement, not a style preference.
-
-**FR-014**: Async cache-miss paths MUST tolerate concurrent fetches for the same key without deadlocking or throwing. When multiple threads concurrently miss the same cache entry and independently fetch the key, the last write MUST win silently (idempotent cache insert). The implementation MAY additionally deduplicate in-flight requests via a `ConcurrentDictionary<key, Task<value>>` pattern to avoid redundant AKV HTTP calls under load, though this is not required for correctness.
-
-**FR-015**: If any async operation in Phase 3 must run before `EnclaveSessionCache.CreateSession` stores a session, the `lock(enclaveCacheLock)` statement in `EnclaveSessionCache` MUST be replaced with a `SemaphoreSlim`, because `lock` statements cannot span `await` expressions. Operations that are purely synchronous (key derivation from already-available material) may remain inside a `lock`.
+| ID | Requirement |
+|----|-------------|
+| FR-001 | Add `virtual` async counterparts for `DecryptColumnEncryptionKey`, `EncryptColumnEncryptionKey`, `SignColumnMasterKeyMetadata`, and `VerifyColumnMasterKeyMetadata` to `SqlColumnEncryptionKeyStoreProvider`. |
+| FR-002 | Each async method provides two overloads: `virtual` with `CancellationToken` + non-virtual without. Default checks token before sync fallback. |
+| FR-003 | Default async implementations wrap sync via `Task.FromResult`; return faulted Tasks (not synchronous throws) on exception. |
+| FR-004 | `SqlColumnEncryptionAzureKeyVaultProvider` overrides all 4 async methods with truly async Azure SDK calls. |
+| FR-005 | AKV provider propagates `CancellationToken` to all Azure SDK calls. |
+| FR-006 | Internal async counterparts added to enclave provider base class and all implementations. |
+| FR-007 | Enclave providers with HTTP I/O (Azure Attestation, HGS) implement truly async attestation. |
+| FR-008 | Async utility methods added: `SqlSecurityUtility.DecryptSymmetricKeyAsync` (returns tuple), `VerifyColumnMasterKeySignatureAsync`, `SqlSymmetricKeyCache.GetKeyAsync`. All propagate `CancellationToken`. |
+| FR-009 | `SqlCommand` async paths use async AE methods when `isAsync=true`. `GetParameterEncryptionDataReaderAsync` becomes true `async Task`. |
+| FR-010 | No changes to existing sync code paths or behavior. |
+| FR-011 | All new public APIs declared in `src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs`. |
+| FR-012 | Async caching: `IMemoryCache` sites use `GetOrCreateAsync`; custom-cache sites use check-release-fetch-relock with `SemaphoreSlim`. No lock held during I/O. |
+| FR-013 | Every `await` uses `.ConfigureAwait(false)`. Enforced in CI. |
+| FR-014 | Concurrent cache misses tolerated without deadlock. Last write wins. Optional deduplication via `ConcurrentDictionary<key, Task<value>>`. |
+| FR-015 | `lock(enclaveCacheLock)` replaced with `SemaphoreSlim` if async operations must run before session storage. Sync-only paths may retain `lock`. |
 
 ### Key Entities
 
-- **`SqlColumnEncryptionKeyStoreProvider`** (public abstract class): Base class for all column encryption key store providers. Gains 4 new virtual async methods.
-- **`SqlColumnEncryptionAzureKeyVaultProvider`** (public class, separate package): The only built-in provider that benefits from truly async — every operation is HTTP I/O to Azure Key Vault.
-- **`AzureSqlKeyCryptographer`** (internal class, AKV package): Wrapper around Azure SDK `CryptographyClient`/`KeyClient`. Gets async counterparts for `AddKey`, `UnwrapKey`, `WrapKey`, `SignData`, `VerifyData`.
-- **`SqlColumnEncryptionEnclaveProvider`** (internal abstract class): Base class for enclave providers. Gains 4 internal abstract async methods with tuple returns.
-- **`EnclaveDelegate`** (internal sealed class): Dispatcher that routes enclave calls to the correct provider. Gets async dispatcher methods.
-- **`SqlSecurityUtility`** (internal static class): Orchestrator for encryption/decryption operations. Gets `DecryptSymmetricKeyAsync`, `VerifyColumnMasterKeySignatureAsync`.
-- **`SqlSymmetricKeyCache`** (internal sealed class, singleton): Global cache for decrypted column encryption keys. Gets `GetKeyAsync` with async cache locking.
+| Entity | Scope | Changes |
+|--------|-------|---------|
+| `SqlColumnEncryptionKeyStoreProvider` | public abstract | +4 virtual async methods, +4 non-virtual convenience overloads |
+| `SqlColumnEncryptionAzureKeyVaultProvider` | public (separate package) | Overrides all 4 async methods with Azure SDK async calls |
+| `AzureSqlKeyCryptographer` | internal (AKV package) | +async counterparts for `AddKey`, `UnwrapKey`, `WrapKey`, `SignData`, `VerifyData` |
+| `SqlColumnEncryptionEnclaveProvider` | internal abstract | +4 abstract async methods with tuple returns |
+| `EnclaveDelegate` | internal sealed | +async dispatcher methods |
+| `SqlSecurityUtility` | internal static | +`DecryptSymmetricKeyAsync`, `VerifyColumnMasterKeySignatureAsync` |
+| `SqlSymmetricKeyCache` | internal sealed, singleton | +`GetKeyAsync` with check-release-fetch-relock |
 
 ## Implementation Phases
 
-### Phase 1: Base Class API Design (PR #3673 — in progress)
+### Phase 1: Base Class API (PR #3673 — in progress)
 
-#### Depends on: nothing
+*Depends on: nothing*
 
-Add 4 virtual async methods to `SqlColumnEncryptionKeyStoreProvider` with `CancellationToken`, update ref assemblies and XML docs.
+Add 4 virtual async methods + 4 convenience overloads to `SqlColumnEncryptionKeyStoreProvider`, update ref assemblies and XML docs.
 
-**Files:**
-
+**Files**:
 - `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs`
 - `src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs`
 - `doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml`
@@ -232,192 +166,133 @@ Add 4 virtual async methods to `SqlColumnEncryptionKeyStoreProvider` with `Cance
 
 #### 2A. AzureKeyVaultProvider (truly async)
 
-- `src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/AzureSqlKeyCryptographer.cs` — Add `AddKeyAsync`, `UnwrapKeyAsync`, `WrapKeyAsync`, `SignDataAsync`, `VerifyDataAsync` using Azure SDK async APIs. `AddKeyAsync` MUST apply the check-release-fetch-relock pattern to `_keyDictionarySemaphore` (per Decision 7 and FR-012) — the semaphore must be released before calling `KeyClient.GetKeyAsync()` over HTTP
-- `src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/SqlColumnEncryptionAzureKeyVaultProvider.cs` — Override all 4 async methods; convert `_cacheSemaphore.Wait()` to the **check-release-fetch-relock pattern** in async paths (per Decision 7 and FR-012):
-  - `GetOrCreateColumnEncryptionKey` cannot use `IMemoryCache.GetOrCreate` with a sync factory in the async path — replace with explicit `TryGetValue` + async compute + `Set` (per Decision 8 and FR-012)
-  - All `await` MUST use `.ConfigureAwait(false)` (per Decision 6 and FR-013)
+- `AzureSqlKeyCryptographer.cs` — Add async counterparts using Azure SDK. `AddKeyAsync` uses check-release-fetch-relock on `_keyDictionarySemaphore` (uses `Dictionary`, not `IMemoryCache`).
+- `SqlColumnEncryptionAzureKeyVaultProvider.cs` — Override 4 async methods. Use `GetOrCreateAsync` on `_columnEncryptionKeyCache`:
 
-**Async key-unwrap flow** for `DecryptColumnEncryptionKeyAsync`:
+**Async key-unwrap flow**:
+1. `await _columnEncryptionKeyCache.GetOrCreateAsync(cacheKey, async entry => { ... }).ConfigureAwait(false)`
+2. Inside factory: `await KeyCryptographer.UnwrapKeyAsync(..., ct).ConfigureAwait(false)` — I/O runs without user-managed locks
+3. Configure entry expiration via `ICacheEntry`
+4. `MemoryCache` handles cache insertion
 
-1. `await _cacheSemaphore.WaitAsync(ct).ConfigureAwait(false)`
-2. If cache hit: release semaphore, return cached value
-3. If cache miss: release semaphore immediately
-4. `await KeyCryptographer.UnwrapKeyAsync(..., ct).ConfigureAwait(false)`  ← I/O happens lock-free
-5. `await _cacheSemaphore.WaitAsync(ct).ConfigureAwait(false)`, then cache the result, release
+The sync path remains unchanged (`_cacheSemaphore.Wait()` + `GetOrCreate`). `GetOrCreateSignatureVerificationResult` stays sync (CPU-bound RSA).
 
-#### 2B-2D. CertificateStore, CNG, CSP Providers
+#### 2B–2D. CertificateStore, CNG, CSP Providers
 
-- No changes — default base class fallback is sufficient for local crypto operations
+No changes — default base class fallback is sufficient.
 
 ### Phase 3: Enclave Provider Async APIs
 
 *Depends on: nothing. Parallel with Phase 2.*
 
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.cs` — 4 internal abstract async methods
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs` — `GetEnclaveSessionHelperAsync()`
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveSessionCache.cs` — Audit `lock(enclaveCacheLock)`: if any async operation must execute before `CreateSession` stores a session, replace `lock` with `SemaphoreSlim` per FR-015; cache-only paths (no `await` inside) may retain `lock`
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs` — Sync wrappers (no real I/O)
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs` — Truly async (`ConfigurationManager.GetConfigurationAsync()`)
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs` — Abstract `MakeRequestAsync`, `VerifyAttestationInfoAsync`, `GetSigningCertificateAsync`
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs` — Truly async (`HttpClient.GetStreamAsync` without `.Result`)
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.Crypto.cs` — Async dispatcher methods
-
-All `await` in all files above MUST use `.ConfigureAwait(false)` per FR-013.
+- `SqlColumnEncryptionEnclaveProvider.cs` — 4 internal abstract async methods
+- `EnclaveProviderBase.cs` — `GetEnclaveSessionHelperAsync()`
+- `EnclaveSessionCache.cs` — Replace `lock` with `SemaphoreSlim` where async operations precede session storage (FR-015)
+- `NoneAttestationEnclaveProvider.cs` — Sync wrappers (no real I/O)
+- `AzureAttestationBasedEnclaveProvider.cs` — Truly async (`GetConfigurationAsync()`)
+- `VirtualSecureModeEnclaveProviderBase.cs` — Abstract `MakeRequestAsync`, `VerifyAttestationInfoAsync`
+- `VirtualSecureModeEnclaveProvider.cs` — Truly async (`HttpClient.GetStreamAsync`)
+- `EnclaveDelegate.Crypto.cs` — Async dispatcher methods
 
 ### Phase 4: Async Utility Layer
 
-#### Depends on: Phase 1. (Phase 2 required for AKV end-to-end testing but not for compilation.)
+*Depends on: Phase 1.*
 
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs`:
-  - `DecryptSymmetricKeyAsync` — returns `Task<(SqlClientSymmetricKey Key, SqlEncryptionKeyInfo KeyInfoChosen)>` per Decision 9 (replaces `out` parameters); accepts and propagates `CancellationToken`
-  - `GetKeyFromLocalProvidersAsync` — internal async counterpart; accepts and propagates `CancellationToken`
-  - `VerifyColumnMasterKeySignatureAsync` — accepts and propagates `CancellationToken`
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs`:
-  - `GetKeyAsync` — implements check-release-fetch-relock pattern per Decision 7 (FR-012); `_cacheLock` is **static**, making the lock-during-I/O problem especially severe for concurrency; accepts and propagates `CancellationToken` to `provider.DecryptColumnEncryptionKeyAsync`
+- `SqlSecurityUtility.cs`:
+  - `DecryptSymmetricKeyAsync` → returns `Task<(SqlClientSymmetricKey Key, SqlEncryptionKeyInfo KeyInfoChosen)>`
+  - `GetKeyFromLocalProvidersAsync` — propagates `CancellationToken`
+  - `VerifyColumnMasterKeySignatureAsync` — propagates `CancellationToken`
+- `SqlSymmetricKeyCache.cs`:
+  - `GetKeyAsync` — check-release-fetch-relock on static `_cacheLock`; propagates `CancellationToken`
 
-All `await` in all files above MUST use `.ConfigureAwait(false)` per FR-013.
-
-> **Note**: Phases 1–4 deliver async infrastructure but provide no end-to-end benefit until Phase 5 ships. The `SqlCommand` async path (`GetParameterEncryptionDataReaderAsync`) still uses `Task.Run` wrapping sync calls until Phase 5. SC-001 and SC-003 are only achieved after Phase 5.
+> **Note**: Phases 1–4 deliver async infrastructure. End-to-end benefit requires Phase 5.
 
 ### Phase 5: Async Call-Site Integration
 
 *Depends on: Phase 4.*
 
-- `src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs`:
+- `SqlCommand.Encryption.cs`:
   1. `ReadDescribeEncryptionParameterResultsKeysAsync` → `VerifyColumnMasterKeySignatureAsync()`
-  2. `ReadDescribeEncryptionParameterResultsMetadataAsync` → `DecryptSymmetricKeyAsync()` (**highest impact**); consume the `(Key, KeyInfoChosen)` tuple result per Decision 9
+  2. `ReadDescribeEncryptionParameterResultsMetadataAsync` → `DecryptSymmetricKeyAsync()` (**highest impact**)
   3. `ReadDescribeEncryptionParameterResultsAsync` → orchestrates above
-  4. **Refactor `GetParameterEncryptionDataReaderAsync` into a true `async Task` method** (per Decision 10): remove the `Task.Run(() => { ... })` wrapper entirely; the method must `await` each I/O step directly. Do NOT extend the `AsyncHelper.ContinueTaskWithState` callback pattern used by the sync counterpart — the async path should use clean `async/await`.
-  5. `TryFetchInputParameterEncryptionInfoAsync` → `EnclaveDelegate.GetEnclaveSessionAsync()`, `GetAttestationParametersAsync()`
-
-All `await` in all files above MUST use `.ConfigureAwait(false)` per FR-013.
+  4. **Refactor `GetParameterEncryptionDataReaderAsync`** into true `async Task` — remove `Task.Run` wrapper
+  5. `TryFetchInputParameterEncryptionInfoAsync` → `EnclaveDelegate.GetEnclaveSessionAsync()`
 
 ### Phase 6: Testing & Documentation
 
 *Spans all phases.*
 
-**Unit Tests** (`src/Microsoft.Data.SqlClient/tests/UnitTests/`):
-
-- Default async fallback behavior
-- CancellationToken propagation
-- Faulted Task exception behavior
-
-**Static Analysis (CI gate)**:
-
-- Run a Roslyn analyzer or `grep`-based CI check to verify every `await` in `Microsoft.Data.SqlClient` and `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider` assemblies uses `.ConfigureAwait(false)`. A single missed instance can cause production deadlocks in ASP.NET Framework / WPF / WinForms hosts. This MUST be enforced in CI, not left to manual review.
-
-**Functional Tests** (`src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/`):
-
-- Extend `DummyKeyStoreProvider` with async overrides
-- Test async methods on `SqlColumnEncryptionKeyStoreProvider`
-
-**Manual/Integration Tests** (`src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/`):
-
-- AKV async decrypt/encrypt end-to-end
-- Enclave session creation async (Azure Attestation, HGS)
-- End-to-end async query with encrypted parameters
-
-**Documentation**:
-
-- `doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml`
-- `doc/samples/` — Async AE usage sample code
+**Unit Tests** (`tests/UnitTests/`): Default fallback, cancellation, faulted Tasks  
+**Functional Tests** (`tests/FunctionalTests/`): `DummyKeyStoreProvider` async overrides  
+**Manual Tests** (`tests/ManualTests/`): AKV end-to-end, enclave attestation async, encrypted query async  
+**CI Gate**: Roslyn analyzer or grep check for `.ConfigureAwait(false)` on every `await`  
+**Documentation**: XML docs, `doc/samples/` async AE examples
 
 ## New Public API Surface
 
-### SqlColumnEncryptionKeyStoreProvider (4 new virtual methods)
+### SqlColumnEncryptionKeyStoreProvider
 
 ```csharp
 public abstract class SqlColumnEncryptionKeyStoreProvider
 {
-    // Existing abstract methods (unchanged)
+    // Existing (unchanged)
     public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
     public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
-
-    // Existing virtual methods (unchanged)
     public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations);
     public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature);
     public virtual TimeSpan? ColumnEncryptionKeyCacheTtl { get; set; }
 
-    // NEW async virtual methods
-    public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(
-        string masterKeyPath,
-        string encryptionAlgorithm,
-        byte[] encryptedColumnEncryptionKey,
-        CancellationToken cancellationToken = default);
+    // NEW: Async with CancellationToken (virtual, overridable)
+    public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken);
+    public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, CancellationToken cancellationToken);
+    public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, CancellationToken cancellationToken);
+    public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, CancellationToken cancellationToken);
 
-    public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(
-        string masterKeyPath,
-        string encryptionAlgorithm,
-        byte[] columnEncryptionKey,
-        CancellationToken cancellationToken = default);
-
-    public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(
-        string masterKeyPath,
-        bool allowEnclaveComputations,
-        CancellationToken cancellationToken = default);
-
-    public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(
-        string masterKeyPath,
-        bool allowEnclaveComputations,
-        byte[] signature,
-        CancellationToken cancellationToken = default);
+    // NEW: Convenience overloads (non-virtual, delegate with CancellationToken.None)
+    public Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
+    public Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
+    public Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations);
+    public Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature);
 }
 ```
 
-### SqlColumnEncryptionAzureKeyVaultProvider (4 new override methods)
+### SqlColumnEncryptionAzureKeyVaultProvider
 
 ```csharp
 public class SqlColumnEncryptionAzureKeyVaultProvider : SqlColumnEncryptionKeyStoreProvider
 {
-    // NEW async overrides (truly async via Azure SDK)
-    public override Task<byte[]> DecryptColumnEncryptionKeyAsync(
-        string masterKeyPath, string encryptionAlgorithm,
-        byte[] encryptedColumnEncryptionKey,
-        CancellationToken cancellationToken = default);
-
-    public override Task<byte[]> EncryptColumnEncryptionKeyAsync(
-        string masterKeyPath, string encryptionAlgorithm,
-        byte[] columnEncryptionKey,
-        CancellationToken cancellationToken = default);
-
-    public override Task<byte[]> SignColumnMasterKeyMetadataAsync(
-        string masterKeyPath, bool allowEnclaveComputations,
-        CancellationToken cancellationToken = default);
-
-    public override Task<bool> VerifyColumnMasterKeyMetadataAsync(
-        string masterKeyPath, bool allowEnclaveComputations,
-        byte[] signature,
-        CancellationToken cancellationToken = default);
+    // Overrides — truly async via Azure SDK
+    public override Task<byte[]> DecryptColumnEncryptionKeyAsync(..., CancellationToken cancellationToken);
+    public override Task<byte[]> EncryptColumnEncryptionKeyAsync(..., CancellationToken cancellationToken);
+    public override Task<byte[]> SignColumnMasterKeyMetadataAsync(..., CancellationToken cancellationToken);
+    public override Task<bool> VerifyColumnMasterKeyMetadataAsync(..., CancellationToken cancellationToken);
 }
 ```
 
 ## Success Criteria
 
-**SC-001**: After implementation, `ExecuteReaderAsync` with AE-encrypted columns and AKV keys MUST NOT block any ThreadPool thread on HTTP I/O (verifiable via diagnostic tracing or async call stack inspection).
-
-**SC-002**: All existing AE tests (unit, functional, manual) pass unchanged — zero regressions in sync code paths.
-
-**SC-003**: `Task.Run` is no longer used in `GetParameterEncryptionDataReaderAsync` for AE operations.
-
-**SC-004**: `CancellationToken` is properly propagated from `SqlCommand` async methods through to Azure SDK calls.
-
-**SC-005**: Custom third-party `SqlColumnEncryptionKeyStoreProvider` implementations that only implement sync methods continue to work in both sync and async query paths.
+| ID | Criterion |
+|----|-----------|
+| SC-001 | `ExecuteReaderAsync` with AE + AKV does NOT block any ThreadPool thread on HTTP I/O. |
+| SC-002 | All existing AE tests pass unchanged — zero sync regressions. |
+| SC-003 | `Task.Run` is no longer used in `GetParameterEncryptionDataReaderAsync`. |
+| SC-004 | `CancellationToken` propagates from `SqlCommand` async methods through to Azure SDK calls. |
+| SC-005 | Custom providers with only sync implementations continue to work in async paths. |
 
 ## Assumptions
 
-- Azure SDK (`Azure.Security.KeyVault.Keys.Cryptography`) async methods (`UnwrapKeyAsync`, `WrapKeyAsync`, etc.) are stable and production-ready.
-- `SemaphoreSlim` supports mixed `.Wait()` / `.WaitAsync()` usage on the same instance (per .NET documentation).
-- `SqlColumnEncryptionEnclaveProvider` is internal and can have its API changed freely.
-- The existing `isAsync` flag pattern in `SqlCommand` is the correct mechanism for choosing sync vs async AE paths.
-- `HostGuardianServiceEnclaveProvider.MakeRequest()` currently calls `HttpClient.GetStreamAsync().Result` internally (hidden sync-over-async), which the async version should simply `await`.
-- PR #3673 has not shipped, so adding `CancellationToken` to the base class methods is a non-breaking change.
-- Certificate/CNG/CSP providers perform local crypto that does not benefit from async; `Task.FromResult` wrapping is sufficient.
+- Azure SDK async methods (`UnwrapKeyAsync`, `WrapKeyAsync`, etc.) are stable and production-ready.
+- `SemaphoreSlim` supports mixed `.Wait()` / `.WaitAsync()` on the same instance.
+- `SqlColumnEncryptionEnclaveProvider` is internal — API changes have no public impact.
+- The existing `isAsync` flag in `SqlCommand` determines sync vs async AE paths.
+- PR #3673 has not shipped — adding `CancellationToken` is non-breaking.
+- Certificate/CNG/CSP providers perform local crypto; `Task.FromResult` is sufficient.
+- `Microsoft.Extensions.Caching.Abstractions` (already referenced by AKV provider) provides `GetOrCreateAsync`.
 
 ## Further Considerations
 
-1. **`ConfigureAwait(false)` enforcement**: Consider adding a Roslyn analyzer rule to flag missing `ConfigureAwait(false)` in this assembly, similar to how `ConfigureAwaitAnalyzer` can be applied. This would prevent regressions as new async code is added.
-2. **Third-party provider migration**: Document guidance for custom provider authors on how to override the new async methods for providers that do real I/O. Specifically: they should use `.ConfigureAwait(false)`, implement proper cancellation support, and not hold locks during I/O.
-3. **Performance benchmarking**: After Phase 5, benchmark async AE queries against sync baseline to quantify ThreadPool thread savings and latency improvements under load.
-4. **In-flight request deduplication (optional optimization)**: If high concurrency with cold-cache scenarios is observed in benchmarks, consider a `ConcurrentDictionary<string, Task<byte[]>>` for in-flight AKV requests (per FR-014) so concurrent misses for the same key share a single HTTP call rather than each making an independent one.
-5. **`GetOrCreateSignatureVerificationResult` in AKV provider**: `_columnMasterKeyMetadataSignatureVerificationCache.GetOrCreate` for CMK signature verification uses a sync factory (CPU-bound RSA). This is acceptable for async paths since RSA verification is fast and non-blocking; no async variant is needed here.
-6. **`ValueTask<T>` for internal cache-hit fast paths**: Decision 1 correctly uses `Task<T>` for public virtual APIs (safer for third-party implementers). However, internal methods like `SqlSymmetricKeyCache.GetKeyAsync` have a high cache-hit rate where the result is returned synchronously from `MemoryCache`. Using `ValueTask<T>` for these internal methods would avoid a `Task` allocation on the fast path. This is a P2 optimization that can be adopted later without API impact since these methods are internal.
+1. **`ConfigureAwait(false)` CI enforcement**: Add a Roslyn analyzer or grep-based check to prevent regressions.
+2. **Third-party provider guidance**: Document how custom providers should override async methods, use `ConfigureAwait(false)`, support cancellation, and avoid lock-during-I/O.
+3. **Performance benchmarking**: After Phase 5, quantify ThreadPool savings and latency improvements under load.
+4. **In-flight request deduplication**: Optional `ConcurrentDictionary<string, Task<byte[]>>` for concurrent cold-cache AKV requests (FR-014).
+5. **`ValueTask<T>` for internal fast paths**: Internal methods like `SqlSymmetricKeyCache.GetKeyAsync` have high cache-hit rates — `ValueTask<T>` avoids Task allocations. P2 optimization with no API impact.

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
@@ -705,19 +705,27 @@ public abstract class SqlColumnEncryptionKeyStoreProvider
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKey/*'/>
     public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsync/*'/>
+#nullable enable
     public virtual System.Threading.Tasks.Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, System.Threading.CancellationToken cancellationToken = default) { throw null; }
+#nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKey/*'/>
     public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsync/*'/>
+#nullable enable
     public virtual System.Threading.Tasks.Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, System.Threading.CancellationToken cancellationToken = default) { throw null; }
+#nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadata/*'/>
     public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsync/*'/>
+#nullable enable
     public virtual System.Threading.Tasks.Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, System.Threading.CancellationToken cancellationToken = default) { throw null; }
+#nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadata/*'/>
     public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsync/*'/>
+#nullable enable
     public virtual System.Threading.Tasks.Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, System.Threading.CancellationToken cancellationToken = default) { throw null; }
+#nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/ColumnEncryptionKeyCacheTtl/*'/>
     public virtual System.TimeSpan? ColumnEncryptionKeyCacheTtl { get { throw null; } set { } }
 }

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
@@ -705,27 +705,19 @@ public abstract class SqlColumnEncryptionKeyStoreProvider
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKey/*'/>
     public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsync/*'/>
-    public virtual System.Threading.Tasks.Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, System.Threading.CancellationToken cancellationToken) { throw null; }
-    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsyncNoCancellation/*'/>
-    public System.Threading.Tasks.Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey) { throw null; }
+    public virtual System.Threading.Tasks.Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKey/*'/>
     public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsync/*'/>
-    public virtual System.Threading.Tasks.Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, System.Threading.CancellationToken cancellationToken) { throw null; }
-    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsyncNoCancellation/*'/>
-    public System.Threading.Tasks.Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey) { throw null; }
+    public virtual System.Threading.Tasks.Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadata/*'/>
     public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsync/*'/>
-    public virtual System.Threading.Tasks.Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, System.Threading.CancellationToken cancellationToken) { throw null; }
-    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsyncNoCancellation/*'/>
-    public System.Threading.Tasks.Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations) { throw null; }
+    public virtual System.Threading.Tasks.Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadata/*'/>
     public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsync/*'/>
-    public virtual System.Threading.Tasks.Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, System.Threading.CancellationToken cancellationToken) { throw null; }
-    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsyncNoCancellation/*'/>
-    public System.Threading.Tasks.Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) { throw null; }
+    public virtual System.Threading.Tasks.Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/ColumnEncryptionKeyCacheTtl/*'/>
     public virtual System.TimeSpan? ColumnEncryptionKeyCacheTtl { get { throw null; } set { } }
 }

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
@@ -705,35 +705,27 @@ public abstract class SqlColumnEncryptionKeyStoreProvider
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKey/*'/>
     public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsync/*'/>
-#nullable enable
     public virtual System.Threading.Tasks.Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, System.Threading.CancellationToken cancellationToken) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsyncNoCancellation/*'/>
     public System.Threading.Tasks.Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey) { throw null; }
-#nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKey/*'/>
     public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsync/*'/>
-#nullable enable
     public virtual System.Threading.Tasks.Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, System.Threading.CancellationToken cancellationToken) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsyncNoCancellation/*'/>
     public System.Threading.Tasks.Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey) { throw null; }
-#nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadata/*'/>
     public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsync/*'/>
-#nullable enable
     public virtual System.Threading.Tasks.Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, System.Threading.CancellationToken cancellationToken) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsyncNoCancellation/*'/>
     public System.Threading.Tasks.Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations) { throw null; }
-#nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadata/*'/>
     public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsync/*'/>
-#nullable enable
     public virtual System.Threading.Tasks.Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, System.Threading.CancellationToken cancellationToken) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsyncNoCancellation/*'/>
     public System.Threading.Tasks.Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) { throw null; }
-#nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/ColumnEncryptionKeyCacheTtl/*'/>
     public virtual System.TimeSpan? ColumnEncryptionKeyCacheTtl { get { throw null; } set { } }
 }

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
@@ -704,12 +704,20 @@ public abstract class SqlColumnEncryptionKeyStoreProvider
     protected SqlColumnEncryptionKeyStoreProvider() { }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKey/*'/>
     public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsync/*'/>
+    public virtual System.Threading.Tasks.Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKey/*'/>
     public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsync/*'/>
+    public virtual System.Threading.Tasks.Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadata/*'/>
     public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations) { throw null; }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsync/*'/>
+    public virtual System.Threading.Tasks.Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadata/*'/>
     public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) { throw null; }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsync/*'/>
+    public virtual System.Threading.Tasks.Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, System.Threading.CancellationToken cancellationToken = default) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/ColumnEncryptionKeyCacheTtl/*'/>
     public virtual System.TimeSpan? ColumnEncryptionKeyCacheTtl { get { throw null; } set { } }
 }

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.cs
@@ -706,25 +706,33 @@ public abstract class SqlColumnEncryptionKeyStoreProvider
     public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsync/*'/>
 #nullable enable
-    public virtual System.Threading.Tasks.Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, System.Threading.CancellationToken cancellationToken = default) { throw null; }
+    public virtual System.Threading.Tasks.Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, System.Threading.CancellationToken cancellationToken) { throw null; }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsyncNoCancellation/*'/>
+    public System.Threading.Tasks.Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey) { throw null; }
 #nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKey/*'/>
     public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsync/*'/>
 #nullable enable
-    public virtual System.Threading.Tasks.Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, System.Threading.CancellationToken cancellationToken = default) { throw null; }
+    public virtual System.Threading.Tasks.Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, System.Threading.CancellationToken cancellationToken) { throw null; }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsyncNoCancellation/*'/>
+    public System.Threading.Tasks.Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey) { throw null; }
 #nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadata/*'/>
     public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsync/*'/>
 #nullable enable
-    public virtual System.Threading.Tasks.Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, System.Threading.CancellationToken cancellationToken = default) { throw null; }
+    public virtual System.Threading.Tasks.Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, System.Threading.CancellationToken cancellationToken) { throw null; }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsyncNoCancellation/*'/>
+    public System.Threading.Tasks.Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations) { throw null; }
 #nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadata/*'/>
     public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) { throw null; }
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsync/*'/>
 #nullable enable
-    public virtual System.Threading.Tasks.Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, System.Threading.CancellationToken cancellationToken = default) { throw null; }
+    public virtual System.Threading.Tasks.Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, System.Threading.CancellationToken cancellationToken) { throw null; }
+    /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsyncNoCancellation/*'/>
+    public System.Threading.Tasks.Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature) { throw null; }
 #nullable restore
     /// <include file='../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/ColumnEncryptionKeyCacheTtl/*'/>
     public virtual System.TimeSpan? ColumnEncryptionKeyCacheTtl { get { throw null; } set { } }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.Data.SqlClient
 {
@@ -16,17 +17,40 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKey/*'/>
         public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
 
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsync/*'/>
+        public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKey/*'/>
         public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsync/*'/>
+        public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadata/*'/>
         public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
         {
             throw new NotImplementedException();
         }
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsync/*'/>
+        public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadata/*'/>
         public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsync/*'/>
+        public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
@@ -19,29 +19,24 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsync/*'/>
         public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
-        {
-            throw new NotImplementedException();
-        }
+        => Task.FromResult(DecryptColumnEncryptionKey(masterKeyPath, encryptionAlgorithm, encryptedColumnEncryptionKey));
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKey/*'/>
         public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsync/*'/>
         public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
-        {
-            throw new NotImplementedException();
-        }
+        => Task.FromResult(EncryptColumnEncryptionKey(masterKeyPath, encryptionAlgorithm, columnEncryptionKey));
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadata/*'/>
         public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
         {
             throw new NotImplementedException();
         }
+
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsync/*'/>
         public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations)
-        {
-            throw new NotImplementedException();
-        }
+        => Task.FromResult(SignColumnMasterKeyMetadata(masterKeyPath, allowEnclaveComputations));
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadata/*'/>
         public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
@@ -51,8 +46,6 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsync/*'/>
         public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
-        {
-            throw new NotImplementedException();
-        }
+        => Task.FromResult(VerifyColumnMasterKeyMetadata(masterKeyPath, allowEnclaveComputations, signature));
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Data.SqlClient
@@ -18,15 +19,33 @@ namespace Microsoft.Data.SqlClient
         public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsync/*'/>
-        public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
-        => Task.FromResult(DecryptColumnEncryptionKey(masterKeyPath, encryptionAlgorithm, encryptedColumnEncryptionKey));
+        public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return Task.FromResult(DecryptColumnEncryptionKey(masterKeyPath, encryptionAlgorithm, encryptedColumnEncryptionKey));
+            }
+            catch (Exception e)
+            {
+                return Task.FromException<byte[]>(e);
+            }
+        }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKey/*'/>
         public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsync/*'/>
-        public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
-        => Task.FromResult(EncryptColumnEncryptionKey(masterKeyPath, encryptionAlgorithm, columnEncryptionKey));
+        public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return Task.FromResult(EncryptColumnEncryptionKey(masterKeyPath, encryptionAlgorithm, columnEncryptionKey));
+            }
+            catch (Exception e)
+            {
+                return Task.FromException<byte[]>(e);
+            }
+        }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadata/*'/>
         public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
@@ -35,8 +54,17 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsync/*'/>
-        public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations)
-        => Task.FromResult(SignColumnMasterKeyMetadata(masterKeyPath, allowEnclaveComputations));
+        public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return Task.FromResult(SignColumnMasterKeyMetadata(masterKeyPath, allowEnclaveComputations));
+            }
+            catch (Exception e)
+            {
+                return Task.FromException<byte[]>(e);
+            }
+        }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadata/*'/>
         public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
@@ -45,7 +73,16 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsync/*'/>
-        public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
-        => Task.FromResult(VerifyColumnMasterKeyMetadata(masterKeyPath, allowEnclaveComputations, signature));
+        public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return Task.FromResult(VerifyColumnMasterKeyMetadata(masterKeyPath, allowEnclaveComputations, signature));
+            }
+            catch (Exception e)
+            {
+                return Task.FromException<bool>(e);
+            }
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient
         public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsync/*'/>
-        public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken)
+        public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -36,17 +36,11 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsyncNoCancellation/*'/>
-        public Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
-        {
-            return DecryptColumnEncryptionKeyAsync(masterKeyPath, encryptionAlgorithm, encryptedColumnEncryptionKey, CancellationToken.None);
-        }
-
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKey/*'/>
         public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsync/*'/>
-        public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, CancellationToken cancellationToken)
+        public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -63,12 +57,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsyncNoCancellation/*'/>
-        public Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
-        {
-            return EncryptColumnEncryptionKeyAsync(masterKeyPath, encryptionAlgorithm, columnEncryptionKey, CancellationToken.None);
-        }
-
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadata/*'/>
         public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
         {
@@ -76,7 +64,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsync/*'/>
-        public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, CancellationToken cancellationToken)
+        public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -93,12 +81,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsyncNoCancellation/*'/>
-        public Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations)
-        {
-            return SignColumnMasterKeyMetadataAsync(masterKeyPath, allowEnclaveComputations, CancellationToken.None);
-        }
-
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadata/*'/>
         public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
         {
@@ -106,7 +88,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsync/*'/>
-        public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, CancellationToken cancellationToken)
+        public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -121,12 +103,6 @@ namespace Microsoft.Data.SqlClient
             {
                 return Task.FromException<bool>(e);
             }
-        }
-
-        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsyncNoCancellation/*'/>
-        public Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
-        {
-            return VerifyColumnMasterKeyMetadataAsync(masterKeyPath, allowEnclaveComputations, signature, CancellationToken.None);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient
 {
@@ -30,7 +31,7 @@ namespace Microsoft.Data.SqlClient
             {
                 return Task.FromResult(DecryptColumnEncryptionKey(masterKeyPath, encryptionAlgorithm, encryptedColumnEncryptionKey));
             }
-            catch (Exception e)
+            catch (Exception e) when (ADP.IsCatchableExceptionType(e))
             {
                 return Task.FromException<byte[]>(e);
             }
@@ -51,7 +52,7 @@ namespace Microsoft.Data.SqlClient
             {
                 return Task.FromResult(EncryptColumnEncryptionKey(masterKeyPath, encryptionAlgorithm, columnEncryptionKey));
             }
-            catch (Exception e)
+            catch (Exception e) when (ADP.IsCatchableExceptionType(e))
             {
                 return Task.FromException<byte[]>(e);
             }
@@ -75,7 +76,7 @@ namespace Microsoft.Data.SqlClient
             {
                 return Task.FromResult(SignColumnMasterKeyMetadata(masterKeyPath, allowEnclaveComputations));
             }
-            catch (Exception e)
+            catch (Exception e) when (ADP.IsCatchableExceptionType(e))
             {
                 return Task.FromException<byte[]>(e);
             }
@@ -99,7 +100,7 @@ namespace Microsoft.Data.SqlClient
             {
                 return Task.FromResult(VerifyColumnMasterKeyMetadata(masterKeyPath, allowEnclaveComputations, signature));
             }
-            catch (Exception e)
+            catch (Exception e) when (ADP.IsCatchableExceptionType(e))
             {
                 return Task.FromException<bool>(e);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionKeyStoreProvider.cs
@@ -19,8 +19,13 @@ namespace Microsoft.Data.SqlClient
         public abstract byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey);
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsync/*'/>
-        public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken = default)
+        public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<byte[]>(cancellationToken);
+            }
+
             try
             {
                 return Task.FromResult(DecryptColumnEncryptionKey(masterKeyPath, encryptionAlgorithm, encryptedColumnEncryptionKey));
@@ -31,12 +36,23 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/DecryptColumnEncryptionKeyAsyncNoCancellation/*'/>
+        public Task<byte[]> DecryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
+        {
+            return DecryptColumnEncryptionKeyAsync(masterKeyPath, encryptionAlgorithm, encryptedColumnEncryptionKey, CancellationToken.None);
+        }
+
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKey/*'/>
         public abstract byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey);
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsync/*'/>
-        public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, CancellationToken cancellationToken = default)
+        public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<byte[]>(cancellationToken);
+            }
+
             try
             {
                 return Task.FromResult(EncryptColumnEncryptionKey(masterKeyPath, encryptionAlgorithm, columnEncryptionKey));
@@ -47,6 +63,12 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/EncryptColumnEncryptionKeyAsyncNoCancellation/*'/>
+        public Task<byte[]> EncryptColumnEncryptionKeyAsync(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
+        {
+            return EncryptColumnEncryptionKeyAsync(masterKeyPath, encryptionAlgorithm, columnEncryptionKey, CancellationToken.None);
+        }
+
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadata/*'/>
         public virtual byte[] SignColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations)
         {
@@ -54,8 +76,13 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsync/*'/>
-        public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, CancellationToken cancellationToken = default)
+        public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<byte[]>(cancellationToken);
+            }
+
             try
             {
                 return Task.FromResult(SignColumnMasterKeyMetadata(masterKeyPath, allowEnclaveComputations));
@@ -66,6 +93,12 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/SignColumnMasterKeyMetadataAsyncNoCancellation/*'/>
+        public Task<byte[]> SignColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations)
+        {
+            return SignColumnMasterKeyMetadataAsync(masterKeyPath, allowEnclaveComputations, CancellationToken.None);
+        }
+
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadata/*'/>
         public virtual bool VerifyColumnMasterKeyMetadata(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
         {
@@ -73,8 +106,13 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsync/*'/>
-        public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, CancellationToken cancellationToken = default)
+        public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<bool>(cancellationToken);
+            }
+
             try
             {
                 return Task.FromResult(VerifyColumnMasterKeyMetadata(masterKeyPath, allowEnclaveComputations, signature));
@@ -83,6 +121,12 @@ namespace Microsoft.Data.SqlClient
             {
                 return Task.FromException<bool>(e);
             }
+        }
+
+        /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionKeyStoreProvider.xml' path='docs/members[@name="SqlColumnEncryptionKeyStoreProvider"]/VerifyColumnMasterKeyMetadataAsyncNoCancellation/*'/>
+        public Task<bool> VerifyColumnMasterKeyMetadataAsync(string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
+        {
+            return VerifyColumnMasterKeyMetadataAsync(masterKeyPath, allowEnclaveComputations, signature, CancellationToken.None);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/AlwaysEncryptedTests/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
@@ -1,0 +1,127 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
+{
+    public class SqlColumnEncryptionKeyStoreProviderAsyncShould
+    {
+        [Fact]
+        public async Task DecryptColumnEncryptionKeyAsync_DefaultFallback_ReturnsSameResultAsSyncMethod()
+        {
+            var provider = new TestKeyStoreProvider();
+            byte[] expected = provider.DecryptColumnEncryptionKey("path", "algo", new byte[] { 1, 2, 3 });
+            byte[] actual = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1, 2, 3 });
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async Task EncryptColumnEncryptionKeyAsync_DefaultFallback_ReturnsSameResultAsSyncMethod()
+        {
+            var provider = new TestKeyStoreProvider();
+            byte[] expected = provider.EncryptColumnEncryptionKey("path", "algo", new byte[] { 4, 5, 6 });
+            byte[] actual = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 });
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async Task DecryptColumnEncryptionKeyAsync_WhenSyncThrows_ReturnsFaultedTask()
+        {
+            var provider = new ThrowingKeyStoreProvider();
+            Task<byte[]> task = provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1 });
+
+            // Must not throw synchronously — the Task itself should be faulted
+            Assert.True(task.IsFaulted);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => task);
+        }
+
+        [Fact]
+        public async Task EncryptColumnEncryptionKeyAsync_WhenSyncThrows_ReturnsFaultedTask()
+        {
+            var provider = new ThrowingKeyStoreProvider();
+            Task<byte[]> task = provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1 });
+
+            Assert.True(task.IsFaulted);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => task);
+        }
+
+        [Fact]
+        public async Task SignColumnMasterKeyMetadataAsync_DefaultImplementation_ReturnsFaultedTask()
+        {
+            var provider = new TestKeyStoreProvider();
+            Task<byte[]> task = provider.SignColumnMasterKeyMetadataAsync("path", true);
+
+            // The base sync method throws NotImplementedException; the async version
+            // must surface this as a faulted Task, not a synchronous throw.
+            Assert.True(task.IsFaulted);
+            await Assert.ThrowsAsync<NotImplementedException>(() => task);
+        }
+
+        [Fact]
+        public async Task VerifyColumnMasterKeyMetadataAsync_DefaultImplementation_ReturnsFaultedTask()
+        {
+            var provider = new TestKeyStoreProvider();
+            Task<bool> task = provider.VerifyColumnMasterKeyMetadataAsync("path", true, new byte[] { 1 });
+
+            Assert.True(task.IsFaulted);
+            await Assert.ThrowsAsync<NotImplementedException>(() => task);
+        }
+
+        [Fact]
+        public async Task DecryptColumnEncryptionKeyAsync_AcceptsCancellationToken()
+        {
+            var provider = new TestKeyStoreProvider();
+            using var cts = new CancellationTokenSource();
+            byte[] result = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1, 2, 3 }, cts.Token);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task EncryptColumnEncryptionKeyAsync_AcceptsCancellationToken()
+        {
+            var provider = new TestKeyStoreProvider();
+            using var cts = new CancellationTokenSource();
+            byte[] result = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 }, cts.Token);
+            Assert.NotNull(result);
+        }
+
+        /// <summary>
+        /// A test provider that implements sync methods with real (non-throwing) behavior.
+        /// </summary>
+        private class TestKeyStoreProvider : SqlColumnEncryptionKeyStoreProvider
+        {
+            public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
+            {
+                // Simple identity operation for testing
+                return encryptedColumnEncryptionKey;
+            }
+
+            public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
+            {
+                // Simple identity operation for testing
+                return columnEncryptionKey;
+            }
+        }
+
+        /// <summary>
+        /// A test provider whose sync methods throw exceptions.
+        /// </summary>
+        private class ThrowingKeyStoreProvider : SqlColumnEncryptionKeyStoreProvider
+        {
+            public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
+            {
+                throw new InvalidOperationException("Decrypt failed");
+            }
+
+            public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
+            {
+                throw new InvalidOperationException("Encrypt failed");
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
@@ -15,8 +16,10 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
     /// </summary>
     public class SqlColumnEncryptionKeyStoreProviderAsyncShould
     {
+        #region Default fallback behavior
+
         /// <summary>
-        /// Verifies DecryptColumnEncryptionKeyAsync default returns the same result as the sync method.
+        /// Verifies that the default async decrypt implementation wraps the sync result via Task.FromResult.
         /// </summary>
         [Fact]
         public async Task DecryptColumnEncryptionKeyAsync_DefaultFallback_ReturnsSameResultAsSyncMethod()
@@ -27,6 +30,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             Assert.Equal(expected, actual);
         }
 
+        /// <summary>
+        /// Verifies that the default async encrypt implementation wraps the sync result via Task.FromResult.
+        /// </summary>
         [Fact]
         public async Task EncryptColumnEncryptionKeyAsync_DefaultFallback_ReturnsSameResultAsSyncMethod()
         {
@@ -36,17 +42,28 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             Assert.Equal(expected, actual);
         }
 
+        #endregion
+
+        #region Faulted task behavior
+
+        /// <summary>
+        /// Verifies that when the sync decrypt method throws, the async version returns a faulted Task
+        /// rather than throwing synchronously.
+        /// </summary>
         [Fact]
         public async Task DecryptColumnEncryptionKeyAsync_WhenSyncThrows_ReturnsFaultedTask()
         {
             var provider = new ThrowingKeyStoreProvider();
             Task<byte[]> task = provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1 }, CancellationToken.None);
 
-            // Must not throw synchronously — the Task itself should be faulted
             Assert.True(task.IsFaulted);
             await Assert.ThrowsAsync<InvalidOperationException>(() => task);
         }
 
+        /// <summary>
+        /// Verifies that when the sync encrypt method throws, the async version returns a faulted Task
+        /// rather than throwing synchronously.
+        /// </summary>
         [Fact]
         public async Task EncryptColumnEncryptionKeyAsync_WhenSyncThrows_ReturnsFaultedTask()
         {
@@ -57,18 +74,24 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             await Assert.ThrowsAsync<InvalidOperationException>(() => task);
         }
 
+        /// <summary>
+        /// Verifies that the base class SignColumnMasterKeyMetadata throws NotImplementedException,
+        /// and the async version surfaces this as a faulted Task.
+        /// </summary>
         [Fact]
         public async Task SignColumnMasterKeyMetadataAsync_DefaultImplementation_ReturnsFaultedTask()
         {
             var provider = new TestKeyStoreProvider();
             Task<byte[]> task = provider.SignColumnMasterKeyMetadataAsync("path", true, CancellationToken.None);
 
-            // The base sync method throws NotImplementedException; the async version
-            // must surface this as a faulted Task, not a synchronous throw.
             Assert.True(task.IsFaulted);
             await Assert.ThrowsAsync<NotImplementedException>(() => task);
         }
 
+        /// <summary>
+        /// Verifies that the base class VerifyColumnMasterKeyMetadata throws NotImplementedException,
+        /// and the async version surfaces this as a faulted Task.
+        /// </summary>
         [Fact]
         public async Task VerifyColumnMasterKeyMetadataAsync_DefaultImplementation_ReturnsFaultedTask()
         {
@@ -79,6 +102,13 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             await Assert.ThrowsAsync<NotImplementedException>(() => task);
         }
 
+        #endregion
+
+        #region Cancellation behavior
+
+        /// <summary>
+        /// Verifies that passing an already-cancelled token returns a cancelled Task immediately.
+        /// </summary>
         [Fact]
         public void DecryptColumnEncryptionKeyAsync_CancelledToken_ReturnsCancelledTask()
         {
@@ -91,6 +121,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             Assert.True(task.IsCanceled);
         }
 
+        /// <summary>
+        /// Verifies that passing an already-cancelled token returns a cancelled Task immediately.
+        /// </summary>
         [Fact]
         public void EncryptColumnEncryptionKeyAsync_CancelledToken_ReturnsCancelledTask()
         {
@@ -103,6 +136,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             Assert.True(task.IsCanceled);
         }
 
+        /// <summary>
+        /// Verifies that passing an already-cancelled token returns a cancelled Task immediately.
+        /// </summary>
         [Fact]
         public void SignColumnMasterKeyMetadataAsync_CancelledToken_ReturnsCancelledTask()
         {
@@ -115,6 +151,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             Assert.True(task.IsCanceled);
         }
 
+        /// <summary>
+        /// Verifies that passing an already-cancelled token returns a cancelled Task immediately.
+        /// </summary>
         [Fact]
         public void VerifyColumnMasterKeyMetadataAsync_CancelledToken_ReturnsCancelledTask()
         {
@@ -127,35 +166,22 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             Assert.True(task.IsCanceled);
         }
 
-        [Fact]
-        public async Task DecryptColumnEncryptionKeyAsync_NoCancellationOverload_Works()
-        {
-            var provider = new TestKeyStoreProvider();
-            byte[] result = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1, 2, 3 });
-            Assert.NotNull(result);
-            Assert.Equal(new byte[] { 1, 2, 3 }, result);
-        }
-
-        [Fact]
-        public async Task EncryptColumnEncryptionKeyAsync_NoCancellationOverload_Works()
-        {
-            var provider = new TestKeyStoreProvider();
-            byte[] result = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 });
-            Assert.NotNull(result);
-            Assert.Equal(new byte[] { 4, 5, 6 }, result);
-        }
-
+        /// <summary>
+        /// Verifies that a non-cancelled (live) token does not interfere with successful decrypt.
+        /// </summary>
         [Fact]
         public async Task DecryptColumnEncryptionKeyAsync_LiveToken_CompletesSuccessfully()
         {
             var provider = new TestKeyStoreProvider();
             using var cts = new CancellationTokenSource();
 
-            // A non-cancelled token should not interfere with the operation
             byte[] result = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 7, 8, 9 }, cts.Token);
             Assert.Equal(new byte[] { 7, 8, 9 }, result);
         }
 
+        /// <summary>
+        /// Verifies that a non-cancelled (live) token does not interfere with successful encrypt.
+        /// </summary>
         [Fact]
         public async Task EncryptColumnEncryptionKeyAsync_LiveToken_CompletesSuccessfully()
         {
@@ -166,8 +192,68 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
             Assert.Equal(new byte[] { 7, 8, 9 }, result);
         }
 
+        #endregion
+
+        #region Convenience overloads (no CancellationToken)
+
         /// <summary>
-        /// A test provider that implements sync methods with real (non-throwing) behavior.
+        /// Verifies the no-CancellationToken convenience overload delegates correctly for decrypt.
+        /// </summary>
+        [Fact]
+        public async Task DecryptColumnEncryptionKeyAsync_NoCancellationOverload_Works()
+        {
+            var provider = new TestKeyStoreProvider();
+            byte[] result = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1, 2, 3 });
+            Assert.NotNull(result);
+            Assert.Equal(new byte[] { 1, 2, 3 }, result);
+        }
+
+        /// <summary>
+        /// Verifies the no-CancellationToken convenience overload delegates correctly for encrypt.
+        /// </summary>
+        [Fact]
+        public async Task EncryptColumnEncryptionKeyAsync_NoCancellationOverload_Works()
+        {
+            var provider = new TestKeyStoreProvider();
+            byte[] result = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 });
+            Assert.NotNull(result);
+            Assert.Equal(new byte[] { 4, 5, 6 }, result);
+        }
+
+        /// <summary>
+        /// Verifies the no-CancellationToken convenience overload for sign returns a faulted Task
+        /// (base class throws NotImplementedException).
+        /// </summary>
+        [Fact]
+        public async Task SignColumnMasterKeyMetadataAsync_NoCancellationOverload_ReturnsFaultedTask()
+        {
+            var provider = new TestKeyStoreProvider();
+            Task<byte[]> task = provider.SignColumnMasterKeyMetadataAsync("path", true);
+
+            Assert.True(task.IsFaulted);
+            await Assert.ThrowsAsync<NotImplementedException>(() => task);
+        }
+
+        /// <summary>
+        /// Verifies the no-CancellationToken convenience overload for verify returns a faulted Task
+        /// (base class throws NotImplementedException).
+        /// </summary>
+        [Fact]
+        public async Task VerifyColumnMasterKeyMetadataAsync_NoCancellationOverload_ReturnsFaultedTask()
+        {
+            var provider = new TestKeyStoreProvider();
+            Task<bool> task = provider.VerifyColumnMasterKeyMetadataAsync("path", true, new byte[] { 1 });
+
+            Assert.True(task.IsFaulted);
+            await Assert.ThrowsAsync<NotImplementedException>(() => task);
+        }
+
+        #endregion
+
+        #region Test helpers
+
+        /// <summary>
+        /// A test provider that implements sync methods with pass-through behavior (returns input as-is).
         /// </summary>
         private class TestKeyStoreProvider : SqlColumnEncryptionKeyStoreProvider
         {
@@ -183,7 +269,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
         }
 
         /// <summary>
-        /// A test provider whose sync methods throw exceptions.
+        /// A test provider whose sync methods always throw <see cref="InvalidOperationException"/>.
         /// </summary>
         private class ThrowingKeyStoreProvider : SqlColumnEncryptionKeyStoreProvider
         {
@@ -197,5 +283,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
                 throw new InvalidOperationException("Encrypt failed");
             }
         }
+
+        #endregion
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
@@ -9,8 +9,15 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
 {
+    /// <summary>
+    /// Tests for the async virtual methods on <see cref="SqlColumnEncryptionKeyStoreProvider"/>,
+    /// verifying default fallback behavior, cancellation, faulted tasks, and convenience overloads.
+    /// </summary>
     public class SqlColumnEncryptionKeyStoreProviderAsyncShould
     {
+        /// <summary>
+        /// Verifies DecryptColumnEncryptionKeyAsync default returns the same result as the sync method.
+        /// </summary>
         [Fact]
         public async Task DecryptColumnEncryptionKeyAsync_DefaultFallback_ReturnsSameResultAsSyncMethod()
         {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
@@ -194,13 +194,13 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
 
         #endregion
 
-        #region Convenience overloads (no CancellationToken)
+        #region Default CancellationToken parameter
 
         /// <summary>
-        /// Verifies the no-CancellationToken convenience overload delegates correctly for decrypt.
+        /// Verifies calling without CancellationToken (uses default) works for decrypt.
         /// </summary>
         [Fact]
-        public async Task DecryptColumnEncryptionKeyAsync_NoCancellationOverload_Works()
+        public async Task DecryptColumnEncryptionKeyAsync_DefaultCancellationToken_Works()
         {
             var provider = new TestKeyStoreProvider();
             byte[] result = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1, 2, 3 });
@@ -209,10 +209,10 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
         }
 
         /// <summary>
-        /// Verifies the no-CancellationToken convenience overload delegates correctly for encrypt.
+        /// Verifies calling without CancellationToken (uses default) works for encrypt.
         /// </summary>
         [Fact]
-        public async Task EncryptColumnEncryptionKeyAsync_NoCancellationOverload_Works()
+        public async Task EncryptColumnEncryptionKeyAsync_DefaultCancellationToken_Works()
         {
             var provider = new TestKeyStoreProvider();
             byte[] result = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 });
@@ -221,11 +221,11 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
         }
 
         /// <summary>
-        /// Verifies the no-CancellationToken convenience overload for sign returns a faulted Task
+        /// Verifies calling sign without CancellationToken returns a faulted Task
         /// (base class throws NotImplementedException).
         /// </summary>
         [Fact]
-        public async Task SignColumnMasterKeyMetadataAsync_NoCancellationOverload_ReturnsFaultedTask()
+        public async Task SignColumnMasterKeyMetadataAsync_DefaultCancellationToken_ReturnsFaultedTask()
         {
             var provider = new TestKeyStoreProvider();
             Task<byte[]> task = provider.SignColumnMasterKeyMetadataAsync("path", true);
@@ -235,11 +235,11 @@ namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
         }
 
         /// <summary>
-        /// Verifies the no-CancellationToken convenience overload for verify returns a faulted Task
+        /// Verifies calling verify without CancellationToken returns a faulted Task
         /// (base class throws NotImplementedException).
         /// </summary>
         [Fact]
-        public async Task VerifyColumnMasterKeyMetadataAsync_NoCancellationOverload_ReturnsFaultedTask()
+        public async Task VerifyColumnMasterKeyMetadataAsync_DefaultCancellationToken_ReturnsFaultedTask()
         {
             var provider = new TestKeyStoreProvider();
             Task<bool> task = provider.VerifyColumnMasterKeyMetadataAsync("path", true, new byte[] { 1 });

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
+namespace Microsoft.Data.SqlClient.UnitTests.AlwaysEncrypted
 {
     public class SqlColumnEncryptionKeyStoreProviderAsyncShould
     {
@@ -136,6 +136,27 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
             byte[] result = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 });
             Assert.NotNull(result);
             Assert.Equal(new byte[] { 4, 5, 6 }, result);
+        }
+
+        [Fact]
+        public async Task DecryptColumnEncryptionKeyAsync_LiveToken_CompletesSuccessfully()
+        {
+            var provider = new TestKeyStoreProvider();
+            using var cts = new CancellationTokenSource();
+
+            // A non-cancelled token should not interfere with the operation
+            byte[] result = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 7, 8, 9 }, cts.Token);
+            Assert.Equal(new byte[] { 7, 8, 9 }, result);
+        }
+
+        [Fact]
+        public async Task EncryptColumnEncryptionKeyAsync_LiveToken_CompletesSuccessfully()
+        {
+            var provider = new TestKeyStoreProvider();
+            using var cts = new CancellationTokenSource();
+
+            byte[] result = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 7, 8, 9 }, cts.Token);
+            Assert.Equal(new byte[] { 7, 8, 9 }, result);
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/AlwaysEncrypted/SqlColumnEncryptionKeyStoreProviderAsyncShould.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         {
             var provider = new TestKeyStoreProvider();
             byte[] expected = provider.DecryptColumnEncryptionKey("path", "algo", new byte[] { 1, 2, 3 });
-            byte[] actual = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1, 2, 3 });
+            byte[] actual = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1, 2, 3 }, CancellationToken.None);
             Assert.Equal(expected, actual);
         }
 
@@ -25,7 +25,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         {
             var provider = new TestKeyStoreProvider();
             byte[] expected = provider.EncryptColumnEncryptionKey("path", "algo", new byte[] { 4, 5, 6 });
-            byte[] actual = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 });
+            byte[] actual = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 }, CancellationToken.None);
             Assert.Equal(expected, actual);
         }
 
@@ -33,7 +33,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         public async Task DecryptColumnEncryptionKeyAsync_WhenSyncThrows_ReturnsFaultedTask()
         {
             var provider = new ThrowingKeyStoreProvider();
-            Task<byte[]> task = provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1 });
+            Task<byte[]> task = provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1 }, CancellationToken.None);
 
             // Must not throw synchronously — the Task itself should be faulted
             Assert.True(task.IsFaulted);
@@ -44,7 +44,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         public async Task EncryptColumnEncryptionKeyAsync_WhenSyncThrows_ReturnsFaultedTask()
         {
             var provider = new ThrowingKeyStoreProvider();
-            Task<byte[]> task = provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1 });
+            Task<byte[]> task = provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1 }, CancellationToken.None);
 
             Assert.True(task.IsFaulted);
             await Assert.ThrowsAsync<InvalidOperationException>(() => task);
@@ -54,7 +54,7 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         public async Task SignColumnMasterKeyMetadataAsync_DefaultImplementation_ReturnsFaultedTask()
         {
             var provider = new TestKeyStoreProvider();
-            Task<byte[]> task = provider.SignColumnMasterKeyMetadataAsync("path", true);
+            Task<byte[]> task = provider.SignColumnMasterKeyMetadataAsync("path", true, CancellationToken.None);
 
             // The base sync method throws NotImplementedException; the async version
             // must surface this as a faulted Task, not a synchronous throw.
@@ -66,28 +66,76 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         public async Task VerifyColumnMasterKeyMetadataAsync_DefaultImplementation_ReturnsFaultedTask()
         {
             var provider = new TestKeyStoreProvider();
-            Task<bool> task = provider.VerifyColumnMasterKeyMetadataAsync("path", true, new byte[] { 1 });
+            Task<bool> task = provider.VerifyColumnMasterKeyMetadataAsync("path", true, new byte[] { 1 }, CancellationToken.None);
 
             Assert.True(task.IsFaulted);
             await Assert.ThrowsAsync<NotImplementedException>(() => task);
         }
 
         [Fact]
-        public async Task DecryptColumnEncryptionKeyAsync_AcceptsCancellationToken()
+        public void DecryptColumnEncryptionKeyAsync_CancelledToken_ReturnsCancelledTask()
         {
             var provider = new TestKeyStoreProvider();
             using var cts = new CancellationTokenSource();
-            byte[] result = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1, 2, 3 }, cts.Token);
-            Assert.NotNull(result);
+            cts.Cancel();
+
+            Task<byte[]> task = provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1, 2, 3 }, cts.Token);
+
+            Assert.True(task.IsCanceled);
         }
 
         [Fact]
-        public async Task EncryptColumnEncryptionKeyAsync_AcceptsCancellationToken()
+        public void EncryptColumnEncryptionKeyAsync_CancelledToken_ReturnsCancelledTask()
         {
             var provider = new TestKeyStoreProvider();
             using var cts = new CancellationTokenSource();
-            byte[] result = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 }, cts.Token);
+            cts.Cancel();
+
+            Task<byte[]> task = provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 }, cts.Token);
+
+            Assert.True(task.IsCanceled);
+        }
+
+        [Fact]
+        public void SignColumnMasterKeyMetadataAsync_CancelledToken_ReturnsCancelledTask()
+        {
+            var provider = new TestKeyStoreProvider();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Task<byte[]> task = provider.SignColumnMasterKeyMetadataAsync("path", true, cts.Token);
+
+            Assert.True(task.IsCanceled);
+        }
+
+        [Fact]
+        public void VerifyColumnMasterKeyMetadataAsync_CancelledToken_ReturnsCancelledTask()
+        {
+            var provider = new TestKeyStoreProvider();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Task<bool> task = provider.VerifyColumnMasterKeyMetadataAsync("path", true, new byte[] { 1 }, cts.Token);
+
+            Assert.True(task.IsCanceled);
+        }
+
+        [Fact]
+        public async Task DecryptColumnEncryptionKeyAsync_NoCancellationOverload_Works()
+        {
+            var provider = new TestKeyStoreProvider();
+            byte[] result = await provider.DecryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 1, 2, 3 });
             Assert.NotNull(result);
+            Assert.Equal(new byte[] { 1, 2, 3 }, result);
+        }
+
+        [Fact]
+        public async Task EncryptColumnEncryptionKeyAsync_NoCancellationOverload_Works()
+        {
+            var provider = new TestKeyStoreProvider();
+            byte[] result = await provider.EncryptColumnEncryptionKeyAsync("path", "algo", new byte[] { 4, 5, 6 });
+            Assert.NotNull(result);
+            Assert.Equal(new byte[] { 4, 5, 6 }, result);
         }
 
         /// <summary>
@@ -97,13 +145,11 @@ namespace Microsoft.Data.SqlClient.Tests.AlwaysEncryptedTests
         {
             public override byte[] DecryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] encryptedColumnEncryptionKey)
             {
-                // Simple identity operation for testing
                 return encryptedColumnEncryptionKey;
             }
 
             public override byte[] EncryptColumnEncryptionKey(string masterKeyPath, string encryptionAlgorithm, byte[] columnEncryptionKey)
             {
-                // Simple identity operation for testing
                 return columnEncryptionKey;
             }
         }


### PR DESCRIPTION
## Summary

Introduces async API counterparts for the `SqlColumnEncryptionKeyStoreProvider` abstract base class (Always Encrypted). This enables custom key store providers to implement truly asynchronous key operations instead of being forced to block on synchronous calls during query execution.

Fixes #3672

## Public API

Four new `virtual` methods added to `SqlColumnEncryptionKeyStoreProvider`:

```csharp
public virtual Task<byte[]> DecryptColumnEncryptionKeyAsync(
    string masterKeyPath, string encryptionAlgorithm,
    byte[] encryptedColumnEncryptionKey,
    CancellationToken cancellationToken = default);

public virtual Task<byte[]> EncryptColumnEncryptionKeyAsync(
    string masterKeyPath, string encryptionAlgorithm,
    byte[] columnEncryptionKey,
    CancellationToken cancellationToken = default);

public virtual Task<byte[]> SignColumnMasterKeyMetadataAsync(
    string masterKeyPath, bool allowEnclaveComputations,
    CancellationToken cancellationToken = default);

public virtual Task<bool> VerifyColumnMasterKeyMetadataAsync(
    string masterKeyPath, bool allowEnclaveComputations,
    byte[] signature,
    CancellationToken cancellationToken = default);
```

### Design Decisions

- **Single overload with `CancellationToken = default`** — no separate convenience overloads
- **Default implementation wraps sync counterpart** via `Task.FromResult` / `Task.FromException` so existing providers work without changes
- **Fatal exceptions are not caught** — uses `ADP.IsCatchableExceptionType(e)` filter in catch blocks (consistent with runtime patterns for `StackOverflowException`, `OutOfMemoryException`, etc.)

## Changes

| File | Description |
|------|-------------|
| `src/.../SqlColumnEncryptionKeyStoreProvider.cs` | Implementation of 4 virtual async methods |
| `src/.../ref/Microsoft.Data.SqlClient.cs` | Reference assembly surface |
| `doc/snippets/.../SqlColumnEncryptionKeyStoreProvider.xml` | XML documentation |
| `specs/002-async-always-encrypted/spec.md` | Design specification |
| `tests/.../SqlColumnEncryptionKeyStoreProviderAsyncShould.cs` | 16 unit tests |

## Testing

- [x] 16 unit tests covering: default sync fallback, faulted task propagation, cancellation support, default parameter behavior
- [x] Builds clean on all target frameworks (net462, net8.0, net9.0)
- [x] No breaking changes — existing providers continue to work without modification

## Checklist

- [x] Tests added
- [x] Public API changes documented (ref assembly + XML docs)
- [x] Design spec included
- [x] No breaking changes introduced
