### PR TITLE
Switch arm64 jobs to westus2 pool

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -365,7 +365,7 @@ stages:
             LocalDbSharedInstanceName: $(LocalDbSharedInstanceName)
 
         windows_azure_arm64_sql:
-          pool: ADO-CI-PUBLIC-ARM64-1ES-EUS-POOL
+          pool: ADO-CI-PUBLIC-ARM64-1ES-POOL
           images: 
             Win22_Azure_ARM64_Sql: ADO-WIN11-ARM64
           TargetFrameworks: ${{parameters.targetFrameworks }}


### PR DESCRIPTION
## Description

The eus region is currently capacity constrained for arm64 vms. This PR moves arm64 jobs to 1ES hosted pool in the westus2 region.