### PR TITLE
Remove audit sources from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,8 +4,4 @@
     <clear />
     <add key="sqlclient" value="https://sqlclientdrivers.pkgs.visualstudio.com/public/_packaging/sqlclient/nuget/v3/index.json" />
   </packageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
 </configuration>


### PR DESCRIPTION
This is no longer necessary now that AzDO provides the same data and it will make it easier to comply with the CFSClean network isolation policy required by 1ES.
