### PR TITLE
Change expected newline char when parsing crypto test baseline file.

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CoreCryptoTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/CoreCryptoTests.cs
@@ -9,10 +9,9 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
 {
-    public class CoreCryptoTests : IClassFixture<SQLSetupStrategyCertStoreProvider>
+    public class CoreCryptoTests
     {
-        // Synapse: Always Encrypted not supported in Azure Synapse.
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
+        [Fact]
         public void TestAeadCryptoWithNativeBaseline()
         {
             // Initialize the reader for resource text file which has the native code generated baseline.
@@ -45,8 +44,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted
             }
         }
 
-        // Synapse: Always Encrypted not supported in Azure Synapse.
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
+        [Fact]
         public void TestRsaCryptoWithNativeBaseline()
         {
             // Initialize the reader for resource text file which has the native code generated baseline.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CryptoNativeBaselineReader.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/AlwaysEncrypted/TestFixtures/Setup/CryptoNativeBaselineReader.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup
 {
@@ -174,7 +173,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.AlwaysEncrypted.Setup
         /// <summary>
         /// Parameter Data End identifier, to search inside resource text file.
         /// </summary>
-        private static readonly Regex regexEndParameterIdentifier = new Regex(@"\n");
+        private static readonly Regex regexEndParameterIdentifier = new Regex(Environment.NewLine);
 
         private readonly IList<CryptoVector> m_CryptoVectors;
 


### PR DESCRIPTION
## Description
CoreCryptoTests fail when run on linux because line endings are normalized to LF when the repo is checked out. The tests are otherwise still applicable to linux and can pass when the "baseline" files containing the keypairs are properly parsed.

This PR:
- Adjusts keypair files to use LF in place of CRLF.
  - This doesn't show in the diff, unfortunately.
- Adjust file parsing to look for LF.

Successful run: https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=127269&view=results