### PR TITLE
[7.0.0-preview2] Disable Tests in Official Build

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
@@ -163,13 +163,14 @@ extends:
             patterns: '**/*.*nupkg'
             displayName: 'Download NuGet Package'
 
-      - template: eng/pipelines/common/templates/jobs/run-tests-package-reference-job.yml@self
-        parameters:
-          packageFolderName: $(packageFolderName)
-          isPreview: ${{ parameters['isPreview'] }}
-          timeout: ${{ parameters.testsTimeout }}
-          downloadPackageStep:
-            download: current
-            artifact: $(packageFolderName)
-            patterns: '**/*.nupkg'
-            displayName: 'Download NuGet Package'
+# Disabling as of 10/15/2025 due to OneBranch apparently disallowing MSBuild tasks in validation stages.
+#      - template: eng/pipelines/common/templates/jobs/run-tests-package-reference-job.yml@self
+#        parameters:
+#          packageFolderName: $(packageFolderName)
+#          isPreview: ${{ parameters['isPreview'] }}
+#          timeout: ${{ parameters.testsTimeout }}
+#          downloadPackageStep:
+#            download: current
+#            artifact: $(packageFolderName)
+#            patterns: '**/*.nupkg'
+#            displayName: 'Download NuGet Package'


### PR DESCRIPTION
## Description
Disabling test execution in validation stage of official pipeline due to OneBranch removing support for it. Without this, the official build will not launch at all, citing an error like:

<img width="452" height="318" alt="image" src="https://github.com/user-attachments/assets/3a222967-89aa-4b79-9492-4cb8990f2cf5" />

## Testing
A test build with the same change has been launched (although failing due to using official build template on unofficial branch).
https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=127366