### PR TITLE
Suppress PSAvoidUsingConvertToSecureStringWithPlainText in makepfxcert used in tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/makepfxcert.ps1
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/makepfxcert.ps1
@@ -133,7 +133,7 @@ function Invoke-SqlServerCertificateCommand {
 
         # PSScriptAnalyzer rule suppression
         # Suppress the 'PSAvoidUsingConvertToSecureStringWithPlainText' rule for the next line as this is a test certificate with no password
-        [void][Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Test certificate with no real secret")]
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Test certificate with no real secret")]
         $pwd = ConvertTo-SecureString -String 'nopassword' -Force -AsPlainText
         
         # Export the certificate to a pfx format


### PR DESCRIPTION
Addresses https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/39660/ for recently identified psscriptanalyzer warning.