### PR TITLE
[6.1] Backport initial metrics enablement

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientMetrics.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Diagnostics/SqlClientMetrics.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Data.SqlClient.Diagnostics
         private string? _instanceName;
 #endif
 
-        public SqlClientMetrics(SqlClientEventSource eventSource)
+        public SqlClientMetrics(SqlClientEventSource eventSource, bool enableMetrics)
         {
             _eventSource = eventSource;
 
@@ -100,6 +100,11 @@ namespace Microsoft.Data.SqlClient.Diagnostics
             // On .NET Framework, metrics are exposed as performance counters and are always enabled.
             // On .NET Core, metrics are exposed as EventCounters, and require explicit enablement.
             EnablePerformanceCounters();
+#else
+            if (enableMetrics)
+            {
+                EnableEventCounters();
+            }
 #endif
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs
@@ -15,11 +15,13 @@ namespace Microsoft.Data.SqlClient
     [EventSource(Name = "Microsoft.Data.SqlClient.EventSource")]
     internal partial class SqlClientEventSource : EventSource
     {
+        private static bool s_initialMetricsEnabled = false;
+
         // Defines the singleton instance for the Resources ETW provider
         public static readonly SqlClientEventSource Log = new();
 
         // Provides access to metrics.
-        public static readonly SqlClientMetrics Metrics = new SqlClientMetrics(Log);
+        public static readonly SqlClientMetrics Metrics = new SqlClientMetrics(Log, s_initialMetricsEnabled);
 
         private SqlClientEventSource() { }
 
@@ -33,7 +35,14 @@ namespace Microsoft.Data.SqlClient
 
             if (command.Command == EventCommand.Enable)
             {
-                Metrics.EnableEventCounters();
+                if (Metrics == null)
+                {
+                    s_initialMetricsEnabled = true;
+                }
+                else
+                {
+                    Metrics.EnableEventCounters();
+                }
             }
         }
 #endif


### PR DESCRIPTION
## Description

This backports 66a67bc5a32915c086f134e9a00d88507a6cd2ce from #3575 to 6.1.

It's possible to start an application with the M.D.S EventSource already enabled, even before the static constructor for SqlClientEventSource has run. In this situation, the constructor for `Log` will run `OnEventCommand` with an enablement command before it finishes executing. This enablement tries to call `Metrics.EnableEventCounters`, but this hasn't been initialized yet - it relies on the `SqlClientEventSource` instance.

To break this cycle, we record the desired startup state of the metrics in this case, and pass it to the `SqlClientMetrics` constructor.

## Issues

Fixes #3711.

## Testing

The timing makes this difficult to test. In the end, I built a test application locally, referenced 6.1.2 and ran
```
dotnet counters monitor --counters Microsoft.Data.SqlClient.EventSource -- SqlClientTimeQuery.exe
```
This allowed me to reproduce the problem: the counters appear in 6.0, don't appear in 6.1.2, appear again in 7.0-preview2 and now also appear in my local build.

Could someone run CI please? @empowerRob you should be able to verify with the nupkg build artifact.