### PR TITLE
Skip flaky connection pool test

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPoolTest.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
         }
 
         [Fact]
-        [ActiveIssue("Flaky, timing dependent")]
+        [ActiveIssue("https://github.com/dotnet/SqlClient/issues/3730")]
         public async Task GetConnectionAsyncMaxPoolSize_ShouldRespectOrderOfRequest()
         {
             // Arrange


### PR DESCRIPTION
## Description
This test is timing dependent and has proven to be flaky in the pipeline. I'll address it as part of the next connection pooling PR.
