### PR TITLE
[6.1] Update CI pipelines to trigger for PR, commits, and schedules

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -43,7 +43,7 @@ trigger:
 # Scheduled runs.
 schedules:
 
-  # GitHub main on Sundays
+  # GitHub on Sundays 04:30 UTC.
   - cron: '30 4 * * Sun'
     displayName: Sunday Run
     branches:
@@ -51,7 +51,7 @@ schedules:
       - release/6.1
     always: true
 
-  # ADO internal/main on Sundays.
+  # ADO on Sundays 05:30 UTC.
   - cron: '30 5 * * Sun'
     displayName: Sunday Run
     branches:

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -43,7 +43,7 @@ trigger:
 # Scheduled runs.
 schedules:
 
-  # GitHub main on Sundays
+  # GitHub on Sundays 04:00 UTC.
   - cron: '0 4 * * Sun'
     displayName: Sunday Run
     branches:
@@ -51,7 +51,7 @@ schedules:
       - release/6.1
     always: true
 
-  # ADO internal/main on Sundays.
+  # ADO on Sundays 05:00 UTC.
   - cron: '0 5 * * Sun'
     displayName: Sunday Run
     branches:


### PR DESCRIPTION
## Description

We have changed the Azure DevOps configuration for the CI-SqlClient and CI-SqlClient-Package pipelines.  They no longer use Classic UI-based PR triggers.  We now must use the YAML definitions to configure all trigger types (PR, Commit, Schedule).

This PR updates the two CI pipeline YAML definitions to configure PR, Commit, and Schedule triggers.
