### PR TITLE
Perf | Use source generation to serialize user agent JSON

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -995,6 +995,9 @@
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\UserAgent\UserAgentInfoDto.cs">
       <Link>Microsoft\Data\SqlClient\UserAgent\UserAgentInfoDto.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\UserAgent\UserAgentInfoDtoSerializerContext.cs">
+      <Link>Microsoft\Data\SqlClient\UserAgent\UserAgentInfoDtoSerializerContext.cs</Link>
+    </Compile>
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\VirtualSecureModeEnclaveProvider.cs">
       <Link>Microsoft\Data\SqlClient\VirtualSecureModeEnclaveProvider.cs</Link>
     </Compile>

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -1002,6 +1002,9 @@
     <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\UserAgent\UserAgentInfoDto.cs">
       <Link>Microsoft\Data\SqlClient\UserAgent\UserAgentInfoDto.cs</Link>
     </Compile>
+    <Compile Include="$(CommonSourceRoot)Microsoft\Data\SqlClient\UserAgent\UserAgentInfoDtoSerializerContext.cs">
+      <Link>Microsoft\Data\SqlClient\UserAgent\UserAgentInfoDtoSerializerContext.cs</Link>
+    </Compile>
     <Compile Include="$(CommonSourceRoot)Resources\ResCategoryAttribute.cs">
       <Link>Resources\ResCategoryAttribute.cs</Link>
     </Compile>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/UserAgent/UserAgentInfo.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/UserAgent/UserAgentInfo.cs
@@ -133,13 +133,7 @@ internal static class UserAgentInfo
         // - If the payload exceeds 2,047 bytes but remains within sensible limits, we still send it, but note that
         //   some servers may silently drop or reject such packets — behavior we may use for future probing or diagnostics.
         // - If payload exceeds 10KB even after dropping fields , we send an empty payload.
-        var options = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = null,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            WriteIndented = false
-        };
-        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(dto, options);
+        byte[] payload = JsonSerializer.SerializeToUtf8Bytes(dto, UserAgentInfoDtoSerializerContext.Default.UserAgentInfoDto);
 
         // We try to send the payload if it is within the limits.
         // Otherwise we drop some fields to reduce the size of the payload and try one last time
@@ -157,7 +151,7 @@ internal static class UserAgentInfo
             dto.OS.Details = null; // drop OS.Details
         }
 
-        payload = JsonSerializer.SerializeToUtf8Bytes(dto, options);
+        payload = JsonSerializer.SerializeToUtf8Bytes(dto, UserAgentInfoDtoSerializerContext.Default.UserAgentInfoDto);
         if (payload.Length <= JsonPayloadMaxBytes)
         {
             return payload;
@@ -166,7 +160,7 @@ internal static class UserAgentInfo
         dto.OS = null; // drop OS entirely
         // Last attempt to send minimal payload driver + version only
         // As per the comment in AdjustJsonPayloadSize, we know driver + version cannot be larger than the max
-        return JsonSerializer.SerializeToUtf8Bytes(dto, options);
+        return JsonSerializer.SerializeToUtf8Bytes(dto, UserAgentInfoDtoSerializerContext.Default.UserAgentInfoDto);
     }
 
     internal static UserAgentInfoDto BuildDto()

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/UserAgent/UserAgentInfoDtoSerializerContext.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/UserAgent/UserAgentInfoDtoSerializerContext.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+#nullable enable
+
+namespace Microsoft.Data.SqlClient.UserAgent;
+
+[JsonSourceGenerationOptions(WriteIndented = false, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, PropertyNamingPolicy = JsonKnownNamingPolicy.Unspecified)]
+[JsonSerializable(typeof(UserAgentInfoDto), GenerationMode = JsonSourceGenerationMode.Serialization)]
+internal sealed partial class UserAgentInfoDtoSerializerContext : JsonSerializerContext
+{
+}


### PR DESCRIPTION
## Description

#3582 added functionality to send a small user agent JSON structure to SQL Server. While this works, it also drags in a reflection-based dependency, and the populated reflection-based information is held in memory, preventing the AssemblyLoadContext from being unloaded.

This PR swaps this over to using the built-in [source-generated JSON serializer](https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/source-generation-modes). This should improve performance slightly, and it's the second of a set of changes needed to enable AssemblyLoadContext unloading.

While I don't think this'll be a problem, it's worth noting that this means we'll need to compile the netfx library using the net6.0+ SDK.

## Issues

Builds on #3582. Contributes to #1687.

## Testing

Automated unit tests continue to function.