### PR TITLE
Enable code cov to include net9.0 result files

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -56,7 +56,7 @@ parameters:
 - name: codeCovTargetFrameworks
   displayName: 'Code Coverage Target Frameworks'
   type: object
-  default: [net462, net8.0]
+  default: [net462, net8.0, net9.0]
 
 - name: buildType
   displayName: 'Build Type'


### PR DESCRIPTION
Final Code coverage was not merging net9.0 test results, this PR enables the same.