### PR TITLE
Fix code coverage job disk full

### DIFF
--- a/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
@@ -15,6 +15,14 @@ parameters:
     type: boolean
     default: false
 
+  # The pool image to use.
+  - name: image
+    type: string
+
+  # The agent pool name.
+  - name: pool
+    type: string
+
   # Array of target frameworks to process code coverage for:
   #
   #   e.g. [net462, net8.0, net9.0]
@@ -31,9 +39,13 @@ jobs:
   - job: CodeCoverage
     displayName: Publish Code Coverage
 
-    pool: 
-      name: Azure Pipelines
-      vmImage: windows-2022
+    pool:
+      name: ${{ parameters.pool }}
+      ${{ if eq(parameters.pool, 'Azure Pipelines') }}:
+        vmImage: ${{ parameters.image }}
+      ${{ else }}:
+        demands:
+        - imageOverride -equals ${{ parameters.image }}
 
     variables:
       netFxDir: $(Build.SourcesDirectory)\coverageNetFx

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -158,6 +158,8 @@ stages:
         - template: common/templates/jobs/ci-code-coverage-job.yml@self
           parameters:
             debug: ${{ parameters.debug }}
+            image: ADO-MMS22-CodeCov
+            pool: ${{ parameters.defaultPoolName }}
             targetFrameworks: ${{ parameters.codeCovTargetFrameworks }}
 
 # test stages configurations


### PR DESCRIPTION
## Description

The code coverage jobs are running out of disk space.  They appear to consume upwards of 12GB of space to merge/convert  3GB of coverage logs from the various test jobs.  We can diagnose why that is later.  For now, I have:
- Switched the coverage job to use the ADO-MMS22-CodeCov 1ES image rather than a generic Azure Pipelines image.
  - The generic images have 14GB of disk space.
  - Our custom 1ES image has much more space.
- Removed unnecessary parameters/variables for code coverage job.
- Added debug output to help see disk usage throughout the job.

Successful coverage job run: https://sqlclientdrivers.visualstudio.com/public/SqlDevX%20(public)/_build/results?buildId=131331&view=logs&s=78db0df0-7afe-532d-b7fe-bdf808bbfe01