### PR TITLE
[6.1] Fix code coverage job disk full

### DIFF
--- a/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
@@ -3,160 +3,194 @@
 # The .NET Foundation licenses this file to you under the MIT license.          #
 # See the LICENSE file in the project root for more information.                #
 #################################################################################
+
+# This job processes code coverage reports generated during test runs,
+# merges them, generates code coverage reports, publishes them to the
+# pipeline, and uploads them to CodeCov.
+
 parameters:
+  
+  # True to include debug steps.
   - name: debug
     type: boolean
     default: false
 
-  - name: upload
-    type: string
-    default: $(ci_var_uploadTestResult)
-
-  - name: poolName
-    type: string
-    default: $(defaultHostedPoolName)
-
+  # The pool image to use.
   - name: image
     type: string
-    default: 'windows-2022'
-  
-  - name: downloadArtifactsSteps
-    type: stepList
-    default: []
+
+  # The agent pool name.
+  - name: pool
+    type: string
+
+  # Array of target frameworks to process code coverage for:
+  #
+  #   e.g. [net462, net8.0, net9.0]
+  #
+  - name: targetFrameworks
+    type: object
+
+  # True to upload code coverage results to CodeCov.
+  - name: upload
+    type: boolean
+    default: true
 
 jobs:
-- job: CodeCoverage
-  displayName: 'Merge Code Coverage'
+  - job: CodeCoverage
+    displayName: Publish Code Coverage
 
-  variables:
-    uploadTestResult: ${{ parameters.upload }}
+    pool:
+      name: ${{ parameters.pool }}
+      ${{ if eq(parameters.pool, 'Azure Pipelines') }}:
+        vmImage: ${{ parameters.image }}
+      ${{ else }}:
+        demands:
+        - imageOverride -equals ${{ parameters.image }}
 
-  pool: 
-    name: '${{ parameters.poolName }}'
-    vmImage: ${{ parameters.image }}
+    variables:
+      netFxDir: $(Build.SourcesDirectory)\coverageNetFx
+      netCoreDir: $(Build.SourcesDirectory)\coverageNetCore
 
-  steps:
-  - ${{if eq(parameters.debug, true)}}:
-    - powershell: |
-        Get-ChildItem env: | Sort-Object Name
-      displayName: 'List Environment Variables [debug]'
+    steps:
+      - ${{if eq(parameters.debug, true)}}:
+        - pwsh: |
+            Get-ChildItem env: | Sort-Object Name
+          displayName: 'List Environment Variables [debug]'
 
-  - task: NuGetAuthenticate@1
-    displayName: 'NuGet Authenticate'
+        - pwsh: Get-Volume
+          displayName: '[Debug] Show Disk Usage'
 
-  - template: ../steps/ensure-dotnet-version.yml@self
-    parameters:
-        packageType: 'sdk'
-        version: '8.0'
+        - pwsh: 'Get-ChildItem env: | Sort-Object Name'
+          displayName: '[Debug] List Environment Variables'
 
-  - ${{ parameters.downloadArtifactsSteps }}
+      - template: ../steps/ensure-dotnet-version.yml@self
+        parameters:
+            packageType: sdk
+            version: '9.0'
 
-  - ${{ if eq(parameters.debug, true)}}:
-    - powershell: |
-        Get-ChildItem $(Build.SourcesDirectory)\coverageNetFx\ -Recurse -File -Filter *.coverage
-      displayName: 'List coverageNetFx files [debug]'
-    
-    - powershell: |
-        Get-ChildItem $(Build.SourcesDirectory)\coverageNetCore\ -Recurse -File -Filter *.coverage
-      displayName: 'List coverageNetCore files [debug]'
+      - pwsh: |
+          dotnet tool install --global dotnet-coverage
+          dotnet tool install --global dotnet-reportgenerator-globaltool
+        displayName: Install dotnet tools
+              
+      - ${{ each targetFramework in parameters.targetFrameworks }}:
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download Coverage Reports [${{ targetFramework }}]'
+          inputs:
+            itemPattern: '**\${{ targetFramework }}*'
+            ${{ if startsWith(targetFramework, 'net4') }}:
+              targetPath: $(netFxDir)
+            ${{ else }}:
+              targetPath: $(netCoreDir)
 
-  - pwsh: |
-      dotnet tool install --global dotnet-coverage
+      - ${{if eq(parameters.debug, true)}}:
+        - pwsh: Get-Volume
+          displayName: '[Debug] Show Disk Usage'
 
-      function MergeFiles {
-        param(
-        [string]$InputDirectoryPath,
-        [string]$OutputDirectoryName
-        )
+        - pwsh: Get-ChildItem $(netFxDir) -Recurse -File -Filter *.coverage
+          displayName: '[Debug] List coverageNetFx files'
 
-        $files = Get-ChildItem $InputDirectoryPath -Recurse -File -Filter *.coverage
+        - pwsh: Get-ChildItem $(netCoreDir) -Recurse -File -Filter *.coverage
+          displayName: '[Debug] List coverageNetCore files'
 
-        # echo $files
-        mkdir $OutputDirectoryName
-        $counter=0
+      - pwsh: |
+          function MergeFiles {
+            param(
+            [string]$InputDirectoryPath,
+            [string]$OutputDirectoryName
+            )
 
-        $toProcess = @()
+            $files = Get-ChildItem $InputDirectoryPath -Recurse -File -Filter *.coverage
 
-        foreach ($file in $files) {
-            $toProcess += @{ 
-                File = $file.FullName
-                OutputFile = "$OutputDirectoryName\$counter.coveragexml"
+            # echo $files
+            mkdir $OutputDirectoryName
+            $counter=0
+            $toProcess = @()
+
+            foreach ($file in $files) {
+                $toProcess += @{ 
+                    File = $file.FullName
+                    OutputFile = "$OutputDirectoryName\$counter.coveragexml"
+                }
+
+                $counter++
             }
 
-            $counter++
-        }
+            $jobs = @()
+            foreach ($file in $toProcess){
+                $jobs += Start-ThreadJob -ScriptBlock { 
+                    $params = $using:file
+                    & dotnet-coverage merge $($params.File) --output $($params.OutputFile) --output-format xml 
+                } 
+            }
 
-        $jobs = @()
-        foreach ($file in $toProcess){
-            $jobs += Start-ThreadJob -ScriptBlock { 
-                $params = $using:file
-                & dotnet-coverage merge $($params.File) --output $($params.OutputFile) --output-format xml 
-            } 
-        }
+            Write-Host "Merging started..."
+            Wait-Job -Job $jobs
 
-        Write-Host "Merging started..."
-        Wait-Job -Job $jobs
+            foreach ($job in $jobs) {
+                Receive-Job -Job $job -Wait -AutoRemoveJob
+            }
+          }
 
-        foreach ($job in $jobs) {
-            Receive-Job -Job $job -Wait -AutoRemoveJob
-        }
-      }
+          MergeFiles -InputDirectoryPath "$(netFxDir)" -OutputDirectoryName "coverageNetFxXml"
+          MergeFiles -InputDirectoryPath "$(netCoreDir)" -OutputDirectoryName "coverageNetCoreXml"
+          
+          Write-Host "Removing original coverage files..."
+          Remove-Item $(netFxDir) -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item $(netCoreDir) -Recurse -Force -ErrorAction SilentlyContinue
+        displayName: Convert coverage files to xml
 
-      MergeFiles -InputDirectoryPath "$(Build.SourcesDirectory)\coverageNetFx\" -OutputDirectoryName "coverageNetFxXml"
-      MergeFiles -InputDirectoryPath "$(Build.SourcesDirectory)\coverageNetCore\" -OutputDirectoryName "coverageNetCoreXml"
-      
-      # dir coverageNetFxXml\
-      # dir coverageNetCoreXml\
+      - ${{if eq(parameters.debug, true)}}:
+        - pwsh: Get-Volume
+          displayName: '[Debug] Show Disk Usage'
 
-      Write-Host "Clean up disk ... [removing coverageNetFx & coverageNetCore]"
+        - pwsh: |
+            dir coverageNetFxXml\
+            dir coverageNetCoreXml\
+          displayName: '[Debug] List converted files'
 
-      Remove-Item $(Build.SourcesDirectory)\coverageNetFx -Recurse -Force
-      Remove-Item $(Build.SourcesDirectory)\coverageNetCore -Recurse -Force
+      - pwsh: |
+          $jobs = @()
+          $jobs += Start-ThreadJob -ScriptBlock { 
+              & reportgenerator "-reports:coverageNetFxXml\*.coveragexml" "-targetdir:coveragereportNetFx" "-reporttypes:Cobertura;" "-assemblyfilters:+microsoft.data.sqlclient.dll" "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\netfx\src;$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\src" "-classfilters:+Microsoft.Data.*"
+          }
 
-    displayName: 'Convert coverage files to xml'
+          $jobs += Start-ThreadJob -ScriptBlock { 
+              & reportgenerator "-reports:coverageNetCoreXml\*.coveragexml" "-targetdir:coveragereportNetCore" "-reporttypes:Cobertura;" "-assemblyfilters:+microsoft.data.sqlclient.dll" "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\netcore\src;$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\src" "-classfilters:+Microsoft.Data.*"
+          }
 
-  - ${{ if eq(parameters.debug, true)}}:
-    - powershell: |
-        dir coverageNetFxXml\
-        dir coverageNetCoreXml\
-      displayName: 'List converted files [debug]'
+          $jobs += Start-ThreadJob -ScriptBlock { 
+              & reportgenerator "-reports:coverageNetCoreXml\*.coveragexml" "-targetdir:coveragereportAddOns" "-reporttypes:Cobertura;" "-assemblyfilters:+microsoft.data.sqlclient.alwaysencrypted.azurekeyvaultprovider.dll" "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\add-ons\AzureKeyVaultProvider" "-classfilters:+Microsoft.Data.*"
+          }
 
-  - pwsh: |
-      dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools
+          Write-Host "Running ReportGenerator..."
+          Wait-Job -Job $jobs
 
-      $jobs = @()
-      $jobs += Start-ThreadJob -ScriptBlock { 
-          & tools\reportgenerator "-reports:coverageNetFxXml\*.coveragexml" "-targetdir:coveragereportNetFx" "-reporttypes:Cobertura;" "-assemblyfilters:+microsoft.data.sqlclient.dll" "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\netfx\src;$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\src" "-classfilters:+Microsoft.Data.*"
-      }
+          foreach ($job in $jobs) {
+              Receive-Job -Job $job -Wait -AutoRemoveJob
+          }
 
-      $jobs += Start-ThreadJob -ScriptBlock { 
-          & tools\reportgenerator "-reports:coverageNetCoreXml\*.coveragexml" "-targetdir:coveragereportAddOns" "-reporttypes:Cobertura;" "-assemblyfilters:+microsoft.data.sqlclient.alwaysencrypted.azurekeyvaultprovider.dll" "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\add-ons\AzureKeyVaultProvider" "-classfilters:+Microsoft.Data.*"
-      }
+          Write-Host "Removing merged XML files..."
+          Remove-Item coverageNetFxXml -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item coverageNetCoreXml -Recurse -Force -ErrorAction SilentlyContinue
+        displayName: Run ReportGenerator
 
-      $jobs += Start-ThreadJob -ScriptBlock { 
-          & tools\reportgenerator "-reports:coverageNetCoreXml\*.coveragexml" "-targetdir:coveragereportNetCore" "-reporttypes:Cobertura;" "-assemblyfilters:+microsoft.data.sqlclient.dll" "-sourcedirs:$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\netcore\src;$(Build.SourcesDirectory)\src\Microsoft.Data.SqlClient\src" "-classfilters:+Microsoft.Data.*"
-      }
+      - ${{if eq(parameters.debug, true)}}:
+        - pwsh: Get-Volume
+          displayName: '[Debug] Show Disk Usage'
 
-      Write-Host "Running ReportGenerator..."
-      Wait-Job -Job $jobs
+      - task: PublishCodeCoverageResults@2
+        displayName: Publish code coverage results
+        inputs:
+          summaryFileLocation: '*\Cobertura.xml'
 
-      foreach ($job in $jobs) {
-          Receive-Job -Job $job -Wait -AutoRemoveJob
-      }
-    displayName: 'Run ReportGenerator'
-
-  - task: PublishCodeCoverageResults@2
-    displayName: 'Publish code coverage from netcore'
-    inputs:
-      summaryFileLocation: '*\Cobertura.xml'
-
-  - powershell: |
-      #download Codecov CLI
-      $ProgressPreference = 'SilentlyContinue' 
-      Invoke-WebRequest -Uri https://cli.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
-      
-      ./codecov --verbose upload-process --fail-on-error -t $(CODECOV_TOKEN) -f "coveragereportNetFx\Cobertura.xml" -F netfx
-      ./codecov --verbose upload-process --fail-on-error -t $(CODECOV_TOKEN)  -f "coveragereportNetCore\Cobertura.xml" -F netcore
-      ./codecov --verbose upload-process --fail-on-error -t $(CODECOV_TOKEN)  -f "coveragereportAddOns\Cobertura.xml" -F addons
-    displayName: 'Upload to CodeCov'
-    condition: and(succeeded(), eq(variables['uploadTestResult'], 'true'))
+      - ${{if eq(parameters.upload, true)}}:
+        - pwsh: |
+            #download Codecov CLI
+            $ProgressPreference = 'SilentlyContinue' 
+            Invoke-WebRequest -Uri https://cli.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
+            
+            ./codecov --verbose upload-process --fail-on-error -t $(CODECOV_TOKEN) -f "coveragereportNetFx\Cobertura.xml" -F netfx
+            ./codecov --verbose upload-process --fail-on-error -t $(CODECOV_TOKEN) -f "coveragereportNetCore\Cobertura.xml" -F netcore
+            ./codecov --verbose upload-process --fail-on-error -t $(CODECOV_TOKEN) -f "coveragereportAddOns\Cobertura.xml" -F addons
+          displayName: Upload to CodeCov

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -92,9 +92,6 @@ variables:
   - name: artifactName
     value: Artifacts
 
-  - name: defaultHostedPoolName
-    value: 'Azure Pipelines'
-
 stages:
   - stage: build_nugets
     displayName: 'Build NuGet Packages'
@@ -152,16 +149,9 @@ stages:
         - template: common/templates/jobs/ci-code-coverage-job.yml@self
           parameters:
             debug: ${{ parameters.debug }}
-            downloadArtifactsSteps:
-              - ${{ each targetFramework in parameters.codeCovTargetFrameworks }}:
-                - task: DownloadPipelineArtifact@2
-                  displayName: 'Download Coverage Reports [${{ targetFramework }}]'
-                  inputs:
-                    itemPattern: '**\${{ targetFramework }}*'
-                    ${{ if contains(targetFramework, 'net4') }}:
-                      targetPath: '$(Build.SourcesDirectory)\coverageNetFx'
-                    ${{ else }}:
-                      targetPath: '$(Build.SourcesDirectory)\coverageNetCore'
+            image: ADO-MMS22-CodeCov
+            pool: ${{ parameters.defaultPoolName }}
+            targetFrameworks: ${{ parameters.codeCovTargetFrameworks }}
 
 # test stages configurations
   # self hosted SQL Server on Windows
@@ -510,7 +500,7 @@ stages:
 
         # Self hosted SQL Server on Mac
         mac_sql_22:
-          pool: $(defaultHostedPoolName)
+          pool: Azure Pipelines
           hostedPool: true
           images:
             MacOSLatest_Sql22: macos-latest


### PR DESCRIPTION
## Description

**Backport of #3798 to 6.1**

The code coverage jobs are running out of disk space. They appear to consume upwards of 12GB of space to merge/convert 3GB of coverage logs from the various test jobs. We can diagnose why that is later. For now, I have:

- Switched the coverage job to use the ADO-MMS22-CodeCov 1ES image rather than a generic Azure Pipelines image.
  - The generic images have 14GB of disk space.
  - Our custom 1ES image has much more space.
- Removed unnecessary parameters/variables for code coverage job.
- Added debug output to help see disk usage throughout the job.
