### PR TITLE
Disable scanning of Actions in CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,7 +88,9 @@ jobs:
     - name: Run manual build steps
       if: matrix.build-mode == 'manual'
       shell: bash
-      run: dotnet build src/
+      run: |
+        mkdir packages
+        dotnet build src/
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Description.

This PR creates a CodeQL config file that GitHub will use to perform scans.  It disables scanning of Actions since those always fail.  We leave C# scanning active.
