### PR TITLE
Test | Kill tests that run longer than 5 mins.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -226,6 +226,7 @@
         --collect "Code coverage"
         --results-directory $(ResultsDirectory)
         --filter "category!=failing%26category!=flaky"
+        --blame-hang-timeout 5m
         --logger:"trx;LogFilePrefix=Unit-Windows$(TargetGroup)-$(TestSet)"
       </TestCommand>
       <TestCommand>$(TestCommand.Replace($([System.Environment]::NewLine), " "))</TestCommand>
@@ -247,6 +248,7 @@
         --collect "Code coverage"
         --results-directory $(ResultsDirectory)
         --filter "category!=failing%26category!=flaky"
+        --blame-hang-timeout 5m
         --logger:"trx;LogFilePrefix=Unit-Unixnetcoreapp-$(TestSet)"
     </TestCommand>
       <TestCommand>$(TestCommand.Replace($([System.Environment]::NewLine), " "))</TestCommand>
@@ -273,6 +275,7 @@
         --collect "Code coverage"
         --results-directory $(ResultsDirectory)
         --filter "category!=non$(TargetGroup)tests&amp;category!=failing&amp;category!=nonwindowstests"
+        --blame-hang-timeout 5m
         --logger:"trx;LogFilePrefix=Functional-Windows$(TargetGroup)-$(TestSet)"
       </TestCommand>
       <TestCommand>$(TestCommand.Replace($([System.Environment]::NewLine), " "))</TestCommand>
@@ -296,6 +299,7 @@
         --collect "Code coverage"
         --results-directory $(ResultsDirectory)
         --filter "category!=nonnetcoreapptests&amp;category!=failing&amp;category!=nonlinuxtests&amp;category!=nonuaptests"
+        --blame-hang-timeout 5m
         --logger:"trx;LogFilePrefix=Functional-Unixnetcoreapp-$(TestSet)"
       </TestCommand>
       <TestCommand>$(TestCommand.Replace($([System.Environment]::NewLine), " "))</TestCommand>
@@ -322,6 +326,7 @@
         --collect "Code coverage"
         --results-directory $(ResultsDirectory)
         --filter "category!=non$(TargetGroup)tests&amp;category!=failing&amp;category!=nonwindowstests"
+        --blame-hang-timeout 5m
         --logger:"trx;LogFilePrefix=Manual-Windows$(TargetGroup)-$(TestSet)"
       </TestCommand>
       <TestCommand>$(TestCommand.Replace($([System.Environment]::NewLine), " "))</TestCommand>
@@ -345,6 +350,7 @@
         --collect "Code coverage"
         --results-directory $(ResultsDirectory)
         --filter "category!=nonnetcoreapptests&amp;category!=failing&amp;category!=nonlinuxtests&amp;category!=nonuaptests"
+        --blame-hang-timeout 5m
         --logger:"trx;LogFilePrefix=Manual-Unixnetcoreapp-$(TestSet)"
       </TestCommand>
       <TestCommand>$(TestCommand.Replace($([System.Environment]::NewLine), " "))</TestCommand>


### PR DESCRIPTION
## Description

Poor test design and resource contention sometimes lead to test cases that run longer than desired. In other cases, tests are genuinely stuck due to deadlocks. In these situations, it's best to kill the test case and rerun. Unfortunately, because we use xunit2 and vstest, we're stuck with rerunning the whole test suite as there's no option to rerun only failing tests.

All the same tests are run, but they should now "fail fast" instead of sitting and consuming resources.

I'll leave this PR open for a bit and rerun the pipeline on it to see how useful this behavior is in practice.