### PR TITLE
Fixing NullReferenceException issue with SqlDataAdapter

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Encryption.cs
@@ -1293,7 +1293,7 @@ namespace Microsoft.Data.SqlClient
                     // not present as the rpcName, as is the case with non-_batchRPCMode. So
                     // input parameters start at parameters[1]. parameters[0] is the actual
                     // T-SQL Statement. rpcName is sp_executesql.
-                    if (_RPCList[i].systemParams.Length > 1)
+                    if (_RPCList[i].systemParams != null && _RPCList[i].systemParams.Length > 1)
                     {
                         _RPCList[i].needsFetchParameterEncryptionMetadata = true;
 


### PR DESCRIPTION
## Description

This Pull Request addresses issue #3716 by introducing a null check for systemParams, which stores the system-level parameters for SQL RPC (Remote Procedure Call) operations. In batch scenarios, certain SQL RPC calls may not include system parameters, and this change ensures proper handling in such cases.

## Issues

[#3716
](https://github.com/dotnet/SqlClient/issues/3716)