### PR TITLE
Add Release compile step to PR pipelines

### DIFF
--- a/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
@@ -46,6 +46,18 @@ jobs:
   - ${{ if ne(parameters.prebuildSteps, '') }}:
     - ${{ parameters.prebuildSteps }} # extra steps to run before the build like downloading sni and the required configuration
 
+  # When we're performing a Debug build, we still want to try _compiling_ the
+  # code in Release mode to ensure downstream pipelines don't encounter
+  # compilation errors.  We won't use the Release artifacts for anything else
+  # though.
+  - ${{ if eq(parameters.buildConfiguration, 'Debug') }}:
+    - template: ../steps/ci-project-build-step.yml@self
+      parameters:
+        platform: ${{ parameters.platform }}
+        buildConfiguration: Release
+        operatingSystem: Windows
+        build: all
+
   - template: ../steps/ci-project-build-step.yml@self
     parameters:
       platform: ${{ parameters.platform }}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniPhysicalHandle.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ManagedSni/SniPhysicalHandle.netcore.cs
@@ -16,9 +16,8 @@ namespace Microsoft.Data.SqlClient.ManagedSni
     {
         protected const int DefaultPoolSize = 4;
 
-#if DEBUG
         private static int s_packetId;
-#endif
+
         private ObjectPool<SniPacket> _pool;
 
         protected SniPhysicalHandle(int poolSize = DefaultPoolSize)


### PR DESCRIPTION
## Description

- Added Release compilation to PR piplines to help avoid downstream pipeline errors.
- Fixed a Release mode compile error from PR #3859.

## Testing

The updated PR pipelines will now compile in Release in addition to Debug mode.
