### PR TITLE
Ensure that 0 length reads return an empty array not null

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2356,9 +2356,10 @@ namespace Microsoft.Data.SqlClient
                 {
                     // if there is a snapshot which it contains a stored plp buffer take it
                     // and try to use it if it is the right length
-                    buff = TryTakeSnapshotStorage() as byte[];
-                    if (buff != null)
+                    byte[] existingBuff = TryTakeSnapshotStorage() as byte[];
+                    if (existingBuff != null)
                     {
+                        buff = existingBuff;
                         totalBytesRead = _snapshot.GetPacketDataOffset();
                     }
                 }


### PR DESCRIPTION
fixes https://github.com/dotnet/SqlClient/issues/3871

There is an edge case int TdsParserStateObject.TryReadPlpBytes in continue enabled mode where the attempt to fetch the snapshot stored buffer when there is none available causes the return of a null array reference and not an empty array. This introduces a temp variable and only uses the stored buffer in this case if it is non-null.

@dotnet/sqlclientdevteam can you run the CI please

/cc @kaiohenrique
