### PR TITLE
[5.1] Update hardcoded index for TestMicrosoftDataSqlClientVersion property during validation

### DIFF
--- a/eng/pipelines/common/templates/jobs/validate-signed-package-job.yml
+++ b/eng/pipelines/common/templates/jobs/validate-signed-package-job.yml
@@ -312,19 +312,15 @@ jobs:
     displayName: 'Verify "File Version" matches provided pipeline variable "ASSEMBLY_FILE_VERSION" for DLLs'
 
   - powershell: |
-      #Change TestMicrosoftDataSqlClientVersion
-
       [Xml] $versionprops = Get-Content -Path "tools/props/Versions.props" 
       $versionpropspath = "tools\props\Versions.props"
-      $versionprops.Project.PropertyGroup[$versionprops.Project.PropertyGroup.Count-1].TestMicrosoftDataSqlClientVersion ="$(NugetPackageVersion)"
+      $versionprops.Project.PropertyGroup[2].TestMicrosoftDataSqlClientVersion ="$(NugetPackageVersion)"
       Write-Host "Saving Test nuget version at $rootfolder\props ...." -ForegroundColor Green
       $versionprops.Save($versionpropspath)
 
     displayName: 'Modify TestMicrosoftDataSqlClientVersion'
 
   - powershell: |
-      #Change TestMicrosoftDataSqlClientVersion
-
       [Xml] $versionprops = Get-Content -Path "tools/props/Versions.props" 
       $AssemblyFileVersion =  $versionprops.Project.PropertyGroup[0].AssemblyFileVersion
       $AssemblyVersion = $versionprops.Project.PropertyGroup[0].AssemblyVersion


### PR DESCRIPTION
## Description

Our official builds perform a validation phase that executes a series of PowerShell scripts to cross-check a variety of different properties of the build artifacts.  A few of these scripts use hardcoded indices into the XML structure of the csproj/props files, which is terribly fragile.  This PR aligns one of these hardcoded indices with the actual props file.

## Testing

A manual run of the official pipeline will confirm the fix.