### PR TITLE
Disable JsonTest since json type is not available on managed instance

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer), nameof(DataTestUtility.IsNotManagedInstance))]
         public void TestJsonWrite()
         {
             string tableName = DataTestUtility.GenerateObjectName();
@@ -137,7 +137,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer), nameof(DataTestUtility.IsNotManagedInstance))]
         public async Task TestJsonWriteAsync()
         {
             string tableName = DataTestUtility.GenerateObjectName();
@@ -201,7 +201,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer), nameof(DataTestUtility.IsNotManagedInstance))]
         public void TestJsonRead()
         {
             string tableName = DataTestUtility.GenerateObjectName();
@@ -260,7 +260,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer), nameof(DataTestUtility.IsNotManagedInstance))]
         public async Task TestJsonReadAsync()
         {
             string tableName = DataTestUtility.GenerateObjectName();
@@ -319,7 +319,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer), nameof(DataTestUtility.IsNotManagedInstance))]
         public void TestNullJson()
         {
             string tableName = DataTestUtility.GenerateObjectName();
@@ -350,7 +350,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             DataTestUtility.DropTable(connection, tableName);
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer), nameof(DataTestUtility.IsNotManagedInstance))]
         public void TestJsonAPIs()
         {
             string tableName = DataTestUtility.GenerateObjectName();
@@ -398,7 +398,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer), nameof(DataTestUtility.IsNotManagedInstance))]
         public void TestJsonWithMARS()
         {
             string table1Name = DataTestUtility.GenerateObjectName();
@@ -454,7 +454,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer))]
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsAzureServer), nameof(DataTestUtility.IsNotManagedInstance))]
         public void TestJsonSPParams()
         {
             string tableName = DataTestUtility.GenerateObjectName();


### PR DESCRIPTION
## Description

Disable JsonTest for managed instance that does not support json type.

## Issues
[AB#41617](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/41617)

## Testing
To be enabled if the instance gets upgraded.

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
