### PR TITLE
[6.1] Port #3828 to release/6.1

### DIFF
--- a/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
@@ -33,7 +33,6 @@ parameters:
   # True to upload code coverage results to CodeCov.
   - name: upload
     type: boolean
-    default: true
 
 jobs:
   - job: CodeCoverage

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -152,6 +152,14 @@ stages:
             image: ADO-MMS22-CodeCov
             pool: ${{ parameters.defaultPoolName }}
             targetFrameworks: ${{ parameters.codeCovTargetFrameworks }}
+            # This is a Pipeline Variable defined in the Azure DevOps UI.  It
+            # must be defined with a true/false value for all pipelines that
+            # specify a build type of 'Project'.
+            #
+            # You can find Pipeline Variables by visiting the main page of the
+            # pipeline and choosing Edit -> Variables.
+            #
+            upload: ${{ eq(variables.ci_var_uploadTestResult, 'true') }}
 
 # test stages configurations
   # self hosted SQL Server on Windows


### PR DESCRIPTION
## Description

Port #3828 to release/6.1 to fix codeCov upload issues observed in ADO.

## Issues
[AB#41642](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/41642)

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
