### PR TITLE
Port #3828 to release/6.0

### DIFF
--- a/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml
@@ -33,7 +33,6 @@ parameters:
   # True to upload code coverage results to CodeCov.
   - name: upload
     type: boolean
-    default: true
 
 jobs:
   - job: CodeCoverage

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -99,6 +99,14 @@ stages:
             image: ADO-MMS22-CodeCov
             pool: ${{ parameters.defaultPoolName }}
             targetFrameworks: ${{ parameters.codeCovTargetFrameworks }}
+            # This is a Pipeline Variable defined in the Azure DevOps UI.  It
+            # must be defined with a true/false value for all pipelines that
+            # specify a build type of 'Project'.
+            #
+            # You can find Pipeline Variables by visiting the main page of the
+            # pipeline and choosing Edit -> Variables.
+            #
+            upload: ${{ eq(variables.ci_var_uploadTestResult, 'true') }}
 
 # test stages configurations
   # self hosted SQL Server on Windows


### PR DESCRIPTION
## Description
Port https://github.com/dotnet/SqlClient/pull/3828 to release/6.0 to fix CodeCoverage upload issues observed in ADO.
## Issues

[41643](https://sqlclientdrivers.visualstudio.com/ADO.Net/_sprints/taskboard/ADO.NET%20Team/ADO.Net/Krypton/Jan%20%5B1%20of%202%5D?workitem=41023)
