### PR TITLE
Cleanup, Merge | Revert public visibility of internal interop enums

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Kernel32/IoControlCodeAccess.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Kernel32/IoControlCodeAccess.cs
@@ -13,7 +13,7 @@ namespace Interop.Windows.Kernel32
     /// Indicates the type of access that a caller must request when opening the file object that represents the device (see IRP_MJ_CREATE).
     /// </summary>
     [Flags]
-    public enum IoControlCodeAccess
+    internal enum IoControlCodeAccess
     {
         /// <summary>
         /// The I/O manager sends the IRP for any caller that has a handle to the file object that represents the target device object.

--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Kernel32/IoControlTransferType.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Kernel32/IoControlTransferType.cs
@@ -10,7 +10,7 @@ namespace Interop.Windows.Kernel32
     /// <a href="https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/buffer-descriptions-for-i-o-control-codes">TransferType</a>.
     /// Indicates how the system will pass data between the caller of DeviceIoControl (or IoBuildDeviceIoControlRequest) and the driver that handles the IRP.
     /// </summary>
-    public enum IoControlTransferType
+    internal enum IoControlTransferType
     {
         /// <summary>
         /// Specifies the buffered I/O method, which is typically used for transferring small amounts of data per request.


### PR DESCRIPTION
## Description

This is a fairly simple non-functional cleanup of two enums (`IoControlCodeAccess` and `IoControlTransferType`) in the Interop.Windows.Kernel32 namespace. They were accidentally made public in the netfx project as part of the project merge in #2978.

## Issues

None.

## Testing

Automated tests continue to pass.