### PR TITLE
Reduce default test job timeout to 60 minutes

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -150,16 +150,16 @@ parameters:
     type: object
     default: [net8.0, net9.0]
 
+  # The timeout, in minutes, for each test job.
+  - name: testJobTimeout
+    displayName: Test job timeout (in minutes)
+    type: number
+    default: 60
+
   - name: testSets
     displayName: Test Sets
     type: object
     default: [1, 2, 3]
-
-  # The timeout, in minutes, for each test job.
-  - name: testJobTimeout
-    displayName: Test job timeout (in minutes)
-    type: string
-    default: Default
 
   - name: useManagedSNI
     displayName: |
@@ -179,17 +179,6 @@ extends:
     enableStressTests: ${{ parameters.enableStressTests }}
     targetFrameworks: ${{ parameters.targetFrameworks }}
     targetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
+    testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
-    # Populate the actual test job timeout numeric values if Default was
-    # specified.  We choose different values depending on the build
-    # configuration.
-    ${{ if eq(parameters.testJobTimeout, 'Default') }}:
-      # If the build configuration is Debug, we allow a bit of extra time since
-      # some tests run more slowly, and some tests are Debug only.
-      ${{ if eq(parameters.buildConfiguration, 'Debug') }}:
-        testJobTimeout: 110
-      ${{ else }}:
-        testJobTimeout: 90
-    ${{ else }}:
-      testJobTimeout: ${{ parameters.testJobTimeout }}
     useManagedSNI: ${{ parameters.useManagedSNI }}

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -150,16 +150,16 @@ parameters:
     type: object
     default: [net8.0, net9.0]
 
+  # The timeout, in minutes, for each test job.
+  - name: testJobTimeout
+    displayName: Test job timeout (in minutes)
+    type: number
+    default: 60
+
   - name: testSets
     displayName: Test Sets
     type: object
     default: [1, 2, 3]
-
-  # The timeout, in minutes, for each test job.
-  - name: testJobTimeout
-    displayName: Test job timeout (in minutes)
-    type: string
-    default: Default
 
   - name: useManagedSNI
     displayName: |
@@ -179,17 +179,6 @@ extends:
     enableStressTests: ${{ parameters.enableStressTests }}
     targetFrameworks: ${{ parameters.targetFrameworks }}
     targetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
+    testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
-    # Populate the actual test job timeout numeric values if Default was
-    # specified.  We choose different values depending on the build
-    # configuration.
-    ${{ if eq(parameters.testJobTimeout, 'Default') }}:
-      # If the build configuration is Debug, we allow a bit of extra time since
-      # some tests run more slowly, and some tests are Debug only.
-      ${{ if eq(parameters.buildConfiguration, 'Debug') }}:
-        testJobTimeout: 110
-      ${{ else }}:
-        testJobTimeout: 90
-    ${{ else }}:
-      testJobTimeout: ${{ parameters.testJobTimeout }}
     useManagedSNI: ${{ parameters.useManagedSNI }}

--- a/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-signing-pipeline.yml
@@ -67,7 +67,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: testJobTimeout
   displayName: 'Test job timeout (in minutes)'
   type: number
-  default: 90
+  default: 60
 
 variables:
   - template: /eng/pipelines/libraries/variables.yml@self

--- a/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
@@ -105,16 +105,16 @@ parameters:
     type: object
     default: [net8.0, net9.0]
 
+  # The timeout, in minutes, for each test job.
+  - name: testJobTimeout
+    displayName: Test job timeout (in minutes)
+    type: number
+    default: 60
+
   - name: testSets
     displayName: Test Sets
     type: object
     default: [1, 2, 3]
-
-  # The timeout, in minutes, for each test job.
-  - name: testJobTimeout
-    displayName: Test job timeout (in minutes)
-    type: string
-    default: Default
 
   - name: useManagedSNI
     displayName: |
@@ -134,19 +134,8 @@ extends:
     enableStressTests: ${{ parameters.enableStressTests }}
     targetFrameworks: ${{ parameters.targetFrameworks }}
     targetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
+    testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
-    # Populate the actual test job timeout numeric values if Default was
-    # specified.  We choose different values depending on the build
-    # configuration.
-    ${{ if eq(parameters.testJobTimeout, 'Default') }}:
-      # If the build configuration is Debug, we allow a bit of extra time since
-      # some tests run more slowly, and some tests are Debug only.
-      ${{ if eq(parameters.buildConfiguration, 'Debug') }}:
-        testJobTimeout: 110
-      ${{ else }}:
-        testJobTimeout: 90
-    ${{ else }}:
-      testJobTimeout: ${{ parameters.testJobTimeout }}
     useManagedSNI: ${{ parameters.useManagedSNI }}
     # Don't run the AE tests in Debug mode; they rarely succeed.
     ${{ if eq(parameters.buildConfiguration, 'Debug') }}:

--- a/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
@@ -105,16 +105,16 @@ parameters:
     type: object
     default: [net8.0, net9.0]
 
+  # The timeout, in minutes, for each test job.
+  - name: testJobTimeout
+    displayName: Test job timeout (in minutes)
+    type: number
+    default: 60
+
   - name: testSets
     displayName: Test Sets
     type: object
     default: [1, 2, 3]
-
-  # The timeout, in minutes, for each test job.
-  - name: testJobTimeout
-    displayName: Test job timeout (in minutes)
-    type: string
-    default: Default
 
   - name: useManagedSNI
     displayName: |
@@ -134,19 +134,8 @@ extends:
     enableStressTests: ${{ parameters.enableStressTests }}
     targetFrameworks: ${{ parameters.targetFrameworks }}
     targetFrameworksUnix: ${{ parameters.targetFrameworksUnix }}
+    testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
-    # Populate the actual test job timeout numeric values if Default was
-    # specified.  We choose different values depending on the build
-    # configuration.
-    ${{ if eq(parameters.testJobTimeout, 'Default') }}:
-      # If the build configuration is Debug, we allow a bit of extra time since
-      # some tests run more slowly, and some tests are Debug only.
-      ${{ if eq(parameters.buildConfiguration, 'Debug') }}:
-        testJobTimeout: 110
-      ${{ else }}:
-        testJobTimeout: 90
-    ${{ else }}:
-      testJobTimeout: ${{ parameters.testJobTimeout }}
     useManagedSNI: ${{ parameters.useManagedSNI }}
     # Don't run the AE tests in Debug mode; they rarely succeed.
     ${{ if eq(parameters.buildConfiguration, 'Debug') }}:


### PR DESCRIPTION
## Description

Now that we have flaky tests separated out, our test jobs aren't taking as long to complete (not many retries), so we can reduce the default job timeout to 60 minutes.  The Debug runs are also not taking any longer than Release runs, so we don't need the special handling for those any more.

## Testing

The normal PR and CI runs will determine if the new default is suitable.