### PR TITLE
Create stub pipeline files for Abstractions and Azure packages

### DIFF
--- a/eng/pipelines/abstractions/onebranch/non-official-pipeline.yml
+++ b/eng/pipelines/abstractions/onebranch/non-official-pipeline.yml
@@ -1,0 +1,55 @@
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+
+# Stub for Abstractions package non-official builds.
+
+pr: none
+trigger: none
+
+# Parameters visible in the Azure DevOps UI.
+parameters:
+
+  # We build in Release mode by default.
+  - name: buildConfiguration
+    displayName: Build configuration
+    type: string
+    values:
+      - Debug
+      - Release
+    default: Release
+
+  # True to enable debug steps and logging.
+  - name: debug
+    displayName: Enable debug steps and logging
+    type: boolean
+    default: false
+
+  # The verbosity level for the dotnet CLI commands.
+  - name: dotnetVerbosity
+    type: string
+    default: normal
+    values:
+    - quiet
+    - minimal
+    - normal
+    - detailed
+    - diagnostic
+
+  # True to publish symbols after a successful build.
+  - name: publishSymbols
+    displayName: Publish symbols
+    type: boolean
+    default: false
+
+stages:
+  - stage: stub_stage
+    displayName: Stub Stage
+    jobs:
+      - job: stub_job
+        displayName: Stub Job
+        steps:
+          - script: echo "This is a stub pipeline for non-official builds of the Abstractions package."
+            displayName: Stub Step

--- a/eng/pipelines/abstractions/onebranch/official-pipeline.yml
+++ b/eng/pipelines/abstractions/onebranch/official-pipeline.yml
@@ -1,0 +1,55 @@
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+
+# Stub for Abstractions package official builds.
+
+pr: none
+trigger: none
+
+# Parameters visible in the Azure DevOps UI.
+parameters:
+
+  # We build in Release mode by default.
+  - name: buildConfiguration
+    displayName: Build configuration
+    type: string
+    values:
+      - Debug
+      - Release
+    default: Release
+
+  # True to enable debug steps and logging.
+  - name: debug
+    displayName: Enable debug steps and logging
+    type: boolean
+    default: false
+
+  # The verbosity level for the dotnet CLI commands.
+  - name: dotnetVerbosity
+    type: string
+    default: normal
+    values:
+    - quiet
+    - minimal
+    - normal
+    - detailed
+    - diagnostic
+
+  # True to publish symbols after a successful build.
+  - name: publishSymbols
+    displayName: Publish symbols
+    type: boolean
+    default: false
+
+stages:
+  - stage: stub_stage
+    displayName: Stub Stage
+    jobs:
+      - job: stub_job
+        displayName: Stub Job
+        steps:
+          - script: echo "This is a stub pipeline for official builds of the Abstractions package."
+            displayName: Stub Step

--- a/eng/pipelines/azure/onebranch/non-official-pipeline.yml
+++ b/eng/pipelines/azure/onebranch/non-official-pipeline.yml
@@ -1,0 +1,55 @@
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+
+# Stub for Azure package non-official builds.
+
+pr: none
+trigger: none
+
+# Parameters visible in the Azure DevOps UI.
+parameters:
+
+  # We build in Release mode by default.
+  - name: buildConfiguration
+    displayName: Build configuration
+    type: string
+    values:
+      - Debug
+      - Release
+    default: Release
+
+  # True to enable debug steps and logging.
+  - name: debug
+    displayName: Enable debug steps and logging
+    type: boolean
+    default: false
+
+  # The verbosity level for the dotnet CLI commands.
+  - name: dotnetVerbosity
+    type: string
+    default: normal
+    values:
+    - quiet
+    - minimal
+    - normal
+    - detailed
+    - diagnostic
+
+  # True to publish symbols after a successful build.
+  - name: publishSymbols
+    displayName: Publish symbols
+    type: boolean
+    default: false
+
+stages:
+  - stage: stub_stage
+    displayName: Stub Stage
+    jobs:
+      - job: stub_job
+        displayName: Stub Job
+        steps:
+          - script: echo "This is a stub pipeline for non-official builds of the Azure package."
+            displayName: Stub Step

--- a/eng/pipelines/azure/onebranch/official-pipeline.yml
+++ b/eng/pipelines/azure/onebranch/official-pipeline.yml
@@ -1,0 +1,55 @@
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+
+# Stub for Azure package official builds.
+
+pr: none
+trigger: none
+
+# Parameters visible in the Azure DevOps UI.
+parameters:
+
+  # We build in Release mode by default.
+  - name: buildConfiguration
+    displayName: Build configuration
+    type: string
+    values:
+      - Debug
+      - Release
+    default: Release
+
+  # True to enable debug steps and logging.
+  - name: debug
+    displayName: Enable debug steps and logging
+    type: boolean
+    default: false
+
+  # The verbosity level for the dotnet CLI commands.
+  - name: dotnetVerbosity
+    type: string
+    default: normal
+    values:
+    - quiet
+    - minimal
+    - normal
+    - detailed
+    - diagnostic
+
+  # True to publish symbols after a successful build.
+  - name: publishSymbols
+    displayName: Publish symbols
+    type: boolean
+    default: false
+
+stages:
+  - stage: stub_stage
+    displayName: Stub Stage
+    jobs:
+      - job: stub_job
+        displayName: Stub Job
+        steps:
+          - script: echo "This is a stub pipeline for official builds of the Azure package."
+            displayName: Stub Step


### PR DESCRIPTION
## Description

This PR creates stub pipelines files that are required to be on the main branch before Azure DevOps lets you create new pipelines.  This will allow me to test the actual pipelines on dev branches before merging them to main.