### PR TITLE
[6.1] Avoid unintended SPN generation for non-integrated authentication on native SNI path

### DIFF
--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/TdsParserStateObjectNative.cs
@@ -168,20 +168,8 @@ namespace Microsoft.Data.SqlClient
             string hostNameInCertificate,
             string serverCertificateFilename)
         {
-            if (isIntegratedSecurity)
-            {
-                // now allocate proper length of buffer
-                if (!string.IsNullOrEmpty(serverSPN))
-                {
-                    // Native SNI requires the Unicode encoding and any other encoding like UTF8 breaks the code.
-                    SqlClientEventSource.Log.TryTraceEvent("<{0}.{1}|SEC> Server SPN `{2}` from the connection string is used.", nameof(TdsParserStateObjectNative), nameof(CreatePhysicalSNIHandle), serverSPN);
-                }
-                else
-                {
-                    // This will signal to the interop layer that we need to retrieve the SPN
-                    serverSPN = string.Empty;
-                }
-            }
+            // Normalize SPN based on authentication mode
+            serverSPN = NormalizeServerSpn(serverSPN, isIntegratedSecurity);
 
             ConsumerInfo myInfo = CreateConsumerInfo(async);
             SQLDNSInfo cachedDNSInfo;
@@ -189,7 +177,44 @@ namespace Microsoft.Data.SqlClient
 
             _sessionHandle = new SNIHandle(myInfo, serverName, ref serverSPN, timeout.MillisecondsRemainingInt, out instanceName,
                 flushCache, !async, fParallel, ipPreference, cachedDNSInfo, hostNameInCertificate);
-            resolvedSpn = new(serverSPN.TrimEnd());
+
+            // Only produce resolvedSpn when we actually have one.
+            if (!string.IsNullOrWhiteSpace(serverSPN))
+            {
+                resolvedSpn = new(serverSPN.TrimEnd());
+            }
+            else
+            {
+                resolvedSpn = default;
+            }
+        }
+
+        /// <summary>
+        /// Normalizes the serverSPN based on authentication mode.
+        /// </summary>
+        /// <param name="serverSPN">The server SPN value from the connection string.</param>
+        /// <param name="isIntegratedSecurity">Indicates whether integrated security (SSPI) is being used.</param>
+        /// <returns>
+        /// For integrated security: returns <paramref name="serverSPN"/> if provided, otherwise <see cref="string.Empty"/> to trigger SPN generation.
+        /// For SQL auth: returns <see langword="null"/> if <paramref name="serverSPN"/> is empty (no generation), otherwise returns the provided value.
+        /// </returns>
+        internal static string NormalizeServerSpn(string serverSPN, bool isIntegratedSecurity)
+        {
+            if (isIntegratedSecurity)
+            {
+                if (string.IsNullOrWhiteSpace(serverSPN))
+                {
+                    // Empty signifies to interop layer that SPN needs to be generated
+                    return string.Empty;
+                }
+
+                // Native SNI requires the Unicode encoding and any other encoding like UTF8 breaks the code.
+                SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.Connect|SEC> Server SPN `{0}` from the connection string is used.", serverSPN);
+                return serverSPN;
+            }
+
+            // For SQL auth (and other non-SSPI modes), null means "No SPN generation".
+            return string.IsNullOrWhiteSpace(serverSPN) ? null : serverSPN;
         }
 
         protected override uint SniPacketGetData(PacketHandle packet, byte[] _inBuff, ref uint dataSize)

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/TdsParserStateObjectNativeTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/TdsParserStateObjectNativeTests.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NETCOREAPP && WINDOWS
+
+#nullable enable
+
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests
+{
+    public class TdsParserStateObjectNativeTests
+    {
+        [Theory]
+        [InlineData(null, true, "")]           // Integrated + null -> empty (generate SPN)
+        [InlineData("", true, "")]             // Integrated + empty -> empty (generate SPN)
+        [InlineData(" ", true, "")]             // Integrated + whitespace -> empty (generate SPN)
+        [InlineData("MSSQLSvc/host", true, "MSSQLSvc/host")] // Integrated + provided -> use it
+        [InlineData(null, false, null)]        // SQL Auth + null -> null (no generation)
+        [InlineData("", false, null)]          // SQL Auth + empty -> null (no generation)
+        [InlineData(" ", false, null)]          // SQL Auth + whitespace -> null (no generation)
+        [InlineData("MSSQLSvc/host", false, "MSSQLSvc/host")] // SQL Auth + provided -> use it
+        public void NormalizeServerSpn_ReturnsExpectedValue(
+            string? inputSpn,
+            bool isIntegratedSecurity,
+            string? expectedSpn)
+        {
+            string? result = TdsParserStateObjectNative.NormalizeServerSpn(inputSpn, isIntegratedSecurity);
+            Assert.Equal(expectedSpn, result);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Description

Ports #3929 to release/6.1

## Issues

Fixes #3941

## Testing
Issue impacted only the netcore app and not the netfx app.
Added unit test to validate the code changes.
E2E Validation using the repro provided in #3523 and env setup as mentioned in #3929
### Without the fix
```
Data Source=tcp:XXXXXX,XXXX;Initial Catalog=Demo2;User ID=XX;Password=XXXXXXXX;Connect Timeout=10;Encrypt=True;Trust Server Certificate=True;Application Name="Connection test"
Connection successful!
Time taken to connect: 5185 ms ms
```
### With the fix
```
Data Source=tcp:XXXXXX,XXXX;Initial Catalog=Demo2;User ID=XX;Password=XXXXXXXX;Connect Timeout=10;Encrypt=True;Trust Server Certificate=True;Application Name="Connection test"
Connection successful!
Time taken to connect: 263 ms
```

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
