### PR TITLE
Fixing reading of multiple app context switches from a single AppContextSwitchOverrides configuration field.

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAppContextSwitchManager.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAppContextSwitchManager.netcore.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.SqlClient
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Entry point.", TypeName, methodName);
             if (appContextSwitches != null)
             {
-                ApplySwitchValues(appContextSwitches.Value?.Split('=', ';'));
+                ApplySwitchValues(appContextSwitches.Value?.Trim(';')?.Split('=', ';'));
             }
 
             SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Exit point.", TypeName, methodName);
@@ -39,7 +39,7 @@ namespace Microsoft.Data.SqlClient
             if (switches == null || switches.Length == 0 || switches.Length % 2 == 1)
             { return false; }
 
-            for (int i = 0; i < switches.Length / 2; i++)
+            for (int i = 0; i < switches.Length; i += 2)
             {
                 try
                 {


### PR DESCRIPTION
## Description

`SqlAppContextSwitchManager` was unable to correctly parse multiple switches from the single configuration field. In case of such sample configuration:
``` xml
<?xml version="1.0" encoding="utf-8" ?>
<configuration>
  <configSections>
    <section type="Microsoft.Data.SqlClient.AppContextSwitchOverridesSection, Microsoft.Data.SqlClient" name="AppContextSwitchOverrides"/>
  </configSections>
  <AppContextSwitchOverrides value="Switch.Microsoft.Data.SqlClient.EnableUserAgent=true;Switch.Microsoft.Data.SqlClient.UseCompatibilityProcessSni=true;System.Globalization.Invariant=false;"/>
</configuration>
```
following parsing code :
``` csharp
            string[] switches = appContextSwitches.Value?.Split('=', ';');
            ...
            for (int i = 0; i < switches.Length / 2; i++)
            {
                try
                {
                    AppContext.SetSwitch(switches[i], Convert.ToBoolean(switches[i + 1]));
                    SqlClientEventSource.Log.TryTraceEvent("<sc.{0}.{1}|INFO> Successfully assigned the AppContext switch '{2}'={3}.",
                                                           TypeName, methodName, switches[i], switches[i + 1]);
                }
                ...
            }
```
, on the second iteration would confuse switch key with a value and would try to convert key name to `bool`, which would of course fail.

One additional fix is for proper handling of configuration field, if it's content (sequence of switch=value pairs) starts, or ends with semicolon.

## Testing

Changes seems trivial, bet unittests could be added, if deemed necessary.