### PR TITLE
Verify Azure DLL via public key token

### DIFF
--- a/eng/pipelines/steps/compound-build-csproj-step.yml
+++ b/eng/pipelines/steps/compound-build-csproj-step.yml
@@ -4,11 +4,10 @@
 # See the LICENSE file in the project root for more information.                #
 #################################################################################
 
-# Generic build step for csproj-based Extension packages (Logging, Abstractions, Azure).  Each
-# project uses a build.proj target that runs Build only and produces assemblies within
-# $(BUILD_OUTPUT).  Downstream ESRP DLL signing must locate the assemblies within $(BUILD_OUTPUT)
-# for all target frameworks that the csproj targets.  NuGet packaging is done separately via
-# compound-pack-csproj-step.yml after DLL signing.
+# Generic build step for csproj-based packages.  Each project uses a build.proj target that runs
+# Build only and produces assemblies within $(BUILD_OUTPUT).  Downstream ESRP DLL signing must
+# locate the assemblies within $(BUILD_OUTPUT) for all target frameworks that the csproj targets.
+# NuGet packaging is done separately via compound-pack-csproj-step.yml after DLL signing.
 
 parameters:
   # The MSBuild build target in build.proj (e.g. BuildLogging, BuildAbstractions,

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -61,6 +61,12 @@
     <!-- Respect environment variable for the .NET install directory if set; otherwise, use the current default location -->
     <BuildSimulator Condition="'$(BuildSimulator)' != 'true'">false</BuildSimulator>
   </PropertyGroup>
+
+  <!-- Add user-supplied define constants. -->
+  <PropertyGroup Condition="'$(UserDefinedConstants)' != ''">
+    <DefineConstants>$(DefineConstants);$(UserDefinedConstants)</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(BuildSimulator)' == 'true'">
     <DefineConstants>$(DefineConstants);ENCLAVE_SIMULATOR</DefineConstants>
   </PropertyGroup>
@@ -107,6 +113,17 @@
       https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1901-nu1904
     -->
     <!-- <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors> -->
+  </PropertyGroup>
+
+  <!-- Strong name signing ============================================= -->
+
+  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
+  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
+
+    <!-- We also define a constant used for conditional compilation. -->
+    <DefineConstants>$(DefineConstants);STRONG_NAME_SIGNING</DefineConstants>
   </PropertyGroup>
 
   <!-- Packaging  for source link-->

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
@@ -14,14 +14,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <!-- Otherwise, we're not signing, so we are permitted to expose our internals to tests. -->
+  <!-- When we're not signing, we are permitted to expose our internals to tests. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <InternalsVisibleTo Include="$(AssemblyName).Test" />
   </ItemGroup>

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
@@ -14,14 +14,7 @@
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <!-- Otherwise, we're not signing, so we are permitted to expose our internals to tests. -->
+  <!-- When we're not signing, we are permitted to expose our internals to tests. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <InternalsVisibleTo Include="$(AssemblyName).Test" />
   </ItemGroup>

--- a/src/Microsoft.Data.SqlClient.Extensions/Logging/src/Logging.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Logging/src/Logging.csproj
@@ -14,14 +14,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <!-- Otherwise, we're not signing, so we are permitted to expose our internals to tests. -->
+  <!-- When we're not signing, we are permitted to expose our internals to tests. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <InternalsVisibleTo Include="$(AssemblyName).Test" />
   </ItemGroup>

--- a/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
+++ b/src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
@@ -15,17 +15,9 @@
   </PropertyGroup>
 
   <!-- Trim/AOT Support ================================================ -->
-  <PropertyGroup>
-    <IsTrimmable Condition="'$(TargetFramework)' != 'net462'">true</IsTrimmable>
-    <IsAotCompatible Condition="'$(TargetFramework)' != 'net462'">true</IsAotCompatible>
-  </PropertyGroup>
-
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net462'">
+    <IsTrimmable>true</IsTrimmable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <!-- References ====================================================== -->

--- a/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/ref/Microsoft.Data.SqlClient.csproj
@@ -15,14 +15,6 @@
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-
   <!-- CLS Compliance attribute -->
   <ItemGroup>
     <AssemblyAttribute Include="System.CLSCompliantAttribute">

--- a/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netcore/src/Microsoft.Data.SqlClient.csproj
@@ -20,14 +20,7 @@
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <!-- Otherwise, we're not signing, so we are permitted to expose our internals to tests. -->
+  <!-- When we're not signing, we are permitted to expose our internals to tests. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <InternalsVisibleTo Include="UnitTests" />
   </ItemGroup>

--- a/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/ref/Microsoft.Data.SqlClient.csproj
@@ -10,14 +10,6 @@
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-
   <!-- CLS Compliance -->
   <ItemGroup>
     <AssemblyAttribute Include="System.CLSCompliantAttribute">

--- a/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/netfx/src/Microsoft.Data.SqlClient.csproj
@@ -17,14 +17,7 @@
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <!-- Otherwise, we're not signing, so we are permitted to expose our internals to tests. -->
+  <!-- When we're not signing, we are permitted to expose our internals to tests. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>UnitTests</_Parameter1>

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.csproj
@@ -11,14 +11,6 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-
   <!-- References ====================================================== -->
   <!-- Reference to Abstractions -->
   <ItemGroup>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj
@@ -14,14 +14,7 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-  <!-- Otherwise, we're not signing, so we are permitted to expose our internals to tests. -->
+  <!-- When we're not signing, we are permitted to expose our internals to tests. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>UnitTests</_Parameter1>

--- a/src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj
+++ b/src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj
@@ -70,14 +70,6 @@ Microsoft.SqlServer.Server.Format</Description>
     <None Include="PackageReadme.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
-  <!-- Strong name signing ============================================= -->
-
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
-  <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Remove=".AssemblyAttributes" />
   </ItemGroup>


### PR DESCRIPTION
## Description

- Consolidated strong name signing into Directory.Build.props.
- Added a conditional compilation constant for strong name signing.
- Added public key token check when SqlClient loads the Azure assembly.
- Added a LogWriter property to SqlClientEventSource to fork event messages to any TextWriter.

## Testing

- PR runs will confirm that the public key token check _is not_ active for un-signed builds.
- Manual run of the OneBranch pipelines, followed by manual test app will confirm that the check is active.