### PR TITLE
Add Roslyn analysis

### DIFF
--- a/eng/pipelines/jobs/build-signed-csproj-package-job.yml
+++ b/eng/pipelines/jobs/build-signed-csproj-package-job.yml
@@ -121,6 +121,21 @@ jobs:
       # Install the .NET SDK.
       - template: /eng/pipelines/steps/install-dotnet.yml@self
 
+      # Perform Roslyn analysis before building, since this step will clobber build output.
+      - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
+        displayName: Roslyn Analyzers
+        inputs:
+          msBuildArchitecture: x64
+          msBuildCommandLine: >-
+              msbuild
+              $(REPO_ROOT)/build.proj
+              -t:$(buildTarget)
+              -p:Configuration=${{ parameters.buildConfiguration }}
+              -p:ReferenceType=Package
+              ${{ parameters.versionProperties }}
+          msBuildVersion: 17.0
+          setupCommandLinePicker: vs2022
+
       # Build the package, producing DLLs only (no NuGet package yet).
       - template: /eng/pipelines/steps/compound-build-csproj-step.yml@self
         parameters:


### PR DESCRIPTION
## Description
Add Roslyn Analyzers SDL step to csproj-based OneBranch package jobs


The OneBranch pipeline job template for csproj-based extension packages (`build-signed-csproj-package-job.yml`) was missing the `RoslynAnalyzers@3` SDL security analysis step that is already present for the main `SqlClient` and `AKV` Provider builds.

This change adds the missing step, bringing the Abstractions, Azure, Logging, and SqlServer package jobs into parity with the existing SDL compliance pattern used across the pipeline.