### PR TITLE
Temporarily prevent API Scan from breaking our new OneBranch Official pipeline runs

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-official-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-official-pipeline.yml
@@ -145,7 +145,11 @@ extends:
         enabled: true
       apiscan:
         enabled: true
-        break: true
+        # TODO(https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/42858):
+        # We have temporarily disabled breaking the build on ApiScan results until we can:
+        #   - Register our new packages with API Scan, and/or
+        #   - Publish MSDN/Learn/etc documentation for the new packages.
+        break: false
         # Other ApiScan options are set by the jobs via ob_sdl_apiscan_* variables.
       codeql:
         compiled:


### PR DESCRIPTION
## Description

There is some further setup required for API Scan to be happy with our new NuGet packages.  This shouldn't hold up Preview 4, so I have disabled the breaking feature to allow our Official pipeline to get past the API Scan checks.