### PR TITLE
QoL | Enable incremental build in Visual Studio

### DIFF
--- a/tools/targets/GenerateThisAssemblyCs.targets
+++ b/tools/targets/GenerateThisAssemblyCs.targets
@@ -2,6 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="GenerateThisAssemblyCs"
+          Inputs="$(MSBuildThisFileFullPath)"
+          Outputs="$(IntermediateOutputPath)ThisAssembly.cs"
           BeforeTargets="CoreCompile">
 
     <PropertyGroup>
@@ -10,6 +12,9 @@
       <ThisAssemblyNamespace Condition="'$(ThisAssemblyNamespace)' == ''">System</ThisAssemblyNamespace>
 
       <ThisAssemblyCsContents>
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 namespace $(ThisAssemblyNamespace)
 {
     internal static class ThisAssembly
@@ -21,9 +26,9 @@ namespace $(ThisAssemblyNamespace)
       </ThisAssemblyCsContents>
     </PropertyGroup>
 
-    <!-- Unconditionally write the ThisAssembly.cs file. -->
+    <!-- Write ThisAssembly.cs if this is a new version number, or if it is missing. -->
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)/ThisAssembly.cs"
+      File="$(IntermediateOutputPath)ThisAssembly.cs"
       Lines="$(ThisAssemblyCsContents)"
       Overwrite="true"
       Encoding="Unicode"/>
@@ -32,6 +37,7 @@ namespace $(ThisAssemblyNamespace)
 
   <!-- Ensure the generated ThisAssembly.cs is included in the compilation. -->
   <ItemGroup>
-    <Compile Include="$(IntermediateOutputPath)/ThisAssembly.cs"/>
+    <Compile Include="$(IntermediateOutputPath)ThisAssembly.cs"/>
+    <FileWrites Include="$(IntermediateOutputPath)ThisAssembly.cs"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

At present, Visual Studio builds are fairly slow - even when changing tests, the SqlClient projects are fully rebuilt. This PR makes the `GenerateThisAssemblyCs` target support incremental build, cutting the rebuild times dramatically (particularly noticeable when changing and running tests.)

Variations of GenerateThisAssemblyCs appear in a few places in dotnet/runtime. [Microsoft.XmlSerializer.Generator](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.XmlSerializer.Generator/src/GenerateThisAssemblyCs.targets) has a fairly similar copy. [System.Diagnostics.DiagnosticSource](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj) chooses a slightly different wrapper: a simple `_GenerateThisAssemblyInfo` target in the project file. I've hemmed more closely to the first of these places.

The core changes are twofold:
* Specify `Inputs` and `Outputs` on the target, to indicate that it supports incremental build.
* Add `ThisAssembly.cs` to the `FileWrites` item, ensuring that a clean will remove it when needed.

I also noticed that the license header was missing from the generated file, so added it for completeness' sake. There were also two path separators in the output location, so I removed the second of these.

## Issues

None.

## Testing

Tested rebuilds with Visual Studio. Confirmed that this file is removed by the Clean target.