### PR TITLE
Fix package metadata to meet compliance requirements.

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -36,6 +36,15 @@
 				"@azure-devops/mcp",
 				"SqlClientDrivers"
 			]
+		},
+		"ado-devdiv": {
+			"type": "stdio",
+			"command": "npx",
+			"args": [
+				"-y",
+				"@azure-devops/mcp",
+				"devdiv"
+			]
 		}
 	}
 }

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
@@ -82,11 +82,17 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <Authors>Microsoft Corporation</Authors>
+    <Title>Microsoft.Data.SqlClient.Extensions.Abstractions</Title>
+    <Authors>Microsoft</Authors>
     <Company>Microsoft Corporation</Company>
     <Description>Microsoft.Data.SqlClient Extensions Abstractions</Description>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageTags>sqlclient microsoft.data.sqlclient extensions abstractions</PackageTags>
+    <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dotnet/SqlClient</RepositoryUrl>
+    <PackageProjectUrl>https://aka.ms/sqlclientproject</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>dotnet.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
@@ -82,11 +82,17 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <Authors>Microsoft Corporation</Authors>
+    <Title>Microsoft.Data.SqlClient.Extensions.Azure</Title>
+    <Authors>Microsoft</Authors>
     <Company>Microsoft Corporation</Company>
     <Description>Microsoft.Data.SqlClient Extensions Azure</Description>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageTags>sqlclient microsoft.data.sqlclient extensions azure</PackageTags>
+    <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dotnet/SqlClient</RepositoryUrl>
+    <PackageProjectUrl>https://aka.ms/sqlclientproject</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>dotnet.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Microsoft.Data.SqlClient.Extensions/Logging/src/Logging.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Logging/src/Logging.csproj
@@ -82,11 +82,17 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
-    <Authors>Microsoft Corporation</Authors>
+    <Title>Microsoft.Data.SqlClient.Extensions.Logging</Title>
+    <Authors>Microsoft</Authors>
     <Company>Microsoft Corporation</Company>
     <Description>Microsoft.Data.SqlClient Extensions Logging - ETW EventSource for SqlClient tracing and diagnostics.</Description>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageTags>sqlclient microsoft.data.sqlclient extensions logging</PackageTags>
+    <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dotnet/SqlClient</RepositoryUrl>
+    <PackageProjectUrl>https://aka.ms/sqlclientproject</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageIcon>dotnet.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj
+++ b/src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj
@@ -39,7 +39,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <Title>Microsoft.SqlServer.Server</Title>
-    <Authors>Microsoft Corporation</Authors>
+    <Authors>Microsoft</Authors>
     <Company>Microsoft Corporation</Company>
     <Description>This is a helper library for Microsoft.Data.SqlClient enabling cross framework support of UDT types.
 


### PR DESCRIPTION
This pull request focuses on improving package metadata for several projects and updating development tooling configuration. The most significant changes are enhancements to NuGet package information across multiple `csproj` files, ensuring better discoverability and compliance, as well as an update to the VS Code MCP configuration for a new development workflow.

**NuGet package metadata improvements:**

* Added `Title`, `Copyright`, `PackageTags`, `RepositoryType`, `PackageProjectUrl`, and `PackageRequireLicenseAcceptance` fields to the `Microsoft.Data.SqlClient.Extensions.Abstractions`, `Azure`, and `Logging` project files, and updated `Authors` to "Microsoft" for consistency and compliance. [[1]](diffhunk://#diff-d2e78eaf3aea12ea0a1cf6fb37e8b341e6f3893398340e22425e1e022d0737b6L85-R95) [[2]](diffhunk://#diff-38d1434acdfadd10df49a254f08f4f2c986fc72ad24ba56e03ae02d734a260ccL85-R95) [[3]](diffhunk://#diff-a3b9fd4d0bde20e79e68acfa407e1d8b7cefdda8343670c1770dd09168f7f65aL85-R95)
* Updated the `Authors` field in `Microsoft.SqlServer.Server.csproj` from "Microsoft Corporation" to "Microsoft" for consistency with other packages.

**Development tooling configuration:**

* Added a new `ado-devdiv` entry to `.vscode/mcp.json` to support running the Azure DevOps MCP DevDiv workflow using `npx`, streamlining local development and testing.