### PR TITLE
Use using declaration for paramsCmd

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.cs
@@ -1346,7 +1346,7 @@ namespace Microsoft.Data.SqlClient
                 useManagedDataType = false;
             }
 
-            SqlCommand paramsCmd = new SqlCommand(cmdText.ToString(), Connection, Transaction)
+            using SqlCommand paramsCmd = new SqlCommand(cmdText.ToString(), Connection, Transaction)
             {
                 CommandType = CommandType.StoredProcedure
             };


### PR DESCRIPTION
Change local SqlCommand instantiation to a using declaration so paramsCmd is disposed automatically.
