### PR TITLE
Remove StackOverflow/OutOfMemory checks

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -413,7 +413,8 @@ namespace Microsoft.Data.Common
 
             return ((type != typeof(ThreadAbortException)) &&
                     (type != typeof(NullReferenceException)) &&
-                    (type != typeof(AccessViolationException)));
+                    (type != typeof(AccessViolationException)) &&
+                    (type != typeof(OutOfMemoryException)));
         }
 
         // Invalid Enumeration

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -392,9 +392,7 @@ namespace Microsoft.Data.Common
             Debug.Assert(e != null, "Unexpected null exception!");
             Type type = e.GetType();
 
-            return ((type != typeof(StackOverflowException)) &&
-                    (type != typeof(OutOfMemoryException)) &&
-                    (type != typeof(ThreadAbortException)) &&
+            return ((type != typeof(ThreadAbortException)) &&
                     (type != typeof(NullReferenceException)) &&
                     (type != typeof(AccessViolationException)) &&
                     !typeof(SecurityException).IsAssignableFrom(type));
@@ -413,9 +411,7 @@ namespace Microsoft.Data.Common
             Debug.Assert(e != null, "Unexpected null exception!");
             Type type = e.GetType();
 
-            return ((type != typeof(StackOverflowException)) &&
-                    (type != typeof(OutOfMemoryException)) &&
-                    (type != typeof(ThreadAbortException)) &&
+            return ((type != typeof(ThreadAbortException)) &&
                     (type != typeof(NullReferenceException)) &&
                     (type != typeof(AccessViolationException)));
         }


### PR DESCRIPTION
my understanding is that it is not possible to catch those exception types.

Happy to be educated as to otherwise