### PR TITLE
Add API documentation generation for the Logging package

### DIFF
--- a/src/Microsoft.Data.SqlClient.Extensions/Logging/src/Logging.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Logging/src/Logging.csproj
@@ -122,34 +122,4 @@
   </PropertyGroup>
   <Import Project="$(ToolsDir)/targets/GenerateThisAssemblyCs.targets" />
 
-  <!--
-    Documentation post-processing targets.
-
-    After building, we save the full (untrimmed) XML documentation to the
-    artifacts/doc/ directory for use by public documentation workflows, then
-    trim the in-place copy (removing <remarks> and <example> nodes) so that
-    the NuGet package ships a cleaner IntelliSense XML file.
-  -->
-  <Target Name="SaveUntrimmedDocs" AfterTargets="Build"
-    Condition="'$(GenerateDocumentationFile)' == 'true' AND Exists('$(DocumentationFile)')">
-    <MakeDir Directories="$(Artifacts)/doc/$(TargetFramework)/" />
-    <Copy SourceFiles="$(DocumentationFile)"
-      DestinationFolder="$(Artifacts)/doc/$(TargetFramework)/" />
-  </Target>
-
-  <!--
-    Select the correct PowerShell executable for the current OS so that the
-    TrimDocsForIntelliSense target below does not need to duplicate the command.
-  -->
-  <PropertyGroup>
-    <PowerShellCmd Condition="'$(OS)' == 'Windows_NT'">powershell.exe</PowerShellCmd>
-    <PowerShellCmd Condition="'$(OS)' != 'Windows_NT'">pwsh</PowerShellCmd>
-  </PropertyGroup>
-
-  <Target Name="TrimDocsForIntelliSense" AfterTargets="SaveUntrimmedDocs"
-    Condition="'$(GenerateDocumentationFile)' == 'true' AND Exists('$(DocumentationFile)')">
-    <Exec
-      Command="$(PowerShellCmd) -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;$(ToolsDir)intellisense\TrimDocs.ps1 -inputFile '$(DocumentationFile)' -outputFile '$(DocumentationFile)'&quot;" />
-  </Target>
-
 </Project>

--- a/src/Microsoft.Data.SqlClient.Extensions/Logging/src/SqlClientEventSource.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Logging/src/SqlClientEventSource.cs
@@ -1794,7 +1794,7 @@ namespace Microsoft.Data.SqlClient
         #endregion
 
         #region Write Events
-        // Do not change the first 4 arguments in this Event writer as OpenTelemetry and ApplicationInsight are relating to the same format,
+        // Do not change the first 4 arguments in this Event writer as OpenTelemetry and Application Insights are related to the same format,
         // unless you have checked with them and they are able to change their design. Additional items could be added at the end.
 
         /// <summary>


### PR DESCRIPTION
## Description
Adds XML documentation comments to all public APIs in [Microsoft.Data.SqlClient.Extensions.Logging](vscode-file://vscode-app/c:/Users/apdeshmukh/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and configures the project to generate, preserve, and trim XML documentation — following the same patterns used by the main [Microsoft.Data.SqlClient](vscode-file://vscode-app/c:/Users/apdeshmukh/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) package.

## Issues
[AB#42969](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/42969)

## Changes
Added `<GenerateDocumentationFile>true</GenerateDocumentationFile>` so the compiler generates an XML doc file alongside the assembly. SDK Pack automatically includes it in the NuGet package under `lib/<tfm>/`.
Added `SaveUntrimmedDocs` target — copies the full (untrimmed) XML documentation to `artifacts/doc/<tfm>/` after build, preserving `<remarks>` and `<example>` content for public documentation workflows (e.g., API Drop → Content CI → dotnet/sqlclient-api-docs).
Added TrimDocsForIntelliSense target — runs `TrimDocs.ps1` to strip <remarks> and <example> nodes from the in-place XML file so the NuGet package ships a cleaner IntelliSense experience, matching how the main MDS package handles this.
Added `<summary>, <param>, <typeparam>, <returns>,` and `<remarks>` tags to all ~80+ public members across:
SqlClientEventSource.cs — class-level docs with <remarks> and <example>, all Enable/Disable methods, Trace overloads (with and without if guards), Scope enter/leave methods, Execution Trace, Notification Trace/Scope, Pooler Trace/Scope, Advanced Trace/Scope/Bin/Error, Correlation Trace, State Dump, SNI Trace/Scope, and all WriteEvent methods

## Notes
No pipeline changes needed: SDK Pack automatically includes the XML doc file in the NuGet package when `GenerateDocumentationFile` is set. Both the CI pipeline (pack-logging-package-ci-job.yml) and the OneBranch official pipeline use dotnet pack, which handles this natively.