### PR TITLE
Scope DLL Signing in MDS OneBranch Job

### DIFF
--- a/eng/pipelines/onebranch/jobs/build-signed-sqlclient-package-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-signed-sqlclient-package-job.yml
@@ -84,6 +84,14 @@ jobs:
   - template: /eng/pipelines/onebranch/steps/esrp-code-signing-step.yml@self
     parameters:
       artifactType: dll
+      sourceRoot: $(BUILD_OUTPUT)
+      dllPattern: 'Microsoft.Data.SqlClient.dll'
+
+  - template: /eng/pipelines/onebranch/steps/esrp-code-signing-step.yml@self
+    parameters:
+      artifactType: dll
+      sourceRoot: $(BUILD_OUTPUT)
+      dllPattern: 'Microsoft.Data.SqlClient.resources.dll'
 
   - template: /eng/pipelines/common/templates/steps/generate-nuget-package-step.yml@self
     parameters:
@@ -106,7 +114,7 @@ jobs:
     displayName: Copy DLLs for APIScan
     inputs:
       SourceFolder: $(BUILD_OUTPUT)/Package/bin
-      Contents: '**/Microsoft.Data.SqlClient*.dll'
+      Contents: '**/Microsoft.Data.SqlClient.dll'
       TargetFolder: $(ob_sdl_apiscan_softwareFolder)
       # We must preserve the folder structure since our C# projects may produce multiple
       # identically named DLLs for different target frameworks (e.g. netstandard2.0, net5.0,
@@ -117,7 +125,7 @@ jobs:
     displayName: Copy PDBs for APIScan
     inputs:
       SourceFolder: $(BUILD_OUTPUT)/Package/bin
-      Contents: '**/Microsoft.Data.SqlClient*.pdb'
+      Contents: '**/Microsoft.Data.SqlClient.pdb'
       TargetFolder: $(ob_sdl_apiscan_symbolsFolder)
       flattenFolders: false
 

--- a/eng/pipelines/onebranch/steps/esrp-code-signing-step.yml
+++ b/eng/pipelines/onebranch/steps/esrp-code-signing-step.yml
@@ -13,6 +13,10 @@ parameters:
     type: string
     default: $(REPO_ROOT)
 
+  - name: dllPattern
+    type: string
+    default: 'Microsoft.Data.SqlClient*.dll'
+
   - name: artifactDirectory
     type: string
     default: $(PACK_OUTPUT)
@@ -53,7 +57,7 @@ steps:
       EsrpClientId: '${{parameters.EsrpClientId }}'
       UseMSIAuthentication: true
       FolderPath: '${{parameters.sourceRoot }}'
-      Pattern: 'Microsoft.Data.SqlClient*.dll'
+      Pattern: '${{ parameters.dllPattern }}'
       CleanupTempStorage: 1
       VerboseLogin: 1
 
@@ -69,7 +73,7 @@ steps:
       AuthAKVName: '${{parameters.AuthAKVName }}'
       AuthSignCertName: '${{parameters.AuthSignCertName }}'
       FolderPath: '${{parameters.sourceRoot }}'
-      Pattern: 'Microsoft.Data.SqlClient*.dll'
+      Pattern: '${{ parameters.dllPattern }}'
       signConfigType: inlineSignParams
       inlineOperation: |
           [


### PR DESCRIPTION
## Description

  The MDS (`Microsoft.Data.SqlClient`) code signing job in the OneBranch pipeline was inadvertently signing DLLs from the
  `Extensions.Abstractions` and `Extensions.Logging` packages. This happened because:

   - `esrp-code-signing-step.yml` hardcoded the pattern `Microsoft.Data.SqlClient*.dll`, which matches Extensions DLLs (e.g., 
  `Microsoft.Data.SqlClient.Extensions.Logging.dll`)
   - `sourceRoot` defaulted to `$(REPO_ROOT)`, scanning the entire repo tree instead of just MDS build output
   - The MDS build target (`BuildAllConfigurations`) depends on `BuildLogging` and `BuildAbstractions`, so those DLLs exist in the artifact tree at signing time

## Issues

Fixes https://github.com/dotnet/SqlClient/issues/4023

## Fix
- `esrp-code-signing-step.yml` : Added a `dllPattern` parameter (default: Microsoft.Data.SqlClient*.dll for backward compatibility) and replaced both hardcoded Pattern values with `${{ parameters.dllPattern }}`.

- `build-signed-sqlclient-package-job.yml` :

   - Split the single DLL signing call into two targeted calls with exact patterns: `Microsoft.Data.SqlClient.dll` and 
  `Microsoft.Data.SqlClient.resources.dll`
   - Scoped sourceRoot to `$(BUILD_OUTPUT)` to avoid scanning the entire repo
   - Narrowed` APIScan` copy patterns to exclude Extensions DLLs/PDBs