### PR TITLE
Update sdk version and switch to System.Composition.

### DIFF
--- a/global.json
+++ b/global.json
@@ -15,7 +15,7 @@
     // system, etc.) may use their own installed SDKs unless configured
     // otherwise.
     //
-    "version": "10.0.103",
+    "version": "10.0.104",
 
     // Any 10.x version is acceptable.
     "rollForward": "latestMinor",

--- a/tools/Directory.Packages.props
+++ b/tools/Directory.Packages.props
@@ -6,7 +6,7 @@
     <ItemGroup>
         <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
         <PackageVersion Include="Microsoft.Cci" Version="4.0.0-rc3-24214-00" />
-        <PackageVersion Include="Microsoft.Composition" Version="1.0.31" />
+        <PackageVersion Include="System.Composition" Version="10.0.5" />
         <PackageVersion Include="System.Diagnostics.Contracts" Version="4.3.0" />
         <PackageVersion Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
         <PackageVersion Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/tools/GenAPI/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
+++ b/tools/GenAPI/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Cci" />
-    <PackageReference Include="Microsoft.Composition" />
+    <PackageReference Include="System.Composition" />
     <PackageReference Include="System.Diagnostics.Contracts" />
     <PackageReference Include="System.Diagnostics.TraceSource" />
     <PackageReference Include="System.Reflection.Metadata" />


### PR DESCRIPTION
System.Composition is still actively maintained: https://www.nuget.org/packages/System.Composition
Validated that this addresses component governance warnings: https://sqlclientdrivers.visualstudio.com/ADO.Net/_git/dotnet-sqlclient/pullrequest/7114