### PR TITLE
Validate milestone assignment on pull requests.

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -11,21 +11,14 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Check milestone is set and open
-        env:
-          MILESTONE: ${{ toJson(github.event.pull_request.milestone) }}
+      - name: Check milestone is set
+        if: github.event.pull_request.milestone == null
         run: |
-          if [ "$MILESTONE" = "null" ] || [ -z "$MILESTONE" ]; then
-            echo "::error::This PR does not have a milestone set. Please assign a milestone before merging."
-            exit 1
-          fi
+          echo "::error::This PR does not have a milestone set. Please assign a milestone before merging."
+          exit 1
 
-          STATE=$(echo "$MILESTONE" | jq -r '.state')
-          TITLE=$(echo "$MILESTONE" | jq -r '.title')
-
-          if [ "$STATE" != "open" ]; then
-            echo "::error::Milestone '$TITLE' is $STATE. Please assign an open milestone."
-            exit 1
-          fi
-
-          echo "Milestone '$TITLE' is set and open."
+      - name: Check milestone is open
+        if: github.event.pull_request.milestone != null && github.event.pull_request.milestone.state != 'open'
+        run: |
+          echo "::error::Milestone '${{ github.event.pull_request.milestone.title }}' is ${{ github.event.pull_request.milestone.state }}. Please assign an open milestone."
+          exit 1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce milestone assignment for pull requests. The workflow ensures that every pull request has an open milestone before it can be merged, helping maintain project tracking and release management.

Milestone validation automation:

* Added `.github/workflows/check-milestone.yml` workflow to validate that a pull request has a milestone set and that the milestone is open; the workflow prevents merging if these conditions are not met.