### PR TITLE
Changed SBOM package version to use build number

### DIFF
--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -154,7 +154,7 @@ extends:
       sbom:
         enabled: true
         packageName: Microsoft.Data.SqlClient
-        packageVersion: $(assemblyBuildNumber)
+        packageVersion: $(Build.BuildNumber)
       policheck:
         enabled: true
         break: true

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -179,7 +179,7 @@ extends:
       sbom:
         enabled: true
         packageName: Microsoft.Data.SqlClient
-        packageVersion: $(assemblyBuildNumber)
+        packageVersion: $(Build.BuildNumber)
       policheck:
         enabled: true
         break: true


### PR DESCRIPTION
## Description

OneBranch doesn't provide a way to specify per-job SBOM parameters, so we can't use our actual package names and versions.  Instead, we must specify a single SBOM name and version that applies to all packages the pipeline creates.  The build number is unique enough for this purpose.

## Testing

The normal scheduled OneBranch Non-Official runs will confirm.