### PR TITLE
[7.0] Test | Fix Transient Fault handling and other flaky unit tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/Common/MultipartIdentifierTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/Common/MultipartIdentifierTests.cs
@@ -26,6 +26,7 @@ public class MultipartIdentifierTests
         {
             ReadOnlySpan<string> part1Words = ["word1", "word 1"];
             TheoryData<string, string[]> data = [];
+            HashSet<string> seen = [];
 
             // Combination 1: embedded and non-embedded whitespace.
             // Combination 2: leading and/or trailing whitespace, and no whitespace
@@ -36,6 +37,13 @@ public class MultipartIdentifierTests
             {
                 foreach ((string p1Combination, string p1Expected) in GeneratePartCombinations(part1))
                 {
+                    // Skip duplicates — different generation paths can produce
+                    // identical (input, expected) pairs, which xUnit rejects.
+                    if (!seen.Add(p1Combination))
+                    {
+                        continue;
+                    }
+
                     string onePartCombination = p1Combination;
                     string[] onePartExpected = [p1Expected];
 

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlTypes/SqlTypeWorkaroundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlTypes/SqlTypeWorkaroundsTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.SqlClient.UnitTests
             };
         
         [Theory]
-        [MemberData(nameof(SqlDecimalWriteTdsValue_NonNullInput_Data))]
+        [MemberData(nameof(SqlDecimalWriteTdsValue_NonNullInput_Data), DisableDiscoveryEnumeration = true)]
         public void SqlDecimalWriteTdsValue_NonNullInput(SqlDecimal input)
         {
             // Arrange
@@ -155,7 +155,7 @@ namespace Microsoft.Data.SqlClient.UnitTests
             };
         
         [Theory]
-        [MemberData(nameof(LongToSqlMoney_Data))]
+        [MemberData(nameof(LongToSqlMoney_Data), DisableDiscoveryEnumeration = true)]
         public void LongToSqlMoney(long input, SqlMoney expected)
         {
             // Act
@@ -176,7 +176,7 @@ namespace Microsoft.Data.SqlClient.UnitTests
             };
         
         [Theory]
-        [MemberData(nameof(SqlMoneyToLong_NonNullInput_Data))]
+        [MemberData(nameof(SqlMoneyToLong_NonNullInput_Data), DisableDiscoveryEnumeration = true)]
         public void SqlMoneyToLong_NonNullInput(SqlMoney input, long expected)
         {
             // Act

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
-    [Trait("Category", "flaky")]
     [Collection("SimulatedServerTests")]
     public class ConnectionFailoverTests
     {
@@ -70,7 +69,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             Assert.Equal($"localhost,{initialServer.EndPoint.Port}", secondConnection.DataSource);
 
             // 1 for the initial connection, 2 for the second connection
-            Assert.Equal(3, initialServer.PreLoginCount);
+            Assert.Equal(3, initialServer.PreLoginCount - initialServer.AbandonedPreLoginCount);
             // A failover should not be triggered, so prelogin count to the failover server should be 0
             Assert.Equal(0, failoverServer.PreLoginCount);
         }
@@ -219,6 +218,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 InitialCatalog = "master", // Required for failover partner to work
                 ConnectTimeout = 5,
                 Encrypt = false,
+                Pooling = false, // Disable pooling to ensure a fresh connection attempt is made
                 MultiSubnetFailover = false,
 #if NETFRAMEWORK
                 TransparentNetworkIPResolution = false,
@@ -268,6 +268,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 ConnectRetryCount = 0, // Disable retry
                 FailoverPartner = $"localhost,{failoverServer.EndPoint.Port}", // User provided failover partner
                 Encrypt = false,
+                Pooling = false, // Disable pooling to ensure a fresh connection attempt is made on failover
             };
             using SqlConnection connection = new(builder.ConnectionString);
 
@@ -313,6 +314,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 ConnectRetryInterval = 1,
                 FailoverPartner = $"localhost,{failoverServer.EndPoint.Port}", // User provided failover partner
                 Encrypt = false,
+#if NETFRAMEWORK
+                TransparentNetworkIPResolution = false,
+#endif
             };
             using SqlConnection connection = new(builder.ConnectionString);
             // Act
@@ -324,7 +328,8 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             Assert.Equal(ConnectionState.Open, connection.State);
             Assert.Equal($"localhost,{failoverServer.EndPoint.Port}", connection.DataSource);
             Assert.Equal(1, server.PreLoginCount);
-            Assert.Equal(1, failoverServer.PreLoginCount);
+            Assert.Equal(0, server.Login7Count);
+            Assert.Equal(1, failoverServer.PreLoginCount - failoverServer.AbandonedPreLoginCount);
         }
 
         [Theory]
@@ -357,7 +362,8 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 InitialCatalog = "master",
                 ConnectTimeout = 30,
                 ConnectRetryInterval = 1,
-                Encrypt = false
+                Encrypt = false,
+                Pooling = false, // Disable pooling to ensure a fresh connection attempt is made
             };
             using SqlConnection connection = new(builder.ConnectionString);
 
@@ -369,7 +375,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             Assert.Equal($"localhost,{server.EndPoint.Port}", connection.DataSource);
 
             // Failures should prompt the client to return to the original server, resulting in a login count of 2
-            Assert.Equal(2, server.PreLoginCount);
+            Assert.Equal(2, server.PreLoginCount - server.AbandonedPreLoginCount);
         }
 
         [Theory]
@@ -454,7 +460,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 FailoverPartner = $"localhost:{failoverServer.EndPoint.Port}", // User provided failover partner
             };
             using SqlConnection connection = new(builder.ConnectionString);
-                
+
             // Act
             connection.Open();
 
@@ -463,7 +469,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             Assert.Equal($"localhost,{server.EndPoint.Port}", connection.DataSource);
 
             // Failures should prompt the client to return to the original server, resulting in a login count of 2
-            Assert.Equal(2, server.PreLoginCount);
+            Assert.Equal(2, server.PreLoginCount - server.AbandonedPreLoginCount);
         }
 
         [Theory]
@@ -559,10 +565,13 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             // Close the connection to return it to the pool
             connection.Close();
 
-
             // Act
             // Dispose of the server to trigger a failover
             server.Dispose();
+
+            // Clear the pool to ensure the next connection attempt doesn't reuse
+            // the pooled connection to the now-disposed primary server.
+            SqlConnection.ClearAllPools();
 
             // Opening a new connection will use the failover partner stored in the pool group.
             // This will fail if the server provided failover partner was stored to the pool group.
@@ -573,9 +582,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             Assert.Equal(ConnectionState.Open, failoverConnection.State);
             Assert.Equal($"localhost,{failoverServer.EndPoint.Port}", failoverConnection.DataSource);
             // 1 for the initial connection
-            Assert.Equal(1, server.PreLoginCount);
+            Assert.Equal(1, server.PreLoginCount - server.AbandonedPreLoginCount);
             // 1 for the failover connection
-            Assert.Equal(1, failoverServer.PreLoginCount);
+            Assert.Equal(1, failoverServer.PreLoginCount - failoverServer.AbandonedPreLoginCount);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
-    [Trait("Category", "flaky")]
     [Collection("SimulatedServerTests")]
     public class ConnectionRoutingTests
     {
@@ -58,8 +57,8 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             Assert.Equal($"localhost,{router.EndPoint.Port}", connection.DataSource);
 
             // Failures should prompt the client to return to the original server, resulting in a login count of 2
-            Assert.Equal(2, router.PreLoginCount);
-            Assert.Equal(2, server.PreLoginCount);
+            Assert.Equal(2, router.PreLoginCount - router.AbandonedPreLoginCount);
+            Assert.Equal(2, server.PreLoginCount - server.AbandonedPreLoginCount);
         }
 
         [Theory]

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTestsAzure.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTestsAzure.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
-    [Trait("Category", "flaky")]
     [Collection("SimulatedServerTests")]
     public class ConnectionRoutingTestsAzure : IDisposable
     {
@@ -76,8 +75,8 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             Assert.Equal($"localhost,{router.EndPoint.Port}", connection.DataSource);
 
             // Failures should prompt the client to return to the original server, resulting in a login count of 2
-            Assert.Equal(2, router.PreLoginCount);
-            Assert.Equal(2, server.PreLoginCount);
+            Assert.Equal(2, router.PreLoginCount - router.AbandonedPreLoginCount);
+            Assert.Equal(2, server.PreLoginCount - server.AbandonedPreLoginCount);
         }
 
         [Theory]

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionTests.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         {
             using TdsServer server = new(new TdsServerArguments() { });
             server.Start();
-            var connStr = new SqlConnectionStringBuilder() {
+            var connStr = new SqlConnectionStringBuilder()
+            {
                 DataSource = $"localhost,{server.EndPoint.Port}",
                 Encrypt = SqlConnectionEncryptOption.Optional,
             }.ConnectionString;
@@ -43,7 +44,8 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         {
             using TdsServer server = new(new TdsServerArguments() { });
             server.Start();
-            var connStr = new SqlConnectionStringBuilder() {
+            var connStr = new SqlConnectionStringBuilder()
+            {
                 DataSource = $"localhost,{server.EndPoint.Port}",
                 Encrypt = SqlConnectionEncryptOption.Optional,
             }.ConnectionString;
@@ -61,9 +63,10 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         [Fact]
         public async Task RequestEncryption_ServerDoesNotSupportEncryption_ShouldFail()
         {
-            using TdsServer server = new(new TdsServerArguments() {Encryption = TDSPreLoginTokenEncryptionType.None });
+            using TdsServer server = new(new TdsServerArguments() { Encryption = TDSPreLoginTokenEncryptionType.None });
             server.Start();
-            var connStr = new SqlConnectionStringBuilder() {
+            var connStr = new SqlConnectionStringBuilder()
+            {
                 DataSource = $"localhost,{server.EndPoint.Port}"
             }.ConnectionString;
 
@@ -72,7 +75,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             Assert.Contains("The instance of SQL Server you attempted to connect to does not support encryption.", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
-        [Trait("Category", "flaky")]
         [Theory]
         [InlineData(40613)]
         [InlineData(42108)]
@@ -80,26 +82,28 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         public async Task TransientFault_RetryEnabled_ShouldSucceed_Async(uint errorCode)
         {
             using TransientTdsErrorTdsServer server = new(
-                new TransientTdsErrorTdsServerArguments() 
+                new TransientTdsErrorTdsServerArguments()
                 {
-                  IsEnabledTransientError = true,
-                  Number = errorCode,
+                    IsEnabledTransientError = true,
+                    Number = errorCode,
                 });
             server.Start();
             SqlConnectionStringBuilder builder = new()
             {
                 DataSource = "localhost," + server.EndPoint.Port,
-                Encrypt = SqlConnectionEncryptOption.Optional
+                Encrypt = SqlConnectionEncryptOption.Optional,
+#if NETFRAMEWORK
+                TransparentNetworkIPResolution = false
+#endif
             };
 
             using SqlConnection connection = new(builder.ConnectionString);
             await connection.OpenAsync();
             Assert.Equal(ConnectionState.Open, connection.State);
             Assert.Equal($"localhost,{server.EndPoint.Port}", connection.DataSource);
-            Assert.Equal(2, server.PreLoginCount);
+            Assert.Equal(2, server.PreLoginCount - server.AbandonedPreLoginCount);
         }
 
-        [Trait("Category", "flaky")]
         [Theory]
         [InlineData(40613)]
         [InlineData(42108)]
@@ -123,10 +127,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             connection.Open();
             Assert.Equal(ConnectionState.Open, connection.State);
             Assert.Equal($"localhost,{server.EndPoint.Port}", connection.DataSource);
-            Assert.Equal(2, server.PreLoginCount);
+            Assert.Equal(2, server.PreLoginCount - server.AbandonedPreLoginCount);
         }
 
-        [Trait("Category", "flaky")]
         [Theory]
         [InlineData(40613)]
         [InlineData(42108)]
@@ -151,10 +154,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             SqlException e = await Assert.ThrowsAsync<SqlException>(async () => await connection.OpenAsync());
             Assert.Equal((int)errorCode, e.Number);
             Assert.Equal(ConnectionState.Closed, connection.State);
-            Assert.Equal(1, server.PreLoginCount);
+            Assert.Equal(1, server.PreLoginCount - server.AbandonedPreLoginCount);
         }
 
-        [Trait("Category", "flaky")]
         [Theory]
         [InlineData(40613)]
         [InlineData(42108)]
@@ -179,10 +181,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             SqlException e = Assert.Throws<SqlException>(() => connection.Open());
             Assert.Equal((int)errorCode, e.Number);
             Assert.Equal(ConnectionState.Closed, connection.State);
-            Assert.Equal(1, server.PreLoginCount);
+            Assert.Equal(1, server.PreLoginCount - server.AbandonedPreLoginCount);
         }
 
-        [Trait("Category", "flaky")]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -200,6 +201,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                 DataSource = "localhost," + server.EndPoint.Port,
                 Encrypt = SqlConnectionEncryptOption.Optional,
                 ConnectTimeout = 5,
+                Pooling = false, // Disable pooling to ensure a fresh connection attempt is made
                 MultiSubnetFailover = multiSubnetFailoverEnabled,
 #if NETFRAMEWORK
                 TransparentNetworkIPResolution = multiSubnetFailoverEnabled
@@ -216,11 +218,10 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             }
             else
             {
-                Assert.Equal(1, server.PreLoginCount);
+                Assert.Equal(1, server.PreLoginCount - server.AbandonedPreLoginCount);
             }
         }
 
-        [Trait("Category", "flaky")]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -261,11 +262,10 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             }
             else
             {
-                Assert.Equal(1, server.PreLoginCount);
+                Assert.Equal(1, server.PreLoginCount - server.AbandonedPreLoginCount);
             }
         }
 
-        [Trait("Category", "flaky")]
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -306,7 +306,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             }
             else
             {
-                Assert.Equal(1, server.PreLoginCount);
+                Assert.Equal(1, server.PreLoginCount - server.AbandonedPreLoginCount);
             }
         }
 
@@ -467,7 +467,8 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             //TODO: do we even need a server for this test?
             using TdsServer server = new();
             server.Start();
-            var connStr = new SqlConnectionStringBuilder() {
+            var connStr = new SqlConnectionStringBuilder()
+            {
                 DataSource = $"localhost,{server.EndPoint.Port}",
                 ConnectTimeout = timeout,
                 Encrypt = SqlConnectionEncryptOption.Optional

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTdsServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTdsServer.cs
@@ -95,6 +95,11 @@ namespace Microsoft.SqlServer.TDS.Servers
         /// </summary>
         private int _preLoginCount = 0;
 
+        /// <summary>
+        /// Counts Login7 requests to the server.
+        /// </summary>
+        protected int _login7Count = 0;
+
         private TDSServerEndPoint _endpoint;
 
         /// <summary>
@@ -137,6 +142,18 @@ namespace Microsoft.SqlServer.TDS.Servers
         /// </summary>
         public int PreLoginCount => _preLoginCount;
 
+        /// <summary>
+        /// Counts Login7 requests to the server.
+        /// </summary>
+        public int Login7Count => _login7Count;
+
+        /// <summary>
+        /// Counts pre-login requests that did not result in a Login7 request,
+        /// which indicates the client abandoned the connection (e.g. interval
+        /// timer timeout during TNIR or failover).
+        /// </summary>
+        public int AbandonedPreLoginCount => _preLoginCount - _login7Count;
+
         public OnAuthenticationCompletedDelegate OnAuthenticationResponseCompleted { private get; set; }
 
         public OnLogin7ValidatedDelegate OnLogin7Validated { private get; set; }
@@ -148,9 +165,12 @@ namespace Microsoft.SqlServer.TDS.Servers
             {
                 throw new InvalidOperationException("Server is already started");
             }
-            _endpoint = new TDSServerEndPoint(this) { ServerEndPoint = new IPEndPoint(IPAddress.Any, 0) };
-            _endpoint.EndpointName = methodName;
-            _endpoint.EventLog = Arguments.Log;
+            _endpoint = new TDSServerEndPoint(this)
+            {
+                ServerEndPoint = new IPEndPoint(IPAddress.Any, 0),
+                EndpointName = methodName,
+                EventLog = Arguments.Log
+            };
             _endpoint.Start();
         }
 
@@ -245,6 +265,8 @@ namespace Microsoft.SqlServer.TDS.Servers
         /// </summary>
         public virtual TDSMessageCollection OnLogin7Request(ITDSServerSession session, TDSMessage request)
         {
+            Interlocked.Increment(ref _login7Count);
+
             // Inflate login7 request from the message
             TDSLogin7Token loginRequest = request[0] as TDSLogin7Token;
 

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TransientTdsErrorTdsServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TransientTdsErrorTdsServer.cs
@@ -60,6 +60,8 @@ namespace Microsoft.SqlServer.TDS.Servers
             // Check if we're still going to raise transient error
             if (Arguments.IsEnabledTransientError && RequestCounter < Arguments.RepeatCount)
             {
+                // Increment Login7 count since we won't call base.OnLogin7Request
+                Interlocked.Increment(ref _login7Count);
                 return GenerateErrorMessage(request);
             }
 


### PR DESCRIPTION
Cherry-pick of #4080 to release/7.0

---

## Original PR Description

_[Attempted fix with Copilot]_

## The Problem

When `SqlConnection.Open()` runs on **.NET Framework** (`net462`), the internal `LoginNoFailover` method enters **parallel/interval-timer mode** by default because **TNIR (Transparent Network IP Resolution)** is enabled. `LoginWithFailover` always uses interval timers on all platforms.

These interval timers give each login attempt only a **small fraction** of the total `ConnectTimeout`:

| Path | Fraction | With 30s timeout |
|------|----------|-----------------|
| `LoginWithFailover` | 8% (`FailoverTimeoutStep`) | **2.4s** per attempt |
| `LoginNoFailover` + TNIR | 12.5% (`FailoverTimeoutStepForTnir`) | **1.875s** per attempt |

On a busy Windows CI machine, when one of these interval timers expires mid-login, the client **disconnects and retries internally** inside the login loop — before the outer transient-fault retry loop ever sees the error. This produces an extra `PreLogin` on the TDS server that never gets a corresponding `Login7` (the client abandoned the connection).

## Additional fixes
* Fixes the multipart identifier getting skipped due to duplicate IDs
* Fixes failover port test failure, by ensuring connection pools are cleared before connecting to failover partner.
* Fixes SqlTypeWorkaroundsTests discovery by setting `DisableDiscoveryEnumeration` to true.