### PR TITLE
Test | Fix Kerberos SSPI authentication failure when using TCP proxy in manual tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ProxyServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/ProxyServer.cs
@@ -321,6 +321,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             // Build builders
             SqlConnectionStringBuilder connStringbuilder = new SqlConnectionStringBuilder(connectionString);
             DataSourceBuilder dataSourceBuilder = new DataSourceBuilder(connStringbuilder.DataSource);
+            string originalServerName = dataSourceBuilder.ServerName;
 
             // Setup proxy
             Task<System.Net.IPHostEntry> ipEntryTask = Dns.GetHostEntryAsync(dataSourceBuilder.ServerName);
@@ -337,6 +338,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             dataSourceBuilder.Port = proxy.LocalPort;
             connStringbuilder.DataSource = dataSourceBuilder.ToString();
             connStringbuilder.Remove("Network Library");
+
+            if (string.IsNullOrEmpty(connStringbuilder.ServerSPN))
+            {
+                connStringbuilder.ServerSPN = $"MSSQLSvc/{DataTestUtility.GetMachineFQDN(originalServerName)}";
+            }
 
             newConnectionString = connStringbuilder.ToString();
             return proxy;


### PR DESCRIPTION
**Problem**:
CreateAndStartProxy used in manual tests rewrites the connection string address to 127.0.0.1, causing kerberos to construct the wrong SPN (MSSQLSvc/localhost) instead of the real server name. Since localhost is not registered in Active Directory, SSPI authentication fails with 
```Microsoft.Data.SqlClient.SqlException: The target principal name is incorrect. Cannot generate SSPI context.```

Kerberos builds the SPN from the resolved connection address. When the proxy rewrites the address to 127.0.0.1, the SPN is constructed from localhost instead of the actual server hostname, breaking AD lookup.

**Fix:**
Capture the original server name before the proxy rewrites the address. After rewriting, explicitly set ServerSPN in the connection string to the real server's SPN using DataTestUtility.GetMachineFQDN, but only if ServerSPN is not already set by the caller.
This fix only applies if ServerSPN is not set already.

**Tests Affected:**
SqlCommandCancelTest.TimeOutDuringRead_Tcp— previously failing with SSPI error, now passing



