### PR TITLE
avoid Lock acquisition on ErrorCount/WarningCount when no errors exist

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2672,7 +2672,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (!Volatile.Read(ref _hasErrorOrWarning) &&
+                if (!_hasErrorOrWarning &&
                     Volatile.Read(ref _errors) == null &&
                     Volatile.Read(ref _warnings) == null)
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2719,7 +2719,7 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (!_hasErrorOrWarning)
+                if (!_hasErrorOrWarning && _warnings == null)
                 {
                     return 0;
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -2672,7 +2672,9 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
-                if (!_hasErrorOrWarning)
+                if (!Volatile.Read(ref _hasErrorOrWarning) &&
+                    Volatile.Read(ref _errors) == null &&
+                    Volatile.Read(ref _warnings) == null)
                 {
                     return 0;
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Data.SqlClient
         internal SqlErrorCollection _errors;
         internal SqlErrorCollection _warnings;
         internal object _errorAndWarningsLock = new object();
-        private bool _hasErrorOrWarning;
+        private volatile bool _hasErrorOrWarning;
 
         // local exceptions to cache warnings and errors that occurred prior to sending attention
         internal SqlErrorCollection _preAttentionErrors;
@@ -2672,6 +2672,10 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
+                if (!_hasErrorOrWarning)
+                {
+                    return 0;
+                }
                 int count = 0;
                 lock (_errorAndWarningsLock)
                 {
@@ -2713,6 +2717,10 @@ namespace Microsoft.Data.SqlClient
         {
             get
             {
+                if (!_hasErrorOrWarning)
+                {
+                    return 0;
+                }
                 int count = 0;
                 lock (_errorAndWarningsLock)
                 {


### PR DESCRIPTION
  1. _hasErrorOrWarning marked volatile (line 278) -- the field was already read without a lock at line 1212, so this  makes the existing pattern and the new fast paths correct across all memory models.
  2. ErrorCount fast path -- returns 0 immediately when _hasErrorOrWarning is false, skipping the lock. Safe because  _hasErrorOrWarning is only set to false under the lock when _errors is also nulled.
  3. WarningCount fast path -- same treatment.
