### PR TITLE
Quarantine flaky tests

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/LocalizationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/LocalizationTest.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("ru-RU")]
         [InlineData("zh-Hans")]
         [InlineData("zh-Hant")]
+        [Trait("Category", "flaky")]
         public void Localization_Tests(string culture)
         {
             string localized = GetLocalizedErrorMessage(culture);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncTimeoutTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncTimeoutTest.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: WAITFOR DELAY not supported [Parse error at line: 1, column: 1: Incorrect syntax near 'WAITFOR'.]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [ClassData(typeof(AsyncTimeoutTestVariations))]
+        [Trait("Category", "flaky")]
         public static void TestDelayedAsyncTimeout(AsyncAPI api, string commonObj, int delayPeriod, bool marsEnabled) =>
             RunTest(api, commonObj, delayPeriod, marsEnabled);
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// </summary>
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [ClassData(typeof(ConnectionPoolConnectionStringProvider))]
+        [Trait("Category", "flaky")]
         public static void BasicConnectionPoolingTest(string connectionString)
         {
             SqlConnection.ClearAllPools();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs
@@ -944,6 +944,7 @@ INSERT INTO [{tableName}] (Data) VALUES (@data);";
             }
         }
 
+        [Trait("Category", "flaky")]
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         public static async Task CanReadAwkwardDataLengths()
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -180,6 +180,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings))]
+        [Trait("Category", "flaky")]
         public static void ReadStream_ReadsStreamDataCorrectly(string connectionString)
         {
             ReadStream(connectionString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/MetricsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/TracingTests/MetricsTest.cs
@@ -278,6 +278,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [Trait("Category", "flaky")]
         public void ConnectionPoolGroupsCounter_Functional()
         {
             SqlConnection.ClearAllPools();

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
@@ -239,6 +239,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         }
 
         [Fact]
+        [Trait("Category", "flaky")]
         public void NetworkError_WithUserProvidedPartner_RetryDisabled_ShouldConnectToFailoverPartner()
         {
             using TdsServer failoverServer = new(
@@ -286,6 +287,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         }
 
         [Fact]
+        [Trait("Category", "flaky")]
         public void NetworkError_WithUserProvidedPartner_RetryEnabled_ShouldConnectToFailoverPartner()
         {
             using TdsServer failoverServer = new(
@@ -430,6 +432,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         [InlineData(40613)]
         [InlineData(42108)]
         [InlineData(42109)]
+        [Trait("Category", "flaky")]
         public void TransientFault_WithUserProvidedPartner_ShouldConnectToPrimary(uint errorCode)
         {
             // Arrange

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
     public class ConnectionFailoverTests
     {
         //TODO parameterize for transient errors
+        [Trait("Category", "flaky")]
         [Theory]
         [InlineData(40613)]
         [InlineData(42108)]
@@ -74,6 +75,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             Assert.Equal(0, failoverServer.PreLoginCount);
         }
 
+        [Trait("Category", "flaky")]
         [Fact]
         public void NetworkError_TriggersFailover_ClearsPool()
         {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTests.cs
@@ -156,6 +156,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         }
 
         [Fact]
+        [Trait("Category", "flaky")]
         public void NetworkTimeoutAtRoutedLocation_RetryDisabled_ShouldFail()
         {
             // Arrange


### PR DESCRIPTION
## Summary

Quarantine 12 intermittently failing tests by adding `[Trait("Category", "flaky")]` so they are excluded from regular CI runs and only execute in quarantine pipeline steps.

## Tests quarantined

| Test | File |
|------|------|
| `DataStreamTest.ReadStream_ReadsStreamDataCorrectly` | `tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs` |
| `AsyncTimeoutTest.TestDelayedAsyncTimeout` | `tests/ManualTests/SQL/AsyncTest/AsyncTimeoutTest.cs` |
| `MetricsTest.ConnectionPoolGroupsCounter_Functional` | `tests/ManualTests/TracingTests/MetricsTest.cs` |
| `ConnectionFailoverTests.NetworkError_..._RetryDisabled_...` | `tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs` |
| `ConnectionFailoverTests.NetworkError_..._RetryEnabled_...` | `tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs` |
| `ConnectionFailoverTests.TransientFault_..._ShouldConnectToPrimary` | `tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs` |
| `ConnectionRoutingTests.NetworkTimeoutAtRoutedLocation_..._ShouldFail` | `tests/UnitTests/SimulatedServerTests/ConnectionRoutingTests.cs` |
| `ConnectionPoolTest.BasicConnectionPoolingTest` | `tests/ManualTests/SQL/ConnectionPoolTest/ConnectionPoolTest.cs` |
| `LocalizationTest.Localization_Tests` | `tests/FunctionalTests/LocalizationTest.cs` |
| `ConnectionFailoverTests.TransientFault_NoFailover_DoesNotClearPool` | `tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs` |
| `ConnectionFailoverTests.NetworkError_TriggersFailover_ClearsPool` | `tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs` |
| `DataReaderTest.CanReadAwkwardDataLengths` | `tests/ManualTests/SQL/DataReaderTest/DataReaderTest.cs` |

## Checklist
- [x] Tests updated (quarantine trait added)
- [x] Root causes investigated and tracked separately