### PR TITLE
[6.1] Fix symbol publishing connectivity and extract into testable script

### DIFF
--- a/eng/pipelines/common/templates/steps/Publish-Symbols.ps1
+++ b/eng/pipelines/common/templates/steps/Publish-Symbols.ps1
@@ -1,0 +1,201 @@
+<#
+.SYNOPSIS
+    Publishes symbols to the Microsoft symbol publishing service (SymWeb/MSDL).
+
+.DESCRIPTION
+    This script uploads and publishes debug symbols (.pdb files) to internal and/or public
+    Microsoft symbol servers via the Symbols Publishing Pipeline REST API.
+
+    It performs three steps:
+      1. Acquires a bearer token from Azure CLI for the symbol publishing service.
+      2. Registers a unique request name with the publishing service.
+      3. Submits the request to publish symbols to the specified servers.
+      4. Queries the publishing status for confirmation.
+
+    For more details on the Symbols Publishing Pipeline, see:
+    https://www.osgwiki.com/wiki/Symbols_Publishing_Pipeline_to_SymWeb_and_MSDL
+
+.PARAMETER PublishServer
+    The hostname prefix of the symbol publishing service. This value is prepended to
+    '.trafficmanager.net' to construct the service base URL.
+
+.PARAMETER PublishTokenUri
+    The resource URI used to acquire a bearer token from Azure CLI
+    (via 'az account get-access-token --resource <uri>').
+
+.PARAMETER PublishProjectName
+    The project name registered with the symbol publishing service (decided during onboarding).
+
+.PARAMETER ArtifactName
+    The base name for the publishing request. A job attempt suffix is appended to ensure
+    uniqueness across retries.
+
+.PARAMETER JobAttempt
+    The job attempt number (from Azure Pipelines' System.JobAttempt). Appended to ArtifactName
+    to create a unique request name per execution.
+
+.PARAMETER PublishToInternal
+    Whether to publish symbols to the internal symbol server. Defaults to $true.
+
+.PARAMETER PublishToPublic
+    Whether to publish symbols to the public symbol server. Defaults to $true.
+
+.EXAMPLE
+    .\Publish-Symbols.ps1 `
+        -PublishServer "mysymbolserver" `
+        -PublishTokenUri "https://login.microsoftonline.com/..." `
+        -PublishProjectName "Microsoft.Data.SqlClient.SNI" `
+        -ArtifactName "mds_symbols_MyProject_dotnet-sqlclient_main_6.1.5_abc123" `
+        -JobAttempt 1
+
+    Publishes symbols to both internal and public servers using the specified parameters.
+
+.EXAMPLE
+    .\Publish-Symbols.ps1 `
+        -PublishServer "mysymbolserver" `
+        -PublishTokenUri "https://login.microsoftonline.com/..." `
+        -PublishProjectName "Microsoft.Data.SqlClient.SNI" `
+        -ArtifactName "mds_symbols_MyProject_dotnet-sqlclient_main_6.1.5_abc123" `
+        -JobAttempt 2 `
+        -PublishToPublic $false
+
+    Publishes symbols to the internal server only (retry attempt 2).
+
+.NOTES
+    File Name : Publish-Symbols.ps1
+    Requires  : Azure CLI (az) must be installed and authenticated.
+    Called by : publish-symbols-step.yml (Azure Pipelines template)
+
+    Publishing status codes returned by the service:
+
+    PublishingStatus:
+      0 - NotRequested: The request has not been requested to publish.
+      1 - Submitted: The request is submitted to be published.
+      2 - Processing: The request is still being processed.
+      3 - Completed: Processing finished. Check PublishingResult for details.
+
+    PublishingResult:
+      0 - Pending: The request has not completed or has not been requested.
+      1 - Succeeded: The request published successfully.
+      2 - Failed: The request failed to publish.
+      3 - Cancelled: The request was cancelled.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, HelpMessage = "Hostname prefix of the symbol publishing service (prepended to .trafficmanager.net).")]
+    [ValidateNotNullOrEmpty()]
+    [string]$PublishServer,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Resource URI for acquiring a bearer token via Azure CLI.")]
+    [ValidateNotNullOrEmpty()]
+    [string]$PublishTokenUri,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Project name registered with the symbol publishing service.")]
+    [ValidateNotNullOrEmpty()]
+    [string]$PublishProjectName,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Base artifact name for the publishing request.")]
+    [ValidateNotNullOrEmpty()]
+    [string]$ArtifactName,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Job attempt number (System.JobAttempt) for uniqueness.")]
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$JobAttempt,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Publish symbols to the internal symbol server.")]
+    [bool]$PublishToInternal = $true,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Publish symbols to the public symbol server.")]
+    [bool]$PublishToPublic = $true
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# --- Log input parameters ---
+Write-Host "=== Publish Symbols Parameters ==="
+Write-Host "PublishServer:      ${PublishServer}"
+Write-Host "PublishTokenUri:    ${PublishTokenUri}"
+Write-Host "PublishProjectName: ${PublishProjectName}"
+Write-Host "ArtifactName:       ${ArtifactName}"
+Write-Host "JobAttempt:         ${JobAttempt}"
+Write-Host "PublishToInternal:  ${PublishToInternal}"
+Write-Host "PublishToPublic:    ${PublishToPublic}"
+Write-Host "=================================="
+
+# --- Build request name and URLs ---
+$requestName = "${ArtifactName}_${JobAttempt}"
+$baseUrl     = "https://${PublishServer}.trafficmanager.net/projects/${PublishProjectName}"
+$registerUrl = "${baseUrl}/requests"
+$requestUrl  = "${baseUrl}/requests/${requestName}"
+
+Write-Host "=== Constructed URLs ==="
+Write-Host "Request Name: ${requestName}"
+Write-Host "Base URL:     ${baseUrl}"
+Write-Host "Register URL: ${registerUrl}"
+Write-Host "Request URL:  ${requestUrl}"
+Write-Host "========================"
+
+# --- Step 1: Acquire token ---
+Write-Host ">  1. Acquiring symbol publishing token..."
+$symbolPublishingToken = az account get-access-token --resource ${PublishTokenUri} --query accessToken -o tsv
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to acquire symbol publishing token via Azure CLI (exit code: ${LASTEXITCODE})."
+}
+Write-Host ">  1. Symbol publishing token acquired."
+
+$authHeaders = @{ Authorization = "Bearer ${symbolPublishingToken}" }
+
+# --- Step 2: Register request name ---
+Write-Host ">  2. Registering request name..."
+$requestNameRegistrationBody = @{ requestName = $requestName } | ConvertTo-Json -Compress
+try {
+    Invoke-RestMethod -Method POST -Uri ${registerUrl} -Headers ${authHeaders} -ContentType "application/json" -Body ${requestNameRegistrationBody}
+} catch {
+    Write-Error "Failed to register request name. URI: ${registerUrl} | Body: ${requestNameRegistrationBody} | Error: $_"
+    throw
+}
+Write-Host ">  2. Request name registered successfully."
+
+# --- Step 3: Publish symbols ---
+Write-Host ">  3. Submitting request to publish symbols..."
+$publishSymbolsBody = @{
+    publishToInternalServer = $PublishToInternal
+    publishToPublicServer   = $PublishToPublic
+} | ConvertTo-Json -Compress
+Write-Host "Publishing symbols request body: ${publishSymbolsBody}"
+try {
+    Invoke-RestMethod -Method POST -Uri ${requestUrl} -Headers ${authHeaders} -ContentType "application/json" -Body ${publishSymbolsBody}
+} catch {
+    Write-Error "Failed to publish symbols. URI: ${requestUrl} | Body: ${publishSymbolsBody} | Error: $_"
+    throw
+}
+Write-Host ">  3. Request to publish symbols submitted successfully."
+
+# --- Step 4: Check status ---
+Write-Host ">  4. Checking the status of the request..."
+try {
+    $status = Invoke-RestMethod -Method GET -Uri ${requestUrl} -Headers ${authHeaders} -ContentType "application/json"
+    $status
+} catch {
+    Write-Error "Failed to check request status. URI: ${requestUrl} | Error: $_"
+    throw
+}
+
+Write-Host ""
+Write-Host "Use below tables to interpret the xxxServerStatus and xxxServerResult fields from the response."
+Write-Host ""
+Write-Host "PublishingStatus"
+Write-Host "-----------------"
+Write-Host "0  NotRequested - The request has not been requested to publish."
+Write-Host "1  Submitted    - The request is submitted to be published."
+Write-Host "2  Processing   - The request is still being processed."
+Write-Host "3  Completed    - Processing finished. Check PublishingResult for details."
+Write-Host ""
+Write-Host "PublishingResult"
+Write-Host "-----------------"
+Write-Host "0  Pending   - The request has not completed or has not been requested."
+Write-Host "1  Succeeded - The request published successfully."
+Write-Host "2  Failed    - The request failed to publish."
+Write-Host "3  Cancelled - The request was cancelled."

--- a/eng/pipelines/common/templates/steps/Publish-Symbols.ps1
+++ b/eng/pipelines/common/templates/steps/Publish-Symbols.ps1
@@ -6,7 +6,7 @@
     This script uploads and publishes debug symbols (.pdb files) to internal and/or public
     Microsoft symbol servers via the Symbols Publishing Pipeline REST API.
 
-    It performs three steps:
+    It performs four steps:
       1. Acquires a bearer token from Azure CLI for the symbol publishing service.
       2. Registers a unique request name with the publishing service.
       3. Submits the request to publish symbols to the specified servers.
@@ -56,6 +56,10 @@
     Publishes symbols to the internal server only (retry attempt 2).
 
 .NOTES
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+
     File Name : Publish-Symbols.ps1
     Requires  : Azure CLI (az) must be installed and authenticated.
     Called by : publish-symbols-step.yml (Azure Pipelines template)

--- a/eng/pipelines/common/templates/steps/Publish-Symbols.ps1
+++ b/eng/pipelines/common/templates/steps/Publish-Symbols.ps1
@@ -27,12 +27,8 @@
     The project name registered with the symbol publishing service (decided during onboarding).
 
 .PARAMETER ArtifactName
-    The base name for the publishing request. A job attempt suffix is appended to ensure
-    uniqueness across retries.
-
-.PARAMETER JobAttempt
-    The job attempt number (from Azure Pipelines' System.JobAttempt). Appended to ArtifactName
-    to create a unique request name per execution.
+    The name of the publishing request. This must match the SymbolsArtifactName used by
+    the PublishSymbols@2 upload task so that upload and publish reference the same artifact.
 
 .PARAMETER PublishToInternal
     Whether to publish symbols to the internal symbol server. Defaults to $true.
@@ -45,8 +41,7 @@
         -PublishServer "mysymbolserver" `
         -PublishTokenUri "https://login.microsoftonline.com/..." `
         -PublishProjectName "Microsoft.Data.SqlClient.SNI" `
-        -ArtifactName "mds_symbols_MyProject_dotnet-sqlclient_main_6.1.5_abc123" `
-        -JobAttempt 1
+        -ArtifactName "mds_symbols_MyProject_dotnet-sqlclient_main_6.1.5_abc123_1"
 
     Publishes symbols to both internal and public servers using the specified parameters.
 
@@ -55,8 +50,7 @@
         -PublishServer "mysymbolserver" `
         -PublishTokenUri "https://login.microsoftonline.com/..." `
         -PublishProjectName "Microsoft.Data.SqlClient.SNI" `
-        -ArtifactName "mds_symbols_MyProject_dotnet-sqlclient_main_6.1.5_abc123" `
-        -JobAttempt 2 `
+        -ArtifactName "mds_symbols_MyProject_dotnet-sqlclient_main_6.1.5_abc123_2" `
         -PublishToPublic $false
 
     Publishes symbols to the internal server only (retry attempt 2).
@@ -95,13 +89,9 @@ param(
     [ValidateNotNullOrEmpty()]
     [string]$PublishProjectName,
 
-    [Parameter(Mandatory = $true, HelpMessage = "Base artifact name for the publishing request.")]
+    [Parameter(Mandatory = $true, HelpMessage = "Artifact name for the publishing request (must match PublishSymbols@2 SymbolsArtifactName).")]
     [ValidateNotNullOrEmpty()]
     [string]$ArtifactName,
-
-    [Parameter(Mandatory = $true, HelpMessage = "Job attempt number (System.JobAttempt) for uniqueness.")]
-    [ValidateRange(1, [int]::MaxValue)]
-    [int]$JobAttempt,
 
     [Parameter(Mandatory = $false, HelpMessage = "Publish symbols to the internal symbol server.")]
     [bool]$PublishToInternal = $true,
@@ -119,13 +109,12 @@ Write-Host "PublishServer:      ${PublishServer}"
 Write-Host "PublishTokenUri:    ${PublishTokenUri}"
 Write-Host "PublishProjectName: ${PublishProjectName}"
 Write-Host "ArtifactName:       ${ArtifactName}"
-Write-Host "JobAttempt:         ${JobAttempt}"
 Write-Host "PublishToInternal:  ${PublishToInternal}"
 Write-Host "PublishToPublic:    ${PublishToPublic}"
 Write-Host "=================================="
 
 # --- Build request name and URLs ---
-$requestName = "${ArtifactName}_${JobAttempt}"
+$requestName = ${ArtifactName}
 $baseUrl     = "https://${PublishServer}.trafficmanager.net/projects/${PublishProjectName}"
 $registerUrl = "${baseUrl}/requests"
 $requestUrl  = "${baseUrl}/requests/${requestName}"
@@ -143,6 +132,12 @@ $symbolPublishingToken = az account get-access-token --resource ${PublishTokenUr
 if ($LASTEXITCODE -ne 0) {
     throw "Failed to acquire symbol publishing token via Azure CLI (exit code: ${LASTEXITCODE})."
 }
+if ($null -ne $symbolPublishingToken) {
+    $symbolPublishingToken = $symbolPublishingToken.Trim()
+}
+if ([string]::IsNullOrWhiteSpace($symbolPublishingToken)) {
+    throw "Failed to acquire symbol publishing token via Azure CLI: received an empty or whitespace-only access token."
+}
 Write-Host ">  1. Symbol publishing token acquired."
 
 $authHeaders = @{ Authorization = "Bearer ${symbolPublishingToken}" }
@@ -153,8 +148,7 @@ $requestNameRegistrationBody = @{ requestName = $requestName } | ConvertTo-Json 
 try {
     Invoke-RestMethod -Method POST -Uri ${registerUrl} -Headers ${authHeaders} -ContentType "application/json" -Body ${requestNameRegistrationBody}
 } catch {
-    Write-Error "Failed to register request name. URI: ${registerUrl} | Body: ${requestNameRegistrationBody} | Error: $_"
-    throw
+    throw "Failed to register request name. URI: ${registerUrl} | Body: ${requestNameRegistrationBody} | Error: $_"
 }
 Write-Host ">  2. Request name registered successfully."
 
@@ -168,8 +162,7 @@ Write-Host "Publishing symbols request body: ${publishSymbolsBody}"
 try {
     Invoke-RestMethod -Method POST -Uri ${requestUrl} -Headers ${authHeaders} -ContentType "application/json" -Body ${publishSymbolsBody}
 } catch {
-    Write-Error "Failed to publish symbols. URI: ${requestUrl} | Body: ${publishSymbolsBody} | Error: $_"
-    throw
+    throw "Failed to publish symbols. URI: ${requestUrl} | Body: ${publishSymbolsBody} | Error: $_"
 }
 Write-Host ">  3. Request to publish symbols submitted successfully."
 
@@ -179,8 +172,7 @@ try {
     $status = Invoke-RestMethod -Method GET -Uri ${requestUrl} -Headers ${authHeaders} -ContentType "application/json"
     $status
 } catch {
-    Write-Error "Failed to check request status. URI: ${requestUrl} | Error: $_"
-    throw
+    throw "Failed to check request status. URI: ${requestUrl} | Error: $_"
 }
 
 Write-Host ""

--- a/eng/pipelines/common/templates/steps/publish-symbols-step.yml
+++ b/eng/pipelines/common/templates/steps/publish-symbols-step.yml
@@ -4,11 +4,11 @@
 # See the LICENSE file in the project root for more information.                   #
 #                                                                                  #
 # doc: https://www.osgwiki.com/wiki/Symbols_Publishing_Pipeline_to_SymWeb_and_MSDL #
-#                                                                                  #
-# The Symbols* variable defaults (e.g. SymbolsPublishServer, SymbolsUploadAccount) #
-# are sourced from the 'akv-variables-v2' variable group, imported via             #
-# eng/pipelines/libraries/mds-variables.yml.                                       #
 ####################################################################################
+
+# The Symbols* variable defaults (e.g. SymbolsPublishServer, SymbolsUploadAccount) are sourced from
+# the 'Symbols Publishing' variable group, imported via eng/pipelines/libraries/mds-variables.yml.
+
 parameters:
   - name: SymAccount
     type: string

--- a/eng/pipelines/common/templates/steps/publish-symbols-step.yml
+++ b/eng/pipelines/common/templates/steps/publish-symbols-step.yml
@@ -4,11 +4,15 @@
 # See the LICENSE file in the project root for more information.                   #
 #                                                                                  #
 # doc: https://www.osgwiki.com/wiki/Symbols_Publishing_Pipeline_to_SymWeb_and_MSDL #
+#                                                                                  #
+# The Symbols* variable defaults (e.g. SymbolsPublishServer, SymbolsUploadAccount) #
+# are sourced from the 'akv-variables-v2' variable group, imported via             #
+# eng/pipelines/libraries/mds-variables.yml.                                       #
 ####################################################################################
 parameters:
   - name: SymAccount
     type: string
-    default: 'SqlClientDrivers'
+    default: '$(SymbolsUploadAccount)'
 
   - name: publishSymbols
     type: string
@@ -28,6 +32,14 @@ parameters:
 
   - name: symbolsArtifactName
     type: string
+
+  - name: symbolsAzureSubscription
+    type: string
+    default: '$(SymbolsAzureSubscription)'
+
+  - name: symbolsPublishProjectName
+    type: string
+    default: '$(SymbolsPublishProjectName)'
 
   - name: publishToServers
     type: object
@@ -74,14 +86,14 @@ steps:
   displayName: 'Publish symbols'
   condition: and(succeeded(), ${{ eq(parameters.publishSymbols, 'true') }})
   inputs:
-    azureSubscription: 'Symbols publishing Workload Identity federation service-ADO.Net'
+    azureSubscription: '${{parameters.symbolsAzureSubscription }}'
     scriptType: ps
     scriptLocation: scriptPath
     scriptPath: '$(Build.SourcesDirectory)/eng/pipelines/common/templates/steps/Publish-Symbols.ps1'
     arguments: >-
       -PublishServer "${{parameters.symbolServer }}"
       -PublishTokenUri "${{parameters.symbolTokenUri }}"
-      -PublishProjectName "Microsoft.Data.SqlClient.SNI"
+      -PublishProjectName "${{parameters.symbolsPublishProjectName }}"
       -ArtifactName "${{parameters.symbolsArtifactName }}_$(System.JobAttempt)"
       -PublishToInternal $${{parameters.publishToServers.internal }}
       -PublishToPublic $${{parameters.publishToServers.public }}

--- a/eng/pipelines/common/templates/steps/publish-symbols-step.yml
+++ b/eng/pipelines/common/templates/steps/publish-symbols-step.yml
@@ -66,7 +66,7 @@ steps:
       SymbolExpirationInDays: 1825 # 5 years
       SymbolsProduct: Microsoft.Data.SqlClient
       SymbolsVersion: ${{parameters.symbolsVersion }}
-      SymbolsArtifactName: ${{parameters.symbolsArtifactName }}
+      SymbolsArtifactName: ${{parameters.symbolsArtifactName }}_$(System.JobAttempt)
       Pat: $(System.AccessToken)
     condition: and(succeeded(), ${{ eq(parameters.publishSymbols, 'true') }})
 
@@ -82,7 +82,6 @@ steps:
       -PublishServer "${{parameters.symbolServer }}"
       -PublishTokenUri "${{parameters.symbolTokenUri }}"
       -PublishProjectName "Microsoft.Data.SqlClient.SNI"
-      -ArtifactName "${{parameters.symbolsArtifactName }}"
-      -JobAttempt $(System.JobAttempt)
+      -ArtifactName "${{parameters.symbolsArtifactName }}_$(System.JobAttempt)"
       -PublishToInternal $${{parameters.publishToServers.internal }}
       -PublishToPublic $${{parameters.publishToServers.public }}

--- a/eng/pipelines/common/templates/steps/publish-symbols-step.yml
+++ b/eng/pipelines/common/templates/steps/publish-symbols-step.yml
@@ -20,18 +20,18 @@ parameters:
 
   - name: symbolServer
     type: string
-    default: '$(SymbolServer)'
-  
+    default: '$(SymbolsPublishServer)'
+
   - name: symbolTokenUri
     type: string
-    default: '$(SymbolTokenUri)'
-  
+    default: '$(SymbolsPublishTokenUri)'
+
   - name: symbolsArtifactName
     type: string
-  
+
   - name: publishToServers
     type: object
-    default: 
+    default:
       internal: true
       public: true
 
@@ -76,56 +76,13 @@ steps:
   inputs:
     azureSubscription: 'Symbols publishing Workload Identity federation service-ADO.Net'
     scriptType: ps
-    scriptLocation: inlineScript
-    inlineScript: |
-      $publishToInternalServer = "${{parameters.publishToServers.internal }}".ToLower()
-      $publishToPublicServer = "${{parameters.publishToServers.public }}".ToLower()
-
-      echo "Publishing request name: ${{parameters.symbolsArtifactName }}"
-      echo "Publish to internal server: $publishToInternalServer"
-      echo "Publish to public server: $publishToPublicServer"      
-
-      $symbolServer = "${{parameters.symbolServer }}"
-      $tokenUri = "${{parameters.symbolTokenUri }}"
-      # Registered project name in the symbol publishing pipeline: https://portal.microsofticm.com/imp/v3/incidents/incident/520844254/summary
-      $projectName = "Microsoft.Data.SqlClient.SNI"
-
-      # Get the access token for the symbol publishing service
-      $symbolPublishingToken = az account get-access-token --resource $tokenUri --query accessToken -o tsv
-
-      echo ">  1.Symbol publishing token acquired."
-
-      echo "Registering the request name ..."
-      $requestName = "${{parameters.symbolsArtifactName }}"
-      $requestNameRegistrationBody = "{'requestName': '$requestName'}"
-      Invoke-RestMethod -Method POST -Uri "https://$symbolServer.trafficmanager.net/projects/$projectName/requests" -Headers @{ Authorization = "Bearer $symbolPublishingToken" } -ContentType "application/json" -Body $requestNameRegistrationBody
-
-      echo ">  2.Registration of request name succeeded."
-
-      echo "Publishing the symbols ..."
-      $publishSymbolsBody = "{'publishToInternalServer': $publishToInternalServer, 'publishToPublicServer': $publishToPublicServer}"
-      echo "Publishing symbols request body: $publishSymbolsBody"
-      Invoke-RestMethod -Method POST -Uri "https://$symbolServer.trafficmanager.net/projects/$projectName/requests/$requestName" -Headers @{ Authorization = "Bearer $symbolPublishingToken" } -ContentType "application/json" -Body $publishSymbolsBody
-
-      echo ">  3.Request to publish symbols succeeded."
-
-      # The following REST calls are used to check publishing status.
-      echo ">  4.Checking the status of the request ..."
-
-      Invoke-RestMethod -Method GET -Uri "https://$symbolServer.trafficmanager.net/projects/$projectName/requests/$requestName" -Headers @{ Authorization = "Bearer $symbolPublishingToken" } -ContentType "application/json"
-      
-      echo "Use below tables to interpret the values of xxxServerStatus and xxxServerResult fields from the response."
-      
-      echo "PublishingStatus"
-      echo "-----------------"
-      echo "0	NotRequested; The request has not been requested to publish."
-      echo "1	Submitted; The request is submitted to be published"
-      echo "2	Processing; The request is still being processed"
-      echo "3	Completed; The request has been completed processing. It can be failed or successful. Check PublishingResult to get more details"
-      
-      echo "PublishingResult"
-      echo "-----------------"
-      echo "0	Pending; The request has not completed or has not been requested."
-      echo "1	Succeeded; The request has published successfully"
-      echo "2	Failed; The request has failed to publish"
-      echo "3	Cancelled; The request was cancelled"
+    scriptLocation: scriptPath
+    scriptPath: '$(Build.SourcesDirectory)/eng/pipelines/common/templates/steps/Publish-Symbols.ps1'
+    arguments: >-
+      -PublishServer "${{parameters.symbolServer }}"
+      -PublishTokenUri "${{parameters.symbolTokenUri }}"
+      -PublishProjectName "Microsoft.Data.SqlClient.SNI"
+      -ArtifactName "${{parameters.symbolsArtifactName }}"
+      -JobAttempt $(System.JobAttempt)
+      -PublishToInternal $${{parameters.publishToServers.internal }}
+      -PublishToPublic $${{parameters.publishToServers.public }}

--- a/eng/pipelines/common/templates/steps/tests/Publish-Symbols.Tests.ps1
+++ b/eng/pipelines/common/templates/steps/tests/Publish-Symbols.Tests.ps1
@@ -1,5 +1,8 @@
 <#
-.SYNOPSIS
+    Licensed to the .NET Foundation under one or more agreements.
+    The .NET Foundation licenses this file to you under the MIT license.
+    See the LICENSE file in the project root for more information.
+
     Pester tests for Publish-Symbols.ps1
 #>
 

--- a/eng/pipelines/common/templates/steps/tests/Publish-Symbols.Tests.ps1
+++ b/eng/pipelines/common/templates/steps/tests/Publish-Symbols.Tests.ps1
@@ -7,20 +7,26 @@ BeforeAll {
     $scriptPath = Join-Path $PSScriptRoot '..' 'Publish-Symbols.ps1'
 }
 
+AfterAll {
+    # Clean up global variables used by mocks
+    Remove-Variable -Name 'restCalls' -Scope Global -ErrorAction SilentlyContinue
+    Remove-Variable -Name 'mockCallCount' -Scope Global -ErrorAction SilentlyContinue
+}
+
 Describe 'Publish-Symbols.ps1 Parameter Validation' {
 
     It 'Should reject an empty PublishServer' {
-        { & $scriptPath -PublishServer '' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName 'art' -JobAttempt 1 } |
+        { & $scriptPath -PublishServer '' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName 'art' } |
             Should -Throw
     }
 
     It 'Should reject an empty PublishTokenUri' {
-        { & $scriptPath -PublishServer 'server' -PublishTokenUri '' -PublishProjectName 'proj' -ArtifactName 'art' -JobAttempt 1 } |
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri '' -PublishProjectName 'proj' -ArtifactName 'art' } |
             Should -Throw
     }
 
     It 'Should reject an empty PublishProjectName' {
-        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName '' -ArtifactName 'art' -JobAttempt 1 } |
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName '' -ArtifactName 'art' } |
             Should -Throw
     }
 
@@ -33,24 +39,21 @@ Describe 'Publish-Symbols.ps1 Parameter Validation' {
 Describe 'Publish-Symbols.ps1 URL Construction' {
 
     BeforeAll {
-        # Mock az CLI to return a fake token
-        Mock -CommandName 'az' -MockWith { 'fake-token-12345' }
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token-12345' }
 
-        # Mock Invoke-RestMethod to capture calls without making real HTTP requests
-        $script:restCalls = @()
+        $global:restCalls = @()
         Mock -CommandName 'Invoke-RestMethod' -MockWith {
-            $script:restCalls += @{
+            $global:restCalls += @{
                 Method = $Method
                 Uri    = $Uri
                 Body   = $Body
             }
-            # Return a fake response for the GET status call
             return @{ internalServerStatus = 0; publicServerStatus = 0 }
         }
     }
 
     BeforeEach {
-        $script:restCalls = @()
+        $global:restCalls = @()
     }
 
     It 'Should construct the correct base URL from PublishServer and PublishProjectName' {
@@ -60,19 +63,19 @@ Describe 'Publish-Symbols.ps1 URL Construction' {
             -PublishProjectName 'My.Project' `
             -ArtifactName 'test_artifact'
 
-        $script:restCalls.Count | Should -Be 3
+        $global:restCalls.Count | Should -Be 3
 
         # Registration call
-        $script:restCalls[0].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests'
-        $script:restCalls[0].Method | Should -Be 'POST'
+        $global:restCalls[0].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests'
+        $global:restCalls[0].Method | Should -Be 'POST'
 
         # Publish call
-        $script:restCalls[1].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact'
-        $script:restCalls[1].Method | Should -Be 'POST'
+        $global:restCalls[1].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact'
+        $global:restCalls[1].Method | Should -Be 'POST'
 
         # Status call
-        $script:restCalls[2].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact'
-        $script:restCalls[2].Method | Should -Be 'GET'
+        $global:restCalls[2].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact'
+        $global:restCalls[2].Method | Should -Be 'GET'
     }
 
     It 'Should use ArtifactName directly as the request name' {
@@ -82,20 +85,19 @@ Describe 'Publish-Symbols.ps1 URL Construction' {
             -PublishProjectName 'proj' `
             -ArtifactName 'myartifact_3'
 
-        # All request-specific URLs should use the artifact name as-is
-        $script:restCalls[1].Uri | Should -BeLike '*myartifact_3'
-        $script:restCalls[2].Uri | Should -BeLike '*myartifact_3'
+        $global:restCalls[1].Uri | Should -BeLike '*myartifact_3'
+        $global:restCalls[2].Uri | Should -BeLike '*myartifact_3'
     }
 }
 
 Describe 'Publish-Symbols.ps1 Request Bodies' {
 
     BeforeAll {
-        Mock -CommandName 'az' -MockWith { 'fake-token-12345' }
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token-12345' }
 
-        $script:restCalls = @()
+        $global:restCalls = @()
         Mock -CommandName 'Invoke-RestMethod' -MockWith {
-            $script:restCalls += @{
+            $global:restCalls += @{
                 Method = $Method
                 Uri    = $Uri
                 Body   = $Body
@@ -105,7 +107,7 @@ Describe 'Publish-Symbols.ps1 Request Bodies' {
     }
 
     BeforeEach {
-        $script:restCalls = @()
+        $global:restCalls = @()
     }
 
     It 'Should send the correct request name in the registration body' {
@@ -115,7 +117,7 @@ Describe 'Publish-Symbols.ps1 Request Bodies' {
             -PublishProjectName 'proj' `
             -ArtifactName 'my_artifact_1'
 
-        $body = $script:restCalls[0].Body | ConvertFrom-Json
+        $body = $global:restCalls[0].Body | ConvertFrom-Json
         $body.requestName | Should -Be 'my_artifact_1'
     }
 
@@ -126,7 +128,7 @@ Describe 'Publish-Symbols.ps1 Request Bodies' {
             -PublishProjectName 'proj' `
             -ArtifactName 'art'
 
-        $body = $script:restCalls[1].Body | ConvertFrom-Json
+        $body = $global:restCalls[1].Body | ConvertFrom-Json
         $body.publishToInternalServer | Should -Be $true
         $body.publishToPublicServer | Should -Be $true
     }
@@ -139,7 +141,7 @@ Describe 'Publish-Symbols.ps1 Request Bodies' {
             -ArtifactName 'art' `
             -PublishToInternal $false
 
-        $body = $script:restCalls[1].Body | ConvertFrom-Json
+        $body = $global:restCalls[1].Body | ConvertFrom-Json
         $body.publishToInternalServer | Should -Be $false
         $body.publishToPublicServer | Should -Be $true
     }
@@ -152,17 +154,13 @@ Describe 'Publish-Symbols.ps1 Request Bodies' {
             -ArtifactName 'art' `
             -PublishToPublic $false
 
-        $body = $script:restCalls[1].Body | ConvertFrom-Json
+        $body = $global:restCalls[1].Body | ConvertFrom-Json
         $body.publishToInternalServer | Should -Be $true
         $body.publishToPublicServer | Should -Be $false
     }
 }
 
 Describe 'Publish-Symbols.ps1 Error Handling' {
-
-    BeforeAll {
-        Mock -CommandName 'az' -MockWith { 'fake-token-12345' }
-    }
 
     It 'Should throw when token acquisition fails' {
         Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 1; return '' }
@@ -200,11 +198,11 @@ Describe 'Publish-Symbols.ps1 Error Handling' {
 
     It 'Should throw with URI details when publish fails' {
         Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token' }
-        $callCount = 0
+        $global:mockCallCount = 0
         Mock -CommandName 'Invoke-RestMethod' -MockWith {
-            $callCount++
-            if ($callCount -eq 1) { return @{} }       # registration succeeds
-            throw "Service unavailable"                  # publish fails
+            $global:mockCallCount++
+            if ($global:mockCallCount -eq 1) { return @{} }
+            throw "Service unavailable"
         }
 
         { & $scriptPath `
@@ -217,11 +215,11 @@ Describe 'Publish-Symbols.ps1 Error Handling' {
 
     It 'Should throw with URI details when status check fails' {
         Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token' }
-        $callCount = 0
+        $global:mockCallCount = 0
         Mock -CommandName 'Invoke-RestMethod' -MockWith {
-            $callCount++
-            if ($callCount -le 2) { return @{} }       # registration + publish succeed
-            throw "Timeout"                              # status check fails
+            $global:mockCallCount++
+            if ($global:mockCallCount -le 2) { return @{} }
+            throw "Timeout"
         }
 
         { & $scriptPath `

--- a/eng/pipelines/common/templates/steps/tests/Publish-Symbols.Tests.ps1
+++ b/eng/pipelines/common/templates/steps/tests/Publish-Symbols.Tests.ps1
@@ -25,17 +25,7 @@ Describe 'Publish-Symbols.ps1 Parameter Validation' {
     }
 
     It 'Should reject an empty ArtifactName' {
-        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName '' -JobAttempt 1 } |
-            Should -Throw
-    }
-
-    It 'Should reject JobAttempt of 0' {
-        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName 'art' -JobAttempt 0 } |
-            Should -Throw
-    }
-
-    It 'Should reject a negative JobAttempt' {
-        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName 'art' -JobAttempt -1 } |
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName '' } |
             Should -Throw
     }
 }
@@ -68,8 +58,7 @@ Describe 'Publish-Symbols.ps1 URL Construction' {
             -PublishServer 'myserver' `
             -PublishTokenUri 'https://token-uri' `
             -PublishProjectName 'My.Project' `
-            -ArtifactName 'test_artifact' `
-            -JobAttempt 1
+            -ArtifactName 'test_artifact'
 
         $script:restCalls.Count | Should -Be 3
 
@@ -78,46 +67,24 @@ Describe 'Publish-Symbols.ps1 URL Construction' {
         $script:restCalls[0].Method | Should -Be 'POST'
 
         # Publish call
-        $script:restCalls[1].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact_1'
+        $script:restCalls[1].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact'
         $script:restCalls[1].Method | Should -Be 'POST'
 
         # Status call
-        $script:restCalls[2].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact_1'
+        $script:restCalls[2].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact'
         $script:restCalls[2].Method | Should -Be 'GET'
     }
 
-    It 'Should append JobAttempt to the request name' {
+    It 'Should use ArtifactName directly as the request name' {
         & $scriptPath `
             -PublishServer 'srv' `
             -PublishTokenUri 'https://token-uri' `
             -PublishProjectName 'proj' `
-            -ArtifactName 'myartifact' `
-            -JobAttempt 3
+            -ArtifactName 'myartifact_3'
 
-        # All request-specific URLs should end with _3
+        # All request-specific URLs should use the artifact name as-is
         $script:restCalls[1].Uri | Should -BeLike '*myartifact_3'
         $script:restCalls[2].Uri | Should -BeLike '*myartifact_3'
-    }
-
-    It 'Should produce different request names for different JobAttempt values' {
-        & $scriptPath `
-            -PublishServer 'srv' `
-            -PublishTokenUri 'https://token-uri' `
-            -PublishProjectName 'proj' `
-            -ArtifactName 'art' `
-            -JobAttempt 1
-
-        $attempt1Urls = $script:restCalls.Clone()
-        $script:restCalls = @()
-
-        & $scriptPath `
-            -PublishServer 'srv' `
-            -PublishTokenUri 'https://token-uri' `
-            -PublishProjectName 'proj' `
-            -ArtifactName 'art' `
-            -JobAttempt 2
-
-        $attempt1Urls[1].Uri | Should -Not -Be $script:restCalls[1].Uri
     }
 }
 
@@ -146,8 +113,7 @@ Describe 'Publish-Symbols.ps1 Request Bodies' {
             -PublishServer 'srv' `
             -PublishTokenUri 'https://token-uri' `
             -PublishProjectName 'proj' `
-            -ArtifactName 'my_artifact' `
-            -JobAttempt 1
+            -ArtifactName 'my_artifact_1'
 
         $body = $script:restCalls[0].Body | ConvertFrom-Json
         $body.requestName | Should -Be 'my_artifact_1'
@@ -158,8 +124,7 @@ Describe 'Publish-Symbols.ps1 Request Bodies' {
             -PublishServer 'srv' `
             -PublishTokenUri 'https://token-uri' `
             -PublishProjectName 'proj' `
-            -ArtifactName 'art' `
-            -JobAttempt 1
+            -ArtifactName 'art'
 
         $body = $script:restCalls[1].Body | ConvertFrom-Json
         $body.publishToInternalServer | Should -Be $true
@@ -172,7 +137,6 @@ Describe 'Publish-Symbols.ps1 Request Bodies' {
             -PublishTokenUri 'https://token-uri' `
             -PublishProjectName 'proj' `
             -ArtifactName 'art' `
-            -JobAttempt 1 `
             -PublishToInternal $false
 
         $body = $script:restCalls[1].Body | ConvertFrom-Json
@@ -186,7 +150,6 @@ Describe 'Publish-Symbols.ps1 Request Bodies' {
             -PublishTokenUri 'https://token-uri' `
             -PublishProjectName 'proj' `
             -ArtifactName 'art' `
-            -JobAttempt 1 `
             -PublishToPublic $false
 
         $body = $script:restCalls[1].Body | ConvertFrom-Json
@@ -208,9 +171,19 @@ Describe 'Publish-Symbols.ps1 Error Handling' {
             -PublishServer 'srv' `
             -PublishTokenUri 'https://token-uri' `
             -PublishProjectName 'proj' `
-            -ArtifactName 'art' `
-            -JobAttempt 1 } |
+            -ArtifactName 'art' } |
             Should -Throw '*token*'
+    }
+
+    It 'Should throw when token is empty' {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return '  ' }
+
+        { & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' } |
+            Should -Throw '*empty*'
     }
 
     It 'Should throw with URI details when registration fails' {
@@ -221,8 +194,7 @@ Describe 'Publish-Symbols.ps1 Error Handling' {
             -PublishServer 'srv' `
             -PublishTokenUri 'https://token-uri' `
             -PublishProjectName 'proj' `
-            -ArtifactName 'art' `
-            -JobAttempt 1 } |
+            -ArtifactName 'art' } |
             Should -Throw '*Failed to register*'
     }
 
@@ -239,8 +211,7 @@ Describe 'Publish-Symbols.ps1 Error Handling' {
             -PublishServer 'srv' `
             -PublishTokenUri 'https://token-uri' `
             -PublishProjectName 'proj' `
-            -ArtifactName 'art' `
-            -JobAttempt 1 } |
+            -ArtifactName 'art' } |
             Should -Throw '*Failed to publish*'
     }
 
@@ -257,8 +228,7 @@ Describe 'Publish-Symbols.ps1 Error Handling' {
             -PublishServer 'srv' `
             -PublishTokenUri 'https://token-uri' `
             -PublishProjectName 'proj' `
-            -ArtifactName 'art' `
-            -JobAttempt 1 } |
+            -ArtifactName 'art' } |
             Should -Throw '*Failed to check*'
     }
 }

--- a/eng/pipelines/common/templates/steps/tests/Publish-Symbols.Tests.ps1
+++ b/eng/pipelines/common/templates/steps/tests/Publish-Symbols.Tests.ps1
@@ -1,0 +1,264 @@
+<#
+.SYNOPSIS
+    Pester tests for Publish-Symbols.ps1
+#>
+
+BeforeAll {
+    $scriptPath = Join-Path $PSScriptRoot '..' 'Publish-Symbols.ps1'
+}
+
+Describe 'Publish-Symbols.ps1 Parameter Validation' {
+
+    It 'Should reject an empty PublishServer' {
+        { & $scriptPath -PublishServer '' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName 'art' -JobAttempt 1 } |
+            Should -Throw
+    }
+
+    It 'Should reject an empty PublishTokenUri' {
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri '' -PublishProjectName 'proj' -ArtifactName 'art' -JobAttempt 1 } |
+            Should -Throw
+    }
+
+    It 'Should reject an empty PublishProjectName' {
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName '' -ArtifactName 'art' -JobAttempt 1 } |
+            Should -Throw
+    }
+
+    It 'Should reject an empty ArtifactName' {
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName '' -JobAttempt 1 } |
+            Should -Throw
+    }
+
+    It 'Should reject JobAttempt of 0' {
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName 'art' -JobAttempt 0 } |
+            Should -Throw
+    }
+
+    It 'Should reject a negative JobAttempt' {
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName 'art' -JobAttempt -1 } |
+            Should -Throw
+    }
+}
+
+Describe 'Publish-Symbols.ps1 URL Construction' {
+
+    BeforeAll {
+        # Mock az CLI to return a fake token
+        Mock -CommandName 'az' -MockWith { 'fake-token-12345' }
+
+        # Mock Invoke-RestMethod to capture calls without making real HTTP requests
+        $script:restCalls = @()
+        Mock -CommandName 'Invoke-RestMethod' -MockWith {
+            $script:restCalls += @{
+                Method = $Method
+                Uri    = $Uri
+                Body   = $Body
+            }
+            # Return a fake response for the GET status call
+            return @{ internalServerStatus = 0; publicServerStatus = 0 }
+        }
+    }
+
+    BeforeEach {
+        $script:restCalls = @()
+    }
+
+    It 'Should construct the correct base URL from PublishServer and PublishProjectName' {
+        & $scriptPath `
+            -PublishServer 'myserver' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'My.Project' `
+            -ArtifactName 'test_artifact' `
+            -JobAttempt 1
+
+        $script:restCalls.Count | Should -Be 3
+
+        # Registration call
+        $script:restCalls[0].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests'
+        $script:restCalls[0].Method | Should -Be 'POST'
+
+        # Publish call
+        $script:restCalls[1].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact_1'
+        $script:restCalls[1].Method | Should -Be 'POST'
+
+        # Status call
+        $script:restCalls[2].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact_1'
+        $script:restCalls[2].Method | Should -Be 'GET'
+    }
+
+    It 'Should append JobAttempt to the request name' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'myartifact' `
+            -JobAttempt 3
+
+        # All request-specific URLs should end with _3
+        $script:restCalls[1].Uri | Should -BeLike '*myartifact_3'
+        $script:restCalls[2].Uri | Should -BeLike '*myartifact_3'
+    }
+
+    It 'Should produce different request names for different JobAttempt values' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -JobAttempt 1
+
+        $attempt1Urls = $script:restCalls.Clone()
+        $script:restCalls = @()
+
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -JobAttempt 2
+
+        $attempt1Urls[1].Uri | Should -Not -Be $script:restCalls[1].Uri
+    }
+}
+
+Describe 'Publish-Symbols.ps1 Request Bodies' {
+
+    BeforeAll {
+        Mock -CommandName 'az' -MockWith { 'fake-token-12345' }
+
+        $script:restCalls = @()
+        Mock -CommandName 'Invoke-RestMethod' -MockWith {
+            $script:restCalls += @{
+                Method = $Method
+                Uri    = $Uri
+                Body   = $Body
+            }
+            return @{ internalServerStatus = 0; publicServerStatus = 0 }
+        }
+    }
+
+    BeforeEach {
+        $script:restCalls = @()
+    }
+
+    It 'Should send the correct request name in the registration body' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'my_artifact' `
+            -JobAttempt 1
+
+        $body = $script:restCalls[0].Body | ConvertFrom-Json
+        $body.requestName | Should -Be 'my_artifact_1'
+    }
+
+    It 'Should default to publishing to both internal and public servers' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -JobAttempt 1
+
+        $body = $script:restCalls[1].Body | ConvertFrom-Json
+        $body.publishToInternalServer | Should -Be $true
+        $body.publishToPublicServer | Should -Be $true
+    }
+
+    It 'Should respect PublishToInternal=false' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -JobAttempt 1 `
+            -PublishToInternal $false
+
+        $body = $script:restCalls[1].Body | ConvertFrom-Json
+        $body.publishToInternalServer | Should -Be $false
+        $body.publishToPublicServer | Should -Be $true
+    }
+
+    It 'Should respect PublishToPublic=false' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -JobAttempt 1 `
+            -PublishToPublic $false
+
+        $body = $script:restCalls[1].Body | ConvertFrom-Json
+        $body.publishToInternalServer | Should -Be $true
+        $body.publishToPublicServer | Should -Be $false
+    }
+}
+
+Describe 'Publish-Symbols.ps1 Error Handling' {
+
+    BeforeAll {
+        Mock -CommandName 'az' -MockWith { 'fake-token-12345' }
+    }
+
+    It 'Should throw when token acquisition fails' {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 1; return '' }
+
+        { & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -JobAttempt 1 } |
+            Should -Throw '*token*'
+    }
+
+    It 'Should throw with URI details when registration fails' {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token' }
+        Mock -CommandName 'Invoke-RestMethod' -MockWith { throw "Connection refused" }
+
+        { & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -JobAttempt 1 } |
+            Should -Throw '*Failed to register*'
+    }
+
+    It 'Should throw with URI details when publish fails' {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token' }
+        $callCount = 0
+        Mock -CommandName 'Invoke-RestMethod' -MockWith {
+            $callCount++
+            if ($callCount -eq 1) { return @{} }       # registration succeeds
+            throw "Service unavailable"                  # publish fails
+        }
+
+        { & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -JobAttempt 1 } |
+            Should -Throw '*Failed to publish*'
+    }
+
+    It 'Should throw with URI details when status check fails' {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token' }
+        $callCount = 0
+        Mock -CommandName 'Invoke-RestMethod' -MockWith {
+            $callCount++
+            if ($callCount -le 2) { return @{} }       # registration + publish succeed
+            throw "Timeout"                              # status check fails
+        }
+
+        { & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -JobAttempt 1 } |
+            Should -Throw '*Failed to check*'
+    }
+}

--- a/eng/pipelines/common/templates/steps/tests/README.md
+++ b/eng/pipelines/common/templates/steps/tests/README.md
@@ -1,0 +1,43 @@
+# Publish-Symbols Tests
+
+Pester tests for the `Publish-Symbols.ps1` script used by the symbol publishing pipeline step.
+
+## Prerequisites
+
+- PowerShell 5.1+ or PowerShell 7+
+- [Pester v5](https://pester.dev/) (`Install-Module Pester -MinimumVersion 5.0 -Scope CurrentUser`)
+
+## Running the Tests
+
+From this directory:
+
+```powershell
+Invoke-Pester ./Publish-Symbols.Tests.ps1
+```
+
+Or from the repository root:
+
+```powershell
+Invoke-Pester ./eng/pipelines/common/templates/steps/tests/
+```
+
+For detailed output:
+
+```powershell
+Invoke-Pester ./Publish-Symbols.Tests.ps1 -Output Detailed
+```
+
+## Test Coverage
+
+| Area                  | What's tested                                                    |
+|-----------------------|------------------------------------------------------------------|
+| Parameter validation  | Empty strings, zero/negative `JobAttempt`                        |
+| URL construction      | Base URL, register URL, request URL with `JobAttempt` suffix     |
+| Request uniqueness    | Different `JobAttempt` values produce different request names     |
+| Request bodies        | Registration body, default publish flags, flag overrides         |
+| Error handling        | Token failure, registration failure, publish failure, status failure — all verify expanded URI in error message |
+
+## Notes
+
+- All external calls (`az`, `Invoke-RestMethod`) are mocked — no network access or Azure credentials are required.
+- Tests validate the script at `../Publish-Symbols.ps1` relative to this directory.

--- a/eng/pipelines/common/templates/steps/tests/README.md
+++ b/eng/pipelines/common/templates/steps/tests/README.md
@@ -29,13 +29,12 @@ Invoke-Pester ./Publish-Symbols.Tests.ps1 -Output Detailed
 
 ## Test Coverage
 
-| Area                  | What's tested                                                    |
-|-----------------------|------------------------------------------------------------------|
-| Parameter validation  | Empty strings, zero/negative `JobAttempt`                        |
-| URL construction      | Base URL, register URL, request URL with `JobAttempt` suffix     |
-| Request uniqueness    | Different `JobAttempt` values produce different request names     |
-| Request bodies        | Registration body, default publish flags, flag overrides         |
-| Error handling        | Token failure, registration failure, publish failure, status failure — all verify expanded URI in error message |
+| Area                 | What's tested                                                    |
+|----------------------|------------------------------------------------------------------|
+| Parameter validation | Empty strings rejected for all mandatory parameters              |
+| URL construction     | Base URL, register URL, request URL built from parameters        |
+| Request bodies       | Registration body, default publish flags, flag overrides         |
+| Error handling       | Token failure, empty token, registration/publish/status failures |
 
 ## Notes
 

--- a/eng/pipelines/libraries/mds-variables.yml
+++ b/eng/pipelines/libraries/mds-variables.yml
@@ -5,7 +5,7 @@
 #################################################################################
 
 variables:
-  - group: 'akv-variables-v2'
+  - group: Symbols Publishing
     # Shared symbols publishing variables:
     # SymbolsAzureSubscription
     # SymbolsPublishProjectName

--- a/eng/pipelines/libraries/mds-variables.yml
+++ b/eng/pipelines/libraries/mds-variables.yml
@@ -7,5 +7,8 @@
 variables:
   - group: 'akv-variables-v2'
     # Shared symbols publishing variables:
+    # SymbolsAzureSubscription
+    # SymbolsPublishProjectName
     # SymbolsPublishServer
     # SymbolsPublishTokenUri
+    # SymbolsUploadAccount

--- a/eng/pipelines/libraries/mds-variables.yml
+++ b/eng/pipelines/libraries/mds-variables.yml
@@ -5,6 +5,7 @@
 #################################################################################
 
 variables:
-  - group: Release Variables
-    # SymbolServer
-    # SymbolTokenUri
+  - group: 'akv-variables-v2'
+    # Shared symbols publishing variables:
+    # SymbolsPublishServer
+    # SymbolsPublishTokenUri


### PR DESCRIPTION
## Summary

- Adds diagnostics to help identify problems with symbols publishing.
- Replaces use of `Release Variables` group with `akv-variables-v2` to help eliminate duplicate LIbrary variables.
- Improves testability of the PowerShell parts of publishing.

# Testing

- PR/CI pipelines aren't affected.
- Manual run of OneBranch Non-Official pipeline to see what happens...
