### PR TITLE
Add SQL Server readiness checks to Windows pipeline setup

### DIFF
--- a/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
@@ -162,11 +162,29 @@ steps:
         #Change the access level for FileStream for SQLServer
         Set-ExecutionPolicy Unrestricted
         Import-Module "sqlps"
-        Invoke-Sqlcmd -ServerInstance "$machineName" @"
-            EXEC sp_configure filestream_access_level, 2;
-            RECONFIGURE;
+
+        # Retry loop: SQL Server may be temporarily unavailable after enabling FileStream via WMI
+        $tries = 0
+        while ($true) {
+            $tries++
+            try {
+                Invoke-Sqlcmd -ServerInstance "$machineName" @"
+                    EXEC sp_configure filestream_access_level, 2;
+                    RECONFIGURE;
         "@
+                Write-Host "FileStream access level configured successfully."
+                break
+            } catch {
+                if ($tries -ge 10) {
+                    Write-Host "##[error]Failed to configure FileStream access level after $tries tries."
+                    throw
+                }
+                Write-Host "Failed to connect to SQL Server (attempt $tries/10). Retrying in 5 seconds..."
+                Start-Sleep -Seconds 5
+            }
+        }
       displayName: 'Enable FileStream [Win]'
+      retryCountOnTaskFailure: 1
       env:
         SQL_USER: ${{parameters.user }}
         SQL_PASSWD: ${{ parameters.saPassword }}
@@ -249,6 +267,30 @@ steps:
 
       Restart-Service -Name "$serviceName" -Force
       Restart-Service -Name MSSQLSERVER* -Force
+
+      # Wait for SQL Server to be ready to accept connections after restart
+      $machineName = $env:COMPUTERNAME
+      if ("${{parameters.instanceName }}" -ne "MSSQLSERVER") {
+          $machineName += "\${{parameters.instanceName }}"
+      }
+
+      Import-Module "sqlps"
+      $tries = 0
+      while ($true) {
+          $tries++
+          try {
+              Invoke-Sqlcmd -ServerInstance "$machineName" -Query "SELECT @@VERSION" -ConnectionTimeout 5
+              Write-Host "SQL Server is ready after restart (attempt $tries)."
+              break
+          } catch {
+              if ($tries -ge 20) {
+                  Write-Host "##[error]SQL Server did not become ready after $tries attempts."
+                  throw
+              }
+              Write-Host "Waiting for SQL Server to start (attempt $tries/20)..."
+              Start-Sleep -Seconds 3
+          }
+      }
 
     displayName: 'Restart SQL Server [Win]'
 

--- a/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
@@ -163,12 +163,13 @@ steps:
         Set-ExecutionPolicy Unrestricted
         Import-Module "sqlps"
 
-        # Retry loop: SQL Server may be temporarily unavailable after enabling FileStream via WMI
+        # Retry loop: SQL Server may be temporarily unavailable after enabling FileStream via WMI.
+        # Worst-case budget: 10 attempts x (5s connection timeout + 5s sleep) = ~100s
         $tries = 0
         while ($true) {
             $tries++
             try {
-                Invoke-Sqlcmd -ServerInstance "$machineName" @"
+                Invoke-Sqlcmd -ServerInstance "$machineName" -ConnectionTimeout 5 @"
                     EXEC sp_configure filestream_access_level, 2;
                     RECONFIGURE;
         "@
@@ -268,7 +269,8 @@ steps:
       Restart-Service -Name "$serviceName" -Force
       Restart-Service -Name MSSQLSERVER* -Force
 
-      # Wait for SQL Server to be ready to accept connections after restart
+      # Wait for SQL Server to be ready to accept connections after restart.
+      # Worst-case budget: 20 attempts x (5s connection timeout + 3s sleep) = ~160s
       $machineName = $env:COMPUTERNAME
       if ("${{parameters.instanceName }}" -ne "MSSQLSERVER") {
           $machineName += "\${{parameters.instanceName }}"

--- a/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml
@@ -185,7 +185,6 @@ steps:
             }
         }
       displayName: 'Enable FileStream [Win]'
-      retryCountOnTaskFailure: 1
       env:
         SQL_USER: ${{parameters.user }}
         SQL_PASSWD: ${{ parameters.saPassword }}


### PR DESCRIPTION
## Problem

The **Enable FileStream [Win]** pipeline step fails intermittently because SQL Server is temporarily unreachable after the WMI `EnableFilestream` call. The `Invoke-Sqlcmd` runs immediately with no retry logic, hitting:

> Named Pipes Provider, error: 40 – Could not open a connection to SQL Server

[Failed build log](https://sqlclientdrivers.visualstudio.com/904996cc-6198-4d39-8540-eca72bdf0b7b/_apis/build/builds/146894/logs/2683)

## Changes

1. **Enable FileStream step** – wrapped `Invoke-Sqlcmd` in a retry loop with `-ConnectionTimeout 5` (10 attempts × (5 s timeout + 5 s sleep) ≈ 100 s worst-case budget).
2. **Restart SQL Server step** – added a post-restart readiness poll using `SELECT @@VERSION` with `-ConnectionTimeout 5` (20 attempts × (5 s timeout + 3 s sleep) ≈ 160 s worst-case budget), so downstream steps (SQL Browser, LocalDB) don't run against a still-starting instance.

Both patterns match the readiness loops already present in the Linux and macOS setup scripts.

## Checklist
- [x] Pipeline-only change, no product code modified
- [x] Retry budgets are generous but bounded
- [x] Follows existing retry pattern from 'Create SQL user' step