### PR TITLE
Use Rosetta 2 and improve robustness for macOS SQL Server CI setup

### DIFF
--- a/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
@@ -87,9 +87,9 @@ steps:
         fi
 
         # Verify the container is still running; no point retrying if it crashed.
-        if ! docker ps --filter "name=sql1" --filter "status=running" --format '{{.Names}}' | grep -q sql1; then
+        if ! docker ps --filter "name=^/sql1$" --filter "status=running" --format '{{.Names}}' | grep -Fxq 'sql1'; then
           echo "ERROR: sql1 container is no longer running."
-          docker ps -a --filter "name=sql1"
+          docker ps -a --filter "name=^/sql1$"
           echo "--- Container logs ---"
           docker logs sql1 2>&1 | tail -50
           rm -f $SQLCMD_ERRORS
@@ -112,7 +112,7 @@ steps:
         echo "--- sqlcmd errors ---"
         cat $SQLCMD_ERRORS
         echo "--- Container status ---"
-        docker ps -a --filter "name=sql1"
+        docker ps -a --filter "name=^/sql1$"
         echo "--- Container logs (last 80 lines) ---"
         docker logs sql1 2>&1 | tail -80
         rm -f $SQLCMD_ERRORS

--- a/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
@@ -29,36 +29,40 @@ steps:
       export PS4='+ [$(date "+%Y-%m-%d %H:%M:%S")] '
       set -x
 
-      # Install Docker and SQLCMD tools.
+      # Install Docker CLI (not Desktop — Colima provides the daemon) and SQLCMD tools.
       brew install colima
-      brew install --cask docker
+      brew install docker
       brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
       brew update
       HOMEBREW_ACCEPT_EULA=Y brew install mssql-tools18
-      colima start --arch x86_64
+
+      # Start Colima with Rosetta 2 for x86_64 binary translation on Apple Silicon.
+      # This is dramatically faster than --arch x86_64 (full QEMU VM emulation).
+      # Requires macOS >= 13 (Ventura) and Colima >= 0.5.3.
+      colima start --vm-type vz --vz-rosetta --cpu 4 --memory 4
       docker --version
-      docker pull mcr.microsoft.com/mssql/server:2025-latest
+      docker pull --platform linux/amd64 mcr.microsoft.com/mssql/server:2025-latest
 
       # Password for the SA user (required)
       MSSQL_SA_PW="${{ parameters.saPassword }}"
 
-      docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=$MSSQL_SA_PW" -p 1433:1433 -p 1434:1434 --name sql1 --hostname sql1 -d mcr.microsoft.com/mssql/server:2025-latest
+      docker run --platform linux/amd64 -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=$MSSQL_SA_PW" -p 1433:1433 -p 1434:1434 --name sql1 --hostname sql1 -d mcr.microsoft.com/mssql/server:2025-latest
 
-      sleep 5
+      sleep 10
 
       docker ps -a
 
       # Connect to the SQL Server container and get its version.
       #
-      # It can take a while for the docker container to start listening and be
-      # ready for connections, so we will wait for up to 2 minutes, checking every
-      # 3 seconds.
+      # With Rosetta 2 emulation, SQL Server starts much faster than under full
+      # QEMU emulation, but it can still take a minute or two.  We allow up to
+      # 6 minutes (72 attempts × 5 seconds) as a generous upper bound.
 
-      # Wait 3 seconds between attempts.
-      delay=3
+      # Wait 5 seconds between attempts.
+      delay=5
 
-      # Try up to 40 times (2 minutes) to connect.
-      maxAttempts=40
+      # Try up to 72 times (~6 minutes) to connect.
+      maxAttempts=72
 
       # Attempt counter.
       attempt=1
@@ -71,12 +75,23 @@ steps:
 
         echo "Waiting for SQL Server to start (attempt #$attempt of $maxAttempts)..."
 
-        sqlcmd -S 127.0.0.1 -No -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" >> $SQLCMD_ERRORS 2>&1
+        # -C trusts the self-signed certificate inside the container.
+        sqlcmd -S 127.0.0.1 -No -C -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" >> $SQLCMD_ERRORS 2>&1
 
         # If the command was successful, then the SQL Server is ready.
         if [ $? -eq 0 ]; then
           ready=1
           break
+        fi
+
+        # Verify the container is still running; no point retrying if it crashed.
+        if ! docker ps --filter "name=sql1" --filter "status=running" --format '{{.Names}}' | grep -q sql1; then
+          echo "ERROR: sql1 container is no longer running."
+          docker ps -a --filter "name=sql1"
+          echo "--- Container logs ---"
+          docker logs sql1 2>&1 | tail -50
+          rm -f $SQLCMD_ERRORS
+          exit 1
         fi
 
         # Increment the attempt counter.
@@ -91,8 +106,13 @@ steps:
       if [ $ready -eq 0 ]
       then
         # No, so report the error(s) and exit.
-        echo Cannot connect to SQL Server; installation aborted; errors were:
+        echo "Cannot connect to SQL Server after $maxAttempts attempts; installation aborted."
+        echo "--- sqlcmd errors ---"
         cat $SQLCMD_ERRORS
+        echo "--- Container status ---"
+        docker ps -a --filter "name=sql1"
+        echo "--- Container logs (last 80 lines) ---"
+        docker logs sql1 2>&1 | tail -80
         rm -f $SQLCMD_ERRORS
         exit 1
       fi
@@ -101,18 +121,18 @@ steps:
 
       echo "Use sqlcmd to show which IP addresses are being listened on..."
       echo 0.0.0.0
-      sqlcmd -S 0.0.0.0 -No -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" -l 2
+      sqlcmd -S 0.0.0.0 -No -C -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" -l 2
       echo 127.0.0.1
-      sqlcmd -S 127.0.0.1 -No -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" -l 2
+      sqlcmd -S 127.0.0.1 -No -C -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" -l 2
       echo ::1
-      sqlcmd -S ::1 -No -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" -l 2
+      sqlcmd -S ::1 -No -C -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" -l 2
       echo localhost
-      sqlcmd -S localhost -No -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" -l 2
+      sqlcmd -S localhost -No -C -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" -l 2
       echo "(sqlcmd default / not specified)"
-      sqlcmd -No -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" -l 2
+      sqlcmd -No -C -U sa -P "$MSSQL_SA_PW" -Q "SELECT @@VERSION" -l 2
 
       echo "Configuring Dedicated Administer Connections to allow remote connections..."
-      sqlcmd -S 127.0.0.1 -No -U sa -P "$MSSQL_SA_PW" -Q "sp_configure 'remote admin connections', 1; RECONFIGURE;"
+      sqlcmd -S 127.0.0.1 -No -C -U sa -P "$MSSQL_SA_PW" -Q "sp_configure 'remote admin connections', 1; RECONFIGURE;"
       if [ $? = 1 ]
       then
         echo "Error configuring DAC for remote access."

--- a/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
@@ -36,10 +36,12 @@ steps:
       brew update
       HOMEBREW_ACCEPT_EULA=Y brew install mssql-tools18
 
-      # Start Colima with Rosetta 2 for x86_64 binary translation on Apple Silicon.
-      # This is dramatically faster than --arch x86_64 (full QEMU VM emulation).
-      # Requires macOS >= 13 (Ventura) and Colima >= 0.5.3.
-      colima start --vm-type vz --vz-rosetta --cpu 4 --memory 4
+      # Start Colima with Virtualization.framework for x86_64 binary translation
+      # on Apple Silicon.  Rosetta/binfmt emulation is enabled by default in
+      # Colima >= 0.8 when using --vm-type vz, which is dramatically faster than
+      # --arch x86_64 (full QEMU VM emulation).
+      # Requires macOS >= 13 (Ventura).
+      colima start --vm-type vz --cpu 4 --memory 4
       docker --version
       docker pull --platform linux/amd64 mcr.microsoft.com/mssql/server:2025-latest
 


### PR DESCRIPTION
## Summary

Fixes macOS CI failures where SQL Server never became ready within the 2-minute timeout (see [build 146894 log](https://sqlclientdrivers.visualstudio.com/904996cc-6198-4d39-8540-eca72bdf0b7b/_apis/build/builds/146894/logs/4174)).

### Root Cause
SQL Server 2025 running under full QEMU x86_64 VM emulation (`colima start --arch x86_64`) on ARM macOS agents takes well over 2 minutes to start. All 40 sqlcmd retry attempts were exhausted with TLS handshake errors (`0x2746`).

### Changes

| Area | Before | After |
|------|--------|-------|
| **VM emulation** | `--arch x86_64` (QEMU) | `--vm-type vz` (Rosetta 2) — near-native perf |
| **Docker install** | `brew install --cask docker` (Desktop, ~4 min) | `brew install docker` (CLI only) |
| **Platform** | Implicit | `--platform linux/amd64` on pull/run |
| **Retry budget** | 40 × 3s = 2 min | 72 × 5s = ~6 min |
| **Cert trust** | Missing | `-C` flag on all sqlcmd calls |
| **Crash detection** | None | `docker ps` check per retry; bail if container exited |
| **Failure diagnostics** | sqlcmd errors only | + `docker logs` + container status |
| **Error messages** | Unquoted (caused `command not found`) | Properly quoted |
| **VM resources** | Default (2 CPU / 2 GB) | 4 CPU / 4 GB |

### Checklist
- [x] Tests added or updated: N/A (pipeline infra change)
- [x] Public API changes documented: N/A
- [x] Verified against customer repro: N/A
- [x] Ensure no breaking changes introduced