### PR TITLE
[7.0] Extract Publish-Symbols.ps1 script and add retry safety for symbol publishing

### DIFF
--- a/.github/instructions/onebranch-pipeline-design.instructions.md
+++ b/.github/instructions/onebranch-pipeline-design.instructions.md
@@ -347,10 +347,10 @@ dotnet-sqlclient-official-pipeline.yml
   └─ libraries/variables.yml
        └─ libraries/build-variables.yml
             ├─ group: 'Release Variables'
-            ├─ group: 'Symbols publishing'          ← SymbolsPublishServer, SymbolsPublishTokenUri, etc.
+            ├─ group: 'Symbols Publishing'          ← SymbolsPublishServer, SymbolsPublishTokenUri, etc.
             └─ libraries/common-variables.yml
                  ├─ group: 'ESRP Federated Creds (AME)'  ← ESRP signing credentials
-                 ├─ SymbolServer / SymbolTokenUri aliases ← mapped from Symbols publishing group
+                 ├─ SymbolServer / SymbolTokenUri aliases ← mapped from Symbols Publishing group
                  └─ all package versions, paths, build variables
 ```
 
@@ -382,7 +382,7 @@ The pipeline resolves `effective*Version` variables at compile time based on the
 | Group | Included In | Purpose |
 |-------|------------|---------|
 | `Release Variables` | `build-variables.yml` | Release-specific configuration |
-| `Symbols publishing` | `build-variables.yml` | Symbol publishing credentials (`SymbolsAzureSubscription`, `SymbolsPublishServer`, `SymbolsPublishTokenUri`, `SymbolsUploadAccount`, `SymbolsPublishProjectName`) |
+| `Symbols Publishing` | `build-variables.yml` | Symbol publishing credentials (`SymbolsAzureSubscription`, `SymbolsPublishServer`, `SymbolsPublishTokenUri`, `SymbolsUploadAccount`, `SymbolsPublishProjectName`) |
 | `ESRP Federated Creds (AME)` | `common-variables.yml` | Federated identity for ESRP signing (`ESRPConnectedServiceName`, `ESRPClientId`, `AppRegistrationClientId`, `AppRegistrationTenantId`, `AuthAKVName`, `AuthSignCertName`) |
 
 ---
@@ -513,7 +513,7 @@ pr: none
 | **Build agents** | OneBranch-managed Windows containers (`WindowsHostVersion: 1ESWindows2022`) |
 | **.NET SDK** | Pinned via `global.json` (with `useGlobalJson: true` in install steps) |
 | **Code signing** | ESRP v2 with federated identity (Azure Key Vault backed) |
-| **Symbol publishing** | Optional, controlled by `publishSymbols` parameter; uses `Symbols publishing` variable group (aliases `SymbolServer`/`SymbolTokenUri` defined in `common-variables.yml`) |
+| **Symbol publishing** | Optional, controlled by `publishSymbols` parameter; uses `Symbols Publishing` variable group (aliases `SymbolServer`/`SymbolTokenUri` defined in `common-variables.yml`) |
 
 ---
 

--- a/.github/instructions/onebranch-pipeline-design.instructions.md
+++ b/.github/instructions/onebranch-pipeline-design.instructions.md
@@ -349,7 +349,6 @@ dotnet-sqlclient-official-pipeline.yml
             ├─ group: 'Symbols Publishing'          ← SymbolsPublishServer, SymbolsPublishTokenUri, etc.
             └─ libraries/common-variables.yml
                  ├─ group: 'ESRP Federated Creds (AME)'  ← ESRP signing credentials
-                 ├─ SymbolServer / SymbolTokenUri aliases ← mapped from Symbols Publishing group
                  └─ all package versions, paths, build variables
 ```
 
@@ -373,8 +372,11 @@ The pipeline resolves `effective*Version` variables at compile time based on the
 | Variable | Defined In | Purpose |
 |----------|-----------|---------|
 | `NuGetServiceConnection` | `libraries/common-variables.yml` | External NuGet service connection name for `NuGetCommand@2` push |
-| `SymbolServer` | `libraries/common-variables.yml` (alias) | Alias for `$(SymbolsPublishServer)` — used by MDS `publish-symbols-step.yml` |
-| `SymbolTokenUri` | `libraries/common-variables.yml` (alias) | Alias for `$(SymbolsPublishTokenUri)` — used by MDS `publish-symbols-step.yml` |
+| `SymbolsPublishServer` | `Symbols Publishing` variable group | Symbol publishing service hostname prefix |
+| `SymbolsPublishTokenUri` | `Symbols Publishing` variable group | Resource URI for acquiring a bearer token |
+| `SymbolsAzureSubscription` | `Symbols Publishing` variable group | Azure subscription for the AzureCLI@2 publish task |
+| `SymbolsUploadAccount` | `Symbols Publishing` variable group | Account name for the PublishSymbols@2 upload task |
+| `SymbolsPublishProjectName` | `Symbols Publishing` variable group | Project name registered with the symbol publishing service |
 
 ### 6.4 Variable Groups
 
@@ -512,7 +514,7 @@ pr: none
 | **Build agents** | OneBranch-managed Windows containers (`WindowsHostVersion: 1ESWindows2022`) |
 | **.NET SDK** | Pinned via `global.json` (with `useGlobalJson: true` in install steps) |
 | **Code signing** | ESRP v2 with federated identity (Azure Key Vault backed) |
-| **Symbol publishing** | Optional, controlled by `publishSymbols` parameter; uses `Symbols Publishing` variable group (aliases `SymbolServer`/`SymbolTokenUri` defined in `common-variables.yml`) |
+| **Symbol publishing** | Optional, controlled by `publishSymbols` parameter; uses `Symbols Publishing` variable group variables directly. The publish step calls an extracted `Publish-Symbols.ps1` script with structured error handling. `_$(System.JobAttempt)` is appended to the artifact name for retry safety. |
 
 ---
 

--- a/.github/instructions/onebranch-pipeline-design.instructions.md
+++ b/.github/instructions/onebranch-pipeline-design.instructions.md
@@ -382,7 +382,6 @@ The pipeline resolves `effective*Version` variables at compile time based on the
 
 | Group | Included In | Purpose |
 |-------|------------|---------|
-
 | `Symbols Publishing` | `build-variables.yml` | Symbol publishing credentials (`SymbolsAzureSubscription`, `SymbolsPublishServer`, `SymbolsPublishTokenUri`, `SymbolsUploadAccount`, `SymbolsPublishProjectName`) |
 | `ESRP Federated Creds (AME)` | `common-variables.yml` | Federated identity for ESRP signing (`ESRPConnectedServiceName`, `ESRPClientId`, `AppRegistrationClientId`, `AppRegistrationTenantId`, `AuthAKVName`, `AuthSignCertName`) |
 

--- a/.github/instructions/onebranch-pipeline-design.instructions.md
+++ b/.github/instructions/onebranch-pipeline-design.instructions.md
@@ -346,7 +346,6 @@ Variables are defined in a layered template chain. All variable groups live insi
 dotnet-sqlclient-official-pipeline.yml
   └─ libraries/variables.yml
        └─ libraries/build-variables.yml
-            ├─ group: 'Release Variables'
             ├─ group: 'Symbols Publishing'          ← SymbolsPublishServer, SymbolsPublishTokenUri, etc.
             └─ libraries/common-variables.yml
                  ├─ group: 'ESRP Federated Creds (AME)'  ← ESRP signing credentials
@@ -381,7 +380,7 @@ The pipeline resolves `effective*Version` variables at compile time based on the
 
 | Group | Included In | Purpose |
 |-------|------------|---------|
-| `Release Variables` | `build-variables.yml` | Release-specific configuration |
+
 | `Symbols Publishing` | `build-variables.yml` | Symbol publishing credentials (`SymbolsAzureSubscription`, `SymbolsPublishServer`, `SymbolsPublishTokenUri`, `SymbolsUploadAccount`, `SymbolsPublishProjectName`) |
 | `ESRP Federated Creds (AME)` | `common-variables.yml` | Federated identity for ESRP signing (`ESRPConnectedServiceName`, `ESRPClientId`, `AppRegistrationClientId`, `AppRegistrationTenantId`, `AuthAKVName`, `AuthSignCertName`) |
 

--- a/eng/pipelines/onebranch/steps/Publish-Symbols.ps1
+++ b/eng/pipelines/onebranch/steps/Publish-Symbols.ps1
@@ -1,0 +1,193 @@
+<#
+.SYNOPSIS
+    Publishes symbols to the Microsoft symbol publishing service (SymWeb/MSDL).
+
+.DESCRIPTION
+    This script uploads and publishes debug symbols (.pdb files) to internal and/or public
+    Microsoft symbol servers via the Symbols Publishing Pipeline REST API.
+
+    It performs three steps:
+      1. Acquires a bearer token from Azure CLI for the symbol publishing service.
+      2. Registers a unique request name with the publishing service.
+      3. Submits the request to publish symbols to the specified servers.
+      4. Queries the publishing status for confirmation.
+
+    For more details on the Symbols Publishing Pipeline, see:
+    https://www.osgwiki.com/wiki/Symbols_Publishing_Pipeline_to_SymWeb_and_MSDL
+
+.PARAMETER PublishServer
+    The hostname prefix of the symbol publishing service. This value is prepended to
+    '.trafficmanager.net' to construct the service base URL.
+
+.PARAMETER PublishTokenUri
+    The resource URI used to acquire a bearer token from Azure CLI
+    (via 'az account get-access-token --resource <uri>').
+
+.PARAMETER PublishProjectName
+    The project name registered with the symbol publishing service (decided during onboarding).
+
+.PARAMETER ArtifactName
+    The name of the publishing request. This must match the SymbolsArtifactName used by
+    the PublishSymbols@2 upload task so that upload and publish reference the same artifact.
+
+.PARAMETER PublishToInternal
+    Whether to publish symbols to the internal symbol server. Defaults to $true.
+
+.PARAMETER PublishToPublic
+    Whether to publish symbols to the public symbol server. Defaults to $true.
+
+.EXAMPLE
+    .\Publish-Symbols.ps1 `
+        -PublishServer "mysymbolserver" `
+        -PublishTokenUri "https://login.microsoftonline.com/..." `
+        -PublishProjectName "Microsoft.Data.SqlClient.SNI" `
+        -ArtifactName "mds_symbols_MyProject_dotnet-sqlclient_main_7.0.0_abc123_1"
+
+    Publishes symbols to both internal and public servers using the specified parameters.
+
+.EXAMPLE
+    .\Publish-Symbols.ps1 `
+        -PublishServer "mysymbolserver" `
+        -PublishTokenUri "https://login.microsoftonline.com/..." `
+        -PublishProjectName "Microsoft.Data.SqlClient.SNI" `
+        -ArtifactName "mds_symbols_MyProject_dotnet-sqlclient_main_7.0.0_abc123_2" `
+        -PublishToPublic $false
+
+    Publishes symbols to the internal server only (retry attempt 2).
+
+.NOTES
+    File Name : Publish-Symbols.ps1
+    Requires  : Azure CLI (az) must be installed and authenticated.
+    Called by : publish-symbols-step.yml (Azure Pipelines template)
+
+    Publishing status codes returned by the service:
+
+    PublishingStatus:
+      0 - NotRequested: The request has not been requested to publish.
+      1 - Submitted: The request is submitted to be published.
+      2 - Processing: The request is still being processed.
+      3 - Completed: Processing finished. Check PublishingResult for details.
+
+    PublishingResult:
+      0 - Pending: The request has not completed or has not been requested.
+      1 - Succeeded: The request published successfully.
+      2 - Failed: The request failed to publish.
+      3 - Cancelled: The request was cancelled.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, HelpMessage = "Hostname prefix of the symbol publishing service (prepended to .trafficmanager.net).")]
+    [ValidateNotNullOrEmpty()]
+    [string]$PublishServer,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Resource URI for acquiring a bearer token via Azure CLI.")]
+    [ValidateNotNullOrEmpty()]
+    [string]$PublishTokenUri,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Project name registered with the symbol publishing service.")]
+    [ValidateNotNullOrEmpty()]
+    [string]$PublishProjectName,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Artifact name for the publishing request (must match PublishSymbols@2 SymbolsArtifactName).")]
+    [ValidateNotNullOrEmpty()]
+    [string]$ArtifactName,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Publish symbols to the internal symbol server.")]
+    [bool]$PublishToInternal = $true,
+
+    [Parameter(Mandatory = $false, HelpMessage = "Publish symbols to the public symbol server.")]
+    [bool]$PublishToPublic = $true
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# --- Log input parameters ---
+Write-Host "=== Publish Symbols Parameters ==="
+Write-Host "PublishServer:      ${PublishServer}"
+Write-Host "PublishTokenUri:    ${PublishTokenUri}"
+Write-Host "PublishProjectName: ${PublishProjectName}"
+Write-Host "ArtifactName:       ${ArtifactName}"
+Write-Host "PublishToInternal:  ${PublishToInternal}"
+Write-Host "PublishToPublic:    ${PublishToPublic}"
+Write-Host "=================================="
+
+# --- Build request name and URLs ---
+$requestName = ${ArtifactName}
+$baseUrl     = "https://${PublishServer}.trafficmanager.net/projects/${PublishProjectName}"
+$registerUrl = "${baseUrl}/requests"
+$requestUrl  = "${baseUrl}/requests/${requestName}"
+
+Write-Host "=== Constructed URLs ==="
+Write-Host "Request Name: ${requestName}"
+Write-Host "Base URL:     ${baseUrl}"
+Write-Host "Register URL: ${registerUrl}"
+Write-Host "Request URL:  ${requestUrl}"
+Write-Host "========================"
+
+# --- Step 1: Acquire token ---
+Write-Host ">  1. Acquiring symbol publishing token..."
+$symbolPublishingToken = az account get-access-token --resource ${PublishTokenUri} --query accessToken -o tsv
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to acquire symbol publishing token via Azure CLI (exit code: ${LASTEXITCODE})."
+}
+if ($null -ne $symbolPublishingToken) {
+    $symbolPublishingToken = $symbolPublishingToken.Trim()
+}
+if ([string]::IsNullOrWhiteSpace($symbolPublishingToken)) {
+    throw "Failed to acquire symbol publishing token via Azure CLI: received an empty or whitespace-only access token."
+}
+Write-Host ">  1. Symbol publishing token acquired."
+
+$authHeaders = @{ Authorization = "Bearer ${symbolPublishingToken}" }
+
+# --- Step 2: Register request name ---
+Write-Host ">  2. Registering request name..."
+$requestNameRegistrationBody = @{ requestName = $requestName } | ConvertTo-Json -Compress
+try {
+    Invoke-RestMethod -Method POST -Uri ${registerUrl} -Headers ${authHeaders} -ContentType "application/json" -Body ${requestNameRegistrationBody}
+} catch {
+    throw "Failed to register request name. URI: ${registerUrl} | Body: ${requestNameRegistrationBody} | Error: $_"
+}
+Write-Host ">  2. Request name registered successfully."
+
+# --- Step 3: Publish symbols ---
+Write-Host ">  3. Submitting request to publish symbols..."
+$publishSymbolsBody = @{
+    publishToInternalServer = $PublishToInternal
+    publishToPublicServer   = $PublishToPublic
+} | ConvertTo-Json -Compress
+Write-Host "Publishing symbols request body: ${publishSymbolsBody}"
+try {
+    Invoke-RestMethod -Method POST -Uri ${requestUrl} -Headers ${authHeaders} -ContentType "application/json" -Body ${publishSymbolsBody}
+} catch {
+    throw "Failed to publish symbols. URI: ${requestUrl} | Body: ${publishSymbolsBody} | Error: $_"
+}
+Write-Host ">  3. Request to publish symbols submitted successfully."
+
+# --- Step 4: Check status ---
+Write-Host ">  4. Checking the status of the request..."
+try {
+    $status = Invoke-RestMethod -Method GET -Uri ${requestUrl} -Headers ${authHeaders} -ContentType "application/json"
+    $status
+} catch {
+    throw "Failed to check request status. URI: ${requestUrl} | Error: $_"
+}
+
+Write-Host ""
+Write-Host "Use below tables to interpret the xxxServerStatus and xxxServerResult fields from the response."
+Write-Host ""
+Write-Host "PublishingStatus"
+Write-Host "-----------------"
+Write-Host "0  NotRequested - The request has not been requested to publish."
+Write-Host "1  Submitted    - The request is submitted to be published."
+Write-Host "2  Processing   - The request is still being processed."
+Write-Host "3  Completed    - Processing finished. Check PublishingResult for details."
+Write-Host ""
+Write-Host "PublishingResult"
+Write-Host "-----------------"
+Write-Host "0  Pending   - The request has not completed or has not been requested."
+Write-Host "1  Succeeded - The request published successfully."
+Write-Host "2  Failed    - The request failed to publish."
+Write-Host "3  Cancelled - The request was cancelled."

--- a/eng/pipelines/onebranch/steps/Publish-Symbols.ps1
+++ b/eng/pipelines/onebranch/steps/Publish-Symbols.ps1
@@ -6,7 +6,7 @@
     This script uploads and publishes debug symbols (.pdb files) to internal and/or public
     Microsoft symbol servers via the Symbols Publishing Pipeline REST API.
 
-    It performs three steps:
+    It performs four steps:
       1. Acquires a bearer token from Azure CLI for the symbol publishing service.
       2. Registers a unique request name with the publishing service.
       3. Submits the request to publish symbols to the specified servers.

--- a/eng/pipelines/onebranch/steps/publish-symbols-step.yml
+++ b/eng/pipelines/onebranch/steps/publish-symbols-step.yml
@@ -5,6 +5,10 @@
 #                                                                                  #
 # doc: https://www.osgwiki.com/wiki/Symbols_Publishing_Pipeline_to_SymWeb_and_MSDL #
 ####################################################################################
+
+# The Symbols* variable defaults (e.g. SymbolsPublishServer, SymbolsUploadAccount) are sourced from
+# the 'Symbols Publishing' variable group, imported via common-variables.yml.
+
 parameters:
 
   # The full name of the package whose symbols are being published.
@@ -18,17 +22,17 @@ parameters:
   # Our symbols account name.
   - name: symbolsAccount
     type: string
-    default: SqlClientDrivers
+    default: $(SymbolsUploadAccount)
 
   # The symbols server to publish to.
   - name: symbolServer
     type: string
-    default: $(SymbolServer)
+    default: $(SymbolsPublishServer)
 
   # The token URI for the symbol publishing service.
   - name: symbolTokenUri
     type: string
-    default: $(SymbolTokenUri)
+    default: $(SymbolsPublishTokenUri)
 
   # A pair of flags indicating whether to publish to the internal and public symbol servers.  Both
   # default to true.
@@ -62,7 +66,7 @@ steps:
 - task: AzureCLI@2
   displayName: 'Publish symbols'
   inputs:
-    azureSubscription: 'Symbols publishing Workload Identity federation service-ADO.Net'
+    azureSubscription: $(SymbolsAzureSubscription)
     scriptType: ps
     scriptLocation: inlineScript
     inlineScript: |
@@ -76,7 +80,7 @@ steps:
       $symbolServer = "${{parameters.symbolServer }}"
       $tokenUri = "${{parameters.symbolTokenUri }}"
       # Registered project name in the symbol publishing pipeline: https://portal.microsofticm.com/imp/v3/incidents/incident/520844254/summary
-      $projectName = "Microsoft.Data.SqlClient.SNI"
+      $projectName = "$(SymbolsPublishProjectName)"
 
       # Get the access token for the symbol publishing service
       $symbolPublishingToken = az account get-access-token --resource $tokenUri --query accessToken -o tsv

--- a/eng/pipelines/onebranch/steps/publish-symbols-step.yml
+++ b/eng/pipelines/onebranch/steps/publish-symbols-step.yml
@@ -34,6 +34,16 @@ parameters:
     type: string
     default: $(SymbolsPublishTokenUri)
 
+  # The Azure subscription to use for the AzureCLI@2 publish task.
+  - name: symbolsAzureSubscription
+    type: string
+    default: $(SymbolsAzureSubscription)
+
+  # The project name registered with the symbol publishing service.
+  - name: symbolsPublishProjectName
+    type: string
+    default: $(SymbolsPublishProjectName)
+
   # A pair of flags indicating whether to publish to the internal and public symbol servers.  Both
   # default to true.
   - name: publishToServers
@@ -60,64 +70,20 @@ steps:
     SymbolExpirationInDays: 1825 # 5 years
     SymbolsProduct: ${{ parameters.packageFullName }}
     SymbolsVersion: ${{ parameters.packageVersion }}
-    SymbolsArtifactName: $(symbolsArtifactName)
+    SymbolsArtifactName: $(symbolsArtifactName)_$(System.JobAttempt)
     Pat: $(System.AccessToken)
 
 - task: AzureCLI@2
   displayName: 'Publish symbols'
   inputs:
-    azureSubscription: $(SymbolsAzureSubscription)
+    azureSubscription: '${{parameters.symbolsAzureSubscription }}'
     scriptType: ps
-    scriptLocation: inlineScript
-    inlineScript: |
-      $publishToInternalServer = "${{parameters.publishToServers.internal }}".ToLower()
-      $publishToPublicServer = "${{parameters.publishToServers.public }}".ToLower()
-
-      echo "Publishing request name: $(symbolsArtifactName)"
-      echo "Publish to internal server: $publishToInternalServer"
-      echo "Publish to public server: $publishToPublicServer"
-
-      $symbolServer = "${{parameters.symbolServer }}"
-      $tokenUri = "${{parameters.symbolTokenUri }}"
-      # Registered project name in the symbol publishing pipeline: https://portal.microsofticm.com/imp/v3/incidents/incident/520844254/summary
-      $projectName = "$(SymbolsPublishProjectName)"
-
-      # Get the access token for the symbol publishing service
-      $symbolPublishingToken = az account get-access-token --resource $tokenUri --query accessToken -o tsv
-
-      echo ">  1.Symbol publishing token acquired."
-
-      echo "Registering the request name ..."
-      $requestName = "$(symbolsArtifactName)"
-      $requestNameRegistrationBody = "{'requestName': '$requestName'}"
-      Invoke-RestMethod -Method POST -Uri "https://$symbolServer.trafficmanager.net/projects/$projectName/requests" -Headers @{ Authorization = "Bearer $symbolPublishingToken" } -ContentType "application/json" -Body $requestNameRegistrationBody
-
-      echo ">  2.Registration of request name succeeded."
-
-      echo "Publishing the symbols ..."
-      $publishSymbolsBody = "{'publishToInternalServer': $publishToInternalServer, 'publishToPublicServer': $publishToPublicServer}"
-      echo "Publishing symbols request body: $publishSymbolsBody"
-      Invoke-RestMethod -Method POST -Uri "https://$symbolServer.trafficmanager.net/projects/$projectName/requests/$requestName" -Headers @{ Authorization = "Bearer $symbolPublishingToken" } -ContentType "application/json" -Body $publishSymbolsBody
-
-      echo ">  3.Request to publish symbols succeeded."
-
-      # The following REST calls are used to check publishing status.
-      echo ">  4.Checking the status of the request ..."
-
-      Invoke-RestMethod -Method GET -Uri "https://$symbolServer.trafficmanager.net/projects/$projectName/requests/$requestName" -Headers @{ Authorization = "Bearer $symbolPublishingToken" } -ContentType "application/json"
-
-      echo "Use below tables to interpret the values of xxxServerStatus and xxxServerResult fields from the response."
-
-      echo "PublishingStatus"
-      echo "-----------------"
-      echo "0	NotRequested; The request has not been requested to publish."
-      echo "1	Submitted; The request is submitted to be published"
-      echo "2	Processing; The request is still being processed"
-      echo "3	Completed; The request has been completed processing. It can be failed or successful. Check PublishingResult to get more details"
-
-      echo "PublishingResult"
-      echo "-----------------"
-      echo "0	Pending; The request has not completed or has not been requested."
-      echo "1	Succeeded; The request has published successfully"
-      echo "2	Failed; The request has failed to publish"
-      echo "3	Cancelled; The request was cancelled"
+    scriptLocation: scriptPath
+    scriptPath: '$(Build.SourcesDirectory)/eng/pipelines/onebranch/steps/Publish-Symbols.ps1'
+    arguments: >-
+      -PublishServer "${{parameters.symbolServer }}"
+      -PublishTokenUri "${{parameters.symbolTokenUri }}"
+      -PublishProjectName "${{parameters.symbolsPublishProjectName }}"
+      -ArtifactName "$(symbolsArtifactName)_$(System.JobAttempt)"
+      -PublishToInternal $${{parameters.publishToServers.internal }}
+      -PublishToPublic $${{parameters.publishToServers.public }}

--- a/eng/pipelines/onebranch/steps/tests/Publish-Symbols.Tests.ps1
+++ b/eng/pipelines/onebranch/steps/tests/Publish-Symbols.Tests.ps1
@@ -1,0 +1,232 @@
+<#
+.SYNOPSIS
+    Pester tests for Publish-Symbols.ps1
+#>
+
+BeforeAll {
+    $scriptPath = Join-Path $PSScriptRoot '..' 'Publish-Symbols.ps1'
+}
+
+AfterAll {
+    # Clean up global variables used by mocks
+    Remove-Variable -Name 'restCalls' -Scope Global -ErrorAction SilentlyContinue
+    Remove-Variable -Name 'mockCallCount' -Scope Global -ErrorAction SilentlyContinue
+}
+
+Describe 'Publish-Symbols.ps1 Parameter Validation' {
+
+    It 'Should reject an empty PublishServer' {
+        { & $scriptPath -PublishServer '' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName 'art' } |
+            Should -Throw
+    }
+
+    It 'Should reject an empty PublishTokenUri' {
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri '' -PublishProjectName 'proj' -ArtifactName 'art' } |
+            Should -Throw
+    }
+
+    It 'Should reject an empty PublishProjectName' {
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName '' -ArtifactName 'art' } |
+            Should -Throw
+    }
+
+    It 'Should reject an empty ArtifactName' {
+        { & $scriptPath -PublishServer 'server' -PublishTokenUri 'https://token' -PublishProjectName 'proj' -ArtifactName '' } |
+            Should -Throw
+    }
+}
+
+Describe 'Publish-Symbols.ps1 URL Construction' {
+
+    BeforeAll {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token-12345' }
+
+        $global:restCalls = @()
+        Mock -CommandName 'Invoke-RestMethod' -MockWith {
+            $global:restCalls += @{
+                Method = $Method
+                Uri    = $Uri
+                Body   = $Body
+            }
+            return @{ internalServerStatus = 0; publicServerStatus = 0 }
+        }
+    }
+
+    BeforeEach {
+        $global:restCalls = @()
+    }
+
+    It 'Should construct the correct base URL from PublishServer and PublishProjectName' {
+        & $scriptPath `
+            -PublishServer 'myserver' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'My.Project' `
+            -ArtifactName 'test_artifact'
+
+        $global:restCalls.Count | Should -Be 3
+
+        # Registration call
+        $global:restCalls[0].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests'
+        $global:restCalls[0].Method | Should -Be 'POST'
+
+        # Publish call
+        $global:restCalls[1].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact'
+        $global:restCalls[1].Method | Should -Be 'POST'
+
+        # Status call
+        $global:restCalls[2].Uri | Should -Be 'https://myserver.trafficmanager.net/projects/My.Project/requests/test_artifact'
+        $global:restCalls[2].Method | Should -Be 'GET'
+    }
+
+    It 'Should use ArtifactName directly as the request name' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'myartifact_3'
+
+        $global:restCalls[1].Uri | Should -BeLike '*myartifact_3'
+        $global:restCalls[2].Uri | Should -BeLike '*myartifact_3'
+    }
+}
+
+Describe 'Publish-Symbols.ps1 Request Bodies' {
+
+    BeforeAll {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token-12345' }
+
+        $global:restCalls = @()
+        Mock -CommandName 'Invoke-RestMethod' -MockWith {
+            $global:restCalls += @{
+                Method = $Method
+                Uri    = $Uri
+                Body   = $Body
+            }
+            return @{ internalServerStatus = 0; publicServerStatus = 0 }
+        }
+    }
+
+    BeforeEach {
+        $global:restCalls = @()
+    }
+
+    It 'Should send the correct request name in the registration body' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'my_artifact_1'
+
+        $body = $global:restCalls[0].Body | ConvertFrom-Json
+        $body.requestName | Should -Be 'my_artifact_1'
+    }
+
+    It 'Should default to publishing to both internal and public servers' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art'
+
+        $body = $global:restCalls[1].Body | ConvertFrom-Json
+        $body.publishToInternalServer | Should -Be $true
+        $body.publishToPublicServer | Should -Be $true
+    }
+
+    It 'Should respect PublishToInternal=false' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -PublishToInternal $false
+
+        $body = $global:restCalls[1].Body | ConvertFrom-Json
+        $body.publishToInternalServer | Should -Be $false
+        $body.publishToPublicServer | Should -Be $true
+    }
+
+    It 'Should respect PublishToPublic=false' {
+        & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' `
+            -PublishToPublic $false
+
+        $body = $global:restCalls[1].Body | ConvertFrom-Json
+        $body.publishToInternalServer | Should -Be $true
+        $body.publishToPublicServer | Should -Be $false
+    }
+}
+
+Describe 'Publish-Symbols.ps1 Error Handling' {
+
+    It 'Should throw when token acquisition fails' {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 1; return '' }
+
+        { & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' } |
+            Should -Throw '*token*'
+    }
+
+    It 'Should throw when token is empty' {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return '  ' }
+
+        { & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' } |
+            Should -Throw '*empty*'
+    }
+
+    It 'Should throw with URI details when registration fails' {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token' }
+        Mock -CommandName 'Invoke-RestMethod' -MockWith { throw "Connection refused" }
+
+        { & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' } |
+            Should -Throw '*Failed to register*'
+    }
+
+    It 'Should throw with URI details when publish fails' {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token' }
+        $global:mockCallCount = 0
+        Mock -CommandName 'Invoke-RestMethod' -MockWith {
+            $global:mockCallCount++
+            if ($global:mockCallCount -eq 1) { return @{} }
+            throw "Service unavailable"
+        }
+
+        { & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' } |
+            Should -Throw '*Failed to publish*'
+    }
+
+    It 'Should throw with URI details when status check fails' {
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 0; return 'fake-token' }
+        $global:mockCallCount = 0
+        Mock -CommandName 'Invoke-RestMethod' -MockWith {
+            $global:mockCallCount++
+            if ($global:mockCallCount -le 2) { return @{} }
+            throw "Timeout"
+        }
+
+        { & $scriptPath `
+            -PublishServer 'srv' `
+            -PublishTokenUri 'https://token-uri' `
+            -PublishProjectName 'proj' `
+            -ArtifactName 'art' } |
+            Should -Throw '*Failed to check*'
+    }
+}

--- a/eng/pipelines/onebranch/steps/tests/README.md
+++ b/eng/pipelines/onebranch/steps/tests/README.md
@@ -1,0 +1,42 @@
+# Publish-Symbols Tests
+
+Pester tests for the `Publish-Symbols.ps1` script used by the symbol publishing pipeline step.
+
+## Prerequisites
+
+- PowerShell 5.1+ or PowerShell 7+
+- [Pester v5](https://pester.dev/) (`Install-Module Pester -MinimumVersion 5.0 -Scope CurrentUser`)
+
+## Running the Tests
+
+From this directory:
+
+```powershell
+Invoke-Pester ./Publish-Symbols.Tests.ps1
+```
+
+Or from the repository root:
+
+```powershell
+Invoke-Pester ./eng/pipelines/onebranch/steps/tests/
+```
+
+For detailed output:
+
+```powershell
+Invoke-Pester ./Publish-Symbols.Tests.ps1 -Output Detailed
+```
+
+## Test Coverage
+
+| Area                  | What's tested                                                    |
+|-----------------------|------------------------------------------------------------------|
+| Parameter validation  | Empty strings rejected for all mandatory parameters              |
+| URL construction      | Base URL, register URL, request URL built from parameters        |
+| Request bodies        | Registration body, default publish flags, flag overrides         |
+| Error handling        | Token failure, registration failure, publish failure, status failure — all verify expanded URI in error message |
+
+## Notes
+
+- All external calls (`az`, `Invoke-RestMethod`) are mocked — no network access or Azure credentials are required.
+- Tests validate the script at `../Publish-Symbols.ps1` relative to this directory.

--- a/eng/pipelines/onebranch/variables/common-variables.yml
+++ b/eng/pipelines/onebranch/variables/common-variables.yml
@@ -4,13 +4,11 @@
 # See the LICENSE file in the project root for more information.                #
 #################################################################################
 
-# Common variables shared across all OneBranch Official pipelines.
+# Common variables shared across all OneBranch pipelines.
 
 variables:
-  - group: Release Variables
-
-  # Symbols publishing credentials
-  - group: Symbols publishing
+  # Symbols Publishing credentials
+  - group: Symbols Publishing
     # SymbolsAzureSubscription
     # SymbolsPublishProjectName
     # SymbolsPublishServer
@@ -174,14 +172,3 @@ variables:
   # The AssemblyFileVersion for all assemblies in the AKV Provider package.
   - name: akvAssemblyFileVersion
     value: 7.0.0.$(assemblyBuildNumber)
-
-  # ----------------------------------------------------------------------------
-  # MDS Symbols Publishing
-  #
-  # Alias variables for MDS publish-symbols-step.yml, which defaults to
-  # $(SymbolServer) and $(SymbolTokenUri).  These map to the values provided
-  # by the "Symbols publishing" library group.
-  - name: SymbolServer
-    value: $(SymbolsPublishServer)
-  - name: SymbolTokenUri
-    value: $(SymbolsPublishTokenUri)

--- a/eng/pipelines/onebranch/variables/sqlclient-validation-variables.yml
+++ b/eng/pipelines/onebranch/variables/sqlclient-validation-variables.yml
@@ -7,7 +7,6 @@
 # This file is only included in MDS OneBranch Official pipelines.
 
 variables:
-  - group: Release Variables
   - template: /eng/pipelines/onebranch/variables/common-variables.yml@self
 
   - name: TempFolderName # extract the nuget package here


### PR DESCRIPTION
## Summary

Ports the symbol publishing improvements from the 6.1 branch (`dev/paul/release/6.1/symbols-publishing`) to the 7.0 OneBranch pipeline.

## Changes

- **Extract inline PowerShell → standalone `Publish-Symbols.ps1`** with:
  - Cmdlet parameter validation (`ValidateNotNullOrEmpty`)
  - `Set-StrictMode -Version Latest` and `$ErrorActionPreference = "Stop"`
  - Structured error handling with URI and body context in error messages
  - Clear step-by-step diagnostic logging
- **Append `_$(System.JobAttempt)` to `SymbolsArtifactName`** — ensures pipeline retries get a unique request name instead of colliding with the previous attempt
- **Add `symbolsAzureSubscription` and `symbolsPublishProjectName` as explicit template parameters** — previously referenced only as inline variables
- **Add Pester v5 tests** (15 tests) covering parameter validation, URL construction, request bodies, and error handling
- **Update design doc** to reflect the extracted script, removed alias variables, and retry suffix

## Test Results

All 15 Pester tests pass:
- Parameter validation (4 tests)
- URL construction (2 tests)
- Request bodies (4 tests)
- Error handling (5 tests)

## Checklist

- [x] Tests added or updated
- [x] Verified Pester tests pass locally
- [ ] Ensure no breaking changes introduced