### PR TITLE
Add 7.0.1 release notes

### DIFF
--- a/.github/prompts/release-notes.prompt.md
+++ b/.github/prompts/release-notes.prompt.md
@@ -1,19 +1,19 @@
 ---
 name: release-notes
 description: Generate release notes for a specific milestone, covering all packages in the repository that have changes.
-argument-hint: <milestone>
+argument-hint: <milestone> <branch>
 agent: agent
-tools: ['edit/createFile', 'edit/editFiles', 'read/readFile']
+tools: ['edit/createFile', 'edit/editFiles', 'read/readFile', 'execute/runInTerminal']
 ---
 
-Generate release notes for the milestone "${input:milestone}".
+Generate release notes for the milestone "${input:milestone}" on the branch "${input:branch}".
 
 This repository ships multiple packages. Only generate release notes for packages that have relevant PRs in the milestone. All packages use the same template: [release-notes/template/release-notes-template.md](release-notes/template/release-notes-template.md).
 
 ## Package Registry
 
 | Package | Release Notes Directory | How to Identify PRs |
-|---------|------------------------|---------------------|
+| ------- | ----------------------- | ------------------- |
 | `Microsoft.Data.SqlClient` | `release-notes/<Major.Minor>/` | Default — PRs not assigned to another package |
 | `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider` | `release-notes/add-ons/AzureKeyVaultProvider/<Major.Minor>/` | Labels containing `AKV`, or PR titles/bodies/files referencing `AzureKeyVaultProvider`, `add-ons/`, or `AlwaysEncrypted.AzureKeyVaultProvider` |
 | `Microsoft.SqlServer.Server` | `release-notes/MSqlServerServer/<Major.Minor>/` | PR titles/bodies/files referencing `Microsoft.SqlServer.Server` or `src/Microsoft.SqlServer.Server/` |
@@ -26,7 +26,7 @@ This repository ships multiple packages. Only generate release notes for package
 Each package has its own versioning and dependency sources. Use these to determine package versions and dependency lists:
 
 | Package | Version Source | Dependency Source |
-|---------|---------------|-------------------|
+| ------- | -------------- | ----------------- |
 | `Microsoft.Data.SqlClient` | [tools/props/Versions.props](tools/props/Versions.props) (`MdsVersionDefault`) | [Directory.Packages.props](Directory.Packages.props) and the [project file](src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj) |
 | `AzureKeyVaultProvider` | [tools/props/Versions.props](tools/props/Versions.props) (`AkvVersionDefault`) | [AKV project file](src/Microsoft.Data.SqlClient/add-ons/AzureKeyVaultProvider/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj) and [Directory.Packages.props](Directory.Packages.props) |
 | `Microsoft.SqlServer.Server` | [tools/props/Versions.props](tools/props/Versions.props) (`SqlServerPackageVersion`) | [SqlServer project file](src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj) |
@@ -46,7 +46,8 @@ This prompt uses the following skill:
 ### 1. Fetch Milestone Items
 
 - Follow the instructions in the [fetch-milestone-prs](.github/skills/fetch-milestone-prs/SKILL.md) skill to fetch all merged PRs for the milestone "${input:milestone}".
-- The output will be saved to `.milestone-prs/${input:milestone}/` with individual JSON files per PR and an `_index.json` summary.
+- The output will be saved to `.milestone-prs/${input:milestone}/${input:branch}` with individual JSON files per PR and an `_index.json` summary.
+- Identify any milestone items that don't have corresponding commits on the release branch "${input:branch}", and vice versa.
 
 ### 2. Analyze and Categorize
 
@@ -118,6 +119,14 @@ For each package that has relevant PRs in the milestone:
   - Add the new release to the appropriate package section.
   - If a section for the package doesn't yet exist, add one following the existing pattern (see the `AzureKeyVaultProvider` and `Microsoft.SqlServer.Server` sections for reference).
   - If the section already exists, add the new version link to its Release Information list.
+
+### 8. Markdown for GitHub Release
+
+- Use the contents of the new release notes markdown file to produce markdown suitable for pasting into a GitHub UI Release textbox.
+  - GitHub renders newlines within paragraphs and lists as hard breaks, so remove those.
+  - Omit the main heading and first sub-heading.
+  - Update any relative links to use absolute URLs pointing to the file in the repository.
+  - Provide this new markdown in a code block that can easily be copied and pasted directly into the GitHub UI.
 
 ## Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 > **Note:** Releases are sorted in reverse chronological order (newest first).
 
-## [Stable Release 7.0.1] - 2026-04-14
+## [Stable Release 7.0.1] - 2026-04-23
 
 This update brings the following changes since the [7.0.0](release-notes/7.0/7.0.0.md) release.
 See the [full release notes](release-notes/7.0/7.0.1.md) for detailed descriptions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 > **Note:** Releases are sorted in reverse chronological order (newest first).
 
+## [Stable Release 7.0.1] - 2026-04-14
+
+This update brings the following changes since the [7.0.0](release-notes/7.0/7.0.0.md) release.
+See the [full release notes](release-notes/7.0/7.0.1.md) for detailed descriptions.
+
+### Fixed
+
+- Fixed `SqlBulkCopy` failing on SQL Server 2016 with `Invalid column name 'graph_type'` error by using dynamic SQL to extract column names.
+  ([#3714](https://github.com/dotnet/SqlClient/issues/3714),
+   [#4092](https://github.com/dotnet/SqlClient/pull/4092),
+   [#4147](https://github.com/dotnet/SqlClient/pull/4147))
+
+- Fixed `SqlBulkCopy` failing on Azure Synapse Analytics dedicated SQL pools by using `STRING_AGG` for the column-list query when targeting Synapse.
+  ([#4149](https://github.com/dotnet/SqlClient/issues/4149),
+   [#4176](https://github.com/dotnet/SqlClient/pull/4176),
+   [#4182](https://github.com/dotnet/SqlClient/pull/4182))
+
+- Fixed `SqlDataReader.GetFieldType()` and `GetProviderSpecificFieldType()` returning incorrect type for vector float32 columns.
+  ([#4104](https://github.com/dotnet/SqlClient/issues/4104),
+   [#4105](https://github.com/dotnet/SqlClient/pull/4105),
+   [#4152](https://github.com/dotnet/SqlClient/pull/4152))
+
+- Added missing `System.Data.Common` (v4.3.0) NuGet package dependency for .NET Framework consumers to resolve `CS0012` compilation errors.
+  ([#4063](https://github.com/dotnet/SqlClient/pull/4063),
+   [#4074](https://github.com/dotnet/SqlClient/pull/4074))
+
+### Changed
+
+- Enabled the User Agent TDS feature extension unconditionally; removed the `Switch.Microsoft.Data.SqlClient.EnableUserAgent` AppContext switch.
+  ([#4124](https://github.com/dotnet/SqlClient/pull/4124),
+   [#4154](https://github.com/dotnet/SqlClient/pull/4154))
+
+- Added type forwards from the core assembly to public types moved to `Microsoft.Data.SqlClient.Extensions.Abstractions`.
+  ([#4067](https://github.com/dotnet/SqlClient/pull/4067),
+   [#4117](https://github.com/dotnet/SqlClient/pull/4117))
+
+- Fixed API documentation include paths and duplicate doc snippets.
+  ([#4084](https://github.com/dotnet/SqlClient/pull/4084),
+   [#4086](https://github.com/dotnet/SqlClient/pull/4086),
+   [#4107](https://github.com/dotnet/SqlClient/pull/4107),
+   [#4161](https://github.com/dotnet/SqlClient/pull/4161))
+
 ## [Stable Release 7.0.0] - 2026-03-17
 
 This section summarizes all changes across the 7.0 preview cycle for users upgrading from the latest 6.1 stable release.

--- a/release-notes/7.0/7.0.1.md
+++ b/release-notes/7.0/7.0.1.md
@@ -1,0 +1,115 @@
+# Release Notes
+
+## Stable Release 7.0.1 - 2026-04-14
+
+This update brings the following changes since the [7.0.0](7.0.0.md) release:
+
+### Fixed
+
+- Fixed `SqlBulkCopy` failing on SQL Server 2016 with `Invalid column name 'graph_type'` error. The column metadata query now uses dynamic SQL so that references to the `graph_type` column (introduced in SQL Server 2017) are not compiled on older versions that lack the column.
+  ([#3714](https://github.com/dotnet/SqlClient/issues/3714),
+   [#4092](https://github.com/dotnet/SqlClient/pull/4092),
+   [#4147](https://github.com/dotnet/SqlClient/pull/4147))
+
+- Fixed `SqlBulkCopy` failing on Azure Synapse Analytics dedicated SQL pools. The column-list query previously used a variable-assignment pattern that Synapse does not support; it now uses `STRING_AGG` when targeting Synapse (engine edition 6) and falls back to the variable-assignment approach for SQL Server 2016 compatibility.
+  ([#4149](https://github.com/dotnet/SqlClient/issues/4149),
+   [#4176](https://github.com/dotnet/SqlClient/pull/4176),
+   [#4182](https://github.com/dotnet/SqlClient/pull/4182))
+
+- Fixed `SqlDataReader.GetFieldType()` and `GetProviderSpecificFieldType()` returning `typeof(byte[])` instead of `typeof(SqlVector<float>)` for vector float32 columns. The methods now follow the same type-determination logic as `GetValue()`.
+  ([#4104](https://github.com/dotnet/SqlClient/issues/4104),
+   [#4105](https://github.com/dotnet/SqlClient/pull/4105),
+   [#4152](https://github.com/dotnet/SqlClient/pull/4152))
+
+- Added missing `System.Data.Common` (v4.3.0) NuGet package dependency for .NET Framework consumers. The inbox `System.Data.Common` assembly on .NET Framework predates APIs such as `IDbColumnSchemaGenerator`; without the explicit NuGet dependency, consumers encountered `CS0012` compilation errors when using these types through `Microsoft.Data.SqlClient`.
+  ([#4063](https://github.com/dotnet/SqlClient/pull/4063),
+   [#4074](https://github.com/dotnet/SqlClient/pull/4074))
+
+### Changed
+
+- Enabled the User Agent TDS feature extension unconditionally. The `Switch.Microsoft.Data.SqlClient.EnableUserAgent` AppContext switch has been removed; the driver now always sends User Agent information during login.
+  ([#4124](https://github.com/dotnet/SqlClient/pull/4124),
+   [#4154](https://github.com/dotnet/SqlClient/pull/4154))
+
+- Added type forwards from the core `Microsoft.Data.SqlClient` assembly to public types that were moved to the `Microsoft.Data.SqlClient.Extensions.Abstractions` package: `SqlAuthenticationMethod`, `SqlAuthenticationParameters`, `SqlAuthenticationProvider`, `SqlAuthenticationProviderException`, and `SqlAuthenticationToken`. This ensures binary compatibility for assemblies compiled against earlier versions of `Microsoft.Data.SqlClient` where these types lived in the core assembly.
+  ([#4067](https://github.com/dotnet/SqlClient/pull/4067),
+   [#4117](https://github.com/dotnet/SqlClient/pull/4117))
+
+- Fixed API documentation include paths and duplicate doc snippets.
+  ([#4084](https://github.com/dotnet/SqlClient/pull/4084),
+   [#4086](https://github.com/dotnet/SqlClient/pull/4086),
+   [#4107](https://github.com/dotnet/SqlClient/pull/4107),
+   [#4161](https://github.com/dotnet/SqlClient/pull/4161))
+
+## Contributors
+
+We thank the following public contributors. Their efforts toward this project are very much appreciated.
+
+- [edwardneal](https://github.com/edwardneal)
+
+## Target Platform Support
+
+- .NET Framework 4.6.2+ (Windows x86, Windows x64, Windows ARM64)
+- .NET 8.0+ (Windows x86, Windows x64, Windows ARM, Windows ARM64, Linux, macOS)
+
+### Dependencies
+
+#### .NET 9.0
+
+- Microsoft.Bcl.Cryptography 9.0.13
+- Microsoft.Data.SqlClient.Extensions.Abstractions 1.0.0
+- Microsoft.Data.SqlClient.Internal.Logging 1.0.0
+- Microsoft.Data.SqlClient.SNI.runtime 6.0.2
+- Microsoft.Extensions.Caching.Memory 9.0.13
+- Microsoft.IdentityModel.JsonWebTokens 8.16.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 8.16.0
+- Microsoft.SqlServer.Server 1.0.0
+- System.Configuration.ConfigurationManager 9.0.13
+- System.Security.Cryptography.Pkcs 9.0.13
+
+#### .NET 8.0
+
+- Microsoft.Bcl.Cryptography 8.0.0
+- Microsoft.Data.SqlClient.Extensions.Abstractions 1.0.0
+- Microsoft.Data.SqlClient.Internal.Logging 1.0.0
+- Microsoft.Data.SqlClient.SNI.runtime 6.0.2
+- Microsoft.Extensions.Caching.Memory 8.0.1
+- Microsoft.IdentityModel.JsonWebTokens 8.16.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 8.16.0
+- Microsoft.SqlServer.Server 1.0.0
+- System.Configuration.ConfigurationManager 8.0.1
+- System.Security.Cryptography.Pkcs 8.0.1
+
+#### .NET Standard 2.0
+
+- Microsoft.Bcl.Cryptography 8.0.0
+- Microsoft.Data.SqlClient.Extensions.Abstractions 1.0.0
+- Microsoft.Data.SqlClient.Internal.Logging 1.0.0
+- Microsoft.Data.SqlClient.SNI.runtime 6.0.2
+- Microsoft.Extensions.Caching.Memory 8.0.1
+- Microsoft.IdentityModel.JsonWebTokens 8.16.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 8.16.0
+- Microsoft.SqlServer.Server 1.0.0
+- System.Configuration.ConfigurationManager 8.0.1
+- System.Security.Cryptography.Pkcs 8.0.1
+- System.Text.Json 10.0.3
+- System.Threading.Channels 10.0.3
+
+#### .NET Framework 4.6.2+
+
+- Microsoft.Bcl.Cryptography 8.0.0
+- Microsoft.Data.SqlClient.Extensions.Abstractions 1.0.0
+- Microsoft.Data.SqlClient.Internal.Logging 1.0.0
+- Microsoft.Data.SqlClient.SNI 6.0.2
+- Microsoft.Extensions.Caching.Memory 8.0.1
+- Microsoft.IdentityModel.JsonWebTokens 8.16.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 8.16.0
+- System.Buffers 4.6.1
+- System.Data.Common 4.3.0
+- System.Diagnostics.DiagnosticSource 10.0.3
+- System.Memory 4.6.3
+- System.Runtime.InteropServices.RuntimeInformation 4.3.0
+- System.Security.Cryptography.Pkcs 8.0.1
+- System.Text.Json 10.0.3
+- System.Threading.Channels 10.0.3
+- System.ValueTuple 4.6.2

--- a/release-notes/7.0/7.0.1.md
+++ b/release-notes/7.0/7.0.1.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Stable Release 7.0.1 - 2026-04-14
+## Stable Release 7.0.1 - 2026-04-23
 
 This update brings the following changes since the [7.0.0](7.0.0.md) release:
 

--- a/release-notes/7.0/README.md
+++ b/release-notes/7.0/README.md
@@ -4,10 +4,9 @@ The following Microsoft.Data.SqlClient 7.0 releases have been shipped:
 
 | Release Date | Version | Notes |
 | :-- | :-- | :--: |
-| 2026-04-14 | 7.0.1 | [Release Notes](7.0.1.md) |
+| 2026-04-23 | 7.0.1 | [Release Notes](7.0.1.md) |
 | 2026-03-17 | 7.0.0 | [Release Notes](7.0.0.md) |
 | 2026-03-05 | 7.0.0-preview4.26064.3 | [Release Notes](7.0.0-preview4.md) |
 | 2025-12-08 | 7.0.0-preview3.25342.7 | [Release Notes](7.0.0-preview3.md) |
 | 2025-10-16 | 7.0.0-preview2.25289.6 | [Release Notes](7.0.0-preview2.md) |
 | 2025-09-12 | 7.0.0-preview1.25257.1 | [Release Notes](7.0.0-preview1.md) |
-

--- a/release-notes/7.0/README.md
+++ b/release-notes/7.0/README.md
@@ -4,6 +4,7 @@ The following Microsoft.Data.SqlClient 7.0 releases have been shipped:
 
 | Release Date | Version | Notes |
 | :-- | :-- | :--: |
+| 2026-04-14 | 7.0.1 | [Release Notes](7.0.1.md) |
 | 2026-03-17 | 7.0.0 | [Release Notes](7.0.0.md) |
 | 2026-03-05 | 7.0.0-preview4.26064.3 | [Release Notes](7.0.0-preview4.md) |
 | 2025-12-08 | 7.0.0-preview3.25342.7 | [Release Notes](7.0.0-preview3.md) |


### PR DESCRIPTION
## Description

Adds release notes for the Microsoft.Data.SqlClient 7.0.1 patch release.

### Files changed

- **release-notes/7.0/7.0.1.md** — New release notes for 7.0.1
- **release-notes/7.0/README.md** — Added 7.0.1 row to the version table
- **CHANGELOG.md** — Added 7.0.1 entry at the top
- **.github/prompts/release-notes.prompt.md** — Minor prompt improvements (branch parameter, GitHub Release markdown step)

### Summary of 7.0.1 changes

#### Fixed
- `SqlBulkCopy` failing on SQL Server 2016 (`graph_type` column error)
- `SqlBulkCopy` failing on Azure Synapse Analytics dedicated SQL pools
- `SqlDataReader.GetFieldType()` / `GetProviderSpecificFieldType()` returning wrong type for vector float32 columns
- Missing `System.Data.Common` package dependency for .NET Framework consumers

#### Changed
- User Agent TDS feature extension enabled unconditionally
- Type forwards added for Abstractions types
- Documentation fixes

## Issues

## Testing

Documentation-only change — no code changes.

## Guidelines

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)