### PR TITLE
Add new conn-string synonyms for cross-driver alignment

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionStringSynonyms.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/DbConnectionStringSynonyms.cs
@@ -10,12 +10,15 @@ namespace Microsoft.Data.Common.ConnectionString
         internal const string Address = "address";
         internal const string App = "app";
         internal const string ApplicationIntent = "applicationintent";
+        internal const string ColumnEncryption = "columnEncryption";
         internal const string ConnectionLifetime = "connection lifetime";
         internal const string ConnectionTimeout = "connection timeout";
         internal const string ConnectRetryCount = "connectretrycount";
         internal const string ConnectRetryInterval = "connectretryinterval";
+        internal const string ConnectTimeout = "connecttimeout";
         internal const string Database = "database";
         internal const string ExtendedProperties = "extended properties";
+        internal const string FailoverPartner = "failoverpartner";
         internal const string FailoverPartnerSpn = "FailoverPartnerSPN";
         internal const string HostNameInCertificate = "hostnameincertificate";
         internal const string InitialFileName = "initial file name";
@@ -26,6 +29,7 @@ namespace Microsoft.Data.Common.ConnectionString
         internal const string Net = "net";
         internal const string Network = "network";
         internal const string NetworkAddress = "network address";
+        internal const string PacketSize = "packetsize";
         internal const string PersistSecurityInfo = "persistsecurityinfo";
         internal const string PoolBlockingPeriod = "poolblockingperiod";
         internal const string Pwd = "pwd";
@@ -38,6 +42,7 @@ namespace Microsoft.Data.Common.ConnectionString
         internal const string TrustServerCertificate = "trustservercertificate";
         internal const string Uid = "uid";
         internal const string User = "user";
+        internal const string WorkstationId = "workstationid";
         internal const string WsId = "wsid";
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionString.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.SqlClient
             internal const string ImplicitUnbind = "Implicit Unbind";
             internal const string ExplicitUnbind = "Explicit Unbind";
         }
-        
+
         private static readonly Dictionary<string, string> s_keywordMap =
             new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
 
@@ -109,9 +109,9 @@ namespace Microsoft.Data.SqlClient
         private static readonly Version s_constTypeSystemAsmVersion11 = new("11.0.0.0");
 
         private readonly string _expandedAttachDBFilename; // expanded during construction so that CreatePermissionSet & Expand are consistent
-        
+
         #region Constructors
-        
+
         /// <summary>
         /// Static constructor to do things that we can't do in a single line initialization.
         /// </summary>
@@ -125,13 +125,14 @@ namespace Microsoft.Data.SqlClient
             AddKeywordToMap(DbConnectionStringKeywords.ApplicationIntent,
                             DbConnectionStringSynonyms.ApplicationIntent);
             AddKeywordToMap(DbConnectionStringKeywords.ApplicationName,
-                            DbConnectionStringSynonyms.App); 
+                            DbConnectionStringSynonyms.App);
             AddKeywordToMap(DbConnectionStringKeywords.AttachDbFilename,
                             DbConnectionStringSynonyms.ExtendedProperties,
                             DbConnectionStringSynonyms.InitialFileName);
             AddKeywordToMap(DbConnectionStringKeywords.AttestationProtocol);
             AddKeywordToMap(DbConnectionStringKeywords.Authentication);
-            AddKeywordToMap(DbConnectionStringKeywords.ColumnEncryptionSetting);
+            AddKeywordToMap(DbConnectionStringKeywords.ColumnEncryptionSetting,
+                            DbConnectionStringSynonyms.ColumnEncryption);
             AddKeywordToMap(DbConnectionStringKeywords.CommandTimeout);
             AddKeywordToMap(DbConnectionStringKeywords.ConnectRetryCount,
                             DbConnectionStringSynonyms.ConnectRetryCount);
@@ -139,6 +140,7 @@ namespace Microsoft.Data.SqlClient
                             DbConnectionStringSynonyms.ConnectRetryInterval);
             AddKeywordToMap(DbConnectionStringKeywords.ConnectTimeout,
                             DbConnectionStringSynonyms.ConnectionTimeout,
+                            DbConnectionStringSynonyms.ConnectTimeout,
                             DbConnectionStringSynonyms.Timeout);
             AddKeywordToMap(DbConnectionStringKeywords.ContextConnection);
             AddKeywordToMap(DbConnectionStringKeywords.CurrentLanguage,
@@ -151,7 +153,8 @@ namespace Microsoft.Data.SqlClient
             AddKeywordToMap(DbConnectionStringKeywords.EnclaveAttestationUrl);
             AddKeywordToMap(DbConnectionStringKeywords.Encrypt);
             AddKeywordToMap(DbConnectionStringKeywords.Enlist);
-            AddKeywordToMap(DbConnectionStringKeywords.FailoverPartner);
+            AddKeywordToMap(DbConnectionStringKeywords.FailoverPartner,
+                            DbConnectionStringSynonyms.FailoverPartner);
             AddKeywordToMap(DbConnectionStringKeywords.FailoverPartnerSpn,
                             DbConnectionStringSynonyms.FailoverPartnerSpn);
             AddKeywordToMap(DbConnectionStringKeywords.HostNameInCertificate,
@@ -170,7 +173,8 @@ namespace Microsoft.Data.SqlClient
             AddKeywordToMap(DbConnectionStringKeywords.MinPoolSize);
             AddKeywordToMap(DbConnectionStringKeywords.MultiSubnetFailover,
                             DbConnectionStringSynonyms.MultiSubnetFailover);
-            AddKeywordToMap(DbConnectionStringKeywords.PacketSize);
+            AddKeywordToMap(DbConnectionStringKeywords.PacketSize,
+                            DbConnectionStringSynonyms.PacketSize);
             AddKeywordToMap(DbConnectionStringKeywords.Password,
                             DbConnectionStringSynonyms.Pwd);
             AddKeywordToMap(DbConnectionStringKeywords.PersistSecurityInfo,
@@ -192,6 +196,7 @@ namespace Microsoft.Data.SqlClient
                             DbConnectionStringSynonyms.User);
             AddKeywordToMap(DbConnectionStringKeywords.UserInstance);
             AddKeywordToMap(DbConnectionStringKeywords.WorkstationId,
+                            DbConnectionStringSynonyms.WorkstationId,
                             DbConnectionStringSynonyms.WsId);
 
             #if NETFRAMEWORK
@@ -203,7 +208,7 @@ namespace Microsoft.Data.SqlClient
                             DbConnectionStringSynonyms.TransparentNetworkIpResolution);
             #endif
         }
-        
+
         internal SqlConnectionString(string connectionString): base(connectionString, s_keywordMap)
         {
 #if !NETFRAMEWORK
@@ -568,12 +573,12 @@ namespace Microsoft.Data.SqlClient
         }
 
         #endregion
-        
+
         internal bool IntegratedSecurity => _integratedSecurity;
 
         // @TODO: This is temporary until we can remove DbConnectionString (see SqlClientPermission)
         internal static IReadOnlyDictionary<string, string> KeywordMap => s_keywordMap;
-        
+
         // We always initialize in Async mode so that both synchronous and asynchronous methods
         // will work.  In the future we can deprecate the keyword entirely.
         internal bool Asynchronous => true;
@@ -983,21 +988,21 @@ namespace Microsoft.Data.SqlClient
         internal string NetworkLibrary => _networkLibrary;
 
 #endif // NETFRAMEWORK
-        
+
         #region Private Methods
-        
+
         private static void AddKeywordToMap(string keyword, params string[] synonyms)
         {
             // Add mapping of keyword to keyword
             s_keywordMap.Add(keyword, keyword);
-            
+
             // Add mapping of synonyms to keyword
             foreach (string synonym in synonyms)
             {
                 s_keywordMap.Add(synonym, keyword);
             }
         }
-        
+
         #endregion
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -273,12 +273,17 @@ namespace Microsoft.Data.SqlClient
                 { DbConnectionStringSynonyms.Uid, Keywords.UserID },
                 { DbConnectionStringSynonyms.User, Keywords.UserID },
                 { DbConnectionStringSynonyms.WsId, Keywords.WorkstationID },
+                { DbConnectionStringSynonyms.WorkstationId, Keywords.WorkstationID },
                 { DbConnectionStringSynonyms.ServerSpn, Keywords.ServerSPN },
                 { DbConnectionStringSynonyms.FailoverPartnerSpn, Keywords.FailoverPartnerSPN },
+                { DbConnectionStringSynonyms.ColumnEncryption, Keywords.ColumnEncryptionSetting },
+                { DbConnectionStringSynonyms.ConnectTimeout, Keywords.ConnectTimeout },
+                { DbConnectionStringSynonyms.FailoverPartner, Keywords.FailoverPartner },
+                { DbConnectionStringSynonyms.PacketSize, Keywords.PacketSize },
             };
             return pairs;
         }
-        
+
         // @TODO These methods are completely unnecessary.
 
         private static bool ConvertToBoolean(object value) => DbConnectionStringUtilities.ConvertToBoolean(value);
@@ -565,7 +570,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // @TODO: These methods can be inlined with the property setters.
-        
+
         private void SetValue(string keyword, bool value) => base[keyword] = value.ToString();
 
         private void SetValue(string keyword, int value) => base[keyword] = value.ToString((System.IFormatProvider)null);

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("WorkstationID = myworkstation")]
         [InlineData("WSID = myworkstation")]
         [InlineData("ConnectTimeout = 30")]
-        [InlineData("FailoverPartner = randomserver.sys.local")]
+        [InlineData("Initial Catalog = Northwind; FailoverPartner = randomserver.sys.local")]
         [InlineData("PacketSize = 8192")]
         [InlineData("columnEncryption = Enabled")]
         [InlineData("Host Name In Certificate = tds.test.com")]
@@ -956,10 +956,10 @@ namespace Microsoft.Data.SqlClient.Tests
         }
 
         [Theory]
-        [InlineData("FailoverPartner = partner.sys.local")]
-        [InlineData("failoverpartner = partner.sys.local")]
-        [InlineData("FAILOVERPARTNER = partner.sys.local")]
-        [InlineData("Failover Partner = partner.sys.local")]
+        [InlineData("Initial Catalog = Northwind; FailoverPartner = partner.sys.local")]
+        [InlineData("Initial Catalog = Northwind; failoverpartner = partner.sys.local")]
+        [InlineData("Initial Catalog = Northwind; FAILOVERPARTNER = partner.sys.local")]
+        [InlineData("Initial Catalog = Northwind; Failover Partner = partner.sys.local")]
         public void FailoverPartnerSynonymsResolveCorrectly(string connectionString)
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlConnectionStringBuilderTest.cs
@@ -93,7 +93,12 @@ namespace Microsoft.Data.SqlClient.Tests
         [InlineData("Type System Version = Latest")]
         [InlineData("User Instance = true")]
         [InlineData("Workstation ID = myworkstation")]
+        [InlineData("WorkstationID = myworkstation")]
         [InlineData("WSID = myworkstation")]
+        [InlineData("ConnectTimeout = 30")]
+        [InlineData("FailoverPartner = randomserver.sys.local")]
+        [InlineData("PacketSize = 8192")]
+        [InlineData("columnEncryption = Enabled")]
         [InlineData("Host Name In Certificate = tds.test.com")]
         [InlineData("HostNameInCertificate = tds.test.com")]
         [InlineData("Server Certificate = c:\\test.cer")]
@@ -935,6 +940,64 @@ namespace Microsoft.Data.SqlClient.Tests
         {
             Assert.IsType<SqlConnectionEncryptOption>(builder.Encrypt);
             Assert.Equal(expectedValue, builder.Encrypt);
+        }
+
+        [Theory]
+        [InlineData("ConnectTimeout = 45", 45)]
+        [InlineData("connecttimeout = 45", 45)]
+        [InlineData("CONNECTTIMEOUT = 45", 45)]
+        [InlineData("Connect Timeout = 45", 45)]
+        [InlineData("Connection Timeout = 45", 45)]
+        [InlineData("Timeout = 45", 45)]
+        public void ConnectTimeoutSynonymsResolveCorrectly(string connectionString, int expected)
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
+            Assert.Equal(expected, builder.ConnectTimeout);
+        }
+
+        [Theory]
+        [InlineData("FailoverPartner = partner.sys.local")]
+        [InlineData("failoverpartner = partner.sys.local")]
+        [InlineData("FAILOVERPARTNER = partner.sys.local")]
+        [InlineData("Failover Partner = partner.sys.local")]
+        public void FailoverPartnerSynonymsResolveCorrectly(string connectionString)
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
+            Assert.Equal("partner.sys.local", builder.FailoverPartner);
+        }
+
+        [Theory]
+        [InlineData("PacketSize = 16000", 16000)]
+        [InlineData("packetsize = 16000", 16000)]
+        [InlineData("PACKETSIZE = 16000", 16000)]
+        [InlineData("Packet Size = 16000", 16000)]
+        public void PacketSizeSynonymsResolveCorrectly(string connectionString, int expected)
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
+            Assert.Equal(expected, builder.PacketSize);
+        }
+
+        [Theory]
+        [InlineData("WorkstationID = myws")]
+        [InlineData("workstationid = myws")]
+        [InlineData("WORKSTATIONID = myws")]
+        [InlineData("Workstation ID = myws")]
+        [InlineData("WSID = myws")]
+        public void WorkstationIdSynonymsResolveCorrectly(string connectionString)
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
+            Assert.Equal("myws", builder.WorkstationID);
+        }
+
+        [Theory]
+        [InlineData("columnEncryption = Enabled")]
+        [InlineData("columnencryption = Enabled")]
+        [InlineData("COLUMNENCRYPTION = Enabled")]
+        [InlineData("Column Encryption Setting = Enabled")]
+        public void ColumnEncryptionSynonymsResolveCorrectly(string connectionString)
+        {
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
+            Assert.Equal(SqlConnectionColumnEncryptionSetting.Enabled, builder.ColumnEncryptionSetting);
         }
 
     }


### PR DESCRIPTION
## Description
Add 5 new connection string keyword synonyms for cross-driver alignment
Adds space-free and camelCase synonym mappings so that connection strings using keywords common across other SQL drivers (ODBC, OLEDB, JDBC, PHP, Python, Rust) are accepted by Microsoft.Data.SqlClient:

| Canonical Keyword | New Synonym |
|---|---|
| `Connect Timeout` | `ConnectTimeout` |
| `Failover Partner` | `FailoverPartner` |
| `Packet Size` | `PacketSize` |
| `Workstation ID` | `WorkstationID` |
| `Column Encryption Setting` | `columnEncryption` |

## Issues
Fixes [AB#44014](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/44014)

## Testing
Added unit tests for the new synonyms

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
