### PR TITLE
Add AOT-safe authentication provider registration

### DIFF
--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.cs
@@ -2,11 +2,29 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.ComponentModel;
+
 namespace Microsoft.Data.SqlClient;
 
 /// <include file='../doc/SqlAuthenticationProvider.xml' path='docs/members[@name="SqlAuthenticationProvider"]/SqlAuthenticationProvider/*'/>
 public abstract partial class SqlAuthenticationProvider
 {
+    /// <summary>
+    /// Providers registered via <see cref="SetProvider"/> before the core
+    /// SqlClient assembly has registered its provider manager callbacks
+    /// via <see cref="RegisterProviderManager"/>. Replayed once the
+    /// manager registers.
+    /// </summary>
+    private static Dictionary<SqlAuthenticationMethod,
+        SqlAuthenticationProvider>? s_pendingProviders;
+
+    private static Func<SqlAuthenticationMethod,
+        SqlAuthenticationProvider?>? s_getProviderCallback;
+
+    private static Func<SqlAuthenticationMethod,
+        SqlAuthenticationProvider, bool>? s_setProviderCallback;
+
     /// <include file='../doc/SqlAuthenticationProvider.xml' path='docs/members[@name="SqlAuthenticationProvider"]/BeforeLoad/*'/>
     public virtual void BeforeLoad(SqlAuthenticationMethod authenticationMethod) { }
 
@@ -19,6 +37,52 @@ public abstract partial class SqlAuthenticationProvider
     /// <include file='../doc/SqlAuthenticationProvider.xml' path='docs/members[@name="SqlAuthenticationProvider"]/AcquireTokenAsync/*'/>
     public abstract Task<SqlAuthenticationToken> AcquireTokenAsync(SqlAuthenticationParameters parameters);
 
+    /// <summary>
+    /// Registers the core SqlClient provider management callbacks.
+    /// This method is called by
+    /// <c>SqlAuthenticationProviderManager</c> during its static
+    /// initialization to wire up the AOT-safe provider bridge between
+    /// the Abstractions layer and the core SqlClient assembly.
+    ///
+    /// Any providers that were registered via
+    /// <see cref="SetProvider"/> before this method was called are
+    /// replayed through <paramref name="setProvider"/> so they are
+    /// not lost.
+    ///
+    /// This is infrastructure -- application code should not call
+    /// this method.
+    /// </summary>
+    /// <param name="getProvider">
+    /// Callback that retrieves a registered provider for a given
+    /// authentication method.
+    /// </param>
+    /// <param name="setProvider">
+    /// Callback that registers a provider for a given authentication
+    /// method.
+    /// </param>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void RegisterProviderManager(
+        Func<SqlAuthenticationMethod,
+            SqlAuthenticationProvider?> getProvider,
+        Func<SqlAuthenticationMethod,
+            SqlAuthenticationProvider, bool> setProvider)
+    {
+        s_getProviderCallback = getProvider;
+        s_setProviderCallback = setProvider;
+
+        // Replay providers that were registered before the core
+        // assembly initialized (e.g. via RegisterAsDefault() called
+        // early in Main).
+        if (s_pendingProviders is not null)
+        {
+            foreach (var kvp in s_pendingProviders)
+            {
+                setProvider(kvp.Key, kvp.Value);
+            }
+
+            s_pendingProviders = null;
+        }
+    }
 
     /// <include file='../doc/SqlAuthenticationProvider.xml' path='docs/members[@name="SqlAuthenticationProvider"]/GetProvider/*'/>
     //
@@ -28,7 +92,13 @@ public abstract partial class SqlAuthenticationProvider
     public static SqlAuthenticationProvider? GetProvider(
         SqlAuthenticationMethod authenticationMethod)
     {
-        return Internal.GetProvider(authenticationMethod);
+        // Prefer the direct callback registered by the core SqlClient
+        // assembly (AOT-safe). Fall back to the reflection-based
+        // approach for backwards compatibility with older versions of
+        // Microsoft.Data.SqlClient that do not register the callback.
+        return s_getProviderCallback is not null
+            ? s_getProviderCallback(authenticationMethod)
+            : Internal.GetProvider(authenticationMethod);
     }
 
     /// <include file='../doc/SqlAuthenticationProvider.xml' path='docs/members[@name="SqlAuthenticationProvider"]/SetProvider/*'/>
@@ -40,6 +110,19 @@ public abstract partial class SqlAuthenticationProvider
         SqlAuthenticationMethod authenticationMethod,
         SqlAuthenticationProvider provider)
     {
-        return Internal.SetProvider(authenticationMethod, provider);
+        // Prefer the direct callback registered by the core SqlClient
+        // assembly (AOT-safe).
+        if (s_setProviderCallback is not null)
+        {
+            return s_setProviderCallback(
+                authenticationMethod, provider);
+        }
+
+        // The core SqlClient assembly has not initialized its
+        // callbacks yet. Buffer the registration and replay it once
+        // RegisterProviderManager is called.
+        s_pendingProviders ??= new();
+        s_pendingProviders[authenticationMethod] = provider;
+        return true;
     }
 }

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/SqlAuthenticationProviderTest.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/SqlAuthenticationProviderTest.cs
@@ -48,8 +48,10 @@ public class SqlAuthenticationProviderTest
     }
 
     /// <summary>
-    /// Test that SetProvider fails predictably when the MDS assembly can't be
-    /// found.
+    /// Test that SetProvider succeeds even when the MDS assembly can't be
+    /// found.  The providers are buffered and will be replayed once the
+    /// core SqlClient assembly registers its provider manager via
+    /// <see cref="SqlAuthenticationProvider.RegisterProviderManager"/>.
     /// </summary>
     [Theory]
     #pragma warning disable CS0618 // Type or member is obsolete
@@ -65,9 +67,9 @@ public class SqlAuthenticationProviderTest
     [InlineData(SqlAuthenticationMethod.ActiveDirectoryWorkloadIdentity)]
     public void SetProvider_NoMdsAssembly(SqlAuthenticationMethod method)
     {
-        // SetProvider() should return false when the MDS assembly can't be
-        // found.
-        Assert.False(
+        // SetProvider() should return true — the provider is buffered for
+        // replay once the core assembly registers via RegisterProviderManager.
+        Assert.True(
             SqlAuthenticationProvider.SetProvider(method, new Provider()));
     }
 

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/SqlAuthenticationProviderTest.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/SqlAuthenticationProviderTest.cs
@@ -81,37 +81,70 @@ public class SqlAuthenticationProviderTest
     [Fact]
     public void SetProvider_BufferedAndReplayed()
     {
-        // Arrange: register a provider while no manager callbacks
-        // are wired up (MDS assembly is not present in this test
-        // project).
-        var provider = new Provider();
-        var method =
-            SqlAuthenticationMethod.ActiveDirectoryManagedIdentity;
+        // Snapshot static state so we can restore it after the
+        // test.  RegisterProviderManager mutates these statics
+        // and would leak into other tests otherwise.
+        var flags = BindingFlags.Static | BindingFlags.NonPublic;
+        var type = typeof(SqlAuthenticationProvider);
 
-        Assert.True(
-            SqlAuthenticationProvider.SetProvider(
-                method, provider));
+        var getField = type.GetField(
+            "s_getProviderCallback", flags)!;
+        var setField = type.GetField(
+            "s_setProviderCallback", flags)!;
+        var pendingField = type.GetField(
+            "s_pendingProviders", flags)!;
 
-        // Before replay, GetProvider returns null (no callback,
-        // and the reflection-based Internal.GetProvider also
-        // returns null since MDS is absent).
-        Assert.Null(
-            SqlAuthenticationProvider.GetProvider(method));
+        var savedGet = getField.GetValue(null);
+        var savedSet = setField.GetValue(null);
+        var savedPending = pendingField.GetValue(null);
 
-        // Act: simulate the core assembly registering its manager
-        // callbacks by calling RegisterProviderManager with simple
-        // dictionary-backed delegates.
-        var store = new Dictionary<SqlAuthenticationMethod,
-            SqlAuthenticationProvider>();
+        try
+        {
+            // Reset to a clean state (no callbacks, no pending).
+            getField.SetValue(null, null);
+            setField.SetValue(null, null);
+            pendingField.SetValue(null, null);
 
-        SqlAuthenticationProvider.RegisterProviderManager(
-            m => store.TryGetValue(m, out var p) ? p : null,
-            (m, p) => { store[m] = p; return true; });
+            // Arrange: register a provider while no manager callbacks
+            // are wired up (MDS assembly is not present in this test
+            // project).
+            var provider = new Provider();
+            var method =
+                SqlAuthenticationMethod.ActiveDirectoryManagedIdentity;
 
-        // Assert: the buffered provider was replayed into the
-        // store and is now retrievable via GetProvider.
-        Assert.Same(provider,
-            SqlAuthenticationProvider.GetProvider(method));
+            Assert.True(
+                SqlAuthenticationProvider.SetProvider(
+                    method, provider));
+
+            // Before replay, GetProvider returns null (no callback,
+            // and the reflection-based Internal.GetProvider also
+            // returns null since MDS is absent).
+            Assert.Null(
+                SqlAuthenticationProvider.GetProvider(method));
+
+            // Act: simulate the core assembly registering its manager
+            // callbacks by calling RegisterProviderManager with simple
+            // dictionary-backed delegates.
+            var store = new Dictionary<SqlAuthenticationMethod,
+                SqlAuthenticationProvider>();
+
+            SqlAuthenticationProvider.RegisterProviderManager(
+                m => store.TryGetValue(m, out var p) ? p : null,
+                (m, p) => { store[m] = p; return true; });
+
+            // Assert: the buffered provider was replayed into the
+            // store and is now retrievable via GetProvider.
+            Assert.Same(provider,
+                SqlAuthenticationProvider.GetProvider(method));
+        }
+        finally
+        {
+            // Restore the original static state so other tests
+            // are not affected.
+            getField.SetValue(null, savedGet);
+            setField.SetValue(null, savedSet);
+            pendingField.SetValue(null, savedPending);
+        }
     }
 
     #endregion

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/SqlAuthenticationProviderTest.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/SqlAuthenticationProviderTest.cs
@@ -73,6 +73,47 @@ public class SqlAuthenticationProviderTest
             SqlAuthenticationProvider.SetProvider(method, new Provider()));
     }
 
+    /// <summary>
+    /// Test that providers registered via SetProvider before
+    /// RegisterProviderManager is called are buffered and replayed
+    /// once the manager registers its callbacks.
+    /// </summary>
+    [Fact]
+    public void SetProvider_BufferedAndReplayed()
+    {
+        // Arrange: register a provider while no manager callbacks
+        // are wired up (MDS assembly is not present in this test
+        // project).
+        var provider = new Provider();
+        var method =
+            SqlAuthenticationMethod.ActiveDirectoryManagedIdentity;
+
+        Assert.True(
+            SqlAuthenticationProvider.SetProvider(
+                method, provider));
+
+        // Before replay, GetProvider returns null (no callback,
+        // and the reflection-based Internal.GetProvider also
+        // returns null since MDS is absent).
+        Assert.Null(
+            SqlAuthenticationProvider.GetProvider(method));
+
+        // Act: simulate the core assembly registering its manager
+        // callbacks by calling RegisterProviderManager with simple
+        // dictionary-backed delegates.
+        var store = new Dictionary<SqlAuthenticationMethod,
+            SqlAuthenticationProvider>();
+
+        SqlAuthenticationProvider.RegisterProviderManager(
+            m => store.TryGetValue(m, out var p) ? p : null,
+            (m, p) => { store[m] = p; return true; });
+
+        // Assert: the buffered provider was replayed into the
+        // store and is now retrievable via GetProvider.
+        Assert.Same(provider,
+            SqlAuthenticationProvider.GetProvider(method));
+    }
+
     #endregion
 
     #region Helpers

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
@@ -77,6 +77,70 @@ public sealed class ActiveDirectoryAuthenticationProvider : SqlAuthenticationPro
         }
     }
 
+    /// <summary>
+    /// Registers a new instance of
+    /// <see cref="ActiveDirectoryAuthenticationProvider"/> as the
+    /// default provider for all Active Directory authentication
+    /// methods via <see cref="SqlAuthenticationProvider.SetProvider"/>.
+    ///
+    /// This is the AOT-safe alternative to the automatic
+    /// reflection-based discovery that SqlClient performs at startup.
+    /// Under NativeAOT the automatic discovery silently fails because
+    /// it relies on
+    /// <see cref="System.Reflection.Assembly.Load(string)"/> and
+    /// <see cref="System.Activator.CreateInstance(System.Type, object[])"/>,
+    /// which are not compatible with trimming. Call this method early
+    /// in your application (before opening any SQL connection) to
+    /// restore the default behavior that SqlClient 6.x provided out
+    /// of the box.
+    ///
+    /// Providers registered via app configuration are not
+    /// overwritten.
+    /// </summary>
+    /// <param name="applicationClientId">
+    /// Optional application (client) ID for interactive and
+    /// device-code flows. If <see langword="null"/>, the built-in
+    /// default client ID is used.
+    /// </param>
+    public static void RegisterAsDefault(
+        string? applicationClientId = null)
+    {
+        var provider = applicationClientId is not null
+            ? new ActiveDirectoryAuthenticationProvider(
+                applicationClientId)
+            : new ActiveDirectoryAuthenticationProvider();
+
+        SetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryIntegrated,
+            provider);
+        #pragma warning disable CS0618 // Type or member is obsolete
+        SetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryPassword,
+            provider);
+        #pragma warning restore CS0618 // Type or member is obsolete
+        SetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryInteractive,
+            provider);
+        SetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryServicePrincipal,
+            provider);
+        SetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow,
+            provider);
+        SetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryManagedIdentity,
+            provider);
+        SetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryMSI,
+            provider);
+        SetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryDefault,
+            provider);
+        SetProvider(
+            SqlAuthenticationMethod.ActiveDirectoryWorkloadIdentity,
+            provider);
+    }
+
     /// <include file='../doc/ActiveDirectoryAuthenticationProvider.xml' path='docs/members[@name="ActiveDirectoryAuthenticationProvider"]/SetDeviceCodeFlowCallback/*'/>
     public void SetDeviceCodeFlowCallback(Func<DeviceCodeResult, Task> deviceCodeFlowCallbackMethod) => _deviceCodeFlowCallback = deviceCodeFlowCallbackMethod;
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using Microsoft.Data.SqlClient.Internal;
@@ -56,6 +57,47 @@ namespace Microsoft.Data.SqlClient
 
             Instance = new SqlAuthenticationProviderManager(configurationSection);
 
+            // Register direct (non-reflection) callbacks with the Abstractions layer
+            // so that SqlAuthenticationProvider.GetProvider/SetProvider work under
+            // NativeAOT without relying on MethodInfo.Invoke across assembly boundaries.
+            SqlAuthenticationProvider.RegisterProviderManager(GetProvider, SetProvider);
+
+            // If our Azure extensions package is present, use its authentication provider
+            // as our default. This uses reflection and is not AOT-compatible.
+            LoadAzureExtensionProvider();
+        }
+
+        /// <summary>
+        /// Attempts to discover and load the Azure extensions authentication provider
+        /// at runtime using reflection. This method is not compatible with NativeAOT/trimming
+        /// because it uses Assembly.Load, Type.GetType, and Activator.CreateInstance.
+        ///
+        /// Under NativeAOT, this method will silently fail and no default providers
+        /// will be registered. Applications should use
+        /// <see cref="ActiveDirectoryAuthenticationProvider.RegisterAsDefault()"/> to
+        /// explicitly register the provider, or use SqlConnection.AccessTokenCallback
+        /// to bypass the provider registry.
+        /// </summary>
+        #if NET
+        [RequiresUnreferencedCode(
+            "Azure extension provider discovery uses Assembly.Load " +
+            "and Activator.CreateInstance which are not compatible " +
+            "with trimming. Use " +
+            "ActiveDirectoryAuthenticationProvider.RegisterAsDefault" +
+            "() to explicitly register the provider, or use " +
+            "SqlConnection.AccessTokenCallback with Azure.Identity " +
+            "instead.")]
+        [RequiresDynamicCode(
+            "Azure extension provider discovery uses " +
+            "Activator.CreateInstance which requires dynamic code " +
+            "generation. Use " +
+            "ActiveDirectoryAuthenticationProvider.RegisterAsDefault" +
+            "() to explicitly register the provider, or use " +
+            "SqlConnection.AccessTokenCallback with Azure.Identity " +
+            "instead.")]
+        #endif
+        private static void LoadAzureExtensionProvider()
+        {
             // If our Azure extensions package is present, use its authentication provider as our
             // default.
             try

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// Attempts to discover and load the Azure extensions authentication provider
         /// at runtime using reflection. This method is not compatible with NativeAOT/trimming
-        /// because it uses Assembly.Load, Type.GetType, and Activator.CreateInstance.
+        /// because it uses Assembly.Load, Assembly.GetType, and Activator.CreateInstance.
         ///
         /// Under NativeAOT, this method will silently fail and no default providers
         /// will be registered. Applications should use

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Data.SqlClient
         ///
         /// Under NativeAOT, this method will silently fail and no default providers
         /// will be registered. Applications should use
-        /// <see cref="ActiveDirectoryAuthenticationProvider.RegisterAsDefault()"/> to
+        /// ActiveDirectoryAuthenticationProvider.RegisterAsDefault() to
         /// explicitly register the provider, or use SqlConnection.AccessTokenCallback
         /// to bypass the provider registry.
         /// </summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -6,7 +6,9 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Configuration;
+#if NET
 using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
 using System.Reflection;
 using Microsoft.Data.SqlClient.Internal;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlAuthenticationProviderManagerTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlAuthenticationProviderManagerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -72,5 +73,37 @@ public class SqlAuthenticationProviderManagerTests
             provider2,
             SqlAuthenticationProvider.GetProvider(
                 SqlAuthenticationMethod.ActiveDirectoryDeviceCodeFlow));
+    }
+
+    // Verify that SqlAuthenticationProviderManager registers its GetProvider
+    // and SetProvider methods as callbacks on SqlAuthenticationProvider during
+    // static initialization.  This is the AOT-safe code path that avoids
+    // reflection-based assembly loading.
+    [Fact]
+    public void CallbackDelegates_RegisteredByManager()
+    {
+        // Accessing SqlAuthenticationProviderManager triggers its static
+        // constructor, which should register the callbacks.
+        _ = SqlAuthenticationProviderManager.GetProvider(
+            SqlAuthenticationMethod.NotSpecified);
+
+        // Use reflection to inspect the private callback fields on
+        // SqlAuthenticationProvider (the test itself doesn't need to be
+        // AOT-safe).
+        BindingFlags flags = BindingFlags.Static | BindingFlags.NonPublic;
+
+        FieldInfo? getCallbackField = typeof(SqlAuthenticationProvider)
+            .GetField("s_getProviderCallback", flags);
+        FieldInfo? setCallbackField = typeof(SqlAuthenticationProvider)
+            .GetField("s_setProviderCallback", flags);
+
+        Assert.NotNull(getCallbackField);
+        Assert.NotNull(setCallbackField);
+
+        object? getCallback = getCallbackField.GetValue(null);
+        object? setCallback = setCallbackField.GetValue(null);
+
+        Assert.NotNull(getCallback);
+        Assert.NotNull(setCallback);
     }
 }


### PR DESCRIPTION
## Description

`SqlAuthenticationProviderManager` discovers the Azure extension at startup via `Assembly.Load` + `Activator.CreateInstance`. Under NativeAOT these reflection APIs are trimmed away, silently leaving all Active Directory auth methods without a provider and causing `Cannot find an authentication provider for &#39;ActiveDirectoryManagedIdentity&#39;` errors at runtime.

This change adds an AOT-safe bridge between the Abstractions and core assemblies:

- **`SqlAuthenticationProvider.RegisterProviderManager(getProvider, setProvider)`**: Called by `SqlAuthenticationProviderManager` during its static initialization to wire up direct (non-reflection) `GetProvider`/`SetProvider` callbacks. Providers that were registered via `SetProvider` before the manager initialized are buffered in a pending dictionary and replayed once `RegisterProviderManager` is called. Marked `[EditorBrowsable(Never)]` since this is infrastructure, not application API.

- **`ActiveDirectoryAuthenticationProvider.RegisterAsDefault()`**: AOT-safe entry point that explicitly registers the MSAL-based provider for all 9 AD auth methods. This replaces the reflection-based discovery under NativeAOT. Applications call this early in `Main()` before opening any SQL connection.

- **`LoadAzureExtensionProvider()`**: Extracted from the static constructor into its own method and annotated with `[RequiresUnreferencedCode]` and `[RequiresDynamicCode]` so the trimmer/AOT analyzer can warn appropriately.

The existing non-AOT code path is unchanged: `LoadAzureExtensionProvider()` still runs after `RegisterProviderManager()` and uses reflection as before.

### Usage under NativeAOT

```csharp
// Call before opening any SQL connection (e.g. top of Main)
ActiveDirectoryAuthenticationProvider.RegisterAsDefault();
```

## Testing

- **Unit test added**: `CallbackDelegates_RegisteredByManager` — verifies that `SqlAuthenticationProviderManager`&#39;s static constructor registers the `_getProviderCallback` and `_setProviderCallback` fields on `SqlAuthenticationProvider`.
- **Existing test updated**: `SetProvider_NoMdsAssembly` in the Abstractions test project — with the new buffering behavior, `SetProvider` returns `true` (buffered for replay) instead of `false` when the core assembly hasn&#39;t loaded yet.
- **Production verified**: Tested on AKS with ARM64 nodes, NativeAOT (`PublishAot=true`, `net10.0`, `linux-arm64`), connecting to Azure SQL with Managed Identity authentication. The service has been running in production successfully.

## Design Notes &amp; Open Questions

This implementation prioritizes minimal diff and backwards compatibility. A few points worth discussing:

- **Thread safety of buffering**: `s_pendingProviders` is a plain `Dictionary` without synchronization. This is safe in practice because both `RegisterAsDefault()` and `RegisterProviderManager()` run on the startup path (single-threaded, before any connections are opened), but it is not formally thread-safe. If reviewers prefer, this could be changed to `ConcurrentDictionary` or protected with a lock.

- **Public API surface**: `RegisterProviderManager()` is technically public (though hidden with `[EditorBrowsable(Never)]`). An alternative would be a `[ModuleInitializer]` in the core assembly, or an internal method with `[InternalsVisibleTo]`, but both have their own drawbacks (module initializers have ordering constraints; `InternalsVisibleTo` creates a tight coupling that breaks under strong-name signing differences). Open to feedback on the preferred approach.

- **No guard against multiple calls**: `RegisterProviderManager()` can be called more than once, silently replacing the callbacks. A guard could be added, but the only legitimate caller is `SqlAuthenticationProviderManager`&#39;s static constructor, which runs exactly once.