### PR TITLE
Update to latest Azure.Core package with Azure.Identity types

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,8 +50,8 @@
   <!-- Dependencies shared by multiple projects -->
 
   <ItemGroup>
-    <PackageVersion Include="Azure.Core" Version="1.51.1" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.0" />
+    <PackageVersion Include="Azure.Core" Version="1.53.0" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
@@ -81,9 +81,7 @@
   <!-- ===================================================================== -->
   <!-- Azure Dependencies -->
 
-  <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.18.0" />
-  </ItemGroup>
+  <!-- None -->
 
   <!-- ===================================================================== -->
   <!-- SqlClient Dependencies -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
 
   <ItemGroup>
     <PackageVersion Include="Azure.Core" Version="1.53.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 

--- a/doc/Directory.Packages.props
+++ b/doc/Directory.Packages.props
@@ -5,8 +5,8 @@
     <!-- Explicitly include Azure.Identity. -->
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <!-- Reference SqlClient package versions that support our needs. -->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0-preview4.26064.3" />
-    <PackageVersion Include="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="7.0.0-preview1.26064.3" />
-    <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0-preview1.26064.3" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/doc/Directory.Packages.props
+++ b/doc/Directory.Packages.props
@@ -2,6 +2,8 @@
   <!-- Import parent Directory.Packages.props -->
   <Import Project="..\Directory.Packages.props" />
   <ItemGroup>
+    <!-- Explicitly include Azure.Identity. -->
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <!-- Reference SqlClient package versions that support our needs. -->
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0-preview4.26064.3" />
     <PackageVersion Include="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="7.0.0-preview1.26064.3" />

--- a/doc/apps/AzureAuthentication/Directory.Packages.props
+++ b/doc/apps/AzureAuthentication/Directory.Packages.props
@@ -4,11 +4,11 @@
   <!-- We purposely do not include any parent Directory.Packages.props files. -->
 
   <PropertyGroup>
-    <!-- Use SqlClient 7.0.0 Preview 4 if no version was specified. -->
-    <SqlClientVersion>7.0.0-preview4.26064.3</SqlClientVersion>
+    <!-- Use SqlClient 7.0.0 if no version was specified. -->
+    <SqlClientVersion>7.0.0</SqlClientVersion>
 
-    <!-- Use AKV Provider 7.0.0 Preview 1 if no version was specified. -->
-    <AkvProviderVersion>7.0.0-preview1.26064.3</AkvProviderVersion>
+    <!-- Use AKV Provider 7.0.0 if no version was specified. -->
+    <AkvProviderVersion>7.0.0</AkvProviderVersion>
   </PropertyGroup>
 
   <!-- SqlClient Packages -->
@@ -25,8 +25,8 @@
 
   <!-- Other Packages -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.3" />
+    <PackageVersion Include="Azure.Core" Version="1.53.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.6" />
   </ItemGroup>
 
 </Project>

--- a/doc/apps/AzureAuthentication/README.md
+++ b/doc/apps/AzureAuthentication/README.md
@@ -105,7 +105,7 @@ Azure Authentication Tester
 
 Packages used:
   SqlClient:     7.0.0
-  AKV Provider:  6.1.2
+  AKV Provider:  7.0.0
   Azure:         1.0.0
 
 Connection details:

--- a/doc/apps/AzureAuthentication/README.md
+++ b/doc/apps/AzureAuthentication/README.md
@@ -33,8 +33,8 @@ Package versions are controlled through MSBuild properties. Pass them on the com
 
 | Property | Default | Description |
 | --- | --- | --- |
-| `SqlClientVersion` | `7.0.0-preview4.26064.3` | Version of `Microsoft.Data.SqlClient` to reference. |
-| `AkvProviderVersion` | `7.0.0-preview1.26064.3` | Version of `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider` to reference. |
+| `SqlClientVersion` | `7.0.0` | Version of `Microsoft.Data.SqlClient` to reference. |
+| `AkvProviderVersion` | `7.0.0` | Version of `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider` to reference. |
 | `AzureVersion` | None | Version of `Microsoft.Data.SqlClient.Extensions.Azure` to reference.  When omitted, the `Azure` package will not be referenced. |
 
 ## Local Package Source
@@ -68,9 +68,9 @@ Description:
 
   Supply specific package versions when building to test different versions of the SqlClient suite, for example:
 
-    -p:SqlClientVersion=7.0.0.preview4
-    -p:AkvProviderVersion=7.0.1-preview2
-    -p:AzureVersion=1.0.0-preview1
+    -p:SqlClientVersion=7.1.0.preview1
+    -p:AkvProviderVersion=7.0.0
+    -p:AzureVersion=1.1.0-preview1
 
 Usage:
   AzureAuthentication [options]
@@ -104,9 +104,9 @@ Azure Authentication Tester
 ---------------------------
 
 Packages used:
-  SqlClient:     7.0.0-preview4.26055.1
+  SqlClient:     7.0.0
   AKV Provider:  6.1.2
-  Azure:         1.0.0-preview1.26055.1
+  Azure:         1.0.0
 
 Connection details:
   Data Source:      adotest.database.windows.net
@@ -142,19 +142,19 @@ authentication provider.
 Run against locally-built packages (drop `.nupkg` files into the `packages/` folder first):
 
 ```bash
-dotnet run -p:SqlClientVersion=7.0.0-preview4 -- -c "<connection string>"
+dotnet run -p:SqlClientVersion=7.1.0-preview1 -- -c "<connection string>"
 ```
 
 Run including the `Azure` extensions package:
 
 ```bash
-dotnet run -p:AzureVersion=1.0.0-preview1 -- -c "<connection string>"
+dotnet run -p:AzureVersion=1.0.0 -- -c "<connection string>"
 ```
 
 Override all three versions at once:
 
 ```bash
-dotnet run -p:SqlClientVersion=7.0.0-preview1 -p:AkvProviderVersion=7.0.0-preview1 -p:AzureVersion=1.0.0-preview1 -- -c "<connection string>"
+dotnet run -p:SqlClientVersion=7.1.0-preview1 -p:AkvProviderVersion=7.1.0-preview1 -p:AzureVersion=1.0.0 -- -c "<connection string>"
 ```
 
 ## Prerequisites

--- a/doc/samples/Microsoft.Data.SqlClient.Samples.csproj
+++ b/doc/samples/Microsoft.Data.SqlClient.Samples.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.SqlServer.Server" />

--- a/doc/samples/Microsoft.Data.SqlClient.Samples.csproj
+++ b/doc/samples/Microsoft.Data.SqlClient.Samples.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.SqlServer.Server" />
     <PackageReference Include="Microsoft.Data.SqlClient" />

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
@@ -129,7 +129,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
-    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <!-- Explicitly depend on the same version of Microsoft.Identity.Client as SqlClient. -->
     <PackageReference Include="Microsoft.Identity.Client" />

--- a/src/Microsoft.Data.SqlClient/tests/Common/Microsoft.Data.SqlClient.TestCommon.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Microsoft.Data.SqlClient.TestCommon.csproj
@@ -24,7 +24,7 @@
 
   <!-- References for netfx -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
@@ -33,7 +33,7 @@
 
   <!-- References for netcore -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
     <PackageReference Include="xunit" />

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.FunctionalTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.FunctionalTests.csproj
@@ -66,7 +66,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Transactions" />
 
-    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.Bcl.Cryptography" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI"
                       Condition="'$(ReferenceType)' != 'Package'" />
@@ -97,7 +97,7 @@
 
   <!-- References for netcore -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.Bcl.Cryptography" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI.runtime"
                       Condition="'$(ReferenceType)' != 'Package'" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTests.csproj
@@ -355,7 +355,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Transactions" />
 
-    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.Bcl.Cryptography" />
     <PackageReference Include="System.Memory" />
     <PackageReference Include="System.ValueTuple" />
@@ -391,7 +391,7 @@
 
   <!-- References for netcore -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.Bcl.Cryptography" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI.runtime"
                       Condition="'$(ReferenceType)' != 'Package'" />


### PR DESCRIPTION
Update to latest Azure.Core package with Azure.Identity types (which now contains the Azure.Identity types)

https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/MigrationGuide.md

This pull request updates shared dependency versions and removes an unused Azure dependency from the project configuration files. The main focus is on keeping dependencies up to date and cleaning up unnecessary references.

Dependency updates:

* Updated `Azure.Core` to version `1.53.0` and `Microsoft.Identity.Client` to version `4.83.3` in `Directory.Packages.props` to ensure the latest features and security patches are used.

Dependency cleanup:

* Removed the `Azure.Identity` package version specification from `Directory.Packages.props` since it is no longer needed.
* Removed the `Azure.Identity` package reference from `src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj` to clean up unused dependencies.

Question: Should I update the app and readme in doc/apps/AzureAuthentication - it still refers to preview.4 etc?
