### PR TITLE
Symbols Publishing Follow-up

### DIFF
--- a/.github/instructions/onebranch-pipeline-design.instructions.md
+++ b/.github/instructions/onebranch-pipeline-design.instructions.md
@@ -70,6 +70,8 @@ When adding a new csproj-based package:
 - The `publish-symbols-step.yml` accepts a `symbolsFolder` parameter to point at the downloaded PDB location
 - The publish step calls an extracted `publish-symbols.ps1` script with structured error handling and diagnostic logging
 - Symbols publishing credentials come from the `Symbols Publishing` variable group
+- In the official pipeline, symbol server destination follows `releaseToProduction`: Production when true, PPE when false
+- Non-official pipeline always targets the PPE symbol server
 
 ## Release Stage
 
@@ -99,7 +101,9 @@ Release parameters (all boolean, default `false`):
 - `releaseSqlServerServer`, `releaseLogging`, `releaseAbstractions`, `releaseSqlClient`, `releaseAzure`, `releaseAKVProvider`
 
 Official-only parameter:
-- `releaseToProduction` — push to NuGet Production feed (default `false`)
+- `releaseToProduction` — controls both NuGet target feed and symbol server destination (default `false`):
+  - `true` → NuGet Production feed + Production symbol server
+  - `false` → NuGet Test feed + PPE symbol server
 
 When `isPreview` is true, pipeline resolves `effective*Version` variables to preview versions; otherwise GA versions. All versions defined in `variables/common-variables.yml`.
 

--- a/eng/pipelines/onebranch/jobs/publish-symbols-job.yml
+++ b/eng/pipelines/onebranch/jobs/publish-symbols-job.yml
@@ -54,11 +54,13 @@ jobs:
   - job: publish_symbols_${{ parameters.packageName }}
     displayName: 'Publish Symbols: ${{ parameters.packageFullName }}'
     pool:
-      type: windows
+      type: linux
 
     variables:
-      # OneBranch requires ob_outputDirectory to be set, even if this job produces no artifacts.
-      ob_outputDirectory: $(JOB_OUTPUT)
+      # OneBranch requires ob_outputDirectory to be set. Pipeline Artifacts are always on and
+      # cannot be disabled. To prevent this job from publishing artifacts, a .artifactignore
+      # that excludes all files is written into ob_outputDirectory before the auto-publish step.
+      ob_outputDirectory: $(Build.SourcesDirectory)/no_publish
 
       # Disable SDL scanning — this job only uploads/publishes PDBs and produces no
       # assemblies to scan. APIScan and BinSkim are handled by the build jobs.
@@ -73,6 +75,13 @@ jobs:
       symbolsPath: $(Pipeline.Workspace)/${{ parameters.artifactName }}/symbols
 
     steps:
+      # Create ob_outputDirectory with a .artifactignore that excludes everything,
+      # so OneBranch's auto-publish uploads an empty artifact.
+      - pwsh: |
+          New-Item -Path "$(ob_outputDirectory)" -ItemType Directory -Force
+          "**" | Out-File -FilePath "$(ob_outputDirectory)/.artifactignore" -Encoding ascii
+        displayName: 'Suppress artifact publishing'
+
       - task: DownloadPipelineArtifact@2
         displayName: 'Download ${{ parameters.packageFullName }} Artifact'
         inputs:

--- a/eng/pipelines/onebranch/jobs/publish-symbols-job.yml
+++ b/eng/pipelines/onebranch/jobs/publish-symbols-job.yml
@@ -74,6 +74,16 @@ jobs:
       # Path to the PDB files within the downloaded artifact.
       symbolsPath: $(Pipeline.Workspace)/${{ parameters.artifactName }}/symbols
 
+      # PublishSymbols@2 runs on the OneBranch host agent (outside the build container) due to 1ES
+      # Pipeline Template credential isolation. On Linux, the host resolves to the Microsoft org by
+      # default. Setting this variable at job level ensures the task sees it and connects to the
+      # correct org's symbol store.
+      #
+      # Reference:
+      # https://www.osgwiki.com/wiki/Symbols_Publishing_Pipeline_to_SymWeb_and_MSDL#Option_B:_OneBranch
+      #
+      ArtifactServices.Symbol.AccountName: ${{ parameters.symbolsUploadAccount }}
+
     steps:
       # Create ob_outputDirectory with a .artifactignore that excludes everything,
       # so OneBranch's auto-publish uploads an empty artifact.

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -33,9 +33,10 @@ parameters:
     type: boolean
     default: false
 
-  # Push packages to NuGet Production (otherwise pushes to NuGet Test).
+  # When true, publish symbols and push NuGet packages to Production environments.  When false,
+  # symbols use PPE and NuGet packages use QA/Test.
   - name: releaseToProduction
-    displayName: Release to NuGet Production
+    displayName: Publish Symbols and NuGet Packages to Production
     type: boolean
     default: false
 
@@ -254,9 +255,14 @@ extends:
 
           symbolsAzureSubscription: '$(SymbolsAzureSubscription)'
           symbolsPublishProjectName: '$(SymbolsPublishProjectNameSqlClient)'
-          # Official pipelines must publish to the Production symbol server.
-          symbolsPublishServer: '$(SymbolsPublishServerProd)'
-          symbolsPublishTokenUri: '$(SymbolsPublishTokenUriProd)'
+          # Symbol server target follows releaseToProduction: Production for
+          # real releases, PPE for test/QA releases.
+          ${{ if eq(parameters.releaseToProduction, true) }}:
+            symbolsPublishServer: '$(SymbolsPublishServerProd)'
+            symbolsPublishTokenUri: '$(SymbolsPublishTokenUriProd)'
+          ${{ else }}:
+            symbolsPublishServer: '$(SymbolsPublishServerPPE)'
+            symbolsPublishTokenUri: '$(SymbolsPublishTokenUriPPE)'
           symbolsUploadAccount: '$(SymbolsUploadAccount)'
 
       - template: /eng/pipelines/onebranch/stages/release-stages.yml@self

--- a/eng/pipelines/onebranch/steps/publish-symbols-step.yml
+++ b/eng/pipelines/onebranch/steps/publish-symbols-step.yml
@@ -75,16 +75,19 @@ parameters:
       type: string
 
 steps:
-    # Set variable for downstream tasks (allegedly).
+    # Set the ARTIFACTSERVICES_SYMBOL_ACCOUNTNAME environment variable required by the publishing
+    # tasks, as documented here:
     #
-    # Note: Because variables cannot be set in top-level of template, this has to be done during
-    # runtime.
+    # https://www.osgwiki.com/wiki/Symbols_Publishing_Pipeline_to_SymWeb_and_MSDL#Option_B:_OneBranch
+    #
+    # Note that Azure Pipelines converts variable names with dots to all-caps with underscores when
+    # setting environment variables.
     #
     - script: 'echo ##vso[task.setvariable variable=ArtifactServices.Symbol.AccountName;]${{ parameters.uploadAccount }}'
       displayName: 'Set ArtifactServices.Symbol.AccountName to ${{ parameters.uploadAccount }}'
 
-    # Log the PDB files that match the search pattern so we can verify no
-    # unexpected files are included in the upload.
+    # Log the PDB files that match the search pattern so we can verify no unexpected files are
+    # included in the upload.
     - pwsh: |
         $folder = '${{ parameters.symbolsFolder }}'
         $glob   = '${{ parameters.searchPattern }}'

--- a/eng/pipelines/onebranch/steps/publish-symbols-step.yml
+++ b/eng/pipelines/onebranch/steps/publish-symbols-step.yml
@@ -75,16 +75,13 @@ parameters:
       type: string
 
 steps:
-    # Set the ARTIFACTSERVICES_SYMBOL_ACCOUNTNAME environment variable required by the publishing
-    # tasks, as documented here:
+    # NOTE: ArtifactServices.Symbol.AccountName is set as a job-level variable in
+    # publish-symbols-job.yml. On OneBranch Linux agents, PublishSymbols@2 runs on the host (outside
+    # the build container) due to 1ES PT credential isolation. A ##vso[task.setvariable] inside the
+    # container is not visible to host-level tasks, so the variable must be declared at job scope.
     #
+    # Reference:
     # https://www.osgwiki.com/wiki/Symbols_Publishing_Pipeline_to_SymWeb_and_MSDL#Option_B:_OneBranch
-    #
-    # Note that Azure Pipelines converts variable names with dots to all-caps with underscores when
-    # setting environment variables.
-    #
-    - script: 'echo ##vso[task.setvariable variable=ArtifactServices.Symbol.AccountName;]${{ parameters.uploadAccount }}'
-      displayName: 'Set ArtifactServices.Symbol.AccountName to ${{ parameters.uploadAccount }}'
 
     # Log the PDB files that match the search pattern so we can verify no unexpected files are
     # included in the upload.

--- a/eng/pipelines/onebranch/variables/onebranch-variables.yml
+++ b/eng/pipelines/onebranch/variables/onebranch-variables.yml
@@ -39,6 +39,12 @@ variables:
   - name: Packaging.EnableSBOMSigning
     value: true
 
-  # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+  # OneBranch supplies a variety of container images we must use for our jobs.
+  #
+  # Windows jobs use this image.
   - name: WindowsContainerImage
-    value: "onebranch.azurecr.io/windows/ltsc2022/vse2022:latest"
+    value: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
+
+  # Linux jobs use this image.
+  - name: LinuxContainerImage
+    value: mcr.microsoft.com/onebranch/azurelinux/build:3.0


### PR DESCRIPTION
## Summary

Switches the OneBranch publish symbols jobs from Windows to Linux agents, fixes a cross-org authentication issue discovered during validation, and routes official symbols to PPE when `releaseToProduction` is false.

Follow-up to #4175.

## Changes

### Linux Pool for Symbols Jobs
- Change `pool.type` from `windows` to `linux` in `publish-symbols-job.yml`.
- Add `LinuxContainerImage` variable to `onebranch-variables.yml`.
- Add `.artifactignore` step to suppress empty artifact auto-publishing on Linux.

### Fix cross-org symbol upload authentication (VS30063)
- Move `ArtifactServices.Symbol.AccountName` from a runtime `##vso[task.setvariable]` step (which ran inside the build container) to a **job-level variable**.
- **Root cause**: On OneBranch Linux agents, `PublishSymbols@2` runs on the host agent (outside the build container) due to 1ES Pipeline Template credential isolation. The host defaults to the `microsoft` org, so `$(System.AccessToken)` (scoped to `SqlClientDrivers`) could not authenticate against `https://microsoft.artifacts.visualstudio.com`. Setting the variable at job scope makes it visible to both container and host steps, routing the upload to `https://SqlClientDrivers.artifacts.visualstudio.com`.
- On Windows this was not an issue because the host agent was already in the `SqlClientDrivers` org context.

### Route official symbols to PPE when releaseToProduction is false
- The official pipeline's `publishSymbols` stage was hardcoded to the Production symbol server regardless of the `releaseToProduction` flag. This meant there was no way to do a full dry-run release targeting both NuGet Test and symbol server PPE.
- Now `releaseToProduction` drives both destinations:
  - `true` → NuGet Production + Production symbol server
  - `false` → NuGet Test + PPE symbol server
- The `publishSymbols` flag still independently controls whether symbols are published at all.
- The non-official pipeline is unchanged (always PPE).

## Testing
- Non-official pipeline build 148586 failed with `VssUnauthorizedException (VS30063)` on Linux → root cause identified → fix applied → re-run expected to succeed.
- TBD: Validate ESRP minimatch changes with an Official pipeline run (since ESRP tasks only execute in Official runs).