### PR TITLE
Use symbols-variables-v3 not Symbols Publishing library

### DIFF
--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -227,8 +227,8 @@ extends:
           symbolsAzureSubscription: '$(SymbolsAzureSubscription)'
           symbolsPublishProjectName: '$(SymbolsPublishProjectNameSqlClient)'
           # Non-Official pipelines must publish to the PPE symbol server.
-          symbolsPublishServer: '$(SymbolsPublishServerPPE)'
-          symbolsPublishTokenUri: '$(SymbolsPublishTokenUriPPE)'
+          symbolsPublishServer: '$(SymbolsPublishServerPpe)'
+          symbolsPublishTokenUri: '$(SymbolsPublishTokenUriPpe)'
           symbolsUploadAccount: '$(SymbolsUploadAccount)'
 
       - template: /eng/pipelines/onebranch/stages/release-stages.yml@self

--- a/eng/pipelines/onebranch/variables/onebranch-variables.yml
+++ b/eng/pipelines/onebranch/variables/onebranch-variables.yml
@@ -25,10 +25,12 @@ variables:
   #
   # SymbolsAzureSubscription
   # SymbolsPublishProjectNameSqlClient
-  # SymbolsPublishServerProd / SymbolsPublishServerPPE
-  # SymbolsPublishTokenUriProd / SymbolsPublishTokenUriPPE
+  # SymbolsPublishServerProd
+  # SymbolsPublishServerPpe
+  # SymbolsPublishTokenUriProd
+  # SymbolsPublishTokenUriPpe
   # SymbolsUploadAccount
-  - group: 'Symbols Publishing'
+  - group: 'symbols-variables-v3'
 
   # OneBranch Template Variables ###########################################
 


### PR DESCRIPTION
## Description
Change symbols publishing official/non-official pipeline stage back to using symbols-variables library. "Symbols Publishing" library is deprecated, as per description that was unceremoniously obliterated.
