### PR TITLE
Fix flaky SequentialAccess test with dynamic expected value

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -964,6 +964,7 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
             long cb = 0;
             long di = 0;
             long cbTotal = 0;
+            long expectedTotal = 0;
             object o;
             int i;
             SqlBinary sqlbin;
@@ -971,6 +972,15 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
             using (SqlConnection conn = new SqlConnection(connectionString))
             {
                 conn.Open();
+                // Compute the expected total bytes independently of the C# APIs under test in order to compare.
+                //The inner SELECT generates the XML, CAST converts it to a Unicode string, LEN() * 2 matches s.Length * 2 in C# since UTF-16 uses 2 bytes per character.
+                // SUM() totals across all rows, matching the loop below.
+                using (SqlCommand cmdExpected = new SqlCommand("SELECT SUM(LEN(CAST(xml_data AS NVARCHAR(MAX))) * 2) FROM " +
+                                                "(SELECT CAST((SELECT * FROM orders FOR XML AUTO) AS NVARCHAR(MAX)) AS xml_data) t", conn))
+                {
+                    expectedTotal = (long)cmdExpected.ExecuteScalar();
+                }
+
                 using (SqlCommand cmd = new SqlCommand("select * from orders for xml auto", conn))
                 {
                     // Simple reads
@@ -985,7 +995,7 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
                             }
                         } while (reader.NextResult());
                     }
-                    DataTestUtility.AssertEqualsWithDescription((long)536198, cbTotal, "FAILED: cbTotal result did not have expected value");
+                    DataTestUtility.AssertEqualsWithDescription(expectedTotal, cbTotal, "FAILED: cbTotal result did not have expected value");
 
                     // Simple GetFieldValue<T>
                     cbTotal = 0;
@@ -1000,7 +1010,7 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
                             }
                         } while (reader.NextResult());
                     }
-                    DataTestUtility.AssertEqualsWithDescription((long)536198, cbTotal, "FAILED: cbTotal result did not have expected value");
+                    DataTestUtility.AssertEqualsWithDescription(expectedTotal, cbTotal, "FAILED: cbTotal result did not have expected value");
 
                     // Simple GetFieldValueAsync<T>
                     cbTotal = 0;
@@ -1015,7 +1025,7 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
                             }
                         } while (reader.NextResult());
                     }
-                    DataTestUtility.AssertEqualsWithDescription((long)536198, cbTotal, "FAILED: cbTotal result did not have expected value");
+                    DataTestUtility.AssertEqualsWithDescription(expectedTotal, cbTotal, "FAILED: cbTotal result did not have expected value");
 
                     // test sequential access reading everything
                     cbTotal = 0;
@@ -1039,7 +1049,7 @@ CREATE TABLE {tableName} (id INT, foo VARBINARY(MAX))
                             }
                         } while (reader.NextResult());
                     }
-                    DataTestUtility.AssertEqualsWithDescription((long)536198, cbTotal, "FAILED: cbTotal result did not have expected value");
+                    DataTestUtility.AssertEqualsWithDescription(expectedTotal, cbTotal, "FAILED: cbTotal result did not have expected value");
                 }
 
                 // Test IsDBNull


### PR DESCRIPTION
**Description:**
The SequentialAccess test in DataStreamTest.cs was asserting a hardcoded byte count (536198) for the result of 
`SELECT * FROM orders FOR XML AUTO. `
This value was tied to a specific state of the Northwind database and would fail whenever the Orders table content differed across test environments or servers.

**Fix:**
Replace the hardcoded expected value with a dynamically computed baseline using a direct SQL query, independent of the C# APIs under test. 
-All 4 hardcoded assertions replaced with expectedTotal

