### PR TITLE
Revert "Update to latest Azure.Core package with Azure.Identity types"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,8 +50,8 @@
   <!-- Dependencies shared by multiple projects -->
 
   <ItemGroup>
-    <PackageVersion Include="Azure.Core" Version="1.53.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.3" />
+    <PackageVersion Include="Azure.Core" Version="1.51.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.83.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
@@ -81,7 +81,9 @@
   <!-- ===================================================================== -->
   <!-- Azure Dependencies -->
 
-  <!-- None -->
+  <ItemGroup>
+    <PackageVersion Include="Azure.Identity" Version="1.18.0" />
+  </ItemGroup>
 
   <!-- ===================================================================== -->
   <!-- SqlClient Dependencies -->

--- a/doc/Directory.Packages.props
+++ b/doc/Directory.Packages.props
@@ -2,11 +2,9 @@
   <!-- Import parent Directory.Packages.props -->
   <Import Project="..\Directory.Packages.props" />
   <ItemGroup>
-    <!-- Explicitly include Azure.Identity. -->
-    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <!-- Reference SqlClient package versions that support our needs. -->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0-preview4.26064.3" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="7.0.0-preview1.26064.3" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0-preview1.26064.3" />
   </ItemGroup>
 </Project>

--- a/doc/apps/AzureAuthentication/Directory.Packages.props
+++ b/doc/apps/AzureAuthentication/Directory.Packages.props
@@ -4,11 +4,11 @@
   <!-- We purposely do not include any parent Directory.Packages.props files. -->
 
   <PropertyGroup>
-    <!-- Use SqlClient 7.0.0 if no version was specified. -->
-    <SqlClientVersion>7.0.0</SqlClientVersion>
+    <!-- Use SqlClient 7.0.0 Preview 4 if no version was specified. -->
+    <SqlClientVersion>7.0.0-preview4.26064.3</SqlClientVersion>
 
-    <!-- Use AKV Provider 7.0.0 if no version was specified. -->
-    <AkvProviderVersion>7.0.0</AkvProviderVersion>
+    <!-- Use AKV Provider 7.0.0 Preview 1 if no version was specified. -->
+    <AkvProviderVersion>7.0.0-preview1.26064.3</AkvProviderVersion>
   </PropertyGroup>
 
   <!-- SqlClient Packages -->
@@ -25,8 +25,8 @@
 
   <!-- Other Packages -->
   <ItemGroup>
-    <PackageVersion Include="Azure.Core" Version="1.53.0" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.6" />
+    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.3" />
   </ItemGroup>
 
 </Project>

--- a/doc/apps/AzureAuthentication/README.md
+++ b/doc/apps/AzureAuthentication/README.md
@@ -33,8 +33,8 @@ Package versions are controlled through MSBuild properties. Pass them on the com
 
 | Property | Default | Description |
 | --- | --- | --- |
-| `SqlClientVersion` | `7.0.0` | Version of `Microsoft.Data.SqlClient` to reference. |
-| `AkvProviderVersion` | `7.0.0` | Version of `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider` to reference. |
+| `SqlClientVersion` | `7.0.0-preview4.26064.3` | Version of `Microsoft.Data.SqlClient` to reference. |
+| `AkvProviderVersion` | `7.0.0-preview1.26064.3` | Version of `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider` to reference. |
 | `AzureVersion` | None | Version of `Microsoft.Data.SqlClient.Extensions.Azure` to reference.  When omitted, the `Azure` package will not be referenced. |
 
 ## Local Package Source
@@ -68,9 +68,9 @@ Description:
 
   Supply specific package versions when building to test different versions of the SqlClient suite, for example:
 
-    -p:SqlClientVersion=7.1.0.preview1
-    -p:AkvProviderVersion=7.0.0
-    -p:AzureVersion=1.1.0-preview1
+    -p:SqlClientVersion=7.0.0.preview4
+    -p:AkvProviderVersion=7.0.1-preview2
+    -p:AzureVersion=1.0.0-preview1
 
 Usage:
   AzureAuthentication [options]
@@ -104,9 +104,9 @@ Azure Authentication Tester
 ---------------------------
 
 Packages used:
-  SqlClient:     7.0.0
-  AKV Provider:  7.0.0
-  Azure:         1.0.0
+  SqlClient:     7.0.0-preview4.26055.1
+  AKV Provider:  6.1.2
+  Azure:         1.0.0-preview1.26055.1
 
 Connection details:
   Data Source:      adotest.database.windows.net
@@ -142,19 +142,19 @@ authentication provider.
 Run against locally-built packages (drop `.nupkg` files into the `packages/` folder first):
 
 ```bash
-dotnet run -p:SqlClientVersion=7.1.0-preview1 -- -c "<connection string>"
+dotnet run -p:SqlClientVersion=7.0.0-preview4 -- -c "<connection string>"
 ```
 
 Run including the `Azure` extensions package:
 
 ```bash
-dotnet run -p:AzureVersion=1.0.0 -- -c "<connection string>"
+dotnet run -p:AzureVersion=1.0.0-preview1 -- -c "<connection string>"
 ```
 
 Override all three versions at once:
 
 ```bash
-dotnet run -p:SqlClientVersion=7.1.0-preview1 -p:AkvProviderVersion=7.1.0-preview1 -p:AzureVersion=1.0.0 -- -c "<connection string>"
+dotnet run -p:SqlClientVersion=7.0.0-preview1 -p:AkvProviderVersion=7.0.0-preview1 -p:AzureVersion=1.0.0-preview1 -- -c "<connection string>"
 ```
 
 ## Prerequisites

--- a/doc/samples/Microsoft.Data.SqlClient.Samples.csproj
+++ b/doc/samples/Microsoft.Data.SqlClient.Samples.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.Identity.Client" />
     <PackageReference Include="Microsoft.SqlServer.Server" />
     <PackageReference Include="Microsoft.Data.SqlClient" />

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
@@ -129,6 +129,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <!-- Explicitly depend on the same version of Microsoft.Identity.Client as SqlClient. -->
     <PackageReference Include="Microsoft.Identity.Client" />

--- a/src/Microsoft.Data.SqlClient/tests/Common/Microsoft.Data.SqlClient.TestCommon.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Microsoft.Data.SqlClient.TestCommon.csproj
@@ -30,14 +30,14 @@
 
   <!-- References for netfx -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" />
   </ItemGroup>
 
   <!-- References for netcore -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.FunctionalTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/Microsoft.Data.SqlClient.FunctionalTests.csproj
@@ -66,7 +66,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Transactions" />
 
-    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Bcl.Cryptography" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI"
                       Condition="'$(ReferenceType)' != 'Package'" />
@@ -97,7 +97,7 @@
 
   <!-- References for netcore -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Bcl.Cryptography" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI.runtime"
                       Condition="'$(ReferenceType)' != 'Package'" />

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTests.csproj
@@ -355,7 +355,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Transactions" />
 
-    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Bcl.Cryptography" />
     <PackageReference Include="System.Memory" />
     <PackageReference Include="System.ValueTuple" />
@@ -391,7 +391,7 @@
 
   <!-- References for netcore -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="Azure.Core" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Bcl.Cryptography" />
     <PackageReference Include="Microsoft.Data.SqlClient.SNI.runtime"
                       Condition="'$(ReferenceType)' != 'Package'" />


### PR DESCRIPTION
Reverts dotnet/SqlClient#4200 for 7.1.0-preview1 - as we do not plan to release new versions of Azure and Abstractions packages right now.

We will take these changes later for 7.1.0-preview2 milestone.

There are dependency leak issues that need to be resolved in 7.0.x before new versions of Azure and Abstractions can be released.