### PR TITLE
Added instructions for identifying changes specific to a subset of TFMs and OSes, where applicable.

### DIFF
--- a/.github/prompts/release-notes.prompt.md
+++ b/.github/prompts/release-notes.prompt.md
@@ -58,7 +58,7 @@ This prompt uses the following skill:
 - Identify the contributors for the "Contributors" section.
 - **Assign each PR to one or more packages** using the identification rules in the Package Registry table. A PR may be relevant to multiple packages. PRs not matching any non-core package belong to `Microsoft.Data.SqlClient`.
 
-### 2.5. Determine Target Framework (TFM) Scope Per Change
+### 2.1. Determine Target Framework (TFM) Scope Per Change
 
 For each PR included in release notes, determine whether it applies to all supported TFMs for the package or only a subset.
 
@@ -79,7 +79,7 @@ When writing notes:
 
 Do not infer TFM scope from labels alone; verify from changed files and code paths.
 
-### 2.6. Determine Operating System (OS) Scope Per Change
+### 2.2. Determine Operating System (OS) Scope Per Change
 
 For each PR included in release notes, determine whether it applies to all supported OS targets for the package or only a subset.
 
@@ -130,7 +130,7 @@ For each package that has relevant PRs in the milestone:
    - Use the template from [release-notes/template/release-notes-template.md](release-notes/template/release-notes-template.md).
    - Fill in the template following the instructions in each section.
    - Only include sections (Added, Changed, Fixed, Removed) that have entries.
-    - For each Added/Changed/Fixed/Removed item, include TFM and OS scope qualifiers when Step 2.5 or Step 2.6 determines the change is not universal across the package's supported targets.
+   - For each Added/Changed/Fixed/Removed item, include TFM and OS scope qualifiers when Step 2.1 or Step 2.2 determines the change is not universal across the package's supported targets.
    - Look up dependencies using the Dependency Sources from the lookup table above. Resolve concrete versions from [Directory.Packages.props](Directory.Packages.props).
    - List dependencies per target framework. Use the project file's `<TargetFrameworks>` to determine which frameworks to list.
    - Omit the Contributors section for packages with no public contributors.

--- a/.github/prompts/release-notes.prompt.md
+++ b/.github/prompts/release-notes.prompt.md
@@ -58,6 +58,52 @@ This prompt uses the following skill:
 - Identify the contributors for the "Contributors" section.
 - **Assign each PR to one or more packages** using the identification rules in the Package Registry table. A PR may be relevant to multiple packages. PRs not matching any non-core package belong to `Microsoft.Data.SqlClient`.
 
+### 2.5. Determine Target Framework (TFM) Scope Per Change
+
+For each PR included in release notes, determine whether it applies to all supported TFMs for the package or only a subset.
+
+Use source-level evidence (not assumptions) to classify scope:
+
+- **TFM-specific files** indicate scoped impact (for example, `.netfx.cs`, `.netcore.cs`).
+- **Conditional compilation** indicates scoped impact (for example, `#if NETFRAMEWORK`, `#if NET`).
+- **Project or build conditions** indicate scoped impact (for example, `Condition` expressions on `TargetFramework` or `TargetFrameworks`).
+- **Tests-only TFM changes** should not be called out as customer-facing unless the behavior change is also present in product code.
+
+When writing notes:
+
+- If the change affects **all supported TFMs** for that package, do not add a TFM qualifier.
+- If the change affects **only some TFMs**, include an explicit qualifier in the relevant bullet or section title.
+- Use concise qualifiers like:
+  - `(net462 only)`
+  - `(net8.0/net9.0 only)`
+
+Do not infer TFM scope from labels alone; verify from changed files and code paths.
+
+### 2.6. Determine Operating System (OS) Scope Per Change
+
+For each PR included in release notes, determine whether it applies to all supported OS targets for the package or only a subset.
+
+Use source-level evidence (not assumptions) to classify scope:
+
+- **OS-specific files** indicate scoped impact (for example, `.windows.cs`, `.unix.cs`).
+- **OS preprocessor symbols** indicate scoped impact (for example, `#if _WINDOWS`, `#if _UNIX`).
+- **Project/build conditions** indicate scoped impact (for example, `TargetOs`, `NormalizedTargetOs`, or OS-conditional `ItemGroup`/`PropertyGroup` entries).
+- **SNI implementation or native dependency gates** can imply OS scope when behavior changes only apply to native Windows SNI vs managed cross-platform paths.
+- **Tests-only OS changes** should not be called out as customer-facing unless the behavior change is also present in product code.
+
+When writing notes:
+
+- If the change affects **all supported OS targets**, do not add an OS qualifier.
+- If the change affects **only some OS targets**, include an explicit qualifier in the relevant bullet or section title.
+- Use concise qualifiers like:
+  - `(Windows only)`
+  - `(Unix only)`
+  - `(Linux only)`
+  - `(macOS only)`
+- If both TFM and OS are scoped, combine them in one qualifier, for example: `(net8.0/net9.0 on Windows only)`.
+
+Do not infer OS scope from labels alone; verify from changed files and code paths.
+
 ### 3. Enrich Feature Sections with Issue Context
 
 For significant features or bug fixes that reference a GitHub issue:
@@ -84,6 +130,7 @@ For each package that has relevant PRs in the milestone:
    - Use the template from [release-notes/template/release-notes-template.md](release-notes/template/release-notes-template.md).
    - Fill in the template following the instructions in each section.
    - Only include sections (Added, Changed, Fixed, Removed) that have entries.
+    - For each Added/Changed/Fixed/Removed item, include TFM and OS scope qualifiers when Step 2.5 or Step 2.6 determines the change is not universal across the package's supported targets.
    - Look up dependencies using the Dependency Sources from the lookup table above. Resolve concrete versions from [Directory.Packages.props](Directory.Packages.props).
    - List dependencies per target framework. Use the project file's `<TargetFrameworks>` to determine which frameworks to list.
    - Omit the Contributors section for packages with no public contributors.


### PR DESCRIPTION
## Summary

Enhances the `release-notes` prompt with explicit guidance for identifying and annotating changes that only affect a subset of the driver's supported targets.

## Changes

### New Step 2.1 — TFM Scope Detection
Instructs the agent to examine each PR's changed files and code for framework-specific evidence before writing release notes:
- File suffixes: `.netfx.cs`, `.netcore.cs`
- Conditional compilation: `#if NETFRAMEWORK`, `#if NET`
- MSBuild `Condition` expressions on `TargetFramework` / `TargetFrameworks`

When a change is framework-scoped, the generated note includes a concise qualifier such as `(net462 only)` or `(net8.0/net9.0 only)`. Universal changes get no qualifier.

### New Step 2.2 — OS Scope Detection
Mirrors Step 2.1 for operating-system-specific changes:
- File suffixes: `.windows.cs`, `.unix.cs`
- Preprocessor symbols: `#if _WINDOWS`, `#if _UNIX`
- MSBuild `TargetOs` / `NormalizedTargetOs` conditions
- Native vs managed SNI path gates

When a change is OS-scoped, the note includes a qualifier such as `(Windows only)` or `(Unix only)`. When both TFM and OS are scoped they are combined: e.g. `(net8.0/net9.0 on Windows only)`.

### Updated Step 5.2 — Generation Requirement
The release-notes writing step now explicitly requires TFM and OS qualifiers to be included for any Added/Changed/Fixed/Removed item where Step 2.1 or Step 2.2 identifies non-universal scope.

## Checklist
- [x] Tests added or updated — N/A (prompt-only change)
- [x] Public API changes documented — N/A
- [x] No breaking changes introduced