### PR TITLE
[7.1.0-preview1] ESRP Globbing

### DIFF
--- a/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
@@ -155,7 +155,7 @@ jobs:
               authSignCertName: '${{ parameters.signingAuthSignCertName }}'
               esrpClientId: '${{ parameters.signingEsrpClientId }}'
               esrpConnectedServiceName: '${{ parameters.signingEsrpConnectedServiceName }}'
-              pattern: '${{ parameters.packageFullName }}.dll'
+              pattern: '**/${{ parameters.packageFullName }}.dll'
 
       # Copy signed/unsigned DLLs and PDBs to APIScan folders.
       - task: CopyFiles@2


### PR DESCRIPTION
## Description
ESRP code signing is failing on internal/main because the search pattern doesn't match any dll files. This is because the esrp task is searching for the dll in the root of the build output. Instead it should be using a glob pattern to search all folders in the build output path.

Small issue, could've been caught if we were allowed to run ESRP signing against non-official pipelines, or run official pipelines against arbitrary branches, but nooooo...
