### PR TITLE
[7.1.0-preview1] ESRP Sign Resources Files, too

### DIFF
--- a/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
@@ -155,7 +155,9 @@ jobs:
               authSignCertName: '${{ parameters.signingAuthSignCertName }}'
               esrpClientId: '${{ parameters.signingEsrpClientId }}'
               esrpConnectedServiceName: '${{ parameters.signingEsrpConnectedServiceName }}'
-              pattern: '**/${{ parameters.packageFullName }}.dll'
+              pattern: |
+                **/${{ parameters.packageFullName }}.dll
+                **/${{ parameters.packageFullName }}.resources.dll
 
       # Copy signed/unsigned DLLs and PDBs to APIScan folders.
       - task: CopyFiles@2


### PR DESCRIPTION
## Description
Official pipeline was failing due to ESRP not signing the *.resources.dll files. This updates the search pattern to include the *.resources.dll files. It explicitly adds that pattern rather than Microsoft.Data.SqlClient*.dll (as per 🤖 suggestion) because it captures only the dlls that we built as part of the current build job.

Worth noting, if we ever switch off package build mode for official/non-official builds, we will need to change this pattern, since the dependencies will also be unsigned.
