### PR TITLE
[v7.1.0-preview1] ESRP Nuget Signing Path Fix

### DIFF
--- a/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
@@ -201,8 +201,8 @@ jobs:
               authSignCertName: '${{ parameters.signingAuthSignCertName }}'
               esrpClientId: '${{ parameters.signingEsrpClientId }}'
               esrpConnectedServiceName: '${{ parameters.signingEsrpConnectedServiceName }}'
-              searchPath: '$(PACK_OUTPUT)'
-              searchPattern: '${{ parameters.packageFullName}}.*nupkg'
+              searchPath: '$(BUILD_OUTPUT)'
+              searchPattern: '**/${{ parameters.packageFullName}}.*nupkg'
 
       # Copy the contents of the build output for this package to the artifacts folder
       - task: CopyFiles@2

--- a/eng/pipelines/onebranch/steps/pack-buildproj-step.yml
+++ b/eng/pipelines/onebranch/steps/pack-buildproj-step.yml
@@ -5,7 +5,7 @@
 #################################################################################
 
 # Generic pack step for build.proj packages. This step runs the Pack* target to generate a NuGet
-# package of the target package. The generated NuGet packages will then be copied to $(PACK_OUTPUT).
+# package of the target package.
 #
 # Note: This step assumes that the package has been built previously using a Build* target.
 #   `-p:PackBuild=false` will be passed to msbuild to ensure the previously built assemblies are
@@ -71,14 +71,3 @@ steps:
 
   - script: tree /a /f $(BUILD_OUTPUT)
     displayName: Output Build Output Tree
-
-  - task: CopyFiles@2
-    displayName: 'Copy NuGet Packages to PACK_OUTPUT'
-    inputs:
-      contents: '**/${{ parameters.packageFullName }}*.*nupkg'
-      flattenFolders: true
-      sourceFolder: '$(BUILD_OUTPUT)/${{ parameters.packageFullName }}/'
-      targetFolder: '$(PACK_OUTPUT)'
-
-  - script: tree /a /f $(PACK_OUTPUT)
-    displayName: Output Package Output Tree


### PR DESCRIPTION
## Description
An artifact of the churn in pipelines lately. Packages were being copied to PACK_OUTPUT, and that's where ESRP signing was pulling from. Indeed, it found two nuget package files and it signed them. But the problem is 1) PACK_OUTPUT isn't published as the build artifacts, BUILD_OUTPUT is, and the nuget package files in that folder aren't being signed, and 2) PACK_OUTPUT isn't even defined anymore, so it's literally copying them to $(PACK_OUTPUT).

This fixes the issue by removing the step to copy to PACK_OUTPUT, and changes ESRP nuget signing to point at BUILD_OUTPUT. 🤖 has verified this should fix everything.