### PR TITLE
Fix non-deterministic NuGet packages by enabling ContinuousIntegrationBuild for OneBranch builds

### DIFF
--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -96,6 +96,14 @@ variables:
     parameters:
       isPreview: ${{ parameters.isPreview }}
 
+  # Drives ContinuousIntegrationBuild=true in src/Directory.Build.props so this
+  # pipeline produces deterministic packages identical (modulo signing) to the
+  # official pipeline.  Keeping this enabled here ensures the deterministic
+  # build path is exercised on every non-official run, catching regressions
+  # before they reach the official release pipeline.
+  - name: BuildForRelease
+    value: true
+
 resources:
   repositories:
     - repository: templates

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -120,8 +120,8 @@ variables:
 
   # Drives ContinuousIntegrationBuild=true in src/Directory.Build.props so the shipped
   # DLLs/PDBs embed portable /_/... source paths and the produced NuGet packages pass
-  # NuGet Package Explorer's "Deterministic (build)" check.  Set only on the official
-  # release pipeline; PR/CI and non-official builds leave it unset (false).
+  # NuGet Package Explorer's "Deterministic (build)" check.  Set on both OneBranch
+  # pipelines; PR/CI builds leave it unset (false).
   - name: BuildForRelease
     value: true
 

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -118,6 +118,13 @@ variables:
     parameters:
       isPreview: ${{ parameters.isPreview }}
 
+  # Drives ContinuousIntegrationBuild=true in src/Directory.Build.props so the shipped
+  # DLLs/PDBs embed portable /_/... source paths and the produced NuGet packages pass
+  # NuGet Package Explorer's "Deterministic (build)" check.  Set only on the official
+  # release pipeline; PR/CI and non-official builds leave it unset (false).
+  - name: BuildForRelease
+    value: true
+
 resources:
   repositories:
     - repository: templates

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -126,6 +126,31 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUnTrackedSources>true</EmbedUnTrackedSources>
     <DisableSourceLinkTranslation Condition="'$(DisableSourceLinkTranslation)' == ''">false</DisableSourceLinkTranslation>
+
+    <!--
+      BuildForRelease gates the release-only behaviors below.  It defaults to false so that
+      PR validation, scheduled CI, and the OneBranch non-official pipeline build with the
+      same behavior as a local developer build.  The OneBranch official pipeline sets this
+      to true via a pipeline variable so that release packages are built deterministically.
+    -->
+    <BuildForRelease Condition="'$(BuildForRelease)' == ''">false</BuildForRelease>
+
+    <!--
+      Explicit deterministic build flag.  This is also the SDK default, but we set it
+      explicitly so the build does not silently regress if a future SDK changes the default.
+    -->
+    <Deterministic>true</Deterministic>
+
+    <!--
+      ContinuousIntegrationBuild enables DeterministicSourcePaths, which remaps the source
+      root to a portable form (/_/...) inside embedded PDB paths.  Without this property
+      set to true, NuGet Package Explorer's "Deterministic (build)" check fails because
+      the PDBs embed absolute build-agent paths (e.g. C:\__w\1\s\...).
+
+      Gated on BuildForRelease so PR/CI builds keep their pre-#4204 behavior; only the
+      OneBranch official pipeline (which sets BuildForRelease=true) enables this.
+    -->
+    <ContinuousIntegrationBuild Condition="'$(ContinuousIntegrationBuild)' == ''">$(BuildForRelease)</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <!-- Provides Build properties -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -129,9 +129,10 @@
 
     <!--
       BuildForRelease gates the release-only behaviors below.  It defaults to false so that
-      PR validation, scheduled CI, and the OneBranch non-official pipeline build with the
-      same behavior as a local developer build.  The OneBranch official pipeline sets this
-      to true via a pipeline variable so that release packages are built deterministically.
+      PR validation, scheduled CI, and local developer builds use the simpler dev-friendly
+      behavior.  Both OneBranch pipelines (official and non-official) set this to true via
+      a pipeline variable so that release packages are built deterministically and the
+      non-official pipeline exercises the same path as official before any release.
     -->
     <BuildForRelease Condition="'$(BuildForRelease)' == ''">false</BuildForRelease>
 
@@ -147,8 +148,8 @@
       set to true, NuGet Package Explorer's "Deterministic (build)" check fails because
       the PDBs embed absolute build-agent paths (e.g. C:\__w\1\s\...).
 
-      Gated on BuildForRelease so PR/CI builds keep their pre-#4204 behavior; only the
-      OneBranch official pipeline (which sets BuildForRelease=true) enables this.
+      Gated on BuildForRelease so PR/CI/local builds keep their pre-#4204 behavior; both
+      OneBranch pipelines (which set BuildForRelease=true) enable this.
     -->
     <ContinuousIntegrationBuild Condition="'$(ContinuousIntegrationBuild)' == ''">$(BuildForRelease)</ContinuousIntegrationBuild>
   </PropertyGroup>


### PR DESCRIPTION
## Description
Restore deterministic builds for OneBranch-produced NuGet packages so they pass NuGet Package Explorer's "Deterministic (build)" check.
Introduced a `BuildForRelease` gate in `src/Directory.Build.props` that drives `ContinuousIntegrationBuild`. The two OneBranch pipelines set `BuildForRelease: true`; PR/CI and local dev builds are unchanged.


## Testing
The official and non-official run should validate this change.

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
