### PR TITLE
[7.1.0-preview1] Fix TFM Attributes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -57,10 +57,6 @@
     <FileVersionBuildNumber>$(BuildNumber.Split('.')[0])</FileVersionBuildNumber>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(BuildForRelease) == 'true'">
-    <!-- Release builds embed generated assembly-info as source. -->
-  </PropertyGroup>
-
   <ItemGroup Condition="$(BuildForRelease) == 'true'">
     <SourceRoot Include="$(MSBuildThisFileDirectory)/" />
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -57,9 +57,8 @@
     <FileVersionBuildNumber>$(BuildNumber.Split('.')[0])</FileVersionBuildNumber>
   </PropertyGroup>
 
-  <!-- @TODO: What is this? -->
   <PropertyGroup Condition="$(BuildForRelease) == 'true'">
-    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+    <!-- Release builds embed generated assembly-info as source. -->
   </PropertyGroup>
 
   <ItemGroup Condition="$(BuildForRelease) == 'true'">

--- a/src/Microsoft.Data.SqlClient.slnx
+++ b/src/Microsoft.Data.SqlClient.slnx
@@ -134,6 +134,7 @@
   </Folder>
   <Folder Name="/src/">
     <File Path="Directory.Build.props" />
+    <File Path="src/Directory.Build.targets" />
   </Folder>
   <Folder Name="/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/">
     <Project Path="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj" />

--- a/src/Microsoft.Data.SqlClient.slnx
+++ b/src/Microsoft.Data.SqlClient.slnx
@@ -134,7 +134,7 @@
   </Folder>
   <Folder Name="/src/">
     <File Path="Directory.Build.props" />
-    <File Path="src/Directory.Build.targets" />
+    <File Path="Directory.Build.targets" />
   </Folder>
   <Folder Name="/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/">
     <Project Path="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj" />


### PR DESCRIPTION
Investigation and fix was done via 🤖 Here's it's explanation of the issue and the proposed solution:

---

We investigated the TFM mismatch seen in the Microsoft.Data.SqlClient release artifacts and package. The short version is that this does not look like a nuspec bug or an ESRP signing bug.
 
  What we verified:
 
  - The package layout is correct. net8.0, net9.0, and net462 assets are being pulled from their expected build-output folders.
  - The signed build-output DLLs and the DLLs inside the package match byte-for-byte, so packaging is not copying the wrong binaries.
  - The binaries are not all the same assembly. Their hashes, sizes, and framework references differ as expected.
  - However, several final artifacts have the wrong managed TargetFrameworkAttribute embedded in metadata. For example, some net9.0 and net462 outputs report .NETCoreApp,Version=v8.0 even though their actual assembly references still line up with the correct target.
 
  We traced this to a recent release-only build change in src/Directory.Build.props. Specifically, when BuildForRelease=true, we override
  TargetFrameworkMonikerAssemblyAttributesPath. In the normal build path, that property resolves to separate per-TFM files like:
 
  - obj/Release/net8.0/.NETCoreApp,Version=v8.0.AssemblyAttributes.cs
  - obj/Release/net9.0/.NETCoreApp,Version=v9.0.AssemblyAttributes.cs
  - obj/Release/net462/.NETFramework,Version=v4.6.2.AssemblyAttributes.cs
 
  With BuildForRelease=true, it instead collapses to a shared path:
 
  - .AssemblyAttributes
 
  That means multiple target frameworks can reuse/overwrite the same generated assembly-attributes file, which explains how the final binaries can end up with the wrong TargetFrameworkAttribute while still otherwise being the correct target-specific build.
 
  Recommendation:
  I would not treat this as safe to ignore, even for a preview release. It is probably not catastrophic for NuGet asset selection or normal runtime behavior, because the actual binaries and references appear correct. But it is still a real release-quality issue:
 
  - tools and reflection can observe the wrong target framework
  - net462 especially reporting .NETCoreApp metadata is bad and confusing
  - we have an identified likely root cause in the repo, not just a tooling glitch
 
  My recommendation is to fix this before release if at all possible. The likely fix is to remove or move that TargetFrameworkMonikerAssemblyAttributesPath override so it is evaluated later, after per-target intermediate paths are established. If schedule pressure is extreme, I would at minimum block on a quick validation build after changing that override, because this looks like a deterministic regression introduced by the release-only build path rather than a benign display issue.

---
Ben again, I don't even think we need this file at all, but I do not have the bandwidth at the moment to validate it will still report as deterministic if I just delete it. But the 🤖 says this is safer, so we can go with it for now.