### PR TITLE
Consolidate OS detection to OsConstants

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -13,13 +13,13 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security;
-using Microsoft.Data.SqlClient;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.Data.Common.ConnectionString;
+using Microsoft.Data.SqlClient;
 using Microsoft.Data.SqlClient.Connection;
 using Microsoft.SqlServer.Server;
 using Microsoft.Win32;
@@ -425,7 +425,7 @@ namespace Microsoft.Data.Common
         internal static object LocalMachineRegistryValue(string subkey, string queryvalue)
         {
             #if NET
-            if (OsConstants.IsUnix)
+            if (!OsConstants.IsWindows)
             {
                 // No registry in non-Windows environments
                 return null;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -13,13 +13,13 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security;
+using Microsoft.Data.SqlClient;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.Data.Common.ConnectionString;
-using Microsoft.Data.SqlClient;
 using Microsoft.Data.SqlClient.Connection;
 using Microsoft.SqlServer.Server;
 using Microsoft.Win32;
@@ -64,22 +64,6 @@ namespace Microsoft.Data.Common
         /// Max duration for buffer in seconds
         /// </summary>
         internal const int MaxBufferAccessTokenExpiry = 600;
-
-        /// <summary>
-        /// This member returns true if the current OS platform is Windows.
-        /// </summary>
-        /// <remarks>
-        /// This is a const on .NET Framework, and a property on .NET Core, because of differing API availability and JIT requirements.
-        /// .NET Framework will perform basic dead branch elimination when a const value is encountered, while .NET Core can trim Windows-specific
-        /// code when published to non-Windows platforms.
-        /// .NET Core's trimming is very limited though, so this must be used inline within methods to throw PlatformNotSupportedException,
-        /// rather than in a throw helper.
-        /// </remarks>
-        #if NETFRAMEWORK
-        public const bool IsWindows = true;
-        #else
-        public static bool IsWindows => OperatingSystem.IsWindows();
-        #endif
 
         #region UDT
 
@@ -159,10 +143,10 @@ namespace Microsoft.Data.Common
                 state,
                 TimeSpan.FromMilliseconds(dueTimeMilliseconds),
                 TimeSpan.FromMilliseconds(periodMilliseconds));
-        
+
         internal static Timer UnsafeCreateTimer(TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
         {
-            // Don't capture the current ExecutionContext and its AsyncLocals onto 
+            // Don't capture the current ExecutionContext and its AsyncLocals onto
             // a global timer causing them to live forever
             bool restoreFlow = false;
             try
@@ -184,7 +168,7 @@ namespace Microsoft.Data.Common
                 }
             }
         }
-            
+
 
 #region COM+ exceptions
         internal static ArgumentException Argument(string error)
@@ -451,7 +435,7 @@ namespace Microsoft.Data.Common
         internal static object LocalMachineRegistryValue(string subkey, string queryvalue)
         {
             #if NET
-            if (!IsWindows)
+            if (OsConstants.IsUnix)
             {
                 // No registry in non-Windows environments
                 return null;
@@ -639,7 +623,7 @@ namespace Microsoft.Data.Common
         {
             StringBuilder bld = new();
             // Assume we want to build a full multi-part name with all parts except trimming separators for
-            // leading empty names (null or empty strings, but not whitespace). Separators in the middle 
+            // leading empty names (null or empty strings, but not whitespace). Separators in the middle
             // should be added, even if the name part is null/empty, to maintain proper location of the parts.
             for (int i = 0; i < strings.Length; i++)
             {
@@ -839,14 +823,14 @@ namespace Microsoft.Data.Common
         /// Represents a collection of Azure SQL Server endpoint URLs for various regions and environments.
         /// </summary>
         /// <remarks>This array includes endpoint URLs for Azure SQL in global, Germany, US Government,
-        /// China, and Fabric environments. These endpoints are used to identify and interact with Azure SQL services 
+        /// China, and Fabric environments. These endpoints are used to identify and interact with Azure SQL services
         /// in their respective regions or environments.</remarks>
         internal static readonly List<string> s_azureSqlServerEndpoints = new() { AZURE_SQL,
                                                                         AZURE_SQL_GERMANY,
                                                                         AZURE_SQL_USGOV,
                                                                         AZURE_SQL_CHINA,
                                                                         AZURE_SQL_FABRIC };
-        
+
         /// <summary>
         /// Contains endpoint strings for Azure SQL Server on-demand services.
         /// Each entry is a combination of the ONDEMAND_PREFIX and a specific Azure SQL endpoint string.
@@ -872,9 +856,9 @@ namespace Microsoft.Data.Common
         internal static bool IsAzureSynapseOnDemandEndpoint(string dataSource)
         {
             return IsEndpoint(dataSource, s_azureSynapseOnDemandEndpoints)
-                || dataSource.IndexOf(AZURE_SYNAPSE, StringComparison.OrdinalIgnoreCase) >= 0; 
+                || dataSource.IndexOf(AZURE_SYNAPSE, StringComparison.OrdinalIgnoreCase) >= 0;
         }
-        
+
         internal static bool IsAzureSqlServerEndpoint(string dataSource)
         {
             return IsEndpoint(dataSource, s_azureSqlServerEndpoints);
@@ -1088,7 +1072,7 @@ namespace Microsoft.Data.Common
 
             SqlDependencyObtainProcessDispatcherFailureObjectHandle = 50,
             SqlDependencyProcessDispatcherFailureCreateInstance = 51,
-            
+
             SqlDependencyCommandHashIsNotAssociatedWithNotification = 53,
 
             UnknownTransactionFailure = 60,

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -13,13 +13,13 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security;
+using Microsoft.Data.SqlClient;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.Data.Common.ConnectionString;
-using Microsoft.Data.SqlClient;
 using Microsoft.Data.SqlClient.Connection;
 using Microsoft.SqlServer.Server;
 using Microsoft.Win32;
@@ -64,22 +64,6 @@ namespace Microsoft.Data.Common
         /// Max duration for buffer in seconds
         /// </summary>
         internal const int MaxBufferAccessTokenExpiry = 600;
-
-        /// <summary>
-        /// This member returns true if the current OS platform is Windows.
-        /// </summary>
-        /// <remarks>
-        /// This is a const on .NET Framework, and a property on .NET Core, because of differing API availability and JIT requirements.
-        /// .NET Framework will perform basic dead branch elimination when a const value is encountered, while .NET Core can trim Windows-specific
-        /// code when published to non-Windows platforms.
-        /// .NET Core's trimming is very limited though, so this must be used inline within methods to throw PlatformNotSupportedException,
-        /// rather than in a throw helper.
-        /// </remarks>
-        #if NETFRAMEWORK
-        public const bool IsWindows = true;
-        #else
-        public static bool IsWindows => OperatingSystem.IsWindows();
-        #endif
 
         #region UDT
 
@@ -441,7 +425,7 @@ namespace Microsoft.Data.Common
         internal static object LocalMachineRegistryValue(string subkey, string queryvalue)
         {
             #if NET
-            if (!IsWindows)
+            if (OsConstants.IsUnix)
             {
                 // No registry in non-Windows environments
                 return null;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -13,13 +13,13 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security;
-using Microsoft.Data.SqlClient;
 using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
 using Microsoft.Data.Common.ConnectionString;
+using Microsoft.Data.SqlClient;
 using Microsoft.Data.SqlClient.Connection;
 using Microsoft.SqlServer.Server;
 using Microsoft.Win32;
@@ -435,7 +435,7 @@ namespace Microsoft.Data.Common
         internal static object LocalMachineRegistryValue(string subkey, string queryvalue)
         {
             #if NET
-            if (OsConstants.IsUnix)
+            if (!OsConstants.IsWindows)
             {
                 // No registry in non-Windows environments
                 return null;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -635,7 +635,7 @@ internal static class LocalAppContextSwitches
                 return s_useManagedNetworking == SwitchValue.True;
             }
 
-            if (!OperatingSystem.IsWindows())
+            if (OsConstants.IsUnix)
             {
                 s_useManagedNetworking = SwitchValue.True;
                 return true;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -635,7 +635,7 @@ internal static class LocalAppContextSwitches
                 return s_useManagedNetworking == SwitchValue.True;
             }
 
-            if (OsConstants.IsUnix)
+            if (!OsConstants.IsWindows)
             {
                 s_useManagedNetworking = SwitchValue.True;
                 return true;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -562,7 +562,7 @@ internal static class LocalAppContextSwitches
                 return s_useManagedNetworking == SwitchValue.True;
             }
 
-            if (OsConstants.IsUnix)
+            if (!OsConstants.IsWindows)
             {
                 s_useManagedNetworking = SwitchValue.True;
                 return true;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/LocalAppContextSwitches.cs
@@ -562,7 +562,7 @@ internal static class LocalAppContextSwitches
                 return s_useManagedNetworking == SwitchValue.True;
             }
 
-            if (!OperatingSystem.IsWindows())
+            if (OsConstants.IsUnix)
             {
                 s_useManagedNetworking = SwitchValue.True;
                 return true;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/OsConstants.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/OsConstants.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Data.SqlClient;
@@ -13,16 +14,18 @@ namespace Microsoft.Data.SqlClient;
 /// This type exists to keep OS detection terse and in one place: callers write
 /// <c>OsConstants.IsWindows</c> instead of repeating <c>RuntimeInformation.IsOSPlatform(...)</c>
 /// throughout the codebase.  Centralizing it also gives us a single seam to adjust if a specific
-/// OS ever needs special handling (for example, a different detection mechanism, a finer-grained
+/// OS needs special handling (for example, a different detection mechanism, a finer-grained
 /// flag, or an override for testing) without touching every call site.
 /// </remarks>
 /// <remarks>
-/// Each flag is exposed as a property that directly returns the result of
-/// <see cref="RuntimeInformation.IsOSPlatform"/>.  This is deliberate: the IL trimmer (and the JIT)
-/// recognize these calls as intrinsics and can substitute a constant value for them at
-/// publish/compile time.  Caching the results in static fields (for example, via a static
-/// constructor) would defeat this — the trimmer cannot analyze a static constructor, so it would
-/// be unable to prove which branches are dead and would keep OS-specific code (including
+/// Each flag is exposed as a property that directly returns an OS check.  On .NET, that check is
+/// <c>OperatingSystem.Is*()</c>, which the JIT treats as an intrinsic and constant-folds (and which
+/// the IL trimmer also recognizes).  On .NET Framework — where the <see cref="System.OperatingSystem"/>
+/// platform-check helpers do not exist — the check falls back to
+/// <see cref="RuntimeInformation.IsOSPlatform"/>.  Either way, returning the check directly is
+/// deliberate: caching the results in static fields (for example, via a static constructor) would
+/// defeat both the JIT folding and the trimmer — the trimmer cannot analyze a static constructor,
+/// so it would be unable to prove which branches are dead and would keep OS-specific code (including
 /// Windows-only native dependencies) in apps published for other platforms.
 /// </remarks>
 /// <remarks>
@@ -67,17 +70,29 @@ internal static class OsConstants
     /// <summary>
     /// Gets a value indicating whether the runtime is executing on Windows.
     /// </summary>
+    #if NET
+    internal static bool IsWindows => OperatingSystem.IsWindows();
+    #else
     internal static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+    #endif
 
     /// <summary>
     /// Gets a value indicating whether the runtime is executing on Linux.
     /// </summary>
+    #if NET
+    internal static bool IsLinux => OperatingSystem.IsLinux();
+    #else
     internal static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+    #endif
 
     /// <summary>
     /// Gets a value indicating whether the runtime is executing on macOS.
     /// </summary>
+    #if NET
+    internal static bool IsMacOS => OperatingSystem.IsMacOS();
+    #else
     internal static bool IsMacOS => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+    #endif
 
     #if NET
     /// <summary>
@@ -87,6 +102,6 @@ internal static class OsConstants
     /// FreeBSD support is only available in .NET 5+ and later. This property will be
     /// <c>false</c> on .NET Framework or if the runtime does not support FreeBSD detection.
     /// </remarks>
-    internal static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD);
+    internal static bool IsFreeBSD => OperatingSystem.IsFreeBSD();
     #endif
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/OsConstants.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/OsConstants.cs
@@ -10,61 +10,83 @@ namespace Microsoft.Data.SqlClient;
 /// Provides platform detection flags for OS-specific code paths.
 /// </summary>
 /// <remarks>
-/// These constants are computed at runtime and cached as static readonly fields.  This design
-/// allows the JIT compiler to elide branches in hot paths based on whether the OS flags are known
-/// constants at JIT compilation time.
+/// This type exists to keep OS detection terse and in one place: callers write
+/// <c>OsConstants.IsWindows</c> instead of repeating <c>RuntimeInformation.IsOSPlatform(...)</c>
+/// throughout the codebase.  Centralizing it also gives us a single seam to adjust if a specific
+/// OS ever needs special handling (for example, a different detection mechanism, a finer-grained
+/// flag, or an override for testing) without touching every call site.
+/// </remarks>
+/// <remarks>
+/// Each flag is exposed as a property that directly returns the result of
+/// <see cref="RuntimeInformation.IsOSPlatform"/>.  This is deliberate: the IL trimmer (and the JIT)
+/// recognize these calls as intrinsics and can substitute a constant value for them at
+/// publish/compile time.  Caching the results in static fields (for example, via a static
+/// constructor) would defeat this — the trimmer cannot analyze a static constructor, so it would
+/// be unable to prove which branches are dead and would keep OS-specific code (including
+/// Windows-only native dependencies) in apps published for other platforms.
+/// </remarks>
+/// <remarks>
+/// <para>
+/// IL trimming note: when a downstream app is published for a specific OS (a RID-specific publish),
+/// the IL trimmer substitutes the underlying <see cref="RuntimeInformation.IsOSPlatform"/> /
+/// <c>OperatingSystem.Is*</c> checks with constant <c>true</c>/<c>false</c> for the target OS and
+/// then removes the dead branch (along with everything it transitively references, such as
+/// Windows-only native entry points).  This is what lets a single cross-platform assembly trim
+/// away the OS-specific code that does not apply to the published target.
+/// </para>
+/// <para>
+/// For this to work, each guard must be used <b>inline</b> in the same method as the OS-specific
+/// code it gates.  The trimmer's constant folding is shallow: it reasons within the method that
+/// contains the guard, so a guard hidden behind a helper traps the constant inside that helper and
+/// leaves the protected code reachable (and therefore not trimmed).
+/// </para>
+/// <para>
+/// Do — guard inline, so the trimmer can drop the branch and its dependencies:
+/// <code>
+/// if (OsConstants.IsWindows)
+/// {
+///     WindowsOnlyNativeCall();   // becomes `if (false) { ... }` off-Windows, then removed
+/// }
+/// </code>
+/// </para>
+/// <para>
+/// Don't — hide the guard in a throw helper; the trimmer cannot prove the call below is dead:
+/// <code>
+/// static void ThrowIfNotWindows()
+/// {
+///     if (!OsConstants.IsWindows) throw new PlatformNotSupportedException();
+/// }
+/// // caller:
+/// ThrowIfNotWindows();
+/// WindowsOnlyNativeCall();   // still reachable to the trimmer; kept even off-Windows
+/// </code>
+/// </para>
 /// </remarks>
 internal static class OsConstants
 {
     /// <summary>
     /// Gets a value indicating whether the runtime is executing on Windows.
     /// </summary>
-    internal static readonly bool IsWindows;
+    internal static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
     /// <summary>
     /// Gets a value indicating whether the runtime is executing on Linux.
     /// </summary>
-    internal static readonly bool IsLinux;
+    internal static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 
     /// <summary>
     /// Gets a value indicating whether the runtime is executing on macOS.
     /// </summary>
-    internal static readonly bool IsMacOS;
+    internal static bool IsMacOS => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
     #if NET
     /// <summary>
     /// Gets a value indicating whether the runtime is executing on FreeBSD.
     /// </summary>
     /// <remarks>
-    /// FreeBSD support is only available in .NET 5+ and later. This field will be
+    /// FreeBSD support is only available in .NET 5+ and later. This property will be
     /// <c>false</c> on .NET Framework or if the runtime does not support FreeBSD detection.
     /// </remarks>
-    internal static readonly bool IsFreeBSD;
+    internal static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD);
     #endif
-
-    /// <summary>
-    /// Initializes platform detection flags by querying <see cref="RuntimeInformation"/>.
-    /// </summary>
-    /// <remarks>
-    /// We use a static constructor instead of a module initializer ([ModuleInitializer]) to avoid
-    /// the CA2255 security concern. Module initializers can be problematic because: 1. They run in
-    /// an unpredictable order relative to other initialization code.  2. They run before the app
-    /// initialization sequence, potentially before security policies are set.  3. They can
-    /// complicate debugging and profiling.
-    ///
-    /// Using a static constructor ensures initialization happens in a well-defined, type-safe
-    /// manner that is compatible with the CLR's type loading guarantees.
-    ///
-    /// The trade-off is that the OS flags won't be initialized until the OsConstants type is first
-    /// accessed, which may cause a slight delay in a hot path, but only once.
-    /// </remarks>
-    static OsConstants()
-    {
-        IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-        IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-        #if NET
-        IsFreeBSD = RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD);
-        #endif
-    }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/OsConstants.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/OsConstants.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Data.SqlClient;
+
+/// <summary>
+/// Provides platform detection flags for OS-specific code paths.
+/// </summary>
+/// <remarks>
+/// These constants are computed at runtime and cached as static readonly fields.  This design
+/// allows the JIT compiler to elide branches in hot paths based on whether the OS flags are known
+/// constants at JIT compilation time.
+/// </remarks>
+internal static class OsConstants
+{
+    /// <summary>
+    /// Gets a value indicating whether the runtime is executing on Windows.
+    /// </summary>
+    internal static readonly bool IsWindows;
+
+    /// <summary>
+    /// Gets a value indicating whether the runtime is executing on Linux.
+    /// </summary>
+    internal static readonly bool IsLinux;
+
+    /// <summary>
+    /// Gets a value indicating whether the runtime is executing on macOS.
+    /// </summary>
+    internal static readonly bool IsMacOS;
+
+#if NET
+    /// <summary>
+    /// Gets a value indicating whether the runtime is executing on FreeBSD.
+    /// </summary>
+    /// <remarks>
+    /// FreeBSD support is only available in .NET 5+ and later. This field will be
+    /// <c>false</c> on .NET Framework or if the runtime does not support FreeBSD detection.
+    /// </remarks>
+    internal static readonly bool IsFreeBSD;
+#endif
+
+    /// <summary>
+    /// Gets a value indicating whether the runtime is executing on a Unix-like operating system.
+    /// </summary>
+    /// <remarks>
+    /// This is <c>true</c> for Linux, macOS, FreeBSD, and other Unix-like platforms.
+    /// It is <c>false</c> only on Windows.
+    /// </remarks>
+    internal static readonly bool IsUnix;
+
+    /// <summary>
+    /// Initializes platform detection flags by querying <see cref="RuntimeInformation"/>.
+    /// </summary>
+    /// <remarks>
+    /// We use a static constructor instead of a module initializer ([ModuleInitializer]) to avoid
+    /// the CA2255 security concern. Module initializers can be problematic because: 1. They run in
+    /// an unpredictable order relative to other initialization code.  2. They run before the app
+    /// initialization sequence, potentially before security policies are set.  3. They can
+    /// complicate debugging and profiling.
+    ///
+    /// Using a static constructor ensures initialization happens in a well-defined, type-safe
+    /// manner that is compatible with the CLR's type loading guarantees.
+    ///
+    /// The trade-off is that the OS flags won't be initialized until the OsConstants type is first
+    /// accessed, which may cause a slight delay in a hot path, but only once.
+    /// </remarks>
+    static OsConstants()
+    {
+        IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+#if NET
+        IsFreeBSD = RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD);
+        IsUnix = IsLinux || IsMacOS || IsFreeBSD;
+#else
+        IsUnix = IsLinux || IsMacOS;
+#endif
+    }
+}

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/OsConstants.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/OsConstants.cs
@@ -31,7 +31,7 @@ internal static class OsConstants
     /// </summary>
     internal static readonly bool IsMacOS;
 
-#if NET
+    #if NET
     /// <summary>
     /// Gets a value indicating whether the runtime is executing on FreeBSD.
     /// </summary>
@@ -40,16 +40,7 @@ internal static class OsConstants
     /// <c>false</c> on .NET Framework or if the runtime does not support FreeBSD detection.
     /// </remarks>
     internal static readonly bool IsFreeBSD;
-#endif
-
-    /// <summary>
-    /// Gets a value indicating whether the runtime is executing on a Unix-like operating system.
-    /// </summary>
-    /// <remarks>
-    /// This is <c>true</c> for Linux, macOS, FreeBSD, and other Unix-like platforms.
-    /// It is <c>false</c> only on Windows.
-    /// </remarks>
-    internal static readonly bool IsUnix;
+    #endif
 
     /// <summary>
     /// Initializes platform detection flags by querying <see cref="RuntimeInformation"/>.
@@ -72,11 +63,8 @@ internal static class OsConstants
         IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-#if NET
+        #if NET
         IsFreeBSD = RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD);
-        IsUnix = IsLinux || IsMacOS || IsFreeBSD;
-#else
-        IsUnix = IsLinux || IsMacOS;
-#endif
+        #endif
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCertificateStoreProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Data.SqlClient
         /// Gets a string array containing valid certificate locations.
         /// </summary>
         private static string[] ValidCertificateLocations =>
-            Environment.OSVersion.Platform == PlatformID.Win32NT
+            OsConstants.IsWindows
                 ? [CertLocationLocalMachine, CertLocationCurrentUser]
                 : [CertLocationCurrentUser];
 
@@ -158,14 +158,13 @@ namespace Microsoft.Data.SqlClient
             }
 
             // Extract the store location where the cert is stored
-            if (storeLocationSpan.IsEmpty
-                && Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (storeLocationSpan.IsEmpty && OsConstants.IsWindows)
             {
                 // Default to Local Machine on Windows. Non-Windows platforms only support CurrentUser
                 storeLocation = StoreLocation.LocalMachine;
             }
             else if (storeLocationSpan.Equals(CertLocationLocalMachine.AsSpan(), StringComparison.OrdinalIgnoreCase)
-                && Environment.OSVersion.Platform == PlatformID.Win32NT)
+                && OsConstants.IsWindows)
             {
                 storeLocation = StoreLocation.LocalMachine;
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCngProvider.xml' path='docs/members[@name="SqlColumnEncryptionCngProvider"]/DecryptColumnEncryptionKey/*' />
         public override byte[] DecryptColumnEncryptionKey(string? masterKeyPath, string? encryptionAlgorithm, byte[]? encryptedColumnEncryptionKey)
         {
-            if (OsConstants.IsUnix)
+            if (!OsConstants.IsWindows)
             {
                 throw new PlatformNotSupportedException();
             }
@@ -180,7 +180,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCngProvider.xml' path='docs/members[@name="SqlColumnEncryptionCngProvider"]/EncryptColumnEncryptionKey/*' />
         public override byte[] EncryptColumnEncryptionKey(string? masterKeyPath, string? encryptionAlgorithm, byte[]? columnEncryptionKey)
         {
-            if (OsConstants.IsUnix)
+            if (!OsConstants.IsWindows)
             {
                 throw new PlatformNotSupportedException();
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCngProvider.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCngProvider.xml' path='docs/members[@name="SqlColumnEncryptionCngProvider"]/DecryptColumnEncryptionKey/*' />
         public override byte[] DecryptColumnEncryptionKey(string? masterKeyPath, string? encryptionAlgorithm, byte[]? encryptedColumnEncryptionKey)
         {
-            if (!ADP.IsWindows)
+            if (OsConstants.IsUnix)
             {
                 throw new PlatformNotSupportedException();
             }
@@ -180,7 +180,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCngProvider.xml' path='docs/members[@name="SqlColumnEncryptionCngProvider"]/EncryptColumnEncryptionKey/*' />
         public override byte[] EncryptColumnEncryptionKey(string? masterKeyPath, string? encryptionAlgorithm, byte[]? columnEncryptionKey)
         {
-            if (!ADP.IsWindows)
+            if (OsConstants.IsUnix)
             {
                 throw new PlatformNotSupportedException();
             }
@@ -211,7 +211,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCngProvider.xml' path='docs/members[@name="SqlColumnEncryptionCngProvider"]/SignColumnMasterKeyMetadata/*' />
         public override byte[] SignColumnMasterKeyMetadata(string? masterKeyPath, bool allowEnclaveComputations)
         {
-            throw ADP.IsWindows
+            throw OsConstants.IsWindows
                 ? new NotSupportedException()
                 : new PlatformNotSupportedException();
         }
@@ -219,7 +219,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCngProvider.xml' path='docs/members[@name="SqlColumnEncryptionCngProvider"]/VerifyColumnMasterKeyMetadata/*' />
         public override bool VerifyColumnMasterKeyMetadata(string? masterKeyPath, bool allowEnclaveComputations, byte[]? signature)
         {
-            throw ADP.IsWindows
+            throw OsConstants.IsWindows
                 ? new NotSupportedException()
                 : new PlatformNotSupportedException();
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCspProvider.xml' path='docs/members[@name="SqlColumnEncryptionCspProvider"]/DecryptColumnEncryptionKey/*' />
         public override byte[] DecryptColumnEncryptionKey(string? masterKeyPath, string? encryptionAlgorithm, byte[]? encryptedColumnEncryptionKey)
         {
-            if (!ADP.IsWindows)
+            if (OsConstants.IsUnix)
             {
                 throw new PlatformNotSupportedException();
             }
@@ -182,7 +182,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCspProvider.xml' path='docs/members[@name="SqlColumnEncryptionCspProvider"]/EncryptColumnEncryptionKey/*' />
         public override byte[] EncryptColumnEncryptionKey(string? masterKeyPath, string? encryptionAlgorithm, byte[]? columnEncryptionKey)
         {
-            if (!ADP.IsWindows)
+            if (OsConstants.IsUnix)
             {
                 throw new PlatformNotSupportedException();
             }
@@ -213,7 +213,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCspProvider.xml' path='docs/members[@name="SqlColumnEncryptionCspProvider"]/SignColumnMasterKeyMetadata/*' />
         public override byte[] SignColumnMasterKeyMetadata(string? masterKeyPath, bool allowEnclaveComputations)
         {
-            throw ADP.IsWindows
+            throw OsConstants.IsWindows
                 ? new NotSupportedException()
                 : new PlatformNotSupportedException();
         }
@@ -221,7 +221,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCspProvider.xml' path='docs/members[@name="SqlColumnEncryptionCspProvider"]/VerifyColumnMasterKeyMetadata/*' />
         public override bool VerifyColumnMasterKeyMetadata(string? masterKeyPath, bool allowEnclaveComputations, byte[]? signature)
         {
-            throw ADP.IsWindows
+            throw OsConstants.IsWindows
                 ? new NotSupportedException()
                 : new PlatformNotSupportedException();
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionCspProvider.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCspProvider.xml' path='docs/members[@name="SqlColumnEncryptionCspProvider"]/DecryptColumnEncryptionKey/*' />
         public override byte[] DecryptColumnEncryptionKey(string? masterKeyPath, string? encryptionAlgorithm, byte[]? encryptedColumnEncryptionKey)
         {
-            if (OsConstants.IsUnix)
+            if (!OsConstants.IsWindows)
             {
                 throw new PlatformNotSupportedException();
             }
@@ -182,7 +182,7 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionCspProvider.xml' path='docs/members[@name="SqlColumnEncryptionCspProvider"]/EncryptColumnEncryptionKey/*' />
         public override byte[] EncryptColumnEncryptionKey(string? masterKeyPath, string? encryptionAlgorithm, byte[]? columnEncryptionKey)
         {
-            if (OsConstants.IsUnix)
+            if (!OsConstants.IsWindows)
             {
                 throw new PlatformNotSupportedException();
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -1141,7 +1141,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception NullCertificatePath(string[] validLocations, bool isSystemOp)
         {
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (OsConstants.IsWindows)
             {
                 Debug.Assert(validLocations.Length == 2);
                 if (isSystemOp)
@@ -1193,7 +1193,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception InvalidCertificatePath(string actualCertificatePath, string[] validLocations, bool isSystemOp)
         {
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (OsConstants.IsWindows)
             {
                 Debug.Assert(validLocations.Length == 2);
                 if (isSystemOp)
@@ -1329,7 +1329,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception InvalidCertificateLocation(string certificateLocation, string certificatePath, string[] validLocations, bool isSystemOp)
         {
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (OsConstants.IsWindows)
             {
                 Debug.Assert(validLocations.Length == 2);
                 if (isSystemOp)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -1376,7 +1376,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception NullCertificatePath(string[] validLocations, bool isSystemOp)
         {
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (OsConstants.IsWindows)
             {
                 Debug.Assert(validLocations.Length == 2);
                 if (isSystemOp)
@@ -1428,7 +1428,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception InvalidCertificatePath(string actualCertificatePath, string[] validLocations, bool isSystemOp)
         {
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (OsConstants.IsWindows)
             {
                 Debug.Assert(validLocations.Length == 2);
                 if (isSystemOp)
@@ -1564,7 +1564,7 @@ namespace Microsoft.Data.SqlClient
 
         internal static Exception InvalidCertificateLocation(string certificateLocation, string certificatePath, string[] validLocations, bool isSystemOp)
         {
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            if (OsConstants.IsWindows)
             {
                 Debug.Assert(validLocations.Length == 2);
                 if (isSystemOp)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -979,7 +979,7 @@ namespace Microsoft.Data.SqlClient
             // Channel Bindings as part of the Windows Authentication context build (SSL handshake must complete
             // before calling SNISecGenClientContext).
 #if NET
-            if (OperatingSystem.IsWindows())
+            if (OsConstants.IsWindows)
 #endif
             {
                 error = _physicalStateObj.WaitForSSLHandShakeToComplete(out protocol);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -981,7 +981,7 @@ namespace Microsoft.Data.SqlClient
             // Channel Bindings as part of the Windows Authentication context build (SSL handshake must complete
             // before calling SNISecGenClientContext).
 #if NET
-            if (OperatingSystem.IsWindows())
+            if (OsConstants.IsWindows)
 #endif
             {
                 error = _physicalStateObj.WaitForSSLHandShakeToComplete(out protocol);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient
@@ -173,7 +172,7 @@ namespace Microsoft.Data.SqlClient
 
             byte[] nicAddress = null;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OsConstants.IsWindows)
             {
                 // NIC address is stored in NetworkAddress key.  However, if NetworkAddressLocal key
                 // has a value that is not zero, then we cannot use the NetworkAddress key and must

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/UserAgent.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/UserAgent.cs
@@ -120,25 +120,24 @@ internal static class UserAgent
         // specific values.
         //
         string osType = Unknown;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (OsConstants.IsWindows)
         {
             osType = Windows;
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (OsConstants.IsLinux)
         {
             osType = Linux;
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        else if (OsConstants.IsMacOS)
         {
             osType = macOS;
         }
-        // The FreeBSD platform doesn't exist in .NET Framework at all.
-        #if NET
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+#if NET
+        else if (OsConstants.IsFreeBSD)
         {
             osType = FreeBSD;
         }
-        #endif
+#endif
 
         // Build it!
         Value = Build(

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Data.SqlTypes
             FileOptions options,
             long allocationSize)
         {
-            if (OsConstants.IsUnix)
+            if (!OsConstants.IsWindows)
             {
                 throw new PlatformNotSupportedException(Strings.SqlFileStream_NotSupported);
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlTypes/SqlFileStream.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Data.SqlTypes
             FileOptions options,
             long allocationSize)
         {
-            if (!ADP.IsWindows)
+            if (OsConstants.IsUnix)
             {
                 throw new PlatformNotSupportedException(Strings.SqlFileStream_NotSupported);
             }


### PR DESCRIPTION
## Summary

This PR consolidates all OS detection logic into a single internal `OsConstants` class, giving the codebase one consistent, terse way to ask "what OS are we on?" (`OsConstants.IsWindows`, `IsLinux`, `IsMacOS`, `IsFreeBSD`) and a single seam for any future OS-specific handling.

Just as importantly, the flags are implemented so they remain **statically analyzable**, which is what lets the JIT and the IL trimmer eliminate OS-specific branches (and their dependencies, including Windows-only native SNI) in downstream apps.

## OsConstants design

- Each flag is an expression-bodied **property** that returns an OS check directly — it is **not** cached in a static field or computed in a static constructor.
- On **.NET** (`net8.0`/`net9.0`): uses `OperatingSystem.IsWindows()/IsLinux()/IsMacOS()/IsFreeBSD()`, which the JIT recognizes as intrinsics and constant-folds, and which the IL trimmer also understands.
- On **.NET Framework** (`net462`): falls back to `RuntimeInformation.IsOSPlatform(...)`, since the `OperatingSystem` platform-check helpers don't exist there. `IsFreeBSD` is `#if NET`-only.

### Why not static readonly fields / a static constructor?

The original approach cached the results in `static readonly` fields populated by a static constructor. That defeats trimming: the IL trimmer can't analyze a static constructor, so it can't prove a flag is constant-`false` on a given OS and conservatively keeps the OS-specific code (including the native SNI DLL graph) in apps published for other platforms. Returning the intrinsic check directly preserves both the JIT constant-folding and trimmer dead-code elimination.

### Usage requirement (documented in the class)

For trimming to actually drop a branch, each guard must be used **inline** in the same method as the OS-specific code it gates. The trimmer's constant folding is shallow, so a guard hidden behind a throw-helper traps the constant inside that helper and leaves the protected code reachable. The class XML docs include do/don't examples.

## Call-site replacements (10 files)

Consolidated assorted ad-hoc OS checks onto `OsConstants`:

- **TdsParserStaticMethods.cs**, **TdsParser.cs**, **LocalAppContextSwitches.cs** — replaced `RuntimeInformation.IsOSPlatform()` / `OperatingSystem.IsWindows()`.
- **UserAgent.cs** — replaced `RuntimeInformation.IsOSPlatform()` and added FreeBSD detection.
- **AdapterUtil.cs** — removed the `ADP.IsWindows` member; `OsConstants` is now the single source.
- **SqlFileStream.cs**, **SqlColumnEncryptionCngProvider.cs**, **SqlColumnEncryptionCspProvider.cs** — replaced `ADP.IsWindows`.
- **SqlColumnEncryptionCertificateStoreProvider.cs**, **SqlUtil.cs** — replaced `Environment.OSVersion`-based checks.

All existing guards were verified to be inline with the code they protect (no throw-helper indirection), so they remain trimmer-foldable.

## Benefits

- Single, consistent point of control for OS detection.
- Preserves JIT constant-folding on .NET via `OperatingSystem.Is*()` intrinsics.
- Preserves IL trimming so apps published for a specific RID can drop other-OS code paths (incl. Windows-only native dependencies) — supporting the goal of a single managed assembly per TFM.
- Correct on .NET-Framework-on-non-Windows (no longer hard-codes `IsWindows = true`).

## Notes

- The `UseManagedNetworking` IL trimming substitution (`ILLink.Substitutions.xml`) is independent of this change — it body-stubs the getter based on the `UseManagedNetworkingOnWindows` feature switch and never reads `OsConstants`.
