### PR TITLE
Fix package path for release

### DIFF
--- a/eng/pipelines/onebranch/jobs/publish-nuget-package-job.yml
+++ b/eng/pipelines/onebranch/jobs/publish-nuget-package-job.yml
@@ -74,7 +74,7 @@ jobs:
         value: $(Pipeline.Workspace)/${{ parameters.artifactName }}
 
       - name: packageToPush
-        value: $(artifactPath)/${{ coalesce(parameters.packagePath, format('packages/{0}.*.nupkg', parameters.packageName)) }}
+        value: $(artifactPath)/${{ coalesce(parameters.packagePath, format('Package-Release/{0}.*.nupkg', parameters.packageName)) }}
 
     # Template context inputs are used to pass parameters to the deployment job since it doesn't
     # automatically download pipeline artifacts.

--- a/eng/pipelines/onebranch/stages/release-stages.yml
+++ b/eng/pipelines/onebranch/stages/release-stages.yml
@@ -193,7 +193,7 @@ stages:
             parameters:
               packageName: Microsoft.SqlServer.Server
               artifactName: '${{ parameters.sqlServerArtifactsName }}'
-              packagePath: 'packages/Microsoft.SqlServer.Server.${{ parameters.sqlServerPackageVersion }}.nupkg'
+              packagePath: 'Package-Release/Microsoft.SqlServer.Server.${{ parameters.sqlServerPackageVersion }}.nupkg'
               nugetServiceConnection: ${{ variables.nugetServiceConnection }}
               isProduction: ${{ parameters.isOfficial }}
               displaySuffix: ${{ variables.nugetTargetSuffix }}
@@ -203,7 +203,7 @@ stages:
             parameters:
               packageName: Microsoft.Data.SqlClient.Internal.Logging
               artifactName: '${{ parameters.loggingArtifactsName }}'
-              packagePath: 'packages/Microsoft.Data.SqlClient.Internal.Logging.${{ parameters.loggingPackageVersion }}.nupkg'
+              packagePath: 'Package-Release/Microsoft.Data.SqlClient.Internal.Logging.${{ parameters.loggingPackageVersion }}.nupkg'
               nugetServiceConnection: ${{ variables.nugetServiceConnection }}
               isProduction: ${{ parameters.isOfficial }}
               displaySuffix: ${{ variables.nugetTargetSuffix }}
@@ -213,7 +213,7 @@ stages:
             parameters:
               packageName: Microsoft.Data.SqlClient.Extensions.Abstractions
               artifactName: '${{ parameters.abstractionsArtifactsName }}'
-              packagePath: 'packages/Microsoft.Data.SqlClient.Extensions.Abstractions.${{ parameters.abstractionsPackageVersion }}.nupkg'
+              packagePath: 'Package-Release/Microsoft.Data.SqlClient.Extensions.Abstractions.${{ parameters.abstractionsPackageVersion }}.nupkg'
               nugetServiceConnection: ${{ variables.nugetServiceConnection }}
               isProduction: ${{ parameters.isOfficial }}
               displaySuffix: ${{ variables.nugetTargetSuffix }}
@@ -223,7 +223,7 @@ stages:
             parameters:
               packageName: Microsoft.Data.SqlClient
               artifactName: '${{ parameters.sqlClientArtifactsName }}'
-              packagePath: 'packages/Microsoft.Data.SqlClient.${{ parameters.sqlClientPackageVersion }}.nupkg'
+              packagePath: 'Package-Release/Microsoft.Data.SqlClient.${{ parameters.sqlClientPackageVersion }}.nupkg'
               nugetServiceConnection: ${{ variables.nugetServiceConnection }}
               isProduction: ${{ parameters.isOfficial }}
               displaySuffix: ${{ variables.nugetTargetSuffix }}
@@ -233,7 +233,7 @@ stages:
             parameters:
               packageName: Microsoft.Data.SqlClient.Extensions.Azure
               artifactName: '${{ parameters.azureArtifactsName }}'
-              packagePath: 'packages/Microsoft.Data.SqlClient.Extensions.Azure.${{ parameters.azurePackageVersion }}.nupkg'
+              packagePath: 'Package-Release/Microsoft.Data.SqlClient.Extensions.Azure.${{ parameters.azurePackageVersion }}.nupkg'
               nugetServiceConnection: ${{ variables.nugetServiceConnection }}
               isProduction: ${{ parameters.isOfficial }}
               displaySuffix: ${{ variables.nugetTargetSuffix }}
@@ -243,7 +243,7 @@ stages:
             parameters:
               packageName: Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider
               artifactName: '${{ parameters.akvProviderArtifactsName }}'
-              packagePath: 'packages/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.${{ parameters.akvProviderPackageVersion }}.nupkg'
+              packagePath: 'Package-Release/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.${{ parameters.akvProviderPackageVersion }}.nupkg'
               nugetServiceConnection: ${{ variables.nugetServiceConnection }}
               isProduction: ${{ parameters.isOfficial }}
               displaySuffix: ${{ variables.nugetTargetSuffix }}


### PR DESCRIPTION
This pull request updates the pipeline configuration to change the expected location of NuGet package artifacts from the `packages/` directory to `Package-Release/`. This ensures that all package publishing steps reference the correct artifact paths after a directory structure change.

**Pipeline artifact path updates:**

* Updated the `packageToPush` variable in `publish-nuget-package-job.yml` to use the `Package-Release/` directory instead of `packages/`.

* Updated all `packagePath` parameters in `release-stages.yml` for the following packages to use the `Package-Release/` directory:
  - `Microsoft.SqlServer.Server`
  - `Microsoft.Data.SqlClient.Internal.Logging`
  - `Microsoft.Data.SqlClient.Extensions.Abstractions`
  - `Microsoft.Data.SqlClient`
  - `Microsoft.Data.SqlClient.Extensions.Azure`
  - `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider`