### PR TITLE
Remove extra connection options parameters

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
@@ -62,9 +62,8 @@ namespace Microsoft.Data.ProviderBase
         internal override bool TryOpenConnection(
             DbConnection outerConnection,
             SqlConnectionFactory connectionFactory,
-            TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions) =>
-            TryOpenConnectionInternal(outerConnection, connectionFactory, retry, userOptions);
+            TaskCompletionSource<DbConnectionInternal> retry) =>
+            TryOpenConnectionInternal(outerConnection, connectionFactory, retry);
 
         /// <inheritdoc/>
         internal override void ResetConnection() => throw ADP.ClosedConnectionError();
@@ -79,8 +78,7 @@ namespace Microsoft.Data.ProviderBase
         internal override bool TryOpenConnection(
             DbConnection outerConnection,
             SqlConnectionFactory connectionFactory,
-            TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions)
+            TaskCompletionSource<DbConnectionInternal> retry)
             => throw ADP.ConnectionAlreadyOpen(State);
     }
 
@@ -121,15 +119,13 @@ namespace Microsoft.Data.ProviderBase
         internal override bool TryReplaceConnection(
             DbConnection outerConnection,
             SqlConnectionFactory connectionFactory,
-            TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions) =>
-            TryOpenConnection(outerConnection, connectionFactory, retry, userOptions);
+            TaskCompletionSource<DbConnectionInternal> retry) =>
+            TryOpenConnection(outerConnection, connectionFactory, retry);
 
         internal override bool TryOpenConnection(
             DbConnection outerConnection,
             SqlConnectionFactory connectionFactory,
-            TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions)
+            TaskCompletionSource<DbConnectionInternal> retry)
         {
             if (retry == null || !retry.Task.IsCompleted)
             {
@@ -177,8 +173,7 @@ namespace Microsoft.Data.ProviderBase
         internal override bool TryReplaceConnection(
             DbConnection outerConnection,
             SqlConnectionFactory connectionFactory,
-            TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions) =>
-            TryOpenConnection(outerConnection, connectionFactory, retry, userOptions);
+            TaskCompletionSource<DbConnectionInternal> retry) =>
+            TryOpenConnection(outerConnection, connectionFactory, retry);
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -688,7 +688,7 @@ namespace Microsoft.Data.ProviderBase
 
         internal virtual void OpenConnection(DbConnection outerConnection, SqlConnectionFactory connectionFactory)
         {
-            if (!TryOpenConnection(outerConnection, connectionFactory, null, null))
+            if (!TryOpenConnection(outerConnection, connectionFactory, null))
             {
                 throw ADP.InternalError(ADP.InternalErrorCode.SynchronousConnectReturnedPending);
             }
@@ -800,8 +800,7 @@ namespace Microsoft.Data.ProviderBase
         internal virtual bool TryOpenConnection(
             DbConnection outerConnection,
             SqlConnectionFactory connectionFactory,
-            TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions)
+            TaskCompletionSource<DbConnectionInternal> retry)
         {
             throw ADP.ConnectionAlreadyOpen(State);
         }
@@ -809,8 +808,7 @@ namespace Microsoft.Data.ProviderBase
         internal virtual bool TryReplaceConnection(
             DbConnection outerConnection,
             SqlConnectionFactory connectionFactory,
-            TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions)
+            TaskCompletionSource<DbConnectionInternal> retry)
         {
             throw ADP.MethodNotImplemented();
         }
@@ -912,8 +910,7 @@ namespace Microsoft.Data.ProviderBase
         protected bool TryOpenConnectionInternal(
             DbConnection outerConnection,
             SqlConnectionFactory connectionFactory,
-            TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions)
+            TaskCompletionSource<DbConnectionInternal> retry)
         {
             // ?->Connecting: prevent set_ConnectionString during Open
             if (connectionFactory.SetInnerConnectionFrom(outerConnection, DbConnectionClosedConnecting.SingletonInstance, this))
@@ -922,7 +919,7 @@ namespace Microsoft.Data.ProviderBase
                 try
                 {
                     connectionFactory.PermissionDemand(outerConnection);
-                    if (!connectionFactory.TryGetConnection(outerConnection, retry, userOptions, this, out openConnection))
+                    if (!connectionFactory.TryGetConnection(outerConnection, retry, this, out openConnection))
                     {
                         return false;
                     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -312,8 +312,6 @@ namespace Microsoft.Data.SqlClient.Connection
         /// - Although the new password is generally not used it must be passed to the ctor. The
         ///   new Login7 packet will always write out the new password (or a length of zero and no
         ///   bytes if not present).
-        /// - userConnectionOptions may be different to connectionOptions if the connection string
-        ///   has been expanded (see SqlConnectionOptions.Expand)
         /// </remarks>
         // @TODO: We really really need simplify what we pass into this. All these optional parameters need to go!
         internal SqlConnectionInternal(
@@ -324,7 +322,6 @@ namespace Microsoft.Data.SqlClient.Connection
             string newPassword,
             SecureString newSecurePassword,
             bool redirectedUserInstance,
-            SqlConnectionOptions userConnectionOptions = null,
             SessionData reconnectSessionData = null,
             bool applyTransientFaultHandling = false,
             string accessToken = null,
@@ -341,29 +338,6 @@ namespace Microsoft.Data.SqlClient.Connection
             {
                 reconnectSessionData._debugReconnectDataApplied = true;
             }
-
-            #if NETFRAMEWORK
-            try
-            {
-                // use this to help validate this object is only created after the following
-                // permission has been previously demanded in the current codepath
-                if (userConnectionOptions != null)
-                {
-                    // As mentioned above, userConnectionOptions may be different to
-                    // connectionOptions, so we need to demand on the correct connection string
-                    userConnectionOptions.DemandPermission();
-                }
-                else
-                {
-                    connectionOptions.DemandPermission();
-                }
-            }
-            catch (SecurityException)
-            {
-                Debug.Assert(false, "unexpected SecurityException for current codepath");
-                throw;
-            }
-            #endif
             #endif
 
             Debug.Assert(reconnectSessionData == null || connectionOptions.ConnectRetryCount > 0,
@@ -1970,10 +1944,9 @@ namespace Microsoft.Data.SqlClient.Connection
         internal override bool TryReplaceConnection(
             DbConnection outerConnection,
             SqlConnectionFactory connectionFactory,
-            TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions)
+            TaskCompletionSource<DbConnectionInternal> retry)
         {
-            return TryOpenConnectionInternal(outerConnection, connectionFactory, retry, userOptions);
+            return TryOpenConnectionInternal(outerConnection, connectionFactory, retry);
         }
 
         internal void ValidateConnectionForExecute(SqlCommand command)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/ChannelDbConnectionPool.cs
@@ -224,7 +224,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <inheritdoc />
         public DbConnectionInternal ReplaceConnection(
             DbConnection owningObject, 
-            SqlConnectionOptions userOptions, 
             DbConnectionInternal oldConnection)
         {
             throw new NotImplementedException();
@@ -282,7 +281,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         public bool TryGetConnection(
             DbConnection owningObject, 
             TaskCompletionSource<DbConnectionInternal>? taskCompletionSource,
-            SqlConnectionOptions userOptions, 
             out DbConnectionInternal? connection)
         {
             var timeout = TimeSpan.FromSeconds(owningObject.ConnectionTimeout);
@@ -292,7 +290,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             {
                 var task = GetInternalConnection(
                         owningObject,
-                        userOptions,
                         async: false,
                         timeout);
 
@@ -340,7 +337,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 {
                     connection = await GetInternalConnection(
                         owningObject,
-                        userOptions,
                         async: true,
                         timeout
                     ).ConfigureAwait(false);
@@ -375,7 +371,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// Opens a new internal connection to the database.
         /// </summary>
         /// <param name="owningConnection">The owning connection.</param>
-        /// <param name="userOptions">The options for the connection.</param>
         /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
         /// <returns>A task representing the asynchronous operation, with a result of the new internal connection.</returns>
         /// <exception cref="OperationCanceledException">
@@ -383,7 +378,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// </exception>
         private DbConnectionInternal? OpenNewInternalConnection(
             DbConnection? owningConnection, 
-            SqlConnectionOptions userOptions, 
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -405,8 +399,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     // when this support is added to DbConnectionInternal.
                     var connection = ConnectionFactory.CreatePooledConnection(
                         owningConnection,
-                        this,
-                        userOptions);
+                        this);
 
                     if (connection is not null)
                     {
@@ -498,7 +491,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// Gets an internal connection from the pool, either by retrieving an idle connection or opening a new one.
         /// </summary>
         /// <param name="owningConnection">The DbConnection that will own this internal connection</param>
-        /// <param name="userOptions">The user options to set on the internal connection</param>
         /// <param name="async">A boolean indicating whether the operation should be asynchronous.</param>
         /// <param name="timeout">The timeout for the operation.</param>
         /// <returns>Returns a DbConnectionInternal that is retrieved from the pool.</returns>
@@ -512,7 +504,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// </exception>
         private async Task<DbConnectionInternal> GetInternalConnection(
             DbConnection owningConnection, 
-            SqlConnectionOptions userOptions, 
             bool async, 
             TimeSpan timeout)
         {
@@ -533,7 +524,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     // If we didn't find an idle connection, try to open a new one.  
                     connection ??= OpenNewInternalConnection(
                         owningConnection,
-                        userOptions,
                         cancellationToken);
 
                     // If we're at max capacity and couldn't open a connection. Block on the idle channel with a

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/IDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/IDbConnectionPool.cs
@@ -119,19 +119,17 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// <param name="owningObject">The SqlConnection that will own this internal connection.</param>
         /// <param name="taskCompletionSource">Used when calling this method in an async context. 
         /// The internal connection will be set on completion source rather than passed out via the out parameter.</param>
-        /// <param name="userOptions">The user options to use if a new connection must be opened.</param>
         /// <param name="connection">The retrieved connection will be passed out via this parameter.</param>
         /// <returns>True if a connection was set in the out parameter, otherwise returns false.</returns>
-        bool TryGetConnection(DbConnection owningObject, TaskCompletionSource<DbConnectionInternal>? taskCompletionSource, SqlConnectionOptions userOptions, out DbConnectionInternal? connection);
+        bool TryGetConnection(DbConnection owningObject, TaskCompletionSource<DbConnectionInternal>? taskCompletionSource, out DbConnectionInternal? connection);
 
         /// <summary>
         /// Replaces the internal connection currently associated with owningObject with a new internal connection from the pool.
         /// </summary>
-        /// <param name="owningObject">The connection whos internal connection should be replaced.</param>
-        /// <param name="userOptions">The user options to use if a new connection must be opened.</param>
+        /// <param name="owningObject">The connection whose internal connection should be replaced.</param>
         /// <param name="oldConnection">The internal connection currently associated with the owning object.</param>
         /// <returns>A reference to the new DbConnectionInternal.</returns>
-        DbConnectionInternal ReplaceConnection(DbConnection owningObject, SqlConnectionOptions userOptions, DbConnectionInternal oldConnection);
+        DbConnectionInternal ReplaceConnection(DbConnection owningObject, DbConnectionInternal oldConnection);
 
         /// <summary>
         /// Returns an internal connection to the pool.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
@@ -1271,7 +1271,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                                         {
                                             try
                                             {
-                                                // Don't specify any user options because there is no outer connection associated with the new connection
                                                 newObj = CreateObject(owningObject: null, oldConnection: null);
                                             }
                                             catch

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
@@ -61,17 +61,15 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
 
         private sealed class PendingGetConnection
         {
-            public PendingGetConnection(long dueTime, DbConnection owner, TaskCompletionSource<DbConnectionInternal> completion, SqlConnectionOptions userOptions)
+            public PendingGetConnection(long dueTime, DbConnection owner, TaskCompletionSource<DbConnectionInternal> completion)
             {
                 DueTime = dueTime;
                 Owner = owner;
                 Completion = completion;
-                UserOptions = userOptions;
             }
             public long DueTime { get; private set; }
             public DbConnection Owner { get; private set; }
             public TaskCompletionSource<DbConnectionInternal> Completion { get; private set; }
-            public SqlConnectionOptions UserOptions { get; private set; }
         }
 
         private sealed class PoolWaitHandles
@@ -522,7 +520,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             }
         }
 
-        private DbConnectionInternal CreateObject(DbConnection owningObject, SqlConnectionOptions userOptions, DbConnectionInternal oldConnection)
+        private DbConnectionInternal CreateObject(DbConnection owningObject, DbConnectionInternal oldConnection)
         {
             DbConnectionInternal newObj = null;
 
@@ -530,8 +528,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             {
                 newObj = _connectionFactory.CreatePooledConnection(
                     owningObject,
-                    this,
-                    userOptions);
+                    this);
 
                 lock (_objectList)
                 {
@@ -837,7 +834,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                                 delay,
                                 allowCreate: true,
                                 onlyOneCheckConnection: false,
-                                next.UserOptions,
                                 out connection);
                         }
                         // @TODO: CER Exception Handling was removed here (see GH#3581)
@@ -875,7 +871,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             } while (_pendingOpens.TryPeek(out next));
         }
 
-        public bool TryGetConnection(DbConnection owningObject, TaskCompletionSource<DbConnectionInternal> taskCompletionSource, SqlConnectionOptions userOptions, out DbConnectionInternal connection)
+        public bool TryGetConnection(DbConnection owningObject, TaskCompletionSource<DbConnectionInternal> taskCompletionSource, out DbConnectionInternal connection)
         {
             uint waitForMultipleObjectsTimeout = 0;
             bool allowCreate = false;
@@ -901,7 +897,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             }
 
             bool onlyOneCheckConnection = true;
-            if (TryGetConnection(owningObject, waitForMultipleObjectsTimeout, allowCreate, onlyOneCheckConnection, userOptions, out connection))
+            if (TryGetConnection(owningObject, waitForMultipleObjectsTimeout, allowCreate, onlyOneCheckConnection, out connection))
             {
                 return true;
             }
@@ -915,8 +911,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                 new PendingGetConnection(
                     CreationTimeout == 0 ? Timeout.Infinite : ADP.TimerCurrent() + ADP.TimerFromSeconds(CreationTimeout / 1000),
                     owningObject,
-                    taskCompletionSource,
-                    userOptions);
+                    taskCompletionSource);
             _pendingOpens.Enqueue(pendingGetConnection);
 
             // it is better to StartNew too many times than not enough
@@ -934,7 +929,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
 #if NETFRAMEWORK
         [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods")] // copied from Triaged.cs
 #endif
-        private bool TryGetConnection(DbConnection owningObject, uint waitForMultipleObjectsTimeout, bool allowCreate, bool onlyOneCheckConnection, SqlConnectionOptions userOptions, out DbConnectionInternal connection)
+        private bool TryGetConnection(DbConnection owningObject, uint waitForMultipleObjectsTimeout, bool allowCreate, bool onlyOneCheckConnection, out DbConnectionInternal connection)
         {
             DbConnectionInternal obj = null;
             Transaction transaction = null;
@@ -985,7 +980,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                                 SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Creating new connection.", Id);
                                 try
                                 {
-                                    obj = UserCreateRequest(owningObject, userOptions);
+                                    obj = UserCreateRequest(owningObject);
                                 }
                                 catch
                                 {
@@ -1045,7 +1040,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                                         if (semaphoreHolder.Obtained)
                                         {
                                             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionPool.GetConnection|RES|CPOOL> {0}, Creating new connection.", Id);
-                                            obj = UserCreateRequest(owningObject, userOptions);
+                                            obj = UserCreateRequest(owningObject);
                                         }
                                         else
                                         {
@@ -1131,13 +1126,12 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
         /// Creates a new connection to replace an existing connection
         /// </summary>
         /// <param name="owningObject">Outer connection that currently owns <paramref name="oldConnection"/></param>
-        /// <param name="userOptions">Options used to create the new connection</param>
         /// <param name="oldConnection">Inner connection that will be replaced</param>
         /// <returns>A new inner connection that is attached to the <paramref name="owningObject"/></returns>
-        public DbConnectionInternal ReplaceConnection(DbConnection owningObject, SqlConnectionOptions userOptions, DbConnectionInternal oldConnection)
+        public DbConnectionInternal ReplaceConnection(DbConnection owningObject, DbConnectionInternal oldConnection)
         {
             SqlClientEventSource.Log.TryPoolerTraceEvent("<prov.DbConnectionPool.ReplaceConnection|RES|CPOOL> {0}, replacing connection.", Id);
-            DbConnectionInternal newConnection = UserCreateRequest(owningObject, userOptions, oldConnection);
+            DbConnectionInternal newConnection = UserCreateRequest(owningObject, oldConnection);
 
             if (newConnection != null)
             {
@@ -1278,7 +1272,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                                             try
                                             {
                                                 // Don't specify any user options because there is no outer connection associated with the new connection
-                                                newObj = CreateObject(owningObject: null, userOptions: null, oldConnection: null);
+                                                newObj = CreateObject(owningObject: null, oldConnection: null);
                                             }
                                             catch
                                             {
@@ -1522,7 +1516,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             }
         }
 
-        private DbConnectionInternal UserCreateRequest(DbConnection owningObject, SqlConnectionOptions userOptions, DbConnectionInternal oldConnection = null)
+        private DbConnectionInternal UserCreateRequest(DbConnection owningObject, DbConnectionInternal oldConnection = null)
         {
             // called by user when they were not able to obtain a free object but
             // instead obtained creation mutex
@@ -1542,7 +1536,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
                     // TODO: Consider implement a control knob here; why do we only check for dead objects ever other time?  why not every 10th time or every time?
                     if ((oldConnection != null) || (Count & 0x1) == 0x1 || !ReclaimEmancipatedObjects())
                     {
-                        obj = CreateObject(owningObject, userOptions, oldConnection);
+                        obj = CreateObject(owningObject, oldConnection);
                     }
                 }
                 return obj;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -2228,14 +2228,14 @@ namespace Microsoft.Data.SqlClient
         {
             if (ForceNewConnection)
             {
-                if (!InnerConnection.TryReplaceConnection(this, ConnectionFactory, retry, UserConnectionOptions))
+                if (!InnerConnection.TryReplaceConnection(this, ConnectionFactory, retry))
                 {
                     return false;
                 }
             }
             else
             {
-                if (!InnerConnection.TryOpenConnection(this, ConnectionFactory, retry, UserConnectionOptions))
+                if (!InnerConnection.TryOpenConnection(this, ConnectionFactory, retry))
                 {
                     return false;
                 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -115,8 +115,7 @@ namespace Microsoft.Data.SqlClient
         
         internal DbConnectionInternal CreateNonPooledConnection(
             DbConnection owningConnection,
-            DbConnectionPoolGroup poolGroup,
-            SqlConnectionOptions userOptions)
+            DbConnectionPoolGroup poolGroup)
         {
             Debug.Assert(owningConnection is not null, "null owningConnection?");
             Debug.Assert(poolGroup is not null, "null poolGroup?");
@@ -126,8 +125,7 @@ namespace Microsoft.Data.SqlClient
                 poolGroup.PoolKey,
                 poolGroup.ProviderInfo,
                 pool: null,
-                owningConnection,
-                userOptions);
+                owningConnection);
             if (newConnection is not null)
             {
                 SqlClientDiagnostics.Metrics.HardConnectRequest();
@@ -140,8 +138,7 @@ namespace Microsoft.Data.SqlClient
 
         internal DbConnectionInternal CreatePooledConnection(
             DbConnection owningConnection,
-            IDbConnectionPool pool,
-            SqlConnectionOptions userOptions)
+            IDbConnectionPool pool)
         {
             Debug.Assert(pool != null, "null pool?");
 
@@ -150,8 +147,7 @@ namespace Microsoft.Data.SqlClient
                 pool.PoolGroup.PoolKey,
                 pool.PoolGroup.ProviderInfo,
                 pool,
-                owningConnection,
-                userOptions);
+                owningConnection);
 
             if (newConnection is null)
             {
@@ -316,7 +312,6 @@ namespace Microsoft.Data.SqlClient
         internal bool TryGetConnection(
             DbConnection owningConnection,
             TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions,
             DbConnectionInternal oldConnection,
             out DbConnectionInternal connection)
         {
@@ -387,7 +382,6 @@ namespace Microsoft.Data.SqlClient
                                 s_pendingOpenNonPooled[idx],
                                 owningConnection,
                                 retry,
-                                userOptions,
                                 oldConnection,
                                 poolGroup,
                                 cancellationTokenSource);
@@ -413,7 +407,7 @@ namespace Microsoft.Data.SqlClient
                         return false;
                     }
 
-                    connection = CreateNonPooledConnection(owningConnection, poolGroup, userOptions);
+                    connection = CreateNonPooledConnection(owningConnection, poolGroup);
 
                     SqlClientDiagnostics.Metrics.EnterNonPooledConnection();
                 }
@@ -423,11 +417,11 @@ namespace Microsoft.Data.SqlClient
                     {
                         Debug.Assert(oldConnection is not DbConnectionClosed, "Force new connection, but there is no old connection");
                         
-                        connection = connectionPool.ReplaceConnection(owningConnection, userOptions, oldConnection);
+                        connection = connectionPool.ReplaceConnection(owningConnection, oldConnection);
                     }
                     else
                     {
-                        if (!connectionPool.TryGetConnection(owningConnection, retry, userOptions, out connection))
+                        if (!connectionPool.TryGetConnection(owningConnection, retry, out connection))
                         {
                             return false;
                         }
@@ -579,8 +573,7 @@ namespace Microsoft.Data.SqlClient
             ConnectionPoolKey poolKey,
             DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
             IDbConnectionPool pool,
-            DbConnection owningConnection,
-            SqlConnectionOptions userOptions)
+            DbConnection owningConnection)
         {
             SqlConnectionOptions opt = options;
             ConnectionPoolKey key = poolKey;
@@ -588,16 +581,6 @@ namespace Microsoft.Data.SqlClient
 
             SqlConnection sqlOwningConnection = owningConnection as SqlConnection;
             bool applyTransientFaultHandling = sqlOwningConnection?._applyTransientFaultHandling ?? false;
-
-            SqlConnectionOptions userOpt = null;
-            if (userOptions != null)
-            {
-                userOpt = userOptions;
-            }
-            else if (sqlOwningConnection != null)
-            {
-                userOpt = sqlOwningConnection.UserConnectionOptions;
-            }
 
             if (sqlOwningConnection != null)
             {
@@ -700,7 +683,6 @@ namespace Microsoft.Data.SqlClient
                 newPassword: string.Empty,
                 newSecurePassword: null,
                 redirectedUserInstance,
-                userOpt,
                 recoverySessionData,
                 applyTransientFaultHandling,
                 key.AccessToken,
@@ -768,7 +750,6 @@ namespace Microsoft.Data.SqlClient
             Task<DbConnectionInternal> task,
             DbConnection owningConnection,
             TaskCompletionSource<DbConnectionInternal> retry,
-            SqlConnectionOptions userOptions,
             DbConnectionInternal oldConnection,
             DbConnectionPoolGroup poolGroup,
             CancellationTokenSource cancellationTokenSource)
@@ -781,7 +762,7 @@ namespace Microsoft.Data.SqlClient
                     {
                         ADP.SetCurrentTransaction(retry.Task.AsyncState as System.Transactions.Transaction);
                         
-                        DbConnectionInternal newConnection = CreateNonPooledConnection(owningConnection, poolGroup, userOptions);
+                        DbConnectionInternal newConnection = CreateNonPooledConnection(owningConnection, poolGroup);
                         
                         if (oldConnection?.State == ConnectionState.Open)
                         {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/ChannelDbConnectionPoolTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -63,7 +63,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var completed = pool.TryGetConnection(
                     new SqlConnection(),
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? internalConnection
                 );
 
@@ -93,7 +92,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var completed = pool.TryGetConnection(
                     new SqlConnection(),
                     tcs,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? internalConnection
                 );
 
@@ -119,7 +117,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var completed = pool.TryGetConnection(
                     new SqlConnection(),
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? internalConnection
                 );
 
@@ -133,7 +130,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var exceeded = pool.TryGetConnection(
                     new SqlConnection("Timeout=1"),
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? extraConnection
                 );
             }
@@ -159,7 +155,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var completed = pool.TryGetConnection(
                     new SqlConnection(),
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? internalConnection
                 );
 
@@ -174,7 +169,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var exceeded = pool.TryGetConnection(
                     new SqlConnection("Timeout=1"),
                     taskCompletionSource,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? extraConnection
                 );
                 await taskCompletionSource.Task;
@@ -200,7 +194,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 firstOwningConnection,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? firstConnection
             );
 
@@ -209,7 +202,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var completed = pool.TryGetConnection(
                     new SqlConnection(),
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? internalConnection
                 );
 
@@ -225,7 +217,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var exceeded = pool.TryGetConnection(
                     new SqlConnection(""),
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? extraConnection
                 );
                 return extraConnection;
@@ -247,7 +238,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 firstOwningConnection,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? firstConnection
             );
 
@@ -256,7 +246,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var completed = pool.TryGetConnection(
                     new SqlConnection(),
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? internalConnection
                 );
 
@@ -270,7 +259,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             var exceeded = pool.TryGetConnection(
                 new SqlConnection(""),
                 taskCompletionSource,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? recycledConnection
             );
             pool.ReturnInternalConnection(firstConnection!, firstOwningConnection);
@@ -291,7 +279,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 firstOwningConnection,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? firstConnection
             );
 
@@ -300,7 +287,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var completed = pool.TryGetConnection(
                     new SqlConnection(),
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? internalConnection
                 );
 
@@ -321,7 +307,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 pool.TryGetConnection(
                     new SqlConnection(""),
                     null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? recycledConnection
                 );
                 return recycledConnection;
@@ -334,7 +319,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 pool.TryGetConnection(
                     new SqlConnection("Timeout=1"),
                     null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? failedConnection
                 );
                 return failedConnection;
@@ -360,7 +344,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 firstOwningConnection,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? firstConnection
             );
 
@@ -369,7 +352,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var completed = pool.TryGetConnection(
                     new SqlConnection(),
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? internalConnection
                 );
 
@@ -384,7 +366,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             var exceeded = pool.TryGetConnection(
                 new SqlConnection(""),
                 recycledTaskCompletionSource,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? recycledConnection
             );
 
@@ -394,7 +375,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             var exceeded2 = pool.TryGetConnection(
                 new SqlConnection("Timeout=1"),
                 failedCompletionSource,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? failedConnection
             );
 
@@ -417,7 +397,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             var completed1 = pool.TryGetConnection(
                 owningConnection,
                 null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? internalConnection1
             );
 
@@ -432,7 +411,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             var completed2 = pool.TryGetConnection(
                 owningConnection,
                 null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? internalConnection2
             );
 
@@ -454,7 +432,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var completed = pool.TryGetConnection(
                     new SqlConnection(),
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? internalConnection
                 );
             });
@@ -475,7 +452,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 var completed = pool.TryGetConnection(
                     new SqlConnection(),
                     taskCompletionSource,
-                    new SqlConnectionOptions(""),
                     out DbConnectionInternal? internalConnection
                 );
 
@@ -500,7 +476,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                     var completed = pool.TryGetConnection(
                         owningObject,
                         taskCompletionSource: null,
-                        new SqlConnectionOptions(""),
                         out DbConnectionInternal? internalConnection
                     );
                     if (completed)
@@ -534,7 +509,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                     var completed = pool.TryGetConnection(
                         owningObject,
                         taskCompletionSource,
-                        new SqlConnectionOptions(""),
                         out DbConnectionInternal? internalConnection
                     );
                     internalConnection = await taskCompletionSource.Task;
@@ -692,7 +666,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
         public void TestReplaceConnection()
         {
             var pool = ConstructPool(SuccessfulConnectionFactory);
-            Assert.Throws<NotImplementedException>(() => pool.ReplaceConnection(null!, null!, null!));
+            Assert.Throws<NotImplementedException>(() => pool.ReplaceConnection(null!, null!));
         }
 
         [Fact]
@@ -731,7 +705,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 pool.TryGetConnection(
                     owningConnections[i],
                     taskCompletionSource: null,
-                    new SqlConnectionOptions(""),
                     out internalConnections[i]
                 );
                 Assert.Equal(0, internalConnections[i]!.ClearGeneration);
@@ -760,7 +733,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 owningConnection,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? busyConnection
             );
             Assert.NotNull(busyConnection);
@@ -784,7 +756,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 owningConnection,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? busyConnection
             );
             Assert.NotNull(busyConnection);
@@ -814,13 +785,11 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 busyOwner,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? busyConnection
             );
             pool.TryGetConnection(
                 idleOwner,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? idleConnection
             );
             Assert.NotNull(busyConnection);
@@ -853,7 +822,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 owningConnection,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? oldConnection
             );
             Assert.Equal(0, oldConnection!.ClearGeneration);
@@ -867,7 +835,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 newOwner,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? newConnection
             );
             Assert.NotNull(newConnection);
@@ -885,7 +852,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 reuseOwner,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? reusedConnection
             );
             Assert.Same(newConnection, reusedConnection);
@@ -902,7 +868,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 owningConnection,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? connection
             );
             Assert.Equal(0, connection!.ClearGeneration);
@@ -921,7 +886,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
             pool.TryGetConnection(
                 newOwner,
                 taskCompletionSource: null,
-                new SqlConnectionOptions(""),
                 out DbConnectionInternal? newConnection
             );
             Assert.NotNull(newConnection);
@@ -939,8 +903,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 ConnectionPoolKey poolKey,
                 DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
                 IDbConnectionPool pool,
-                DbConnection owningConnection,
-                SqlConnectionOptions userOptions)
+                DbConnection owningConnection)
             {
                 return new StubDbConnectionInternal();
             }
@@ -953,8 +916,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.ConnectionPool
                 ConnectionPoolKey poolKey,
                 DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
                 IDbConnectionPool pool,
-                DbConnection owningConnection,
-                SqlConnectionOptions userOptions)
+                DbConnection owningConnection)
             {
                 throw ADP.PooledOpenTimeout();
             }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/TransactedConnectionPoolTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/TransactedConnectionPoolTest.cs
@@ -676,12 +676,12 @@ public class TransactedConnectionPoolTest
 
         public void Clear() => throw new NotImplementedException();
 
-        public bool TryGetConnection(DbConnection owningObject, TaskCompletionSource<DbConnectionInternal>? taskCompletionSource, SqlConnectionOptions userOptions, out DbConnectionInternal? connection)
+        public bool TryGetConnection(DbConnection owningObject, TaskCompletionSource<DbConnectionInternal>? taskCompletionSource, out DbConnectionInternal? connection)
         {
             throw new NotImplementedException();
         }
 
-        public DbConnectionInternal ReplaceConnection(DbConnection owningObject, SqlConnectionOptions userOptions, DbConnectionInternal oldConnection)
+        public DbConnectionInternal ReplaceConnection(DbConnection owningObject, DbConnectionInternal oldConnection)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/WaitHandleDbConnectionPoolTransactionTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/ConnectionPool/WaitHandleDbConnectionPoolTransactionTest.cs
@@ -82,7 +82,6 @@ public class WaitHandleDbConnectionPoolTransactionTest : IDisposable
         _pool.TryGetConnection(
             owner,
             taskCompletionSource: null,
-            new SqlConnectionOptions(""),
             out DbConnectionInternal? connection);
         return connection!;
     }
@@ -95,7 +94,6 @@ public class WaitHandleDbConnectionPoolTransactionTest : IDisposable
         _pool.TryGetConnection(
             owner,
             taskCompletionSource: tcs,
-            new SqlConnectionOptions(""),
             out DbConnectionInternal? connection);
         return connection ?? await tcs.Task;
     }
@@ -904,8 +902,7 @@ public class WaitHandleDbConnectionPoolTransactionTest : IDisposable
             ConnectionPoolKey poolKey,
             DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
             IDbConnectionPool pool,
-            DbConnection owningConnection,
-            SqlConnectionOptions userOptions)
+            DbConnection owningConnection)
         {
             return new MockDbConnectionInternal();
         }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/CasTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/CasTest.cs
@@ -7,7 +7,7 @@ using System;
 using System.Data;
 using Xunit;
 
-namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
+namespace Microsoft.Data.SqlClient.UnitTests
 {
     /// <summary>
     /// Tests for Code Access Security (CAS) permission demands in SqlConnection.

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/CasTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/CasTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Data.SqlClient.UnitTests
             permissions.AddPermission(new System.Security.Permissions.SecurityPermission(
                 System.Security.Permissions.SecurityPermissionFlag.Execution));
             var sqlPerm = new SqlClientPermission(System.Security.Permissions.PermissionState.None);
-            sqlPerm.Add("Server=will_not_resolve_12345;", "", KeyRestrictionBehavior.AllowOnly);
+            sqlPerm.Add("Server=will_not_resolve_12345;Connect Timeout=1;", "", KeyRestrictionBehavior.AllowOnly);
             permissions.AddPermission(sqlPerm);
 
             var setup = new AppDomainSetup
@@ -127,7 +127,7 @@ namespace Microsoft.Data.SqlClient.UnitTests
 
         private static void OpenConnectionInSandbox()
         {
-            using var connection = new SqlConnection("Server=will_not_resolve_12345;");
+            using var connection = new SqlConnection("Server=will_not_resolve_12345;Connect Timeout=1;");
             connection.Open();
         }
     }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/CasTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/CasTest.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NETFRAMEWORK
+using System;
+using System.Data;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
+{
+    /// <summary>
+    /// Tests for Code Access Security (CAS) permission demands in SqlConnection.
+    ///
+    /// CAS is a .NET Framework security mechanism that restricts what code can do based on
+    /// its origin and identity. SqlConnection.Open() calls DemandPermission(), which performs
+    /// a stack walk to verify that all callers have been granted SqlClientPermission. If any
+    /// caller lacks the permission, a SecurityException is thrown before any network I/O occurs.
+    ///
+    /// These tests use AppDomain sandboxing to create partial-trust environments with controlled
+    /// permission sets, proving that the permission demand is enforced during Open().
+    /// </summary>
+    public class CasTest
+    {
+        /// <summary>
+        /// Verify that calling Open() in a partial-trust sandbox without SqlClientPermission
+        /// causes a SecurityException. Paired with the next test, this experimentally proves
+        /// that SqlClientPermission is the specific permission being demanded: the only
+        /// difference between the two sandboxes is SqlClientPermission being granted.
+        /// </summary>
+        [Fact]
+        public void Open_WithoutSqlClientPermission_ThrowsSecurityException()
+        {
+            var permissions = new System.Security.PermissionSet(System.Security.Permissions.PermissionState.None);
+            permissions.AddPermission(new System.Security.Permissions.SecurityPermission(
+                System.Security.Permissions.SecurityPermissionFlag.Execution));
+
+            var setup = new AppDomainSetup
+            {
+                ApplicationBase = AppDomain.CurrentDomain.SetupInformation.ApplicationBase
+            };
+
+            AppDomain sandbox = AppDomain.CreateDomain("PermissionTest_NoPerm", null, setup, permissions);
+            try
+            {
+                Assert.Throws<System.Security.SecurityException>(() =>
+                    sandbox.DoCallBack(OpenConnectionInSandbox));
+            }
+            finally
+            {
+                AppDomain.Unload(sandbox);
+            }
+        }
+
+        /// <summary>
+        /// Same sandbox as above, but with a narrow SqlClientPermission granted for the exact
+        /// connection string used in OpenConnectionInSandbox. The SecurityException goes away,
+        /// proving that the CAS demand is specifically for SqlClientPermission scoped to that
+        /// connection string. (Open still fails with a non-security error because we can't connect.)
+        /// </summary>
+        [Fact]
+        public void Open_WithSqlClientPermission_DoesNotThrowSecurityException()
+        {
+            var permissions = new System.Security.PermissionSet(System.Security.Permissions.PermissionState.None);
+            permissions.AddPermission(new System.Security.Permissions.SecurityPermission(
+                System.Security.Permissions.SecurityPermissionFlag.Execution));
+            var sqlPerm = new SqlClientPermission(System.Security.Permissions.PermissionState.None);
+            sqlPerm.Add("Server=will_not_resolve_12345;", "", KeyRestrictionBehavior.AllowOnly);
+            permissions.AddPermission(sqlPerm);
+
+            var setup = new AppDomainSetup
+            {
+                ApplicationBase = AppDomain.CurrentDomain.SetupInformation.ApplicationBase
+            };
+
+            AppDomain sandbox = AppDomain.CreateDomain("PermissionTest_WithPerm", null, setup, permissions);
+            try
+            {
+                var ex = Record.Exception(() => sandbox.DoCallBack(OpenConnectionInSandbox));
+                Assert.NotNull(ex);
+                Assert.IsNotType<System.Security.SecurityException>(ex);
+            }
+            finally
+            {
+                AppDomain.Unload(sandbox);
+            }
+        }
+
+        /// <summary>
+        /// Grant a narrow SqlClientPermission for a different server than the one used in Open().
+        /// This proves that the permission demand checks the connection string content, not just
+        /// whether any SqlClientPermission is present.
+        /// </summary>
+        [Fact]
+        public void Open_WithMismatchedSqlClientPermission_ThrowsSecurityException()
+        {
+            var permissions = new System.Security.PermissionSet(System.Security.Permissions.PermissionState.None);
+            permissions.AddPermission(new System.Security.Permissions.SecurityPermission(
+                System.Security.Permissions.SecurityPermissionFlag.Execution));
+            var sqlPerm = new SqlClientPermission(System.Security.Permissions.PermissionState.None);
+            sqlPerm.Add("Server=some_other_server;", "", KeyRestrictionBehavior.AllowOnly);
+            permissions.AddPermission(sqlPerm);
+
+            var setup = new AppDomainSetup
+            {
+                ApplicationBase = AppDomain.CurrentDomain.SetupInformation.ApplicationBase
+            };
+
+            AppDomain sandbox = AppDomain.CreateDomain("PermissionTest_Mismatch", null, setup, permissions);
+            try
+            {
+                var ex = Record.Exception(() => sandbox.DoCallBack(OpenConnectionInSandbox));
+                Assert.NotNull(ex);
+                // The demand fails because the granted permission ("some_other_server") doesn't
+                // cover the demanded permission ("will_not_resolve_12345"). This surfaces as
+                // SecurityException or FileLoadException (the CLR encounters a circular assembly
+                // load when constructing SecurityException with the custom permission type).
+                Assert.True(
+                    ex is System.Security.SecurityException || ex is System.IO.FileLoadException,
+                    $"Expected security failure, got {ex.GetType().FullName}: {ex.Message}");
+            }
+            finally
+            {
+                AppDomain.Unload(sandbox);
+            }
+        }
+
+        private static void OpenConnectionInSandbox()
+        {
+            using var connection = new SqlConnection("Server=will_not_resolve_12345;");
+            connection.Open();
+        }
+    }
+}
+#endif


### PR DESCRIPTION

This pull request refactors the connection management code to simplify method signatures and remove the use of the `SqlConnectionOptions userOptions` parameter from internal APIs and connection pool implementations. The main goal is to streamline the process of opening and replacing connections, making the codebase easier to maintain and less error-prone.

**Connection Management API Simplification:**

* Removed the `SqlConnectionOptions userOptions` parameter from the signatures of `TryOpenConnection`, `TryReplaceConnection`, and related methods in `DbConnectionInternal`, `DbConnectionClosed`, and `SqlConnectionInternal`. All internal logic and calls have been updated accordingly. [[1]](diffhunk://#diff-3404451f5336da9ed837b7a128aa13b9a3a23cd39c303855d1b3a43419761074L803-R811) [[2]](diffhunk://#diff-e0a862430cc788df302890d5a766146c83431e8ba4f6dec3231da5455a28df1dL65-R66) [[3]](diffhunk://#diff-e0a862430cc788df302890d5a766146c83431e8ba4f6dec3231da5455a28df1dL124-R128) [[4]](diffhunk://#diff-e0a862430cc788df302890d5a766146c83431e8ba4f6dec3231da5455a28df1dL180-R177) [[5]](diffhunk://#diff-fdf34d72a7d901d6ceee976f54f360c4d26eea3f536578e656acebcc465b786dL1973-R1949)
* Updated the implementation of `TryOpenConnectionInternal` and its callers to no longer require or pass `userOptions`. [[1]](diffhunk://#diff-3404451f5336da9ed837b7a128aa13b9a3a23cd39c303855d1b3a43419761074L915-R913) [[2]](diffhunk://#diff-3404451f5336da9ed837b7a128aa13b9a3a23cd39c303855d1b3a43419761074L925-R922)

**Connection Pool Interface and Implementation Updates:**

* Simplified the `IDbConnectionPool` interface by removing the `userOptions` parameter from `TryGetConnection` and `ReplaceConnection`, and updated all implementing classes (`ChannelDbConnectionPool`, `WaitHandleDbConnectionPool`) to match the new signatures. [[1]](diffhunk://#diff-9062eeeba73117efeaf91e3e8d4af076600b9e1e175fb47c44a1e08742c23678L122-R132) [[2]](diffhunk://#diff-143f5828ac538b129f458e4224cede7e7134a0c59d2c26253a3ba2d92c898522L227) [[3]](diffhunk://#diff-143f5828ac538b129f458e4224cede7e7134a0c59d2c26253a3ba2d92c898522L285) [[4]](diffhunk://#diff-143f5828ac538b129f458e4224cede7e7134a0c59d2c26253a3ba2d92c898522L408-R402) [[5]](diffhunk://#diff-923fa9d8547589a438d38063dca52e998bbb4120f907f1d1232b98fb3dfc5278L64-L74) [[6]](diffhunk://#diff-923fa9d8547589a438d38063dca52e998bbb4120f907f1d1232b98fb3dfc5278L525-R531)
* Refactored all usages of connection pool methods to remove the now-unnecessary `userOptions` argument, including internal helper methods such as `OpenNewInternalConnection` and `GetInternalConnection`. [[1]](diffhunk://#diff-143f5828ac538b129f458e4224cede7e7134a0c59d2c26253a3ba2d92c898522L378-L386) [[2]](diffhunk://#diff-143f5828ac538b129f458e4224cede7e7134a0c59d2c26253a3ba2d92c898522L515) [[3]](diffhunk://#diff-143f5828ac538b129f458e4224cede7e7134a0c59d2c26253a3ba2d92c898522L536) [[4]](diffhunk://#diff-143f5828ac538b129f458e4224cede7e7134a0c59d2c26253a3ba2d92c898522L295) [[5]](diffhunk://#diff-143f5828ac538b129f458e4224cede7e7134a0c59d2c26253a3ba2d92c898522L343)

**Code Clean-up and Comments:**

* Removed obsolete comments and code related to `userConnectionOptions`, including .NET Framework-specific permission demand logic that is no longer relevant. [[1]](diffhunk://#diff-fdf34d72a7d901d6ceee976f54f360c4d26eea3f536578e656acebcc465b786dL315-L316) [[2]](diffhunk://#diff-fdf34d72a7d901d6ceee976f54f360c4d26eea3f536578e656acebcc465b786dL327) [[3]](diffhunk://#diff-fdf34d72a7d901d6ceee976f54f360c4d26eea3f536578e656acebcc465b786dL344-L366)

**New tests for CAS Functionality**

* Added tests to verify that the appropriate permissions are demanded when opening a connection. CAS is a deprecated feature, but we maintain it for backwards compatibility.

These changes collectively modernize and clarify the connection handling logic, reducing unnecessary complexity and improving maintainability.