### PR TITLE
Introduce Auto-assign workflows for qualifying PRs

### DIFF
--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   load-balance-assignees:
-    # Only run for assignment-eligible PRs: same-repo PRs on pull_request, or fork PRs on pull_request_target.
-    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true))
+    # Only run for assignment-eligible PRs: non-draft PRs with a milestone 
+    # (indicating they're ready for review and not just a work in progress), 
+    # since those are the ones we most want to ensure get assigned and 
+    # don't want to risk assigning reviewers to PRs that aren't ready.
+    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   load-balance-assignees:
     # Only run for assignment-eligible PRs: same-repo PRs on pull_request, or fork PRs on pull_request_target.
-    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true))
+    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -20,6 +20,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Keep the candidate pool centralized in one place so both assignment paths use the same ranking.
             const pool = ['cheenamalhotra', 'paulmedynski', 'priyankatiwari08', 'benrr101', 'mdaigle', 'apoorvdeshmukh'];
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -28,6 +29,7 @@ jobs:
             const currentAssignees = context.payload.pull_request.assignees.map(a => a.login);
             const isForkPr = context.eventName === 'pull_request_target' && context.payload.pull_request.head.repo.fork === true;
             const marker = '<!-- auto-assign-fork-note -->';
+            const normalizeLogin = login => login.toLowerCase();
 
             console.log(`PR Author: ${author}`);
             console.log(`Current Assignees: ${currentAssignees.join(', ')}`);
@@ -40,8 +42,8 @@ jobs:
             const neededAssigneesCount = 2 - currentAssignees.length;
 
             const candidates = pool.filter(user => 
-              user.toLowerCase() !== author.toLowerCase() &&
-              !currentAssignees.some(a => a.toLowerCase() === user.toLowerCase())
+              normalizeLogin(user) !== normalizeLogin(author) &&
+              !currentAssignees.some(a => normalizeLogin(a) === normalizeLogin(user))
             );
 
             if (candidates.length === 0) {
@@ -52,12 +54,13 @@ jobs:
             const workloads = {};
             const canonicalCandidateByLower = {};
             candidates.forEach(user => {
-              const lower = user.toLowerCase();
+              const lower = normalizeLogin(user);
               workloads[lower] = 0;
               canonicalCandidateByLower[lower] = user;
             });
 
             try {
+              // Rank candidates by current assignment count across all open PRs.
               const iterator = github.paginate.iterator(github.rest.pulls.list, {
                 owner,
                 repo,
@@ -69,7 +72,7 @@ jobs:
                 for (const pr of response.data) {
                   if (pr.assignees) {
                     for (const assignee of pr.assignees) {
-                      const login = assignee.login.toLowerCase();
+                      const login = normalizeLogin(assignee.login);
                       if (workloads[login] !== undefined) {
                         workloads[login]++;
                       }
@@ -78,16 +81,16 @@ jobs:
                 }
               }
             } catch (error) {
-              console.error(`Failed to fetch open PRs: ${error.message}`);
-              return; // Safer to abort than to assign incorrectly
+              throw new Error(`Failed to fetch open PRs for auto-assignment: ${error.message}`);
             }
 
             const workloadArray = candidates.map(user => {
-              const lower = user.toLowerCase();
+              const lower = normalizeLogin(user);
               return { user: canonicalCandidateByLower[lower], count: workloads[lower] };
             });
             console.log('Current Workloads:', workloadArray);
 
+            // Shuffle before sorting so ties are broken fairly instead of favoring pool order.
             for (let i = workloadArray.length - 1; i > 0; i--) {
               const j = Math.floor(Math.random() * (i + 1));
               [workloadArray[i], workloadArray[j]] = [workloadArray[j], workloadArray[i]];
@@ -105,13 +108,15 @@ jobs:
 
             if (!isForkPr) {
               await github.rest.issues.addAssignees({
-                owner: owner,
-                repo: repo,
+                owner,
+                repo,
                 issue_number: prNumber,
                 assignees: selectedAssignees
               });
               return;
             }
+
+            // Fork PRs cannot be auto-assigned by the pull_request workflow token, so leave a tracked note instead.
             const mentions = selectedAssignees.map(user => `@${user}`).join(' ');
             const body = `${marker}
             Auto-assignment is not available to the \`pull_request\` workflow for fork-based PRs.
@@ -125,8 +130,15 @@ jobs:
               per_page: 100
             });
 
-            if (comments.some(comment => comment.body && comment.body.includes(marker))) {
-              console.log('Fork-note comment already exists. No action needed.');
+            const existingComment = comments.find(comment => comment.body && comment.body.includes(marker));
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body
+              });
+              console.log('Updated existing fork-note comment.');
               return;
             }
 

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   load-balance-assignees:
     # Only run for assignment-eligible PRs: same-repo PRs on pull_request, or fork PRs on pull_request_target.
-    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
+    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -27,11 +27,12 @@ jobs:
             const prNumber = context.issue.number;
             const author = context.payload.pull_request.user.login;
             const currentAssignees = context.payload.pull_request.assignees.map(a => a.login);
-            const isForkPr = context.eventName === 'pull_request_target' && context.payload.pull_request.head.repo.fork === true;
+            const isForkPr = context.payload.pull_request.head.repo.fork === true;
             const marker = '<!-- auto-assign-fork-note -->';
             const normalizeLogin = login => login.toLowerCase();
 
             console.log(`PR Author: ${author}`);
+            console.log(`Event Name: ${context.eventName}; Is Fork PR: ${isForkPr}`);
             console.log(`Current Assignees: ${currentAssignees.join(', ')}`);
 
             if (currentAssignees.length >= 2) {

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -130,7 +130,7 @@ jobs:
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
               repo,
-              issue_number,
+              issue_number: prNumber,
               per_page: 100
             });
 
@@ -149,6 +149,6 @@ jobs:
             await github.rest.issues.createComment({
               owner,
               repo,
-              issue_number,
+              issue_number: prNumber,
               body
             });

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -8,14 +8,12 @@ on:
 
 jobs:
   load-balance-assignees:
-    # Only run for assignment-eligible PRs: non-draft PRs with a milestone 
-    # (indicating they're ready for review and not just a work in progress), 
-    # since those are the ones we most want to ensure get assigned and 
-    # don't want to risk assigning reviewers to PRs that aren't ready.
-    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
+    # Only run for assignment-eligible PRs, and keep same-repo and fork PRs on
+    # the event type that has the right token behavior for assignment.
+    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true))
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      pull-requests: read
       issues: write
     
     steps:
@@ -23,19 +21,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Keep the candidate pool centralized in one place so both assignment paths use the same ranking.
+            // Keep the candidate pool centralized in one place so every PR uses the same ranking.
             const pool = ['cheenamalhotra', 'paulmedynski', 'priyankatiwari08', 'benrr101', 'mdaigle', 'apoorvdeshmukh'];
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const prNumber = context.issue.number;
             const author = context.payload.pull_request.user.login;
             const currentAssignees = context.payload.pull_request.assignees.map(a => a.login);
-            const isForkPr = context.payload.pull_request.head.repo.fork === true;
-            const marker = '<!-- auto-assign-fork-note -->';
             const normalizeLogin = login => login.toLowerCase();
 
             console.log(`PR Author: ${author}`);
-            console.log(`Event Name: ${context.eventName}; Is Fork PR: ${isForkPr}`);
+            console.log(`Event Name: ${context.eventName}; Is Fork PR: ${context.payload.pull_request.head.repo.fork === true}`);
             console.log(`Current Assignees: ${currentAssignees.join(', ')}`);
 
             if (currentAssignees.length >= 2) {
@@ -110,45 +106,9 @@ jobs:
               return;
             }
 
-            if (!isForkPr) {
-              await github.rest.issues.addAssignees({
-                owner,
-                repo,
-                issue_number: prNumber,
-                assignees: selectedAssignees
-              });
-              return;
-            }
-
-            // Fork PRs cannot be auto-assigned by the pull_request workflow token, so leave a tracked note instead.
-            const mentions = selectedAssignees.map(user => `@${user}`).join(' ');
-            const body = `${marker}
-            Auto-assignment is not available to the \`pull_request\` workflow for fork-based PRs.
-
-            Potential assignees to add manually: ${mentions}`;
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
+            await github.rest.issues.addAssignees({
               owner,
               repo,
               issue_number: prNumber,
-              per_page: 100
-            });
-
-            const existingComment = comments.find(comment => comment.body && comment.body.includes(marker));
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existingComment.id,
-                body
-              });
-              console.log('Updated existing fork-note comment.');
-              return;
-            }
-
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: prNumber,
-              body
+              assignees: selectedAssignees
             });

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -8,31 +8,30 @@ on:
 
 jobs:
   load-balance-assignees:
-    # Only run on pull_request events when PR is not a draft, has a milestone, and is from the same repo
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.milestone != null && github.event.pull_request.head.repo.fork == false
+    # Only run for assignment-eligible PRs: same-repo PRs on pull_request, or fork PRs on pull_request_target.
+    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true))
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       issues: write
     
     steps:
-      - name: Calculate Workload and Assign
+      - name: Calculate Workload and Apply
         uses: actions/github-script@v7
         with:
           script: |
-            // 1. Define your 6 aliases here
             const pool = ['cheenamalhotra', 'paulmedynski', 'priyankatiwari08', 'benrr101', 'mdaigle', 'apoorvdeshmukh'];
-            
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const prNumber = context.issue.number;
             const author = context.payload.pull_request.user.login;
             const currentAssignees = context.payload.pull_request.assignees.map(a => a.login);
+            const isForkPr = context.eventName === 'pull_request_target' && context.payload.pull_request.head.repo.fork === true;
+            const marker = '<!-- auto-assign-fork-note -->';
 
             console.log(`PR Author: ${author}`);
             console.log(`Current Assignees: ${currentAssignees.join(', ')}`);
 
-            // 2. Check how many assignees we need to assign (max 2 total)
             if (currentAssignees.length >= 2) {
               console.log('PR already has 2 or more assignees. No action needed.');
               return;
@@ -40,18 +39,16 @@ jobs:
             
             const neededAssigneesCount = 2 - currentAssignees.length;
 
-            // 3. Filter out the PR author and already assigned users
-            let candidates = pool.filter(user => 
+            const candidates = pool.filter(user => 
               user.toLowerCase() !== author.toLowerCase() &&
               !currentAssignees.some(a => a.toLowerCase() === user.toLowerCase())
             );
 
             if (candidates.length === 0) {
-              console.log('No valid candidates left in the pool to assign.');
+              console.log('No valid candidates left in the pool.');
               return;
             }
 
-            // 4. Fetch all open PRs in the repository to calculate workloads locally
             const workloads = {};
             const canonicalCandidateByLower = {};
             candidates.forEach(user => {
@@ -61,10 +58,9 @@ jobs:
             });
 
             try {
-              // Using pagination in case there are a lot of open PRs
               const iterator = github.paginate.iterator(github.rest.pulls.list, {
-                owner: owner,
-                repo: repo,
+                owner,
+                repo,
                 state: 'open',
                 per_page: 100
               });
@@ -92,46 +88,35 @@ jobs:
             });
             console.log('Current Workloads:', workloadArray);
 
-            // 5. Shuffle the array first for true tie-breaking randomness (Fisher-Yates)
             for (let i = workloadArray.length - 1; i > 0; i--) {
               const j = Math.floor(Math.random() * (i + 1));
               [workloadArray[i], workloadArray[j]] = [workloadArray[j], workloadArray[i]];
             }
 
-            // 6. Sort by assignment count
             workloadArray.sort((a, b) => a.count - b.count);
 
-            // 7. Select new assignees
             const selectedAssignees = workloadArray.slice(0, neededAssigneesCount).map(w => w.user);
-            console.log(`Selected new assignees: ${selectedAssignees.join(', ')}`);
+            console.log(`Selected candidates: ${selectedAssignees.join(', ')}`);
 
-            if (selectedAssignees.length > 0) {
+            if (selectedAssignees.length === 0) {
+              console.log('No assignees selected. No action needed.');
+              return;
+            }
+
+            if (!isForkPr) {
               await github.rest.issues.addAssignees({
                 owner: owner,
                 repo: repo,
                 issue_number: prNumber,
                 assignees: selectedAssignees
               });
+              return;
             }
-
-  notify-fork-pr-assignment-skipped:
-    # Mirror the same assignment-eligibility checks as the main job, but for fork PRs post an explanation comment.
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && github.event.pull_request.milestone != null && github.event.pull_request.head.repo.fork == true
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Comment when assignee auto-balance is skipped for forks
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Security note: this pull_request_target job does not check out or execute PR code.
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const issue_number = context.issue.number;
-            const marker = '<!-- auto-assign-fork-note -->';
+            const mentions = selectedAssignees.map(user => `@${user}`).join(' ');
             const body = `${marker}
-            Auto-assignment is skipped for fork-based PRs because write operations (like setting assignees) are not available to the \`pull_request\` workflow token in this context.`;
+            Auto-assignment is not available to the \`pull_request\` workflow for fork-based PRs.
+
+            Potential assignees to add manually: ${mentions}`;
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner,

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -3,11 +3,13 @@ name: Auto Assign PR Load Balancer
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, milestoned]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, milestoned]
 
 jobs:
   load-balance-assignees:
-    # Only run if the PR is not a draft and has a milestone
-    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
+    # Only run on pull_request events when PR is not a draft, has a milestone, and is from the same repo
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.milestone != null && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -111,3 +113,41 @@ jobs:
                 assignees: selectedAssignees
               });
             }
+
+  notify-fork-pr-assignment-skipped:
+    # On fork-origin PRs, pull_request GITHUB_TOKEN is read-only for write APIs (like assignee updates)
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && github.event.pull_request.milestone != null && github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: write
+    steps:
+      - name: Comment when assignee auto-balance is skipped for forks
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const marker = '<!-- auto-assign-fork-note -->';
+            const body = `${marker}
+            Auto-assignment is skipped for fork-based PRs because write operations (like setting assignees) are not available to the \`pull_request\` workflow token in this context.`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+
+            if (comments.some(comment => comment.body && comment.body.includes(marker))) {
+              console.log('Fork-note comment already exists. No action needed.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body
+            });

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -6,12 +6,12 @@ on:
 
 jobs:
   load-balance-assignees:
-    # Only run if the PR is not a draft, has a milestone, and is from the same repo (not a fork)
-    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null && github.event.pull_request.head.repo.fork == false
+    # Only run if the PR is not a draft and has a milestone
+    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      issues: write
+      issues: read
     
     steps:
       - name: Calculate Workload and Assign

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,0 +1,105 @@
+name: Auto Assign PR Load Balancer
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, milestoned]
+
+jobs:
+  load-balance-assignees:
+    # Only run if the PR is not a draft and has a milestone
+    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: read
+    
+    steps:
+      - name: Calculate Workload and Assign
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // 1. Define your 6 aliases here
+            const pool = ['cheenamalhotra', 'paulmedynski', 'priyankatiwari08', 'benrr101', 'mdaigle', 'apoorvdeshmukh'];
+            
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.issue.number;
+            const author = context.payload.pull_request.user.login;
+            const currentAssignees = context.payload.pull_request.assignees.map(a => a.login);
+
+            console.log(`PR Author: ${author}`);
+            console.log(`Current Assignees: ${currentAssignees.join(', ')}`);
+
+            // 2. Check how many assignees we need to assign (max 2 total)
+            if (currentAssignees.length >= 2) {
+              console.log('PR already has 2 or more assignees. No action needed.');
+              return;
+            }
+            
+            const neededAssigneesCount = 2 - currentAssignees.length;
+
+            // 3. Filter out the PR author and already assigned users
+            let candidates = pool.filter(user => 
+              user.toLowerCase() !== author.toLowerCase() &&
+              !currentAssignees.some(a => a.toLowerCase() === user.toLowerCase())
+            );
+
+            if (candidates.length === 0) {
+              console.log('No valid candidates left in the pool to assign.');
+              return;
+            }
+
+            // 4. Fetch all open PRs in the repository to calculate workloads locally
+            const workloads = {};
+            candidates.forEach(user => workloads[user] = 0);
+
+            try {
+              // Using pagination in case there are a lot of open PRs
+              const iterator = github.paginate.iterator(github.rest.pulls.list, {
+                owner: owner,
+                repo: repo,
+                state: 'open',
+                per_page: 100
+              });
+
+              for await (const response of iterator) {
+                for (const pr of response.data) {
+                  if (pr.assignees) {
+                    for (const assignee of pr.assignees) {
+                      const login = assignee.login;
+                      if (workloads[login] !== undefined) {
+                        workloads[login]++;
+                      }
+                    }
+                  }
+                }
+              }
+            } catch (error) {
+              console.error(`Failed to fetch open PRs: ${error.message}`);
+              return; // Safer to abort than to assign incorrectly
+            }
+
+            const workloadArray = candidates.map(user => ({ user, count: workloads[user] }));
+            console.log('Current Workloads:', workloadArray);
+
+            // 5. Shuffle the array first for true tie-breaking randomness (Fisher-Yates)
+            for (let i = workloadArray.length - 1; i > 0; i--) {
+              const j = Math.floor(Math.random() * (i + 1));
+              [workloadArray[i], workloadArray[j]] = [workloadArray[j], workloadArray[i]];
+            }
+
+            // 6. Sort by assignment count
+            workloadArray.sort((a, b) => a.count - b.count);
+
+            // 7. Select new assignees
+            const selectedAssignees = workloadArray.slice(0, neededAssigneesCount).map(w => w.user);
+            console.log(`Selected new assignees: ${selectedAssignees.join(', ')}`);
+
+            if (selectedAssignees.length > 0) {
+              await github.rest.issues.addAssignees({
+                owner: owner,
+                repo: repo,
+                issue_number: prNumber,
+                assignees: selectedAssignees
+              });
+            }

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   load-balance-assignees:
-    # Only run if the PR is not a draft and has a milestone
-    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
+    # Only run if the PR is not a draft, has a milestone, and is from the same repo (not a fork)
+    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -115,17 +115,17 @@ jobs:
             }
 
   notify-fork-pr-assignment-skipped:
-    # On fork-origin PRs, pull_request GITHUB_TOKEN is read-only for write APIs (like assignee updates)
+    # Mirror the same assignment-eligibility checks as the main job, but for fork PRs post an explanation comment.
     if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false && github.event.pull_request.milestone != null && github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
       issues: write
     steps:
       - name: Comment when assignee auto-balance is skipped for forks
         uses: actions/github-script@v7
         with:
           script: |
+            // Security note: this pull_request_target job does not check out or execute PR code.
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const issue_number = context.issue.number;

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      issues: read
+      issues: write
     
     steps:
       - name: Calculate Workload and Assign

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -51,7 +51,12 @@ jobs:
 
             // 4. Fetch all open PRs in the repository to calculate workloads locally
             const workloads = {};
-            candidates.forEach(user => workloads[user] = 0);
+            const canonicalCandidateByLower = {};
+            candidates.forEach(user => {
+              const lower = user.toLowerCase();
+              workloads[lower] = 0;
+              canonicalCandidateByLower[lower] = user;
+            });
 
             try {
               // Using pagination in case there are a lot of open PRs
@@ -66,7 +71,7 @@ jobs:
                 for (const pr of response.data) {
                   if (pr.assignees) {
                     for (const assignee of pr.assignees) {
-                      const login = assignee.login;
+                      const login = assignee.login.toLowerCase();
                       if (workloads[login] !== undefined) {
                         workloads[login]++;
                       }
@@ -79,7 +84,10 @@ jobs:
               return; // Safer to abort than to assign incorrectly
             }
 
-            const workloadArray = candidates.map(user => ({ user, count: workloads[user] }));
+            const workloadArray = candidates.map(user => {
+              const lower = user.toLowerCase();
+              return { user: canonicalCandidateByLower[lower], count: workloads[lower] };
+            });
             console.log('Current Workloads:', workloadArray);
 
             // 5. Shuffle the array first for true tie-breaking randomness (Fisher-Yates)


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to auto-assign up to 2 assignees to PRs once they are open, non-draft, and associated with a milestone.

## What changed
- Added PR triggers for `opened`, `reopened`, `ready_for_review`, and `milestoned`
- Only runs for qualifying PRs with `draft == false` and `milestone != null`
- Preserves existing assignees and only adds new ones when fewer than 2 are assigned
- Excludes the PR author from assignment
- Selects assignees from the configured 6-person pool based on the lowest number of active open assigned PRs
- Uses `pulls.list` pagination instead of Search API calls to avoid search rate-limit pressure
- Randomizes tie-breaking before sorting by workload

## Validation
- [x] Reviewed qualifying PR trigger conditions
- [x] Reviewed additive assignment behavior for 0 or 1 existing assignee
- [x] Reviewed edge cases for author exclusion, tie handling, and candidate exhaustion

## Demo

[GitHub Actions](https://github.com/dotnet/SqlClient/actions/runs/25705738270) assigned reviewers on this PR:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/b5b063fb-3151-49f8-9008-21d8430fc42c" />
