### PR TITLE
Actions | Introduce auto-assign-pr workflow

### DIFF
--- a/.github/scripts/auto-assign-pr.js
+++ b/.github/scripts/auto-assign-pr.js
@@ -16,9 +16,8 @@ module.exports = async ({ github, context, core }) => {
 
   // Fallback pool keeps behavior unchanged when no repo variable is configured.
   const defaultPool = ['cheenamalhotra', 'paulmedynski', 'priyankatiwari08', 'benrr101', 'mdaigle', 'apoorvdeshmukh'];
-  const configuredPool = parseCsvLogins(process.env.AUTO_ASSIGN_PR_POOL);
+  const configuredPool = parseCsvLogins(process.env.PR_REVIEWER_POOL);
   const rawPool = configuredPool.length > 0 ? configuredPool : defaultPool;
-  const skipUsers = new Set(parseCsvLogins(process.env.AUTO_ASSIGN_PR_SKIP).map(normalizeLogin));
   const seenPoolUsers = new Set();
   const pool = [];
   for (const user of rawPool) {
@@ -61,7 +60,6 @@ module.exports = async ({ github, context, core }) => {
 
   const candidates = pool.filter(user =>
     normalizeLogin(user) !== normalizeLogin(author) &&
-    !skipUsers.has(normalizeLogin(user)) &&
     !currentAssignees.some(a => normalizeLogin(a) === normalizeLogin(user))
   );
 

--- a/.github/scripts/auto-assign-pr.js
+++ b/.github/scripts/auto-assign-pr.js
@@ -41,8 +41,8 @@ module.exports = async ({ github, context, core }) => {
     throw new Error(`Failed to fetch latest PR details: ${error.message}`);
   }
 
-  if (latestPr.draft || !latestPr.milestone) {
-    console.log('PR is no longer assignment-eligible (draft or missing milestone).');
+  if (latestPr.state !== 'open' || latestPr.draft || !latestPr.milestone) {
+    console.log('PR is no longer assignment-eligible (not open, draft, or missing milestone).');
     return;
   }
 

--- a/.github/scripts/auto-assign-pr.js
+++ b/.github/scripts/auto-assign-pr.js
@@ -1,0 +1,135 @@
+// Auto-assign PR load balancer.
+//
+// Selects up to 2 assignees for a qualifying PR from a configurable pool,
+// balancing by current open-PR assignment count. Invoked by the
+// `auto-assign-pr.yml` workflow via `actions/github-script`.
+module.exports = async ({ github, context, core }) => {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const prNumber = context.issue.number;
+  const author = context.payload.pull_request.user.login;
+  const normalizeLogin = login => login.toLowerCase();
+  const parseCsvLogins = value => (value ?? '')
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0);
+
+  // Fallback pool keeps behavior unchanged when no repo variable is configured.
+  const defaultPool = ['cheenamalhotra', 'paulmedynski', 'priyankatiwari08', 'benrr101', 'mdaigle', 'apoorvdeshmukh'];
+  const configuredPool = parseCsvLogins(process.env.AUTO_ASSIGN_PR_POOL);
+  const rawPool = configuredPool.length > 0 ? configuredPool : defaultPool;
+  const skipUsers = new Set(parseCsvLogins(process.env.AUTO_ASSIGN_PR_SKIP).map(normalizeLogin));
+  const seenPoolUsers = new Set();
+  const pool = [];
+  for (const user of rawPool) {
+    const normalized = normalizeLogin(user);
+    if (!seenPoolUsers.has(normalized)) {
+      seenPoolUsers.add(normalized);
+      pool.push(user);
+    }
+  }
+
+  let latestPr;
+  try {
+    const response = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: prNumber
+    });
+    latestPr = response.data;
+  } catch (error) {
+    throw new Error(`Failed to fetch latest PR details: ${error.message}`);
+  }
+
+  if (latestPr.draft || !latestPr.milestone) {
+    console.log('PR is no longer assignment-eligible (draft or missing milestone).');
+    return;
+  }
+
+  const currentAssignees = (latestPr.assignees ?? []).map(a => a.login);
+
+  console.log(`PR Author: ${author}`);
+  console.log(`Event Name: ${context.eventName}; Is Fork PR: ${context.payload.pull_request.head.repo.fork === true}`);
+  console.log(`Current Assignees: ${currentAssignees.join(', ')}`);
+
+  if (currentAssignees.length >= 2) {
+    console.log('PR already has 2 or more assignees. No action needed.');
+    return;
+  }
+
+  const neededAssigneesCount = 2 - currentAssignees.length;
+
+  const candidates = pool.filter(user =>
+    normalizeLogin(user) !== normalizeLogin(author) &&
+    !skipUsers.has(normalizeLogin(user)) &&
+    !currentAssignees.some(a => normalizeLogin(a) === normalizeLogin(user))
+  );
+
+  if (candidates.length === 0) {
+    console.log('No valid candidates left in the pool.');
+    return;
+  }
+
+  const workloads = {};
+  const canonicalCandidateByNormalized = {};
+  candidates.forEach(user => {
+    const normalized = normalizeLogin(user);
+    workloads[normalized] = 0;
+    canonicalCandidateByNormalized[normalized] = user;
+  });
+
+  try {
+    // Rank candidates by current assignment count across all open PRs.
+    const iterator = github.paginate.iterator(github.rest.pulls.list, {
+      owner,
+      repo,
+      state: 'open',
+      per_page: 100
+    });
+
+    for await (const response of iterator) {
+      for (const pr of response.data) {
+        if (pr.draft) continue;
+        if (pr.assignees) {
+          for (const assignee of pr.assignees) {
+            const login = normalizeLogin(assignee.login);
+            if (workloads[login] !== undefined) {
+              workloads[login]++;
+            }
+          }
+        }
+      }
+    }
+  } catch (error) {
+    throw new Error(`Failed to fetch open PRs for auto-assignment: ${error.message}`);
+  }
+
+  const workloadArray = candidates.map(user => {
+    const normalized = normalizeLogin(user);
+    return { user: canonicalCandidateByNormalized[normalized], count: workloads[normalized] };
+  });
+  console.log('Current Workloads:', workloadArray);
+
+  // Shuffle before sorting so ties are broken fairly instead of favoring pool order.
+  for (let i = workloadArray.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [workloadArray[i], workloadArray[j]] = [workloadArray[j], workloadArray[i]];
+  }
+
+  workloadArray.sort((a, b) => a.count - b.count);
+
+  const selectedAssignees = workloadArray.slice(0, neededAssigneesCount).map(w => w.user);
+  console.log(`Selected candidates: ${selectedAssignees.join(', ')}`);
+
+  if (selectedAssignees.length === 0) {
+    console.log('No assignees selected. No action needed.');
+    return;
+  }
+
+  await github.rest.issues.addAssignees({
+    owner,
+    repo,
+    issue_number: prNumber,
+    assignees: selectedAssignees
+  });
+};

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -112,6 +112,7 @@ jobs:
 
               for await (const response of iterator) {
                 for (const pr of response.data) {
+                  if (pr.draft) continue;
                   if (pr.assignees) {
                     for (const assignee of pr.assignees) {
                       const login = normalizeLogin(assignee.login);

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -18,19 +18,39 @@ jobs:
     permissions:
       issues: write
       pull-requests: read
+    env:
+      AUTO_ASSIGN_PR_POOL: ${{ vars.AUTO_ASSIGN_PR_POOL }}
+      AUTO_ASSIGN_PR_SKIP: ${{ vars.AUTO_ASSIGN_PR_SKIP }}
     
     steps:
       - name: Calculate Workload and Apply
         uses: actions/github-script@v7
         with:
           script: |
-            // Keep the candidate pool centralized in one place so every PR uses the same ranking.
-            const pool = ['cheenamalhotra', 'paulmedynski', 'priyankatiwari08', 'benrr101', 'mdaigle', 'apoorvdeshmukh'];
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const prNumber = context.issue.number;
             const author = context.payload.pull_request.user.login;
             const normalizeLogin = login => login.toLowerCase();
+            const parseCsvLogins = value => (value ?? '')
+              .split(',')
+              .map(entry => entry.trim())
+              .filter(entry => entry.length > 0);
+
+            // Fallback pool keeps behavior unchanged when no repo variable is configured.
+            const defaultPool = ['cheenamalhotra', 'paulmedynski', 'priyankatiwari08', 'benrr101', 'mdaigle', 'apoorvdeshmukh'];
+            const configuredPool = parseCsvLogins(process.env.AUTO_ASSIGN_PR_POOL);
+            const rawPool = configuredPool.length > 0 ? configuredPool : defaultPool;
+            const skipUsers = new Set(parseCsvLogins(process.env.AUTO_ASSIGN_PR_SKIP).map(normalizeLogin));
+            const seenPoolUsers = new Set();
+            const pool = [];
+            for (const user of rawPool) {
+              const lower = normalizeLogin(user);
+              if (!seenPoolUsers.has(lower)) {
+                seenPoolUsers.add(lower);
+                pool.push(user);
+              }
+            }
 
             let latestPr;
             try {
@@ -64,6 +84,7 @@ jobs:
 
             const candidates = pool.filter(user => 
               normalizeLogin(user) !== normalizeLogin(author) &&
+              !skipUsers.has(normalizeLogin(user)) &&
               !currentAssignees.some(a => normalizeLogin(a) === normalizeLogin(user))
             );
 

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,0 +1,114 @@
+name: Auto Assign PR Load Balancer
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, milestoned]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, milestoned]
+
+jobs:
+  load-balance-assignees:
+    # Only run for assignment-eligible PRs, and keep same-repo and fork PRs on
+    # the event type that has the right token behavior for assignment.
+    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true))
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: write
+    
+    steps:
+      - name: Calculate Workload and Apply
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Keep the candidate pool centralized in one place so every PR uses the same ranking.
+            const pool = ['cheenamalhotra', 'paulmedynski', 'priyankatiwari08', 'benrr101', 'mdaigle', 'apoorvdeshmukh'];
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.issue.number;
+            const author = context.payload.pull_request.user.login;
+            const currentAssignees = context.payload.pull_request.assignees.map(a => a.login);
+            const normalizeLogin = login => login.toLowerCase();
+
+            console.log(`PR Author: ${author}`);
+            console.log(`Event Name: ${context.eventName}; Is Fork PR: ${context.payload.pull_request.head.repo.fork === true}`);
+            console.log(`Current Assignees: ${currentAssignees.join(', ')}`);
+
+            if (currentAssignees.length >= 2) {
+              console.log('PR already has 2 or more assignees. No action needed.');
+              return;
+            }
+            
+            const neededAssigneesCount = 2 - currentAssignees.length;
+
+            const candidates = pool.filter(user => 
+              normalizeLogin(user) !== normalizeLogin(author) &&
+              !currentAssignees.some(a => normalizeLogin(a) === normalizeLogin(user))
+            );
+
+            if (candidates.length === 0) {
+              console.log('No valid candidates left in the pool.');
+              return;
+            }
+
+            const workloads = {};
+            const canonicalCandidateByLower = {};
+            candidates.forEach(user => {
+              const lower = normalizeLogin(user);
+              workloads[lower] = 0;
+              canonicalCandidateByLower[lower] = user;
+            });
+
+            try {
+              // Rank candidates by current assignment count across all open PRs.
+              const iterator = github.paginate.iterator(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100
+              });
+
+              for await (const response of iterator) {
+                for (const pr of response.data) {
+                  if (pr.assignees) {
+                    for (const assignee of pr.assignees) {
+                      const login = normalizeLogin(assignee.login);
+                      if (workloads[login] !== undefined) {
+                        workloads[login]++;
+                      }
+                    }
+                  }
+                }
+              }
+            } catch (error) {
+              throw new Error(`Failed to fetch open PRs for auto-assignment: ${error.message}`);
+            }
+
+            const workloadArray = candidates.map(user => {
+              const lower = normalizeLogin(user);
+              return { user: canonicalCandidateByLower[lower], count: workloads[lower] };
+            });
+            console.log('Current Workloads:', workloadArray);
+
+            // Shuffle before sorting so ties are broken fairly instead of favoring pool order.
+            for (let i = workloadArray.length - 1; i > 0; i--) {
+              const j = Math.floor(Math.random() * (i + 1));
+              [workloadArray[i], workloadArray[j]] = [workloadArray[j], workloadArray[i]];
+            }
+
+            workloadArray.sort((a, b) => a.count - b.count);
+
+            const selectedAssignees = workloadArray.slice(0, neededAssigneesCount).map(w => w.user);
+            console.log(`Selected candidates: ${selectedAssignees.join(', ')}`);
+
+            if (selectedAssignees.length === 0) {
+              console.log('No assignees selected. No action needed.');
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number: prNumber,
+              assignees: selectedAssignees
+            });

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,7 +1,7 @@
 name: Auto Assign PR Load Balancer
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, ready_for_review, milestoned]
 
 concurrency:

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -16,6 +16,7 @@ jobs:
     if: github.repository == 'dotnet/SqlClient' && github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && github.event.pull_request.milestone != null
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
       pull-requests: read
     env:

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     env:
       PR_REVIEWER_POOL: ${{ vars.PR_REVIEWER_POOL }}
     steps:

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -25,8 +25,19 @@ jobs:
     steps:
       - name: Calculate Workload and Apply
         uses: actions/github-script@v7
+        env:
+          PR_REVIEWER_POOL: ${{ vars.PR_REVIEWER_POOL }}
         with:
           script: |
+            // Read the candidate pool from the repository variable PR_REVIEWER_POOL
+            // (Settings > Secrets and variables > Actions > Variables).
+            // Value is a comma-separated list of GitHub logins who are qualified to be assigned PRs to review.
+            const rawPool = process.env.PR_REVIEWER_POOL ?? '';
+            const pool = rawPool.split(',').map(s => s.trim()).filter(Boolean);
+            if (pool.length === 0) {
+              core.warning('PR_REVIEWER_POOL variable is empty or not set. Skipping auto-assignment.');
+              return;
+            }
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const prNumber = context.issue.number;

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -19,9 +19,7 @@ jobs:
       issues: write
       pull-requests: read
     env:
-      AUTO_ASSIGN_PR_POOL: ${{ vars.AUTO_ASSIGN_PR_POOL }}
-      AUTO_ASSIGN_PR_SKIP: ${{ vars.AUTO_ASSIGN_PR_SKIP }}
-    
+      PR_REVIEWER_POOL: ${{ vars.PR_REVIEWER_POOL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -11,9 +11,9 @@ concurrency:
 jobs:
   load-balance-assignees:
     # Only run for assignment-eligible PRs in the upstream repository. Use
-    # pull_request_target for both same-repo and fork PRs so the workflow
-    # only runs once per PR event.
-    if: github.repository == 'dotnet/SqlClient' && github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && github.event.pull_request.milestone != null
+    # pull_request_target so the workflow only runs once per PR event.
+    # Exclude PRs from forks as GitHub Actions does not have permissions to assign users on PRs from forks.
+    if: github.repository == 'dotnet/SqlClient' && github.event.pull_request.state == 'open'  && github.event.pull_request.draft == false && github.event.pull_request.milestone != null && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -6,9 +6,10 @@ on:
 
 jobs:
   load-balance-assignees:
-    # Only run for assignment-eligible PRs. Use pull_request_target for both
-    # same-repo and fork PRs so the workflow only runs once per PR event.
-    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
+    # Only run for assignment-eligible PRs in the upstream repository. Use
+    # pull_request_target for both same-repo and fork PRs so the workflow
+    # only runs once per PR event.
+    if: github.repository == 'dotnet/SqlClient' && github.event.pull_request.draft == false && github.event.pull_request.milestone != null
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,16 +1,14 @@
 name: Auto Assign PR Load Balancer
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, milestoned]
   pull_request_target:
     types: [opened, reopened, ready_for_review, milestoned]
 
 jobs:
   load-balance-assignees:
-    # Only run for assignment-eligible PRs, and keep same-repo and fork PRs on
-    # the event type that has the right token behavior for assignment.
-    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true))
+    # Only run for assignment-eligible PRs. Use pull_request_target for both
+    # same-repo and fork PRs so the workflow only runs once per PR event.
+    if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true))
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: write
       issues: write
     
     steps:

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -11,7 +11,6 @@ jobs:
     if: github.event.pull_request.draft == false && github.event.pull_request.milestone != null
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
       issues: write
     
     steps:

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -25,19 +25,8 @@ jobs:
     steps:
       - name: Calculate Workload and Apply
         uses: actions/github-script@v7
-        env:
-          PR_REVIEWER_POOL: ${{ vars.PR_REVIEWER_POOL }}
         with:
           script: |
-            // Read the candidate pool from the repository variable PR_REVIEWER_POOL
-            // (Settings > Secrets and variables > Actions > Variables).
-            // Value is a comma-separated list of GitHub logins who are qualified to be assigned PRs to review.
-            const rawPool = process.env.PR_REVIEWER_POOL ?? '';
-            const pool = rawPool.split(',').map(s => s.trim()).filter(Boolean);
-            if (pool.length === 0) {
-              core.warning('PR_REVIEWER_POOL variable is empty or not set. Skipping auto-assignment.');
-              return;
-            }
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const prNumber = context.issue.number;

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review, milestoned]
 
+concurrency:
+  group: auto-assign-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   load-balance-assignees:
     # Only run for assignment-eligible PRs in the upstream repository. Use
@@ -13,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: read
     
     steps:
       - name: Calculate Workload and Apply
@@ -25,8 +30,26 @@ jobs:
             const repo = context.repo.repo;
             const prNumber = context.issue.number;
             const author = context.payload.pull_request.user.login;
-            const currentAssignees = context.payload.pull_request.assignees.map(a => a.login);
             const normalizeLogin = login => login.toLowerCase();
+
+            let latestPr;
+            try {
+              const response = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber
+              });
+              latestPr = response.data;
+            } catch (error) {
+              throw new Error(`Failed to fetch latest PR details: ${error.message}`);
+            }
+
+            if (latestPr.draft || !latestPr.milestone) {
+              console.log('PR is no longer assignment-eligible (draft or missing milestone).');
+              return;
+            }
+
+            const currentAssignees = (latestPr.assignees ?? []).map(a => a.login);
 
             console.log(`PR Author: ${author}`);
             console.log(`Event Name: ${context.eventName}; Is Fork PR: ${context.payload.pull_request.head.repo.fork === true}`);

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -1,7 +1,7 @@
 name: Auto Assign PR Load Balancer
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, ready_for_review, milestoned]
 
 concurrency:

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -13,7 +13,7 @@ jobs:
     # Only run for assignment-eligible PRs in the upstream repository. Use
     # pull_request_target for both same-repo and fork PRs so the workflow
     # only runs once per PR event.
-    if: github.repository == 'dotnet/SqlClient' && github.event.pull_request.draft == false && github.event.pull_request.milestone != null
+    if: github.repository == 'dotnet/SqlClient' && github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && github.event.pull_request.milestone != null
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/auto-assign-pr.yml
+++ b/.github/workflows/auto-assign-pr.yml
@@ -23,135 +23,17 @@ jobs:
       AUTO_ASSIGN_PR_SKIP: ${{ vars.AUTO_ASSIGN_PR_SKIP }}
     
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/scripts/auto-assign-pr.js
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Calculate Workload and Apply
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prNumber = context.issue.number;
-            const author = context.payload.pull_request.user.login;
-            const normalizeLogin = login => login.toLowerCase();
-            const parseCsvLogins = value => (value ?? '')
-              .split(',')
-              .map(entry => entry.trim())
-              .filter(entry => entry.length > 0);
-
-            // Fallback pool keeps behavior unchanged when no repo variable is configured.
-            const defaultPool = ['cheenamalhotra', 'paulmedynski', 'priyankatiwari08', 'benrr101', 'mdaigle', 'apoorvdeshmukh'];
-            const configuredPool = parseCsvLogins(process.env.AUTO_ASSIGN_PR_POOL);
-            const rawPool = configuredPool.length > 0 ? configuredPool : defaultPool;
-            const skipUsers = new Set(parseCsvLogins(process.env.AUTO_ASSIGN_PR_SKIP).map(normalizeLogin));
-            const seenPoolUsers = new Set();
-            const pool = [];
-            for (const user of rawPool) {
-              const lower = normalizeLogin(user);
-              if (!seenPoolUsers.has(lower)) {
-                seenPoolUsers.add(lower);
-                pool.push(user);
-              }
-            }
-
-            let latestPr;
-            try {
-              const response = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: prNumber
-              });
-              latestPr = response.data;
-            } catch (error) {
-              throw new Error(`Failed to fetch latest PR details: ${error.message}`);
-            }
-
-            if (latestPr.draft || !latestPr.milestone) {
-              console.log('PR is no longer assignment-eligible (draft or missing milestone).');
-              return;
-            }
-
-            const currentAssignees = (latestPr.assignees ?? []).map(a => a.login);
-
-            console.log(`PR Author: ${author}`);
-            console.log(`Event Name: ${context.eventName}; Is Fork PR: ${context.payload.pull_request.head.repo.fork === true}`);
-            console.log(`Current Assignees: ${currentAssignees.join(', ')}`);
-
-            if (currentAssignees.length >= 2) {
-              console.log('PR already has 2 or more assignees. No action needed.');
-              return;
-            }
-            
-            const neededAssigneesCount = 2 - currentAssignees.length;
-
-            const candidates = pool.filter(user => 
-              normalizeLogin(user) !== normalizeLogin(author) &&
-              !skipUsers.has(normalizeLogin(user)) &&
-              !currentAssignees.some(a => normalizeLogin(a) === normalizeLogin(user))
-            );
-
-            if (candidates.length === 0) {
-              console.log('No valid candidates left in the pool.');
-              return;
-            }
-
-            const workloads = {};
-            const canonicalCandidateByLower = {};
-            candidates.forEach(user => {
-              const lower = normalizeLogin(user);
-              workloads[lower] = 0;
-              canonicalCandidateByLower[lower] = user;
-            });
-
-            try {
-              // Rank candidates by current assignment count across all open PRs.
-              const iterator = github.paginate.iterator(github.rest.pulls.list, {
-                owner,
-                repo,
-                state: 'open',
-                per_page: 100
-              });
-
-              for await (const response of iterator) {
-                for (const pr of response.data) {
-                  if (pr.draft) continue;
-                  if (pr.assignees) {
-                    for (const assignee of pr.assignees) {
-                      const login = normalizeLogin(assignee.login);
-                      if (workloads[login] !== undefined) {
-                        workloads[login]++;
-                      }
-                    }
-                  }
-                }
-              }
-            } catch (error) {
-              throw new Error(`Failed to fetch open PRs for auto-assignment: ${error.message}`);
-            }
-
-            const workloadArray = candidates.map(user => {
-              const lower = normalizeLogin(user);
-              return { user: canonicalCandidateByLower[lower], count: workloads[lower] };
-            });
-            console.log('Current Workloads:', workloadArray);
-
-            // Shuffle before sorting so ties are broken fairly instead of favoring pool order.
-            for (let i = workloadArray.length - 1; i > 0; i--) {
-              const j = Math.floor(Math.random() * (i + 1));
-              [workloadArray[i], workloadArray[j]] = [workloadArray[j], workloadArray[i]];
-            }
-
-            workloadArray.sort((a, b) => a.count - b.count);
-
-            const selectedAssignees = workloadArray.slice(0, neededAssigneesCount).map(w => w.user);
-            console.log(`Selected candidates: ${selectedAssignees.join(', ')}`);
-
-            if (selectedAssignees.length === 0) {
-              console.log('No assignees selected. No action needed.');
-              return;
-            }
-
-            await github.rest.issues.addAssignees({
-              owner,
-              repo,
-              issue_number: prNumber,
-              assignees: selectedAssignees
-            });
+            const script = require('./.github/scripts/auto-assign-pr.js');
+            await script({ github, context, core });


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to auto-assign up to 2 assignees to PRs once they are open, non-draft, and associated with a milestone.

## What changed
- Added PR triggers for `opened`, `reopened`, `ready_for_review`, and `milestoned`
- Only runs for qualifying PRs with `draft == false` and `milestone != null`
- Preserves existing assignees and only adds new ones when fewer than 2 are assigned
- Excludes the PR author from assignment
- Selects assignees from the configured 6-person pool based on the lowest number of active open assigned PRs
- Uses `pulls.list` pagination instead of Search API calls to avoid search rate-limit pressure
- Randomizes tie-breaking before sorting by workload

## Validation
- [x] Reviewed qualifying PR trigger conditions
- [x] Reviewed additive assignment behavior for 0 or 1 existing assignee
- [x] Reviewed edge cases for author exclusion, tie handling, and candidate exhaustion
- [x] Reviewed action runs successfully on PRs created from same repo branches.
- [x] Need to review actions on fork-based PRs after this actions is available on 'main' branch, which will come under 'pull_request_target' event.
## Demo

Action on this PR ran successfully:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6ee5c326-389f-475c-a811-beaedcd3c96d" />
