### PR TITLE
[CodeQL] Suppress Random Dictionary Key Warning in SqlDependencyUtils

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDependencyUtils.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Data.SqlClient
 #if NETFRAMEWORK
                 _timeoutTimer = new Timer(new TimerCallback(TimeoutTimerCallback), null, Timeout.Infinite, Timeout.Infinite);
 
-                // If rude abort - we'll leak.  This is acceptable for now.  
+                // If rude abort - we'll leak.  This is acceptable for now.
                 AppDomain.CurrentDomain.DomainUnload += new EventHandler(UnloadEventHandler);
 #else
                 _timeoutTimer = ADP.UnsafeCreateTimer(
@@ -131,7 +131,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        //  When remoted across appdomains, MarshalByRefObject links by default time out if there is no activity 
+        //  When remoted across appdomains, MarshalByRefObject links by default time out if there is no activity
         //  within a few minutes.  Add this override to prevent marshaled links from timing out.
 #if NET
         [Obsolete("InitializeLifetimeService() is not supported after .Net5.0 and throws PlatformNotSupportedException.")]
@@ -216,7 +216,7 @@ namespace Microsoft.Data.SqlClient
                             dependencyList.Add(dep);
 
                             // map command hash to notification we just created to reuse it for the next client
-                            _commandHashToNotificationId.Add(commandHash, notificationId);
+                            _commandHashToNotificationId.Add(commandHash, notificationId); // CodeQL [SM04207] This value is an opaque query-notification correlation identifier, not a secret or security token. It is used only for uniqueness and exact dictionary lookup after SQL Server round-trips the user data. Guid.NewGuid provides sufficient collision resistance for the expected in-process notification cardinality, and changing the generator would not materially improve security.
                             _notificationIdToDependenciesHash.Add(notificationId, dependencyList);
                         }
 


### PR DESCRIPTION
## Description
This PR addresses a CodeQL issue that was raised recently. The issue is that we are using "randomly generated" dictionary keys. Technically this is true, as the keys we're using in this case is partially generated by a `Guid.NewGuid()` call. The "fix" for this is to replace the `Guid.NewGuid()` calls with cryptographically secure random number generation. However, there's little reason to go to this trouble - even with hundreds of thousands of IDs being generated, the risk of a collision is exceedingly small. Therefore, rather than rewrite the key generation (and likely all the other instances where IDs are generated by GUIDs), I've opted to suppress this specific line of code.

## Issues
CodeQL issue.

## 🤖 
Suppression message generated by 🤖 