### PR TITLE
Remove labeling from agentic issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ddda208c8014c64e57436e95b5e1c92431c6815b5d0f782bb6a01ee1e84a63d9","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"20b8fbbfaae4d08b3206fb6b2f4000e43b8915e37f5afc9a534056f8ce9a563b","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41","digest":"sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41@sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41","digest":"sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41@sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41","digest":"sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41@sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -189,20 +189,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_bef3a8b6a480c883_EOF'
+          cat << 'GH_AW_PROMPT_b5f7a25dd7272e5f_EOF'
           <system>
-          GH_AW_PROMPT_bef3a8b6a480c883_EOF
+          GH_AW_PROMPT_b5f7a25dd7272e5f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bef3a8b6a480c883_EOF'
+          cat << 'GH_AW_PROMPT_b5f7a25dd7272e5f_EOF'
           <safe-output-tools>
-          Tools: add_comment, add_labels(max:5), missing_tool, missing_data, noop
+          Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_bef3a8b6a480c883_EOF
+          GH_AW_PROMPT_b5f7a25dd7272e5f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_bef3a8b6a480c883_EOF'
+          cat << 'GH_AW_PROMPT_b5f7a25dd7272e5f_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -231,12 +231,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_bef3a8b6a480c883_EOF
+          GH_AW_PROMPT_b5f7a25dd7272e5f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bef3a8b6a480c883_EOF'
+          cat << 'GH_AW_PROMPT_b5f7a25dd7272e5f_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_bef3a8b6a480c883_EOF
+          GH_AW_PROMPT_b5f7a25dd7272e5f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -430,16 +430,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6f7dd6f136148d14_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1},"add_labels":{"max":5},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6f7dd6f136148d14_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_421fab10d521b1cd_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_421fab10d521b1cd_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading.",
-                "add_labels": " CONSTRAINTS: Maximum 5 label(s) can be added."
+                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -461,25 +460,6 @@ jobs:
                   "reply_to_id": {
                     "type": "string",
                     "maxLength": 256
-                  },
-                  "repo": {
-                    "type": "string",
-                    "maxLength": 256
-                  }
-                }
-              },
-              "add_labels": {
-                "defaultMax": 5,
-                "fields": {
-                  "item_number": {
-                    "issueNumberOrTemporaryId": true
-                  },
-                  "labels": {
-                    "required": true,
-                    "type": "array",
-                    "itemType": "string",
-                    "itemSanitize": true,
-                    "itemMaxLength": 128
                   },
                   "repo": {
                     "type": "string",
@@ -639,7 +619,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_47425e2eb31c9c9e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_95017dc8ef4cee83_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -683,7 +663,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_47425e2eb31c9c9e_EOF
+          GH_AW_MCP_CONFIG_95017dc8ef4cee83_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1314,7 +1294,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"add_labels\":{\"max\":5},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -19,8 +19,6 @@ safe-outputs:
   add-comment:
     max: 1
     hide-older-comments: true
-  add-labels:
-    max: 5
 ---
 
 # SqlClient Issue Auto-Triage
@@ -29,10 +27,10 @@ You are a triage specialist for **Microsoft.Data.SqlClient**.
 A new issue has just been opened. Your job is to:
 
 1. Read the issue silently using GitHub read tools
-2. Apply labels silently using `add_labels`
-3. Post **one** triage summary comment using `add_comment`
+2. Post **one** triage summary comment using `add_comment`
 
 That is the entire workflow. Do NOT call `add_comment` more than once.
+Do NOT call `add_labels`. Do NOT apply any labels.
 Do NOT post intermediate findings. Do NOT post separate comments for
 area detection, duplicate checking, or environment validation.
 Everything goes into the single triage summary at the end.
@@ -90,19 +88,9 @@ Proceed with all remaining triage steps regardless of missing environment detail
 
 ---
 
-## Actions (execute in this order)
+## Actions
 
-**First**: Call `add_labels` with at most 5 labels total (safe-outputs limit):
-- `Triage Needed :new:` (always)
-- Exactly **one** `Area\*` label from the table above (pick the single best match)
-- `Needs More Info :information_source:` if critical environment details are missing (bugs only)
-- `Repro Available :heavy_check_mark:` if repro steps are provided
-- `Regression :boom:` if this appears to be a regression
-
-If the issue spans multiple areas, pick the primary area as the label and mention
-other relevant areas in the triage summary comment instead.
-
-**Then**: Call `add_comment` exactly **once** with this markdown:
+Call `add_comment` exactly **once** with this markdown:
 
 ```
 ## 🔍 Triage Summary
@@ -111,7 +99,7 @@ other relevant areas in the triage summary comment instead.
 |-------|--------|
 | Issue type | <Bug / Feature / Question / Task> |
 | Environment | <All required environment details provided for investigation / ⚠️ Missing: list specific fields> |
-| Area | <Area label applied or "no match"> |
+| Area | <Best matching area from classification table> |
 | Duplicates | <None found / Potentially related: #NNN, #NNN> |
 | Regression | <Not indicated / Likely regression from vX.Y.Z / Inconclusive> |
 


### PR DESCRIPTION
## Summary

Follow-up to #4177. Removes all label-related functionality from the agentic issue triage workflow per team decision to manage labels via GitHub Projects and human triage instead.

### Changes

**Frontmatter:**
- Removed `add-labels: max: 5` from safe-outputs (workflow can no longer apply labels)

**Workflow instructions:**
- Removed `add_labels` from the task list (now: read → comment only)
- Added explicit instruction: "Do NOT call `add_labels`. Do NOT apply any labels."
- Removed "Required Context" section (no longer scans all `.github/` markdown files)
- Removed entire `add_labels` action block (Triage Needed, Area, Needs More Info, Repro Available, Regression labels)
- Updated triage summary template: Area field now says "Best matching area from classification table" instead of "Area label applied"
- Moved AI disclaimer note before Next Steps guidance
- Refined Next Steps to be maintainer-focused guidance

**Lock file:**
- Recompiled `issue-triage.lock.yml` via `gh aw compile`
- `safe_outputs` job no longer includes label-related steps

### What the workflow still does

1. Reads the new issue via GitHub MCP (read-only)
2. Classifies: issue type, area, environment completeness, duplicates, regression
3. Posts **one** triage summary comment with structured analysis table

### Prerequisites simplified

With labeling removed, the only prerequisite for this workflow is:
1. **`COPILOT_GITHUB_TOKEN` secret** — required for Copilot inference

The `Triage Needed :new:` label creation is **no longer required**.

### Tested on

Developed on [priyankatiwari08/SqlClient-test-prtiwar](https://github.com/priyankatiwari08/SqlClient-test-prtiwar)