### PR TITLE
Add CI package pipeline for building and publishing NuGet packages

### DIFF
--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -91,7 +91,7 @@ variables:
   # Signing key argument passed to build.proj. On internal builds this references the secure file
   # downloaded by DownloadSecureFile@1; on public builds it expands to empty.
   - name: signingKeyArg
-    ${{ if eq(variables.isInternalBuild, 'True') }}:
+    ${{ if eq(variables.isInternalBuild, true) }}:
       value: '-p:SigningKeyPath="$(keyFile.secureFilePath)"'
     ${{ else }}:
       value: ''
@@ -101,7 +101,7 @@ jobs:
     displayName: Pack All Packages
 
     pool:
-      ${{ if eq(variables.isInternalBuild, 'True') }}:
+      ${{ if eq(variables.isInternalBuild, true) }}:
         name: ADO-1ES-Pool
       ${{ else }}:
         name: ADO-CI-1ES-Pool
@@ -131,7 +131,7 @@ jobs:
         displayName: Clean packages/ directory
 
       # On internal builds, download the strong-name signing key.
-      - ${{ if eq(variables.isInternalBuild, 'True') }}:
+      - ${{ if eq(variables.isInternalBuild, true) }}:
         - task: DownloadSecureFile@1
           displayName: Download Signing Key
           inputs:
@@ -151,7 +151,7 @@ jobs:
             -p:BuildNumber="$(Build.BuildNumber)"
             -p:BuildSuffix=ci
             $(signingKeyArg)
-            -verbosity:${{ parameters.dotnetVerbosity }}
+            --verbosity ${{ parameters.dotnetVerbosity }}
 
       # List produced packages for diagnostics.
       - pwsh: |

--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -96,9 +96,9 @@ variables:
   #- name: skipComponentGovernanceDetection
   #  value: true
 
-  # Whether this is an internal (ADO) build that should strong-name sign.
+  # Whether this is an internal (ADO.Net project) or public (Public project) build.
   - name: isInternalBuild
-    value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/') }}
+    value: ${{ eq(variables['System.TeamProject'], 'ADO.Net') }}
 
   # Package version suffix for CI builds.
   - name: buildSuffix

--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -121,6 +121,9 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
+      # Restore dotnet local tools (pwsh, apicompat, etc.).
+      - template: /eng/pipelines/steps/restore-dotnet-tools.yml@self
+
       # Clean any pre-existing .nupkg / .snupkg files from the packages/ directory
       # to ensure we only publish packages produced by this run.
       - pwsh: |

--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -84,19 +84,17 @@ parameters:
       - diagnostic
 
 variables:
-  # Disable codesign validation injection for CI builds.
-  #
-  # TODO: Should we enable this for internal/main since those builds produce signed assemblies?
-  #- name: runCodesignValidationInjection
-  #  value: false
-
   # Whether this is an internal (ADO.Net project) or public (Public project) build.
   - name: isInternalBuild
     value: ${{ eq(variables['System.TeamProject'], 'ADO.Net') }}
 
-  # Package version suffix for CI builds.
-  - name: buildSuffix
-    value: ci
+  # Signing key argument passed to build.proj. On internal builds this references the secure file
+  # downloaded by DownloadSecureFile@1; on public builds it expands to empty.
+  - name: signingKeyArg
+    ${{ if eq(variables.isInternalBuild, 'True') }}:
+      value: '-p:SigningKeyPath="$(keyFile.secureFilePath)"'
+    ${{ else }}:
+      value: ''
 
 jobs:
   - job: pack_all_packages
@@ -132,7 +130,7 @@ jobs:
           Write-Host 'Done.'
         displayName: Clean packages/ directory
 
-      # On internal/main, download the strong-name signing key and setup assembly signing.
+      # On internal builds, download the strong-name signing key.
       - ${{ if eq(variables.isInternalBuild, 'True') }}:
         - task: DownloadSecureFile@1
           displayName: Download Signing Key
@@ -140,12 +138,7 @@ jobs:
             secureFile: netfxKeypair.snk
           name: keyFile
 
-        - pwsh: |
-            Write-Host "##vso[task.setvariable variable=signingKeyArg]-p:SigningKeyPath=`"$(keyFile.secureFilePath)`""
-          displayName: Set Signing Key Argument
-
       # Run the Pack target via build.proj.
-      # On internal/main the signing key path is included via $(signingKeyArg).
       - task: DotNetCoreCLI@2
         displayName: build.proj - Pack (ReferenceType=Package)
         inputs:
@@ -156,7 +149,7 @@ jobs:
             -p:Configuration=${{ parameters.buildConfiguration }}
             -p:ReferenceType=Package
             -p:BuildNumber="$(Build.BuildNumber)"
-            -p:BuildSuffix=$(buildSuffix)
+            -p:BuildSuffix=ci
             $(signingKeyArg)
             -verbosity:${{ parameters.dotnetVerbosity }}
 

--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -1,0 +1,181 @@
+#################################################################################
+# Licensed to the .NET Foundation under one or more agreements.                 #
+# The .NET Foundation licenses this file to you under the MIT license.          #
+# See the LICENSE file in the project root for more information.                #
+#################################################################################
+
+# This pipeline builds all packages using the build.proj Pack target with ReferenceType=Package,
+# then publishes the resulting .nupkg and .snupkg files as a single pipeline artifact.
+#
+# It runs:
+#   - On pushes to GitHub main and ADO internal/main (batched)
+#   - Nightly at 00:00 UTC on both branches
+#
+# On internal/main the strong-name signing key is downloaded and used to sign assemblies during the
+# build.
+#
+# GOTCHA: This pipeline definition is triggered by GitHub _and_ ADO CI.  We distinguish the two via
+# branch filters:
+#
+#   - Only the GitHub repo has a 'main' branch.
+#   - Only the ADO repo has an 'internal/main' branch.
+
+name: $(DayOfYear)$(Rev:rr)
+
+# Do not trigger this pipeline for PRs.
+pr: none
+
+# Trigger on pushes to main and internal/main, batching concurrent commits.
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+      - internal/main
+
+# Nightly schedule at 00:00 UTC.
+schedules:
+  - cron: '0 0 * * *'
+    displayName: Nightly Build
+    branches:
+      include:
+        - main
+        - internal/main
+    always: true
+
+# Pipeline parameters visible in the Azure DevOps UI.
+parameters:
+
+  # The agent image to use for the build.  This must exist in both the ADO-1ES-Pool and
+  # ADO-CI-1ES-Pool agent pools.
+  - name: agentImage
+    displayName: Agent Image
+    type: string
+    default: ADO-UB24
+    values:
+      - ADO-UB24
+      - ADO-Win25
+
+  # The build configuration to use, either Debug or Release.
+  - name: buildConfiguration
+    displayName: Build Configuration
+    type: string
+    default: Release
+    values:
+      - Debug
+      - Release
+
+  # True to enable debug steps and output.
+  - name: debug
+    displayName: Enable debug output
+    type: boolean
+    default: false
+
+  # The verbosity level of dotnet CLI commands.
+  - name: dotnetVerbosity
+    displayName: dotnet CLI Verbosity
+    type: string
+    default: normal
+    values:
+      - quiet
+      - minimal
+      - normal
+      - detailed
+      - diagnostic
+
+variables:
+  # Disable codesign validation injection for CI builds.
+  #
+  # TODO: Should we enable this for internal/main since those builds produce signed assemblies?
+  - name: runCodesignValidationInjection
+    value: false
+
+  # Skip component governance detection for CI builds.
+  #
+  # TODO: This should never be skipped, should it?
+  #- name: skipComponentGovernanceDetection
+  #  value: true
+
+  # Whether this is an internal (ADO) build that should strong-name sign.
+  - name: isInternalBuild
+    value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/') }}
+
+  # Package version suffix for CI builds.
+  - name: buildSuffix
+    value: ci
+
+jobs:
+  - job: pack_all_packages
+    displayName: Pack All Packages
+
+    pool:
+      ${{ if eq(variables.isInternalBuild, 'True') }}:
+        name: ADO-1ES-Pool
+      ${{ else }}:
+        name: ADO-CI-1ES-Pool
+      demands:
+        - ImageOverride -equals ${{ parameters.agentImage }}
+
+    steps:
+
+      # Emit environment variables if debug is enabled.
+      - ${{ if eq(parameters.debug, true) }}:
+        - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
+          displayName: '[Debug] Print Environment Variables'
+
+      # Install the .NET SDK from global.json.
+      - template: /eng/pipelines/steps/install-dotnet.yml@self
+        parameters:
+          debug: ${{ parameters.debug }}
+
+      # Clean any pre-existing .nupkg / .snupkg files from the packages/ directory
+      # to ensure we only publish packages produced by this run.
+      - pwsh: |
+          Write-Host 'Cleaning packages/ directory...'
+          Remove-Item -Force "$(Build.SourcesDirectory)/packages/*.nupkg" -ErrorAction SilentlyContinue
+          Remove-Item -Force "$(Build.SourcesDirectory)/packages/*.snupkg" -ErrorAction SilentlyContinue
+          Write-Host 'Done.'
+        displayName: Clean packages/ directory
+
+      # On internal/main, download the strong-name signing key and setup assembly signing.
+      - ${{ if eq(variables.isInternalBuild, 'True') }}:
+        - task: DownloadSecureFile@1
+          displayName: Download Signing Key
+          inputs:
+            secureFile: netfxKeypair.snk
+          name: keyFile
+
+        - pwsh: |
+            Write-Host "##vso[task.setvariable variable=signingKeyArg]-p:SigningKeyPath=`"$(keyFile.secureFilePath)`""
+          displayName: Set Signing Key Argument
+
+      # Run the Pack target via build.proj.
+      # On internal/main the signing key path is included via $(signingKeyArg).
+      - task: DotNetCoreCLI@2
+        displayName: build.proj - Pack (ReferenceType=Package)
+        inputs:
+          command: build
+          projects: '$(Build.SourcesDirectory)/build.proj'
+          arguments: >-
+            -t:Pack
+            -p:Configuration=${{ parameters.buildConfiguration }}
+            -p:ReferenceType=Package
+            -p:BuildNumber="$(Build.BuildNumber)"
+            -p:BuildSuffix=$(buildSuffix)
+            $(signingKeyArg)
+            -verbosity:${{ parameters.dotnetVerbosity }}
+
+      # List produced packages for diagnostics.
+      - pwsh: |
+          Write-Host 'Packages produced:'
+          Get-ChildItem "$(Build.SourcesDirectory)/packages/*.nupkg" -ErrorAction SilentlyContinue | Format-Table Name, Length
+          Get-ChildItem "$(Build.SourcesDirectory)/packages/*.snupkg" -ErrorAction SilentlyContinue | Format-Table Name, Length
+        displayName: List produced packages
+
+      # Publish all .nupkg and .snupkg files from packages/ as a pipeline artifact.
+      - task: PublishPipelineArtifact@1
+        displayName: Publish NuGet Packages
+        inputs:
+          targetPath: '$(Build.SourcesDirectory)/packages'
+          artifactName: Packages
+          publishLocation: pipeline

--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -87,14 +87,8 @@ variables:
   # Disable codesign validation injection for CI builds.
   #
   # TODO: Should we enable this for internal/main since those builds produce signed assemblies?
-  - name: runCodesignValidationInjection
-    value: false
-
-  # Skip component governance detection for CI builds.
-  #
-  # TODO: This should never be skipped, should it?
-  #- name: skipComponentGovernanceDetection
-  #  value: true
+  #- name: runCodesignValidationInjection
+  #  value: false
 
   # Whether this is an internal (ADO.Net project) or public (Public project) build.
   - name: isInternalBuild
@@ -120,7 +114,8 @@ jobs:
 
       # Emit environment variables if debug is enabled.
       - ${{ if eq(parameters.debug, true) }}:
-        - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
+        - pwsh: |
+            Get-ChildItem Env: | Sort-Object Name | Format-Table -AutoSize -Wrap
           displayName: '[Debug] Print Environment Variables'
 
       # Install the .NET SDK from global.json.
@@ -168,8 +163,8 @@ jobs:
       # List produced packages for diagnostics.
       - pwsh: |
           Write-Host 'Packages produced:'
-          Get-ChildItem "$(Build.SourcesDirectory)/packages/*.nupkg" -ErrorAction SilentlyContinue | Format-Table Name, Length
-          Get-ChildItem "$(Build.SourcesDirectory)/packages/*.snupkg" -ErrorAction SilentlyContinue | Format-Table Name, Length
+          Get-ChildItem "$(Build.SourcesDirectory)/packages/*.nupkg" -ErrorAction SilentlyContinue | Format-Table Name, Length -AutoSize -Wrap
+          Get-ChildItem "$(Build.SourcesDirectory)/packages/*.snupkg" -ErrorAction SilentlyContinue | Format-Table Name, Length -AutoSize -Wrap
         displayName: List produced packages
 
       # Publish all .nupkg and .snupkg files from packages/ as a pipeline artifact.

--- a/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-package-ref-pipeline.yml
@@ -51,6 +51,7 @@ pr:
       - global.json
       - NuGet.config
     exclude:
+      - eng/pipelines/ci/*
       - eng/pipelines/kerberos/*
       - eng/pipelines/onebranch/*
       - eng/pipelines/stress/*

--- a/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
+++ b/eng/pipelines/sqlclient-pr-project-ref-pipeline.yml
@@ -51,6 +51,7 @@ pr:
       - global.json
       - NuGet.config
     exclude:
+      - eng/pipelines/ci/*
       - eng/pipelines/kerberos/*
       - eng/pipelines/onebranch/*
       - eng/pipelines/stress/*


### PR DESCRIPTION
Adds a new top-level pipeline at `eng/pipelines/ci/package/sqlclient-package.yml` that:

- Runs on pushes to GitHub `main` and ADO `internal/main` branches (batched)
- Runs nightly at 00:00 UTC on those same branches
- Cleans the `packages/` directory before building
- Uses `build.proj` Pack target with `ReferenceType=Package`
- On internal builds, downloads the signing key and strong-name signs assemblies
- Publishes all produced .nupkg/.snupkg files as a pipeline artifact

Tested ADO.Net project runs here:
- Linux:  https://dev.azure.com/SqlClientDrivers/ADO.Net/_build/results?buildId=154236&view=results
- Windows:  https://dev.azure.com/SqlClientDrivers/ADO.Net/_build/results?buildId=154237&view=results
- All pipeline parameters were tested between these 2 runs.

We can't test Public project runs until this merges, because we can only create new pipelines based on GitHub for YAML files on main.