### PR TITLE
Enforce `gh aw compile` + lock-file regeneration for agentic workflows

### DIFF
--- a/.github/instructions/agentic-workflows.instructions.md
+++ b/.github/instructions/agentic-workflows.instructions.md
@@ -1,0 +1,49 @@
+---
+applyTo: ".github/workflows/**/*.md"
+description: Rules for editing gh-aw agentic workflow Markdown files.
+---
+
+# Agentic Workflow Edit Rules (`gh aw`)
+
+This repository authors GitHub Actions agentic workflows in Markdown using
+[`gh aw`](https://github.com/githubnext/gh-aw). Each workflow `.md` file under
+`.github/workflows/` compiles to a sibling `.lock.yml`, and **only the
+`.lock.yml` is executed by GitHub Actions at runtime.**
+
+## Mandatory rule
+
+Whenever you create, edit, rename, or delete a file matching
+`.github/workflows/**/*.md`, you **MUST**, in the **same commit / PR**:
+
+1. Run `gh aw compile` from the repository root.
+2. Stage and commit the regenerated sibling `<name>.lock.yml`.
+3. If you deleted a workflow `.md`, also delete its `.lock.yml`.
+
+If the `.lock.yml` is stale or missing, the workflow fails at runtime
+(see PR #4279 for the exact failure mode). The
+`Verify gh aw lock files` CI check will block the PR in that case.
+
+## How to verify locally
+
+```bash
+gh aw compile
+git status        # both the .md and .lock.yml should appear
+gh aw compile     # second run must be a no-op (clean diff)
+```
+
+## Code-review checklist
+
+When reviewing a PR that touches `.github/workflows/**/*.md`:
+
+- [ ] A matching `.lock.yml` is updated in the same PR.
+- [ ] `gh aw compile` produces no further diff on top of the PR.
+- [ ] If new tools, network endpoints, or permissions are added in the `.md`,
+      they are present in the regenerated `.lock.yml`.
+
+## Out of scope
+
+- Do **not** hand-edit `.lock.yml` files. They are generated; edit the `.md`
+  source and recompile.
+- For deeper authoring guidance (creating, debugging, upgrading workflows),
+  invoke the `agentic-workflows` agent at
+  `.github/agents/agentic-workflows.agent.md`.

--- a/.github/workflows/verify-aw-lock.yml
+++ b/.github/workflows/verify-aw-lock.yml
@@ -16,17 +16,17 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install gh-aw extension
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh extension install githubnext/gh-aw
+        uses: github/gh-aw-actions/setup-cli@bc56a0cad2f450c562810785ef38649c04db812a # v0.72.1
+        with:
+          version: v0.72.1
 
       - name: Recompile agentic workflows
         run: gh aw compile
 
-      - name: Fail if any .lock.yml is stale
+      - name: Fail if any .lock.yml is out of date
         run: |
           if ! git diff --exit-code -- '.github/workflows/**/*.lock.yml'; then
-            echo "::error::A .github/workflows/**/*.md file changed but its .lock.yml is stale."
-            echo "::error::Run 'gh aw compile' locally and commit the regenerated .lock.yml in this PR."
+            echo "::error::One or more .github/workflows/**/*.lock.yml files are out of date relative to their .md source (running 'gh aw compile' produced a diff)."
+            echo "::error::Run 'gh aw compile' locally and commit the regenerated .lock.yml files in this PR."
             exit 1
           fi

--- a/.github/workflows/verify-aw-lock.yml
+++ b/.github/workflows/verify-aw-lock.yml
@@ -1,0 +1,32 @@
+name: Verify gh aw lock files
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**/*.md'
+      - '.github/workflows/**/*.lock.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gh-aw extension
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh extension install githubnext/gh-aw
+
+      - name: Recompile agentic workflows
+        run: gh aw compile
+
+      - name: Fail if any .lock.yml is stale
+        run: |
+          if ! git diff --exit-code -- '.github/workflows/**/*.lock.yml'; then
+            echo "::error::A .github/workflows/**/*.md file changed but its .lock.yml is stale."
+            echo "::error::Run 'gh aw compile' locally and commit the regenerated .lock.yml in this PR."
+            exit 1
+          fi


### PR DESCRIPTION
## What

Enforces that any edit to a `gh aw` agentic workflow (`.github/workflows/**/*.md`) is accompanied by its regenerated sibling `.lock.yml` in the same PR.

Two changes:

1. **New path-scoped instruction file** — `.github/instructions/agentic-workflows.instructions.md`
   - `applyTo: ".github/workflows/**/*.md"` so GitHub Copilot (chat, coding agent, PR review) auto-loads the rule whenever a workflow `.md` is being edited or reviewed.
   - Spells out the mandatory `gh aw compile` + commit-the-`.lock.yml` rule, local verification steps, and a reviewer checklist.

2. **New CI guard workflow** — `.github/workflows/verify-aw-lock.yml`
   - Triggers on PRs that touch `.github/workflows/**/*.md` or `**/*.lock.yml`.
   - Installs `gh-aw`, runs `gh aw compile`, and fails the PR if any `.lock.yml` is stale relative to its `.md` source.

## Why

We hit a runtime failure in #4279 because a workflow `.md` was edited without regenerating its `.lock.yml`. Documentation alone is not enough — this PR adds both an AI-readable nudge (the instruction file) and a hard CI gate (the verify workflow) so the failure mode is prevented going forward.

## How it works

| Layer | Mechanism | Audience |
|---|---|---|
| `.github/instructions/agentic-workflows.instructions.md` | Auto-loaded into Copilot's context whenever a matching file is edited/reviewed | Copilot chat, coding agent, PR review |
| `.github/workflows/verify-aw-lock.yml` | Required CI check that diffs against a fresh `gh aw compile` | Everyone (humans + any agent) |

## Follow-ups (not in this PR)

- Once this CI check is green and trusted, add it to branch protection on `main` as a required status check.

## Validation

- [ ] CI check runs and passes on this PR (since this PR does not modify any `.md` workflow).
- [ ] Manually validated locally: editing a workflow `.md` without recompiling produces a non-zero diff in `git diff --exit-code -- '.github/workflows/**/*.lock.yml'` after running `gh aw compile`.