### PR TITLE
Enable InternalsVisibleTo for UnitTests in Package mode

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -877,6 +877,10 @@
   <!-- TestAbstractions: Runs Microsoft.Data.SqlClient.Extensions.Abstractions.Tests -->
   <Target Name="TestAbstractions">
     <PropertyGroup>
+      <!--
+        Note: This test exclusively uses project references, so neither ReferenceType nor any
+        package version arguments are specified in this command.
+      -->
       <LogFilePrefix>AbstractionsTests-$(OS)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
 
@@ -887,9 +891,6 @@
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
-        $(ReferenceTypeArgument)
-        $(TestSigningKeyPathArgument)
-        $(PackageVersionAbstractionsArgument)
         --results-directory "$(TestResultsFolderPath)"
         --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
       </DotnetCommand>
@@ -993,9 +994,7 @@
 
         <!-- Reference type arguments -->
         $(ReferenceTypeArgument)
-        $(TestSigningKeyPathArgument)
         $(PackageVersionAbstractionsArgument)
-        $(PackageVersionAzureArgument)
         $(PackageVersionLoggingArgument)
         $(PackageVersionSqlClientArgument)
         $(PackageVersionSqlServerArgument)

--- a/build.proj
+++ b/build.proj
@@ -261,13 +261,10 @@
 
     <!--
       TestSigningKeyPath
-      Applies to:     Test* targets
+      Applies to:     TestSqlClientUnit
       Description:    Path to the key used to sign test assemblies. Required in Package mode when
                       SigningKeyPath is set so that InternalsVisibleTo grants from signed driver
                       assemblies can be fulfilled.
-                      If SigningKeyPath is set and ReferenceType is Package but TestSigningKeyPath
-                      is omitted, test builds that access internals will fail with CS0234 errors
-                      because the driver assembly's IVT requires a matching public key.
       Default value:  [blank]
       Example:        C:\path\to\sqlclient-test-key.snk
     -->

--- a/build.proj
+++ b/build.proj
@@ -260,6 +260,23 @@
     </SigningKeyPathArgument>
 
     <!--
+      TestSigningKeyPath
+      Applies to:     Test* targets
+      Description:    Path to the key used to sign test assemblies. Required in Package mode when
+                      SigningKeyPath is set so that InternalsVisibleTo grants from signed driver
+                      assemblies can be fulfilled.
+                      If SigningKeyPath is set and ReferenceType is Package but TestSigningKeyPath
+                      is omitted, test builds that access internals will fail with CS0234 errors
+                      because the driver assembly's IVT requires a matching public key.
+      Default value:  [blank]
+      Example:        C:\path\to\sqlclient-test-key.snk
+    -->
+    <TestSigningKeyPath Condition="'$(TestSigningKeyPath)' == ''" />
+    <TestSigningKeyPathArgument Condition="'$(TestSigningKeyPath)' != ''">
+      -p:TestSigningKeyPath="$(TestSigningKeyPath)"
+    </TestSigningKeyPathArgument>
+
+    <!--
       TestBlameTimeout
       Applies to:     Test* targets
       Description:    How long to wait on a test before timing it out. This will be fed to the
@@ -678,10 +695,6 @@
   <!-- TestSqlClientUnit: Runs unit tests for SqlClient -->
   <Target Name="TestSqlClientUnit">
     <PropertyGroup>
-      <!--
-        Note: This test exclusively uses project references, so neither ReferenceType nor any
-            package version arguments are specified in this command.
-      -->
       <LogFilePrefix>SqlClientUnit-$(OS)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
 
@@ -692,6 +705,10 @@
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
+        $(ReferenceTypeArgument)
+        $(TestSigningKeyPathArgument)
+        $(PackageVersionSqlClientArgument)
+        $(PackageVersionSqlServerArgument)
         --results-directory "$(TestResultsFolderPath)"
         --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
       </DotnetCommand>
@@ -860,10 +877,6 @@
   <!-- TestAbstractions: Runs Microsoft.Data.SqlClient.Extensions.Abstractions.Tests -->
   <Target Name="TestAbstractions">
     <PropertyGroup>
-      <!--
-        Note: This test exclusively uses project references, so neither ReferenceType nor any
-            package version arguments are specified in this command.
-      -->
       <LogFilePrefix>AbstractionsTests-$(OS)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
 
@@ -874,6 +887,9 @@
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
+        $(ReferenceTypeArgument)
+        $(TestSigningKeyPathArgument)
+        $(PackageVersionAbstractionsArgument)
         --results-directory "$(TestResultsFolderPath)"
         --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
       </DotnetCommand>
@@ -977,7 +993,9 @@
 
         <!-- Reference type arguments -->
         $(ReferenceTypeArgument)
+        $(TestSigningKeyPathArgument)
         $(PackageVersionAbstractionsArgument)
+        $(PackageVersionAzureArgument)
         $(PackageVersionLoggingArgument)
         $(PackageVersionSqlClientArgument)
         $(PackageVersionSqlServerArgument)

--- a/eng/pipelines/common/templates/steps/run-all-tests-step.yml
+++ b/eng/pipelines/common/templates/steps/run-all-tests-step.yml
@@ -79,51 +79,62 @@ steps:
     condition: succeededOrFailed()
 
 - ${{if eq(parameters.operatingSystem, 'Windows')}}:
-  - ${{if eq(parameters.referenceType, 'Project')}}:
-    - task: DotNetCoreCLI@2
-      displayName: 'Run Unit Tests ${{parameters.msbuildArchitecture }}'
-      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-      inputs:
-        command: build
-        projects: build.proj
-        ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
-          arguments: >-
-            -t:TestSqlClientUnit
-            -p:TestFramework=${{ parameters.targetFramework }}
-            -p:Configuration=${{ parameters.buildConfiguration }}
-            -p:TestResultsFolderPath=TestResults
-        ${{ else }}: # x86
-          arguments: >-
-            -t:TestSqlClientUnit
-            -p:TestFramework=${{ parameters.targetFramework }}
-            -p:Configuration=${{ parameters.buildConfiguration }}
-            -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
-            -p:TestResultsFolderPath=TestResults
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests ${{parameters.msbuildArchitecture }}'
+    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+    inputs:
+      command: build
+      projects: build.proj
+      ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
+        arguments: >-
+          -t:TestSqlClientUnit
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:TestResultsFolderPath=TestResults
+      ${{ else }}: # x86
+        arguments: >-
+          -t:TestSqlClientUnit
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
+          -p:TestResultsFolderPath=TestResults
 
-    - task: DotNetCoreCLI@2
-      displayName: 'Run Flaky Unit Tests ${{parameters.msbuildArchitecture }}'
-      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-      inputs:
-        command: build
-        projects: build.proj
-        ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
-          arguments: >-
-            -t:TestSqlClientUnit
-            -p:TestFramework=${{ parameters.targetFramework }}
-            -p:Configuration=${{ parameters.buildConfiguration }}
-            -p:TestFilters="category=flaky"
-            -p:TestResultsFolderPath=TestResults
-            -p:TestCodeCoverage=false
-        ${{ else }}: # x86
-          arguments: >-
-            -t:TestSqlClientUnit
-            -p:TestFramework=${{ parameters.targetFramework }}
-            -p:Configuration=${{ parameters.buildConfiguration }}
-            -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
-            -p:TestFilters="category=flaky"
-            -p:TestResultsFolderPath=TestResults
-            -p:TestCodeCoverage=false
-      continueOnError: true
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Flaky Unit Tests ${{parameters.msbuildArchitecture }}'
+    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+    inputs:
+      command: build
+      projects: build.proj
+      ${{ if eq(parameters.msbuildArchitecture, 'x64') }}:
+        arguments: >-
+          -t:TestSqlClientUnit
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+      ${{ else }}: # x86
+        arguments: >-
+          -t:TestSqlClientUnit
+          -p:TestFramework=${{ parameters.targetFramework }}
+          -p:ReferenceType=${{ parameters.referenceType }}
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+          -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
+          -p:TestFilters="category=flaky"
+          -p:TestResultsFolderPath=TestResults
+          -p:TestCodeCoverage=false
+    continueOnError: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Functional Tests ${{parameters.msbuildArchitecture }}'
@@ -261,33 +272,38 @@ steps:
     continueOnError: true
 
 - ${{ else }}: # Linux or macOS
-  - ${{if eq(parameters.referenceType, 'Project')}}:
-    - task: DotNetCoreCLI@2
-      displayName: 'Run Unit Tests'
-      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-      inputs:
-        command: build
-        projects: build.proj
-        arguments: >-
-          -t:TestSqlClientUnit
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:TestResultsFolderPath=TestResults
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests'
+    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+    inputs:
+      command: build
+      projects: build.proj
+      arguments: >-
+        -t:TestSqlClientUnit
+        -p:TestFramework=${{ parameters.targetFramework }}
+        -p:ReferenceType=${{ parameters.referenceType }}
+        -p:Configuration=${{ parameters.buildConfiguration }}
+        -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+        -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+        -p:TestResultsFolderPath=TestResults
 
-    - task: DotNetCoreCLI@2
-      displayName: 'Run Flaky Unit Tests'
-      condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
-      inputs:
-        command: build
-        projects: build.proj
-        arguments: >-
-          -t:TestSqlClientUnit
-          -p:TestFramework=${{ parameters.targetFramework }}
-          -p:Configuration=${{ parameters.buildConfiguration }}
-          -p:TestFilters="category=flaky"
-          -p:TestResultsFolderPath=TestResults
-          -p:TestCodeCoverage=false
-      continueOnError: true
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Flaky Unit Tests'
+    condition: and(eq(variables['setupSucceeded'], 'true'), succeededOrFailed())
+    inputs:
+      command: build
+      projects: build.proj
+      arguments: >-
+        -t:TestSqlClientUnit
+        -p:TestFramework=${{ parameters.targetFramework }}
+        -p:ReferenceType=${{ parameters.referenceType }}
+        -p:Configuration=${{ parameters.buildConfiguration }}
+        -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
+        -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+        -p:TestFilters="category=flaky"
+        -p:TestResultsFolderPath=TestResults
+        -p:TestCodeCoverage=false
+    continueOnError: true
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Functional Tests'

--- a/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj
@@ -62,10 +62,23 @@
 
   <!-- Strong name signing ============================================= -->
   <!-- Strong naming is being done in Directory.Build.props -->
-  <!-- If we're not signing, we are permitted to expose our internals to tests. -->
+
+  <!-- Unsigned: expose internals to UnitTests in any reference mode. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <!--
+    Signed + Package mode: expose internals to UnitTests signed with the test key.
+    Signed + Project mode is intentionally omitted: production-signed assemblies should not
+    grant internal access to test assemblies during local development. Tests that need internals
+    in Project mode run unsigned; only the CI package-validation pipeline uses signed packages.
+  -->
+  <ItemGroup Condition="'$(SigningKeyPath)' != '' AND '$(ReferenceType)' == 'Package'">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>UnitTests, PublicKey=00240000048000001401000006020000002400005253413100080000010001003D19684676DA365F331D00CE7BD4B8EF03E74102F39A5681B40622703D68F0298ECACECC723D3FFC1EA9365AF4958578550EA1EBEEC084B0B3757F3762449F5365E872802A4B548056760764FAD062BFEE81ED26183109AD46810E7E6E965419D0A10473680144D20C1BFE1027A5F586CA987523C06F5C126C44EA7D4F51EB023867A9F294315F95775ACEFD2D678186919458DFCCB4DE2E9F53AEFC766C7CBCEC474ED21C1616E5A9414D366D91D121C39F5FE6641295ADC058EF3FB10593BCDE2E82D9F217C2634909EEF496CD53AE78ABBEA572B871D72EBFC5378205950ABA97C7CCC2B9635D96933D5F9C9624D71FF53EE2094CF3A6BD38534D66E414B7</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/src/Microsoft.Data.SqlClient/tests/Common/Microsoft.Data.SqlClient.TestCommon.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Microsoft.Data.SqlClient.TestCommon.csproj
@@ -12,6 +12,13 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
+  <!-- Strong name signing ============================================= -->
+  <!-- Sign with the test key so signed test assemblies can reference this project. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
   <!-- Target Frameworks =============================================== -->
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
@@ -26,7 +33,10 @@
   <!-- References ====================================================== -->
   <!-- Test target reference -->
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj" />
+    <ProjectReference Include="$(RepoRoot)src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj"
+                      Condition="'$(ReferenceType)' != 'Package'" />
+    <PackageReference Include="Microsoft.Data.SqlClient"
+                      Condition="'$(ReferenceType)' == 'Package'" />
   </ItemGroup>
 
   <!-- References for netfx -->

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj
@@ -36,22 +36,51 @@
     </None>
   </ItemGroup>
 
+  <!-- Strong name signing ============================================= -->
+  <!-- When a test signing key is provided, sign UnitTests so IVT from signed SqlClient works. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
   <!-- References ====================================================== -->
   <!-- Test target reference -->
-  <ItemGroup>
-    <!--
-      The Unit Test project only supports ReferenceType = Project since it needs access to the
-      internals of sibling packages.
-    -->
+  <ItemGroup Condition="'$(ReferenceType)' != 'Package'">
     <ProjectReference Include="$(RepoRoot)src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj" />
     <ProjectReference Include="$(RepoRoot)src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj" />
   </ItemGroup>
 
-  <Target Name="ValidateReferenceType"
-          BeforeTargets="Restore;PrepareForBuild"
-          Condition="'$(ReferenceType)' != 'Project'">
-    <Error Text="Microsoft.Data.SqlClient.UnitTests.csproj only supports ReferenceType=Project." />
-  </Target>
+  <!--
+    Package mode: Unit tests exercise internal types that only exist in the implementation assembly
+    (runtimes/{rid}/lib/{tfm}/), not in the ref assembly (ref/{tfm}/).  We exclude the ref
+    compile asset and reference the runtime DLL directly so the compiler can see internals.
+
+    TODO: This is fragile, depending on our SqlClient NuGet package layout and supported TFMs.  This
+    could all be avoided if we didn't ship ref assemblies.
+  -->
+  <PropertyGroup Condition="'$(ReferenceType)' == 'Package'">
+    <_SqlClientRid Condition="'$(OS)' != 'Windows_NT'">unix</_SqlClientRid>
+    <_SqlClientRid Condition="'$(OS)' == 'Windows_NT'">win</_SqlClientRid>
+    <!-- Map test TFM to the closest available package TFM (package ships net8.0/net9.0/net462) -->
+    <_SqlClientPackageTfm Condition="'$(TargetFramework)' == 'net8.0'">net8.0</_SqlClientPackageTfm>
+    <_SqlClientPackageTfm Condition="'$(TargetFramework)' == 'net462'">net462</_SqlClientPackageTfm>
+    <_SqlClientPackageTfm Condition="'$(_SqlClientPackageTfm)' == ''">net9.0</_SqlClientPackageTfm>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(ReferenceType)' == 'Package'">
+    <!-- Brings in transitive dependencies and runtime deployment; ExcludeAssets="compile" prevents
+         the compiler from using the ref assembly (which only contains public API surface).
+         GeneratePathProperty="true" causes NuGet restore to emit $(PkgMicrosoft_Data_SqlClient)
+         pointing to the extracted package folder in the global packages cache. -->
+    <PackageReference Include="Microsoft.Data.SqlClient"
+                      GeneratePathProperty="true"
+                      ExcludeAssets="compile" />
+    <!-- Compile against the implementation assembly so the compiler can resolve internal types
+         exposed via InternalsVisibleTo.  The path uses $(PkgMicrosoft_Data_SqlClient) generated
+         above to locate the runtime DLL inside the NuGet package layout. -->
+    <Reference Include="Microsoft.Data.SqlClient"
+               HintPath="$(PkgMicrosoft_Data_SqlClient)/runtimes/$(_SqlClientRid)/lib/$(_SqlClientPackageTfm)/Microsoft.Data.SqlClient.dll" />
+    <PackageReference Include="Microsoft.SqlServer.Server" />
+  </ItemGroup>
 
   <!-- References for netframework -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj
@@ -55,8 +55,10 @@
     (runtimes/{rid}/lib/{tfm}/), not in the ref assembly (ref/{tfm}/).  We exclude the ref
     compile asset and reference the runtime DLL directly so the compiler can see internals.
 
-    TODO: This is fragile, depending on our SqlClient NuGet package layout and supported TFMs.  This
-    could all be avoided if we didn't ship ref assemblies.
+    TODO: This is fragile, depending on our SqlClient NuGet package layout and supported TFMs.  It
+    is only necessary because we produce ref and not-supported assemblies and package them.  By
+    default, the compiler will use the ref assemblies if present, which we must explicitly override
+    as explained above.
   -->
   <PropertyGroup Condition="'$(ReferenceType)' == 'Package'">
     <_SqlClientRid Condition="'$(OS)' != 'Windows_NT'">unix</_SqlClientRid>

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Microsoft.Data.SqlClient.TestUtilities.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Microsoft.Data.SqlClient.TestUtilities.csproj
@@ -2,6 +2,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
+  <!-- Strong name signing ============================================= -->
+  <!-- Sign with the test key so signed test assemblies can reference this project. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
   <Target Name="CopyConfig" BeforeTargets="Compile">
     <Copy SourceFiles="config.default.json" DestinationFiles="config.json" Condition="!Exists('config.json')" />
   </Target>

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.EndPoint/TDS.EndPoint.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.EndPoint/TDS.EndPoint.csproj
@@ -3,6 +3,15 @@
     <RootNamespace>Microsoft.SqlServer.TDS.EndPoint</RootNamespace>
     <AssemblyName>Microsoft.SqlServer.TDS.EndPoint</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Sign when a test key is provided so signed test assemblies can reference this. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TDS.Servers.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TDS.Servers.csproj
@@ -4,6 +4,12 @@
     <AssemblyName>Microsoft.SqlServer.TDS.Servers</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
+  <!-- Sign when a test key is provided so signed test assemblies can reference this. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.EndPoint/TDS.EndPoint.csproj" />
     <ProjectReference Include="$(RepoRoot)src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDS.csproj" />

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDS.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDS.csproj
@@ -4,4 +4,10 @@
     <AssemblyName>Microsoft.SqlServer.TDS</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
+  <!-- Sign when a test key is provided so signed test assemblies can reference this. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Enables `InternalsVisibleTo` for SqlClient `UnitTests` across package/project reference modes with an explicit signing policy.  This supports the upcoming `sqlclient-test` pipeline that will use package mode to run all tests.  It will also be signing assemblies when it runs in the ADO.Net project - a gap in our current CI pipelines.

## Behavior

| Signing | ReferenceType | IVT Granted? |
|---------|---------------|--------------|
| Unsigned | Project | Yes |
| Unsigned | Package | Yes |
| Signed | Package | Yes (with PublicKey) |
| Signed | Project | **No** |

## Changes

- **SqlClient.csproj**: Added unsigned IVT (`InternalsVisibleTo("UnitTests")`) and signed+Package IVT block with test key public key
- **UnitTests.csproj**: Removed `ValidateReferenceType` error target; added conditional ProjectReference/PackageReference with `ExcludeAssets="compile"` and explicit Reference to the runtime DLL; added `TestSigningKeyPath` signing
- **TestCommon.csproj**: Made SqlClient reference conditional on ReferenceType; added `TestSigningKeyPath` signing
- **TestUtilities.csproj**: Added `TestSigningKeyPath` signing (prevents CS8002 when referenced by signed tests)
- **TDS projects**: Added `TestSigningKeyPath` signing blocks
- **build.proj**: Declared `TestSigningKeyPath` property and plumbed it into `TestSqlClientUnit` target

## Pipeline Changes

- **run-all-tests-step.yml**: Unit test steps now pass `-p:ReferenceType`, `-p:PackageVersionSqlClient`, and `-p:PackageVersionSqlServer` directly (matching the Functional/Manual test pattern) instead of conditionally gating on Project mode

## Relates to
[AB#45126](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/45126), [AB#45162](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/45162)

## Testing

- PR runs will ensure no regressions in Project mode, and will confirm the new Package mode paths.
- CI runs will do the same.  These never perform assembly signing, so the Package+Signing mode isn't tested here.
- Package+Signing:
  - I will manually run the new sqlclient-package pipeline (based on this PR) to produce artifacts that are signed _and_ include the new `InternalsVisibleTo` via public key.
  - Then, I will build, sign, and run the tests locally.
  - We will fully prove these changes out via the forthcoming sqlclient-test pipeline.
