### PR TITLE
Tests | Disable Async cancellation tests on Kerberos/Managed Instance pipelines

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -387,6 +387,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static bool IsKerberosTest => !string.IsNullOrEmpty(KerberosDomainUser) && !string.IsNullOrEmpty(KerberosDomainPassword);
 
+        public static bool IsNotKerberosTest => !IsKerberosTest;
+
         #nullable enable
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncCancelledConnectionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncCancelledConnectionsTest.cs
@@ -25,7 +25,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private Random _random;
 
         // Disabled on Azure since this test fails on concurrent runs on same database.
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
+        // Disabled on Kerberos and Managed Instance pipelines due to environment-specific instability.
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup),
+            nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotManagedInstance),
+            nameof(DataTestUtility.IsNotKerberosTest))]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CancelAsyncConnections(bool useMars)


### PR DESCRIPTION
Addresses frequent failures in Kerberos/Managed Instance pipelines due to this test case that's not necessary to be run on all environments.