### PR TITLE
Tests | Fix Stress Tests pipeline and fail on test failures

### DIFF
--- a/eng/pipelines/stress/stress-tests-job.yml
+++ b/eng/pipelines/stress/stress-tests-job.yml
@@ -212,7 +212,9 @@ jobs:
       #
       - ${{ each runtime in parameters.netTestRuntimes }}:
         - pwsh: |
-            dotnet run --project "$(project)" $(runArguments) --no-build -f ${{ runtime }} -- $(testArguments)
+            $cmd = 'dotnet run --project "$(project)" $(runArguments) --no-build -f ${{ runtime }} -- $(testArguments)'
+            Write-Host "##[command]$cmd"
+            Invoke-Expression $cmd
             $exitCode = $LASTEXITCODE
             if ($exitCode -ne 0) {
               Write-Host "##vso[task.logissue type=error]Stress tests [${{ runtime }}] failed: runner exited with code $exitCode ($exitCode distinct test/exception pairs recorded)."
@@ -227,7 +229,9 @@ jobs:
       # Run the stress tests for each .NET Framework runtime.
       - ${{ each runtime in parameters.netFrameworkTestRuntimes }}:
         - pwsh: |
-            dotnet run --project "$(project)" $(runArguments) --no-build -f ${{ runtime }} -- $(testArguments)
+            $cmd = 'dotnet run --project "$(project)" $(runArguments) --no-build -f ${{ runtime }} -- $(testArguments)'
+            Write-Host "##[command]$cmd"
+            Invoke-Expression $cmd
             $exitCode = $LASTEXITCODE
             if ($exitCode -ne 0) {
               Write-Host "##vso[task.logissue type=error]Stress tests [${{ runtime }}] failed: runner exited with code $exitCode ($exitCode distinct test/exception pairs recorded)."

--- a/eng/pipelines/stress/stress-tests-job.yml
+++ b/eng/pipelines/stress/stress-tests-job.yml
@@ -211,7 +211,7 @@ jobs:
           inputs:
             command: run
             projects: $(project)
-            arguments: $(runArguments) --no-build -f ${{ runtime }} -- $(testArguments)
+            arguments: $(runArguments) --no-build -f ${{ runtime }} $(testArguments)
 
       # Run the stress tests for each .NET Framework runtime.
       - ${{ each runtime in parameters.netFrameworkTestRuntimes }}:
@@ -224,4 +224,4 @@ jobs:
           inputs:
             command: run
             projects: $(project)
-            arguments: $(runArguments) --no-build -f ${{ runtime }} -- $(testArguments)
+            arguments: $(runArguments) --no-build -f ${{ runtime }} $(testArguments)

--- a/eng/pipelines/stress/stress-tests-job.yml
+++ b/eng/pipelines/stress/stress-tests-job.yml
@@ -205,10 +205,12 @@ jobs:
           displayName: Test [${{ runtime }}]
           condition: and(succeededOrFailed(), eq(variables['buildSucceeded'], 'true'))
           continueOnError: ${{ not(parameters.failOnTestFailure) }}
+          env:
+            STRESS_CONFIG_FILE: config.json
           inputs:
             command: run
             projects: $(project)
-            arguments: $(runArguments) --no-build -f ${{ runtime }} -e STRESS_CONFIG_FILE=config.json -- $(testArguments)
+            arguments: $(runArguments) --no-build -f ${{ runtime }} -- $(testArguments)
 
       # Run the stress tests for each .NET Framework runtime.
       - ${{ each runtime in parameters.netFrameworkTestRuntimes }}:
@@ -216,7 +218,9 @@ jobs:
           displayName: Test [${{ runtime }}]
           condition: and(succeededOrFailed(), eq(variables['buildSucceeded'], 'true'))
           continueOnError: ${{ not(parameters.failOnTestFailure) }}
+          env:
+            STRESS_CONFIG_FILE: config.json
           inputs:
             command: run
             projects: $(project)
-            arguments: $(runArguments) --no-build -f ${{ runtime }} -e STRESS_CONFIG_FILE=config.json -- $(testArguments)
+            arguments: $(runArguments) --no-build -f ${{ runtime }} -- $(testArguments)

--- a/eng/pipelines/stress/stress-tests-job.yml
+++ b/eng/pipelines/stress/stress-tests-job.yml
@@ -201,27 +201,40 @@ jobs:
       #     - When failOnTestFailure is true, continueOnError is false: a test failure fails the
       #       job (red), though subsequent runtimes still run due to the condition above.
       #
+      # We invoke `dotnet run` via a script step (rather than DotNetCoreCLI@2) because that task
+      # strips the `--` separator from arguments, which would cause `dotnet run` to interpret the
+      # stress test runner's own flags (e.g. `-a`) as its own options (e.g. `--arch`).
+      #
+      # The runner's exit code equals the number of distinct (test x exception) pairs recorded
+      # during the run.  A non-zero exit code is surfaced as a pipeline error annotation so test
+      # failures appear in the build summary, and the exit code is then propagated so the step
+      # itself fails (subject to continueOnError).
+      #
       - ${{ each runtime in parameters.netTestRuntimes }}:
-        - task: DotNetCoreCLI@2
+        - pwsh: |
+            dotnet run --project "$(project)" $(runArguments) --no-build -f ${{ runtime }} -- $(testArguments)
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -ne 0) {
+              Write-Host "##vso[task.logissue type=error]Stress tests [${{ runtime }}] failed: runner exited with code $exitCode ($exitCode distinct test/exception pairs recorded)."
+            }
+            exit $exitCode
           displayName: Test [${{ runtime }}]
           condition: and(succeededOrFailed(), eq(variables['buildSucceeded'], 'true'))
           continueOnError: ${{ not(parameters.failOnTestFailure) }}
           env:
             STRESS_CONFIG_FILE: config.json
-          inputs:
-            command: run
-            projects: $(project)
-            arguments: $(runArguments) --no-build -f ${{ runtime }} $(testArguments)
 
       # Run the stress tests for each .NET Framework runtime.
       - ${{ each runtime in parameters.netFrameworkTestRuntimes }}:
-        - task: DotNetCoreCLI@2
+        - pwsh: |
+            dotnet run --project "$(project)" $(runArguments) --no-build -f ${{ runtime }} -- $(testArguments)
+            $exitCode = $LASTEXITCODE
+            if ($exitCode -ne 0) {
+              Write-Host "##vso[task.logissue type=error]Stress tests [${{ runtime }}] failed: runner exited with code $exitCode ($exitCode distinct test/exception pairs recorded)."
+            }
+            exit $exitCode
           displayName: Test [${{ runtime }}]
           condition: and(succeededOrFailed(), eq(variables['buildSucceeded'], 'true'))
           continueOnError: ${{ not(parameters.failOnTestFailure) }}
           env:
             STRESS_CONFIG_FILE: config.json
-          inputs:
-            command: run
-            projects: $(project)
-            arguments: $(runArguments) --no-build -f ${{ runtime }} $(testArguments)

--- a/eng/pipelines/stress/stress-tests-job.yml
+++ b/eng/pipelines/stress/stress-tests-job.yml
@@ -52,6 +52,7 @@ parameters:
   # (SucceededWithIssues) but do not fail the job.
   - name: failOnTestFailure
     type: boolean
+    default: true
 
   # The list of .NET Framework runtimes to test against.
   - name: netFrameworkTestRuntimes

--- a/eng/pipelines/stress/stress-tests-pipeline.yml
+++ b/eng/pipelines/stress/stress-tests-pipeline.yml
@@ -73,12 +73,12 @@ parameters:
     type: boolean
     default: false
 
-  # True to fail the pipeline when stress tests fail.  When false (default), test failures produce
+  # True to fail the pipeline when stress tests fail (default).  When false, test failures produce
   # warnings but do not fail the overall pipeline run.
   - name: failOnTestFailure
     displayName: Fail pipeline on test failure
     type: boolean
-    default: false
+    default: true
 
   # Dotnet CLI verbosity level.
   - name: dotnetVerbosity

--- a/eng/pipelines/stress/stress-tests-stage.yml
+++ b/eng/pipelines/stress/stress-tests-stage.yml
@@ -32,9 +32,10 @@ parameters:
     type: boolean
     default: false
 
-  # True to fail the job when stress tests fail.  When false, test failures produce warnings.
+  # True to fail the job when stress tests fail (default).  When false, test failures produce warnings.
   - name: failOnTestFailure
     type: boolean
+    default: true
 
   # The verbosity level for the dotnet CLI commands.
   - name: dotnetVerbosity

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Runner/StressEngine.cs
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/SqlClient.Stress.Runner/StressEngine.cs
@@ -71,6 +71,7 @@ namespace DPStressHarness
             TraceListener listener = new TextWriterTraceListener(Console.Out);
             Trace.Listeners.Add(listener);
             Trace.UseGlobalLock = true;
+            Trace.AutoFlush = true;
 
             _threadsRunning = 0;
             _continue = true;


### PR DESCRIPTION
Randomly looked into the pipeline and realized that the stress tests in pipeline had been [running in Help mode](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=153972&view=logs&j=359e4e8d-bbc4-580a-38bc-4fe2844794fe&t=b681fd87-ad60-5086-61bb-7905eaa1db91&l=67) for a while, which means the tests weren't running at all - without any indication on build status.

We need to make sure:
* The tests run to completion on every job in default configuration.
* The pipeline always fails when tests don't succeed, i.e. 0 tolerance on any new failing tests.