### PR TITLE
Eng | Fix official and kerberos pipelines

### DIFF
--- a/eng/pipelines/kerberos/sqlclient-kerberos.yml
+++ b/eng/pipelines/kerberos/sqlclient-kerberos.yml
@@ -291,7 +291,7 @@ stages:
     dependsOn:
       - windows
       - linux
-    condition: succeededOrFailed()
+    condition: succeeded()
     jobs:
       - template: /eng/pipelines/common/templates/jobs/ci-code-coverage-job.yml@self
         parameters:

--- a/eng/pipelines/kerberos/sqlclient-kerberos.yml
+++ b/eng/pipelines/kerberos/sqlclient-kerberos.yml
@@ -131,6 +131,10 @@ stages:
             parameters:
               runtimes: [8.x, 9.x]
 
+          # Restore dotnet local tools (pwsh, apicompat, etc.). Required by build.proj targets
+          # such as _CheckPwshToolRestored that run during the SqlClient ref project build.
+          - template: /eng/pipelines/steps/restore-dotnet-tools.yml@self
+
           # --- Update test configuration ---
           # Uses runtime variables from the matrix ($(managedSNI)) so we use
           # inline PowerShell instead of the shared config template which
@@ -223,6 +227,10 @@ stages:
           - template: /eng/pipelines/steps/install-dotnet.yml@self
             parameters:
               runtimes: [8.x, 9.x]
+
+          # Restore dotnet local tools (pwsh, apicompat, etc.). Required by build.proj targets
+          # such as _CheckPwshToolRestored that run during the SqlClient ref project build.
+          - template: /eng/pipelines/steps/restore-dotnet-tools.yml@self
 
           # --- Update test configuration (with Kerberos credentials) ---
           - pwsh: |

--- a/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
@@ -130,6 +130,10 @@ jobs:
       # Install the .NET SDK.
       - template: /eng/pipelines/steps/install-dotnet.yml@self
 
+      # Restore dotnet local tools (pwsh, apicompat, etc.). Required by build.proj targets
+      # such as _CheckPwshToolRestored that run during RoslynAnalyzers and Build.
+      - template: /eng/pipelines/steps/restore-dotnet-tools.yml@self
+
       # Perform Roslyn analysis before building, since this step will clobber build output.
       - template: /eng/pipelines/onebranch/steps/roslyn-analyzers-buildproj-step.yml@self
         parameters:


### PR DESCRIPTION
Fixes official and kerberos pipelines:
Running builds:
* [sqlclient-non-official](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=153996)
* [sqlclient-kerberos](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=153995&view=results) 
  * Additionally, fixed the behavior where Kerberos pipeline merged code coverage even when previous stages failed, leading to error when rerun passes and code coverage cannot be re-evaluated. [new build](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=154023&view=results)