### PR TITLE
Tests | Address transient errors in CI pipelines

### DIFF
--- a/eng/pipelines/steps/install-dotnet.yml
+++ b/eng/pipelines/steps/install-dotnet.yml
@@ -55,8 +55,12 @@ steps:
   - ${{ if ne(parameters.architecture, 'arm64') }}:
 
     # Install the SDK listed in the global.json file.
+    #
+    # retryCountOnTaskFailure is set because UseDotNet@2 fails intermittently
+    # in CI due to transient network/CDN issues when downloading the SDK.
     - task: UseDotNet@2
       displayName: Install .NET SDK (global.json)
+      retryCountOnTaskFailure: 3
       inputs:
         installationPath: ${{ parameters.installDir }}
         packageType: sdk
@@ -69,6 +73,7 @@ steps:
     - ${{ each version in parameters.runtimes }}:
       - task: UseDotNet@2
         displayName: Install .NET ${{ version }} Runtime
+        retryCountOnTaskFailure: 3
         inputs:
           installationPath: ${{ parameters.installDir }}
           packageType: runtime
@@ -81,8 +86,13 @@ steps:
   - ${{ else }}:
 
     # Use the install script for ARM64.
+    #
+    # retryCountOnTaskFailure provides an outer retry around the script's
+    # internal retry loop, in case the script download itself or the entire
+    # step fails due to transient issues.
     - task: PowerShell@2
       displayName: Install .NET SDK and Runtimes for ARM64
+      retryCountOnTaskFailure: 3
       inputs:
         targetType: filePath
         pwsh: true

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/LocalAppContextSwitchesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/LocalAppContextSwitchesTest.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using Microsoft.Data.SqlClient.Tests.Common;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests;
@@ -18,6 +18,37 @@ public class LocalAppContextSwitchesTest
     [Fact]
     public void TestDefaultAppContextSwitchValues()
     {
+        // LocalAppContextSwitches caches each switch value on first access for
+        // the lifetime of the process.  Other tests running in parallel may
+        // already have triggered caching, or may use LocalAppContextSwitchesHelper
+        // to mutate the cached fields via reflection.  To make this test
+        // deterministic, acquire the helper (which serializes against every
+        // other helper user via a process-wide semaphore) and reset each
+        // cached field to None so the properties re-read from AppContext.
+        using LocalAppContextSwitchesHelper switchesHelper = new();
+
+        switchesHelper.EnableMultiSubnetFailoverByDefault = null;
+        switchesHelper.IgnoreServerProvidedFailoverPartner = null;
+        switchesHelper.UseLegacyFailoverAlternationOnLoginSqlErrors = null;
+        switchesHelper.LegacyRowVersionNullBehavior = null;
+        switchesHelper.LegacyVarTimeZeroScaleBehaviour = null;
+        switchesHelper.MakeReadAsyncBlocking = null;
+        switchesHelper.SuppressInsecureTlsWarning = null;
+        switchesHelper.TruncateScaledDecimal = null;
+        switchesHelper.UseCompatibilityAsyncBehaviour = null;
+        switchesHelper.UseCompatibilityProcessSni = null;
+        switchesHelper.UseConnectionPoolV2 = null;
+        switchesHelper.UseMinimumLoginTimeout = null;
+        #if NET
+        switchesHelper.GlobalizationInvariantMode = null;
+        #endif
+        #if NET && _WINDOWS
+        switchesHelper.UseManagedNetworking = null;
+        #endif
+        #if NETFRAMEWORK
+        switchesHelper.DisableTnirByDefault = null;
+        #endif
+
         Assert.False(LocalAppContextSwitches.LegacyRowVersionNullBehavior);
         Assert.False(LocalAppContextSwitches.SuppressInsecureTlsWarning);
         Assert.False(LocalAppContextSwitches.MakeReadAsyncBlocking);

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
@@ -395,6 +395,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         [InlineData(40613)]
         [InlineData(42108)]
         [InlineData(42109)]
+        [Trait("Category", "flaky")]
         public void TransientFault_RetryDisabled_ShouldFail(uint errorCode)
         {
             // Arrange
@@ -498,6 +499,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         [InlineData(40613)]
         [InlineData(42108)]
         [InlineData(42109)]
+        [Trait("Category", "flaky")]
         public void TransientFault_WithUserProvidedPartner_RetryDisabled_ShouldFail(uint errorCode)
         {
             // Arrange

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTestsAzure.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTestsAzure.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         }
 
         [Fact]
+        [Trait("Category", "flaky")]
         public void NetworkTimeoutAtRoutedLocation_RetryDisabled_ShouldFail()
         {
             // Arrange


### PR DESCRIPTION
All CI pipelines were affected due to these common issues:
* Transient errors when donwloading .NET version
* Mark Flaky tests.
* Fix TestDefaultAppContextSwitchValues to not fail intermittently.