### PR TITLE
Auto-triage: label-gated follow-up, partial-progress acknowledgement, and /triage on-demand command

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e98945dcd5993e27b71e3600298e58d5205517079d21b6024c05b338fbfded9c","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"21eedcd5a09375ea9a462f00a298d6c69e02b68f8fc6a5c648829756047fc57b","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41","digest":"sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41@sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41","digest":"sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41@sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41","digest":"sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41@sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -68,8 +68,14 @@ jobs:
       github.event_name == 'issues' ||
       (github.event_name == 'issue_comment'
       && github.event.issue.pull_request == null
-      && github.event.comment.user.login == github.event.issue.user.login
-      && !endsWith(github.event.comment.user.login, '[bot]'))
+      && !endsWith(github.event.comment.user.login, '[bot]')
+      && (
+      (startsWith(github.event.comment.body, '/triage')
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+      ||
+      (github.event.comment.user.login == github.event.issue.user.login
+      && contains(github.event.issue.labels.*.name, 'Auto-Triage: Waiting for Author'))
+      ))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -199,20 +205,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_60eee03d4a80bfe8_EOF'
+          cat << 'GH_AW_PROMPT_33a2cf7d0b286eee_EOF'
           <system>
-          GH_AW_PROMPT_60eee03d4a80bfe8_EOF
+          GH_AW_PROMPT_33a2cf7d0b286eee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_60eee03d4a80bfe8_EOF'
+          cat << 'GH_AW_PROMPT_33a2cf7d0b286eee_EOF'
           <safe-output-tools>
-          Tools: add_comment(max:2), missing_tool, missing_data, noop
+          Tools: add_comment, add_labels, remove_labels, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_60eee03d4a80bfe8_EOF
+          GH_AW_PROMPT_33a2cf7d0b286eee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_60eee03d4a80bfe8_EOF'
+          cat << 'GH_AW_PROMPT_33a2cf7d0b286eee_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -241,15 +247,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_60eee03d4a80bfe8_EOF
+          GH_AW_PROMPT_33a2cf7d0b286eee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_60eee03d4a80bfe8_EOF'
+          cat << 'GH_AW_PROMPT_33a2cf7d0b286eee_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_60eee03d4a80bfe8_EOF
+          GH_AW_PROMPT_33a2cf7d0b286eee_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -445,15 +451,17 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2157aa132fb5ea9a_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_2157aa132fb5ea9a_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_dbc8638f997c86b3_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":1},"add_labels":{"allowed":["Auto-Triage: Waiting for Author"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["Auto-Triage: Waiting for Author"],"max":1},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_dbc8638f997c86b3_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added. Supports reply_to_id for discussion threading."
+                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading.",
+                "add_labels": " CONSTRAINTS: Maximum 1 label(s) can be added. Only these labels are allowed: [\"Auto-Triage: Waiting for Author\"].",
+                "remove_labels": " CONSTRAINTS: Maximum 1 label(s) can be removed. Only these labels can be removed: [Auto-Triage: Waiting for Author]."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -475,6 +483,25 @@ jobs:
                   "reply_to_id": {
                     "type": "string",
                     "maxLength": 256
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
+                  }
+                }
+              },
+              "add_labels": {
+                "defaultMax": 5,
+                "fields": {
+                  "item_number": {
+                    "issueNumberOrTemporaryId": true
+                  },
+                  "labels": {
+                    "required": true,
+                    "type": "array",
+                    "itemType": "string",
+                    "itemSanitize": true,
+                    "itemMaxLength": 128
                   },
                   "repo": {
                     "type": "string",
@@ -536,6 +563,25 @@ jobs:
                     "type": "string",
                     "sanitize": true,
                     "maxLength": 65000
+                  }
+                }
+              },
+              "remove_labels": {
+                "defaultMax": 5,
+                "fields": {
+                  "item_number": {
+                    "issueNumberOrTemporaryId": true
+                  },
+                  "labels": {
+                    "required": true,
+                    "type": "array",
+                    "itemType": "string",
+                    "itemSanitize": true,
+                    "itemMaxLength": 128
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
                   }
                 }
               },
@@ -634,7 +680,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_36b6676afb0bfd5f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_0d32003b70b529f1_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -678,7 +724,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_36b6676afb0bfd5f_EOF
+          GH_AW_MCP_CONFIG_0d32003b70b529f1_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1309,7 +1355,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":2},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"add_labels\":{\"allowed\":[\"Auto-Triage: Waiting for Author\"],\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"allowed\":[\"Auto-Triage: Waiting for Author\"],\"max\":1},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"21eedcd5a09375ea9a462f00a298d6c69e02b68f8fc6a5c648829756047fc57b","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7d77e70ffe2772c27c3cc90aade0b8069d7913514f4690c3a68d3d44bb7d3438","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41","digest":"sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41@sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41","digest":"sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41@sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41","digest":"sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41@sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -205,20 +205,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_33a2cf7d0b286eee_EOF'
+          cat << 'GH_AW_PROMPT_36e97a2a98d09a83_EOF'
           <system>
-          GH_AW_PROMPT_33a2cf7d0b286eee_EOF
+          GH_AW_PROMPT_36e97a2a98d09a83_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_33a2cf7d0b286eee_EOF'
+          cat << 'GH_AW_PROMPT_36e97a2a98d09a83_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels, remove_labels, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_33a2cf7d0b286eee_EOF
+          GH_AW_PROMPT_36e97a2a98d09a83_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_33a2cf7d0b286eee_EOF'
+          cat << 'GH_AW_PROMPT_36e97a2a98d09a83_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -247,15 +247,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_33a2cf7d0b286eee_EOF
+          GH_AW_PROMPT_36e97a2a98d09a83_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_33a2cf7d0b286eee_EOF'
+          cat << 'GH_AW_PROMPT_36e97a2a98d09a83_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_33a2cf7d0b286eee_EOF
+          GH_AW_PROMPT_36e97a2a98d09a83_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -451,9 +451,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_dbc8638f997c86b3_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1},"add_labels":{"allowed":["Auto-Triage: Waiting for Author"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["Auto-Triage: Waiting for Author"],"max":1},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_dbc8638f997c86b3_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_856fbe336737a31c_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":1},"add_labels":{"allowed":["Auto-Triage: Waiting for Author"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"remove_labels":{"allowed":["Auto-Triage: Waiting for Author"],"max":1},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_856fbe336737a31c_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -680,7 +680,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_0d32003b70b529f1_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e27d5702ce667e27_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -724,7 +724,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_0d32003b70b529f1_EOF
+          GH_AW_MCP_CONFIG_e27d5702ce667e27_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1004,7 +1004,7 @@ jobs:
           GH_AW_WORKFLOW_NAME: "SqlClient Issue Auto-Triage"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_NOOP_REPORT_AS_ISSUE: "true"
+          GH_AW_NOOP_REPORT_AS_ISSUE: "false"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1355,7 +1355,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"add_labels\":{\"allowed\":[\"Auto-Triage: Waiting for Author\"],\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"allowed\":[\"Auto-Triage: Waiting for Author\"],\"max\":1},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"add_labels\":{\"allowed\":[\"Auto-Triage: Waiting for Author\"],\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"remove_labels\":{\"allowed\":[\"Auto-Triage: Waiting for Author\"],\"max\":1},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"20b8fbbfaae4d08b3206fb6b2f4000e43b8915e37f5afc9a534056f8ce9a563b","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e98945dcd5993e27b71e3600298e58d5205517079d21b6024c05b338fbfded9c","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41","digest":"sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41@sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41","digest":"sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41@sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41","digest":"sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41@sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -47,6 +47,9 @@
 
 name: "SqlClient Issue Auto-Triage"
 "on":
+  issue_comment:
+    types:
+    - created
   issues:
     types:
     - opened
@@ -61,6 +64,12 @@ run-name: "SqlClient Issue Auto-Triage"
 
 jobs:
   activation:
+    if: >
+      github.event_name == 'issues' ||
+      (github.event_name == 'issue_comment'
+      && github.event.issue.pull_request == null
+      && github.event.comment.user.login == github.event.issue.user.login
+      && !endsWith(github.event.comment.user.login, '[bot]'))
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -185,24 +194,25 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b5f7a25dd7272e5f_EOF'
+          cat << 'GH_AW_PROMPT_60eee03d4a80bfe8_EOF'
           <system>
-          GH_AW_PROMPT_b5f7a25dd7272e5f_EOF
+          GH_AW_PROMPT_60eee03d4a80bfe8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b5f7a25dd7272e5f_EOF'
+          cat << 'GH_AW_PROMPT_60eee03d4a80bfe8_EOF'
           <safe-output-tools>
-          Tools: add_comment, missing_tool, missing_data, noop
+          Tools: add_comment(max:2), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_b5f7a25dd7272e5f_EOF
+          GH_AW_PROMPT_60eee03d4a80bfe8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_b5f7a25dd7272e5f_EOF'
+          cat << 'GH_AW_PROMPT_60eee03d4a80bfe8_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -231,12 +241,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b5f7a25dd7272e5f_EOF
+          GH_AW_PROMPT_60eee03d4a80bfe8_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b5f7a25dd7272e5f_EOF'
+          if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
+            cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
+          fi
+          cat << 'GH_AW_PROMPT_60eee03d4a80bfe8_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_b5f7a25dd7272e5f_EOF
+          GH_AW_PROMPT_60eee03d4a80bfe8_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -261,6 +274,7 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
+          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
         with:
           script: |
@@ -281,6 +295,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
+                GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
                 GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
               }
             });
@@ -430,15 +445,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_421fab10d521b1cd_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_421fab10d521b1cd_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2157aa132fb5ea9a_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":2},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_2157aa132fb5ea9a_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading."
+                "add_comment": " CONSTRAINTS: Maximum 2 comment(s) can be added. Supports reply_to_id for discussion threading."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -619,7 +634,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_95017dc8ef4cee83_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_36b6676afb0bfd5f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -663,7 +678,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_95017dc8ef4cee83_EOF
+          GH_AW_MCP_CONFIG_36b6676afb0bfd5f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1294,7 +1309,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":2},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c9c5fd8d2287fe7015e05f72413362d8d3b0f8762eff06565ccea5fe0529a491","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3fbe69c77302fcde863ac1c3f9df536f89e6a71a6b141b505437f06ed45182bc","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41","digest":"sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41@sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41","digest":"sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41@sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41","digest":"sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41@sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -70,10 +70,11 @@ jobs:
       && github.event.issue.pull_request == null
       && !endsWith(github.event.comment.user.login, '[bot]')
       && (
-      (startsWith(github.event.comment.body, '/triage')
+      ((github.event.comment.body == '/triage' || startsWith(github.event.comment.body, '/triage '))
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
       ||
-      (!startsWith(github.event.comment.body, '/triage')
+      (github.event.comment.body != '/triage'
+      && !startsWith(github.event.comment.body, '/triage ')
       && github.event.comment.user.login == github.event.issue.user.login
       && contains(github.event.issue.labels.*.name, 'Auto-Triage: Waiting for Author'))
       ))
@@ -206,20 +207,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_c9d734e17df95a1a_EOF'
+          cat << 'GH_AW_PROMPT_ab488ada0396c523_EOF'
           <system>
-          GH_AW_PROMPT_c9d734e17df95a1a_EOF
+          GH_AW_PROMPT_ab488ada0396c523_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c9d734e17df95a1a_EOF'
+          cat << 'GH_AW_PROMPT_ab488ada0396c523_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels, remove_labels, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_c9d734e17df95a1a_EOF
+          GH_AW_PROMPT_ab488ada0396c523_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_c9d734e17df95a1a_EOF'
+          cat << 'GH_AW_PROMPT_ab488ada0396c523_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -248,15 +249,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c9d734e17df95a1a_EOF
+          GH_AW_PROMPT_ab488ada0396c523_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_c9d734e17df95a1a_EOF'
+          cat << 'GH_AW_PROMPT_ab488ada0396c523_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_c9d734e17df95a1a_EOF
+          GH_AW_PROMPT_ab488ada0396c523_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -452,9 +453,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7c4d50b04fb7885f_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a309dbbfe73b9ee4_EOF'
           {"add_comment":{"hide_older_comments":true,"max":1},"add_labels":{"allowed":["Auto-Triage: Waiting for Author"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"remove_labels":{"allowed":["Auto-Triage: Waiting for Author"],"max":1},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_7c4d50b04fb7885f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a309dbbfe73b9ee4_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -681,7 +682,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_b22add5bb2a40b36_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_52e7f3ed4af388a8_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -725,7 +726,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b22add5bb2a40b36_EOF
+          GH_AW_MCP_CONFIG_52e7f3ed4af388a8_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7d77e70ffe2772c27c3cc90aade0b8069d7913514f4690c3a68d3d44bb7d3438","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c9c5fd8d2287fe7015e05f72413362d8d3b0f8762eff06565ccea5fe0529a491","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41","digest":"sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41@sha256:cb2b565d070116d4b67e355775340528b5a2c3cb18b2c9049638bcc2df681770"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41","digest":"sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41@sha256:fadd0de387209f69a9a7a1b8722bb5e7fdfb80ba9749a5c60f0e4cd7582a74d0"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41","digest":"sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41@sha256:1260445d25968dbf3ae70143964177a0e5914cf2ce07a6117f7d3caec6c3e3c4"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -73,7 +73,8 @@ jobs:
       (startsWith(github.event.comment.body, '/triage')
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
       ||
-      (github.event.comment.user.login == github.event.issue.user.login
+      (!startsWith(github.event.comment.body, '/triage')
+      && github.event.comment.user.login == github.event.issue.user.login
       && contains(github.event.issue.labels.*.name, 'Auto-Triage: Waiting for Author'))
       ))
     runs-on: ubuntu-slim
@@ -205,20 +206,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_36e97a2a98d09a83_EOF'
+          cat << 'GH_AW_PROMPT_c9d734e17df95a1a_EOF'
           <system>
-          GH_AW_PROMPT_36e97a2a98d09a83_EOF
+          GH_AW_PROMPT_c9d734e17df95a1a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_36e97a2a98d09a83_EOF'
+          cat << 'GH_AW_PROMPT_c9d734e17df95a1a_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels, remove_labels, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_36e97a2a98d09a83_EOF
+          GH_AW_PROMPT_c9d734e17df95a1a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_36e97a2a98d09a83_EOF'
+          cat << 'GH_AW_PROMPT_c9d734e17df95a1a_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -247,15 +248,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_36e97a2a98d09a83_EOF
+          GH_AW_PROMPT_c9d734e17df95a1a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_36e97a2a98d09a83_EOF'
+          cat << 'GH_AW_PROMPT_c9d734e17df95a1a_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_36e97a2a98d09a83_EOF
+          GH_AW_PROMPT_c9d734e17df95a1a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -451,9 +452,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_856fbe336737a31c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7c4d50b04fb7885f_EOF'
           {"add_comment":{"hide_older_comments":true,"max":1},"add_labels":{"allowed":["Auto-Triage: Waiting for Author"],"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"remove_labels":{"allowed":["Auto-Triage: Waiting for Author"],"max":1},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_856fbe336737a31c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_7c4d50b04fb7885f_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -680,7 +681,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e27d5702ce667e27_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b22add5bb2a40b36_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -724,7 +725,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e27d5702ce667e27_EOF
+          GH_AW_MCP_CONFIG_b22add5bb2a40b36_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -126,10 +126,10 @@ The agent (you) is responsible for keeping this label accurate — see the
 "Actions" section below for exactly when to call `add_labels` /
 `remove_labels`.
 
-Only if all three checks pass, proceed to the triage instructions below
-and produce a fresh summary. Treat the prior summary as **invalidated** —
-the new one supersedes it (the older one will be collapsed automatically
-by `hide-older-comments`).
+Only if the workflow-level `if:` gate above evaluated to true, proceed to the
+triage instructions below and produce a fresh summary. Treat the prior summary
+as **invalidated** — the new one supersedes it (the older one will be collapsed
+automatically by `hide-older-comments`).
 
 ---
 

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -6,21 +6,37 @@ on:
     types: [created]
   roles: all
 
-# Cheap gate before the agent boots:
-#   - issues.opened          -> always run (initial triage)
-#   - issue_comment.created  -> only when the commenter IS the issue author,
-#                               the comment is on an issue (not a PR), and
-#                               the author is not a bot. The deeper checks
-#                               ("prior triage flagged missing env" and
-#                               "no second triage already posted") are done
-#                               inside the prompt because they require
-#                               reading existing comments.
+# Cheap gate evaluated BEFORE the agent boots. The activation job is skipped
+# (zero compute, $0) if this is false. Only events matching one of the
+# following three conditions cause the workflow to run:
+#
+#   1. issues.opened
+#        -> Initial triage. Always runs.
+#
+#   2. issue_comment.created from the issue's original author, on an issue
+#      (not a PR), not a bot, AND the issue currently has the label
+#      "Auto-Triage: Waiting for Author".
+#        -> Follow-up triage. The label is applied by the initial triage
+#           only when environment fields were missing, and removed by the
+#           follow-up triage once the author supplies them. Without the
+#           label, author comments do NOT boot the agent.
+#
+#   3. issue_comment.created whose body starts with "/triage", from a repo
+#      OWNER, MEMBER, or COLLABORATOR (maintainer-only on-demand override).
+#        -> On-demand triage. Bypasses the follow-up gate; produces a fresh
+#           triage summary regardless of label or prior summaries.
 if: |
   github.event_name == 'issues' ||
   (github.event_name == 'issue_comment'
    && github.event.issue.pull_request == null
-   && github.event.comment.user.login == github.event.issue.user.login
-   && !endsWith(github.event.comment.user.login, '[bot]'))
+   && !endsWith(github.event.comment.user.login, '[bot]')
+   && (
+     (startsWith(github.event.comment.body, '/triage')
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+     ||
+     (github.event.comment.user.login == github.event.issue.user.login
+      && contains(github.event.issue.labels.*.name, 'Auto-Triage: Waiting for Author'))
+   ))
 
 engine: copilot
 
@@ -34,12 +50,20 @@ tools:
     min-integrity: none
 
 safe-outputs:
-  # Allow up to 2 triage summaries per issue (initial + one follow-up).
-  # `hide-older-comments` collapses the previous summary so the latest one
-  # is the only visible "current state".
+  # One triage summary per run. `hide-older-comments` collapses previous
+  # summaries so only the latest is visible.
   add-comment:
-    max: 2
+    max: 1
     hide-older-comments: true
+  # Allow the workflow to apply/remove ONLY this one internal-state label.
+  # The label is the YAML-level flag that lets the cheap `if:` gate above
+  # decide whether an author comment should boot the agent at all.
+  add-labels:
+    allowed: ["Auto-Triage: Waiting for Author"]
+    max: 1
+  remove-labels:
+    allowed: ["Auto-Triage: Waiting for Author"]
+    max: 1
 ---
 
 # SqlClient Issue Auto-Triage
@@ -48,41 +72,53 @@ You are a triage specialist for **Microsoft.Data.SqlClient**.
 Your job is to post **at most one** triage summary comment per workflow run
 using `add_comment`.
 
-This workflow runs in two situations:
+This workflow runs in three situations. Identify which one **before** doing
+any work, then follow the matching flow:
 
-1. **Initial triage** — a new issue was just opened (`event_name == "issues"`).
-2. **Follow-up triage** — the original issue author posted a comment
-   (`event_name == "issue_comment"`). In this case you must first decide
-   whether a follow-up triage is actually warranted (see "Follow-up gate"
-   below) and call `noop` if it is not.
+1. **Initial triage** — `event_name == "issues"`. A new issue was just opened.
+   Always proceed to the triage instructions below.
+2. **Follow-up triage** — `event_name == "issue_comment"` and the comment body
+   does NOT start with `/triage`. The workflow-level `if:` has already verified
+   the issue currently carries the label `Auto-Triage: Waiting for Author`,
+   so a prior triage flagged missing env info and the author has now responded.
+   Treat later author comments as part of the issue body and re-validate the
+   environment. There are three sub-cases routed by "Follow-up routing" under
+   Instructions:
+   - **No progress** (comment supplied no new env field, e.g. "will share
+     soon") → silent `noop`, label stays, no comment posted.
+   - **Partial progress** (comment supplied at least one new env field but
+     others are still missing) → post a fresh summary acknowledging what
+     was provided and re-asking for the rest, KEEP the label.
+   - **Complete** (all required env fields are now present) → post a fresh
+     summary, REMOVE the label.
+3. **On-demand triage** — `event_name == "issue_comment"` and the comment body
+   starts with `/triage`. A maintainer is explicitly requesting a fresh triage.
+   Ignore label state and prior summary counts; proceed to the triage
+   instructions and produce a new summary. Do NOT change the label as part of
+   `/triage` runs (leave it as-is).
 
 Do NOT call `add_comment` more than once per run.
-Do NOT call `add_labels`. Do NOT apply any labels.
+Do NOT call `add_labels` or `remove_labels` for any label other than
+`Auto-Triage: Waiting for Author` — that single label is the only one this
+workflow is permitted to manage.
 Do NOT post intermediate findings. Do NOT post separate comments for
 area detection, duplicate checking, or environment validation.
 Everything goes into the single triage summary at the end.
 
 ---
 
-## Follow-up gate (only when `event_name == "issue_comment"`)
+## Label-managed state
 
-Before doing any triage work on a comment event, list all existing comments
-on the issue using GitHub read tools and verify **all** of the following.
-If any check fails, call `noop` with a short reason and stop — do NOT post
-a comment.
+The workflow uses one internal-state label to decide cheaply (at the YAML
+`if:` level) whether an author comment should boot the agent at all:
 
-1. **Exactly one prior triage summary exists.** Count comments authored by
-   `github-actions[bot]` whose body contains the string `🔍 Triage Summary`.
-   - If the count is `0`, the initial triage hasn't happened yet — call `noop`.
-   - If the count is `≥ 2`, the follow-up has already been posted — call
-     `noop`. We never post a third summary.
-2. **The prior triage flagged missing environment fields.** The single
-   existing `🔍 Triage Summary` comment body must contain the string
-   `⚠️ Missing:`. If it does not, the first triage had complete info and
-   no follow-up is needed — call `noop`.
-3. **The triggering comment is from the issue's original author.** This is
-   already enforced by the workflow-level `if:`, but re-verify defensively:
-   `comment.user.login == issue.user.login`. If not, call `noop`.
+- **`Auto-Triage: Waiting for Author`** — present iff the most recent
+  triage summary flagged `⚠️ Missing:` or `⚠️ Partial:` environment fields
+  and we are waiting for the issue author to supply them.
+
+The agent (you) is responsible for keeping this label accurate — see the
+"Actions" section below for exactly when to call `add_labels` /
+`remove_labels`.
 
 Only if all three checks pass, proceed to the triage instructions below
 and produce a fresh summary. Treat the prior summary as **invalidated** —
@@ -106,9 +142,51 @@ environment validation, and analysis. Do not skip this step.
 
 ## Instructions
 
-Read the issue body **and, for follow-up runs, every subsequent comment**.
-Then do ALL of the following analysis silently (using read tools and search
-only — no comments, no outputs):
+Read the issue body **and, for follow-up / on-demand runs, every subsequent
+comment**. Then do ALL of the following analysis silently (using read tools
+and search only — no comments, no outputs):
+
+### Follow-up routing (scenario 2 only)
+
+Before running the full analysis on a follow-up run, decide which of three
+sub-cases this comment falls into. Use the rules in step **B** below to
+determine which environment fields each source supplies.
+
+Compute two snapshots:
+
+- **BEFORE** = env fields supplied by the issue body + every author comment
+  EXCEPT the triggering comment.
+- **AFTER**  = env fields supplied by the issue body + every author comment
+  INCLUDING the triggering comment.
+
+Then route as follows:
+
+1. **No progress** — `AFTER == BEFORE` (the new comment did not supply any
+   new env field; e.g. "okay, will share details soon", a question, an
+   unrelated remark). → Call `noop` with a short reason like `"Author
+   commented but supplied no new env info"` and STOP. Do NOT call
+   `add_comment`. Do NOT change the label. The label stays so the next
+   author comment can re-trigger this workflow.
+
+2. **Partial progress** — `AFTER` adds at least one new env field but is
+   still incomplete (some required fields are still missing). → Proceed
+   to the full analysis below and post a fresh triage summary. The
+   `Environment` row MUST acknowledge what was just provided and list
+   only the fields that are STILL missing, e.g.
+   `⚠️ Partial: received SqlClient version and OS; still missing: .NET TFM, SQL Server version`.
+   Keep the label `Auto-Triage: Waiting for Author` on the issue (i.e. call
+   `add_labels` with that label — it is a no-op if already present).
+
+3. **Complete** — `AFTER` contains every required env field. → Proceed to
+   the full analysis below and post a fresh triage summary. The
+   `Environment` row says `All required environment details provided for
+   investigation`. Call `remove_labels` with the label.
+
+This routing does NOT apply to initial triage (scenario 1) or on-demand
+`/triage` (scenario 3) — those always produce a fresh summary using the
+standard label-management rules in the Actions section below.
+
+### Full analysis
 
 **A. Classify issue type**: Bug (reports unexpected behavior, crash, regression, or incorrect results), Feature (has proposal), Question, or Task.
 
@@ -147,8 +225,9 @@ Proceed with all remaining triage steps regardless of missing environment detail
 
 ## Actions
 
-Call `add_comment` exactly **once** with this markdown (for follow-up runs,
-add the parenthetical "(updated after author response)" to the heading):
+Call `add_comment` exactly **once** with this markdown. For follow-up runs
+add "(updated after author response)" to the heading; for on-demand `/triage`
+runs add "(on-demand re-triage)" to the heading:
 
 ```
 ## 🔍 Triage Summary
@@ -156,7 +235,7 @@ add the parenthetical "(updated after author response)" to the heading):
 | Check | Result |
 |-------|--------|
 | Issue type | <Bug / Feature / Question / Task> |
-| Environment | <All required environment details provided for investigation / ⚠️ Missing: list specific fields> |
+| Environment | <All required environment details provided for investigation / ⚠️ Partial: received <list>; still missing: <list> / ⚠️ Missing: list specific fields> |
 | Area | <Best matching area from classification table> |
 | Duplicates | <None found / Potentially related: #NNN, #NNN> |
 | Regression | <Not indicated / Likely regression from vX.Y.Z / Inconclusive> |
@@ -181,5 +260,16 @@ and severity assessment (P0-P3)>
 
 > **Note**: This triage summary is auto-generated by an AI agent. The analysis and suggestions above have not been verified by a human maintainer. Please treat as preliminary guidance only.
 ```
+
+**Then manage the label**:
+
+- For **on-demand `/triage` runs**, do NOT touch the label — preserve
+  whatever state existed before.
+- For **initial triage** and **follow-up triage**, base the decision on the
+  `Environment` row of the summary you just posted:
+  - If it contains `⚠️ Missing:` or `⚠️ Partial:` → call `add_labels` with
+    `["Auto-Triage: Waiting for Author"]` (no-op if already present).
+  - Otherwise (env complete) → call `remove_labels` with
+    `["Auto-Triage: Waiting for Author"]` (safe to call even if absent).
 
 If the issue is spam or no action is needed, call the `noop` tool instead.

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -34,7 +34,8 @@ if: |
      (startsWith(github.event.comment.body, '/triage')
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
      ||
-     (github.event.comment.user.login == github.event.issue.user.login
+     (!startsWith(github.event.comment.body, '/triage')
+      && github.event.comment.user.login == github.event.issue.user.login
       && contains(github.event.issue.labels.*.name, 'Auto-Triage: Waiting for Author'))
    ))
 

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -2,7 +2,25 @@
 on:
   issues:
     types: [opened]
+  issue_comment:
+    types: [created]
   roles: all
+
+# Cheap gate before the agent boots:
+#   - issues.opened          -> always run (initial triage)
+#   - issue_comment.created  -> only when the commenter IS the issue author,
+#                               the comment is on an issue (not a PR), and
+#                               the author is not a bot. The deeper checks
+#                               ("prior triage flagged missing env" and
+#                               "no second triage already posted") are done
+#                               inside the prompt because they require
+#                               reading existing comments.
+if: |
+  github.event_name == 'issues' ||
+  (github.event_name == 'issue_comment'
+   && github.event.issue.pull_request == null
+   && github.event.comment.user.login == github.event.issue.user.login
+   && !endsWith(github.event.comment.user.login, '[bot]'))
 
 engine: copilot
 
@@ -16,24 +34,60 @@ tools:
     min-integrity: none
 
 safe-outputs:
+  # Allow up to 2 triage summaries per issue (initial + one follow-up).
+  # `hide-older-comments` collapses the previous summary so the latest one
+  # is the only visible "current state".
   add-comment:
-    max: 1
+    max: 2
     hide-older-comments: true
 ---
 
 # SqlClient Issue Auto-Triage
 
 You are a triage specialist for **Microsoft.Data.SqlClient**.
-A new issue has just been opened. Your job is to:
+Your job is to post **at most one** triage summary comment per workflow run
+using `add_comment`.
 
-1. Read the issue silently using GitHub read tools
-2. Post **one** triage summary comment using `add_comment`
+This workflow runs in two situations:
 
-That is the entire workflow. Do NOT call `add_comment` more than once.
+1. **Initial triage** — a new issue was just opened (`event_name == "issues"`).
+2. **Follow-up triage** — the original issue author posted a comment
+   (`event_name == "issue_comment"`). In this case you must first decide
+   whether a follow-up triage is actually warranted (see "Follow-up gate"
+   below) and call `noop` if it is not.
+
+Do NOT call `add_comment` more than once per run.
 Do NOT call `add_labels`. Do NOT apply any labels.
 Do NOT post intermediate findings. Do NOT post separate comments for
 area detection, duplicate checking, or environment validation.
 Everything goes into the single triage summary at the end.
+
+---
+
+## Follow-up gate (only when `event_name == "issue_comment"`)
+
+Before doing any triage work on a comment event, list all existing comments
+on the issue using GitHub read tools and verify **all** of the following.
+If any check fails, call `noop` with a short reason and stop — do NOT post
+a comment.
+
+1. **Exactly one prior triage summary exists.** Count comments authored by
+   `github-actions[bot]` whose body contains the string `🔍 Triage Summary`.
+   - If the count is `0`, the initial triage hasn't happened yet — call `noop`.
+   - If the count is `≥ 2`, the follow-up has already been posted — call
+     `noop`. We never post a third summary.
+2. **The prior triage flagged missing environment fields.** The single
+   existing `🔍 Triage Summary` comment body must contain the string
+   `⚠️ Missing:`. If it does not, the first triage had complete info and
+   no follow-up is needed — call `noop`.
+3. **The triggering comment is from the issue's original author.** This is
+   already enforced by the workflow-level `if:`, but re-verify defensively:
+   `comment.user.login == issue.user.login`. If not, call `noop`.
+
+Only if all three checks pass, proceed to the triage instructions below
+and produce a fresh summary. Treat the prior summary as **invalidated** —
+the new one supersedes it (the older one will be collapsed automatically
+by `hide-older-comments`).
 
 ---
 
@@ -52,8 +106,9 @@ environment validation, and analysis. Do not skip this step.
 
 ## Instructions
 
-Read the issue body. Then do ALL of the following analysis silently
-(using read tools and search only — no comments, no outputs):
+Read the issue body **and, for follow-up runs, every subsequent comment**.
+Then do ALL of the following analysis silently (using read tools and search
+only — no comments, no outputs):
 
 **A. Classify issue type**: Bug (reports unexpected behavior, crash, regression, or incorrect results), Feature (has proposal), Question, or Task.
 
@@ -61,6 +116,8 @@ Read the issue body. Then do ALL of the following analysis silently
 SqlClient version, .NET target framework, SQL Server version, OS,
 repro steps, expected vs actual behavior.
 If any are missing, list them explicitly in the triage summary (e.g. "Missing: SQL Server version, OS").
+For follow-up runs, treat information supplied in any later comment by the
+issue author as if it were part of the original issue body.
 Proceed with all remaining triage steps regardless of missing environment details.
 
 **C. Classify area**: Based on the issue content, pick the single best matching area label from this list:
@@ -90,7 +147,8 @@ Proceed with all remaining triage steps regardless of missing environment detail
 
 ## Actions
 
-Call `add_comment` exactly **once** with this markdown:
+Call `add_comment` exactly **once** with this markdown (for follow-up runs,
+add the parenthetical "(updated after author response)" to the heading):
 
 ```
 ## 🔍 Triage Summary

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -31,10 +31,11 @@ if: |
    && github.event.issue.pull_request == null
    && !endsWith(github.event.comment.user.login, '[bot]')
    && (
-     (startsWith(github.event.comment.body, '/triage')
+     ((github.event.comment.body == '/triage' || startsWith(github.event.comment.body, '/triage '))
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
      ||
-     (!startsWith(github.event.comment.body, '/triage')
+     (github.event.comment.body != '/triage'
+      && !startsWith(github.event.comment.body, '/triage ')
       && github.event.comment.user.login == github.event.issue.user.login
       && contains(github.event.issue.labels.*.name, 'Auto-Triage: Waiting for Author'))
    ))

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -64,6 +64,11 @@ safe-outputs:
   remove-labels:
     allowed: ["Auto-Triage: Waiting for Author"]
     max: 1
+  # Silently skip noop runs (e.g. random author comment with no new env info).
+  # Without this, gh-aw auto-creates a tracking issue "[aw] No-Op Runs" and
+  # appends a comment to it for every noop.
+  noop:
+    report-as-issue: false
 ---
 
 # SqlClient Issue Auto-Triage


### PR DESCRIPTION
## Summary

Today the `SqlClient Issue Auto-Triage` workflow runs exactly once — when an issue is opened. When that initial summary reports `⚠️ Missing:` and asks the author to supply more info, the author's reply currently produces no new triage analysis, even though the previous summary is effectively stale.

This change extends the workflow with three new capabilities, all controlled cheaply at the YAML `if:` level so the Copilot agent only boots when worthwhile:

1. **Label-gated follow-up triage** — when an initial triage flags `⚠️ Missing:`, the workflow applies an internal-state label and the issue author's subsequent comments re-trigger the workflow until the env is complete.
2. **Partial-progress acknowledgement** — if the author supplies some but not all required env fields, the follow-up posts an updated summary acknowledging what's now present and re-asking for what's still missing, keeping the label on.
3. **`/triage` on-demand command** — repo maintainers can comment `/triage` on any issue to force a fresh triage analysis, bypassing label state and prior-summary counts.

## Behavior

| Situation | Activation gate (`if:`) | Agent action |
|---|---|---|
| Issue opened | runs | Initial triage; adds `Auto-Triage: Waiting for Author` label if env is missing |
| Author comment, label present, supplies **no** new env field ("will share soon") | runs (boots agent) | Silent `noop` — no comment posted, label stays |
| Author comment, label present, supplies **some** new env fields | runs | Posts `⚠️ Partial: received X, Y; still missing: A, B` summary, label stays |
| Author comment, label present, supplies **all** remaining env fields | runs | Posts complete summary, removes label |
| Author comment after label was removed | **skipped (`$0`)** | — |
| Comment from anyone other than the issue author | **skipped (`$0`)** | — |
| Comment on a pull request (not an issue) | **skipped (`$0`)** | — |
| Bot-authored comment | **skipped (`$0`)** | — |
| `/triage` from a repo `OWNER` / `MEMBER` / `COLLABORATOR` | runs | Fresh triage regardless of label state; label untouched |
| `/triage` from a non-maintainer (drive-by commenter) | **skipped (`$0`)** | — |

## How it's enforced

**Layer 1 — Workflow-level `if:` (free, $0 if it returns false):**

```yaml
if: |
  github.event_name == 'issues' ||
  (github.event_name == 'issue_comment'
   && github.event.issue.pull_request == null
   && !endsWith(github.event.comment.user.login, '[bot]')
   && (
     (startsWith(github.event.comment.body, '/triage')
      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     ||
     (github.event.comment.user.login == github.event.issue.user.login
      && contains(github.event.issue.labels.*.name, 'Auto-Triage: Waiting for Author'))
   ))
```

This filters out the obvious non-matches (bot commenter, non-author commenter on un-labeled issue, PR comments, non-maintainer `/triage`) before the agent activation job runs. Skipped activation jobs use zero compute.

**Layer 2 — Prompt-level "Follow-up routing":** instructs the agent to compute `BEFORE` and `AFTER` env-field snapshots and route into one of three sub-cases — `No progress` → silent `noop`, `Partial progress` → fresh summary + keep label, `Complete` → fresh summary + remove label. The agent is responsible for adding/removing the label via the new `add-labels` / `remove-labels` safe-outputs (both restricted to the single label `Auto-Triage: Waiting for Author` via `allowed:`).

`safe-outputs.add-comment.max` stays at `1` per run (the workflow simply runs multiple times, once per author comment that passes the gate). `hide-older-comments: true` collapses the previous summary so only the latest is visible.

## New label

This PR introduces one new internal-state label:

- **`Auto-Triage: Waiting for Author`** — applied by the workflow when env fields are missing, removed when they are complete. Maintainers should not apply/remove it manually; the workflow manages it.

The `safe-outputs.add-labels.allowed` / `remove-labels.allowed` lists restrict the workflow to managing only this one label.

## Files changed

- `.github/workflows/issue-triage.md` — new `if:` expression, `add-labels` / `remove-labels` safe-outputs, three-scenario overview (Initial / Follow-up / On-demand), Label-managed state section, Follow-up routing section, `⚠️ Partial:` env-row format, label-management actions.
- `.github/workflows/issue-triage.lock.yml` — regenerated by `gh aw compile v0.72.1`. **Included in this PR — no maintainer compile step required.**

## Validation

End-to-end tested on a personal fork (`priyankatiwari08/SqlClient-test-prtiwar`):

| Test | Expected | Observed |
|---|---|---|
| Open issue with missing env | Initial summary `⚠️ Missing:` + label added | ✅ |
| Author comments "okay will share details" | Silent noop, no comment, label stays | ✅ |
| Author comments with some env fields | `⚠️ Partial:` summary, label stays | ✅ |
| Author comments with remaining fields | Complete summary, label removed | ✅ |
| Author comments again after label removed | Activation skipped ($0) | ✅ |
| Maintainer comments `/triage` on any issue | Fresh triage runs, label untouched | ✅ |

## Cost shape

- Initial triage: 1 agent run per opened issue (unchanged from today).
- Follow-up triage: bounded by author comments while the label is present. Non-substantive author comments cost a single inference call (no public spam); substantive ones post a fresh summary.
- All other comment events (non-author, non-maintainer, bots, PR comments, author comments after label removal): **skipped at the YAML `if:` level, zero compute cost.**

