### PR TITLE
[6.1] SDK install retry. Disable flaky tests.

### DIFF
--- a/eng/pipelines/steps/install-dotnet.yml
+++ b/eng/pipelines/steps/install-dotnet.yml
@@ -57,8 +57,12 @@ steps:
   - ${{ if ne(parameters.architecture, 'arm64') }}:
   
     # Install the SDK listed in the global.json file.
+    #
+    # retryCountOnTaskFailure is set because UseDotNet@2 fails intermittently
+    # in CI due to transient network/CDN issues when downloading the SDK.
     - task: UseDotNet@2
       displayName: Install .NET SDK (global.json)
+      retryCountOnTaskFailure: 3
       inputs:
         installationPath: ${{ parameters.installDir }}
         packageType: sdk
@@ -71,6 +75,7 @@ steps:
     - ${{ each version in parameters.runtimes }}:
       - task: UseDotNet@2
         displayName: Install .NET ${{ version }} Runtime
+        retryCountOnTaskFailure: 3
         inputs:
           installationPath: ${{ parameters.installDir }}
           packageType: runtime
@@ -83,8 +88,13 @@ steps:
   - ${{ else }}:
 
     # Use the install script for ARM64.
+    #
+    # retryCountOnTaskFailure provides an outer retry around the script's
+    # internal retry loop, in case the script download itself or the entire
+    # step fails due to transient issues.
     - task: PowerShell@2
       displayName: Install .NET SDK and Runtimes for ARM64
+      retryCountOnTaskFailure: 3
       inputs:
         targetType: filePath
         pwsh: true

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
@@ -389,6 +389,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         [InlineData(40613)]
         [InlineData(42108)]
         [InlineData(42109)]
+        [Trait("Category", "flaky")]
         public void TransientFault_RetryDisabled_ShouldFail(uint errorCode)
         {
             // Arrange
@@ -484,6 +485,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         [InlineData(40613)]
         [InlineData(42108)]
         [InlineData(42109)]
+        [Trait("Category", "flaky")]
         public void TransientFault_WithUserProvidedPartner_RetryDisabled_ShouldFail(uint errorCode)
         {
             // Arrange

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTestsAzure.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTestsAzure.cs
@@ -159,6 +159,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
         }
 
         [Fact]
+        [Trait("Category", "flaky")]
         public void NetworkTimeoutAtRoutedLocation_RetryDisabled_ShouldFail()
         {
             // Arrange


### PR DESCRIPTION
Ports #4314 

This pull request improves reliability in CI pipelines by adding retry logic to .NET installation steps and marks certain flaky tests to help with test management. The most important changes are grouped below: