### PR TITLE
[6.1] Disable flaky CancelAsyncConnections test on kerberos

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -289,6 +289,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         public static bool IsKerberosTest => !string.IsNullOrEmpty(KerberosDomainUser) && !string.IsNullOrEmpty(KerberosDomainPassword);
 
+        public static bool IsNotKerberosTest => !IsKerberosTest;
+
         #nullable enable
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncCancelledConnectionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncCancelledConnectionsTest.cs
@@ -27,12 +27,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup),
             nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotManagedInstance),
             nameof(DataTestUtility.IsNotKerberosTest))]
-        public void CancelAsyncConnections()
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CancelAsyncConnections(bool useMars)
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString);
-            builder.MultipleActiveResultSets = false;
-            RunCancelAsyncConnections(builder);
-            builder.MultipleActiveResultSets = true;
+            builder.MultipleActiveResultSets = useMars;
             RunCancelAsyncConnections(builder);
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncCancelledConnectionsTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/AsyncCancelledConnectionsTest.cs
@@ -22,8 +22,11 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             _output = output;
         }
 
-        // Disabled on Azure since this test fails on concurrent runs on same database.
-        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer))]
+
+        // Disabled on Azure, Kerberos, and Managed Instance pipelines due to environment-specific instability.
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup),
+            nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotManagedInstance),
+            nameof(DataTestUtility.IsNotKerberosTest))]
         public void CancelAsyncConnections()
         {
             SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString);


### PR DESCRIPTION
Ports #4311 

**Test utility improvements:**

* Added a new property `IsNotKerberosTest` to `DataTestUtility` to simplify checking for non-Kerberos environments.

**Test attribute updates:**

* Updated the `AsyncCancelledConnectionsTest` to use `[ConditionalTheory]` and skip execution on Azure, Kerberos, and Managed Instance pipelines by including `IsNotKerberosTest` and `IsNotManagedInstance` in the test conditions.