### PR TITLE
Fix fetching signature verification result from cache

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SignatureVerificationCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SignatureVerificationCache.cs
@@ -10,6 +10,22 @@ using Microsoft.Extensions.Caching.Memory;
 namespace Microsoft.Data.SqlClient
 {
     /// <summary>
+    /// Tri-state result returned by <see cref="ColumnMasterKeyMetadataSignatureVerificationCache.GetSignatureVerificationResult"/>.
+    /// Distinguishes a cache miss from a cached negative result so callers cannot conflate the two.
+    /// </summary>
+    internal enum SignatureVerificationResult
+    {
+        /// <summary>No cached entry exists for the requested CMK metadata. The caller must verify the signature with the key store provider.</summary>
+        NotFound,
+
+        /// <summary>A cached entry exists and indicates that signature verification previously failed.</summary>
+        False,
+
+        /// <summary>A cached entry exists and indicates that signature verification previously succeeded.</summary>
+        True,
+    }
+
+    /// <summary>
     /// Cache for storing result of signature verification of CMK Metadata
     /// </summary>
     internal class ColumnMasterKeyMetadataSignatureVerificationCache
@@ -29,6 +45,9 @@ namespace Microsoft.Data.SqlClient
         private static readonly TimeSpan s_verificationCacheTimeout = TimeSpan.FromDays(10);
 
         //singleton instance
+        /// <summary>
+        /// Gets the process-wide singleton instance of the signature verification cache.
+        /// </summary>
         internal static ColumnMasterKeyMetadataSignatureVerificationCache Instance { get { return _signatureVerificationCache; } }
 
         private readonly MemoryCache _cache;
@@ -41,13 +60,23 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <summary>
-        /// Get signature verification result for given CMK metadata (KeystoreName, MasterKeyPath, allowEnclaveComputations) and a given signature
+        /// Get signature verification result for given CMK metadata 
+        /// (KeystoreName, MasterKeyPath, allowEnclaveComputations) and a given signature
         /// </summary>
         /// <param name="keyStoreName">Key Store name for CMK</param>
         /// <param name="masterKeyPath">Key Path for CMK</param>
         /// <param name="allowEnclaveComputations">boolean indicating whether the key can be sent to enclave</param>
         /// <param name="signature">Signature for the CMK metadata</param>
-        internal bool GetSignatureVerificationResult(string keyStoreName, string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
+        /// <returns>Tri-state result indicating whether signature verification succeeded, failed, or was not found in cache</returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when <paramref name="masterKeyPath"/>, <paramref name="keyStoreName"/>, 
+        /// or <paramref name="signature"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <paramref name="masterKeyPath"/> or <paramref name="keyStoreName"/> 
+        /// is empty or whitespace, or when <paramref name="signature"/> has length zero.
+        /// </exception>
+        internal SignatureVerificationResult GetSignatureVerificationResult(string keyStoreName, string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
         {
             ValidateStringArgumentNotNullOrEmpty(masterKeyPath, _masterkeypathArgumentName, _getSignatureVerificationResultMethodName);
             ValidateStringArgumentNotNullOrEmpty(keyStoreName, _keyStoreNameArgumentName, _getSignatureVerificationResultMethodName);
@@ -55,17 +84,31 @@ namespace Microsoft.Data.SqlClient
 
             string cacheLookupKey = GetCacheLookupKey(masterKeyPath, allowEnclaveComputations, signature, keyStoreName);
 
-            return _cache.TryGetValue<bool>(cacheLookupKey, out bool value) && value;
+            if (!_cache.TryGetValue<bool>(cacheLookupKey, out bool value))
+            {
+                return SignatureVerificationResult.NotFound;
+            }
+
+            return value ? SignatureVerificationResult.True : SignatureVerificationResult.False;
         }
 
         /// <summary>
-        /// Add signature verification result for given CMK metadata (KeystoreName, MasterKeyPath, allowEnclaveComputations) and a given signature in the cache
+        /// Add signature verification result for given CMK metadata (KeystoreName, 
+        /// MasterKeyPath, allowEnclaveComputations) and a given signature in the cache
         /// </summary>
         /// <param name="keyStoreName">Key Store name for CMK</param>
         /// <param name="masterKeyPath">Key Path for CMK</param>
         /// <param name="allowEnclaveComputations">boolean indicating whether the key can be sent to enclave</param>
         /// <param name="signature">Signature for the CMK metadata</param>
         /// <param name="result">result indicating signature verification success/failure</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when <paramref name="masterKeyPath"/>, <paramref name="keyStoreName"/>, 
+        /// or <paramref name="signature"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when <paramref name="masterKeyPath"/> or <paramref name="keyStoreName"/> is empty or whitespace, 
+        /// or when <paramref name="signature"/> has length zero.
+        /// </exception>
         internal void AddSignatureVerificationResult(string keyStoreName, string masterKeyPath, bool allowEnclaveComputations, byte[] signature, bool result)
         {
             ValidateStringArgumentNotNullOrEmpty(masterKeyPath, _masterkeypathArgumentName, _addSignatureVerificationResultMethodName);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SignatureVerificationCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SignatureVerificationCache.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Data.SqlClient
 
             string cacheLookupKey = GetCacheLookupKey(masterKeyPath, allowEnclaveComputations, signature, keyStoreName);
 
-            return _cache.TryGetValue<bool>(cacheLookupKey, out bool value);
+            return _cache.TryGetValue<bool>(cacheLookupKey, out bool value) && value;
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SignatureVerificationCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SignatureVerificationCache.cs
@@ -15,13 +15,20 @@ namespace Microsoft.Data.SqlClient
     /// </summary>
     internal enum SignatureVerificationResult
     {
-        /// <summary>No cached entry exists for the requested CMK metadata. The caller must verify the signature with the key store provider.</summary>
+        /// <summary>
+        /// No cached entry exists for the requested CMK metadata. 
+        /// The caller must verify the signature with the key store provider.
+        /// </summary>
         NotFound,
 
-        /// <summary>A cached entry exists and indicates that signature verification previously failed.</summary>
+        /// <summary>
+        /// A cached entry exists and indicates that signature verification previously failed.
+        /// </summary>
         False,
 
-        /// <summary>A cached entry exists and indicates that signature verification previously succeeded.</summary>
+        /// <summary>
+        /// A cached entry exists and indicates that signature verification previously succeeded.
+        /// </summary>
         True,
     }
 
@@ -32,31 +39,21 @@ namespace Microsoft.Data.SqlClient
     {
         private const int CacheSize = 2000; // Cache size in number of entries.
         private const int CacheTrimThreshold = 300; // Threshold above the cache size when we start trimming.
-
-        private const string _className = "ColumnMasterKeyMetadataSignatureVerificationCache";
-        private const string _getSignatureVerificationResultMethodName = "GetSignatureVerificationResult";
-        private const string _addSignatureVerificationResultMethodName = "AddSignatureVerificationResult";
-        private const string _masterkeypathArgumentName = "masterKeyPath";
-        private const string _keyStoreNameArgumentName = "keyStoreName";
-        private const string _signatureName = "signature";
         private const string _cacheLookupKeySeparator = ":";
 
-        private static readonly ColumnMasterKeyMetadataSignatureVerificationCache _signatureVerificationCache = new ColumnMasterKeyMetadataSignatureVerificationCache();
         private static readonly TimeSpan s_verificationCacheTimeout = TimeSpan.FromDays(10);
 
-        //singleton instance
         /// <summary>
         /// Gets the process-wide singleton instance of the signature verification cache.
         /// </summary>
-        internal static ColumnMasterKeyMetadataSignatureVerificationCache Instance { get { return _signatureVerificationCache; } }
+        internal static ColumnMasterKeyMetadataSignatureVerificationCache Instance { get; } = new();
 
         private readonly MemoryCache _cache;
-        private int _inTrim = 0;
+        private int _inTrim;
 
         private ColumnMasterKeyMetadataSignatureVerificationCache()
         {
             _cache = new MemoryCache(new MemoryCacheOptions());
-            _inTrim = 0;
         }
 
         /// <summary>
@@ -78,13 +75,13 @@ namespace Microsoft.Data.SqlClient
         /// </exception>
         internal SignatureVerificationResult GetSignatureVerificationResult(string keyStoreName, string masterKeyPath, bool allowEnclaveComputations, byte[] signature)
         {
-            ValidateStringArgumentNotNullOrEmpty(masterKeyPath, _masterkeypathArgumentName, _getSignatureVerificationResultMethodName);
-            ValidateStringArgumentNotNullOrEmpty(keyStoreName, _keyStoreNameArgumentName, _getSignatureVerificationResultMethodName);
-            ValidateSignatureNotNullOrEmpty(signature, _getSignatureVerificationResultMethodName);
+            ValidateStringArgumentNotNullOrEmpty(masterKeyPath, nameof(masterKeyPath), nameof(GetSignatureVerificationResult));
+            ValidateStringArgumentNotNullOrEmpty(keyStoreName, nameof(keyStoreName), nameof(GetSignatureVerificationResult));
+            ValidateSignatureNotNullOrEmpty(signature, nameof(GetSignatureVerificationResult));
 
             string cacheLookupKey = GetCacheLookupKey(masterKeyPath, allowEnclaveComputations, signature, keyStoreName);
 
-            if (!_cache.TryGetValue<bool>(cacheLookupKey, out bool value))
+            if (!_cache.TryGetValue(cacheLookupKey, out bool value))
             {
                 return SignatureVerificationResult.NotFound;
             }
@@ -111,86 +108,90 @@ namespace Microsoft.Data.SqlClient
         /// </exception>
         internal void AddSignatureVerificationResult(string keyStoreName, string masterKeyPath, bool allowEnclaveComputations, byte[] signature, bool result)
         {
-            ValidateStringArgumentNotNullOrEmpty(masterKeyPath, _masterkeypathArgumentName, _addSignatureVerificationResultMethodName);
-            ValidateStringArgumentNotNullOrEmpty(keyStoreName, _keyStoreNameArgumentName, _addSignatureVerificationResultMethodName);
-            ValidateSignatureNotNullOrEmpty(signature, _addSignatureVerificationResultMethodName);
+            ValidateStringArgumentNotNullOrEmpty(masterKeyPath, nameof(masterKeyPath), nameof(AddSignatureVerificationResult));
+            ValidateStringArgumentNotNullOrEmpty(keyStoreName, nameof(keyStoreName), nameof(AddSignatureVerificationResult));
+            ValidateSignatureNotNullOrEmpty(signature, nameof(AddSignatureVerificationResult));
 
             string cacheLookupKey = GetCacheLookupKey(masterKeyPath, allowEnclaveComputations, signature, keyStoreName);
 
             TrimCacheIfNeeded();
 
             // By default evict after 10 days.
-            _cache.Set<bool>(cacheLookupKey, result, absoluteExpirationRelativeToNow: s_verificationCacheTimeout);
+            _cache.Set(cacheLookupKey, result, absoluteExpirationRelativeToNow: s_verificationCacheTimeout);
         }
 
-        private void ValidateSignatureNotNullOrEmpty(byte[] signature, string methodName)
+        private static void ValidateSignatureNotNullOrEmpty(byte[] signature, string methodName)
         {
-            if (signature == null || signature.Length == 0)
+            if (signature is null)
             {
-                if (signature == null)
-                {
-                    throw SQL.NullArgumentInternal(_signatureName, _className, methodName);
-                }
-                else
-                {
-                    throw SQL.EmptyArgumentInternal(_signatureName, _className, methodName);
-                }
+                throw SQL.NullArgumentInternal(nameof(signature), nameof(ColumnMasterKeyMetadataSignatureVerificationCache), methodName);
+            }
+            if (signature.Length == 0)
+            {
+                throw SQL.EmptyArgumentInternal(nameof(signature), nameof(ColumnMasterKeyMetadataSignatureVerificationCache), methodName);
             }
         }
 
-        private void ValidateStringArgumentNotNullOrEmpty(string stringArgValue, string stringArgName, string methodName)
+        private static void ValidateStringArgumentNotNullOrEmpty(string value, string argumentName, string methodName)
         {
-            if (string.IsNullOrWhiteSpace(stringArgValue))
+            if (value is null)
             {
-                if (stringArgValue == null)
-                {
-                    throw SQL.NullArgumentInternal(stringArgName, _className, methodName);
-                }
-                else
-                {
-                    throw SQL.EmptyArgumentInternal(stringArgName, _className, methodName);
-                }
+                throw SQL.NullArgumentInternal(argumentName, nameof(ColumnMasterKeyMetadataSignatureVerificationCache), methodName);
+            }
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw SQL.EmptyArgumentInternal(argumentName, nameof(ColumnMasterKeyMetadataSignatureVerificationCache), methodName);
             }
         }
+
 
         private void TrimCacheIfNeeded()
         {
             // If the size of the cache exceeds the threshold, set that we are in trimming and trim the cache accordingly.
             long currentCacheSize = _cache.Count;
-            if ((currentCacheSize > CacheSize + CacheTrimThreshold) && (0 == Interlocked.CompareExchange(ref _inTrim, 1, 0)))
+            if (currentCacheSize <= CacheSize + CacheTrimThreshold || Interlocked.CompareExchange(ref _inTrim, 1, 0) != 0)
             {
-                try
-                {
-                    // Example: 2301 - 2000 = 301; 301 / 2301 = 0.1308 * 100 = 13% compacting
-                    _cache.Compact((((double)(currentCacheSize - CacheSize) / (double)currentCacheSize) * 100));
-                }
-                finally
-                {
-                    // Reset _inTrim flag
-                    Interlocked.CompareExchange(ref _inTrim, 0, 1);
-                }
+                return;
+            }
+
+            try
+            {
+                // Example: 2301 - 2000 = 301; 301 / 2301 = 0.1308 * 100 = 13% compacting
+                _cache.Compact((double)(currentCacheSize - CacheSize) / currentCacheSize * 100);
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _inTrim, 0);
             }
         }
 
-        private string GetCacheLookupKey(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, string keyStoreName)
+        /// <summary>
+        /// Generates a cache key for the given CMK metadata and signature. The key is a
+        /// concatenation of the key store name, master key path, allowEnclaveComputations value, and signature, separated by a delimiter.
+        /// </summary>
+        /// <param name="masterKeyPath">The master key path.</param>
+        /// <param name="allowEnclaveComputations">Whether enclave computations are allowed.</param>
+        /// <param name="signature">The signature.</param>
+        /// <param name="keyStoreName">The key store name.</param>
+        /// <returns>A string that can be used as a cache key.</returns>
+        private static string GetCacheLookupKey(string masterKeyPath, bool allowEnclaveComputations, byte[] signature, string keyStoreName)
         {
-            StringBuilder cacheLookupKeyBuilder = new StringBuilder(keyStoreName,
-                capacity:
-                    keyStoreName.Length +
-                    masterKeyPath.Length +
-                    SqlSecurityUtility.GetBase64LengthFromByteLength(signature.Length) +
-                    3 /*separators*/ +
-                    10 /*boolean value + somebuffer*/);
+            int cacheCapacity =
+                keyStoreName.Length +
+                masterKeyPath.Length +
+                SqlSecurityUtility.GetBase64LengthFromByteLength(signature.Length) +
+                4 * _cacheLookupKeySeparator.Length +
+                10 /* boolean value + buffer */;
 
-            cacheLookupKeyBuilder.Append(_cacheLookupKeySeparator);
-            cacheLookupKeyBuilder.Append(masterKeyPath);
-            cacheLookupKeyBuilder.Append(_cacheLookupKeySeparator);
-            cacheLookupKeyBuilder.Append(allowEnclaveComputations);
-            cacheLookupKeyBuilder.Append(_cacheLookupKeySeparator);
-            cacheLookupKeyBuilder.Append(Convert.ToBase64String(signature));
-            cacheLookupKeyBuilder.Append(_cacheLookupKeySeparator);
-            string cacheLookupKey = cacheLookupKeyBuilder.ToString();
-            return cacheLookupKey;
+            return new StringBuilder(keyStoreName, capacity: cacheCapacity)
+                .Append(_cacheLookupKeySeparator)
+                .Append(masterKeyPath)
+                .Append(_cacheLookupKeySeparator)
+                .Append(allowEnclaveComputations)
+                .Append(_cacheLookupKeySeparator)
+                .Append(Convert.ToBase64String(signature))
+                .Append(_cacheLookupKeySeparator)
+                .ToString();
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
@@ -332,18 +332,21 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    bool signatureVerificationResult = ColumnMasterKeyMetadataSignatureVerificationCache.GetSignatureVerificationResult(keyStoreName, keyPath, isEnclaveEnabled, CMKSignature);
-                    if (signatureVerificationResult == false)
+                    SignatureVerificationResult cachedResult = ColumnMasterKeyMetadataSignatureVerificationCache.GetSignatureVerificationResult(keyStoreName, keyPath, isEnclaveEnabled, CMKSignature);
+                    switch (cachedResult)
                     {
-                        // We will simply bubble up the exception from VerifyColumnMasterKeyMetadata function.
-                        isValidSignature = provider.VerifyColumnMasterKeyMetadata(keyPath, isEnclaveEnabled,
-                                CMKSignature);
-
-                        ColumnMasterKeyMetadataSignatureVerificationCache.AddSignatureVerificationResult(keyStoreName, keyPath, isEnclaveEnabled, CMKSignature, isValidSignature);
-                    }
-                    else
-                    {
-                        isValidSignature = signatureVerificationResult;
+                        case SignatureVerificationResult.True:
+                            isValidSignature = true;
+                            break;
+                        case SignatureVerificationResult.False:
+                            isValidSignature = false;
+                            break;
+                        default:
+                            // Cache miss: verify with the provider and cache the result.
+                            // We will simply bubble up the exception from VerifyColumnMasterKeyMetadata function.
+                            isValidSignature = provider.VerifyColumnMasterKeyMetadata(keyPath, isEnclaveEnabled, CMKSignature);
+                            ColumnMasterKeyMetadataSignatureVerificationCache.AddSignatureVerificationResult(keyStoreName, keyPath, isEnclaveEnabled, CMKSignature, isValidSignature);
+                            break;
                     }
                 }
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSecurityUtility.cs
@@ -332,21 +332,20 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    SignatureVerificationResult cachedResult = ColumnMasterKeyMetadataSignatureVerificationCache.GetSignatureVerificationResult(keyStoreName, keyPath, isEnclaveEnabled, CMKSignature);
-                    switch (cachedResult)
+                    SignatureVerificationResult cachedResult = ColumnMasterKeyMetadataSignatureVerificationCache.Instance
+                        .GetSignatureVerificationResult(keyStoreName, keyPath, isEnclaveEnabled, CMKSignature);
+
+                    if (cachedResult == SignatureVerificationResult.NotFound)
                     {
-                        case SignatureVerificationResult.True:
-                            isValidSignature = true;
-                            break;
-                        case SignatureVerificationResult.False:
-                            isValidSignature = false;
-                            break;
-                        default:
-                            // Cache miss: verify with the provider and cache the result.
-                            // We will simply bubble up the exception from VerifyColumnMasterKeyMetadata function.
-                            isValidSignature = provider.VerifyColumnMasterKeyMetadata(keyPath, isEnclaveEnabled, CMKSignature);
-                            ColumnMasterKeyMetadataSignatureVerificationCache.AddSignatureVerificationResult(keyStoreName, keyPath, isEnclaveEnabled, CMKSignature, isValidSignature);
-                            break;
+                        // Cache miss: verify with the provider and cache the result.
+                        // Exceptions from VerifyColumnMasterKeyMetadata bubble up to the outer catch.
+                        isValidSignature = provider.VerifyColumnMasterKeyMetadata(keyPath, isEnclaveEnabled, CMKSignature);
+                        ColumnMasterKeyMetadataSignatureVerificationCache.Instance
+                            .AddSignatureVerificationResult(keyStoreName, keyPath, isEnclaveEnabled, CMKSignature, isValidSignature);
+                    }
+                    else
+                    {
+                        isValidSignature = cachedResult == SignatureVerificationResult.True;
                     }
                 }
             }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SignatureVerificationCacheTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SignatureVerificationCacheTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Data.SqlClient.UnitTests
     public class SignatureVerificationCacheTests
     {
         [Fact]
-        public void GetSignatureVerificationResult_DoesNotTreatCachedFailureAsSuccess()
+        public void GetSignatureVerificationResult_ReturnsFalseForCachedFailure()
         {
             ColumnMasterKeyMetadataSignatureVerificationCache cache = ColumnMasterKeyMetadataSignatureVerificationCache.Instance;
             string keyStoreName = $"TEST_PROVIDER_{Guid.NewGuid():N}";
@@ -19,7 +19,7 @@ namespace Microsoft.Data.SqlClient.UnitTests
 
             cache.AddSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature, result: false);
 
-            Assert.False(cache.GetSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature));
+            Assert.Equal(SignatureVerificationResult.False, cache.GetSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature));
         }
 
         [Fact]
@@ -32,7 +32,18 @@ namespace Microsoft.Data.SqlClient.UnitTests
 
             cache.AddSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature, result: true);
 
-            Assert.True(cache.GetSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature));
+            Assert.Equal(SignatureVerificationResult.True, cache.GetSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature));
+        }
+
+        [Fact]
+        public void GetSignatureVerificationResult_ReturnsNotFoundForCacheMiss()
+        {
+            ColumnMasterKeyMetadataSignatureVerificationCache cache = ColumnMasterKeyMetadataSignatureVerificationCache.Instance;
+            string keyStoreName = $"TEST_PROVIDER_{Guid.NewGuid():N}";
+            string masterKeyPath = $"https://unit-test/{Guid.NewGuid():N}";
+            byte[] signature = [9, 9, 9, 9];
+
+            Assert.Equal(SignatureVerificationResult.NotFound, cache.GetSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature));
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SignatureVerificationCacheTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SignatureVerificationCacheTests.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests
+{
+    public class SignatureVerificationCacheTests
+    {
+        [Fact]
+        public void GetSignatureVerificationResult_DoesNotTreatCachedFailureAsSuccess()
+        {
+            ColumnMasterKeyMetadataSignatureVerificationCache cache = ColumnMasterKeyMetadataSignatureVerificationCache.Instance;
+            string keyStoreName = $"TEST_PROVIDER_{Guid.NewGuid():N}";
+            string masterKeyPath = $"https://unit-test/{Guid.NewGuid():N}";
+            byte[] signature = [1, 2, 3, 4];
+
+            cache.AddSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature, result: false);
+
+            Assert.False(cache.GetSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature));
+        }
+
+        [Fact]
+        public void GetSignatureVerificationResult_ReturnsTrueForCachedSuccess()
+        {
+            ColumnMasterKeyMetadataSignatureVerificationCache cache = ColumnMasterKeyMetadataSignatureVerificationCache.Instance;
+            string keyStoreName = $"TEST_PROVIDER_{Guid.NewGuid():N}";
+            string masterKeyPath = $"https://unit-test/{Guid.NewGuid():N}";
+            byte[] signature = [4, 3, 2, 1];
+
+            cache.AddSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature, result: true);
+
+            Assert.True(cache.GetSignatureVerificationResult(keyStoreName, masterKeyPath, allowEnclaveComputations: true, signature));
+        }
+    }
+}


### PR DESCRIPTION
Fixes [AB#45439](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/45439)

**Problem**
`GetSignatureVerificationResult` returned the boolean from `MemoryCache.TryGetValue`(whether the key existed in cache) instead of the cached value itself. Once a CMK signature verification failure was cached `result: false`, subsequent lookups returned true, causing the caller to skip re-verification and treat the column master key as having a valid signature.

**Fix**
Return the actual cached value:

```
return _cache.TryGetValue<bool>(cacheLookupKey, out bool value) && value;
```

**Tests**
Added `SignatureVerificationCacheTests` covering both cached `true` and cached `false` cases (regression test for the bug).