### PR TITLE
Add TDS token data length bounds checks

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -1348,7 +1348,7 @@ namespace Microsoft.Data.SqlClient.Connection
 
                         if (len < 0 || len > data.Length - i)
                         {
-                            throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
+                            throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, len);
                         }
 
                         byte[] stateData = new byte[len];

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -1346,6 +1346,11 @@ namespace Microsoft.Data.SqlClient.Connection
                             len = bLen;
                         }
 
+                        if (len < 0 || len > data.Length - i)
+                        {
+                            throw SQL.ParsingError(ParsingErrorState.CorruptedTdsStream);
+                        }
+
                         byte[] stateData = new byte[len];
                         Buffer.BlockCopy(data, i, stateData, 0, len);
                         i += len;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -400,7 +400,7 @@ namespace Microsoft.Data.SqlClient.Connection
 
             try
             {
-                // If we want to consider pool operations against the overall connect timeout, 
+                // If we want to consider pool operations against the overall connect timeout,
                 // use the provided timeout. Otherwise, start a fresh timeout to receive the full
                 // connect timeout.
                 _timeout = ResolveLoginTimeout(timeout, connectionOptions.ConnectTimeout);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -731,6 +731,10 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ParsingErrorLength, ((int)state).ToString(CultureInfo.InvariantCulture), length));
         }
+        internal static Exception ParsingErrorLength(ParsingErrorState state, uint length)
+        {
+            return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ParsingErrorLength, ((int)state).ToString(CultureInfo.InvariantCulture), length));
+        }
         internal static Exception ParsingErrorStatus(ParsingErrorState state, int status)
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ParsingErrorStatus, ((int)state).ToString(CultureInfo.InvariantCulture), status));

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -84,6 +84,14 @@ namespace Microsoft.Data.SqlClient
         public const int MAX_PACKET_SIZE = 32768;
         public const int MAX_SERVER_USER_NAME = 256;  // obtained from luxor
 
+        // Maximum allowed data length for login-phase token payloads (feature ext ack,
+        // session state, fedauth info). Prevents a malicious server from causing
+        // unbounded memory allocation on the client before authentication completes.
+        internal const int MaxTokenDataLength = 1 << 20; // 1 MB
+
+        // Maximum allowed data length for a DTC promote transaction propagation token.
+        internal const int MaxPromoteTransactionLength = 1 << 16; // 64 KB
+
         // Severity  0 - 10 indicates informational (non-error) messages
         // Severity 11 - 16 indicates errors that can be corrected by user (syntax errors, etc...)
         // Severity 17 - 19 indicates failure due to insufficient resources in the server

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsEnums.cs
@@ -84,13 +84,16 @@ namespace Microsoft.Data.SqlClient
         public const int MAX_PACKET_SIZE = 32768;
         public const int MAX_SERVER_USER_NAME = 256;  // obtained from luxor
 
-        // Maximum allowed data length for login-phase token payloads (feature ext ack,
+        // Maximum allowed data length for token payloads (feature ext ack,
         // session state, fedauth info). Prevents a malicious server from causing
-        // unbounded memory allocation on the client before authentication completes.
+        // unbounded memory allocation via spoofed token length fields.
         internal const int MaxTokenDataLength = 1 << 20; // 1 MB
 
         // Maximum allowed data length for a DTC promote transaction propagation token.
         internal const int MaxPromoteTransactionLength = 1 << 16; // 64 KB
+
+        // Maximum valid wire size for datetime types (DateTimeOffset = 5 time + 3 date + 2 offset).
+        internal const int MaxDateTimeLength = 10;
 
         // Severity  0 - 10 indicates informational (non-error) messages
         // Severity 11 - 16 indicates errors that can be corrected by user (syntax errors, etc...)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -7138,6 +7138,10 @@ namespace Microsoft.Data.SqlClient
             return TdsOperationStatus.Done;
         }
 
+        // length originates as a single byte on the wire (nullable datetime length prefix),
+        // but is kept as int to match the TDS parsing API surface where all lengths are int.
+        // Using byte here would require casts at all call sites and silently truncate values
+        // from the sql_variant path where lenData is computed arithmetically.
         private TdsOperationStatus TryReadSqlDateTime(SqlBuffer value, byte tdsType, int length, byte scale, TdsParserStateObject stateObj)
         {
             // DateTimeOffset is the largest datetime type at 10 bytes (5 time + 3 date + 2 offset).

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3854,10 +3854,11 @@ namespace Microsoft.Data.SqlClient
                     {
                         throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, (int)dataLen);
                     }
-                    byte[] data = new byte[dataLen];
-                    if (dataLen > 0)
+                    int dataLength = (int)dataLen;
+                    byte[] data = new byte[dataLength];
+                    if (dataLength > 0)
                     {
-                        result = stateObj.TryReadByteArray(data, (int)dataLen);
+                        result = stateObj.TryReadByteArray(data, dataLength);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -4932,16 +4932,19 @@ namespace Microsoft.Data.SqlClient
             }
 
             // always read as sql types
-            if (valLen > (ulong)int.MaxValue)
-            {
-                throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, int.MaxValue);
-            }
-
-            int intlen = (int)valLen;
+            int intlen;
 
             if (rec.metaType.IsPlp)
             {
                 intlen = int.MaxValue;    // If plp data, read it all
+            }
+            else if (valLen > (ulong)int.MaxValue)
+            {
+                throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, int.MaxValue);
+            }
+            else
+            {
+                intlen = (int)valLen;
             }
 
             if (rec.type == SqlDbTypeExtensions.Vector)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3852,7 +3852,7 @@ namespace Microsoft.Data.SqlClient
                     }
                     if (dataLen > (uint)TdsEnums.MaxTokenDataLength)
                     {
-                        throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, (int)dataLen);
+                        throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, dataLen);
                     }
                     int dataLength = (int)dataLen;
                     byte[] data = new byte[dataLength];

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -3348,6 +3348,10 @@ namespace Microsoft.Data.SqlClient
                             // new value has 4 byte length
                             return result;
                         }
+                        if (env._newLength < 0 || env._newLength > TdsEnums.MaxPromoteTransactionLength)
+                        {
+                            throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, env._newLength);
+                        }
                         // read new value with 4 byte length
                         env._newBinValue = new byte[env._newLength];
                         result = stateObj.TryReadByteArray(env._newBinValue, env._newLength);
@@ -3846,10 +3850,14 @@ namespace Microsoft.Data.SqlClient
                     {
                         return result;
                     }
+                    if (dataLen > (uint)TdsEnums.MaxTokenDataLength)
+                    {
+                        throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, (int)dataLen);
+                    }
                     byte[] data = new byte[dataLen];
                     if (dataLen > 0)
                     {
-                        result = stateObj.TryReadByteArray(data, checked((int)dataLen));
+                        result = stateObj.TryReadByteArray(data, (int)dataLen);
                         if (result != TdsOperationStatus.Done)
                         {
                             return result;
@@ -4169,6 +4177,10 @@ namespace Microsoft.Data.SqlClient
             {
                 throw SQL.ParsingErrorLength(ParsingErrorState.SessionStateLengthTooShort, length);
             }
+            if (length > TdsEnums.MaxTokenDataLength)
+            {
+                throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, length);
+            }
             uint seqNum;
             TdsOperationStatus result = stateObj.TryReadUInt32(out seqNum);
             if (result != TdsOperationStatus.Done)
@@ -4217,6 +4229,10 @@ namespace Microsoft.Data.SqlClient
                     {
                         return result;
                     }
+                }
+                if (stateLen < 0 || stateLen > TdsEnums.MaxTokenDataLength)
+                {
+                    throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, stateLen);
                 }
                 byte[] buffer = null;
                 lock (sdata._delta)
@@ -4434,6 +4450,10 @@ namespace Microsoft.Data.SqlClient
                 // the token must at least contain a DWORD indicating the number of info IDs
                 SqlClientEventSource.Log.TryTraceEvent("<sc.TdsParser.TryProcessFedAuthInfo|ERR> FEDAUTHINFO token stream length too short for CountOfInfoIDs.");
                 throw SQL.ParsingErrorLength(ParsingErrorState.FedAuthInfoLengthTooShortForCountOfInfoIds, tokenLen);
+            }
+            if (tokenLen > TdsEnums.MaxTokenDataLength)
+            {
+                throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, tokenLen);
             }
 
             // read how many FedAuthInfo options there are
@@ -4912,9 +4932,12 @@ namespace Microsoft.Data.SqlClient
             }
 
             // always read as sql types
-            Debug.Assert(valLen < (ulong)(int.MaxValue), "ProcessReturnValue received data size > 2Gb");
+            if (valLen > (ulong)int.MaxValue)
+            {
+                throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, int.MaxValue);
+            }
 
-            int intlen = valLen > (ulong)(int.MaxValue) ? int.MaxValue : (int)valLen;
+            int intlen = (int)valLen;
 
             if (rec.metaType.IsPlp)
             {
@@ -7113,7 +7136,15 @@ namespace Microsoft.Data.SqlClient
 
         private TdsOperationStatus TryReadSqlDateTime(SqlBuffer value, byte tdsType, int length, byte scale, TdsParserStateObject stateObj)
         {
-            Span<byte> datetimeBuffer = ((uint)length <= 16) ? stackalloc byte[16] : new byte[length];
+            // DateTimeOffset is the largest datetime type at 10 bytes (5 time + 3 date + 2 offset).
+            // Reject anything larger to prevent heap allocation from spoofed metadata.
+            const int MaxDateTimeLength = 10;
+            if (length < 0 || length > MaxDateTimeLength)
+            {
+                throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, length);
+            }
+
+            Span<byte> datetimeBuffer = stackalloc byte[MaxDateTimeLength];
 
             TdsOperationStatus result = stateObj.TryReadByteArray(datetimeBuffer, length);
             if (result != TdsOperationStatus.Done)
@@ -7369,7 +7400,10 @@ namespace Microsoft.Data.SqlClient
                 case TdsEnums.SQLVECTOR:
                     {
                         // Note: Better not come here with plp data!!
-                        Debug.Assert(length <= TdsEnums.MAXSIZE);
+                        if (length < 0 || length > TdsEnums.MAXSIZE)
+                        {
+                            throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, length);
+                        }
                         result = stateObj.TryReadByteArrayWithContinue(length, isPlp: false, out byte[] b);
                         if (result != TdsOperationStatus.Done)
                         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -4940,7 +4940,7 @@ namespace Microsoft.Data.SqlClient
             }
             else if (valLen > (ulong)int.MaxValue)
             {
-                throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, int.MaxValue);
+                throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, unchecked((int)valLen));
             }
             else
             {
@@ -7141,13 +7141,12 @@ namespace Microsoft.Data.SqlClient
         {
             // DateTimeOffset is the largest datetime type at 10 bytes (5 time + 3 date + 2 offset).
             // Reject anything larger to prevent heap allocation from spoofed metadata.
-            const int MaxDateTimeLength = 10;
-            if (length < 0 || length > MaxDateTimeLength)
+            if (length < 0 || length > TdsEnums.MaxDateTimeLength)
             {
                 throw SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, length);
             }
 
-            Span<byte> datetimeBuffer = stackalloc byte[MaxDateTimeLength];
+            Span<byte> datetimeBuffer = stackalloc byte[TdsEnums.MaxDateTimeLength];
 
             TdsOperationStatus result = stateObj.TryReadByteArray(datetimeBuffer, length);
             if (result != TdsOperationStatus.Done)

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionEnhancedRoutingTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionEnhancedRoutingTests.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
 /// <summary>
 /// Tests connection routing using the enhanced routing feature extension and envchange token
 /// </summary>
+// TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
+// need since each test uses its own TDS Server with ephemeral listen port.
 [Collection("SimulatedServerTests")]
 public class ConnectionEnhancedRoutingTests
 {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionFailoverTests.cs
@@ -12,6 +12,8 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
+    // TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
+    // need since each test uses its own TDS Server with ephemeral listen port.
     [Collection("SimulatedServerTests")]
     public class ConnectionFailoverTests
     {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionReadOnlyRoutingTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionReadOnlyRoutingTests.cs
@@ -11,6 +11,8 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
+    // TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
+    // need since each test uses its own TDS Server with ephemeral listen port.
     [Collection("SimulatedServerTests")]
     public class ConnectionReadOnlyRoutingTests
     {
@@ -71,7 +73,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                     router.Start();
                     routingLayers.Push(router);
                     lastEndpoint = router.EndPoint;
-                    lastConnectionString = (new SqlConnectionStringBuilder() { 
+                    lastConnectionString = (new SqlConnectionStringBuilder() {
                         DataSource = $"localhost,{lastEndpoint.Port}",
                         ApplicationIntent = ApplicationIntent.ReadOnly,
                         Encrypt = false
@@ -114,8 +116,8 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
                     router.Start();
                     routingLayers.Push(router);
                     lastEndpoint = router.EndPoint;
-                    lastConnectionString = (new SqlConnectionStringBuilder() { 
-                        DataSource = $"localhost,{lastEndpoint.Port}", 
+                    lastConnectionString = (new SqlConnectionStringBuilder() {
+                        DataSource = $"localhost,{lastEndpoint.Port}",
                         ApplicationIntent = ApplicationIntent.ReadOnly,
                         Encrypt = false
                     }).ConnectionString;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTests.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
+    // TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
+    // need since each test uses its own TDS Server with ephemeral listen port.
     [Collection("SimulatedServerTests")]
     public class ConnectionRoutingTests
     {
@@ -194,7 +196,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             // Act
             var e = Assert.Throws<SqlException>(connection.Open);
 
-            // Assert 
+            // Assert
             Assert.Equal(ConnectionState.Closed, connection.State);
             Assert.Contains("Connection Timeout Expired", e.Message);
         }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTestsAzure.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/ConnectionRoutingTestsAzure.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
 {
+    // TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
+    // need since each test uses its own TDS Server with ephemeral listen port.
     [Collection("SimulatedServerTests")]
     public class ConnectionRoutingTestsAzure : IDisposable
     {
@@ -21,8 +23,8 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             adpHelper.AddAzureSqlServerEndpoint("localhost");
         }
 
-        public void Dispose() 
-        { 
+        public void Dispose()
+        {
             adpHelper.Dispose();
         }
 
@@ -192,7 +194,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests
             // Act
             var e = Assert.Throws<SqlException>(connection.Open);
 
-            // Assert 
+            // Assert
             Assert.Equal(ConnectionState.Closed, connection.State);
             Assert.Contains("Connection Timeout Expired", e.Message);
         }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtAckBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtAckBoundsTests.cs
@@ -18,15 +18,19 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
 /// with data lengths exceeding protocol-reasonable bounds. This prevents a
 /// malicious server from causing unbounded memory allocation on the client.
 /// </summary>
+// TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
+// need since each test uses its own TDS Server with ephemeral listen port.
 [Collection("SimulatedServerTests")]
-public class FeatureExtAckBoundsTests : IClassFixture<TdsServerFixture>
+public class FeatureExtAckBoundsTests : IDisposable
 {
+    private readonly TdsServerFixture _fixture;
     private readonly TdsServer _server;
     private readonly string _connectionString;
 
-    public FeatureExtAckBoundsTests(TdsServerFixture fixture)
+    public FeatureExtAckBoundsTests()
     {
-        _server = fixture.TdsServer;
+        _fixture = new TdsServerFixture();
+        _server = _fixture.TdsServer;
         SqlConnectionStringBuilder builder = new()
         {
             DataSource = $"localhost,{_server.EndPoint.Port}",
@@ -35,6 +39,8 @@ public class FeatureExtAckBoundsTests : IClassFixture<TdsServerFixture>
         };
         _connectionString = builder.ConnectionString;
     }
+
+    public void Dispose() => _fixture.Dispose();
 
     /// <summary>
     /// Verifies that the TDS parser rejects a FeatureExtAck token whose data length
@@ -67,21 +73,14 @@ public class FeatureExtAckBoundsTests : IClassFixture<TdsServerFixture>
                 claimedDataLen: (uint)(TdsEnums.MaxTokenDataLength + 1)));
         };
 
-        try
-        {
-            // Act & Assert: connection should fail with a parsing error, NOT an OutOfMemoryException
-            using SqlConnection connection = new(_connectionString);
-            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        // Act & Assert: connection should fail with a parsing error, NOT an OutOfMemoryException
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
 
-            // The exception message should indicate a corrupted TDS stream (parsing error state 18)
-            // with the oversized length value, not an OOM from attempting the allocation.
-            Assert.Contains("18", ex.Message); // ParsingErrorState.CorruptedTdsStream = 18
-            Assert.Contains((TdsEnums.MaxTokenDataLength + 1).ToString(), ex.Message);
-        }
-        finally
-        {
-            _server.OnAuthenticationResponseCompleted = null;
-        }
+        // The exception message should indicate a corrupted TDS stream
+        // with the oversized length value, not an OOM from attempting the allocation.
+        Assert.Contains("Error state: 18", ex.Message); // ParsingErrorState.CorruptedTdsStream = 18
+        Assert.Contains($"Length: {TdsEnums.MaxTokenDataLength + 1}", ex.Message);
     }
 
     /// <summary>
@@ -116,19 +115,11 @@ public class FeatureExtAckBoundsTests : IClassFixture<TdsServerFixture>
                 claimedDataLen: (uint)TdsEnums.MaxTokenDataLength));
         };
 
-        try
-        {
-            using SqlConnection connection = new(_connectionString);
-            // The connection will fail (insufficient data for the claimed length),
-            // but the failure must NOT be the bounds check (state 18 with MaxTokenDataLength+1).
-            Exception ex = Assert.ThrowsAny<Exception>(connection.Open);
-            // Confirm it's NOT the bounds-check error (which would report MaxTokenDataLength+1)
-            Assert.DoesNotContain((TdsEnums.MaxTokenDataLength + 1).ToString(), ex.Message);
-        }
-        finally
-        {
-            _server.OnAuthenticationResponseCompleted = null;
-        }
+        using SqlConnection connection = new(_connectionString);
+        // The connection will fail (insufficient data for the claimed length),
+        // but the failure must NOT be the bounds-check error.
+        Exception ex = Assert.ThrowsAny<Exception>(connection.Open);
+        Assert.DoesNotContain("Error state: 18", ex.Message);
     }
 
     /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtAckBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtAckBoundsTests.cs
@@ -78,44 +78,50 @@ public class FeatureExtAckBoundsTests : IClassFixture<TdsServerFixture>
     }
 
     /// <summary>
-    /// Verifies that a FeatureExtAck token with a data length at or below the
+    /// Verifies that a FeatureExtAck token with a data length at exactly the
     /// allowed maximum is accepted without error, confirming there is no
     /// off-by-one in the bounds check.
     /// </summary>
     [Fact]
     public void FeatureExtAck_MaxAllowedDataLength_DoesNotThrow()
     {
-        // Arrange: inject a FeatureExtAck token at exactly the maximum allowed size.
-        // We use a small real payload to avoid actually allocating 1 MB in the test;
-        // the server will write a data length that equals the actual data length.
-        // This verifies that the boundary value is accepted (not off-by-one).
-        byte[] legitimateData = new byte[] { 0x01 }; // 1-byte GlobalTransactions ack
-
+        // Arrange: inject a FeatureExtAck token whose declared data length equals
+        // MaxTokenDataLength exactly. The bounds check should NOT fire for this
+        // value. The connection will fail for other reasons (not enough data on
+        // the wire), but the error must NOT be state 18 (CorruptedTdsStream).
         _server.OnAuthenticationResponseCompleted = responseMessage =>
         {
-            // Find existing FeatureExtAck or create one
             var existing = responseMessage.OfType<TDSFeatureExtAckToken>().FirstOrDefault();
-            if (existing == null)
+            if (existing != null)
             {
-                int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
-                if (doneIndex < 0)
-                {
-                    doneIndex = responseMessage.Count;
-                }
-
-                var token = new TDSFeatureExtAckToken(
-                    new TDSFeatureExtAckGenericOption(
-                        (TDSFeatureID)TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS,
-                        (uint)legitimateData.Length,
-                        legitimateData));
-                responseMessage.Insert(doneIndex, token);
+                responseMessage.Remove(existing);
             }
+
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            // Insert token with dataLen = MaxTokenDataLength (at boundary, not over)
+            responseMessage.Insert(doneIndex, new MaliciousFeatureExtAckToken(
+                featureId: (TDSFeatureID)TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS,
+                claimedDataLen: (uint)TdsEnums.MaxTokenDataLength));
         };
 
-        // Act & Assert: connection should open successfully
-        using SqlConnection connection = new(_connectionString);
-        connection.Open();
-        Assert.Equal(System.Data.ConnectionState.Open, connection.State);
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            // The connection will fail (insufficient data for the claimed length),
+            // but the failure must NOT be the bounds check (state 18 with MaxTokenDataLength+1).
+            Exception ex = Assert.ThrowsAny<Exception>(connection.Open);
+            // Confirm it's NOT the bounds-check error (which would report MaxTokenDataLength+1)
+            Assert.DoesNotContain((TdsEnums.MaxTokenDataLength + 1).ToString(), ex.Message);
+        }
+        finally
+        {
+            _server.OnAuthenticationResponseCompleted = null;
+        }
     }
 
     /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtAckBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtAckBoundsTests.cs
@@ -67,14 +67,21 @@ public class FeatureExtAckBoundsTests : IClassFixture<TdsServerFixture>
                 claimedDataLen: (uint)(TdsEnums.MaxTokenDataLength + 1)));
         };
 
-        // Act & Assert: connection should fail with a parsing error, NOT an OutOfMemoryException
-        using SqlConnection connection = new(_connectionString);
-        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        try
+        {
+            // Act & Assert: connection should fail with a parsing error, NOT an OutOfMemoryException
+            using SqlConnection connection = new(_connectionString);
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
 
-        // The exception message should indicate a corrupted TDS stream (parsing error state 18)
-        // with the oversized length value, not an OOM from attempting the allocation.
-        Assert.Contains("18", ex.Message); // ParsingErrorState.CorruptedTdsStream = 18
-        Assert.Contains((TdsEnums.MaxTokenDataLength + 1).ToString(), ex.Message);
+            // The exception message should indicate a corrupted TDS stream (parsing error state 18)
+            // with the oversized length value, not an OOM from attempting the allocation.
+            Assert.Contains("18", ex.Message); // ParsingErrorState.CorruptedTdsStream = 18
+            Assert.Contains((TdsEnums.MaxTokenDataLength + 1).ToString(), ex.Message);
+        }
+        finally
+        {
+            _server.OnAuthenticationResponseCompleted = null;
+        }
     }
 
     /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtAckBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtAckBoundsTests.cs
@@ -1,0 +1,159 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.SqlServer.TDS;
+using Microsoft.SqlServer.TDS.FeatureExtAck;
+using Microsoft.SqlServer.TDS.Servers;
+using TDSDoneToken = global::Microsoft.SqlServer.TDS.Done.TDSDoneToken;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
+
+/// <summary>
+/// Tests that the TDS parser rejects feature extension acknowledgment tokens
+/// with data lengths exceeding protocol-reasonable bounds. This prevents a
+/// malicious server from causing unbounded memory allocation on the client.
+/// </summary>
+[Collection("SimulatedServerTests")]
+public class FeatureExtAckBoundsTests : IClassFixture<TdsServerFixture>
+{
+    private readonly TdsServer _server;
+    private readonly string _connectionString;
+
+    public FeatureExtAckBoundsTests(TdsServerFixture fixture)
+    {
+        _server = fixture.TdsServer;
+        SqlConnectionStringBuilder builder = new()
+        {
+            DataSource = $"localhost,{_server.EndPoint.Port}",
+            Encrypt = SqlConnectionEncryptOption.Optional,
+            Pooling = false
+        };
+        _connectionString = builder.ConnectionString;
+    }
+
+    /// <summary>
+    /// Verifies that the TDS parser rejects a FeatureExtAck token whose data length
+    /// field exceeds <see cref="TdsEnums.MaxTokenDataLength"/> (1 MB), throwing a
+    /// parsing error instead of attempting an unbounded heap allocation.
+    /// This guards against CVE denial-of-service via pre-auth memory exhaustion.
+    /// </summary>
+    [Fact]
+    public void FeatureExtAck_OversizedDataLength_ThrowsParsingError()
+    {
+        // Arrange: inject a malicious FeatureExtAck token with an absurdly large data length
+        _server.OnAuthenticationResponseCompleted = responseMessage =>
+        {
+            // Remove any existing FeatureExtAck token
+            var existing = responseMessage.OfType<TDSFeatureExtAckToken>().FirstOrDefault();
+            if (existing != null)
+            {
+                responseMessage.Remove(existing);
+            }
+
+            // Insert a malicious token with oversized data length before the DONE token
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            responseMessage.Insert(doneIndex, new MaliciousFeatureExtAckToken(
+                featureId: (TDSFeatureID)TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS,
+                claimedDataLen: (uint)(TdsEnums.MaxTokenDataLength + 1)));
+        };
+
+        // Act & Assert: connection should fail with a parsing error, NOT an OutOfMemoryException
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+
+        // The exception message should indicate a corrupted TDS stream (parsing error state 18)
+        // with the oversized length value, not an OOM from attempting the allocation.
+        Assert.Contains("18", ex.Message); // ParsingErrorState.CorruptedTdsStream = 18
+        Assert.Contains((TdsEnums.MaxTokenDataLength + 1).ToString(), ex.Message);
+    }
+
+    /// <summary>
+    /// Verifies that a FeatureExtAck token with a data length at or below the
+    /// allowed maximum is accepted without error, confirming there is no
+    /// off-by-one in the bounds check.
+    /// </summary>
+    [Fact]
+    public void FeatureExtAck_MaxAllowedDataLength_DoesNotThrow()
+    {
+        // Arrange: inject a FeatureExtAck token at exactly the maximum allowed size.
+        // We use a small real payload to avoid actually allocating 1 MB in the test;
+        // the server will write a data length that equals the actual data length.
+        // This verifies that the boundary value is accepted (not off-by-one).
+        byte[] legitimateData = new byte[] { 0x01 }; // 1-byte GlobalTransactions ack
+
+        _server.OnAuthenticationResponseCompleted = responseMessage =>
+        {
+            // Find existing FeatureExtAck or create one
+            var existing = responseMessage.OfType<TDSFeatureExtAckToken>().FirstOrDefault();
+            if (existing == null)
+            {
+                int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+                if (doneIndex < 0)
+                {
+                    doneIndex = responseMessage.Count;
+                }
+
+                var token = new TDSFeatureExtAckToken(
+                    new TDSFeatureExtAckGenericOption(
+                        (TDSFeatureID)TdsEnums.FEATUREEXT_GLOBALTRANSACTIONS,
+                        (uint)legitimateData.Length,
+                        legitimateData));
+                responseMessage.Insert(doneIndex, token);
+            }
+        };
+
+        // Act & Assert: connection should open successfully
+        using SqlConnection connection = new(_connectionString);
+        connection.Open();
+        Assert.Equal(System.Data.ConnectionState.Open, connection.State);
+    }
+
+    /// <summary>
+    /// A custom TDS packet token that writes a FEATUREEXTACK token with a fraudulently
+    /// large data length field. This simulates a malicious server attempting to cause
+    /// the client to allocate an unbounded byte array.
+    /// </summary>
+    private sealed class MaliciousFeatureExtAckToken : TDSPacketToken
+    {
+        private readonly TDSFeatureID _featureId;
+        private readonly uint _claimedDataLen;
+
+        public MaliciousFeatureExtAckToken(TDSFeatureID featureId, uint claimedDataLen)
+        {
+            _featureId = featureId;
+            _claimedDataLen = claimedDataLen;
+        }
+
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // Write the FEATUREEXTACK token type (0xAE)
+            destination.WriteByte((byte)TDSTokenType.FeatureExtAck);
+
+            // Write the feature ID byte
+            destination.WriteByte((byte)_featureId);
+
+            // Write the claimed data length (uint32, little-endian) — this is the lie
+            byte[] lenBytes = BitConverter.GetBytes(_claimedDataLen);
+            destination.Write(lenBytes, 0, 4);
+
+            // Write only 1 byte of actual data (the client will try to read _claimedDataLen bytes
+            // but we only provide 1 — the bounds check should fire before the read attempt)
+            destination.WriteByte(0x01);
+
+            // Write terminator
+            destination.WriteByte((byte)TDSFeatureID.Terminator);
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtensionNegotiationTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/FeatureExtensionNegotiationTests.cs
@@ -13,6 +13,8 @@ using Xunit;
 
 namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
 
+// Serializes execution with other SimulatedServerTests classes to avoid port/resource conflicts.
+// Required here because IClassFixture shares a single TdsServer instance across all tests in this class.
 [Collection("SimulatedServerTests")]
 public class FeatureExtensionNegotiationTests : IClassFixture<TdsServerFixture>
 {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
@@ -821,6 +821,112 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
         }
     }
 
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 10: Post-login batch response — sql_variant with oversized binary
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>TryReadSqlValueInternal</c> rejects a binary value inside
+    /// a sql_variant column whose inner data length exceeds
+    /// <see cref="TdsEnums.MAXSIZE"/> (8000 bytes). The bounds check in the
+    /// sql_variant deserialization path prevents unbounded heap allocation.
+    /// </summary>
+    [Fact]
+    public void BatchResponse_SqlVariantBinary_OversizedLength_ThrowsParsingError()
+    {
+        _server.OnSQLBatchCompleted = responseMessage =>
+        {
+            responseMessage.Clear();
+
+            // COLMETADATA: one SSVariant column
+            var metadata = new TDSColMetadataToken();
+            var col = new TDSColumnData();
+            col.DataType = TDSDataType.SSVariant;
+            col.DataTypeSpecific = (uint)8009; // max length for SSVariant
+            col.Flags.IsNullable = true;
+            col.Name = string.Empty;
+            metadata.Columns.Add(col);
+            responseMessage.Add(metadata);
+
+            // ROW with a sql_variant containing oversized binary data
+            responseMessage.Add(new MaliciousSqlVariantBinaryRowToken());
+
+            // DONE
+            responseMessage.Add(new TDSDoneToken(TDSDoneTokenStatusType.Final | TDSDoneTokenStatusType.Count, TDSDoneTokenCommandType.Select, 1));
+        };
+
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            connection.Open();
+
+            using SqlCommand command = connection.CreateCommand();
+            command.CommandText = "MALICIOUS_QUERY_NOT_RECOGNIZED";
+
+            SqlDataReader reader = command.ExecuteReader();
+            try
+            {
+                Assert.True(reader.Read());
+                Exception ex = Assert.ThrowsAny<InvalidOperationException>(
+                    () => reader.GetValue(0));
+                Assert.Contains("18", ex.Message); // CorruptedTdsStream
+            }
+            finally
+            {
+                using (new DebugAssertSuppressor())
+                {
+                    try { reader.Dispose(); } catch { }
+                }
+            }
+        }
+        finally
+        {
+            _server.OnSQLBatchCompleted = null;
+        }
+    }
+
+    /// <summary>
+    /// Writes a ROW token (0xD1) with a single SSVariant column containing a
+    /// BigVarBinary variant whose inner data length exceeds MAXSIZE (8000).
+    /// Wire layout for the variant:
+    ///   [int32] total variant length = 8005
+    ///   [byte] inner type = 0xA5 (BigVarBinary)
+    ///   [byte] cbPropBytes = 2
+    ///   [ushort] maxLen (property) = 8001
+    ///   [8001 bytes would be data, but we only write 4 to trigger the check]
+    /// lenData = 8005 - 2(SQLVARIANT_SIZE) - 2(cbProps) = 8001 > MAXSIZE → throws
+    /// </summary>
+    private sealed class MaliciousSqlVariantBinaryRowToken : TDSPacketToken
+    {
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // ROW token type
+            destination.WriteByte(0xD1);
+
+            // SSVariant column data: total length (int32 LE)
+            // lenData = totalLength - SQLVARIANT_SIZE(2) - cbPropBytes(2) = totalLength - 4
+            // We want lenData = 8001, so totalLength = 8005
+            int totalLength = 8005;
+            byte[] lenBytes = BitConverter.GetBytes(totalLength);
+            destination.Write(lenBytes, 0, 4);
+
+            // Inner type: BigVarBinary = 0xA5
+            destination.WriteByte(0xA5);
+
+            // cbPropBytes = 2
+            destination.WriteByte(0x02);
+
+            // Properties: maxLen (ushort) = 8001
+            destination.WriteByte(0x41); // 8001 & 0xFF = 0x41
+            destination.WriteByte(0x1F); // 8001 >> 8 = 0x1F
+
+            // Write 4 bytes of dummy data (bounds check fires before trying to read 8001)
+            destination.Write(new byte[4], 0, 4);
+        }
+    }
+
     /// <summary>
     /// Temporarily suppresses Debug.Assert failures by clearing trace listeners.
     /// Used when disposing resources after intentionally corrupting a TDS stream.

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
@@ -168,6 +168,38 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
         Assert.Contains("18", ex.Message); // CorruptedTdsStream
     }
 
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 5: ENV_PROMOTETRANSACTION with oversized newLength
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>TryProcessEnvChange</c> rejects a PromoteTransaction
+    /// environment change token (type 15) whose inner <c>newLength</c> field exceeds
+    /// <see cref="TdsEnums.MaxPromoteTransactionLength"/> (64 KB). A malicious server
+    /// can set the outer uint16 token length to a small value while writing an
+    /// int32 inner length claiming gigabytes, causing unbounded allocation.
+    /// </summary>
+    [Fact]
+    public void EnvChange_PromoteTransaction_OversizedLength_ThrowsParsingError()
+    {
+        _server.OnAuthenticationResponseCompleted = responseMessage =>
+        {
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            // Inject a PromoteTransaction env change with a fraudulently large newLength
+            responseMessage.Insert(doneIndex, new MaliciousPromoteTransactionEnvChangeToken(
+                claimedNewLength: TdsEnums.MaxPromoteTransactionLength + 1));
+        };
+
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("18", ex.Message); // CorruptedTdsStream
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     // Malicious token helpers
     // ══════════════════════════════════════════════════════════════════════════
@@ -339,6 +371,51 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
             // Write minimal data (at least sizeof(uint) to pass the lower bound check,
             // but the upper bound check should fire first)
             destination.Write(new byte[] { 0x01, 0x00, 0x00, 0x00 }, 0, 4); // optionsCount = 1
+        }
+    }
+
+    /// <summary>
+    /// Writes an EnvChange token (0xE3) with type PromoteTransaction (15) whose
+    /// inner int32 newLength exceeds <see cref="TdsEnums.MaxPromoteTransactionLength"/>.
+    /// Wire format: [0xE3][uint16 tokenLen][byte type=15][int32 newLen][data...][byte oldLen=0]
+    /// The outer uint16 tokenLen is set to accommodate the header but the int32
+    /// newLength claims far more data than actually follows, triggering the bounds check.
+    /// </summary>
+    private sealed class MaliciousPromoteTransactionEnvChangeToken : TDSPacketToken
+    {
+        private readonly int _claimedNewLength;
+
+        public MaliciousPromoteTransactionEnvChangeToken(int claimedNewLength)
+        {
+            _claimedNewLength = claimedNewLength;
+        }
+
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // Token type: ENVCHANGE
+            destination.WriteByte((byte)TDSTokenType.EnvironmentChange); // 0xE3
+
+            // Outer token length (uint16): type(1) + newLength(4) + 1 byte data + oldLength(1)
+            // We write just enough to contain the header fields the parser reads before
+            // hitting the bounds check. The parser reads: type(1) + int32 newLen(4) = 5 bytes min.
+            ushort outerLength = 1 + 4 + 1 + 1; // type + newLen + 1 fake byte + oldLen
+            byte[] outerLenBytes = BitConverter.GetBytes(outerLength);
+            destination.Write(outerLenBytes, 0, 2);
+
+            // Env change type: PromoteTransaction = 15
+            destination.WriteByte(15);
+
+            // newLength (int32) — fraudulently large
+            byte[] newLenBytes = BitConverter.GetBytes(_claimedNewLength);
+            destination.Write(newLenBytes, 0, 4);
+
+            // Write 1 byte of fake data (the bounds check fires before attempting to read this much)
+            destination.WriteByte(0x00);
+
+            // Old value length (byte) = 0
+            destination.WriteByte(0x00);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
@@ -20,15 +20,19 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
 /// exceeding protocol-reasonable bounds, preventing unbounded memory allocation
 /// from a malicious server.
 /// </summary>
+// TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
+// need since each test uses its own TDS Server with ephemeral listen port.
 [Collection("SimulatedServerTests")]
-public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
+public class TdsTokenBoundsTests : IDisposable
 {
+    private readonly TdsServerFixture _fixture;
     private readonly TdsServer _server;
     private readonly string _connectionString;
 
-    public TdsTokenBoundsTests(TdsServerFixture fixture)
+    public TdsTokenBoundsTests()
     {
-        _server = fixture.TdsServer;
+        _fixture = new TdsServerFixture();
+        _server = _fixture.TdsServer;
         SqlConnectionStringBuilder builder = new()
         {
             DataSource = $"localhost,{_server.EndPoint.Port}",
@@ -37,6 +41,8 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
         };
         _connectionString = builder.ConnectionString;
     }
+
+    public void Dispose() => _fixture.Dispose();
 
     // ──────────────────────────────────────────────────────────────────────────
     // Test 1: SessionState token with oversized total length
@@ -63,16 +69,10 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
                 claimedTotalLength: (uint)(TdsEnums.MaxTokenDataLength + 1)));
         };
 
-        try
-        {
-            using SqlConnection connection = new(_connectionString);
-            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
-            Assert.Contains("18", ex.Message); // CorruptedTdsStream
-        }
-        finally
-        {
-            _server.OnAuthenticationResponseCompleted = null;
-        }
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+        Assert.Contains($"Length: {TdsEnums.MaxTokenDataLength + 1}", ex.Message);
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -101,16 +101,42 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
                 innerClaimedLength: TdsEnums.MaxTokenDataLength + 1));
         };
 
-        try
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+        Assert.Contains($"Length: {TdsEnums.MaxTokenDataLength + 1}", ex.Message);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 2b: SessionState token with negative inner option length
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>TryProcessSessionState</c> rejects an individual session state
+    /// option whose inner data length (encoded via the 0xFF + DWORD path) is negative,
+    /// which would be interpreted as a huge unsigned value if not bounds-checked.
+    /// </summary>
+    [Fact]
+    public void SessionState_NegativeInnerOptionLength_ThrowsParsingError()
+    {
+        _server.OnAuthenticationResponseCompleted = responseMessage =>
         {
-            using SqlConnection connection = new(_connectionString);
-            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
-            Assert.Contains("18", ex.Message); // CorruptedTdsStream
-        }
-        finally
-        {
-            _server.OnAuthenticationResponseCompleted = null;
-        }
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            // Inject a SessionState token with an inner state option claiming
+            // a negative data length (-1 = 0xFFFFFFFF as uint32)
+            responseMessage.Insert(doneIndex, new MaliciousSessionStateInnerLenToken(
+                innerClaimedLength: -1));
+        };
+
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+        Assert.Contains("Length: -1", ex.Message);
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -146,16 +172,10 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
             responseMessage.Insert(doneIndex, new MaliciousSRecoveryFeatureExtAckToken());
         };
 
-        try
-        {
-            using SqlConnection connection = new(_connectionString);
-            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
-            Assert.Contains("18", ex.Message); // CorruptedTdsStream
-        }
-        finally
-        {
-            _server.OnAuthenticationResponseCompleted = null;
-        }
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+        Assert.Contains("Length: 999", ex.Message);
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -185,16 +205,10 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
                 claimedLength: TdsEnums.MaxTokenDataLength + 1));
         };
 
-        try
-        {
-            using SqlConnection connection = new(_connectionString);
-            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
-            Assert.Contains("18", ex.Message); // CorruptedTdsStream
-        }
-        finally
-        {
-            _server.OnAuthenticationResponseCompleted = null;
-        }
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+        Assert.Contains($"Length: {TdsEnums.MaxTokenDataLength + 1}", ex.Message);
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -224,16 +238,10 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
                 claimedNewLength: TdsEnums.MaxPromoteTransactionLength + 1));
         };
 
-        try
-        {
-            using SqlConnection connection = new(_connectionString);
-            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
-            Assert.Contains("18", ex.Message); // CorruptedTdsStream
-        }
-        finally
-        {
-            _server.OnAuthenticationResponseCompleted = null;
-        }
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+        Assert.Contains($"Length: {TdsEnums.MaxPromoteTransactionLength + 1}", ex.Message);
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -481,22 +489,16 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
                 claimedNewLength: TdsEnums.MaxPromoteTransactionLength + 1));
         };
 
-        try
-        {
-            using SqlConnection connection = new(_connectionString);
-            connection.Open();
+        using SqlConnection connection = new(_connectionString);
+        connection.Open();
 
-            using SqlCommand command = connection.CreateCommand();
-            command.CommandText = "SELECT 1";
+        using SqlCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
 
-            Exception ex = Assert.ThrowsAny<InvalidOperationException>(
-                () => command.ExecuteNonQuery());
-            Assert.Contains("18", ex.Message); // CorruptedTdsStream
-        }
-        finally
-        {
-            _server.OnSQLBatchCompleted = null;
-        }
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(
+            () => command.ExecuteNonQuery());
+        Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+        Assert.Contains($"Length: {TdsEnums.MaxPromoteTransactionLength + 1}", ex.Message);
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -535,37 +537,32 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
             responseMessage.Add(new TDSDoneToken(TDSDoneTokenStatusType.Final | TDSDoneTokenStatusType.Count, TDSDoneTokenCommandType.Select, 1));
         };
 
+        using SqlConnection connection = new(_connectionString);
+        connection.Open();
+
+        using SqlCommand command = connection.CreateCommand();
+        command.CommandText = "MALICIOUS_QUERY_NOT_RECOGNIZED";
+
+        SqlDataReader reader = command.ExecuteReader();
         try
         {
-            using SqlConnection connection = new(_connectionString);
-            connection.Open();
-
-            using SqlCommand command = connection.CreateCommand();
-            command.CommandText = "MALICIOUS_QUERY_NOT_RECOGNIZED";
-
-            SqlDataReader reader = command.ExecuteReader();
-            try
-            {
-                // Read() returns true (data is ready) but doesn't actually parse the
-                // column values — that happens on GetValue/GetTimeSpan. Force the read.
-                Assert.True(reader.Read());
-                Exception ex = Assert.ThrowsAny<InvalidOperationException>(
-                    () => reader.GetValue(0));
-                Assert.Contains("18", ex.Message); // CorruptedTdsStream
-            }
-            finally
-            {
-                // After corrupting the stream, dispose may trigger additional
-                // parsing errors. Suppress them for test stability.
-                using (new DebugAssertSuppressor())
-                {
-                    try { reader.Dispose(); } catch { }
-                }
-            }
+            // Read() returns true (data is ready) but doesn't actually parse the
+            // column values — that happens on GetValue/GetTimeSpan. Force the read.
+            Assert.True(reader.Read());
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(
+                () => reader.GetValue(0));
+            Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+            Assert.Contains("Length: 11", ex.Message);
         }
         finally
         {
-            _server.OnSQLBatchCompleted = null;
+            // Disposing the reader after a corrupted stream causes the driver to
+            // attempt further TDS parsing during teardown, which can trip unrelated
+            // Debug.Assert calls in TdsParser.
+            using (new DebugAssertSuppressor())
+            {
+                try { reader.Dispose(); } catch { }
+            }
         }
     }
 
@@ -615,24 +612,21 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
             responseMessage.Insert(doneIndex, new MaliciousReturnValueToken());
         };
 
-        try
-        {
-            using SqlConnection connection = new(_connectionString);
-            connection.Open();
+        using SqlConnection connection = new(_connectionString);
+        connection.Open();
 
-            using SqlCommand command = connection.CreateCommand();
-            command.CommandText = "SELECT 1";
+        using SqlCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
 
-            using (new DebugAssertSuppressor())
-            {
-                Exception ex = Assert.ThrowsAny<InvalidOperationException>(
-                    () => command.ExecuteNonQuery());
-                Assert.Contains("18", ex.Message); // CorruptedTdsStream
-            }
-        }
-        finally
+        // The malicious RETURNVALUE token corrupts parser state before the
+        // exception propagates. Suppress Debug.Assert calls that fire in
+        // TdsParser during error handling and connection teardown.
+        using (new DebugAssertSuppressor())
         {
-            _server.OnSQLBatchCompleted = null;
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(
+                () => command.ExecuteNonQuery());
+            Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+            Assert.Contains("Length: -1", ex.Message);
         }
     }
 
@@ -734,21 +728,14 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
             responseMessage.Insert(doneIndex, new ValidPlpReturnValueToken());
         };
 
-        try
-        {
-            using SqlConnection connection = new(_connectionString);
-            connection.Open();
+        using SqlConnection connection = new(_connectionString);
+        connection.Open();
 
-            using SqlCommand command = connection.CreateCommand();
-            command.CommandText = "SELECT 1";
+        using SqlCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT 1";
 
-            // Should NOT throw — PLP unknown-length sentinel is valid
-            command.ExecuteNonQuery();
-        }
-        finally
-        {
-            _server.OnSQLBatchCompleted = null;
-        }
+        // Should NOT throw — PLP unknown-length sentinel is valid
+        command.ExecuteNonQuery();
     }
 
     /// <summary>
@@ -855,33 +842,91 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
             responseMessage.Add(new TDSDoneToken(TDSDoneTokenStatusType.Final | TDSDoneTokenStatusType.Count, TDSDoneTokenCommandType.Select, 1));
         };
 
+        using SqlConnection connection = new(_connectionString);
+        connection.Open();
+
+        using SqlCommand command = connection.CreateCommand();
+        command.CommandText = "MALICIOUS_QUERY_NOT_RECOGNIZED";
+
+        SqlDataReader reader = command.ExecuteReader();
         try
         {
-            using SqlConnection connection = new(_connectionString);
-            connection.Open();
-
-            using SqlCommand command = connection.CreateCommand();
-            command.CommandText = "MALICIOUS_QUERY_NOT_RECOGNIZED";
-
-            SqlDataReader reader = command.ExecuteReader();
-            try
-            {
-                Assert.True(reader.Read());
-                Exception ex = Assert.ThrowsAny<InvalidOperationException>(
-                    () => reader.GetValue(0));
-                Assert.Contains("18", ex.Message); // CorruptedTdsStream
-            }
-            finally
-            {
-                using (new DebugAssertSuppressor())
-                {
-                    try { reader.Dispose(); } catch { }
-                }
-            }
+            Assert.True(reader.Read());
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(
+                () => reader.GetValue(0));
+            Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+            Assert.Contains("Length: 8001", ex.Message);
         }
         finally
         {
-            _server.OnSQLBatchCompleted = null;
+            // Disposing the reader after a corrupted stream causes the driver to
+            // attempt further TDS parsing during teardown, which can trip unrelated
+            // Debug.Assert calls in TdsParser.
+            using (new DebugAssertSuppressor())
+            {
+                try { reader.Dispose(); } catch { }
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 11: Post-login batch response — sql_variant with negative inner length
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>TryReadSqlValueInternal</c> rejects a sql_variant binary
+    /// value whose declared total length is too small for the type overhead,
+    /// causing the computed inner data length to be negative. The bounds check
+    /// <c>if (length &lt; 0 || length &gt; TdsEnums.MAXSIZE)</c> catches this.
+    /// </summary>
+    [Fact]
+    public void BatchResponse_SqlVariantBinary_NegativeLength_ThrowsParsingError()
+    {
+        _server.OnSQLBatchCompleted = responseMessage =>
+        {
+            responseMessage.Clear();
+
+            // COLMETADATA: one SSVariant column
+            var metadata = new TDSColMetadataToken();
+            var col = new TDSColumnData();
+            col.DataType = TDSDataType.SSVariant;
+            col.DataTypeSpecific = (uint)8009; // max length for SSVariant
+            col.Flags.IsNullable = true;
+            col.Name = string.Empty;
+            metadata.Columns.Add(col);
+            responseMessage.Add(metadata);
+
+            // ROW with a sql_variant claiming a total length too small for its overhead
+            responseMessage.Add(new NegativeLenSqlVariantBinaryRowToken());
+
+            // DONE
+            responseMessage.Add(new TDSDoneToken(TDSDoneTokenStatusType.Final | TDSDoneTokenStatusType.Count, TDSDoneTokenCommandType.Select, 1));
+        };
+
+        using SqlConnection connection = new(_connectionString);
+        connection.Open();
+
+        using SqlCommand command = connection.CreateCommand();
+        command.CommandText = "MALICIOUS_QUERY_NOT_RECOGNIZED";
+
+        SqlDataReader reader = command.ExecuteReader();
+        try
+        {
+            Assert.True(reader.Read());
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(
+                () => reader.GetValue(0));
+            Assert.Contains("Error state: 18", ex.Message); // CorruptedTdsStream
+            Assert.Contains("Length: -1", ex.Message);
+        }
+        finally
+        {
+            // Disposing the reader after a corrupted stream causes the driver to
+            // attempt further TDS parsing during teardown, which can trip unrelated
+            // Debug.Assert calls in TdsParser.
+            using (new DebugAssertSuppressor())
+            {
+                try { reader.Dispose(); } catch { }
+            }
         }
     }
 
@@ -924,6 +969,42 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
 
             // Write 4 bytes of dummy data (bounds check fires before trying to read 8001)
             destination.Write(new byte[4], 0, 4);
+        }
+    }
+
+    /// <summary>
+    /// Writes a ROW token (0xD1) with a single SSVariant column containing a
+    /// BigVarBinary variant whose total length (3) is too small to cover the
+    /// type overhead (SQLVARIANT_SIZE=2 + cbPropBytes=2 = 4), producing a
+    /// negative computed inner data length: lenData = 3 - 4 = -1.
+    /// </summary>
+    private sealed class NegativeLenSqlVariantBinaryRowToken : TDSPacketToken
+    {
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // ROW token type
+            destination.WriteByte(0xD1);
+
+            // SSVariant column data: total length (int32 LE)
+            // lenConsumed = SQLVARIANT_SIZE(2) + cbPropBytes(2) = 4
+            // lenData = totalLength - lenConsumed = 3 - 4 = -1 → triggers < 0 check
+            int totalLength = 3;
+            byte[] lenBytes = BitConverter.GetBytes(totalLength);
+            destination.Write(lenBytes, 0, 4);
+
+            // Inner type: BigVarBinary = 0xA5
+            destination.WriteByte(0xA5);
+
+            // cbPropBytes = 2
+            destination.WriteByte(0x02);
+
+            // Properties: maxLen (ushort) = 100 (arbitrary, just need 2 bytes)
+            destination.WriteByte(0x64); // 100 & 0xFF
+            destination.WriteByte(0x00); // 100 >> 8
+
+            // No data bytes — the bounds check fires before attempting to read
         }
     }
 

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Microsoft.SqlServer.TDS;
+using Microsoft.SqlServer.TDS.ColMetadata;
 using Microsoft.SqlServer.TDS.Done;
 using Microsoft.SqlServer.TDS.FeatureExtAck;
 using Microsoft.SqlServer.TDS.Servers;
@@ -62,9 +63,16 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
                 claimedTotalLength: (uint)(TdsEnums.MaxTokenDataLength + 1)));
         };
 
-        using SqlConnection connection = new(_connectionString);
-        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
-        Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+            Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        }
+        finally
+        {
+            _server.OnAuthenticationResponseCompleted = null;
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -93,9 +101,16 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
                 innerClaimedLength: TdsEnums.MaxTokenDataLength + 1));
         };
 
-        using SqlConnection connection = new(_connectionString);
-        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
-        Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+            Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        }
+        finally
+        {
+            _server.OnAuthenticationResponseCompleted = null;
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -131,9 +146,16 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
             responseMessage.Insert(doneIndex, new MaliciousSRecoveryFeatureExtAckToken());
         };
 
-        using SqlConnection connection = new(_connectionString);
-        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
-        Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+            Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        }
+        finally
+        {
+            _server.OnAuthenticationResponseCompleted = null;
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -163,9 +185,16 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
                 claimedLength: TdsEnums.MaxTokenDataLength + 1));
         };
 
-        using SqlConnection connection = new(_connectionString);
-        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
-        Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+            Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        }
+        finally
+        {
+            _server.OnAuthenticationResponseCompleted = null;
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -195,9 +224,16 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
                 claimedNewLength: TdsEnums.MaxPromoteTransactionLength + 1));
         };
 
-        using SqlConnection connection = new(_connectionString);
-        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
-        Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+            Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        }
+        finally
+        {
+            _server.OnAuthenticationResponseCompleted = null;
+        }
     }
 
     // ══════════════════════════════════════════════════════════════════════════
@@ -416,6 +452,162 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
 
             // Old value length (byte) = 0
             destination.WriteByte(0x00);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 6: Post-login batch response injection — PromoteTransaction
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that bounds checks fire during command execution (post-login)
+    /// by injecting a malicious PromoteTransaction env change token into the
+    /// SQL batch response. This exercises the <c>OnSQLBatchCompleted</c> hook
+    /// on the simulated server and proves the same bounds check fires regardless
+    /// of whether the token arrives during login or command execution.
+    /// </summary>
+    [Fact]
+    public void BatchResponse_PromoteTransaction_OversizedLength_ThrowsParsingError()
+    {
+        _server.OnSQLBatchCompleted = responseMessage =>
+        {
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            responseMessage.Insert(doneIndex, new MaliciousPromoteTransactionEnvChangeToken(
+                claimedNewLength: TdsEnums.MaxPromoteTransactionLength + 1));
+        };
+
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            connection.Open();
+
+            using SqlCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+
+            Exception ex = Assert.ThrowsAny<InvalidOperationException>(
+                () => command.ExecuteNonQuery());
+            Assert.Contains("18", ex.Message); // CorruptedTdsStream
+        }
+        finally
+        {
+            _server.OnSQLBatchCompleted = null;
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 7: Post-login batch response — DateTime oversized length
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>TryReadSqlDateTime</c> rejects a TIME column value whose
+    /// data length byte exceeds the maximum datetime wire size (10 bytes). A
+    /// malicious server could set this length to a large value, causing the
+    /// parser to attempt an oversized stackalloc.
+    /// </summary>
+    [Fact]
+    public void BatchResponse_DateTime_OversizedLength_ThrowsParsingError()
+    {
+        _server.OnSQLBatchCompleted = responseMessage =>
+        {
+            // Replace the entire response with a crafted result set containing
+            // a TIME column whose ROW data length exceeds the maximum.
+            responseMessage.Clear();
+
+            // Use proper library tokens for COLMETADATA so framing is correct
+            var metadata = new TDSColMetadataToken();
+            var col = new TDSColumnData();
+            col.DataType = TDSDataType.TimeN;
+            col.DataTypeSpecific = (byte)7; // scale = 7
+            col.Flags.IsNullable = true;
+            col.Name = string.Empty;
+            metadata.Columns.Add(col);
+            responseMessage.Add(metadata);
+
+            // Add a malicious ROW token with oversized data length
+            responseMessage.Add(new MaliciousTimeRowToken());
+
+            // Add DONE token
+            responseMessage.Add(new TDSDoneToken(TDSDoneTokenStatusType.Final | TDSDoneTokenStatusType.Count, TDSDoneTokenCommandType.Select, 1));
+        };
+
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            connection.Open();
+
+            using SqlCommand command = connection.CreateCommand();
+            command.CommandText = "MALICIOUS_QUERY_NOT_RECOGNIZED";
+
+            SqlDataReader reader = command.ExecuteReader();
+            try
+            {
+                // Read() returns true (data is ready) but doesn't actually parse the
+                // column values — that happens on GetValue/GetTimeSpan. Force the read.
+                Assert.True(reader.Read());
+                Exception ex = Assert.ThrowsAny<InvalidOperationException>(
+                    () => reader.GetValue(0));
+                Assert.Contains("18", ex.Message); // CorruptedTdsStream
+            }
+            finally
+            {
+                // After corrupting the stream, dispose may trigger additional
+                // parsing errors. Suppress them for test stability.
+                using (new DebugAssertSuppressor())
+                {
+                    try { reader.Dispose(); } catch { }
+                }
+            }
+        }
+        finally
+        {
+            _server.OnSQLBatchCompleted = null;
+        }
+    }
+
+    /// <summary>
+    /// Writes a ROW token (0xD1) with a single TimeN column whose data length
+    /// byte is set to 11 (exceeding the maximum datetime wire size of 10 bytes).
+    /// </summary>
+    private sealed class MaliciousTimeRowToken : TDSPacketToken
+    {
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // ROW token type
+            destination.WriteByte(0xD1);
+
+            // TimeN data: length prefix (1 byte) = 11 (INVALID — max for time is 5, max datetime overall is 10)
+            destination.WriteByte(11);
+
+            // Write 11 bytes of dummy data
+            destination.Write(new byte[11], 0, 11);
+        }
+    }
+
+    /// <summary>
+    /// Temporarily suppresses Debug.Assert failures by clearing trace listeners.
+    /// Used when disposing resources after intentionally corrupting a TDS stream.
+    /// </summary>
+    private sealed class DebugAssertSuppressor : IDisposable
+    {
+        private readonly System.Diagnostics.TraceListener[] _listeners;
+
+        public DebugAssertSuppressor()
+        {
+            _listeners = new System.Diagnostics.TraceListener[System.Diagnostics.Trace.Listeners.Count];
+            System.Diagnostics.Trace.Listeners.CopyTo(_listeners, 0);
+            System.Diagnostics.Trace.Listeners.Clear();
+        }
+
+        public void Dispose()
+        {
+            System.Diagnostics.Trace.Listeners.AddRange(_listeners);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
@@ -507,7 +507,7 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
     /// Verifies that <c>TryReadSqlDateTime</c> rejects a TIME column value whose
     /// data length byte exceeds the maximum datetime wire size (10 bytes). A
     /// malicious server could set this length to a large value, causing the
-    /// parser to attempt an oversized stackalloc.
+    /// parser to attempt an unbounded heap allocation.
     /// </summary>
     [Fact]
     public void BatchResponse_DateTime_OversizedLength_ThrowsParsingError()

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
@@ -590,6 +590,237 @@ public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
         }
     }
 
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 8: Post-login batch response — ReturnValue with oversized data length
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>TryProcessReturnValue</c> rejects a RETURNVALUE token (0xAC)
+    /// whose inner data length (for a non-PLP IMAGE type) exceeds int.MaxValue.
+    /// A malicious server can craft a TEXT/IMAGE return value with a spoofed int32
+    /// data length that becomes a huge value when cast to ulong, triggering unbounded
+    /// allocation.
+    /// </summary>
+    [Fact]
+    public void BatchResponse_ReturnValue_OversizedLength_ThrowsParsingError()
+    {
+        _server.OnSQLBatchCompleted = responseMessage =>
+        {
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            responseMessage.Insert(doneIndex, new MaliciousReturnValueToken());
+        };
+
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            connection.Open();
+
+            using SqlCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+
+            using (new DebugAssertSuppressor())
+            {
+                Exception ex = Assert.ThrowsAny<InvalidOperationException>(
+                    () => command.ExecuteNonQuery());
+                Assert.Contains("18", ex.Message); // CorruptedTdsStream
+            }
+        }
+        finally
+        {
+            _server.OnSQLBatchCompleted = null;
+        }
+    }
+
+    /// <summary>
+    /// Writes a RETURNVALUE token (0xAC) with an IMAGE (0x22) type whose data
+    /// length field is set to -1 (0xFFFFFFFF). When cast to ulong this exceeds
+    /// int.MaxValue, triggering the bounds check in TryProcessReturnValue.
+    /// Wire layout:
+    ///   [0xAC] token
+    ///   [uint16] ordinal
+    ///   [byte] param name length (0)
+    ///   [byte] status
+    ///   [uint32] user type
+    ///   [byte] flags1
+    ///   [byte] flags2
+    ///   [byte] tds type = 0x22 (IMAGE)
+    ///   [int32] max length
+    ///   [byte] textPtrLen = 16
+    ///   [16 bytes] textPtr
+    ///   [8 bytes] timestamp
+    ///   [int32] data length = -1 (INVALID)
+    /// </summary>
+    private sealed class MaliciousReturnValueToken : TDSPacketToken
+    {
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // RETURNVALUE token
+            destination.WriteByte(0xAC);
+
+            // Ordinal (uint16 LE)
+            destination.WriteByte(0x00);
+            destination.WriteByte(0x00);
+
+            // Param name length (byte) = 0
+            destination.WriteByte(0x00);
+
+            // Status (byte) = 0x01 (output parameter)
+            destination.WriteByte(0x01);
+
+            // UserType (uint32 LE) = 0
+            destination.Write(new byte[4], 0, 4);
+
+            // Flags byte 1 (ignored)
+            destination.WriteByte(0x00);
+
+            // Flags byte 2
+            destination.WriteByte(0x00);
+
+            // TDS type = SQLIMAGE (0x22)
+            destination.WriteByte(0x22);
+
+            // MaxLen (int32 LE) — for IMAGE this is read via TryGetTokenLength
+            // which for 0x22 reads int32. Value doesn't matter much, just needs
+            // to be valid for MetaType lookup.
+            destination.Write(new byte[] { 0x10, 0x00, 0x00, 0x00 }, 0, 4); // 16
+
+            // -- TryProcessColumnHeaderNoNBC: IsLong && !IsPlp path --
+            // TextPtr length (byte) = 16
+            destination.WriteByte(0x10);
+
+            // TextPtr data (16 bytes)
+            destination.Write(new byte[16], 0, 16);
+
+            // Timestamp (8 bytes)
+            destination.Write(new byte[8], 0, 8);
+
+            // Data length (int32 LE) = -1 (0xFFFFFFFF)
+            // (ulong)(-1) = 0xFFFFFFFFFFFFFFFF > int.MaxValue → triggers bounds check
+            destination.WriteByte(0xFF);
+            destination.WriteByte(0xFF);
+            destination.WriteByte(0xFF);
+            destination.WriteByte(0xFF);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 9: Post-login batch response — PLP ReturnValue (regression guard)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>TryProcessReturnValue</c> correctly handles PLP
+    /// (Partially Length-Prefixed) return values without triggering the bounds
+    /// check. PLP types use the unknown-length sentinel (0xFFFFFFFFFFFFFFFE)
+    /// which must NOT be rejected by the non-PLP bounds check.
+    /// </summary>
+    [Fact]
+    public void BatchResponse_ReturnValue_PlpUnknownLength_Succeeds()
+    {
+        _server.OnSQLBatchCompleted = responseMessage =>
+        {
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            responseMessage.Insert(doneIndex, new ValidPlpReturnValueToken());
+        };
+
+        try
+        {
+            using SqlConnection connection = new(_connectionString);
+            connection.Open();
+
+            using SqlCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+
+            // Should NOT throw — PLP unknown-length sentinel is valid
+            command.ExecuteNonQuery();
+        }
+        finally
+        {
+            _server.OnSQLBatchCompleted = null;
+        }
+    }
+
+    /// <summary>
+    /// Writes a valid RETURNVALUE token (0xAC) with a PLP VARBINARY(MAX) type
+    /// using the unknown-length sentinel (0xFFFFFFFFFFFFFFFE) followed by an
+    /// immediate PLP terminator (chunk length = 0). This exercises the IsPlp
+    /// branch in TryProcessReturnValue and must NOT trigger the bounds check.
+    /// Wire layout:
+    ///   [0xAC] token
+    ///   [uint16] ordinal
+    ///   [byte] param name length (0)
+    ///   [byte] status
+    ///   [uint32] user type
+    ///   [byte] flags1
+    ///   [byte] flags2
+    ///   [byte] tds type = 0xA5 (BIGVARBINARY)
+    ///   [uint16] max length = 0xFFFF (PLP marker)
+    ///   [uint64] PLP length = 0xFFFFFFFFFFFFFFFE (unknown)
+    ///   [uint32] chunk length = 0 (terminator)
+    /// </summary>
+    private sealed class ValidPlpReturnValueToken : TDSPacketToken
+    {
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // RETURNVALUE token
+            destination.WriteByte(0xAC);
+
+            // Ordinal (uint16 LE)
+            destination.WriteByte(0x00);
+            destination.WriteByte(0x00);
+
+            // Param name length (byte) = 0
+            destination.WriteByte(0x00);
+
+            // Status (byte) = 0x01 (output parameter)
+            destination.WriteByte(0x01);
+
+            // UserType (uint32 LE) = 0
+            destination.Write(new byte[4], 0, 4);
+
+            // Flags byte 1 (ignored)
+            destination.WriteByte(0x00);
+
+            // Flags byte 2
+            destination.WriteByte(0x00);
+
+            // TDS type = SQLBIGVARBINARY (0xA5)
+            destination.WriteByte(0xA5);
+
+            // MaxLen (uint16 LE) = 0xFFFF — PLP marker
+            destination.WriteByte(0xFF);
+            destination.WriteByte(0xFF);
+
+            // -- TryProcessColumnHeaderNoNBC: non-IsLong path --
+            // TryGetDataLength → TryReadPlpLength:
+            //   reads uint64 = 0xFFFFFFFFFFFFFFFE (unknown length sentinel)
+            destination.WriteByte(0xFE);
+            destination.WriteByte(0xFF);
+            destination.WriteByte(0xFF);
+            destination.WriteByte(0xFF);
+            destination.WriteByte(0xFF);
+            destination.WriteByte(0xFF);
+            destination.WriteByte(0xFF);
+            destination.WriteByte(0xFF);
+
+            // PLP chunk terminator (uint32 = 0) — empty data
+            destination.Write(new byte[4], 0, 4);
+        }
+    }
+
     /// <summary>
     /// Temporarily suppresses Debug.Assert failures by clearing trace listeners.
     /// Used when disposing resources after intentionally corrupting a TDS stream.

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
@@ -20,8 +20,9 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
 /// exceeding protocol-reasonable bounds, preventing unbounded memory allocation
 /// from a malicious server.
 /// </summary>
-// TODO: Do we need this collection?  It serializes all tests within it, which we probably don't
-// need since each test uses its own TDS Server with ephemeral listen port.
+// Serializes execution with other SimulatedServerTests classes.  Required here because
+// DebugAssertSuppressor mutates the global Trace.Listeners collection, which is not
+// safe to do concurrently with other tests that may trigger Debug.Assert.
 [Collection("SimulatedServerTests")]
 public class TdsTokenBoundsTests : IDisposable
 {
@@ -1009,15 +1010,18 @@ public class TdsTokenBoundsTests : IDisposable
     }
 
     /// <summary>
-    /// Temporarily suppresses Debug.Assert failures by clearing trace listeners.
-    /// Used when disposing resources after intentionally corrupting a TDS stream.
+    /// Temporarily suppresses Debug.Assert failures by clearing trace listeners.  Used when
+    /// disposing resources after intentionally corrupting a TDS stream.  A static lock serializes
+    /// access for the lifetime of the instance because Trace.Listeners is a global collection.
     /// </summary>
     private sealed class DebugAssertSuppressor : IDisposable
     {
+        private static readonly object s_listenerLock = new();
         private readonly System.Diagnostics.TraceListener[] _listeners;
 
         public DebugAssertSuppressor()
         {
+            System.Threading.Monitor.Enter(s_listenerLock);
             _listeners = new System.Diagnostics.TraceListener[System.Diagnostics.Trace.Listeners.Count];
             System.Diagnostics.Trace.Listeners.CopyTo(_listeners, 0);
             System.Diagnostics.Trace.Listeners.Clear();
@@ -1025,7 +1029,9 @@ public class TdsTokenBoundsTests : IDisposable
 
         public void Dispose()
         {
+            System.Diagnostics.Trace.Listeners.Clear();
             System.Diagnostics.Trace.Listeners.AddRange(_listeners);
+            System.Threading.Monitor.Exit(s_listenerLock);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
@@ -1,0 +1,344 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.SqlServer.TDS;
+using Microsoft.SqlServer.TDS.Done;
+using Microsoft.SqlServer.TDS.FeatureExtAck;
+using Microsoft.SqlServer.TDS.Servers;
+using Microsoft.SqlServer.TDS.SessionState;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
+
+/// <summary>
+/// Tests that the TDS parser rejects various token types with data lengths
+/// exceeding protocol-reasonable bounds, preventing unbounded memory allocation
+/// from a malicious server.
+/// </summary>
+[Collection("SimulatedServerTests")]
+public class TdsTokenBoundsTests : IClassFixture<TdsServerFixture>
+{
+    private readonly TdsServer _server;
+    private readonly string _connectionString;
+
+    public TdsTokenBoundsTests(TdsServerFixture fixture)
+    {
+        _server = fixture.TdsServer;
+        SqlConnectionStringBuilder builder = new()
+        {
+            DataSource = $"localhost,{_server.EndPoint.Port}",
+            Encrypt = SqlConnectionEncryptOption.Optional,
+            Pooling = false
+        };
+        _connectionString = builder.ConnectionString;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 1: SessionState token with oversized total length
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>TryProcessSessionState</c> rejects a SessionState token (0xE4)
+    /// whose total length field exceeds <see cref="TdsEnums.MaxTokenDataLength"/> (1 MB),
+    /// preventing unbounded memory allocation from a spoofed token length.
+    /// </summary>
+    [Fact]
+    public void SessionState_OversizedTotalLength_ThrowsParsingError()
+    {
+        _server.OnAuthenticationResponseCompleted = responseMessage =>
+        {
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            // Inject a SessionState token claiming a total length exceeding MaxTokenDataLength
+            responseMessage.Insert(doneIndex, new MaliciousSessionStateToken(
+                claimedTotalLength: (uint)(TdsEnums.MaxTokenDataLength + 1)));
+        };
+
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("18", ex.Message); // CorruptedTdsStream
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 2: SessionState token with oversized inner option length
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>TryProcessSessionState</c> rejects an individual session state
+    /// option whose inner data length (encoded via the 0xFF + DWORD path) exceeds
+    /// <see cref="TdsEnums.MaxTokenDataLength"/>, even when the outer token length is valid.
+    /// </summary>
+    [Fact]
+    public void SessionState_OversizedInnerOptionLength_ThrowsParsingError()
+    {
+        _server.OnAuthenticationResponseCompleted = responseMessage =>
+        {
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            // Inject a SessionState token with a valid outer length but an inner
+            // state option claiming a huge data length
+            responseMessage.Insert(doneIndex, new MaliciousSessionStateInnerLenToken(
+                innerClaimedLength: TdsEnums.MaxTokenDataLength + 1));
+        };
+
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("18", ex.Message); // CorruptedTdsStream
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 3: SRECOVERY feature ack with malformed inner state data
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the secondary parse of FEATUREEXT_SRECOVERY data in
+    /// <c>SqlConnectionInternal.OnFeatureExtAck</c> rejects inner state options
+    /// whose claimed length exceeds the remaining buffer, preventing an
+    /// out-of-bounds read or over-allocation.
+    /// </summary>
+    [Fact]
+    public void SRecovery_MalformedInnerStateLength_ThrowsParsingError()
+    {
+        _server.OnAuthenticationResponseCompleted = responseMessage =>
+        {
+            // Remove existing FeatureExtAck if present
+            var existing = responseMessage.OfType<TDSFeatureExtAckToken>().FirstOrDefault();
+            if (existing != null)
+            {
+                responseMessage.Remove(existing);
+            }
+
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            // Inject a FeatureExtAck with SessionRecovery feature containing
+            // inner state data where a state option claims a length exceeding the buffer
+            responseMessage.Insert(doneIndex, new MaliciousSRecoveryFeatureExtAckToken());
+        };
+
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("18", ex.Message); // CorruptedTdsStream
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 4: FedAuthInfo token with oversized total length
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>TryProcessFedAuthInfo</c> rejects a FedAuthInfo token (0xEE)
+    /// whose total length exceeds <see cref="TdsEnums.MaxTokenDataLength"/> (1 MB).
+    /// The token type is dispatched unconditionally by <c>TryRun</c>, so this check
+    /// fires regardless of whether federated authentication was negotiated.
+    /// </summary>
+    [Fact]
+    public void FedAuthInfo_OversizedTokenLength_ThrowsParsingError()
+    {
+        _server.OnAuthenticationResponseCompleted = responseMessage =>
+        {
+            int doneIndex = responseMessage.FindIndex(t => t is TDSDoneToken);
+            if (doneIndex < 0)
+            {
+                doneIndex = responseMessage.Count;
+            }
+
+            // Inject a FedAuthInfo token with a total length exceeding MaxTokenDataLength.
+            // The parser dispatches on token type regardless of whether FedAuth was negotiated.
+            responseMessage.Insert(doneIndex, new MaliciousFedAuthInfoToken(
+                claimedLength: TdsEnums.MaxTokenDataLength + 1));
+        };
+
+        using SqlConnection connection = new(_connectionString);
+        Exception ex = Assert.ThrowsAny<InvalidOperationException>(connection.Open);
+        Assert.Contains("18", ex.Message); // CorruptedTdsStream
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Malicious token helpers
+    // ══════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Writes a SessionState token (0xE4) with a fraudulently large total length.
+    /// Wire format: [0xE4][uint32 totalLen][uint32 seqNum][byte status][...]
+    /// The bounds check fires on the totalLen value before any data is read.
+    /// </summary>
+    private sealed class MaliciousSessionStateToken : TDSPacketToken
+    {
+        private readonly uint _claimedTotalLength;
+
+        public MaliciousSessionStateToken(uint claimedTotalLength)
+        {
+            _claimedTotalLength = claimedTotalLength;
+        }
+
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // Token type
+            destination.WriteByte((byte)TDSTokenType.SessionState); // 0xE4
+
+            // Total token length (uint32) — this is the fraudulent value
+            byte[] lenBytes = BitConverter.GetBytes(_claimedTotalLength);
+            destination.Write(lenBytes, 0, 4);
+
+            // Write minimal valid-looking data: seqNum (4 bytes) + status (1 byte)
+            // The bounds check should fire before trying to process option data.
+            destination.Write(new byte[] { 0x01, 0x00, 0x00, 0x00 }, 0, 4); // seqNum = 1
+            destination.WriteByte(0x01); // status = recoverable
+        }
+    }
+
+    /// <summary>
+    /// Writes a SessionState token (0xE4) with a valid outer length but an inner
+    /// state option that claims a huge data length (using the 0xFF + DWORD encoding).
+    /// Wire format: [0xE4][uint32 totalLen][uint32 seqNum][byte status]
+    ///              [byte stateId][0xFF][int32 innerLen][...data...]
+    /// The inner bounds check fires on the innerLen value.
+    /// </summary>
+    private sealed class MaliciousSessionStateInnerLenToken : TDSPacketToken
+    {
+        private readonly int _innerClaimedLength;
+
+        public MaliciousSessionStateInnerLenToken(int innerClaimedLength)
+        {
+            _innerClaimedLength = innerClaimedLength;
+        }
+
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // Token type
+            destination.WriteByte((byte)TDSTokenType.SessionState); // 0xE4
+
+            // Calculate total token length:
+            // seqNum(4) + status(1) + stateId(1) + lenMarker(1) + innerLen(4) + minimal data(1)
+            uint totalLength = 4 + 1 + 1 + 1 + 4 + 1;
+
+            byte[] lenBytes = BitConverter.GetBytes(totalLength);
+            destination.Write(lenBytes, 0, 4);
+
+            // Sequence number
+            destination.Write(new byte[] { 0x01, 0x00, 0x00, 0x00 }, 0, 4);
+
+            // Status (recoverable)
+            destination.WriteByte(0x01);
+
+            // State option: stateId
+            destination.WriteByte(0x00); // UserOptions state ID
+
+            // Length marker: 0xFF means next 4 bytes are the DWORD length
+            destination.WriteByte(0xFF);
+
+            // Inner claimed length — fraudulently large
+            byte[] innerLenBytes = BitConverter.GetBytes(_innerClaimedLength);
+            destination.Write(innerLenBytes, 0, 4);
+
+            // Write only 1 byte of actual data
+            destination.WriteByte(0x42);
+        }
+    }
+
+    /// <summary>
+    /// Writes a FeatureExtAck token (0xAE) with a SessionRecovery feature (ID=1)
+    /// that carries inner state data where a state option claims a length exceeding
+    /// the remaining buffer. This exercises the bounds check in
+    /// SqlConnectionInternal.OnFeatureExtAck for FEATUREEXT_SRECOVERY.
+    /// </summary>
+    private sealed class MaliciousSRecoveryFeatureExtAckToken : TDSPacketToken
+    {
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // Token type: FEATUREEXTACK
+            destination.WriteByte((byte)TDSTokenType.FeatureExtAck); // 0xAE
+
+            // Feature ID: SessionRecovery = 0x01
+            destination.WriteByte(0x01);
+
+            // The feature data for SRECOVERY is parsed by SqlConnectionInternal.OnFeatureExtAck:
+            // It reads pairs of [stateId(1)][lenByte(1)][data(len)] or [stateId(1)][0xFF][int32 len][data(len)]
+            // We'll craft inner data where one option claims length > remaining buffer.
+
+            // Inner data layout:
+            // stateId(1) + 0xFF marker(1) + int32 len(4) + 1 byte actual data
+            byte[] innerData;
+            using (var ms = new MemoryStream())
+            {
+                ms.WriteByte(0x00); // stateId = 0
+
+                // Use 0xFF marker to indicate DWORD length
+                ms.WriteByte(0xFF);
+
+                // Claim a length that exceeds the remaining buffer
+                // The remaining buffer after reading stateId + 0xFF + 4-byte-len will be 1 byte,
+                // but we claim 999 bytes
+                byte[] claimedLen = BitConverter.GetBytes(999);
+                ms.Write(claimedLen, 0, 4);
+
+                // Only provide 1 byte of actual data
+                ms.WriteByte(0x42);
+
+                innerData = ms.ToArray();
+            }
+
+            // Feature data length (uint32)
+            byte[] featureDataLen = BitConverter.GetBytes((uint)innerData.Length);
+            destination.Write(featureDataLen, 0, 4);
+
+            // Feature data
+            destination.Write(innerData, 0, innerData.Length);
+
+            // Terminator
+            destination.WriteByte((byte)TDSFeatureID.Terminator); // 0xFF
+        }
+    }
+
+    /// <summary>
+    /// Writes a FedAuthInfo token (0xEE) with a fraudulently large total length.
+    /// Wire format: [0xEE][int32 tokenLen][...data...]
+    /// The bounds check fires on tokenLen before any data is read.
+    /// </summary>
+    private sealed class MaliciousFedAuthInfoToken : TDSPacketToken
+    {
+        private readonly int _claimedLength;
+
+        public MaliciousFedAuthInfoToken(int claimedLength)
+        {
+            _claimedLength = claimedLength;
+        }
+
+        public override bool Inflate(Stream source) => throw new NotSupportedException();
+
+        public override void Deflate(Stream destination)
+        {
+            // Token type
+            destination.WriteByte(0xEE); // SQLFEDAUTHINFO
+
+            // Token length (int32) — fraudulently large
+            byte[] lenBytes = BitConverter.GetBytes(_claimedLength);
+            destination.Write(lenBytes, 0, 4);
+
+            // Write minimal data (at least sizeof(uint) to pass the lower bound check,
+            // but the upper bound check should fire first)
+            destination.Write(new byte[] { 0x01, 0x00, 0x00, 0x00 }, 0, 4); // optionsCount = 1
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/TdsTokenBoundsTests.cs
@@ -1022,16 +1022,30 @@ public class TdsTokenBoundsTests : IDisposable
         public DebugAssertSuppressor()
         {
             System.Threading.Monitor.Enter(s_listenerLock);
-            _listeners = new System.Diagnostics.TraceListener[System.Diagnostics.Trace.Listeners.Count];
-            System.Diagnostics.Trace.Listeners.CopyTo(_listeners, 0);
-            System.Diagnostics.Trace.Listeners.Clear();
+            try
+            {
+                _listeners = new System.Diagnostics.TraceListener[System.Diagnostics.Trace.Listeners.Count];
+                System.Diagnostics.Trace.Listeners.CopyTo(_listeners, 0);
+                System.Diagnostics.Trace.Listeners.Clear();
+            }
+            catch
+            {
+                System.Threading.Monitor.Exit(s_listenerLock);
+                throw;
+            }
         }
 
         public void Dispose()
         {
-            System.Diagnostics.Trace.Listeners.Clear();
-            System.Diagnostics.Trace.Listeners.AddRange(_listeners);
-            System.Threading.Monitor.Exit(s_listenerLock);
+            try
+            {
+                System.Diagnostics.Trace.Listeners.Clear();
+                System.Diagnostics.Trace.Listeners.AddRange(_listeners);
+            }
+            finally
+            {
+                System.Threading.Monitor.Exit(s_listenerLock);
+            }
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTdsServer.cs
+++ b/src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/GenericTdsServer.cs
@@ -156,6 +156,13 @@ namespace Microsoft.SqlServer.TDS.Servers
 
         public OnAuthenticationCompletedDelegate OnAuthenticationResponseCompleted { private get; set; }
 
+        /// <summary>
+        /// Delegate invoked after a SQL batch response is prepared but before it is
+        /// sent to the client. Tests can use this to inject or replace tokens in the
+        /// response message.
+        /// </summary>
+        public Action<TDSMessage> OnSQLBatchCompleted { get; set; }
+
         public OnLogin7ValidatedDelegate OnLogin7Validated { private get; set; }
 
 
@@ -472,6 +479,9 @@ namespace Microsoft.SqlServer.TDS.Servers
                 // Update session with the new packet size
                 session.PacketSize = (uint)Arguments.PacketSize;
             }
+
+            // Allow tests to modify or inject tokens into the response
+            OnSQLBatchCompleted?.Invoke(responseMessage[0]);
 
             return responseMessage;
         }


### PR DESCRIPTION
## Summary

Adds bounds checks on data lengths read from the TDS wire to prevent unbounded `byte[]` allocation from a malicious server.

All checks throw `SQL.ParsingErrorLength(ParsingErrorState.CorruptedTdsStream, ...)` when a spoofed length exceeds protocol-reasonable maximums.

## Changes

| File | Change | Description | Tests |
|------|--------|-------------|-------|
| `TdsParser.cs` L4180 | `TryProcessSessionState` — total length check | Rejects `tokenLen > MaxTokenDataLength` (1 MB) | `SessionState_OversizedTotalLength` |
| `TdsParser.cs` L4233 | `TryProcessSessionState` — inner option length check | Rejects individual state option with `stateLen < 0` or `stateLen > MaxTokenDataLength` | `SessionState_OversizedInnerOptionLength`, `SessionState_NegativeInnerOptionLength` |
| `TdsParser.cs` L4454 | `TryProcessFedAuthInfo` — token length check | Rejects `tokenLen > MaxTokenDataLength` | `FedAuthInfo_OversizedTokenLength` |
| `TdsParser.cs` L3351 | `TryProcessEnvChange` — PromoteTransaction newLength check | Rejects `newLength > MaxPromoteTransactionLength` (64 KB) | `EnvChange_PromoteTransaction_OversizedLength` (login), `BatchResponse_PromoteTransaction_OversizedLength` (post-login) |
| `TdsParser.cs` L3853 | `TryProcessFeatureExtAck` — data length check | Rejects `dataLen > MaxTokenDataLength` | `FeatureExtAck_OversizedDataLength`, `FeatureExtAck_MaxAllowedDataLength_DoesNotThrow` |
| `TdsParser.cs` L7144 | `TryReadSqlDateTime` — data length check | Rejects `length > MaxDateTimeLength` (10) | `BatchResponse_DateTime_OversizedLength` |
| `TdsParser.cs` L4937-4948 | `TryProcessReturnValue` — non-PLP length check | Restructured: `IsPlp` types skip bounds check; non-PLP rejects `valLen > int.MaxValue` | `BatchResponse_ReturnValue_OversizedLength`, `BatchResponse_ReturnValue_PlpUnknownLength` |
| `TdsParser.cs` L7405 | `TryReadSqlValueInternal` — binary/vector length check | Rejects `length < 0` or `length > MAXSIZE` (8000) for binary types in sql_variant path | `BatchResponse_SqlVariantBinary_OversizedLength`, `BatchResponse_SqlVariantBinary_NegativeLength` |
| `SqlConnectionInternal.cs` L1349 | `OnFeatureExtAck` — SRECOVERY inner state length | Validates inner state option length doesn't exceed remaining buffer | `SRecovery_MalformedInnerStateLength` |
| `TdsEnums.cs` L90-96 | Constants | `MaxTokenDataLength` (1 MB), `MaxPromoteTransactionLength` (64 KB), `MaxDateTimeLength` (10) | *(used by all above)* |

## Impact analysis

### Group 1: New upper-bound constraints

These add hard limits where previously the parser would attempt to allocate whatever the server claimed. A **conforming SQL Server** will never exceed any of these limits, but a misbehaving proxy, network appliance, or third-party TDS implementation could.

| Location | Limit | Rationale |
|----------|-------|-----------|
| FeatureExtAck `dataLen` | 1 MB | No legitimate feature ack payload approaches this |
| SessionState total length | 1 MB | Session state tokens are typically single-digit KB |
| SessionState inner option | ≥ 0 and ≤ 1 MB | Individual state options are even smaller; negative values indicate wire corruption |
| FedAuthInfo `tokenLen` | 1 MB | Contains only STS URL + SPN — a few hundred bytes |
| PromoteTransaction `newLength` | 64 KB | DTC propagation tokens are typically ~200–500 bytes |
| DateTime `length` | 10 bytes | DateTimeOffset (the largest) is exactly 10; this is the protocol ceiling |
| Binary/vector in sql_variant | ≥ 0 and ≤ 8000 | MAXSIZE is the protocol maximum for non-PLP binary; negative `lenData` results from a total variant length smaller than the type overhead |

**Risk to existing apps:** Effectively zero against real SQL Server. Could break connections through a non-conforming TDS proxy that inflates token lengths (e.g., for padding or encapsulation).

### Group 2: Debug.Assert → runtime exception (bug fix)

These replaced `Debug.Assert` (which is stripped in Release builds, meaning the invalid state was silently accepted) with a throwing check:

| Location | Previous behavior (Release) | New behavior |
|----------|----------------------------|--------------| 
| ReturnValue non-PLP `valLen > int.MaxValue` | Silently truncated to `int.MaxValue` | Throws `ParsingErrorLength` |
| Binary/Vector in sql_variant `length > MAXSIZE` | No check at all (assert stripped) | Throws `ParsingErrorLength` |

**Risk to existing apps:** Only if the app was previously "surviving" corrupt data by silently reading garbage. In practice these indicate a corrupted stream that would likely cause downstream failures anyway.

### Group 3: Buffer overrun prevention (defense-in-depth)

| Location | Issue prevented |
|----------|-----------------|
| `SqlConnectionInternal.OnFeatureExtAck` SRECOVERY: `len < 0 \|\| len > data.Length - i` | Out-of-bounds `Buffer.BlockCopy` from a malformed feature ack payload |

**Risk to existing apps:** None — this path only fires if the server sends internally inconsistent SRECOVERY data (claimed inner length exceeds the outer buffer already validated by the FeatureExtAck check).

### Group 4: Behavioral improvement (non-breaking)

| Location | Change |
|----------|--------|
| `TryReadSqlDateTime` | Replaced `((uint)length <= 16) ? stackalloc : new byte[length]` with unconditional `stackalloc byte[10]` |

Since the bounds check guarantees `length ≤ 10`, the conditional heap allocation path is dead code eliminated. Minor perf win. **No user-visible behavior change.**

### Impact summary

| Category | Count | Risk to legitimate apps |
|----------|-------|------------------------|
| New constraints | 6 sites | ~Zero (limits far exceed protocol maximums) |
| Assert → exception | 2 sites | Near-zero (previously silent corruption) |
| Buffer overrun fix | 1 site | None |
| Perf improvement | 1 site | None |

The only scenario where a real application could be affected is if it connects through a non-conforming TDS intermediary (proxy/load balancer) that rewrites token lengths to values exceeding these bounds. Standard SQL Server, Azure SQL, and conforming TDS 7.x/8.0 implementations will never produce values exceeding any of these limits.

## Test infrastructure

- Added `OnSQLBatchCompleted` hook to `GenericTdsServer` for post-login TDS token injection
- Added `OnAuthenticationResponseCompleted` hook usage for login-phase token injection
- Per-test instance fixtures (`IDisposable`) for proper test isolation — each test gets a fresh `TdsServerFixture`
- 14 unit tests covering all bounds checks (login-phase, post-login, positive/negative boundary conditions)

## Checklist

- [x] Tests added or updated
- [x] No breaking changes introduced
- [x] PLP regression verified (test 9 confirms valid PLP sentinel is not rejected)
- [x] 100% patch coverage on new bounds checks