### PR TITLE
Improve `EnclaveDiffieHellmanInfo.Size`

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncryptedEnclaveProviderUtils.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AlwaysEncryptedEnclaveProviderUtils.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.SqlClient
 
     internal class EnclaveDiffieHellmanInfo
     {
-        public int Size => sizeof(int) + sizeof(int) + PublicKey?.Length ?? 0 + PublicKeySignature?.Length ?? 0;
+        public int Size => sizeof(int) + sizeof(int) + (PublicKey?.Length ?? 0) + (PublicKeySignature?.Length ?? 0);
 
         public byte[] PublicKey { get; private set; }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -208,8 +208,7 @@ namespace Microsoft.Data.SqlClient
                     EnclaveDHInfo = new EnclaveDiffieHellmanInfo(attestationInfo, offset);
                     offset += EnclaveDHInfo.Size;
 
-                    // TODO(GH-3604): Fix this failing assertion.
-                    // Debug.Assert(offset == attestationInfo.Length);
+                    Debug.Assert(offset == attestationInfo.Length);
                 }
                 catch (Exception exception)
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs
@@ -153,8 +153,7 @@ namespace Microsoft.Data.SqlClient
             EnclaveDHInfo = new EnclaveDiffieHellmanInfo(attestationInfo, offset);
             offset += Convert.ToInt32(EnclaveDHInfo.Size);
 
-            // TODO(GH-3604): Fix this failing assertion.
-            // Debug.Assert(offset == attestationInfo.Length, $"{offset} == {attestationInfo.Length}");
+            Debug.Assert(offset == attestationInfo.Length, $"{offset} == {attestationInfo.Length}");
         }
     }
 


### PR DESCRIPTION
## Description

Parenthesize `??` as `+` binds stronger

Perhaps this let's us uncomment the following `Debug.Assert`s?
Let me know if I should try uncomment the asserts and see if CI is green.

https://github.com/dotnet/SqlClient/blob/7721c98e8900291dd879e6ef7d8d42f4c2092842/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProvider.cs#L156-L157

https://github.com/dotnet/SqlClient/blob/7721c98e8900291dd879e6ef7d8d42f4c2092842/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs#L211-L212
## Issues

## Testing

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
