### PR TITLE
Add `/ready` slash command and author notification for "Author attention needed" label

### DIFF
--- a/.github/workflows/notify-author-attention.yml
+++ b/.github/workflows/notify-author-attention.yml
@@ -1,0 +1,34 @@
+name: Notify Author Attention Needed
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  notify-author:
+    # Only run when 'Author Attention Needed' label is added to a PR
+    if: >-
+      github.repository == 'dotnet/SqlClient' &&
+      github.event.label.name == 'Author Attention Needed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post comment to PR author
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const issue_number = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const author = context.payload.pull_request.user.login;
+
+            const body = `@${author} This pull request has been marked as **Author Attention Needed**.\n\nWhen you have addressed the reviewer feedback and are ready for another review, please post a comment with \`/ready\` to remove the label and re-engage reviewers.`;
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });
+            core.info(`Posted notification comment on PR #${issue_number}`);

--- a/.github/workflows/notify-author-attention.yml
+++ b/.github/workflows/notify-author-attention.yml
@@ -1,4 +1,4 @@
-name: Notify Author Attention Needed
+name: Notify Author attention needed
 
 on:
   pull_request_target:
@@ -6,10 +6,10 @@ on:
 
 jobs:
   notify-author:
-    # Only run when 'Author Attention Needed' label is added to a PR
+    # Only run when 'Author attention needed' label is added to a PR
     if: >-
       github.repository == 'dotnet/SqlClient' &&
-      github.event.label.name == 'Author Attention Needed'
+      github.event.label.name == 'Author attention needed'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -23,7 +23,7 @@ jobs:
             const repo = context.repo.repo;
             const author = context.payload.pull_request.user.login;
 
-            const body = `@${author} This pull request has been marked as **Author Attention Needed**.\n\nWhen you have addressed the reviewer feedback and are ready for another review, please post a comment with \`/ready\` to remove the label and re-engage reviewers.`;
+            const body = `@${author} This pull request has been marked as **Author attention needed**.\n\nWhen you have addressed the reviewer feedback and are ready for another review, please post a comment with \`/ready\` to remove the label and re-engage reviewers.`;
 
             await github.rest.issues.createComment({
               owner,

--- a/.github/workflows/notify-author-attention.yml
+++ b/.github/workflows/notify-author-attention.yml
@@ -12,6 +12,7 @@ jobs:
       github.event.label.name == 'Author attention needed'
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - name: Post comment to PR author

--- a/.github/workflows/remove-author-attention-label.yml
+++ b/.github/workflows/remove-author-attention-label.yml
@@ -14,6 +14,7 @@ jobs:
       contains(github.event.comment.body, '/ready')
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - name: Remove 'Author Attention Needed' label
@@ -46,19 +47,20 @@ jobs:
               core.info(`PR #${issue_number} does not have the '${labelName}' label. No action taken.`);
             }
 
-            // Re-request reviews from existing reviewers
-            const reviews = await github.rest.pulls.listReviews({
+            // Re-request reviews from existing reviewers (paginate to include all reviews)
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner,
               repo,
               pull_number: issue_number,
+              per_page: 100,
             });
 
             // Collect unique reviewers (exclude the PR author)
             const author = context.payload.issue.user.login;
             const reviewers = [...new Set(
-              reviews.data
-                .map(r => r.user.login)
-                .filter(login => login !== author)
+              reviews
+                .map(r => r.user?.login)
+                .filter(login => login && login !== author)
             )];
 
             if (reviewers.length > 0) {

--- a/.github/workflows/remove-author-attention-label.yml
+++ b/.github/workflows/remove-author-attention-label.yml
@@ -1,0 +1,74 @@
+name: Remove Author Attention Needed Label
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  remove-label:
+    # Only run on PR comments with '/ready' from the PR author
+    if: >-
+      github.repository == 'dotnet/SqlClient' &&
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.login == github.event.issue.user.login &&
+      contains(github.event.comment.body, '/ready')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove 'Author Attention Needed' label
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labelName = 'Author Attention Needed';
+            const issue_number = context.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Check if the label exists on the PR
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number,
+            });
+
+            const hasLabel = labels.data.some(label => label.name === labelName);
+
+            if (hasLabel) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number,
+                name: labelName,
+              });
+              core.info(`Removed '${labelName}' label from PR #${issue_number}`);
+            } else {
+              core.info(`PR #${issue_number} does not have the '${labelName}' label. No action taken.`);
+            }
+
+            // Re-request reviews from existing reviewers
+            const reviews = await github.rest.pulls.listReviews({
+              owner,
+              repo,
+              pull_number: issue_number,
+            });
+
+            // Collect unique reviewers (exclude the PR author)
+            const author = context.payload.issue.user.login;
+            const reviewers = [...new Set(
+              reviews.data
+                .map(r => r.user.login)
+                .filter(login => login !== author)
+            )];
+
+            if (reviewers.length > 0) {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number: issue_number,
+                reviewers,
+              });
+              core.info(`Re-requested reviews from: ${reviewers.join(', ')}`);
+            } else {
+              core.info('No previous reviewers to re-request.');
+            }

--- a/.github/workflows/remove-author-attention-label.yml
+++ b/.github/workflows/remove-author-attention-label.yml
@@ -36,17 +36,18 @@ jobs:
 
             const hasLabel = labels.some(label => label.name === labelName);
 
-            if (hasLabel) {
-              await github.rest.issues.removeLabel({
-                owner,
-                repo,
-                issue_number,
-                name: labelName,
-              });
-              core.info(`Removed '${labelName}' label from PR #${issue_number}`);
-            } else {
+            if (!hasLabel) {
               core.info(`PR #${issue_number} does not have the '${labelName}' label. No action taken.`);
+              return;
             }
+
+            await github.rest.issues.removeLabel({
+              owner,
+              repo,
+              issue_number,
+              name: labelName,
+            });
+            core.info(`Removed '${labelName}' label from PR #${issue_number}`);
 
             // Re-request reviews from existing reviewers (paginate to include all reviews)
             const reviews = await github.paginate(github.rest.pulls.listReviews, {

--- a/.github/workflows/remove-author-attention-label.yml
+++ b/.github/workflows/remove-author-attention-label.yml
@@ -1,4 +1,4 @@
-name: Remove Author Attention Needed Label
+name: Remove Author attention needed Label
 
 on:
   issue_comment:
@@ -17,11 +17,11 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - name: Remove 'Author Attention Needed' label
+      - name: Remove 'Author attention needed' label
         uses: actions/github-script@v9
         with:
           script: |
-            const labelName = 'Author Attention Needed';
+            const labelName = 'Author attention needed';
             const issue_number = context.issue.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/remove-author-attention-label.yml
+++ b/.github/workflows/remove-author-attention-label.yml
@@ -27,13 +27,14 @@ jobs:
             const repo = context.repo.repo;
 
             // Check if the label exists on the PR
-            const labels = await github.rest.issues.listLabelsOnIssue({
+            const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
               owner,
               repo,
               issue_number,
+              per_page: 100,
             });
 
-            const hasLabel = labels.data.some(label => label.name === labelName);
+            const hasLabel = labels.some(label => label.name === labelName);
 
             if (hasLabel) {
               await github.rest.issues.removeLabel({
@@ -59,6 +60,7 @@ jobs:
             const author = context.payload.issue.user.login;
             const reviewers = [...new Set(
               reviews
+                .filter(r => r.user?.type === 'User')
                 .map(r => r.user?.login)
                 .filter(login => login && login !== author)
             )];

--- a/.github/workflows/remove-author-attention-label.yml
+++ b/.github/workflows/remove-author-attention-label.yml
@@ -11,7 +11,7 @@ jobs:
       github.repository == 'dotnet/SqlClient' &&
       github.event.issue.pull_request != null &&
       github.event.comment.user.login == github.event.issue.user.login &&
-      contains(github.event.comment.body, '/ready')
+      startsWith(github.event.comment.body, '/ready')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -67,13 +67,17 @@ jobs:
             )];
 
             if (reviewers.length > 0) {
-              await github.rest.pulls.requestReviewers({
-                owner,
-                repo,
-                pull_number: issue_number,
-                reviewers,
-              });
-              core.info(`Re-requested reviews from: ${reviewers.join(', ')}`);
+              try {
+                await github.rest.pulls.requestReviewers({
+                  owner,
+                  repo,
+                  pull_number: issue_number,
+                  reviewers: reviewers.slice(0, 15),
+                });
+                core.info(`Re-requested reviews from: ${reviewers.join(', ')}`);
+              } catch (err) {
+                core.warning(`Failed to re-request reviewers: ${err.message}`);
+              }
             } else {
               core.info('No previous reviewers to re-request.');
             }


### PR DESCRIPTION
## Summary

This PR adds two GitHub Actions workflows to streamline the review feedback loop:

### 1. Notify Author (`notify-author-attention.yml`)
When the **"Author attention needed"** label is added to a PR, a comment is automatically posted notifying the author to use `/ready` when they've addressed feedback.

### 2. Remove Label on `/ready` (`remove-author-attention-label.yml`)
When the PR author posts a `/ready` comment:
- Removes the "Author attention needed" label
- Re-requests reviews from all previous reviewers

## Workflow

1. Reviewer adds "Author attention needed" label → bot comments notifying the author
2. Author addresses feedback and comments `/ready` → bot removes label and re-engages reviewers

Sample workflow: https://github.com/cheenamalhotra/SqlClient/pull/9

## Changes

- [x] Added `.github/workflows/notify-author-attention.yml`
- [x] Added `.github/workflows/remove-author-attention-label.yml`
