### PR TITLE
Fix macOS CI: trust microsoft/mssql-release tap for Homebrew 5.2+

### DIFF
--- a/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
@@ -33,9 +33,19 @@ steps:
       brew install colima
       brew install docker
       brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
-      brew trust microsoft/mssql-release
       brew update
+      # Homebrew 5.2+ requires explicit trust for third-party taps.  Run this
+      # after 'brew update' so the trust command is available even if the runner
+      # image shipped an older Homebrew version.
+      brew trust microsoft/mssql-release
       HOMEBREW_ACCEPT_EULA=Y brew install mssql-tools18
+
+      # Fail fast if sqlcmd was not installed (e.g. tap-trust or formula error).
+      # Without this check the script would loop for ~6 minutes trying to connect.
+      if ! command -v sqlcmd &>/dev/null; then
+        echo "ERROR: sqlcmd is not on PATH after brew install. Check the mssql-tools18 installation above."
+        exit 1
+      fi
 
       # Start Colima with Virtualization.framework for x86_64 binary translation
       # on Apple Silicon.  Rosetta/binfmt emulation is enabled by default in

--- a/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
+++ b/eng/pipelines/common/templates/steps/configure-sql-server-macos-step.yml
@@ -33,6 +33,7 @@ steps:
       brew install colima
       brew install docker
       brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
+      brew trust microsoft/mssql-release
       brew update
       HOMEBREW_ACCEPT_EULA=Y brew install mssql-tools18
 


### PR DESCRIPTION
## Description

Fixes macOS pipeline failures that started on June 11, 2026 across all PRs.

## Root Cause

Homebrew 5.2.0 made **untrusted-tap enforcement the default**. After `brew update` pulls in the new version, `brew install mssql-tools18` is refused:

```
Error: Refusing to load formula microsoft/mssql-release/mssql-tools18 from untrusted tap microsoft/mssql-release.
Run `brew trust --formula microsoft/mssql-release/mssql-tools18` or `brew trust microsoft/mssql-release` to trust it.
```

Because the script doesn't use `set -e`, execution continues past this failure. Docker/Colima/SQL Server all start correctly, but **`sqlcmd` was never installed** (exit code 127 on every attempt), so the connectivity check loops for 72 attempts (~6 minutes) and then fails.

## Fix

Add `brew trust microsoft/mssql-release` after `brew tap` and `brew update` to explicitly trust the Microsoft tap under the new Homebrew policy.

## Testing

- [ ] Re-run macOS pipeline jobs to confirm the fix resolves the failures