### PR TITLE
Switch SDK rollForward from disable to patch for automatic servicing updates

### DIFF
--- a/global.json
+++ b/global.json
@@ -4,8 +4,9 @@
     // We currently require the .NET 10 SDK to build and test the project.
     "version": "10.0.300",
 
-    // Lock to the above version so that we can control when we take breaking sdk changes.
-    "rollForward": "disable",
+    // Allow roll-forward within the 10.0.3xx feature band so servicing patches
+    // are picked up automatically without requiring a PR for each bump.
+    "rollForward": "patch",
 
     // Do not allow pre-release versions.
     //

--- a/tools/PackageCompatibility/global.json
+++ b/tools/PackageCompatibility/global.json
@@ -7,7 +7,7 @@
   "sdk": {
     // global.json lookup stops at the nearest file and does not merge with the repo-root file.
     // This subtree therefore needs to repeat the root SDK settings so commands run from
-    // tools/PackageCompatibility keep using the same pinned SDK behavior.
+    // tools/PackageCompatibility keep using the same SDK behavior.
     "version": "10.0.300",
     "rollForward": "patch",
     "allowPrerelease": false

--- a/tools/PackageCompatibility/global.json
+++ b/tools/PackageCompatibility/global.json
@@ -9,7 +9,7 @@
     // This subtree therefore needs to repeat the root SDK settings so commands run from
     // tools/PackageCompatibility keep using the same pinned SDK behavior.
     "version": "10.0.300",
-    "rollForward": "disable",
+    "rollForward": "patch",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Description

Switches `global.json` SDK resolution from `"rollForward": "disable"` (exact pin) to `"rollForward": "patch"` (allow roll-forward within the 10.0.3xx feature band).

## Motivation

- Servicing patches (e.g. security fix 10.0.301) are picked up automatically by CI agents and developers without requiring a dedicated PR for each bump.
- The feature band boundary (10.0.3xx) is still respected — no risk of new analyzers, MSBuild behavior changes, or codegen differences sneaking in.
- Reduces maintenance burden of security-bump PRs for patch-level SDK updates.

## Changes

| File | Change |
|------|--------|
| `global.json` | `rollForward`: `disable` → `patch`, updated comment |
| `tools/PackageCompatibility/global.json` | `rollForward`: `disable` → `patch` |

## Notes

- Base version remains `10.0.300` — this is the minimum required SDK
- Any installed 10.0.3xx servicing patch will be used automatically
- Build verified locally: `dotnet build` of the main SqlClient project succeeds with SDK 10.0.300

## Testing

- [x] Local build succeeds with SDK 10.0.300 (lowest in band)
- [ ] CI validation