### PR TITLE
Fix stress pipeline pool name detection and config file mismatch

### DIFF
--- a/eng/pipelines/stress/stress-tests-job.yml
+++ b/eng/pipelines/stress/stress-tests-job.yml
@@ -210,7 +210,7 @@ jobs:
           condition: and(succeededOrFailed(), eq(variables['buildSucceeded'], 'true'))
           continueOnError: ${{ parameters.warnOnTestFailure }}
           env:
-            STRESS_CONFIG_FILE: config.json
+            STRESS_CONFIG_FILE: config.jsonc
           inputs:
             command: run
             projects: $(project)
@@ -223,7 +223,7 @@ jobs:
           condition: and(succeededOrFailed(), eq(variables['buildSucceeded'], 'true'))
           continueOnError: ${{ parameters.warnOnTestFailure }}
           env:
-            STRESS_CONFIG_FILE: config.json
+            STRESS_CONFIG_FILE: config.jsonc
           inputs:
             command: run
             projects: $(project)

--- a/eng/pipelines/stress/stress-tests-pipeline.yml
+++ b/eng/pipelines/stress/stress-tests-pipeline.yml
@@ -92,6 +92,17 @@ parameters:
       - detailed
       - diagnostic
 
+# Pipeline-level variables evaluated at compile time.
+variables:
+  # The 1ES pool name, determined automatically by ADO project:
+  #   - ADO.Net  -> ADO-1ES-Pool
+  #   - public   -> ADO-CI-1ES-Pool
+  - name: poolName
+    ${{ if eq(variables['System.TeamProject'], 'ADO.Net') }}:
+      value: ADO-1ES-Pool
+    ${{ else }}:
+      value: ADO-CI-1ES-Pool
+
 # The stages to run.
 stages:
 
@@ -105,5 +116,6 @@ stages:
     parameters:
       buildConfiguration: ${{ parameters.buildConfiguration }}
       debug: ${{ parameters.debug }}
+      poolName: ${{ variables.poolName }}
       warnOnTestFailure: ${{ parameters.warnOnTestFailure }}
       dotnetVerbosity: ${{ parameters.dotnetVerbosity }}

--- a/eng/pipelines/stress/stress-tests-stage.yml
+++ b/eng/pipelines/stress/stress-tests-stage.yml
@@ -57,6 +57,10 @@ parameters:
     type: object
     default: [net8.0, net9.0, net10.0]
 
+  # The 1ES pool name for Linux and Windows jobs.  macOS always uses 'Azure Pipelines'.
+  - name: poolName
+    type: string
+
 stages:
   - stage: stress_tests_stage
     displayName: Run Stress Tests
@@ -67,15 +71,6 @@ stages:
       # Bring the SA password from the secrets_stage into scope here.
       - name: saPassword
         value: $[stageDependencies.secrets_stage.secrets_job.outputs['SaPassword.Value']]
-
-      # The 1ES pool name, determined automatically by ADO project:
-      #   - ADO.Net  -> ADO-1ES-Pool
-      #   - public   -> ADO-CI-1ES-Pool
-      - name: poolName
-        ${{ if eq(variables['System.TeamProject'], 'ADO.Net') }}:
-          value: ADO-1ES-Pool
-        ${{ else }}:
-          value: ADO-CI-1ES-Pool
 
     jobs:
 
@@ -93,7 +88,7 @@ stages:
         # No .NET Framework runtimes on Linux.
         netFrameworkTestRuntimes: []
         netTestRuntimes: ${{ parameters.netTestRuntimes }}
-        poolName: ${{ variables.poolName }}
+        poolName: ${{ parameters.poolName }}
         saPassword: $(saPassword)
         sqlSetupStep:
           template: /eng/pipelines/common/templates/steps/configure-sql-server-linux-step.yml@self
@@ -115,7 +110,7 @@ stages:
         # Note that we include the .NET Framework runtimes for test runs on Windows.
         netFrameworkTestRuntimes: ${{ parameters.netFrameworkTestRuntimes }}
         netTestRuntimes: ${{ parameters.netTestRuntimes }}
-        poolName: ${{ variables.poolName }}
+        poolName: ${{ parameters.poolName }}
         saPassword: $(saPassword)
         sqlSetupStep:
           template: /eng/pipelines/common/templates/steps/configure-sql-server-win-step.yml@self


### PR DESCRIPTION
# Fix stress pipeline pool name detection and config file mismatch

## Problems

1. **Pool name detection**: The `poolName` variable was defined at stage level, but `${{ variables.poolName }}` in template parameter expressions cannot resolve stage-scoped variables — template expressions only see pipeline-level variables. This caused the wrong pool to be selected in the ADO.Net project.

2. **Config file mismatch**: The pipeline writes the stress config to `config.jsonc` but sets `STRESS_CONFIG_FILE=config.json`. The runner crashes with an unhandled exception when it can't find the file (exit code 134/SIGABRT on Linux, 0xE0434352 on Windows).

## Changes

- Move pool name computation to a pipeline-level `variables:` block in `stress-tests-pipeline.yml` where `${{ variables['System.TeamProject'] }}` resolves at compile time.
- Add a `poolName` parameter to the stage template and pass it through.
- Fix `STRESS_CONFIG_FILE` env var from `config.json` → `config.jsonc` to match the file actually written.

## Validation

- [x] Pipeline YAML parses correctly
- [x] Stress pipeline run succeeds in ADO.Net project: https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=156728&view=results
- [x] Stress pipeline run succeeds in Public project: https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=156714&view=results

## Reviewers

This PR fixes problems with the stress pipelines, not the stress tests themselves.  The tests continue to fail intermittently, but now the pipelines are running correctly in both the Public and ADO.Net projects.