### PR TITLE
Thread assembly signing through CI pipelines and add signed IVT for extension projects

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -247,8 +247,8 @@
     <!--
       SigningKeyPath
       Applies to:     Build*, Pack*
-      Description:    Path to the key to use to strong name sign binaries. If omitted, binaries
-                      will not be strong name signed.
+      Description:    Path to the key to use to sign driver assemblies. If omitted, driver
+                      assemblies will not be signed.
                       For Pack* targets, this only applies to a build - ie, if PackBuild is set to
                       false, SigningKeyPath will have no effect.
       Default value:  [blank]
@@ -318,7 +318,7 @@
     <TestFilters Condition="'$(TestFilters.ToLower())' == 'none'" />
     <!--
       Exclude tests in the "signed" category when building unsigned assemblies.  We have some tests
-      that require signed assemblies, and they would fail with strong name validation exceptions on
+      that require signed assemblies, and they would fail with assembly validation exceptions on
       .NET Framework.
     -->
     <TestFilters Condition="'$(TestFilters)' != '' AND '$(SigningKeyPath)' == ''">$(TestFilters)&amp;category!=signed</TestFilters>

--- a/build.proj
+++ b/build.proj
@@ -452,6 +452,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build "$(SqlClientNotSupportedProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         -p:GenApiPath="@(GenApiArtifactPath->'%(FullPath)')"
         $(SigningKeyPathArgument)
@@ -483,6 +485,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build $(SqlClientRefProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
@@ -491,7 +495,7 @@
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
 
-        <!-- Reference type arguments -->
+        <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
         $(PackageVersionAbstractionsArgument)
         $(PackageVersionSqlServerArgument)
@@ -512,6 +516,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build $(SqlClientProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         -p:TargetOs=Unix
         $(SigningKeyPathArgument)
@@ -543,11 +549,13 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build $(SqlClientProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         -p:TargetOs=Windows_NT
         $(SigningKeyPathArgument)
 
-        <!-- Versioning Arguments -->
+        <!-- Versioning arguments -->
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
@@ -586,6 +594,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack "$(SqlClientProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)
@@ -601,7 +611,7 @@
         $(PackageVersionLoggingArgument)
         $(PackageVersionSqlServerArgument)
 
-        <!-- Pack settings are defined in Microsoft.Data.SqlClient.csproj -->
+        <!-- Pack arguments -->
         -p:PackageOutputPath="$(SqlClientPackageArtifactRoot)"
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
@@ -635,7 +645,12 @@
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(SqlClientFunctionalTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
@@ -680,7 +695,12 @@
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(SqlClientManualTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(ManualTestFiltersArgument)
@@ -710,17 +730,24 @@
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(SqlClientUnitTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
-        $(ReferenceTypeArgument)
-        $(TestSigningKeyPathArgument)
-        $(PackageVersionSqlClientArgument)
-        $(PackageVersionSqlServerArgument)
         --results-directory "$(TestResultsFolderPath)"
         --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
+
+        <!-- Reference Type Arguments -->
+        $(ReferenceTypeArgument)
+        $(PackageVersionSqlClientArgument)
+        $(PackageVersionSqlServerArgument)
       </DotnetCommand>
 
       <!-- Convert more than one whitespace character into one space -->
@@ -746,15 +773,17 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build "$(AkvProviderProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
-        <!--Versioning arguments -->
+        <!-- Versioning arguments -->
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionAkvProviderArgument)
 
-        <!-- Reference type arguments -->
+        <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
         $(PackageVersionAbstractionsArgument)
         $(PackageVersionLoggingArgument)
@@ -774,6 +803,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack "$(AkvProviderProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)
@@ -827,6 +858,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build "$(AbstractionsProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
@@ -852,6 +885,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack "$(AbstractionsProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)
@@ -892,19 +927,23 @@
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(AbstractionsTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
-        $(SigningKeyPathArgument)
-        $(TestSigningKeyPathArgument)
-
-        <!-- Reference type arguments -->
-        $(ReferenceTypeArgument)
-        $(PackageVersionLoggingArgument)
         --results-directory "$(TestResultsFolderPath)"
         --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
+
+        <!-- Reference Type Arguments -->
+        $(ReferenceTypeArgument)
+        $(PackageVersionLoggingArgument)
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
       <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>
@@ -931,6 +970,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build "$(AzureProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
@@ -939,7 +980,7 @@
         $(BuildSuffixArgument)
         $(PackageVersionAzureArgument)
 
-        <!-- Reference type arguments -->
+        <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
         $(PackageVersionLoggingArgument)
       </DotnetCommand>
@@ -956,6 +997,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack "$(AzureProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)
@@ -996,22 +1039,26 @@
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(AzureTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
-        $(SigningKeyPathArgument)
-        $(TestSigningKeyPathArgument)
+        --results-directory "$(TestResultsFolderPath)"
+        --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
 
-        <!-- Reference type arguments -->
+        <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
         $(PackageVersionAbstractionsArgument)
         $(PackageVersionLoggingArgument)
         $(PackageVersionSqlClientArgument)
         $(PackageVersionSqlServerArgument)
-        --results-directory "$(TestResultsFolderPath)"
-        --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
       <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>
@@ -1035,6 +1082,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build $(LoggingProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
@@ -1056,6 +1105,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack $(LoggingProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)
@@ -1092,16 +1143,22 @@
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(LoggingTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
-        $(SigningKeyPathArgument)
-        $(TestSigningKeyPathArgument)
-        $(ReferenceTypeArgument)
         --results-directory "$(TestResultsFolderPath)"
         --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
+
+        <!-- Reference Type Arguments -->
+        $(ReferenceTypeArgument)
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
       <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>
@@ -1124,10 +1181,12 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build $(SqlServerProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
-        <!--Versioning arguments -->
+        <!-- Versioning arguments -->
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlServerArgument)
@@ -1145,6 +1204,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack $(SqlServerProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)

--- a/build.proj
+++ b/build.proj
@@ -394,7 +394,7 @@
       environments. Please consider running project specific test targets or specific test sets
       within the project.
   -->
-  <Target Name="Test" DependsOnTargets="TestAbstractions;TestAzure;TestSqlClient" />
+  <Target Name="Test" DependsOnTargets="TestLogging;TestAbstractions;TestAzure;TestSqlClient" />
 
   <!-- ================================================================= -->
   <!-- Microsoft.Data.SqlClient Targets -->
@@ -887,10 +887,6 @@
   <!-- TestAbstractions: Runs Microsoft.Data.SqlClient.Extensions.Abstractions.Tests -->
   <Target Name="TestAbstractions">
     <PropertyGroup>
-      <!--
-        Note: This test exclusively uses project references, so neither ReferenceType nor any
-        package version arguments are specified in this command.
-      -->
       <LogFilePrefix>AbstractionsTests-$(OS)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
 
@@ -901,6 +897,12 @@
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
+
+        <!-- Reference type arguments -->
+        $(ReferenceTypeArgument)
+        $(PackageVersionLoggingArgument)
         --results-directory "$(TestResultsFolderPath)"
         --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
       </DotnetCommand>
@@ -999,8 +1001,8 @@
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
-        --results-directory "$(TestResultsFolderPath)"
-        --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
 
         <!-- Reference type arguments -->
         $(ReferenceTypeArgument)
@@ -1008,6 +1010,8 @@
         $(PackageVersionLoggingArgument)
         $(PackageVersionSqlClientArgument)
         $(PackageVersionSqlServerArgument)
+        --results-directory "$(TestResultsFolderPath)"
+        --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
       <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>
@@ -1022,6 +1026,7 @@
   <PropertyGroup>
     <LoggingSrcRoot>$(RepoRoot)src/Microsoft.Data.SqlClient.Internal/Logging/src/</LoggingSrcRoot>
     <LoggingProjectPath>$(LoggingSrcRoot)Logging.csproj</LoggingProjectPath>
+    <LoggingTestProjectPath>$(RepoRoot)src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj</LoggingTestProjectPath>
     <LoggingArtifactRoot>$(RepoRoot)artifacts/Microsoft.Data.SqlClient.Internal.Logging/$(Configuration)/</LoggingArtifactRoot>
   </PropertyGroup>
 
@@ -1077,6 +1082,33 @@
       SourceFiles="@(LoggingPackedArtifacts)"
       DestinationFolder="$(PackagesDir)"
       SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- TestLogging: Runs Microsoft.Data.SqlClient.Internal.Logging.Tests -->
+  <Target Name="TestLogging">
+    <PropertyGroup>
+      <LogFilePrefix>LoggingTests-$(OS)</LogFilePrefix>
+      <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
+
+      <DotnetCommand>
+        "$(DotnetPath)dotnet" test "$(LoggingTestProjectPath)"
+        -p:Configuration=$(Configuration)
+        $(TestBlameArgument)
+        $(TestCodeCoverageArgument)
+        $(TestFiltersArgument)
+        $(TestFrameworkArgument)
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
+        $(ReferenceTypeArgument)
+        --results-directory "$(TestResultsFolderPath)"
+        --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
+      </DotnetCommand>
+      <!-- Convert more than one whitespace character into one space -->
+      <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>
+    </PropertyGroup>
+
+    <Message Text=">>> Running tests for Logging via command: $(DotnetCommand)" />
+    <Exec ConsoleToMsBuild="true" Command="$(DotnetCommand)" />
   </Target>
 
   <!-- ================================================================= -->

--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -89,10 +89,10 @@ variables:
     value: ${{ eq(variables['System.TeamProject'], 'ADO.Net') }}
 
   # Signing key argument passed to build.proj. On internal builds this references the secure file
-  # downloaded by DownloadSecureFile@1; on public builds it expands to empty.
+  # downloaded by download-assembly-signing-key.yml; on public builds it expands to empty.
   - name: signingKeyArg
     ${{ if eq(variables.isInternalBuild, true) }}:
-      value: '-p:SigningKeyPath="$(keyFile.secureFilePath)"'
+      value: '-p:SigningKeyPath="$(driverKeyFile.secureFilePath)"'
     ${{ else }}:
       value: ''
 
@@ -133,13 +133,9 @@ jobs:
           Write-Host 'Done.'
         displayName: Clean packages/ directory
 
-      # On internal builds, download the strong-name signing key.
+      # On internal builds, download the assembly signing key.
       - ${{ if eq(variables.isInternalBuild, true) }}:
-        - task: DownloadSecureFile@1
-          displayName: Download Signing Key
-          inputs:
-            secureFile: netfxKeypair.snk
-          name: keyFile
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
       # Run the Pack target via build.proj.
       - task: DotNetCoreCLI@2

--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -11,7 +11,7 @@
 #   - On pushes to GitHub main and ADO internal/main (batched)
 #   - Nightly at 00:00 UTC on both branches
 #
-# On internal/main the strong-name signing key is downloaded and used to sign assemblies during the
+# On internal/main the assembly signing key is downloaded and used to sign assemblies during the
 # build.
 #
 # GOTCHA: This pipeline definition is triggered by GitHub _and_ ADO CI.  We distinguish the two via

--- a/eng/pipelines/common/steps/download-assembly-signing-key.yml
+++ b/eng/pipelines/common/steps/download-assembly-signing-key.yml
@@ -1,0 +1,39 @@
+################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET
+# Foundation licenses this file to you under the MIT license.  See the LICENSE
+# file in the project root for more information.
+################################################################################
+
+# Downloads a signing key from ADO secure files.
+#
+# When isTest is false, downloads the driver signing key and exports it as 'driverKeyFile'.  When
+# isTest is true, downloads the test signing key and exports it as 'testKeyFile'.
+#
+# Downstream steps reference the path via:
+#
+#  $(driverKeyFile.secureFilePath)  or
+#  $(testKeyFile.secureFilePath)
+
+parameters:
+
+  # When false, download the driver signing key.
+  # When true, download the test signing key.
+  - name: isTest
+    type: boolean
+    default: false
+
+steps:
+
+  - ${{ if eq(parameters.isTest, false) }}:
+    - task: DownloadSecureFile@1
+      displayName: Download Driver Signing Key
+      inputs:
+        secureFile: netfxKeypair.snk
+      name: driverKeyFile
+
+  - ${{ if eq(parameters.isTest, true) }}:
+    - task: DownloadSecureFile@1
+      displayName: Download Test Signing Key
+      inputs:
+        secureFile: sqlclient-test-key.snk
+      name: testKeyFile

--- a/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
@@ -87,6 +87,11 @@ parameters:
     type: string
     default: SqlServer.Artifacts
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 - job: build_mds_akv_packages_job
   displayName: Build MDS & AKV Packages
@@ -137,6 +142,10 @@ jobs:
   # Restore dotnet CLI tools (e.g. pwsh, apicompat) before building.
   - template: /eng/pipelines/common/steps/restore-dotnet-tools.yml@self
 
+  # Download the assembly signing key for internal builds.
+  - ${{ if eq(parameters.isInternalBuild, true) }}:
+    - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+
   # When we're performing a Debug build, we still want to try _compiling_ the
   # code in Release mode to ensure downstream pipelines don't encounter
   # compilation errors.  We won't use the Release artifacts for anything else
@@ -148,6 +157,8 @@ jobs:
         buildConfiguration: Release
         referenceType: Project
         build: all
+        ${{ if eq(parameters.isInternalBuild, true) }}:
+          signingKeyPath: $(driverKeyFile.secureFilePath)
 
   - template: /eng/pipelines/common/templates/steps/ci-project-build-step.yml@self
     parameters:
@@ -159,6 +170,8 @@ jobs:
       abstractionsPackageVersion: ${{parameters.abstractionsPackageVersion}}
       loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
       sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+      ${{ if eq(parameters.isInternalBuild, true) }}:
+        signingKeyPath: $(driverKeyFile.secureFilePath)
 
   - task: DotNetCoreCLI@2
     displayName: 'Create MDS NuGet Package'
@@ -206,6 +219,8 @@ jobs:
       mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
       akvPackageVersion: ${{ parameters.akvPackageVersion }}
       sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+      ${{ if eq(parameters.isInternalBuild, true) }}:
+        signingKeyPath: $(driverKeyFile.secureFilePath)
 
   - task: DotNetCoreCLI@2
     displayName: 'Create AKV Provider NuGet Package'

--- a/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
@@ -142,8 +142,8 @@ jobs:
   # Restore dotnet CLI tools (e.g. pwsh, apicompat) before building.
   - template: /eng/pipelines/common/steps/restore-dotnet-tools.yml@self
 
-  # Download the assembly signing key for internal builds.
-  - ${{ if eq(parameters.isInternalBuild, true) }}:
+  # Download the assembly signing key for internal Package-mode builds.
+  - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
     - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
   # When we're performing a Debug build, we still want to try _compiling_ the

--- a/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
@@ -157,8 +157,6 @@ jobs:
         buildConfiguration: Release
         referenceType: Project
         build: all
-        ${{ if eq(parameters.isInternalBuild, true) }}:
-          signingKeyPath: $(driverKeyFile.secureFilePath)
 
   - template: /eng/pipelines/common/templates/steps/ci-project-build-step.yml@self
     parameters:
@@ -170,7 +168,7 @@ jobs:
       abstractionsPackageVersion: ${{parameters.abstractionsPackageVersion}}
       loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
       sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
-      ${{ if eq(parameters.isInternalBuild, true) }}:
+      ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         signingKeyPath: $(driverKeyFile.secureFilePath)
 
   - task: DotNetCoreCLI@2
@@ -219,7 +217,7 @@ jobs:
       mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
       akvPackageVersion: ${{ parameters.akvPackageVersion }}
       sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
-      ${{ if eq(parameters.isInternalBuild, true) }}:
+      ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         signingKeyPath: $(driverKeyFile.secureFilePath)
 
   - task: DotNetCoreCLI@2

--- a/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
@@ -160,6 +160,11 @@ parameters:
   - name: saPassword
     type: string
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 - job: ${{ format('{0}', coalesce(parameters.jobDisplayName, parameters.image, 'unknown_image')) }}
 
@@ -223,6 +228,13 @@ jobs:
   # Restore dotnet CLI tools (e.g. pwsh, apicompat) before building.
   - template: /eng/pipelines/common/steps/restore-dotnet-tools.yml@self
 
+  # Download the assembly signing keys for internal builds.
+  - ${{ if eq(parameters.isInternalBuild, true) }}:
+    - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+    - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+      parameters:
+        isTest: true
+
   - ${{ if ne(parameters.prebuildSteps, '') }}:
     - ${{ parameters.prebuildSteps }} # extra steps to run before the build like downloading sni and the required configuration
 
@@ -232,6 +244,8 @@ jobs:
         build: allNoDocs
         buildConfiguration: ${{ parameters.buildConfiguration }}
         referenceType: Project
+        ${{ if eq(parameters.isInternalBuild, true) }}:
+          signingKeyPath: $(driverKeyFile.secureFilePath)
 
   - ${{ if ne(parameters.configProperties, '{}') }}:
     - template: /eng/pipelines/common/templates/steps/update-config-file-step.yml@self # update config.jsonc file
@@ -378,6 +392,9 @@ jobs:
         loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
         mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
         sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+        ${{ if eq(parameters.isInternalBuild, true) }}:
+          signingKeyPath: $(driverKeyFile.secureFilePath)
+          testSigningKeyPath: $(testKeyFile.secureFilePath)
 
   - ${{ if and(eq(parameters.enableX86Test, true), eq(parameters.operatingSystem, 'Windows')) }}:
     - template: /eng/pipelines/common/templates/steps/run-all-tests-step.yml@self
@@ -394,6 +411,9 @@ jobs:
         loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
         mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
         sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+        ${{ if eq(parameters.isInternalBuild, true) }}:
+          signingKeyPath: $(driverKeyFile.secureFilePath)
+          testSigningKeyPath: $(testKeyFile.secureFilePath)
 
   - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
     parameters:

--- a/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
@@ -244,8 +244,6 @@ jobs:
         build: allNoDocs
         buildConfiguration: ${{ parameters.buildConfiguration }}
         referenceType: Project
-        ${{ if eq(parameters.isInternalBuild, true) }}:
-          signingKeyPath: $(driverKeyFile.secureFilePath)
 
   - ${{ if ne(parameters.configProperties, '{}') }}:
     - template: /eng/pipelines/common/templates/steps/update-config-file-step.yml@self # update config.jsonc file
@@ -392,7 +390,7 @@ jobs:
         loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
         mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
         sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
-        ${{ if eq(parameters.isInternalBuild, true) }}:
+        ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
           signingKeyPath: $(driverKeyFile.secureFilePath)
           testSigningKeyPath: $(testKeyFile.secureFilePath)
 
@@ -411,7 +409,7 @@ jobs:
         loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
         mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
         sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
-        ${{ if eq(parameters.isInternalBuild, true) }}:
+        ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
           signingKeyPath: $(driverKeyFile.secureFilePath)
           testSigningKeyPath: $(testKeyFile.secureFilePath)
 

--- a/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
@@ -228,8 +228,8 @@ jobs:
   # Restore dotnet CLI tools (e.g. pwsh, apicompat) before building.
   - template: /eng/pipelines/common/steps/restore-dotnet-tools.yml@self
 
-  # Download the assembly signing keys for internal builds.
-  - ${{ if eq(parameters.isInternalBuild, true) }}:
+  # Download the assembly signing keys for internal Package-mode builds.
+  - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
     - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
     - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
       parameters:

--- a/eng/pipelines/common/templates/stages/ci-run-tests-stage.yml
+++ b/eng/pipelines/common/templates/stages/ci-run-tests-stage.yml
@@ -88,6 +88,11 @@ parameters:
   - name: testJobTimeout
     type: number
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 stages:
 - ${{ each config in parameters.testConfigurations }}:
   - ${{ each image in config.value.images }}:
@@ -124,6 +129,7 @@ stages:
                   loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
                   mdsArtifactsName: ${{ parameters.mdsArtifactsName }}
                   mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
+                  isInternalBuild: ${{ parameters.isInternalBuild }}
                   sqlServerArtifactsName: ${{ parameters.sqlServerArtifactsName }}
                   sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
                   prebuildSteps: ${{ parameters.prebuildSteps }}
@@ -162,6 +168,7 @@ stages:
                     loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
                     mdsArtifactsName: ${{ parameters.mdsArtifactsName }}
                     mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
+                    isInternalBuild: ${{ parameters.isInternalBuild }}
                     sqlServerArtifactsName: ${{ parameters.sqlServerArtifactsName }}
                     sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
                     prebuildSteps: ${{ parameters.prebuildSteps }}

--- a/eng/pipelines/common/templates/steps/ci-project-build-step.yml
+++ b/eng/pipelines/common/templates/steps/ci-project-build-step.yml
@@ -73,6 +73,13 @@ parameters:
     type: string
     default: $(sqlServerPackageVersion)
 
+  # Path to the assembly signing key file.  When non-empty, passed as -p:SigningKeyPath="" to the
+  # build.  The calling job is responsible for downloading the key (via
+  # download-assembly-signing-key.yml).
+  - name: signingKeyPath
+    type: string
+    default: ''
+
 steps:
   # Build MDS
   - ${{ if or(eq(parameters.build, 'MDS'), eq(parameters.build, 'all'), eq(parameters.build, 'allNoDocs')) }}:
@@ -91,6 +98,7 @@ steps:
           -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
 
   # Build AKV Provider
   - ${{ if or(eq(parameters.build, 'AkvProvider'), eq(parameters.build, 'all'), eq(parameters.build, 'allNoDocs')) }}:
@@ -110,3 +118,4 @@ steps:
           -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"

--- a/eng/pipelines/common/templates/steps/run-all-tests-step.yml
+++ b/eng/pipelines/common/templates/steps/run-all-tests-step.yml
@@ -72,6 +72,18 @@ parameters:
     type: number
     default: 2
 
+  # Path to the assembly signing key file.  When non-empty, passed to build.proj so that the
+  # test-filter logic can include category=signed tests.
+  - name: signingKeyPath
+    type: string
+    default: ''
+
+  # Path to the test assembly signing key file.  When non-empty, passed to build.proj so that test
+  # assemblies are signed and can satisfy InternalsVisibleTo grants from signed source assemblies.
+  - name: testSigningKeyPath
+    type: string
+    default: ''
+
 steps:
 - ${{ if parameters.debug }}:
   - powershell: 'dotnet sdk check'
@@ -94,6 +106,8 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientUnit
@@ -104,6 +118,8 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Unit Tests ${{parameters.msbuildArchitecture }}'
@@ -122,6 +138,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientUnit
@@ -134,6 +152,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true
 
   - task: DotNetCoreCLI@2
@@ -153,6 +173,8 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientFunctional
@@ -165,6 +187,8 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Functional Tests ${{parameters.msbuildArchitecture }}'
@@ -185,6 +209,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientFunctional
@@ -199,6 +225,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true
 
   - task: DotNetCoreCLI@2
@@ -219,6 +247,8 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientManual
@@ -232,6 +262,8 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
   - task: DotNetCoreCLI@2
@@ -254,6 +286,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientManual
@@ -269,6 +303,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true
 
 - ${{ else }}: # Linux or macOS
@@ -286,6 +322,8 @@ steps:
         -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Unit Tests'
@@ -303,6 +341,8 @@ steps:
         -p:TestFilters="category=flaky"
         -p:TestResultsFolderPath=TestResults
         -p:TestCodeCoverage=false
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true
 
   - task: DotNetCoreCLI@2
@@ -321,6 +361,8 @@ steps:
         -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Functional Tests'
@@ -340,6 +382,8 @@ steps:
         -p:TestFilters="category=flaky"
         -p:TestResultsFolderPath=TestResults
         -p:TestCodeCoverage=false
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true
   - task: DotNetCoreCLI@2
     displayName: 'Run Manual Tests'
@@ -358,6 +402,8 @@ steps:
         -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
   - task: DotNetCoreCLI@2
@@ -379,4 +425,6 @@ steps:
         -p:TestFilters="category=flaky"
         -p:TestResultsFolderPath=TestResults
         -p:TestCodeCoverage=false
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -144,6 +144,7 @@ stages:
       buildConfiguration: ${{ parameters.buildConfiguration }}
       debug: ${{ parameters.debug }}
       dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+      isInternalBuild: ${{ parameters.isInternalBuild }}
 
   # Build the Logging package, and publish it to the pipeline artifacts
   # under the given artifact name.  This runs in parallel with the Secrets

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -145,6 +145,7 @@ stages:
       debug: ${{ parameters.debug }}
       dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
       isInternalBuild: ${{ parameters.isInternalBuild }}
+      referenceType: ${{ parameters.referenceType }}
 
   # Build the Logging package, and publish it to the pipeline artifacts
   # under the given artifact name.  This runs in parallel with the Secrets
@@ -158,6 +159,7 @@ stages:
       debug: ${{ parameters.debug }}
       dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
       isInternalBuild: ${{ parameters.isInternalBuild }}
+      referenceType: ${{ parameters.referenceType }}
 
   # Build the Abstractions package, and publish it to the pipeline artifacts
   # under the given artifact name.

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -104,6 +104,12 @@ parameters:
       - detailed
       - diagnostic
 
+  # True when building on the internal ADO.Net project.  Internal builds may perform additional or
+  # different steps, such as assembly signing.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 variables:
   - template: /eng/pipelines/libraries/ci-build-variables.yml@self
 
@@ -150,6 +156,7 @@ stages:
       buildConfiguration: ${{ parameters.buildConfiguration }}
       debug: ${{ parameters.debug }}
       dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+      isInternalBuild: ${{ parameters.isInternalBuild }}
 
   # Build the Abstractions package, and publish it to the pipeline artifacts
   # under the given artifact name.
@@ -167,6 +174,7 @@ stages:
       loggingArtifactsName: $(loggingArtifactsName)
       loggingPackageVersion: $(loggingPackageVersion)
       referenceType: ${{ parameters.referenceType }}
+      isInternalBuild: ${{ parameters.isInternalBuild }}
       # When building Abstractions via packages, we must depend on the Logging
       # package.
       ${{ if eq(parameters.referenceType, 'Package') }}:
@@ -188,6 +196,7 @@ stages:
       mdsPackageVersion: $(mdsPackageVersion)
       akvPackageVersion: $(akvPackageVersion)
       referenceType: ${{ parameters.referenceType }}
+      isInternalBuild: ${{ parameters.isInternalBuild }}
       sqlServerArtifactsName: $(sqlServerArtifactsName)
       sqlServerPackageVersion: $(sqlServerPackageVersion)
       SNIVersion: ${{ parameters.SNIVersion }}
@@ -220,6 +229,7 @@ stages:
           - build_sqlserver_package_stage
           - build_sqlclient_package_stage
       dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+      isInternalBuild: ${{ parameters.isInternalBuild }}
       loggingArtifactsName: $(loggingArtifactsName)
       loggingPackageVersion: $(loggingPackageVersion)
       mdsArtifactsName: $(mdsArtifactsName)
@@ -251,6 +261,7 @@ stages:
       loggingPackageVersion: $(loggingPackageVersion)
       mdsArtifactsName: $(mdsArtifactsName)
       mdsPackageVersion: $(mdsPackageVersion)
+      isInternalBuild: ${{ parameters.isInternalBuild }}
       sqlServerArtifactsName: $(sqlServerArtifactsName)
       sqlServerPackageVersion: $(sqlServerPackageVersion)
       testJobTimeout: ${{ parameters.testJobTimeout }}

--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -174,3 +174,4 @@ extends:
     testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
     useManagedSNI: ${{ parameters.useManagedSNI }}
+    isInternalBuild: ${{ eq(variables['System.TeamProject'], 'ADO.Net') }}

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -174,3 +174,4 @@ extends:
     testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
     useManagedSNI: ${{ parameters.useManagedSNI }}
+    isInternalBuild: ${{ eq(variables['System.TeamProject'], 'ADO.Net') }}

--- a/eng/pipelines/jobs/pack-abstractions-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-abstractions-package-ci-job.yml
@@ -129,20 +129,19 @@ jobs:
       - name: baseBuildProperties
         value: AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }};AbstractionsAssemblyFileVersion=${{ parameters.abstractionsAssemblyFileVersion }}
 
-      - name: packageModeProperties
-        ${{ if eq(parameters.referenceType, 'Package') }}:
-          value: ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }}
-        ${{ else }}:
-          value: ''
-
-      - name: signingProperties
-        ${{ if eq(parameters.isInternalBuild, true) }}:
-          value: SigningKeyPath=$(driverKeyFile.secureFilePath)
-        ${{ else }}:
-          value: ''
-
+      # NOTE: We use compile-time ${{ if }} branches rather than concatenating
+      # separate variables (e.g. "$(base);$(optional);$(signing)") because
+      # when the optional variables are empty the semicolons remain, producing
+      # a trailing ";;" that MSBuild rejects with MSB1005.
       - name: buildProperties
-        value: $(baseBuildProperties);$(packageModeProperties);$(signingProperties)
+        ${{ if and(eq(parameters.referenceType, 'Package'), eq(parameters.isInternalBuild, true)) }}:
+          value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ elseif eq(parameters.referenceType, 'Package') }}:
+          value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }}
+        ${{ elseif eq(parameters.isInternalBuild, true) }}:
+          value: $(baseBuildProperties);SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ else }}:
+          value: $(baseBuildProperties)
 
     steps:
 

--- a/eng/pipelines/jobs/pack-abstractions-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-abstractions-package-ci-job.yml
@@ -138,8 +138,6 @@ jobs:
           value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};SigningKeyPath=$(driverKeyFile.secureFilePath)
         ${{ elseif eq(parameters.referenceType, 'Package') }}:
           value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }}
-        ${{ elseif eq(parameters.isInternalBuild, true) }}:
-          value: $(baseBuildProperties);SigningKeyPath=$(driverKeyFile.secureFilePath)
         ${{ else }}:
           value: $(baseBuildProperties)
 
@@ -164,8 +162,8 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
-      # Download the assembly signing key for internal builds.
-      - ${{ if eq(parameters.isInternalBuild, true) }}:
+      # Download the assembly signing key for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
       # Create the NuGet packages.

--- a/eng/pipelines/jobs/pack-abstractions-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-abstractions-package-ci-job.yml
@@ -77,6 +77,11 @@ parameters:
       # Reference sibling packages as C# projects.
       - Project
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 
   - job: pack_abstractions_package_job
@@ -119,6 +124,26 @@ jobs:
       - name: Configuration
         value: ''
 
+      # Build properties passed to dotnet pack.  Composed from a base set plus
+      # optional suffixes for Package-mode dependencies and assembly signing.
+      - name: baseBuildProperties
+        value: AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }};AbstractionsAssemblyFileVersion=${{ parameters.abstractionsAssemblyFileVersion }}
+
+      - name: packageModeProperties
+        ${{ if eq(parameters.referenceType, 'Package') }}:
+          value: ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }}
+        ${{ else }}:
+          value: ''
+
+      - name: signingProperties
+        ${{ if eq(parameters.isInternalBuild, true) }}:
+          value: SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ else }}:
+          value: ''
+
+      - name: buildProperties
+        value: $(baseBuildProperties);$(packageModeProperties);$(signingProperties)
+
     steps:
 
       # Emit environment variables if debug is enabled.
@@ -140,32 +165,20 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
-      # Create the NuGet packages.
-      #
-      # When referenceType is Package, we must pass ReferenceType and the
-      # dependency version so that Directory.Packages.props applies version
-      # ranges to sibling package dependencies.
-      - ${{ if eq(parameters.referenceType, 'Package') }}:
-        - task: DotNetCoreCLI@2
-          displayName: Create NuGet Package
-          inputs:
-            command: pack
-            packagesToPack: $(project)
-            configurationToPack: ${{ parameters.buildConfiguration }}
-            packDirectory: $(dotnetPackagesDir)
-            verbosityToPack: ${{ parameters.dotnetVerbosity }}
-            buildProperties: AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }};AbstractionsAssemblyFileVersion=${{ parameters.abstractionsAssemblyFileVersion }};ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }}
+      # Download the assembly signing key for internal builds.
+      - ${{ if eq(parameters.isInternalBuild, true) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
-      - ${{ else }}:
-        - task: DotNetCoreCLI@2
-          displayName: Create NuGet Package
-          inputs:
-            command: pack
-            packagesToPack: $(project)
-            configurationToPack: ${{ parameters.buildConfiguration }}
-            packDirectory: $(dotnetPackagesDir)
-            verbosityToPack: ${{ parameters.dotnetVerbosity }}
-            buildProperties: AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }};AbstractionsAssemblyFileVersion=${{ parameters.abstractionsAssemblyFileVersion }}
+      # Create the NuGet packages.
+      - task: DotNetCoreCLI@2
+        displayName: Create NuGet Package
+        inputs:
+          command: pack
+          packagesToPack: $(project)
+          configurationToPack: ${{ parameters.buildConfiguration }}
+          packDirectory: $(dotnetPackagesDir)
+          verbosityToPack: ${{ parameters.dotnetVerbosity }}
+          buildProperties: $(buildProperties)
 
       # Publish the NuGet packages as a named pipeline artifact.
       - task: PublishPipelineArtifact@1

--- a/eng/pipelines/jobs/pack-azure-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-azure-package-ci-job.yml
@@ -150,8 +150,6 @@ jobs:
           value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }};SigningKeyPath=$(driverKeyFile.secureFilePath)
         ${{ elseif eq(parameters.referenceType, 'Package') }}:
           value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }}
-        ${{ elseif eq(parameters.isInternalBuild, true) }}:
-          value: $(baseBuildProperties);SigningKeyPath=$(driverKeyFile.secureFilePath)
         ${{ else }}:
           value: $(baseBuildProperties)
 
@@ -181,8 +179,8 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
-      # Download the assembly signing key for internal builds.
-      - ${{ if eq(parameters.isInternalBuild, true) }}:
+      # Download the assembly signing key for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
       # Create the NuGet packages.

--- a/eng/pipelines/jobs/pack-azure-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-azure-package-ci-job.yml
@@ -89,6 +89,11 @@ parameters:
       # Reference sibling packages as C# projects.
       - Project
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 
   - job: pack_azure_package_job
@@ -131,6 +136,26 @@ jobs:
       - name: Configuration
         value: ''
 
+      # Build properties passed to dotnet pack.  Composed from a base set plus
+      # optional suffixes for Package-mode dependencies and assembly signing.
+      - name: baseBuildProperties
+        value: AzurePackageVersion=${{ parameters.azurePackageVersion }};AzureAssemblyFileVersion=${{ parameters.azureAssemblyFileVersion }}
+
+      - name: packageModeProperties
+        ${{ if eq(parameters.referenceType, 'Package') }}:
+          value: ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }}
+        ${{ else }}:
+          value: ''
+
+      - name: signingProperties
+        ${{ if eq(parameters.isInternalBuild, true) }}:
+          value: SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ else }}:
+          value: ''
+
+      - name: buildProperties
+        value: $(baseBuildProperties);$(packageModeProperties);$(signingProperties)
+
     steps:
 
       # Emit environment variables if debug is enabled.
@@ -157,32 +182,20 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
-      # Create the NuGet packages.
-      #
-      # When referenceType is Package, we must pass ReferenceType and the
-      # dependency versions so that Directory.Packages.props applies version
-      # ranges to sibling package dependencies.
-      - ${{ if eq(parameters.referenceType, 'Package') }}:
-        - task: DotNetCoreCLI@2
-          displayName: Create NuGet Package
-          inputs:
-            command: pack
-            packagesToPack: $(project)
-            configurationToPack: ${{ parameters.buildConfiguration }}
-            packDirectory: $(dotnetPackagesDir)
-            verbosityToPack: ${{ parameters.dotnetVerbosity }}
-            buildProperties: AzurePackageVersion=${{ parameters.azurePackageVersion }};AzureAssemblyFileVersion=${{ parameters.azureAssemblyFileVersion }};ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }}
+      # Download the assembly signing key for internal builds.
+      - ${{ if eq(parameters.isInternalBuild, true) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
-      - ${{ else }}:
-        - task: DotNetCoreCLI@2
-          displayName: Create NuGet Package
-          inputs:
-            command: pack
-            packagesToPack: $(project)
-            configurationToPack: ${{ parameters.buildConfiguration }}
-            packDirectory: $(dotnetPackagesDir)
-            verbosityToPack: ${{ parameters.dotnetVerbosity }}
-            buildProperties: AzurePackageVersion=${{ parameters.azurePackageVersion }};AzureAssemblyFileVersion=${{ parameters.azureAssemblyFileVersion }}
+      # Create the NuGet packages.
+      - task: DotNetCoreCLI@2
+        displayName: Create NuGet Package
+        inputs:
+          command: pack
+          packagesToPack: $(project)
+          configurationToPack: ${{ parameters.buildConfiguration }}
+          packDirectory: $(dotnetPackagesDir)
+          verbosityToPack: ${{ parameters.dotnetVerbosity }}
+          buildProperties: $(buildProperties)
 
       # Publish the NuGet packages as a named pipeline artifact.
       - task: PublishPipelineArtifact@1

--- a/eng/pipelines/jobs/pack-azure-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-azure-package-ci-job.yml
@@ -141,20 +141,19 @@ jobs:
       - name: baseBuildProperties
         value: AzurePackageVersion=${{ parameters.azurePackageVersion }};AzureAssemblyFileVersion=${{ parameters.azureAssemblyFileVersion }}
 
-      - name: packageModeProperties
-        ${{ if eq(parameters.referenceType, 'Package') }}:
-          value: ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }}
-        ${{ else }}:
-          value: ''
-
-      - name: signingProperties
-        ${{ if eq(parameters.isInternalBuild, true) }}:
-          value: SigningKeyPath=$(driverKeyFile.secureFilePath)
-        ${{ else }}:
-          value: ''
-
+      # NOTE: We use compile-time ${{ if }} branches rather than concatenating
+      # separate variables (e.g. "$(base);$(optional);$(signing)") because
+      # when the optional variables are empty the semicolons remain, producing
+      # a trailing ";;" that MSBuild rejects with MSB1005.
       - name: buildProperties
-        value: $(baseBuildProperties);$(packageModeProperties);$(signingProperties)
+        ${{ if and(eq(parameters.referenceType, 'Package'), eq(parameters.isInternalBuild, true)) }}:
+          value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }};SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ elseif eq(parameters.referenceType, 'Package') }}:
+          value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }}
+        ${{ elseif eq(parameters.isInternalBuild, true) }}:
+          value: $(baseBuildProperties);SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ else }}:
+          value: $(baseBuildProperties)
 
     steps:
 

--- a/eng/pipelines/jobs/pack-logging-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-logging-package-ci-job.yml
@@ -53,6 +53,11 @@ parameters:
     - detailed
     - diagnostic
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 
   - job: pack_logging_package_job
@@ -86,6 +91,19 @@ jobs:
       - name: Configuration
         value: ''
 
+      # Build properties passed to dotnet pack.
+      - name: baseBuildProperties
+        value: LoggingPackageVersion=${{ parameters.loggingPackageVersion }};LoggingAssemblyFileVersion=${{ parameters.loggingAssemblyFileVersion }}
+
+      - name: signingProperties
+        ${{ if eq(parameters.isInternalBuild, true) }}:
+          value: SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ else }}:
+          value: ''
+
+      - name: buildProperties
+        value: $(baseBuildProperties);$(signingProperties)
+
     steps:
 
       # Emit environment variables if debug is enabled.
@@ -98,6 +116,10 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
+      # Download the assembly signing key for internal builds.
+      - ${{ if eq(parameters.isInternalBuild, true) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+
       # Create the NuGet packages.
       - task: DotNetCoreCLI@2
         displayName: Create NuGet Package
@@ -107,7 +129,7 @@ jobs:
           configurationToPack: ${{ parameters.buildConfiguration }}
           packDirectory: $(dotnetPackagesDir)
           verbosityToPack: ${{ parameters.dotnetVerbosity }}
-          buildProperties: LoggingPackageVersion=${{ parameters.loggingPackageVersion }};LoggingAssemblyFileVersion=${{ parameters.loggingAssemblyFileVersion }}
+          buildProperties: $(buildProperties)
 
       # Publish the NuGet packages as a named pipeline artifact.
       - task: PublishPipelineArtifact@1

--- a/eng/pipelines/jobs/pack-logging-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-logging-package-ci-job.yml
@@ -95,14 +95,15 @@ jobs:
       - name: baseBuildProperties
         value: LoggingPackageVersion=${{ parameters.loggingPackageVersion }};LoggingAssemblyFileVersion=${{ parameters.loggingAssemblyFileVersion }}
 
-      - name: signingProperties
-        ${{ if eq(parameters.isInternalBuild, true) }}:
-          value: SigningKeyPath=$(driverKeyFile.secureFilePath)
-        ${{ else }}:
-          value: ''
-
+      # NOTE: We use compile-time ${{ if }} branches rather than concatenating
+      # separate variables (e.g. "$(base);$(signing)") because when the
+      # optional variable is empty the semicolons remain, producing a trailing
+      # ";;" that MSBuild rejects with MSB1005.
       - name: buildProperties
-        value: $(baseBuildProperties);$(signingProperties)
+        ${{ if eq(parameters.isInternalBuild, true) }}:
+          value: $(baseBuildProperties);SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ else }}:
+          value: $(baseBuildProperties)
 
     steps:
 

--- a/eng/pipelines/jobs/pack-logging-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-logging-package-ci-job.yml
@@ -53,6 +53,14 @@ parameters:
     - detailed
     - diagnostic
 
+  # The C# project reference type to use when building and packing the packages.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
   # True when building on the internal ADO.Net project.
   - name: isInternalBuild
     type: boolean
@@ -100,7 +108,7 @@ jobs:
       # optional variable is empty the semicolons remain, producing a trailing
       # ";;" that MSBuild rejects with MSB1005.
       - name: buildProperties
-        ${{ if eq(parameters.isInternalBuild, true) }}:
+        ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
           value: $(baseBuildProperties);SigningKeyPath=$(driverKeyFile.secureFilePath)
         ${{ else }}:
           value: $(baseBuildProperties)
@@ -117,8 +125,8 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
-      # Download the assembly signing key for internal builds.
-      - ${{ if eq(parameters.isInternalBuild, true) }}:
+      # Download the assembly signing key for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
       # Create the NuGet packages.

--- a/eng/pipelines/jobs/pack-sqlserver-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-sqlserver-package-ci-job.yml
@@ -49,6 +49,11 @@ parameters:
     - detailed
     - diagnostic
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 
   - job: pack_sqlserver_package_job
@@ -82,6 +87,14 @@ jobs:
       - name: Configuration
         value: ''
 
+      # Build properties passed to dotnet pack.  Composed from a base set plus
+      # optional signing key path for internal builds.
+      - name: buildProperties
+        ${{ if eq(parameters.isInternalBuild, true) }}:
+          value: SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }};SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ else }}:
+          value: SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }}
+
     steps:
 
       # Emit environment variables if debug is enabled.
@@ -94,6 +107,10 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
+      # Download the assembly signing key for internal builds.
+      - ${{ if eq(parameters.isInternalBuild, true) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+
       # Create the NuGet packages.
       - task: DotNetCoreCLI@2
         displayName: Create NuGet Package
@@ -103,7 +120,7 @@ jobs:
           configurationToPack: ${{ parameters.buildConfiguration }}
           packDirectory: $(dotnetPackagesDir)
           verbosityToPack: ${{ parameters.dotnetVerbosity }}
-          buildProperties: SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }}
+          buildProperties: $(buildProperties)
 
       - task: PublishPipelineArtifact@1
         displayName: Publish Pipeline Artifact

--- a/eng/pipelines/jobs/pack-sqlserver-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-sqlserver-package-ci-job.yml
@@ -49,6 +49,14 @@ parameters:
     - detailed
     - diagnostic
 
+  # The C# project reference type to use when building and packing the packages.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
   # True when building on the internal ADO.Net project.
   - name: isInternalBuild
     type: boolean
@@ -88,9 +96,9 @@ jobs:
         value: ''
 
       # Build properties passed to dotnet pack.  Composed from a base set plus
-      # optional signing key path for internal builds.
+      # optional signing key path for internal Package-mode builds.
       - name: buildProperties
-        ${{ if eq(parameters.isInternalBuild, true) }}:
+        ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
           value: SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }};SigningKeyPath=$(driverKeyFile.secureFilePath)
         ${{ else }}:
           value: SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }}
@@ -107,8 +115,8 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
-      # Download the assembly signing key for internal builds.
-      - ${{ if eq(parameters.isInternalBuild, true) }}:
+      # Download the assembly signing key for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
       # Create the NuGet packages.

--- a/eng/pipelines/jobs/test-abstractions-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-abstractions-package-ci-job.yml
@@ -67,6 +67,14 @@ parameters:
     type: boolean
     default: false
 
+  # The C# project reference type to use when building.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
   # The pool VM image to use.
   - name: vmImage
     type: string
@@ -100,8 +108,8 @@ jobs:
           -p:Configuration=${{ parameters.buildConfiguration }}
           --verbosity ${{ parameters.dotnetVerbosity }}
 
-      # Signing arguments — only set for internal builds.
-      - ${{ if eq(parameters.isInternalBuild, true) }}:
+      # Signing arguments — only set for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         - name: signingArguments
           value: >-
             -p:SigningKeyPath=$(driverKeyFile.secureFilePath)
@@ -137,8 +145,8 @@ jobs:
         - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
           displayName: '[Debug] Print Environment Variables'
 
-      # Download the assembly signing keys for internal builds.
-      - ${{ if eq(parameters.isInternalBuild, true) }}:
+      # Download the assembly signing keys for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
         - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
           parameters:

--- a/eng/pipelines/jobs/test-abstractions-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-abstractions-package-ci-job.yml
@@ -95,7 +95,7 @@ jobs:
         value: src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
 
       # dotnet CLI arguments for build/test/pack commands
-      - name: buildArguments
+      - name: dotnetBuildOpts
         value: >-
           -p:Configuration=${{ parameters.buildConfiguration }}
           --verbosity ${{ parameters.dotnetVerbosity }}
@@ -159,7 +159,7 @@ jobs:
         inputs:
           command: build
           projects: $(project)
-          arguments: $(buildArguments) $(signingArguments)
+          arguments: $(dotnetBuildOpts) $(signingArguments)
 
       # Run the tests for each .NET runtime.
       - ${{ each runtime in parameters.netRuntimes }}:
@@ -169,7 +169,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category != failing & category != flaky & category != interactive"
@@ -180,7 +180,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category = flaky"
@@ -193,7 +193,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category != failing & category != flaky & category != interactive"
@@ -204,7 +204,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category = flaky"

--- a/eng/pipelines/jobs/test-abstractions-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-abstractions-package-ci-job.yml
@@ -61,6 +61,12 @@ parameters:
   - name: poolName
     type: string
 
+  # True when building on the internal ADO.Net project.  When set, assemblies
+  # are signed with the driver key and tests are signed with the test key.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
   # The pool VM image to use.
   - name: vmImage
     type: string
@@ -94,6 +100,16 @@ jobs:
           -p:Configuration=${{ parameters.buildConfiguration }}
           --verbosity ${{ parameters.dotnetVerbosity }}
 
+      # Signing arguments — only set for internal builds.
+      - ${{ if eq(parameters.isInternalBuild, true) }}:
+        - name: signingArguments
+          value: >-
+            -p:SigningKeyPath=$(driverKeyFile.secureFilePath)
+            -p:TestSigningKeyPath=$(testKeyFile.secureFilePath)
+      - ${{ else }}:
+        - name: signingArguments
+          value: ''
+
       # Explicitly unset the $PLATFORM environment variable that is set by the
       # 'ADO Build properties' Library in the ADO SqlClientDrivers public project.
       # This is defined with a non-standard Platform of 'AnyCPU', and will fail
@@ -121,6 +137,13 @@ jobs:
         - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
           displayName: '[Debug] Print Environment Variables'
 
+      # Download the assembly signing keys for internal builds.
+      - ${{ if eq(parameters.isInternalBuild, true) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+          parameters:
+            isTest: true
+
       # Install the .NET SDK and Runtimes.
       - template: /eng/pipelines/common/steps/install-dotnet.yml@self
         parameters:
@@ -136,7 +159,7 @@ jobs:
         inputs:
           command: build
           projects: $(project)
-          arguments: $(buildArguments)
+          arguments: $(buildArguments) $(signingArguments)
 
       # Run the tests for each .NET runtime.
       - ${{ each runtime in parameters.netRuntimes }}:

--- a/eng/pipelines/jobs/test-azure-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-azure-package-ci-job.yml
@@ -69,6 +69,12 @@ parameters:
     - detailed
     - diagnostic
 
+  # True when building on the internal ADO.Net project.  When set, assemblies
+  # are signed with the driver key and tests are signed with the test key.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
   # The suffix to append to the job name.
   - name: jobNameSuffix
     type: string
@@ -179,6 +185,16 @@ jobs:
           -p:SqlClientPackageVersion=${{ parameters.mdsPackageVersion }}
           -p:SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }}
 
+      # Signing arguments — only set for internal builds.
+      - ${{ if eq(parameters.isInternalBuild, true) }}:
+        - name: signingArguments
+          value: >-
+            -p:SigningKeyPath=$(driverKeyFile.secureFilePath)
+            -p:TestSigningKeyPath=$(testKeyFile.secureFilePath)
+      - ${{ else }}:
+        - name: signingArguments
+          value: ''
+
       # Explicitly unset the $PLATFORM environment variable that is set by the
       # 'ADO Build properties' Library in the ADO SqlClientDrivers public
       # project.  This is defined with a non-standard Platform of 'AnyCPU', and
@@ -205,6 +221,13 @@ jobs:
       - ${{ if eq(parameters.debug, true) }}:
         - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
           displayName: '[Debug] Print Environment Variables'
+
+      # Download the assembly signing keys for internal builds.
+      - ${{ if eq(parameters.isInternalBuild, true) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+          parameters:
+            isTest: true
 
       # We have a few extra steps for Package reference builds.
       - ${{ if eq(parameters.referenceType, 'Package') }}:
@@ -289,7 +312,7 @@ jobs:
         inputs:
           command: build
           projects: $(project)
-          arguments: $(buildArguments)
+          arguments: $(buildArguments) $(signingArguments)
 
       # List the DLLs in the output directory for debugging purposes.
       - ${{ if eq(parameters.debug, true) }}:

--- a/eng/pipelines/jobs/test-azure-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-azure-package-ci-job.yml
@@ -175,7 +175,7 @@ jobs:
         value: src/Microsoft.Data.SqlClient.Extensions/Azure/test/Azure.Test.csproj
 
       # dotnet CLI arguments for build/test/pack commands.
-      - name: buildArguments
+      - name: dotnetBuildOpts
         value: >-
           -p:Configuration=${{ parameters.buildConfiguration }}
           --verbosity ${{ parameters.dotnetVerbosity }}
@@ -312,7 +312,7 @@ jobs:
         inputs:
           command: build
           projects: $(project)
-          arguments: $(buildArguments) $(signingArguments)
+          arguments: $(dotnetBuildOpts) $(signingArguments)
 
       # List the DLLs in the output directory for debugging purposes.
       - ${{ if eq(parameters.debug, true) }}:
@@ -347,7 +347,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category != failing & category != flaky & category != interactive"
@@ -365,7 +365,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category = flaky"
@@ -385,7 +385,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category != failing & category != flaky & category != interactive"
@@ -403,7 +403,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category = flaky"

--- a/eng/pipelines/jobs/test-azure-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-azure-package-ci-job.yml
@@ -185,8 +185,8 @@ jobs:
           -p:SqlClientPackageVersion=${{ parameters.mdsPackageVersion }}
           -p:SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }}
 
-      # Signing arguments — only set for internal builds.
-      - ${{ if eq(parameters.isInternalBuild, true) }}:
+      # Signing arguments — only set for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         - name: signingArguments
           value: >-
             -p:SigningKeyPath=$(driverKeyFile.secureFilePath)
@@ -222,8 +222,8 @@ jobs:
         - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
           displayName: '[Debug] Print Environment Variables'
 
-      # Download the assembly signing keys for internal builds.
-      - ${{ if eq(parameters.isInternalBuild, true) }}:
+      # Download the assembly signing keys for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
         - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
           parameters:

--- a/eng/pipelines/jobs/test-logging-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-logging-package-ci-job.yml
@@ -71,6 +71,14 @@ parameters:
   - name: vmImage
     type: string
 
+  # The C# project reference type to use when building.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
 jobs:
 
   - job: test_logging_package_job_${{ parameters.jobNameSuffix }}
@@ -100,8 +108,8 @@ jobs:
           -p:Configuration=${{ parameters.buildConfiguration }}
           --verbosity ${{ parameters.dotnetVerbosity }}
 
-      # Signing arguments — only set for internal builds.
-      - ${{ if eq(parameters.isInternalBuild, true) }}:
+      # Signing arguments — only set for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         - name: signingArguments
           value: >-
             -p:SigningKeyPath=$(driverKeyFile.secureFilePath)
@@ -137,8 +145,8 @@ jobs:
         - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
           displayName: '[Debug] Print Environment Variables'
 
-      # Download the assembly signing keys for internal builds.
-      - ${{ if eq(parameters.isInternalBuild, true) }}:
+      # Download the assembly signing keys for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
         - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
         - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
           parameters:

--- a/eng/pipelines/jobs/test-logging-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-logging-package-ci-job.yml
@@ -95,7 +95,7 @@ jobs:
         value: src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
 
       # dotnet CLI arguments for build/test/pack commands
-      - name: buildArguments
+      - name: dotnetBuildOpts
         value: >-
           -p:Configuration=${{ parameters.buildConfiguration }}
           --verbosity ${{ parameters.dotnetVerbosity }}
@@ -159,7 +159,7 @@ jobs:
         inputs:
           command: build
           projects: $(project)
-          arguments: $(buildArguments) $(signingArguments)
+          arguments: $(dotnetBuildOpts) $(signingArguments)
 
       # Run the tests for each .NET runtime.
       - ${{ each runtime in parameters.netRuntimes }}:
@@ -169,7 +169,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category != failing & category != flaky & category != interactive"
@@ -180,7 +180,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category = flaky"
@@ -193,7 +193,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category != failing & category != flaky & category != interactive"
@@ -204,7 +204,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category = flaky"

--- a/eng/pipelines/jobs/test-logging-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-logging-package-ci-job.yml
@@ -1,0 +1,210 @@
+################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET
+# Foundation licenses this file to you under the MIT license.  See the LICENSE
+# file in the project root for more information.
+################################################################################
+
+# This job builds the Logging package and runs its tests for a set of .NET
+# runtimes.
+#
+# This template defines a job named
+# 'test_logging_package_job_<jobNameSuffix>' that can be depended on by
+# downstream jobs.
+
+parameters:
+
+  # The type of build to test (Release or Debug)
+  - name: buildConfiguration
+    type: string
+    values:
+    - Release
+    - Debug
+
+  # True to emit debug information and steps.
+  - name: debug
+    type: boolean
+    default: false
+
+  # The prefix to prepend to the job's display name:
+  #
+  #   [<prefix>] Test Logging Package
+  #
+  - name: displayNamePrefix
+    type: string
+
+  # The verbosity level for the dotnet CLI commands.
+  - name: dotnetVerbosity
+    type: string
+    default: normal
+    values:
+    - quiet
+    - minimal
+    - normal
+    - detailed
+    - diagnostic
+
+  # True when building on the internal ADO.Net project.  When set, assemblies
+  # are signed with the driver key and tests are signed with the test key.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
+  # The suffix to append to the job name.
+  - name: jobNameSuffix
+    type: string
+
+  # The list of .NET Framework runtimes to test against.
+  - name: netFrameworkRuntimes
+    type: object
+    default: []
+
+  # The list of .NET runtimes to test against.
+  - name: netRuntimes
+    type: object
+    default: []
+
+  # The name of the Azure Pipelines pool to use.
+  - name: poolName
+    type: string
+
+  # The pool VM image to use.
+  - name: vmImage
+    type: string
+
+jobs:
+
+  - job: test_logging_package_job_${{ parameters.jobNameSuffix }}
+    displayName: '[${{ parameters.displayNamePrefix }}] Test Logging Package'
+    pool:
+      name: ${{ parameters.poolName }}
+
+      # Images provided by Azure Pipelines must be selected using 'vmImage'.
+      ${{ if eq(parameters.poolName, 'Azure Pipelines') }}:
+        vmImage: ${{ parameters.vmImage }}
+      # Images provided by 1ES must be selected using a demand.
+      ${{ else }}:
+        demands:
+          - imageOverride -equals ${{ parameters.vmImage }}
+
+    variables:
+
+      # The Logging test project file to use for all dotnet CLI commands.
+      #
+      # Building this project implicitly builds the Logging project.
+      - name: project
+        value: src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
+
+      # dotnet CLI arguments for build/test/pack commands
+      - name: buildArguments
+        value: >-
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          --verbosity ${{ parameters.dotnetVerbosity }}
+
+      # Signing arguments — only set for internal builds.
+      - ${{ if eq(parameters.isInternalBuild, true) }}:
+        - name: signingArguments
+          value: >-
+            -p:SigningKeyPath=$(driverKeyFile.secureFilePath)
+            -p:TestSigningKeyPath=$(testKeyFile.secureFilePath)
+      - ${{ else }}:
+        - name: signingArguments
+          value: ''
+
+      # Explicitly unset the $PLATFORM environment variable that is set by the
+      # 'ADO Build properties' Library in the ADO SqlClientDrivers public project.
+      # This is defined with a non-standard Platform of 'AnyCPU', and will fail
+      # the builds if left defined.
+      #
+      # Note that Azure Pipelines will inject this variable as PLATFORM into the
+      # environment of all tasks in this job.
+      #
+      # See:
+      #   https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch
+      #
+      - name: Platform
+        value: ''
+
+      # Do the same for $CONFIGURATION since we explicitly set it using our
+      # 'buildConfiguration' parameter, and we don't want the environment to
+      # override us.
+      - name: Configuration
+        value: ''
+
+    steps:
+
+      # Emit environment variables if debug is enabled.
+      - ${{ if eq(parameters.debug, true) }}:
+        - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
+          displayName: '[Debug] Print Environment Variables'
+
+      # Download the assembly signing keys for internal builds.
+      - ${{ if eq(parameters.isInternalBuild, true) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+          parameters:
+            isTest: true
+
+      # Install the .NET SDK and Runtimes.
+      - template: /eng/pipelines/common/steps/install-dotnet.yml@self
+        parameters:
+          debug: ${{ parameters.debug }}
+          runtimes: [8.x, 9.x]
+
+      # The Windows agent images include a suitable .NET Framework runtime, so
+      # we don't have to install one explicitly.
+
+      # Build the project.
+      - task: DotNetCoreCLI@2
+        displayName: Build Project
+        inputs:
+          command: build
+          projects: $(project)
+          arguments: $(buildArguments) $(signingArguments)
+
+      # Run the tests for each .NET runtime.
+      - ${{ each runtime in parameters.netRuntimes }}:
+        - task: DotNetCoreCLI@2
+          displayName: Test [${{ runtime }}]
+          inputs:
+            command: test
+            projects: $(project)
+            arguments: >-
+              $(buildArguments)
+              --no-build
+              -f ${{ runtime }}
+              --filter "category != failing & category != flaky & category != interactive"
+
+        - task: DotNetCoreCLI@2
+          displayName: Test Flaky [${{ runtime }}]
+          inputs:
+            command: test
+            projects: $(project)
+            arguments: >-
+              $(buildArguments)
+              --no-build
+              -f ${{ runtime }}
+              --filter "category = flaky"
+
+      # Run the tests for each .NET Framework runtime.
+      - ${{ each runtime in parameters.netFrameworkRuntimes }}:
+        - task: DotNetCoreCLI@2
+          displayName: Test [${{ runtime }}]
+          inputs:
+            command: test
+            projects: $(project)
+            arguments: >-
+              $(buildArguments)
+              --no-build
+              -f ${{ runtime }}
+              --filter "category != failing & category != flaky & category != interactive"
+
+        - task: DotNetCoreCLI@2
+          displayName: Test Flaky [${{ runtime }}]
+          inputs:
+            command: test
+            projects: $(project)
+            arguments: >-
+              $(buildArguments)
+              --no-build
+              -f ${{ runtime }}
+              --filter "category = flaky"

--- a/eng/pipelines/onebranch/jobs/validate-signed-package-job.yml
+++ b/eng/pipelines/onebranch/jobs/validate-signed-package-job.yml
@@ -157,8 +157,8 @@ jobs:
           $nugetPackageInstallPath = "${{ variables.nugetPackageInstallPath }}"
           echo "nugetPackageInstallPath= $nugetPackageInstallPath"
 
-          # Verify assembly signing #####################################
-          echo "> 1. Verifying assembly signing of DLLs ..."
+          # Verify strong-name signing ###################################
+          echo "> 1. Verifying strong-name signing of DLLs ..."
 
           # @TODO: This path seems brittle to VS upgrades, can we make it more flexible?
           $snPath = "C:\Program Files (x86)\Microsoft SDKs\Windows\*\bin\NETFX 4.8.1 Tools\sn.exe"

--- a/eng/pipelines/onebranch/jobs/validate-signed-package-job.yml
+++ b/eng/pipelines/onebranch/jobs/validate-signed-package-job.yml
@@ -157,8 +157,8 @@ jobs:
           $nugetPackageInstallPath = "${{ variables.nugetPackageInstallPath }}"
           echo "nugetPackageInstallPath= $nugetPackageInstallPath"
 
-          # Verify strong name signing #####################################
-          echo "> 1. Verifying strong name signing of DLLs ..."
+          # Verify assembly signing #####################################
+          echo "> 1. Verifying assembly signing of DLLs ..."
 
           # @TODO: This path seems brittle to VS upgrades, can we make it more flexible?
           $snPath = "C:\Program Files (x86)\Microsoft SDKs\Windows\*\bin\NETFX 4.8.1 Tools\sn.exe"

--- a/eng/pipelines/onebranch/steps/build-buildproj-step.yml
+++ b/eng/pipelines/onebranch/steps/build-buildproj-step.yml
@@ -7,7 +7,7 @@
 # This collection of steps to build a project via the build.proj. This will execute the "Build*"
 # target in build.proj, where * is the packageShortName provided in the parameters.
 #
-# Note: This differs from the pr/ci build-buildproj-step.yml in that it always strong-name signs
+# Note: This differs from the pr/ci build-buildproj-step.yml in that it always signs
 #    the assemblies, it only builds in package reference mode, and as such allows for version
 #    parameters to be provided.
 

--- a/eng/pipelines/onebranch/steps/build-buildproj-step.yml
+++ b/eng/pipelines/onebranch/steps/build-buildproj-step.yml
@@ -44,12 +44,8 @@ parameters:
     type: string
 
 steps:
-  # Download the strong name signing key from secure file storage
-  - task: DownloadSecureFile@1
-    displayName: 'Download Signing Key'
-    inputs:
-      secureFile: 'netfxKeypair.snk'
-    name: keyFile
+  # Download the assembly signing key from secure file storage.
+  - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
   - task: DotNetCoreCLI@2
     displayName: 'build.proj - Build${{ parameters.packageShortName }}'
@@ -61,7 +57,7 @@ steps:
         -p:Configuration=${{ parameters.buildConfiguration }}
         -p:ReferenceType=Package
         -p:SkipDependencyPack=true
-        -p:SigningKeyPath="$(keyFile.secureFilePath)"
+        -p:SigningKeyPath="$(driverKeyFile.secureFilePath)"
         -p:BuildNumber="$(Build.BuildNumber)"
         -p:PackageVersion${{ parameters.packageShortName }}="${{ parameters.packageVersion }}"
         ${{ parameters.dependencyArguments }}

--- a/eng/pipelines/stages/build-abstractions-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-abstractions-package-ci-stage.yml
@@ -91,6 +91,11 @@ parameters:
       # Reference sibling packages as C# projects.
       - Project
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 stages:
 
   - stage: build_abstractions_package_stage
@@ -112,6 +117,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Linux
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: linux
           netFrameworkRuntimes: []
           netRuntimes: [net8.0, net9.0, net10.0]
@@ -127,6 +133,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Win
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: windows
           netFrameworkRuntimes: [net462]
           netRuntimes: [net8.0, net9.0, net10.0]
@@ -142,6 +149,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: macOS
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: macos
           netFrameworkRuntimes: []
           netRuntimes: [net8.0, net9.0, net10.0]
@@ -168,3 +176,4 @@ stages:
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
           referenceType: ${{ parameters.referenceType }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}

--- a/eng/pipelines/stages/build-abstractions-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-abstractions-package-ci-stage.yml
@@ -122,6 +122,7 @@ stages:
           netFrameworkRuntimes: []
           netRuntimes: [net8.0, net9.0, net10.0]
           poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
           vmImage: ubuntu-latest
 
       # ------------------------------------------------------------------------
@@ -138,6 +139,7 @@ stages:
           netFrameworkRuntimes: [net462]
           netRuntimes: [net8.0, net9.0, net10.0]
           poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
           vmImage: windows-latest
 
       # ------------------------------------------------------------------------
@@ -154,6 +156,7 @@ stages:
           netFrameworkRuntimes: []
           netRuntimes: [net8.0, net9.0, net10.0]
           poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
           vmImage: macos-latest
 
       # ------------------------------------------------------------------------

--- a/eng/pipelines/stages/build-azure-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-azure-package-ci-stage.yml
@@ -152,6 +152,11 @@ parameters:
       # Reference sibling packages as C# projects.
       - Project
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 stages:
 
   - stage: build_azure_package_stage
@@ -180,6 +185,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Linux
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: linux
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
@@ -202,6 +208,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Linux Integration
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: linux_integration
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
@@ -233,6 +240,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Win
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: windows
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
@@ -255,6 +263,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Win Integration
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: windows_integration
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
@@ -295,6 +304,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: macOS
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: macos
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
@@ -331,6 +341,7 @@ stages:
             - test_azure_package_job_windows_integration
             - test_azure_package_job_macos
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
           referenceType: ${{ parameters.referenceType }}

--- a/eng/pipelines/stages/build-logging-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-logging-package-ci-stage.yml
@@ -106,6 +106,7 @@ stages:
           netFrameworkRuntimes: []
           netRuntimes: [net8.0, net9.0, net10.0]
           poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
           vmImage: ubuntu-latest
 
       # ------------------------------------------------------------------------
@@ -122,6 +123,7 @@ stages:
           netFrameworkRuntimes: [net462]
           netRuntimes: [net8.0, net9.0, net10.0]
           poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
           vmImage: windows-latest
 
       # ------------------------------------------------------------------------
@@ -138,6 +140,7 @@ stages:
           netFrameworkRuntimes: []
           netRuntimes: [net8.0, net9.0, net10.0]
           poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
           vmImage: macos-latest
 
       # ------------------------------------------------------------------------

--- a/eng/pipelines/stages/build-logging-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-logging-package-ci-stage.yml
@@ -72,6 +72,14 @@ parameters:
     type: boolean
     default: false
 
+  # The C# project reference type to use when building and packing the packages.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
 stages:
 
   - stage: build_logging_package_stage
@@ -144,3 +152,4 @@ stages:
           debug: ${{ parameters.debug }}
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
           isInternalBuild: ${{ parameters.isInternalBuild }}
+          referenceType: ${{ parameters.referenceType }}

--- a/eng/pipelines/stages/build-logging-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-logging-package-ci-stage.yml
@@ -67,6 +67,11 @@ parameters:
     - detailed
     - diagnostic
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 stages:
 
   - stage: build_logging_package_stage
@@ -79,11 +84,56 @@ stages:
 
     jobs:
 
+      # ------------------------------------------------------------------------
+      # Build and test on Linux.
+
+      - template: /eng/pipelines/jobs/test-logging-package-ci-job.yml@self
+        parameters:
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          debug: ${{ parameters.debug }}
+          displayNamePrefix: Linux
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
+          jobNameSuffix: linux
+          netFrameworkRuntimes: []
+          netRuntimes: [net8.0, net9.0, net10.0]
+          poolName: Azure Pipelines
+          vmImage: ubuntu-latest
+
+      # ------------------------------------------------------------------------
+      # Build and test on Windows.
+
+      - template: /eng/pipelines/jobs/test-logging-package-ci-job.yml@self
+        parameters:
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          debug: ${{ parameters.debug }}
+          displayNamePrefix: Win
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
+          jobNameSuffix: windows
+          netFrameworkRuntimes: [net462]
+          netRuntimes: [net8.0, net9.0, net10.0]
+          poolName: Azure Pipelines
+          vmImage: windows-latest
+
+      # ------------------------------------------------------------------------
+      # Build and test on macOS.
+
+      - template: /eng/pipelines/jobs/test-logging-package-ci-job.yml@self
+        parameters:
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          debug: ${{ parameters.debug }}
+          displayNamePrefix: macOS
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
+          jobNameSuffix: macos
+          netFrameworkRuntimes: []
+          netRuntimes: [net8.0, net9.0, net10.0]
+          poolName: Azure Pipelines
+          vmImage: macos-latest
+
+      # ------------------------------------------------------------------------
       # Create and publish the NuGet package.
-      # Note: No test jobs because the Logging project does not have a test
-      # project yet.  When a test project is added, test jobs should be added
-      # here (mirroring the Abstractions stage pattern) and the pack job should
-      # depend on them.
 
       - template: /eng/pipelines/jobs/pack-logging-package-ci-job.yml@self
         parameters:
@@ -93,3 +143,4 @@ stages:
           buildConfiguration: ${{ parameters.buildConfiguration }}
           debug: ${{ parameters.debug }}
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}

--- a/eng/pipelines/stages/build-sqlclient-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-sqlclient-package-ci-stage.yml
@@ -85,6 +85,11 @@ parameters:
     type: string
     default: ''
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 stages:
 
   - stage: build_sqlclient_package_stage
@@ -109,6 +114,7 @@ stages:
         akvPackageVersion: ${{ parameters.akvPackageVersion }}
         sqlServerArtifactsName: ${{ parameters.sqlServerArtifactsName }}
         sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+        isInternalBuild: ${{ parameters.isInternalBuild }}
         ${{ if ne(parameters.SNIVersion, '') }}:
           prebuildSteps:
             - template: /eng/pipelines/common/templates/steps/override-sni-version.yml@self

--- a/eng/pipelines/stages/build-sqlserver-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-sqlserver-package-ci-stage.yml
@@ -68,6 +68,14 @@ parameters:
     type: boolean
     default: false
 
+  # The C# project reference type to use when building and packing the packages.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
 stages:
 
   - stage: build_sqlserver_package_stage
@@ -87,3 +95,4 @@ stages:
           sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
           isInternalBuild: ${{ parameters.isInternalBuild }}
+          referenceType: ${{ parameters.referenceType }}

--- a/eng/pipelines/stages/build-sqlserver-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-sqlserver-package-ci-stage.yml
@@ -63,6 +63,11 @@ parameters:
     - detailed
     - diagnostic
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 stages:
 
   - stage: build_sqlserver_package_stage
@@ -81,3 +86,4 @@ stages:
           sqlServerArtifactsName: ${{ parameters.sqlServerArtifactsName }}
           sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -106,15 +106,15 @@
     <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
 
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
+  <!-- When a signing key is specified, we will perform assembly signing. -->
   <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
 
     <!-- We also define a constant used for conditional compilation. -->
-    <DefineConstants>$(DefineConstants);STRONG_NAME_SIGNING</DefineConstants>
+    <DefineConstants>$(DefineConstants);ASSEMBLY_SIGNING</DefineConstants>
   </PropertyGroup>
 
   <!-- Packaging for source link-->

--- a/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
+++ b/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
@@ -22,7 +22,7 @@
     <Version>$(AkvProviderPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Build Output ==================================================== -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
@@ -34,8 +34,20 @@
 
   <!-- Strong name signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
+
+  <!-- Unsigned: expose internals to the test assembly in any reference mode. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <InternalsVisibleTo Include="$(AssemblyName).Test" />
+  </ItemGroup>
+
+  <!--
+    Signed + Package mode: expose internals to the test assembly signed with the test key.
+    Signed + Project mode is intentionally omitted: production-signed assemblies should not
+    grant internal access to test assemblies during local development.  Tests that need internals
+    in Project mode run unsigned; only the CI package-validation pipeline uses signed packages.
+  -->
+  <ItemGroup Condition="'$(SigningKeyPath)' != '' AND '$(ReferenceType)' == 'Package'">
+    <InternalsVisibleTo Include="$(AssemblyName).Test, PublicKey=00240000048000001401000006020000002400005253413100080000010001003D19684676DA365F331D00CE7BD4B8EF03E74102F39A5681B40622703D68F0298ECACECC723D3FFC1EA9365AF4958578550EA1EBEEC084B0B3757F3762449F5365E872802A4B548056760764FAD062BFEE81ED26183109AD46810E7E6E965419D0A10473680144D20C1BFE1027A5F586CA987523C06F5C126C44EA7D4F51EB023867A9F294315F95775ACEFD2D678186919458DFCCB4DE2E9F53AEFC766C7CBCEC474ED21C1616E5A9414D366D91D121C39F5FE6641295ADC058EF3FB10593BCDE2E82D9F217C2634909EEF496CD53AE78ABBEA572B871D72EBFC5378205950ABA97C7CCC2B9635D96933D5F9C9624D71FF53EE2094CF3A6BD38534D66E414B7" />
   </ItemGroup>
 
   <!-- Build Output ==================================================== -->
@@ -77,6 +89,11 @@
                       Condition="'$(ReferenceType)' != 'Package'" />
     <PackageReference Include="Microsoft.Data.SqlClient.Internal.Logging"
                       Condition="'$(ReferenceType)' == 'Package'" />
+  </ItemGroup>
+
+  <!-- Polyfills ======================================================= -->
+  <ItemGroup>
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <!-- CodeGen Targets ================================================= -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
@@ -32,7 +32,7 @@
     <Version>$(AbstractionsPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Unsigned: expose internals to the test assembly in any reference mode. -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.Internal.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.Internal.cs
@@ -24,14 +24,6 @@ public abstract partial class SqlAuthenticationProvider
     private static class Internal
     {
         /// <summary>
-        /// The expected public key token of the SqlClient assembly, used to avoid loading imposter
-        /// assemblies.  This is the public key token of the assembly signing key used for all of
-        /// our driver assemblies.
-        /// </summary>
-        private static readonly byte[] _sqlClientPublicKeyToken =
-            [ 0x23, 0xec, 0x7f, 0xc2, 0xd6, 0xea, 0xa4, 0xa5 ];
-
-        /// <summary>
         /// Our handle to the reflected GetProvider() method.
         /// </summary>
         private static readonly MethodInfo? _getProvider = null;
@@ -56,14 +48,20 @@ public abstract partial class SqlAuthenticationProvider
 
                 #if ASSEMBLY_SIGNING
 
+                // The expected public key token of the SqlClient assembly, used to avoid invoking
+                // APIs from imposter assemblies.  This is the public key token of the assembly
+                // signing key used for all of our driver assemblies.
+                byte[] expectedPublicKeyToken =
+                    [ 0x23, 0xec, 0x7f, 0xc2, 0xd6, 0xea, 0xa4, 0xa5 ];
+
                 // When assembly signing is enabled, build a fully-qualified AssemblyName that
                 // includes the expected public key token.
                 Log($"Attempting to load SqlClient assembly={assemblyName} with " +
                     "expected public key token=" +
-                    BitConverter.ToString(_sqlClientPublicKeyToken).Replace("-", ""));
+                    BitConverter.ToString(expectedPublicKeyToken).Replace("-", ""));
 
                 var qualifiedName = new AssemblyName(assemblyName);
-                qualifiedName.SetPublicKeyToken(_sqlClientPublicKeyToken);
+                qualifiedName.SetPublicKeyToken(expectedPublicKeyToken);
 
                 // The .NET Framework runtime enforces the token during binding, causing Load() to
                 // throw if it doesn't match. The .NET (Core) runtime ignores the token, so we
@@ -78,7 +76,7 @@ public abstract partial class SqlAuthenticationProvider
                     byte[]? actualToken = assembly.GetName().GetPublicKeyToken();
 
                     if (actualToken is null ||
-                        !actualToken.AsSpan().SequenceEqual(_sqlClientPublicKeyToken))
+                        !actualToken.AsSpan().SequenceEqual(expectedPublicKeyToken))
                     {
                         Log($"SqlClient assembly={assembly.GetName()} has an " +
                             "unexpected public key token; " +
@@ -90,8 +88,8 @@ public abstract partial class SqlAuthenticationProvider
                 #else
 
                 // Assembly signing is disabled, so we cannot verify the public key token.
-                Log($"Loading SqlClient assembly={assemblyName} without assembly verification; " +
-                    "ensure this assembly is from a trusted source");
+                Log($"Loading SqlClient assembly={assemblyName} without strong-name identity " +
+                    "verification; ensure this assembly is from a trusted source");
 
                 var assembly = Assembly.Load(assemblyName);
 

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.Internal.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.Internal.cs
@@ -24,6 +24,14 @@ public abstract partial class SqlAuthenticationProvider
     private static class Internal
     {
         /// <summary>
+        /// The expected public key token of the SqlClient assembly, used to avoid loading imposter
+        /// assemblies. This is the same token used by all assemblies in this repository when
+        /// strong-name signed.
+        /// </summary>
+        private static readonly byte[] _sqlClientPublicKeyToken =
+            [ 0x23, 0xec, 0x7f, 0xc2, 0xd6, 0xea, 0xa4, 0xa5 ];
+
+        /// <summary>
         /// Our handle to the reflected GetProvider() method.
         /// </summary>
         private static readonly MethodInfo? _getProvider = null;
@@ -40,22 +48,61 @@ public abstract partial class SqlAuthenticationProvider
         {
             const string assemblyName = "Microsoft.Data.SqlClient";
 
-            // If the MDS package is present, load its
+            // If the SqlClient assembly is present, load its
             // SqlAuthenticationProviderManager class and get/set methods.
             try
             {
-                // Try to load the MDS assembly.
+                // Try to load the SqlClient assembly.
+
+                #if STRONG_NAME_SIGNING
+
+                // When strong-name signing is enabled, build a fully-qualified AssemblyName that
+                // includes the expected public key token.
+                Log($"Attempting to load SqlClient assembly={assemblyName} with " +
+                    "expected public key token=" +
+                    BitConverter.ToString(_sqlClientPublicKeyToken).Replace("-", ""));
+
+                var qualifiedName = new AssemblyName(assemblyName);
+                qualifiedName.SetPublicKeyToken(_sqlClientPublicKeyToken);
+
+                // The .NET Framework runtime enforces the token during binding, causing Load() to
+                // throw if it doesn't match. The .NET (Core) runtime ignores the token, so we
+                // verify it ourselves below.
+                var assembly = Assembly.Load(qualifiedName);
+
+                // Defense-in-depth: verify the public key token after loading.  This is necessary
+                // on .NET Core where the runtime does not enforce the token. It is harmless on .NET
+                // Framework.
+                if (assembly is not null)
+                {
+                    byte[]? actualToken = assembly.GetName().GetPublicKeyToken();
+
+                    if (actualToken is null ||
+                        !actualToken.AsSpan().SequenceEqual(_sqlClientPublicKeyToken))
+                    {
+                        Log($"SqlClient assembly={assembly.GetName()} has an " +
+                            "unexpected public key token; " +
+                            "Get/SetProvider() will not function");
+                        return;
+                    }
+                }
+
+                #else
+
+                // Strong-name signing is disabled, so we cannot verify the public key token.
+                Log($"Loading SqlClient assembly={assemblyName} without strong name " +
+                    "verification; ensure this assembly is from a trusted source");
+
                 var assembly = Assembly.Load(assemblyName);
+
+                #endif
 
                 if (assembly is null)
                 {
-                    Log($"MDS assembly={assemblyName} not found; " +
+                    Log($"SqlClient assembly={assemblyName} not found; " +
                         "Get/SetProvider() will not function");
                     return;
                 }
-
-                // TODO(https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/39845):
-                // Verify the assembly is signed by us?
 
                 // Look for the manager class.
                 const string className = "Microsoft.Data.SqlClient.SqlAuthenticationProviderManager";
@@ -63,7 +110,7 @@ public abstract partial class SqlAuthenticationProvider
 
                 if (manager is null)
                 {
-                    Log($"MDS auth manager manager class={className} not found; " +
+                    Log($"SqlClient auth manager class={className} not found; " +
                         "Get/SetProvider() will not function");
                     return;
                 }
@@ -75,7 +122,7 @@ public abstract partial class SqlAuthenticationProvider
 
                 if (_getProvider is null)
                 {
-                    Log($"MDS GetProvider() method not found; " +
+                    Log($"SqlClient GetProvider() method not found; " +
                         "GetProvider() will not function");
                 }
 
@@ -85,7 +132,7 @@ public abstract partial class SqlAuthenticationProvider
 
                 if (_setProvider is null)
                 {
-                    Log($"MDS SetProvider() method not found; " +
+                    Log($"SqlClient SetProvider() method not found; " +
                         "SetProvider() will not function");
                 }
             }
@@ -97,7 +144,7 @@ public abstract partial class SqlAuthenticationProvider
                      or FileLoadException
                      or FileNotFoundException)
             {
-                Log($"MDS assembly={assemblyName} not found or not usable; " +
+                Log($"SqlClient assembly={assemblyName} not found or not usable; " +
                     $"Get/SetProvider() will not function: {ex} ");
             }
             // Any other exceptions are fatal.

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.Internal.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.Internal.cs
@@ -25,8 +25,8 @@ public abstract partial class SqlAuthenticationProvider
     {
         /// <summary>
         /// The expected public key token of the SqlClient assembly, used to avoid loading imposter
-        /// assemblies. This is the same token used by all assemblies in this repository when
-        /// strong-name signed.
+        /// assemblies.  This is the public key token of the assembly signing key used for all of
+        /// our driver assemblies.
         /// </summary>
         private static readonly byte[] _sqlClientPublicKeyToken =
             [ 0x23, 0xec, 0x7f, 0xc2, 0xd6, 0xea, 0xa4, 0xa5 ];
@@ -54,9 +54,9 @@ public abstract partial class SqlAuthenticationProvider
             {
                 // Try to load the SqlClient assembly.
 
-                #if STRONG_NAME_SIGNING
+                #if ASSEMBLY_SIGNING
 
-                // When strong-name signing is enabled, build a fully-qualified AssemblyName that
+                // When assembly signing is enabled, build a fully-qualified AssemblyName that
                 // includes the expected public key token.
                 Log($"Attempting to load SqlClient assembly={assemblyName} with " +
                     "expected public key token=" +
@@ -89,9 +89,9 @@ public abstract partial class SqlAuthenticationProvider
 
                 #else
 
-                // Strong-name signing is disabled, so we cannot verify the public key token.
-                Log($"Loading SqlClient assembly={assemblyName} without strong name " +
-                    "verification; ensure this assembly is from a trusted source");
+                // Assembly signing is disabled, so we cannot verify the public key token.
+                Log($"Loading SqlClient assembly={assemblyName} without assembly verification; " +
+                    "ensure this assembly is from a trusted source");
 
                 var assembly = Assembly.Load(assemblyName);
 

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
@@ -8,6 +8,13 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!-- Strong name signing ============================================= -->
+  <!-- When a test signing key is provided, sign the test assembly so IVT from signed source works. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
   <!-- Compiler Options ================================================ -->
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
@@ -8,7 +8,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- When a test signing key is provided, sign the test assembly so IVT from signed source works. -->
   <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
@@ -2,7 +2,14 @@
   <!-- General Properties ============================================== -->
   <PropertyGroup>
     <AssemblyName>Microsoft.Data.SqlClient.Extensions.Abstractions.Test</AssemblyName>
-    <TargetFrameworks>net462;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+
+    <!--
+      The Abstractions project is not built for net462 unless it is built for Windows. Thus, we
+      will not be able to fulfill the Abstractions for net462 reference unless we are building on
+      Windows.
+    -->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
@@ -34,8 +34,20 @@
 
   <!-- Strong name signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
+
+  <!-- Unsigned: expose internals to the test assembly in any reference mode. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <InternalsVisibleTo Include="$(AssemblyName).Test" />
+  </ItemGroup>
+
+  <!--
+    Signed + Package mode: expose internals to the test assembly signed with the test key.
+    Signed + Project mode is intentionally omitted: production-signed assemblies should not
+    grant internal access to test assemblies during local development.  Tests that need internals
+    in Project mode run unsigned; only the CI package-validation pipeline uses signed packages.
+  -->
+  <ItemGroup Condition="'$(SigningKeyPath)' != '' AND '$(ReferenceType)' == 'Package'">
+    <InternalsVisibleTo Include="$(AssemblyName).Test, PublicKey=00240000048000001401000006020000002400005253413100080000010001003D19684676DA365F331D00CE7BD4B8EF03E74102F39A5681B40622703D68F0298ECACECC723D3FFC1EA9365AF4958578550EA1EBEEC084B0B3757F3762449F5365E872802A4B548056760764FAD062BFEE81ED26183109AD46810E7E6E965419D0A10473680144D20C1BFE1027A5F586CA987523C06F5C126C44EA7D4F51EB023867A9F294315F95775ACEFD2D678186919458DFCCB4DE2E9F53AEFC766C7CBCEC474ED21C1616E5A9414D366D91D121C39F5FE6641295ADC058EF3FB10593BCDE2E82D9F217C2634909EEF496CD53AE78ABBEA572B871D72EBFC5378205950ABA97C7CCC2B9635D96933D5F9C9624D71FF53EE2094CF3A6BD38534D66E414B7" />
   </ItemGroup>
 
   <!-- Build Output ==================================================== -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
@@ -32,7 +32,7 @@
     <Version>$(AzurePackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Unsigned: expose internals to the test assembly in any reference mode. -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/test/Azure.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/test/Azure.Test.csproj
@@ -8,6 +8,13 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!-- Strong name signing ============================================= -->
+  <!-- When a test signing key is provided, sign the test assembly so IVT from signed source works. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
   <!-- Target Frameworks =============================================== -->
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/test/Azure.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/test/Azure.Test.csproj
@@ -8,7 +8,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- When a test signing key is provided, sign the test assembly so IVT from signed source works. -->
   <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/src/Logging.csproj
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/src/Logging.csproj
@@ -36,8 +36,20 @@
 
   <!-- Strong name signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
+
+  <!-- Unsigned: expose internals to the test assembly in any reference mode. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <InternalsVisibleTo Include="$(AssemblyName).Test" />
+  </ItemGroup>
+
+  <!--
+    Signed + Package mode: expose internals to the test assembly signed with the test key.
+    Signed + Project mode is intentionally omitted: production-signed assemblies should not
+    grant internal access to test assemblies during local development.  Tests that need internals
+    in Project mode run unsigned; only the CI package-validation pipeline uses signed packages.
+  -->
+  <ItemGroup Condition="'$(SigningKeyPath)' != '' AND '$(ReferenceType)' == 'Package'">
+    <InternalsVisibleTo Include="$(AssemblyName).Test, PublicKey=00240000048000001401000006020000002400005253413100080000010001003D19684676DA365F331D00CE7BD4B8EF03E74102F39A5681B40622703D68F0298ECACECC723D3FFC1EA9365AF4958578550EA1EBEEC084B0B3757F3762449F5365E872802A4B548056760764FAD062BFEE81ED26183109AD46810E7E6E965419D0A10473680144D20C1BFE1027A5F586CA987523C06F5C126C44EA7D4F51EB023867A9F294315F95775ACEFD2D678186919458DFCCB4DE2E9F53AEFC766C7CBCEC474ED21C1616E5A9414D366D91D121C39F5FE6641295ADC058EF3FB10593BCDE2E82D9F217C2634909EEF496CD53AE78ABBEA572B871D72EBFC5378205950ABA97C7CCC2B9635D96933D5F9C9624D71FF53EE2094CF3A6BD38534D66E414B7" />
   </ItemGroup>
 
   <!-- Build Output ==================================================== -->

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/src/Logging.csproj
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/src/Logging.csproj
@@ -34,7 +34,7 @@
     <Version>$(LoggingPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Unsigned: expose internals to the test assembly in any reference mode. -->

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/test/Directory.Packages.props
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/test/Directory.Packages.props
@@ -1,0 +1,10 @@
+<Project>
+  <!--
+    This file exists because the shared test package versions (xunit, Test.Sdk, etc.) live in the
+    SqlClient tests Directory.Packages.props rather than the repo root.  Without this file, NuGet's
+    CPM directory walk would resolve to the repo-root props and miss the test-only versions.
+    Importing the SqlClient tests props brings in both the shared test dependencies and
+    (transitively) the root production dependencies.
+  -->
+  <Import Project="$(RepoRoot)src/Microsoft.Data.SqlClient/tests/Directory.Packages.props" />
+</Project>

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
@@ -2,7 +2,13 @@
   <!-- General Properties ============================================== -->
   <PropertyGroup>
     <AssemblyName>Microsoft.Data.SqlClient.Internal.Logging.Test</AssemblyName>
-    <TargetFrameworks>net462;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+
+    <!--
+      The Logging project is not built for net462 unless it is built for Windows. Thus, we will
+      not be able to fulfill the Logging for net462 reference unless we are building on Windows.
+    -->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
@@ -8,7 +8,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- When a test signing key is provided, sign the test assembly so IVT from signed source works. -->
   <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- General Properties ============================================== -->
+  <PropertyGroup>
+    <AssemblyName>Microsoft.Data.SqlClient.Internal.Logging.Test</AssemblyName>
+    <TargetFrameworks>net462;net8.0;net9.0;net10.0</TargetFrameworks>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <!-- Strong name signing ============================================= -->
+  <!-- When a test signing key is provided, sign the test assembly so IVT from signed source works. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <!-- Compiler Options ================================================ -->
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!-- Global Usings =================================================== -->
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <!-- Embedded resources and content files ============================ -->
+  <ItemGroup>
+    <Content Include="$(RepoRoot)/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>xunit.runner.json</TargetPath>
+    </Content>
+  </ItemGroup>
+
+  <!-- References ====================================================== -->
+  <!-- Test Target Reference -->
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src/Microsoft.Data.SqlClient.Internal/Logging/src/Logging.csproj" />
+  </ItemGroup>
+
+  <!-- Other References -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.console" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/test/SqlClientEventSourceTest.cs
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/test/SqlClientEventSourceTest.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Data.SqlClient.Internal.Logging.Test;
+
+public class SqlClientEventSourceTest
+{
+    [Fact]
+    public void SqlClientEventSource_Log_IsNotNull()
+    {
+        Assert.NotNull(SqlClientEventSource.Log);
+    }
+}

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/test/SqlClientEventSourceTest.cs
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/test/SqlClientEventSourceTest.cs
@@ -11,4 +11,10 @@ public class SqlClientEventSourceTest
     {
         Assert.NotNull(SqlClientEventSource.Log);
     }
+
+    [Fact]
+    public void SqlClientEventSource_Log_IsSingleton()
+    {
+        Assert.Same(SqlClientEventSource.Log, SqlClientEventSource.Log);
+    }
 }

--- a/src/Microsoft.Data.SqlClient.slnx
+++ b/src/Microsoft.Data.SqlClient.slnx
@@ -146,6 +146,7 @@
   </Folder>
   <Folder Name="/src/Microsoft.Data.SqlClient.Internal.Logging/">
     <Project Path="Microsoft.Data.SqlClient.Internal/Logging/src/Logging.csproj" />
+    <Project Path="Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj" />
   </Folder>
   <Folder Name="/src/Microsoft.Data.SqlClient/">
     <File Path="Microsoft.Data.SqlClient/Versions.props" />

--- a/src/Microsoft.Data.SqlClient/notsupported/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/notsupported/Microsoft.Data.SqlClient.csproj
@@ -83,7 +83,7 @@
     <Version>$(SqlClientPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Build Output ==================================================== -->

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.csproj
@@ -28,7 +28,7 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Build Output ==================================================== -->

--- a/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj
@@ -60,7 +60,7 @@
     <Version>$(SqlClientPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- Strong naming is being done in Directory.Build.props -->
 
   <!-- Unsigned: expose internals to UnitTests in any reference mode. -->

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.TryTraceEvent(
                     nameof(SqlAuthenticationProviderManager) +
                     $": Attempting to load Azure extension assembly={azureAssemblyName} without " +
-                    "assembly verification; ensure this assembly is from a trusted source");
+                    "strong-name identity verification; ensure this assembly is from a trusted source");
 
                 var assembly = Assembly.Load(azureAssemblyName);
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 // Try to load our Azure extension.
-                #if STRONG_NAME_SIGNING
+                #if ASSEMBLY_SIGNING
 
-                // When strong-name signing is enabled, build a fully-qualified AssemblyName
+                // When assembly signing is enabled, build a fully-qualified AssemblyName
                 // that includes the expected public key token.
 
                 SqlClientEventSource.Log.TryTraceEvent(
@@ -109,7 +109,7 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.TryTraceEvent(
                     nameof(SqlAuthenticationProviderManager) +
                     $": Attempting to load Azure extension assembly={azureAssemblyName} without " +
-                    "strong name verification; ensure this assembly is from a trusted source");
+                    "assembly verification; ensure this assembly is from a trusted source");
 
                 var assembly = Assembly.Load(azureAssemblyName);
 

--- a/src/Microsoft.Data.SqlClient/tests/Common/Microsoft.Data.SqlClient.TestCommon.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Microsoft.Data.SqlClient.TestCommon.csproj
@@ -14,7 +14,7 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- Sign with the test key so signed test assemblies can reference this project. -->
   <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlDataRecordTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlDataRecordTest.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Data.SqlClient.Tests
 
         [Theory]
         #if NETFRAMEWORK
-        [Trait("Category", "signed")] // Requires strong-name signed Microsoft.SqlServer.Server
+        [Trait("Category", "signed")] // Requires a signed Microsoft.SqlServer.Server assembly
         #endif
         [MemberData(
             nameof(GetUdtTypeTestData.Get),

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/SqlServerTypesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/SqlServerTypesTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: Parse error at line: 1, column: 48: Incorrect syntax near 'hierarchyid'.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         #if NETFRAMEWORK
-        [Trait("Category", "signed")] // Requires strong-name signed Microsoft.SqlServer.Server
+        [Trait("Category", "signed")] // Requires a signed Microsoft.SqlServer.Server assembly
         #endif
         public static void GetSchemaTableTest()
         {
@@ -66,7 +66,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: Parse error at line: 1, column: 48: Incorrect syntax near 'hierarchyid'.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         #if NETFRAMEWORK
-        [Trait("Category", "signed")] // Requires strong-name signed Microsoft.SqlServer.Server
+        [Trait("Category", "signed")] // Requires a signed Microsoft.SqlServer.Server assembly
         #endif
         public static void GetValueTest()
         {
@@ -227,7 +227,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: Parse error at line: 1, column: 41: Incorrect syntax near 'hierarchyid'.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         #if NETFRAMEWORK
-        [Trait("Category", "signed")] // Requires strong-name signed Microsoft.SqlServer.Server
+        [Trait("Category", "signed")] // Requires a signed Microsoft.SqlServer.Server assembly
         #endif
         public static void TestUdtSchemaMetadata()
         {
@@ -384,7 +384,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: Parse error at line: 1, column: 8: Incorrect syntax near 'geometry'.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         #if NETFRAMEWORK
-        [Trait("Category", "signed")] // Requires strong-name signed Microsoft.SqlServer.Server
+        [Trait("Category", "signed")] // Requires a signed Microsoft.SqlServer.Server assembly
         #endif
         public static void TestSqlServerTypesInsertAndRead()
         {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj
@@ -36,7 +36,7 @@
     </None>
   </ItemGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- When a test signing key is provided, sign UnitTests so IVT from signed SqlClient works. -->
   <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Microsoft.Data.SqlClient.TestUtilities.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Microsoft.Data.SqlClient.TestUtilities.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- Sign with the test key so signed test assemblies can reference this project. -->
   <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj
+++ b/src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj
@@ -16,7 +16,7 @@
     <Version>$(SqlServerPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Build Output ==================================================== -->


### PR DESCRIPTION
## Summary

Closes the assembly signing gap in CI pipelines for Abstractions, Azure, and Logging extension projects. After this change, `#if ASSEMBLY_SIGNING` code paths are exercised during CI test runs for all extension packages, and test assemblies can access internals from signed source assemblies via properly keyed `InternalsVisibleTo` grants.

This was driven by the missing assembly public key checks in Abstrations SqlAuthenticationProvider.Internal, and I discovered we aren't actually signing and testing those paths in our CI pipelines.

## Changes

### Pipeline infrastructure

- Create reusable `eng/pipelines/common/steps/download-assembly-signing-key.yml` template with `isTest` parameter for driver vs test key download
- Migrate all pack jobs to use the template (Abstractions, Azure, Logging, SqlClient, OneBranch)
- Add `isInternalBuild` concept to the CI pipeline so it can decide when to sign assemblies which allows us to select:
  - When InternalsVisibleTo is granted to test projects, and when those grants require the test signing public key.
  - When ASSEMBLY_SIGNING is defined during builds, and which conditional code blocks to compile.
- Add test signing key to the build and pipeline flows that deal with tests that must be signed in order to access their associated driver project IVT grants.

### Source and project file changes

- Add `ASSEMBLY_SIGNING` conditional compilation to `SqlAuthenticationProvider.Internal.cs`
  - This is the main functional driver change that all of the other changes support.
- Add dual `InternalsVisibleTo` blocks to Abstractions, Logging, and Azure source projects:
  - Unsigned (`SigningKeyPath=''`): grants access to test assembly
  - Signed + Package mode (`SigningKeyPath != '' AND ReferenceType == 'Package'`): grants access with test public key
- Wire up the `isInternalBuild`, `SigningKeyPath`, and `TestSigningKeyPath` through the pipeline, build, and project files.

### Logging.Test project and CI coverage

- Create `Logging.Test.csproj` targeting `net462;net8.0;net9.0;net10.0`
- Add `SqlClientEventSourceTest` verifying the singleton instance
- Add PR/CI pipeline support for this new test project.

This avoids the absence of this test project causing the build and pipeline plumbing from existing, which was a confusing divergence from the other changes here.  Also, this project _should_ have some tests, and this creates the empty project where we can easily add tests in a future PR.

### Rename STRONG_NAME_SIGNING to ASSEMBLY_SIGNING

- The new name better reflects what the build/test/pipeline environment is actually doing across TFMs.
  - .NET only does basic public-key signing; it does not perform strong-name signing like .NET Framework does.

### Disable signing in Project-mode pipelines

- Gate all signing key downloads and `SigningKeyPath` propagation on `ne(referenceType, 'Project')` across:
  - Pack jobs: Abstractions, Azure, Logging, SqlServer.Server
  - Test jobs: Abstractions, Azure, Logging
  - Common templates: `ci-run-tests-job.yml`, `ci-build-nugets-job.yml`
- Forward `referenceType` parameter to leaf package stages/jobs that previously lacked it (Logging, SqlServer.Server, Abstractions test jobs)
- This ensures Project-mode builds remain unsigned (preserving IVT without public key), while Package-mode builds are signed for real package consumption.

## Testing

- [x] `dotnet build build.proj -t:TestAbstractions` — 29 tests pass (net8.0/net9.0)
- [x] `dotnet build build.proj -t:TestLogging` — 1 test passes
- [x] `dotnet build build.proj -t:TestAzure` — 4 pass, 16 skipped (no SQL Server)
- [x] All modified YAML files pass `yaml.safe_load()` validation
- [x] Package-mode pipeline (build 157028): all 20 assemblies across 6 packages verified signed with PEReader
- [x] Project-mode pipeline (build 157031): SqlClient + AKV assemblies verified unsigned

## Design Notes

- Signed IVT is intentionally limited to **Package mode only**. In Project mode, source is compiled alongside tests so signing is not needed for IVT.
- `signingArguments` pipeline variable is always defined (empty string for non-internal builds) to avoid undefined `$(...)` variable expansion issues in ADO.
- Key downloads are gated on both `isInternalBuild` and `ne(referenceType, 'Project')` — this avoids downloading keys that won't be used.
