### PR TITLE
Rename STRONG_NAME_SIGNING to ASSEMBLY_SIGNING

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -247,8 +247,8 @@
     <!--
       SigningKeyPath
       Applies to:     Build*, Pack*
-      Description:    Path to the key to use to strong name sign binaries. If omitted, binaries
-                      will not be strong name signed.
+      Description:    Path to the key to use to sign driver assemblies. If omitted, driver
+                      assemblies will not be signed.
                       For Pack* targets, this only applies to a build - ie, if PackBuild is set to
                       false, SigningKeyPath will have no effect.
       Default value:  [blank]
@@ -318,7 +318,7 @@
     <TestFilters Condition="'$(TestFilters.ToLower())' == 'none'" />
     <!--
       Exclude tests in the "signed" category when building unsigned assemblies.  We have some tests
-      that require signed assemblies, and they would fail with strong name validation exceptions on
+      that require signed assemblies, and they would fail with assembly validation exceptions on
       .NET Framework.
     -->
     <TestFilters Condition="'$(TestFilters)' != '' AND '$(SigningKeyPath)' == ''">$(TestFilters)&amp;category!=signed</TestFilters>

--- a/build.proj
+++ b/build.proj
@@ -452,6 +452,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build "$(SqlClientNotSupportedProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         -p:GenApiPath="@(GenApiArtifactPath->'%(FullPath)')"
         $(SigningKeyPathArgument)
@@ -483,6 +485,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build $(SqlClientRefProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
@@ -491,7 +495,7 @@
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
 
-        <!-- Reference type arguments -->
+        <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
         $(PackageVersionAbstractionsArgument)
         $(PackageVersionSqlServerArgument)
@@ -512,6 +516,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build $(SqlClientProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         -p:TargetOs=Unix
         $(SigningKeyPathArgument)
@@ -543,11 +549,13 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build $(SqlClientProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         -p:TargetOs=Windows_NT
         $(SigningKeyPathArgument)
 
-        <!-- Versioning Arguments -->
+        <!-- Versioning arguments -->
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlClientArgument)
@@ -586,6 +594,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack "$(SqlClientProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)
@@ -601,7 +611,7 @@
         $(PackageVersionLoggingArgument)
         $(PackageVersionSqlServerArgument)
 
-        <!-- Pack settings are defined in Microsoft.Data.SqlClient.csproj -->
+        <!-- Pack arguments -->
         -p:PackageOutputPath="$(SqlClientPackageArtifactRoot)"
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
@@ -635,7 +645,12 @@
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(SqlClientFunctionalTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
@@ -680,7 +695,12 @@
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(SqlClientManualTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(ManualTestFiltersArgument)
@@ -710,17 +730,24 @@
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(SqlClientUnitTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
-        $(ReferenceTypeArgument)
-        $(TestSigningKeyPathArgument)
-        $(PackageVersionSqlClientArgument)
-        $(PackageVersionSqlServerArgument)
         --results-directory "$(TestResultsFolderPath)"
         --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
+
+        <!-- Reference Type Arguments -->
+        $(ReferenceTypeArgument)
+        $(PackageVersionSqlClientArgument)
+        $(PackageVersionSqlServerArgument)
       </DotnetCommand>
 
       <!-- Convert more than one whitespace character into one space -->
@@ -746,15 +773,17 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build "$(AkvProviderProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
-        <!--Versioning arguments -->
+        <!-- Versioning arguments -->
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionAkvProviderArgument)
 
-        <!-- Reference type arguments -->
+        <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
         $(PackageVersionAbstractionsArgument)
         $(PackageVersionLoggingArgument)
@@ -774,6 +803,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack "$(AkvProviderProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)
@@ -827,6 +858,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build "$(AbstractionsProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
@@ -852,6 +885,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack "$(AbstractionsProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)
@@ -887,22 +922,28 @@
   <!-- TestAbstractions: Runs Microsoft.Data.SqlClient.Extensions.Abstractions.Tests -->
   <Target Name="TestAbstractions">
     <PropertyGroup>
-      <!--
-        Note: This test exclusively uses project references, so neither ReferenceType nor any
-        package version arguments are specified in this command.
-      -->
       <LogFilePrefix>AbstractionsTests-$(OS)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(AbstractionsTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
         $(TestFrameworkArgument)
         --results-directory "$(TestResultsFolderPath)"
         --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
+
+        <!-- Reference Type Arguments -->
+        $(ReferenceTypeArgument)
+        $(PackageVersionLoggingArgument)
       </DotnetCommand>
       <!-- Convert more than one whitespace character into one space -->
       <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>
@@ -929,6 +970,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build "$(AzureProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
@@ -937,7 +980,7 @@
         $(BuildSuffixArgument)
         $(PackageVersionAzureArgument)
 
-        <!-- Reference type arguments -->
+        <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
         $(PackageVersionLoggingArgument)
       </DotnetCommand>
@@ -954,6 +997,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack "$(AzureProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)
@@ -994,7 +1039,13 @@
 
       <DotnetCommand>
         "$(DotnetPath)dotnet" test "$(AzureTestProjectPath)"
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
+
+        <!-- Test arguments -->
         $(TestBlameArgument)
         $(TestCodeCoverageArgument)
         $(TestFiltersArgument)
@@ -1002,7 +1053,7 @@
         --results-directory "$(TestResultsFolderPath)"
         --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
 
-        <!-- Reference type arguments -->
+        <!-- Reference Type Arguments -->
         $(ReferenceTypeArgument)
         $(PackageVersionAbstractionsArgument)
         $(PackageVersionLoggingArgument)
@@ -1030,6 +1081,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build $(LoggingProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
@@ -1051,6 +1104,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack $(LoggingProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)
@@ -1092,10 +1147,12 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" build $(SqlServerProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(SigningKeyPathArgument)
 
-        <!--Versioning arguments -->
+        <!-- Versioning arguments -->
         $(BuildNumberArgument)
         $(BuildSuffixArgument)
         $(PackageVersionSqlServerArgument)
@@ -1113,6 +1170,8 @@
     <PropertyGroup>
       <DotnetCommand>
         "$(DotnetPath)dotnet" pack $(SqlServerProjectPath)
+
+        <!-- Build arguments -->
         -p:Configuration=$(Configuration)
         $(PackBuildArgument)
         $(SigningKeyPathArgument)

--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -89,10 +89,10 @@ variables:
     value: ${{ eq(variables['System.TeamProject'], 'ADO.Net') }}
 
   # Signing key argument passed to build.proj. On internal builds this references the secure file
-  # downloaded by DownloadSecureFile@1; on public builds it expands to empty.
+  # downloaded by download-assembly-signing-key.yml; on public builds it expands to empty.
   - name: signingKeyArg
     ${{ if eq(variables.isInternalBuild, true) }}:
-      value: '-p:SigningKeyPath="$(keyFile.secureFilePath)"'
+      value: '-p:SigningKeyPath="$(driverKeyFile.secureFilePath)"'
     ${{ else }}:
       value: ''
 
@@ -133,13 +133,9 @@ jobs:
           Write-Host 'Done.'
         displayName: Clean packages/ directory
 
-      # On internal builds, download the strong-name signing key.
+      # On internal builds, download the assembly signing key.
       - ${{ if eq(variables.isInternalBuild, true) }}:
-        - task: DownloadSecureFile@1
-          displayName: Download Signing Key
-          inputs:
-            secureFile: netfxKeypair.snk
-          name: keyFile
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
       # Run the Pack target via build.proj.
       - task: DotNetCoreCLI@2

--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -11,7 +11,7 @@
 #   - On pushes to GitHub main and ADO internal/main (batched)
 #   - Nightly at 00:00 UTC on both branches
 #
-# On internal/main the strong-name signing key is downloaded and used to sign assemblies during the
+# On internal/main the assembly signing key is downloaded and used to sign assemblies during the
 # build.
 #
 # GOTCHA: This pipeline definition is triggered by GitHub _and_ ADO CI.  We distinguish the two via

--- a/eng/pipelines/common/steps/download-assembly-signing-key.yml
+++ b/eng/pipelines/common/steps/download-assembly-signing-key.yml
@@ -1,0 +1,39 @@
+################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET
+# Foundation licenses this file to you under the MIT license.  See the LICENSE
+# file in the project root for more information.
+################################################################################
+
+# Downloads a signing key from ADO secure files.
+#
+# When isTest is false, downloads the driver signing key and exports it as 'driverKeyFile'.  When
+# isTest is true, downloads the test signing key and exports it as 'testKeyFile'.
+#
+# Downstream steps reference the path via:
+#
+#  $(driverKeyFile.secureFilePath)  or
+#  $(testKeyFile.secureFilePath)
+
+parameters:
+
+  # When false, download the driver signing key.
+  # When true, download the test signing key.
+  - name: isTest
+    type: boolean
+    default: false
+
+steps:
+
+  - ${{ if eq(parameters.isTest, false) }}:
+    - task: DownloadSecureFile@1
+      displayName: Download Driver Signing Key
+      inputs:
+        secureFile: netfxKeypair.snk
+      name: driverKeyFile
+
+  - ${{ if eq(parameters.isTest, true) }}:
+    - task: DownloadSecureFile@1
+      displayName: Download Test Signing Key
+      inputs:
+        secureFile: sqlclient-test-key.snk
+      name: testKeyFile

--- a/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-build-nugets-job.yml
@@ -87,6 +87,11 @@ parameters:
     type: string
     default: SqlServer.Artifacts
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 - job: build_mds_akv_packages_job
   displayName: Build MDS & AKV Packages
@@ -137,6 +142,10 @@ jobs:
   # Restore dotnet CLI tools (e.g. pwsh, apicompat) before building.
   - template: /eng/pipelines/common/steps/restore-dotnet-tools.yml@self
 
+  # Download the assembly signing key for internal Package-mode builds.
+  - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+    - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+
   # When we're performing a Debug build, we still want to try _compiling_ the
   # code in Release mode to ensure downstream pipelines don't encounter
   # compilation errors.  We won't use the Release artifacts for anything else
@@ -159,6 +168,8 @@ jobs:
       abstractionsPackageVersion: ${{parameters.abstractionsPackageVersion}}
       loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
       sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+      ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        signingKeyPath: $(driverKeyFile.secureFilePath)
 
   - task: DotNetCoreCLI@2
     displayName: 'Create MDS NuGet Package'
@@ -206,6 +217,8 @@ jobs:
       mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
       akvPackageVersion: ${{ parameters.akvPackageVersion }}
       sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+      ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        signingKeyPath: $(driverKeyFile.secureFilePath)
 
   - task: DotNetCoreCLI@2
     displayName: 'Create AKV Provider NuGet Package'

--- a/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
+++ b/eng/pipelines/common/templates/jobs/ci-run-tests-job.yml
@@ -160,6 +160,11 @@ parameters:
   - name: saPassword
     type: string
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 - job: ${{ format('{0}', coalesce(parameters.jobDisplayName, parameters.image, 'unknown_image')) }}
 
@@ -222,6 +227,13 @@ jobs:
 
   # Restore dotnet CLI tools (e.g. pwsh, apicompat) before building.
   - template: /eng/pipelines/common/steps/restore-dotnet-tools.yml@self
+
+  # Download the assembly signing keys for internal Package-mode builds.
+  - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+    - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+    - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+      parameters:
+        isTest: true
 
   - ${{ if ne(parameters.prebuildSteps, '') }}:
     - ${{ parameters.prebuildSteps }} # extra steps to run before the build like downloading sni and the required configuration
@@ -378,6 +390,9 @@ jobs:
         loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
         mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
         sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+        ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+          signingKeyPath: $(driverKeyFile.secureFilePath)
+          testSigningKeyPath: $(testKeyFile.secureFilePath)
 
   - ${{ if and(eq(parameters.enableX86Test, true), eq(parameters.operatingSystem, 'Windows')) }}:
     - template: /eng/pipelines/common/templates/steps/run-all-tests-step.yml@self
@@ -394,6 +409,9 @@ jobs:
         loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
         mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
         sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+        ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+          signingKeyPath: $(driverKeyFile.secureFilePath)
+          testSigningKeyPath: $(testKeyFile.secureFilePath)
 
   - template: /eng/pipelines/common/templates/steps/publish-test-results-step.yml@self
     parameters:

--- a/eng/pipelines/common/templates/stages/ci-run-tests-stage.yml
+++ b/eng/pipelines/common/templates/stages/ci-run-tests-stage.yml
@@ -88,6 +88,11 @@ parameters:
   - name: testJobTimeout
     type: number
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 stages:
 - ${{ each config in parameters.testConfigurations }}:
   - ${{ each image in config.value.images }}:
@@ -124,6 +129,7 @@ stages:
                   loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
                   mdsArtifactsName: ${{ parameters.mdsArtifactsName }}
                   mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
+                  isInternalBuild: ${{ parameters.isInternalBuild }}
                   sqlServerArtifactsName: ${{ parameters.sqlServerArtifactsName }}
                   sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
                   prebuildSteps: ${{ parameters.prebuildSteps }}
@@ -162,6 +168,7 @@ stages:
                     loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
                     mdsArtifactsName: ${{ parameters.mdsArtifactsName }}
                     mdsPackageVersion: ${{ parameters.mdsPackageVersion }}
+                    isInternalBuild: ${{ parameters.isInternalBuild }}
                     sqlServerArtifactsName: ${{ parameters.sqlServerArtifactsName }}
                     sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
                     prebuildSteps: ${{ parameters.prebuildSteps }}

--- a/eng/pipelines/common/templates/steps/ci-project-build-step.yml
+++ b/eng/pipelines/common/templates/steps/ci-project-build-step.yml
@@ -73,6 +73,13 @@ parameters:
     type: string
     default: $(sqlServerPackageVersion)
 
+  # Path to the assembly signing key file.  When non-empty, passed as -p:SigningKeyPath="" to the
+  # build.  The calling job is responsible for downloading the key (via
+  # download-assembly-signing-key.yml).
+  - name: signingKeyPath
+    type: string
+    default: ''
+
 steps:
   # Build MDS
   - ${{ if or(eq(parameters.build, 'MDS'), eq(parameters.build, 'all'), eq(parameters.build, 'allNoDocs')) }}:
@@ -91,6 +98,7 @@ steps:
           -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
 
   # Build AKV Provider
   - ${{ if or(eq(parameters.build, 'AkvProvider'), eq(parameters.build, 'all'), eq(parameters.build, 'allNoDocs')) }}:
@@ -110,3 +118,4 @@ steps:
           -p:PackageVersionLogging=${{ parameters.loggingPackageVersion }}
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"

--- a/eng/pipelines/common/templates/steps/run-all-tests-step.yml
+++ b/eng/pipelines/common/templates/steps/run-all-tests-step.yml
@@ -72,6 +72,18 @@ parameters:
     type: number
     default: 2
 
+  # Path to the assembly signing key file.  When non-empty, passed to build.proj so that the
+  # test-filter logic can include category=signed tests.
+  - name: signingKeyPath
+    type: string
+    default: ''
+
+  # Path to the test assembly signing key file.  When non-empty, passed to build.proj so that test
+  # assemblies are signed and can satisfy InternalsVisibleTo grants from signed source assemblies.
+  - name: testSigningKeyPath
+    type: string
+    default: ''
+
 steps:
 - ${{ if parameters.debug }}:
   - powershell: 'dotnet sdk check'
@@ -94,6 +106,8 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientUnit
@@ -104,6 +118,8 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Unit Tests ${{parameters.msbuildArchitecture }}'
@@ -122,6 +138,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientUnit
@@ -134,6 +152,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true
 
   - task: DotNetCoreCLI@2
@@ -153,6 +173,8 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientFunctional
@@ -165,6 +187,8 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Functional Tests ${{parameters.msbuildArchitecture }}'
@@ -185,6 +209,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientFunctional
@@ -199,6 +225,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true
 
   - task: DotNetCoreCLI@2
@@ -219,6 +247,8 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientManual
@@ -232,6 +262,8 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
   - task: DotNetCoreCLI@2
@@ -254,6 +286,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientManual
@@ -269,6 +303,8 @@ steps:
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
           -p:TestCodeCoverage=false
+          -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+          -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true
 
 - ${{ else }}: # Linux or macOS
@@ -286,6 +322,8 @@ steps:
         -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Unit Tests'
@@ -303,6 +341,8 @@ steps:
         -p:TestFilters="category=flaky"
         -p:TestResultsFolderPath=TestResults
         -p:TestCodeCoverage=false
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true
 
   - task: DotNetCoreCLI@2
@@ -321,6 +361,8 @@ steps:
         -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Functional Tests'
@@ -340,6 +382,8 @@ steps:
         -p:TestFilters="category=flaky"
         -p:TestResultsFolderPath=TestResults
         -p:TestCodeCoverage=false
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true
   - task: DotNetCoreCLI@2
     displayName: 'Run Manual Tests'
@@ -358,6 +402,8 @@ steps:
         -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
   - task: DotNetCoreCLI@2
@@ -379,4 +425,6 @@ steps:
         -p:TestFilters="category=flaky"
         -p:TestResultsFolderPath=TestResults
         -p:TestCodeCoverage=false
+        -p:SigningKeyPath="${{ parameters.signingKeyPath }}"
+        -p:TestSigningKeyPath="${{ parameters.testSigningKeyPath }}"
     continueOnError: true

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -104,6 +104,12 @@ parameters:
       - detailed
       - diagnostic
 
+  # True when building on the internal ADO.Net project.  Internal builds may perform additional or
+  # different steps, such as assembly signing.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 variables:
   - template: /eng/pipelines/libraries/ci-build-variables.yml@self
 
@@ -167,6 +173,7 @@ stages:
       loggingArtifactsName: $(loggingArtifactsName)
       loggingPackageVersion: $(loggingPackageVersion)
       referenceType: ${{ parameters.referenceType }}
+      isInternalBuild: ${{ parameters.isInternalBuild }}
       # When building Abstractions via packages, we must depend on the Logging
       # package.
       ${{ if eq(parameters.referenceType, 'Package') }}:
@@ -188,6 +195,7 @@ stages:
       mdsPackageVersion: $(mdsPackageVersion)
       akvPackageVersion: $(akvPackageVersion)
       referenceType: ${{ parameters.referenceType }}
+      isInternalBuild: ${{ parameters.isInternalBuild }}
       sqlServerArtifactsName: $(sqlServerArtifactsName)
       sqlServerPackageVersion: $(sqlServerPackageVersion)
       SNIVersion: ${{ parameters.SNIVersion }}
@@ -251,6 +259,7 @@ stages:
       loggingPackageVersion: $(loggingPackageVersion)
       mdsArtifactsName: $(mdsArtifactsName)
       mdsPackageVersion: $(mdsPackageVersion)
+      isInternalBuild: ${{ parameters.isInternalBuild }}
       sqlServerArtifactsName: $(sqlServerArtifactsName)
       sqlServerPackageVersion: $(sqlServerPackageVersion)
       testJobTimeout: ${{ parameters.testJobTimeout }}

--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -174,3 +174,4 @@ extends:
     testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
     useManagedSNI: ${{ parameters.useManagedSNI }}
+    isInternalBuild: ${{ eq(variables['System.TeamProject'], 'ADO.Net') }}

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -174,3 +174,4 @@ extends:
     testJobTimeout: ${{ parameters.testJobTimeout }}
     testSets: ${{ parameters.testSets }}
     useManagedSNI: ${{ parameters.useManagedSNI }}
+    isInternalBuild: ${{ eq(variables['System.TeamProject'], 'ADO.Net') }}

--- a/eng/pipelines/jobs/pack-abstractions-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-abstractions-package-ci-job.yml
@@ -77,6 +77,11 @@ parameters:
       # Reference sibling packages as C# projects.
       - Project
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 
   - job: pack_abstractions_package_job
@@ -119,6 +124,23 @@ jobs:
       - name: Configuration
         value: ''
 
+      # Build properties passed to dotnet pack.  Composed from a base set plus
+      # optional suffixes for Package-mode dependencies and assembly signing.
+      - name: baseBuildProperties
+        value: AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }};AbstractionsAssemblyFileVersion=${{ parameters.abstractionsAssemblyFileVersion }}
+
+      # NOTE: We use compile-time ${{ if }} branches rather than concatenating
+      # separate variables (e.g. "$(base);$(optional);$(signing)") because
+      # when the optional variables are empty the semicolons remain, producing
+      # a trailing ";;" that MSBuild rejects with MSB1005.
+      - name: buildProperties
+        ${{ if and(eq(parameters.referenceType, 'Package'), eq(parameters.isInternalBuild, true)) }}:
+          value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ elseif eq(parameters.referenceType, 'Package') }}:
+          value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }}
+        ${{ else }}:
+          value: $(baseBuildProperties)
+
     steps:
 
       # Emit environment variables if debug is enabled.
@@ -140,32 +162,20 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
-      # Create the NuGet packages.
-      #
-      # When referenceType is Package, we must pass ReferenceType and the
-      # dependency version so that Directory.Packages.props applies version
-      # ranges to sibling package dependencies.
-      - ${{ if eq(parameters.referenceType, 'Package') }}:
-        - task: DotNetCoreCLI@2
-          displayName: Create NuGet Package
-          inputs:
-            command: pack
-            packagesToPack: $(project)
-            configurationToPack: ${{ parameters.buildConfiguration }}
-            packDirectory: $(dotnetPackagesDir)
-            verbosityToPack: ${{ parameters.dotnetVerbosity }}
-            buildProperties: AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }};AbstractionsAssemblyFileVersion=${{ parameters.abstractionsAssemblyFileVersion }};ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }}
+      # Download the assembly signing key for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
-      - ${{ else }}:
-        - task: DotNetCoreCLI@2
-          displayName: Create NuGet Package
-          inputs:
-            command: pack
-            packagesToPack: $(project)
-            configurationToPack: ${{ parameters.buildConfiguration }}
-            packDirectory: $(dotnetPackagesDir)
-            verbosityToPack: ${{ parameters.dotnetVerbosity }}
-            buildProperties: AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }};AbstractionsAssemblyFileVersion=${{ parameters.abstractionsAssemblyFileVersion }}
+      # Create the NuGet packages.
+      - task: DotNetCoreCLI@2
+        displayName: Create NuGet Package
+        inputs:
+          command: pack
+          packagesToPack: $(project)
+          configurationToPack: ${{ parameters.buildConfiguration }}
+          packDirectory: $(dotnetPackagesDir)
+          verbosityToPack: ${{ parameters.dotnetVerbosity }}
+          buildProperties: $(buildProperties)
 
       # Publish the NuGet packages as a named pipeline artifact.
       - task: PublishPipelineArtifact@1

--- a/eng/pipelines/jobs/test-abstractions-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-abstractions-package-ci-job.yml
@@ -61,6 +61,20 @@ parameters:
   - name: poolName
     type: string
 
+  # True when building on the internal ADO.Net project.  When set, assemblies
+  # are signed with the driver key and tests are signed with the test key.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
+  # The C# project reference type to use when building.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
   # The pool VM image to use.
   - name: vmImage
     type: string
@@ -89,10 +103,20 @@ jobs:
         value: src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
 
       # dotnet CLI arguments for build/test/pack commands
-      - name: buildArguments
+      - name: dotnetBuildOpts
         value: >-
           -p:Configuration=${{ parameters.buildConfiguration }}
           --verbosity ${{ parameters.dotnetVerbosity }}
+
+      # Signing arguments — only set for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        - name: signingArguments
+          value: >-
+            -p:SigningKeyPath=$(driverKeyFile.secureFilePath)
+            -p:TestSigningKeyPath=$(testKeyFile.secureFilePath)
+      - ${{ else }}:
+        - name: signingArguments
+          value: ''
 
       # Explicitly unset the $PLATFORM environment variable that is set by the
       # 'ADO Build properties' Library in the ADO SqlClientDrivers public project.
@@ -121,6 +145,13 @@ jobs:
         - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
           displayName: '[Debug] Print Environment Variables'
 
+      # Download the assembly signing keys for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+          parameters:
+            isTest: true
+
       # Install the .NET SDK and Runtimes.
       - template: /eng/pipelines/common/steps/install-dotnet.yml@self
         parameters:
@@ -136,7 +167,7 @@ jobs:
         inputs:
           command: build
           projects: $(project)
-          arguments: $(buildArguments)
+          arguments: $(dotnetBuildOpts) $(signingArguments)
 
       # Run the tests for each .NET runtime.
       - ${{ each runtime in parameters.netRuntimes }}:
@@ -146,7 +177,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category != failing & category != flaky & category != interactive"
@@ -157,7 +188,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category = flaky"
@@ -170,7 +201,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category != failing & category != flaky & category != interactive"
@@ -181,7 +212,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category = flaky"

--- a/eng/pipelines/onebranch/jobs/validate-signed-package-job.yml
+++ b/eng/pipelines/onebranch/jobs/validate-signed-package-job.yml
@@ -157,8 +157,8 @@ jobs:
           $nugetPackageInstallPath = "${{ variables.nugetPackageInstallPath }}"
           echo "nugetPackageInstallPath= $nugetPackageInstallPath"
 
-          # Verify strong name signing #####################################
-          echo "> 1. Verifying strong name signing of DLLs ..."
+          # Verify strong-name signing ###################################
+          echo "> 1. Verifying strong-name signing of DLLs ..."
 
           # @TODO: This path seems brittle to VS upgrades, can we make it more flexible?
           $snPath = "C:\Program Files (x86)\Microsoft SDKs\Windows\*\bin\NETFX 4.8.1 Tools\sn.exe"

--- a/eng/pipelines/onebranch/steps/build-buildproj-step.yml
+++ b/eng/pipelines/onebranch/steps/build-buildproj-step.yml
@@ -7,7 +7,7 @@
 # This collection of steps to build a project via the build.proj. This will execute the "Build*"
 # target in build.proj, where * is the packageShortName provided in the parameters.
 #
-# Note: This differs from the pr/ci build-buildproj-step.yml in that it always strong-name signs
+# Note: This differs from the pr/ci build-buildproj-step.yml in that it always signs
 #    the assemblies, it only builds in package reference mode, and as such allows for version
 #    parameters to be provided.
 

--- a/eng/pipelines/onebranch/steps/build-buildproj-step.yml
+++ b/eng/pipelines/onebranch/steps/build-buildproj-step.yml
@@ -44,12 +44,8 @@ parameters:
     type: string
 
 steps:
-  # Download the strong name signing key from secure file storage
-  - task: DownloadSecureFile@1
-    displayName: 'Download Signing Key'
-    inputs:
-      secureFile: 'netfxKeypair.snk'
-    name: keyFile
+  # Download the assembly signing key from secure file storage.
+  - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
   - task: DotNetCoreCLI@2
     displayName: 'build.proj - Build${{ parameters.packageShortName }}'
@@ -61,7 +57,7 @@ steps:
         -p:Configuration=${{ parameters.buildConfiguration }}
         -p:ReferenceType=Package
         -p:SkipDependencyPack=true
-        -p:SigningKeyPath="$(keyFile.secureFilePath)"
+        -p:SigningKeyPath="$(driverKeyFile.secureFilePath)"
         -p:BuildNumber="$(Build.BuildNumber)"
         -p:PackageVersion${{ parameters.packageShortName }}="${{ parameters.packageVersion }}"
         ${{ parameters.dependencyArguments }}

--- a/eng/pipelines/stages/build-abstractions-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-abstractions-package-ci-stage.yml
@@ -91,6 +91,11 @@ parameters:
       # Reference sibling packages as C# projects.
       - Project
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 stages:
 
   - stage: build_abstractions_package_stage
@@ -112,10 +117,12 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Linux
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: linux
           netFrameworkRuntimes: []
           netRuntimes: [net8.0, net9.0, net10.0]
           poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
           vmImage: ubuntu-latest
 
       # ------------------------------------------------------------------------
@@ -127,10 +134,12 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Win
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: windows
           netFrameworkRuntimes: [net462]
           netRuntimes: [net8.0, net9.0, net10.0]
           poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
           vmImage: windows-latest
 
       # ------------------------------------------------------------------------
@@ -142,10 +151,12 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: macOS
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: macos
           netFrameworkRuntimes: []
           netRuntimes: [net8.0, net9.0, net10.0]
           poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
           vmImage: macos-latest
 
       # ------------------------------------------------------------------------
@@ -168,3 +179,4 @@ stages:
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
           referenceType: ${{ parameters.referenceType }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}

--- a/eng/pipelines/stages/build-sqlclient-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-sqlclient-package-ci-stage.yml
@@ -85,6 +85,11 @@ parameters:
     type: string
     default: ''
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 stages:
 
   - stage: build_sqlclient_package_stage
@@ -109,6 +114,7 @@ stages:
         akvPackageVersion: ${{ parameters.akvPackageVersion }}
         sqlServerArtifactsName: ${{ parameters.sqlServerArtifactsName }}
         sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
+        isInternalBuild: ${{ parameters.isInternalBuild }}
         ${{ if ne(parameters.SNIVersion, '') }}:
           prebuildSteps:
             - template: /eng/pipelines/common/templates/steps/override-sni-version.yml@self

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -106,15 +106,15 @@
     <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
 
-  <!-- When a signing key is specified, we will perform strong name assembly signing. -->
+  <!-- When a signing key is specified, we will perform assembly signing. -->
   <PropertyGroup Condition="'$(SigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SigningKeyPath)</AssemblyOriginatorKeyFile>
 
     <!-- We also define a constant used for conditional compilation. -->
-    <DefineConstants>$(DefineConstants);STRONG_NAME_SIGNING</DefineConstants>
+    <DefineConstants>$(DefineConstants);ASSEMBLY_SIGNING</DefineConstants>
   </PropertyGroup>
 
   <!-- Packaging for source link-->

--- a/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
+++ b/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.csproj
@@ -22,7 +22,7 @@
     <Version>$(AkvProviderPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Build Output ==================================================== -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
@@ -34,8 +34,20 @@
 
   <!-- Strong name signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
+
+  <!-- Unsigned: expose internals to the test assembly in any reference mode. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <InternalsVisibleTo Include="$(AssemblyName).Test" />
+  </ItemGroup>
+
+  <!--
+    Signed + Package mode: expose internals to the test assembly signed with the test key.
+    Signed + Project mode is intentionally omitted: production-signed assemblies should not
+    grant internal access to test assemblies during local development.  Tests that need internals
+    in Project mode run unsigned; only the CI package-validation pipeline uses signed packages.
+  -->
+  <ItemGroup Condition="'$(SigningKeyPath)' != '' AND '$(ReferenceType)' == 'Package'">
+    <InternalsVisibleTo Include="$(AssemblyName).Test, PublicKey=00240000048000001401000006020000002400005253413100080000010001003D19684676DA365F331D00CE7BD4B8EF03E74102F39A5681B40622703D68F0298ECACECC723D3FFC1EA9365AF4958578550EA1EBEEC084B0B3757F3762449F5365E872802A4B548056760764FAD062BFEE81ED26183109AD46810E7E6E965419D0A10473680144D20C1BFE1027A5F586CA987523C06F5C126C44EA7D4F51EB023867A9F294315F95775ACEFD2D678186919458DFCCB4DE2E9F53AEFC766C7CBCEC474ED21C1616E5A9414D366D91D121C39F5FE6641295ADC058EF3FB10593BCDE2E82D9F217C2634909EEF496CD53AE78ABBEA572B871D72EBFC5378205950ABA97C7CCC2B9635D96933D5F9C9624D71FF53EE2094CF3A6BD38534D66E414B7" />
   </ItemGroup>
 
   <!-- Build Output ==================================================== -->
@@ -77,6 +89,11 @@
                       Condition="'$(ReferenceType)' != 'Package'" />
     <PackageReference Include="Microsoft.Data.SqlClient.Internal.Logging"
                       Condition="'$(ReferenceType)' == 'Package'" />
+  </ItemGroup>
+
+  <!-- Polyfills ======================================================= -->
+  <ItemGroup>
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <!-- CodeGen Targets ================================================= -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Abstractions.csproj
@@ -32,7 +32,7 @@
     <Version>$(AbstractionsPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Unsigned: expose internals to the test assembly in any reference mode. -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.Internal.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.Internal.cs
@@ -40,22 +40,67 @@ public abstract partial class SqlAuthenticationProvider
         {
             const string assemblyName = "Microsoft.Data.SqlClient";
 
-            // If the MDS package is present, load its
+            // If the SqlClient assembly is present, load its
             // SqlAuthenticationProviderManager class and get/set methods.
             try
             {
-                // Try to load the MDS assembly.
+                // Try to load the SqlClient assembly.
+
+                #if STRONG_NAME_SIGNING
+
+                // The expected public key token of the SqlClient assembly, used to avoid invoking
+                // APIs from imposter assemblies.  This is the same token used by all assemblies in
+                // this repository when strong-name signed.
+                byte[] expectedPublicKeyToken =
+                    [ 0x23, 0xec, 0x7f, 0xc2, 0xd6, 0xea, 0xa4, 0xa5 ];
+
+                // When strong-name signing is enabled, build a fully-qualified AssemblyName that
+                // includes the expected public key token.
+                Log($"Attempting to load SqlClient assembly={assemblyName} with " +
+                    "expected public key token=" +
+                    BitConverter.ToString(expectedPublicKeyToken).Replace("-", ""));
+
+                var qualifiedName = new AssemblyName(assemblyName);
+                qualifiedName.SetPublicKeyToken(expectedPublicKeyToken);
+
+                // The .NET Framework runtime enforces the token during binding, causing Load() to
+                // throw if it doesn't match. The .NET (Core) runtime ignores the token, so we
+                // verify it ourselves below.
+                var assembly = Assembly.Load(qualifiedName);
+
+                // Defense-in-depth: verify the public key token after loading.  This is necessary
+                // on .NET Core where the runtime does not enforce the token. It is harmless on .NET
+                // Framework.
+                if (assembly is not null)
+                {
+                    byte[]? actualToken = assembly.GetName().GetPublicKeyToken();
+
+                    if (actualToken is null ||
+                        !actualToken.AsSpan().SequenceEqual(expectedPublicKeyToken))
+                    {
+                        Log($"SqlClient assembly={assembly.GetName()} has an " +
+                            "unexpected public key token; " +
+                            "Get/SetProvider() will not function");
+                        return;
+                    }
+                }
+
+                #else
+
+                // Strong-name signing is disabled, so we cannot verify the public key token.
+                Log($"Loading SqlClient assembly={assemblyName} without strong-name identity " +
+                    "verification; ensure this assembly is from a trusted source");
+
                 var assembly = Assembly.Load(assemblyName);
+
+                #endif
 
                 if (assembly is null)
                 {
-                    Log($"MDS assembly={assemblyName} not found; " +
+                    Log($"SqlClient assembly={assemblyName} not found; " +
                         "Get/SetProvider() will not function");
                     return;
                 }
-
-                // TODO(https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/39845):
-                // Verify the assembly is signed by us?
 
                 // Look for the manager class.
                 const string className = "Microsoft.Data.SqlClient.SqlAuthenticationProviderManager";
@@ -63,7 +108,7 @@ public abstract partial class SqlAuthenticationProvider
 
                 if (manager is null)
                 {
-                    Log($"MDS auth manager manager class={className} not found; " +
+                    Log($"SqlClient auth manager class={className} not found; " +
                         "Get/SetProvider() will not function");
                     return;
                 }
@@ -75,7 +120,7 @@ public abstract partial class SqlAuthenticationProvider
 
                 if (_getProvider is null)
                 {
-                    Log($"MDS GetProvider() method not found; " +
+                    Log($"SqlClient GetProvider() method not found; " +
                         "GetProvider() will not function");
                 }
 
@@ -85,7 +130,7 @@ public abstract partial class SqlAuthenticationProvider
 
                 if (_setProvider is null)
                 {
-                    Log($"MDS SetProvider() method not found; " +
+                    Log($"SqlClient SetProvider() method not found; " +
                         "SetProvider() will not function");
                 }
             }
@@ -97,7 +142,7 @@ public abstract partial class SqlAuthenticationProvider
                      or FileLoadException
                      or FileNotFoundException)
             {
-                Log($"MDS assembly={assemblyName} not found or not usable; " +
+                Log($"SqlClient assembly={assemblyName} not found or not usable; " +
                     $"Get/SetProvider() will not function: {ex} ");
             }
             // Any other exceptions are fatal.

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.Internal.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/SqlAuthenticationProvider.Internal.cs
@@ -46,15 +46,15 @@ public abstract partial class SqlAuthenticationProvider
             {
                 // Try to load the SqlClient assembly.
 
-                #if STRONG_NAME_SIGNING
+                #if ASSEMBLY_SIGNING
 
                 // The expected public key token of the SqlClient assembly, used to avoid invoking
-                // APIs from imposter assemblies.  This is the same token used by all assemblies in
-                // this repository when strong-name signed.
+                // APIs from imposter assemblies.  This is the public key token of the assembly
+                // signing key used for all of our driver assemblies.
                 byte[] expectedPublicKeyToken =
                     [ 0x23, 0xec, 0x7f, 0xc2, 0xd6, 0xea, 0xa4, 0xa5 ];
 
-                // When strong-name signing is enabled, build a fully-qualified AssemblyName that
+                // When assembly signing is enabled, build a fully-qualified AssemblyName that
                 // includes the expected public key token.
                 Log($"Attempting to load SqlClient assembly={assemblyName} with " +
                     "expected public key token=" +
@@ -87,7 +87,7 @@ public abstract partial class SqlAuthenticationProvider
 
                 #else
 
-                // Strong-name signing is disabled, so we cannot verify the public key token.
+                // Assembly signing is disabled, so we cannot verify the public key token.
                 Log($"Loading SqlClient assembly={assemblyName} without strong-name identity " +
                     "verification; ensure this assembly is from a trusted source");
 

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
@@ -2,10 +2,24 @@
   <!-- General Properties ============================================== -->
   <PropertyGroup>
     <AssemblyName>Microsoft.Data.SqlClient.Extensions.Abstractions.Test</AssemblyName>
-    <TargetFrameworks>net462;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+
+    <!--
+      The Abstractions project is not built for net462 unless it is built for Windows. Thus, we
+      will not be able to fulfill the Abstractions for net462 reference unless we are building on
+      Windows.
+    -->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <!-- Strong name signing ============================================= -->
+  <!-- When a test signing key is provided, sign the test assembly so IVT from signed source works. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <!-- Compiler Options ================================================ -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/test/Abstractions.Test.csproj
@@ -15,7 +15,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- When a test signing key is provided, sign the test assembly so IVT from signed source works. -->
   <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.Data.SqlClient/notsupported/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/notsupported/Microsoft.Data.SqlClient.csproj
@@ -83,7 +83,7 @@
     <Version>$(SqlClientPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Build Output ==================================================== -->

--- a/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/ref/Microsoft.Data.SqlClient.csproj
@@ -28,7 +28,7 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Build Output ==================================================== -->

--- a/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft.Data.SqlClient.csproj
@@ -60,7 +60,7 @@
     <Version>$(SqlClientPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- Strong naming is being done in Directory.Build.props -->
 
   <!-- Unsigned: expose internals to UnitTests in any reference mode. -->

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlAuthenticationProviderManager.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 // Try to load our Azure extension.
-                #if STRONG_NAME_SIGNING
+                #if ASSEMBLY_SIGNING
 
-                // When strong-name signing is enabled, build a fully-qualified AssemblyName
+                // When assembly signing is enabled, build a fully-qualified AssemblyName
                 // that includes the expected public key token.
 
                 SqlClientEventSource.Log.TryTraceEvent(
@@ -109,7 +109,7 @@ namespace Microsoft.Data.SqlClient
                 SqlClientEventSource.Log.TryTraceEvent(
                     nameof(SqlAuthenticationProviderManager) +
                     $": Attempting to load Azure extension assembly={azureAssemblyName} without " +
-                    "strong name verification; ensure this assembly is from a trusted source");
+                    "strong-name identity verification; ensure this assembly is from a trusted source");
 
                 var assembly = Assembly.Load(azureAssemblyName);
 

--- a/src/Microsoft.Data.SqlClient/tests/Common/Microsoft.Data.SqlClient.TestCommon.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Microsoft.Data.SqlClient.TestCommon.csproj
@@ -14,7 +14,7 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- Sign with the test key so signed test assemblies can reference this project. -->
   <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlDataRecordTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlDataRecordTest.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Data.SqlClient.Tests
 
         [Theory]
         #if NETFRAMEWORK
-        [Trait("Category", "signed")] // Requires strong-name signed Microsoft.SqlServer.Server
+        [Trait("Category", "signed")] // Requires a signed Microsoft.SqlServer.Server assembly
         #endif
         [MemberData(
             nameof(GetUdtTypeTestData.Get),

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/SqlServerTypesTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/UdtTest/SqlServerTypesTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: Parse error at line: 1, column: 48: Incorrect syntax near 'hierarchyid'.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         #if NETFRAMEWORK
-        [Trait("Category", "signed")] // Requires strong-name signed Microsoft.SqlServer.Server
+        [Trait("Category", "signed")] // Requires a signed Microsoft.SqlServer.Server assembly
         #endif
         public static void GetSchemaTableTest()
         {
@@ -66,7 +66,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: Parse error at line: 1, column: 48: Incorrect syntax near 'hierarchyid'.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         #if NETFRAMEWORK
-        [Trait("Category", "signed")] // Requires strong-name signed Microsoft.SqlServer.Server
+        [Trait("Category", "signed")] // Requires a signed Microsoft.SqlServer.Server assembly
         #endif
         public static void GetValueTest()
         {
@@ -227,7 +227,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: Parse error at line: 1, column: 41: Incorrect syntax near 'hierarchyid'.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         #if NETFRAMEWORK
-        [Trait("Category", "signed")] // Requires strong-name signed Microsoft.SqlServer.Server
+        [Trait("Category", "signed")] // Requires a signed Microsoft.SqlServer.Server assembly
         #endif
         public static void TestUdtSchemaMetadata()
         {
@@ -384,7 +384,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Synapse: Parse error at line: 1, column: 8: Incorrect syntax near 'geometry'.
         [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         #if NETFRAMEWORK
-        [Trait("Category", "signed")] // Requires strong-name signed Microsoft.SqlServer.Server
+        [Trait("Category", "signed")] // Requires a signed Microsoft.SqlServer.Server assembly
         #endif
         public static void TestSqlServerTypesInsertAndRead()
         {

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft.Data.SqlClient.UnitTests.csproj
@@ -36,7 +36,7 @@
     </None>
   </ItemGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- When a test signing key is provided, sign UnitTests so IVT from signed SqlClient works. -->
   <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Microsoft.Data.SqlClient.TestUtilities.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/Microsoft.Data.SqlClient.TestUtilities.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- Sign with the test key so signed test assemblies can reference this project. -->
   <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
## Summary

Pure terminology rename: `STRONG_NAME_SIGNING` → `ASSEMBLY_SIGNING` (and related "strong name" wording → "assembly signing" / "strong-name identity") across `src/Directory.Build.props`, source files, csproj files, and pipeline YAML.

No functional change — this only renames the conditional-compilation constant and aligns comments/wording.

## 🔗 PR Stack

Part of a 6-PR stack — current PR marked 👉. Indentation shows the branch base.

- 🏗️ [#4382](https://github.com/dotnet/SqlClient/pull/4382) — Sign CI Package pipeline assemblies & tests · base: `main`
  - ✂️ [#4348](https://github.com/dotnet/SqlClient/pull/4348) — AOT-safe auth provider with feature switch & trimmer support
  - 🏷️ 👉 **[#4383](https://github.com/dotnet/SqlClient/pull/4383) — Rename `STRONG_NAME_SIGNING` → `ASSEMBLY_SIGNING`**
    - 🪵 [#4384](https://github.com/dotnet/SqlClient/pull/4384) — Add Logging test package & CI
    - ☁️ [#4385](https://github.com/dotnet/SqlClient/pull/4385) — Sign Azure extension assembly & tests
    - 🧩 [#4386](https://github.com/dotnet/SqlClient/pull/4386) — Sign `Microsoft.SqlServer.Server` assembly & CI

```mermaid
flowchart TD
    main([main])
    PR1["🏗️ #4382<br/>signing-core"]
    AOT["✂️ #4348<br/>aot"]
    PR2["🏷️ #4383<br/>rename"]
    PR3["🪵 #4384<br/>logging-tests"]
    PR4["☁️ #4385<br/>azure-signing"]
    PR5["🧩 #4386<br/>sqlserver.server"]
    main --> PR1
    PR1 --> AOT
    PR1 --> PR2
    PR2 --> PR3
    PR2 --> PR4
    PR2 --> PR5
    click PR1 "https://github.com/dotnet/SqlClient/pull/4382" _blank
    click AOT "https://github.com/dotnet/SqlClient/pull/4348" _blank
    click PR2 "https://github.com/dotnet/SqlClient/pull/4383" _blank
    click PR3 "https://github.com/dotnet/SqlClient/pull/4384" _blank
    click PR4 "https://github.com/dotnet/SqlClient/pull/4385" _blank
    click PR5 "https://github.com/dotnet/SqlClient/pull/4386" _blank
    classDef current fill:#1f6feb,stroke:#1f6feb,color:#fff;
    class PR2 current;
```

> Note: `SqlAuthenticationProviderManager.cs` here keeps `main`'s WAM Broker rework intact — only the three signing-related lines (`#if` constant + two comments) are changed.

## Checklist
- [x] Tests added or updated (Abstractions: 29/29; SqlClient signed + unsigned compile)
- [x] Public API changes documented (none)
- [x] No `STRONG_NAME_SIGNING` references remain
- [x] No breaking changes
