### PR TITLE
Add Logging test package and CI coverage

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -394,7 +394,7 @@
       environments. Please consider running project specific test targets or specific test sets
       within the project.
   -->
-  <Target Name="Test" DependsOnTargets="TestAbstractions;TestAzure;TestSqlClient" />
+  <Target Name="Test" DependsOnTargets="TestLogging;TestAbstractions;TestAzure;TestSqlClient" />
 
   <!-- ================================================================= -->
   <!-- Microsoft.Data.SqlClient Targets -->
@@ -1073,6 +1073,7 @@
   <PropertyGroup>
     <LoggingSrcRoot>$(RepoRoot)src/Microsoft.Data.SqlClient.Internal/Logging/src/</LoggingSrcRoot>
     <LoggingProjectPath>$(LoggingSrcRoot)Logging.csproj</LoggingProjectPath>
+    <LoggingTestProjectPath>$(RepoRoot)src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj</LoggingTestProjectPath>
     <LoggingArtifactRoot>$(RepoRoot)artifacts/Microsoft.Data.SqlClient.Internal.Logging/$(Configuration)/</LoggingArtifactRoot>
   </PropertyGroup>
 
@@ -1132,6 +1133,39 @@
       SourceFiles="@(LoggingPackedArtifacts)"
       DestinationFolder="$(PackagesDir)"
       SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- TestLogging: Runs Microsoft.Data.SqlClient.Internal.Logging.Tests -->
+  <Target Name="TestLogging">
+    <PropertyGroup>
+      <LogFilePrefix>LoggingTests-$(OS)</LogFilePrefix>
+      <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
+
+      <DotnetCommand>
+        "$(DotnetPath)dotnet" test "$(LoggingTestProjectPath)"
+
+        <!-- Build arguments -->
+        -p:Configuration=$(Configuration)
+        $(SigningKeyPathArgument)
+        $(TestSigningKeyPathArgument)
+
+        <!-- Test arguments -->
+        $(TestBlameArgument)
+        $(TestCodeCoverageArgument)
+        $(TestFiltersArgument)
+        $(TestFrameworkArgument)
+        --results-directory "$(TestResultsFolderPath)"
+        --logger:"trx;LogFilePrefix=$(LogFilePrefix)"
+
+        <!-- Reference Type Arguments -->
+        $(ReferenceTypeArgument)
+      </DotnetCommand>
+      <!-- Convert more than one whitespace character into one space -->
+      <DotnetCommand>$([System.Text.RegularExpressions.Regex]::Replace($(DotnetCommand), "\s+", " "))</DotnetCommand>
+    </PropertyGroup>
+
+    <Message Text=">>> Running tests for Logging via command: $(DotnetCommand)" />
+    <Exec ConsoleToMsBuild="true" Command="$(DotnetCommand)" />
   </Target>
 
   <!-- ================================================================= -->

--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -156,6 +156,8 @@ stages:
       buildConfiguration: ${{ parameters.buildConfiguration }}
       debug: ${{ parameters.debug }}
       dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+      isInternalBuild: ${{ parameters.isInternalBuild }}
+      referenceType: ${{ parameters.referenceType }}
 
   # Build the Abstractions package, and publish it to the pipeline artifacts
   # under the given artifact name.

--- a/eng/pipelines/jobs/pack-logging-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-logging-package-ci-job.yml
@@ -53,6 +53,19 @@ parameters:
     - detailed
     - diagnostic
 
+  # The C# project reference type to use when building and packing the packages.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 
   - job: pack_logging_package_job
@@ -86,6 +99,20 @@ jobs:
       - name: Configuration
         value: ''
 
+      # Build properties passed to dotnet pack.
+      - name: baseBuildProperties
+        value: LoggingPackageVersion=${{ parameters.loggingPackageVersion }};LoggingAssemblyFileVersion=${{ parameters.loggingAssemblyFileVersion }}
+
+      # NOTE: We use compile-time ${{ if }} branches rather than concatenating
+      # separate variables (e.g. "$(base);$(signing)") because when the
+      # optional variable is empty the semicolons remain, producing a trailing
+      # ";;" that MSBuild rejects with MSB1005.
+      - name: buildProperties
+        ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+          value: $(baseBuildProperties);SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ else }}:
+          value: $(baseBuildProperties)
+
     steps:
 
       # Emit environment variables if debug is enabled.
@@ -98,6 +125,10 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
+      # Download the assembly signing key for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+
       # Create the NuGet packages.
       - task: DotNetCoreCLI@2
         displayName: Create NuGet Package
@@ -107,7 +138,7 @@ jobs:
           configurationToPack: ${{ parameters.buildConfiguration }}
           packDirectory: $(dotnetPackagesDir)
           verbosityToPack: ${{ parameters.dotnetVerbosity }}
-          buildProperties: LoggingPackageVersion=${{ parameters.loggingPackageVersion }};LoggingAssemblyFileVersion=${{ parameters.loggingAssemblyFileVersion }}
+          buildProperties: $(buildProperties)
 
       # Publish the NuGet packages as a named pipeline artifact.
       - task: PublishPipelineArtifact@1

--- a/eng/pipelines/jobs/test-logging-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-logging-package-ci-job.yml
@@ -1,0 +1,218 @@
+################################################################################
+# Licensed to the .NET Foundation under one or more agreements.  The .NET
+# Foundation licenses this file to you under the MIT license.  See the LICENSE
+# file in the project root for more information.
+################################################################################
+
+# This job builds the Logging package and runs its tests for a set of .NET
+# runtimes.
+#
+# This template defines a job named
+# 'test_logging_package_job_<jobNameSuffix>' that can be depended on by
+# downstream jobs.
+
+parameters:
+
+  # The type of build to test (Release or Debug)
+  - name: buildConfiguration
+    type: string
+    values:
+    - Release
+    - Debug
+
+  # True to emit debug information and steps.
+  - name: debug
+    type: boolean
+    default: false
+
+  # The prefix to prepend to the job's display name:
+  #
+  #   [<prefix>] Test Logging Package
+  #
+  - name: displayNamePrefix
+    type: string
+
+  # The verbosity level for the dotnet CLI commands.
+  - name: dotnetVerbosity
+    type: string
+    default: normal
+    values:
+    - quiet
+    - minimal
+    - normal
+    - detailed
+    - diagnostic
+
+  # True when building on the internal ADO.Net project.  When set, assemblies
+  # are signed with the driver key and tests are signed with the test key.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
+  # The suffix to append to the job name.
+  - name: jobNameSuffix
+    type: string
+
+  # The list of .NET Framework runtimes to test against.
+  - name: netFrameworkRuntimes
+    type: object
+    default: []
+
+  # The list of .NET runtimes to test against.
+  - name: netRuntimes
+    type: object
+    default: []
+
+  # The name of the Azure Pipelines pool to use.
+  - name: poolName
+    type: string
+
+  # The pool VM image to use.
+  - name: vmImage
+    type: string
+
+  # The C# project reference type to use when building.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
+jobs:
+
+  - job: test_logging_package_job_${{ parameters.jobNameSuffix }}
+    displayName: '[${{ parameters.displayNamePrefix }}] Test Logging Package'
+    pool:
+      name: ${{ parameters.poolName }}
+
+      # Images provided by Azure Pipelines must be selected using 'vmImage'.
+      ${{ if eq(parameters.poolName, 'Azure Pipelines') }}:
+        vmImage: ${{ parameters.vmImage }}
+      # Images provided by 1ES must be selected using a demand.
+      ${{ else }}:
+        demands:
+          - imageOverride -equals ${{ parameters.vmImage }}
+
+    variables:
+
+      # The Logging test project file to use for all dotnet CLI commands.
+      #
+      # Building this project implicitly builds the Logging project.
+      - name: project
+        value: src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
+
+      # dotnet CLI arguments for build/test/pack commands
+      - name: dotnetBuildOpts
+        value: >-
+          -p:Configuration=${{ parameters.buildConfiguration }}
+          --verbosity ${{ parameters.dotnetVerbosity }}
+
+      # Signing arguments — only set for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        - name: signingArguments
+          value: >-
+            -p:SigningKeyPath=$(driverKeyFile.secureFilePath)
+            -p:TestSigningKeyPath=$(testKeyFile.secureFilePath)
+      - ${{ else }}:
+        - name: signingArguments
+          value: ''
+
+      # Explicitly unset the $PLATFORM environment variable that is set by the
+      # 'ADO Build properties' Library in the ADO SqlClientDrivers public project.
+      # This is defined with a non-standard Platform of 'AnyCPU', and will fail
+      # the builds if left defined.
+      #
+      # Note that Azure Pipelines will inject this variable as PLATFORM into the
+      # environment of all tasks in this job.
+      #
+      # See:
+      #   https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch
+      #
+      - name: Platform
+        value: ''
+
+      # Do the same for $CONFIGURATION since we explicitly set it using our
+      # 'buildConfiguration' parameter, and we don't want the environment to
+      # override us.
+      - name: Configuration
+        value: ''
+
+    steps:
+
+      # Emit environment variables if debug is enabled.
+      - ${{ if eq(parameters.debug, true) }}:
+        - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
+          displayName: '[Debug] Print Environment Variables'
+
+      # Download the assembly signing keys for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+          parameters:
+            isTest: true
+
+      # Install the .NET SDK and Runtimes.
+      - template: /eng/pipelines/common/steps/install-dotnet.yml@self
+        parameters:
+          debug: ${{ parameters.debug }}
+          runtimes: [8.x, 9.x]
+
+      # The Windows agent images include a suitable .NET Framework runtime, so
+      # we don't have to install one explicitly.
+
+      # Build the project.
+      - task: DotNetCoreCLI@2
+        displayName: Build Project
+        inputs:
+          command: build
+          projects: $(project)
+          arguments: $(dotnetBuildOpts) $(signingArguments)
+
+      # Run the tests for each .NET runtime.
+      - ${{ each runtime in parameters.netRuntimes }}:
+        - task: DotNetCoreCLI@2
+          displayName: Test [${{ runtime }}]
+          inputs:
+            command: test
+            projects: $(project)
+            arguments: >-
+              $(dotnetBuildOpts)
+              --no-build
+              -f ${{ runtime }}
+              --filter "category != failing & category != flaky & category != interactive"
+
+        - task: DotNetCoreCLI@2
+          displayName: Test Flaky [${{ runtime }}]
+          inputs:
+            command: test
+            projects: $(project)
+            arguments: >-
+              $(dotnetBuildOpts)
+              --no-build
+              -f ${{ runtime }}
+              --filter "category = flaky"
+
+      # Run the tests for each .NET Framework runtime.
+      - ${{ each runtime in parameters.netFrameworkRuntimes }}:
+        - task: DotNetCoreCLI@2
+          displayName: Test [${{ runtime }}]
+          inputs:
+            command: test
+            projects: $(project)
+            arguments: >-
+              $(dotnetBuildOpts)
+              --no-build
+              -f ${{ runtime }}
+              --filter "category != failing & category != flaky & category != interactive"
+
+        - task: DotNetCoreCLI@2
+          displayName: Test Flaky [${{ runtime }}]
+          inputs:
+            command: test
+            projects: $(project)
+            arguments: >-
+              $(dotnetBuildOpts)
+              --no-build
+              -f ${{ runtime }}
+              --filter "category = flaky"

--- a/eng/pipelines/stages/build-logging-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-logging-package-ci-stage.yml
@@ -67,6 +67,19 @@ parameters:
     - detailed
     - diagnostic
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
+  # The C# project reference type to use when building and packing the packages.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
 stages:
 
   - stage: build_logging_package_stage
@@ -79,11 +92,59 @@ stages:
 
     jobs:
 
+      # ------------------------------------------------------------------------
+      # Build and test on Linux.
+
+      - template: /eng/pipelines/jobs/test-logging-package-ci-job.yml@self
+        parameters:
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          debug: ${{ parameters.debug }}
+          displayNamePrefix: Linux
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
+          jobNameSuffix: linux
+          netFrameworkRuntimes: []
+          netRuntimes: [net8.0, net9.0, net10.0]
+          poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
+          vmImage: ubuntu-latest
+
+      # ------------------------------------------------------------------------
+      # Build and test on Windows.
+
+      - template: /eng/pipelines/jobs/test-logging-package-ci-job.yml@self
+        parameters:
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          debug: ${{ parameters.debug }}
+          displayNamePrefix: Win
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
+          jobNameSuffix: windows
+          netFrameworkRuntimes: [net462]
+          netRuntimes: [net8.0, net9.0, net10.0]
+          poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
+          vmImage: windows-latest
+
+      # ------------------------------------------------------------------------
+      # Build and test on macOS.
+
+      - template: /eng/pipelines/jobs/test-logging-package-ci-job.yml@self
+        parameters:
+          buildConfiguration: ${{ parameters.buildConfiguration }}
+          debug: ${{ parameters.debug }}
+          displayNamePrefix: macOS
+          dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
+          jobNameSuffix: macos
+          netFrameworkRuntimes: []
+          netRuntimes: [net8.0, net9.0, net10.0]
+          poolName: Azure Pipelines
+          referenceType: ${{ parameters.referenceType }}
+          vmImage: macos-latest
+
+      # ------------------------------------------------------------------------
       # Create and publish the NuGet package.
-      # Note: No test jobs because the Logging project does not have a test
-      # project yet.  When a test project is added, test jobs should be added
-      # here (mirroring the Abstractions stage pattern) and the pack job should
-      # depend on them.
 
       - template: /eng/pipelines/jobs/pack-logging-package-ci-job.yml@self
         parameters:
@@ -93,3 +154,5 @@ stages:
           buildConfiguration: ${{ parameters.buildConfiguration }}
           debug: ${{ parameters.debug }}
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
+          referenceType: ${{ parameters.referenceType }}

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/src/Logging.csproj
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/src/Logging.csproj
@@ -34,10 +34,22 @@
     <Version>$(LoggingPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
+
+  <!-- Unsigned: expose internals to the test assembly in any reference mode. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <InternalsVisibleTo Include="$(AssemblyName).Test" />
+  </ItemGroup>
+
+  <!--
+    Signed + Package mode: expose internals to the test assembly signed with the test key.
+    Signed + Project mode is intentionally omitted: production-signed assemblies should not
+    grant internal access to test assemblies during local development.  Tests that need internals
+    in Project mode run unsigned; only the CI package-validation pipeline uses signed packages.
+  -->
+  <ItemGroup Condition="'$(SigningKeyPath)' != '' AND '$(ReferenceType)' == 'Package'">
+    <InternalsVisibleTo Include="$(AssemblyName).Test, PublicKey=00240000048000001401000006020000002400005253413100080000010001003D19684676DA365F331D00CE7BD4B8EF03E74102F39A5681B40622703D68F0298ECACECC723D3FFC1EA9365AF4958578550EA1EBEEC084B0B3757F3762449F5365E872802A4B548056760764FAD062BFEE81ED26183109AD46810E7E6E965419D0A10473680144D20C1BFE1027A5F586CA987523C06F5C126C44EA7D4F51EB023867A9F294315F95775ACEFD2D678186919458DFCCB4DE2E9F53AEFC766C7CBCEC474ED21C1616E5A9414D366D91D121C39F5FE6641295ADC058EF3FB10593BCDE2E82D9F217C2634909EEF496CD53AE78ABBEA572B871D72EBFC5378205950ABA97C7CCC2B9635D96933D5F9C9624D71FF53EE2094CF3A6BD38534D66E414B7" />
   </ItemGroup>
 
   <!-- Build Output ==================================================== -->

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/test/Directory.Packages.props
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/test/Directory.Packages.props
@@ -1,0 +1,10 @@
+<Project>
+  <!--
+    This file exists because the shared test package versions (xunit, Test.Sdk, etc.) live in the
+    SqlClient tests Directory.Packages.props rather than the repo root.  Without this file, NuGet's
+    CPM directory walk would resolve to the repo-root props and miss the test-only versions.
+    Importing the SqlClient tests props brings in both the shared test dependencies and
+    (transitively) the root production dependencies.
+  -->
+  <Import Project="$(RepoRoot)src/Microsoft.Data.SqlClient/tests/Directory.Packages.props" />
+</Project>

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj
@@ -1,0 +1,57 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- General Properties ============================================== -->
+  <PropertyGroup>
+    <AssemblyName>Microsoft.Data.SqlClient.Internal.Logging.Test</AssemblyName>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+
+    <!--
+      The Logging project is not built for net462 unless it is built for Windows. Thus, we will
+      not be able to fulfill the Logging for net462 reference unless we are building on Windows.
+    -->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <!-- Assembly signing ============================================= -->
+  <!-- When a test signing key is provided, sign the test assembly so IVT from signed source works. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <!-- Compiler Options ================================================ -->
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!-- Global Usings =================================================== -->
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <!-- Embedded resources and content files ============================ -->
+  <ItemGroup>
+    <Content Include="$(RepoRoot)/src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>xunit.runner.json</TargetPath>
+    </Content>
+  </ItemGroup>
+
+  <!-- References ====================================================== -->
+  <!-- Test Target Reference -->
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src/Microsoft.Data.SqlClient.Internal/Logging/src/Logging.csproj" />
+  </ItemGroup>
+
+  <!-- Other References -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.console" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/test/SqlClientEventSourceTest.cs
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/test/SqlClientEventSourceTest.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Data.SqlClient.Internal.Logging.Test;
+
+public class SqlClientEventSourceTest
+{
+    [Fact]
+    public void SqlClientEventSource_Log_IsNotNull()
+    {
+        Assert.NotNull(SqlClientEventSource.Log);
+    }
+
+    [Fact]
+    public void SqlClientEventSource_Log_IsSingleton()
+    {
+        Assert.Same(SqlClientEventSource.Log, SqlClientEventSource.Log);
+    }
+}

--- a/src/Microsoft.Data.SqlClient.slnx
+++ b/src/Microsoft.Data.SqlClient.slnx
@@ -149,6 +149,7 @@
   </Folder>
   <Folder Name="/src/Microsoft.Data.SqlClient.Internal.Logging/">
     <Project Path="Microsoft.Data.SqlClient.Internal/Logging/src/Logging.csproj" />
+    <Project Path="Microsoft.Data.SqlClient.Internal/Logging/test/Logging.Test.csproj" />
   </Folder>
   <Folder Name="/src/Microsoft.Data.SqlClient/">
     <File Path="Microsoft.Data.SqlClient/Versions.props" />


### PR DESCRIPTION
## Summary

Adds the `Microsoft.Data.SqlClient.Internal.Logging` test project and wires it into the build and CI.

### What's included
- New `Logging/test/` project (`Logging.Test.csproj`, `Directory.Packages.props`, `SqlClientEventSourceTest.cs`).
- `TestLogging` build target + project path in `build.proj`.
- New `test-logging-package-ci-job.yml`; Logging package CI stage wired for signed internal builds.
- Solution (`.slnx`) entry for the test project.

## 🔗 PR Stack

Part of a 6-PR stack — current PR marked 👉. Indentation shows the branch base.

- 🏗️ [#4382](https://github.com/dotnet/SqlClient/pull/4382) — Sign CI Package pipeline assemblies & tests · base: `main`
  - ✂️ [#4348](https://github.com/dotnet/SqlClient/pull/4348) — AOT-safe auth provider with feature switch & trimmer support
  - 🏷️ [#4383](https://github.com/dotnet/SqlClient/pull/4383) — Rename `STRONG_NAME_SIGNING` → `ASSEMBLY_SIGNING`
    - 🪵 👉 **[#4384](https://github.com/dotnet/SqlClient/pull/4384) — Add Logging test package & CI**
    - ☁️ [#4385](https://github.com/dotnet/SqlClient/pull/4385) — Sign Azure extension assembly & tests
    - 🧩 [#4386](https://github.com/dotnet/SqlClient/pull/4386) — Sign `Microsoft.SqlServer.Server` assembly & CI

```mermaid
flowchart TD
    main([main])
    PR1["🏗️ #4382<br/>signing-core"]
    AOT["✂️ #4348<br/>aot"]
    PR2["🏷️ #4383<br/>rename"]
    PR3["🪵 #4384<br/>logging-tests"]
    PR4["☁️ #4385<br/>azure-signing"]
    PR5["🧩 #4386<br/>sqlserver.server"]
    main --> PR1
    PR1 --> AOT
    PR1 --> PR2
    PR2 --> PR3
    PR2 --> PR4
    PR2 --> PR5
    click PR1 "https://github.com/dotnet/SqlClient/pull/4382" _blank
    click AOT "https://github.com/dotnet/SqlClient/pull/4348" _blank
    click PR2 "https://github.com/dotnet/SqlClient/pull/4383" _blank
    click PR3 "https://github.com/dotnet/SqlClient/pull/4384" _blank
    click PR4 "https://github.com/dotnet/SqlClient/pull/4385" _blank
    click PR5 "https://github.com/dotnet/SqlClient/pull/4386" _blank
    classDef current fill:#1f6feb,stroke:#1f6feb,color:#fff;
    class PR3 current;
```

> Only this PR touches `build.proj`. Each of PR3/PR4/PR5 edits a different stage hunk in `dotnet-sqlclient-ci-core.yml`; whichever merges first, the others need a trivial rebase.

## Checklist
- [x] Tests added (Logging: 2/2)
- [x] Public API changes documented (none)
- [x] No breaking changes
