### PR TITLE
Sign the Azure extension assembly and tests

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -228,6 +228,7 @@ stages:
           - build_sqlserver_package_stage
           - build_sqlclient_package_stage
       dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+      isInternalBuild: ${{ parameters.isInternalBuild }}
       loggingArtifactsName: $(loggingArtifactsName)
       loggingPackageVersion: $(loggingPackageVersion)
       mdsArtifactsName: $(mdsArtifactsName)

--- a/eng/pipelines/jobs/pack-azure-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-azure-package-ci-job.yml
@@ -89,6 +89,11 @@ parameters:
       # Reference sibling packages as C# projects.
       - Project
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 
   - job: pack_azure_package_job
@@ -131,6 +136,23 @@ jobs:
       - name: Configuration
         value: ''
 
+      # Build properties passed to dotnet pack.  Composed from a base set plus
+      # optional suffixes for Package-mode dependencies and assembly signing.
+      - name: baseBuildProperties
+        value: AzurePackageVersion=${{ parameters.azurePackageVersion }};AzureAssemblyFileVersion=${{ parameters.azureAssemblyFileVersion }}
+
+      # NOTE: We use compile-time ${{ if }} branches rather than concatenating
+      # separate variables (e.g. "$(base);$(optional);$(signing)") because
+      # when the optional variables are empty the semicolons remain, producing
+      # a trailing ";;" that MSBuild rejects with MSB1005.
+      - name: buildProperties
+        ${{ if and(eq(parameters.referenceType, 'Package'), eq(parameters.isInternalBuild, true)) }}:
+          value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }};SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ elseif eq(parameters.referenceType, 'Package') }}:
+          value: $(baseBuildProperties);ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }}
+        ${{ else }}:
+          value: $(baseBuildProperties)
+
     steps:
 
       # Emit environment variables if debug is enabled.
@@ -157,32 +179,20 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
-      # Create the NuGet packages.
-      #
-      # When referenceType is Package, we must pass ReferenceType and the
-      # dependency versions so that Directory.Packages.props applies version
-      # ranges to sibling package dependencies.
-      - ${{ if eq(parameters.referenceType, 'Package') }}:
-        - task: DotNetCoreCLI@2
-          displayName: Create NuGet Package
-          inputs:
-            command: pack
-            packagesToPack: $(project)
-            configurationToPack: ${{ parameters.buildConfiguration }}
-            packDirectory: $(dotnetPackagesDir)
-            verbosityToPack: ${{ parameters.dotnetVerbosity }}
-            buildProperties: AzurePackageVersion=${{ parameters.azurePackageVersion }};AzureAssemblyFileVersion=${{ parameters.azureAssemblyFileVersion }};ReferenceType=Package;LoggingPackageVersion=${{ parameters.loggingPackageVersion }};AbstractionsPackageVersion=${{ parameters.abstractionsPackageVersion }}
+      # Download the assembly signing key for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
 
-      - ${{ else }}:
-        - task: DotNetCoreCLI@2
-          displayName: Create NuGet Package
-          inputs:
-            command: pack
-            packagesToPack: $(project)
-            configurationToPack: ${{ parameters.buildConfiguration }}
-            packDirectory: $(dotnetPackagesDir)
-            verbosityToPack: ${{ parameters.dotnetVerbosity }}
-            buildProperties: AzurePackageVersion=${{ parameters.azurePackageVersion }};AzureAssemblyFileVersion=${{ parameters.azureAssemblyFileVersion }}
+      # Create the NuGet packages.
+      - task: DotNetCoreCLI@2
+        displayName: Create NuGet Package
+        inputs:
+          command: pack
+          packagesToPack: $(project)
+          configurationToPack: ${{ parameters.buildConfiguration }}
+          packDirectory: $(dotnetPackagesDir)
+          verbosityToPack: ${{ parameters.dotnetVerbosity }}
+          buildProperties: $(buildProperties)
 
       # Publish the NuGet packages as a named pipeline artifact.
       - task: PublishPipelineArtifact@1

--- a/eng/pipelines/jobs/test-azure-package-ci-job.yml
+++ b/eng/pipelines/jobs/test-azure-package-ci-job.yml
@@ -69,6 +69,12 @@ parameters:
     - detailed
     - diagnostic
 
+  # True when building on the internal ADO.Net project.  When set, assemblies
+  # are signed with the driver key and tests are signed with the test key.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
   # The suffix to append to the job name.
   - name: jobNameSuffix
     type: string
@@ -169,7 +175,7 @@ jobs:
         value: src/Microsoft.Data.SqlClient.Extensions/Azure/test/Azure.Test.csproj
 
       # dotnet CLI arguments for build/test/pack commands.
-      - name: buildArguments
+      - name: dotnetBuildOpts
         value: >-
           -p:Configuration=${{ parameters.buildConfiguration }}
           --verbosity ${{ parameters.dotnetVerbosity }}
@@ -178,6 +184,16 @@ jobs:
           -p:LoggingPackageVersion=${{ parameters.loggingPackageVersion }}
           -p:SqlClientPackageVersion=${{ parameters.mdsPackageVersion }}
           -p:SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }}
+
+      # Signing arguments — only set for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        - name: signingArguments
+          value: >-
+            -p:SigningKeyPath=$(driverKeyFile.secureFilePath)
+            -p:TestSigningKeyPath=$(testKeyFile.secureFilePath)
+      - ${{ else }}:
+        - name: signingArguments
+          value: ''
 
       # Explicitly unset the $PLATFORM environment variable that is set by the
       # 'ADO Build properties' Library in the ADO SqlClientDrivers public
@@ -205,6 +221,13 @@ jobs:
       - ${{ if eq(parameters.debug, true) }}:
         - pwsh: 'Get-ChildItem Env: | Sort-Object Name'
           displayName: '[Debug] Print Environment Variables'
+
+      # Download the assembly signing keys for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+          parameters:
+            isTest: true
 
       # We have a few extra steps for Package reference builds.
       - ${{ if eq(parameters.referenceType, 'Package') }}:
@@ -289,7 +312,7 @@ jobs:
         inputs:
           command: build
           projects: $(project)
-          arguments: $(buildArguments)
+          arguments: $(dotnetBuildOpts) $(signingArguments)
 
       # List the DLLs in the output directory for debugging purposes.
       - ${{ if eq(parameters.debug, true) }}:
@@ -324,7 +347,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category != failing & category != flaky & category != interactive"
@@ -342,7 +365,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category = flaky"
@@ -362,7 +385,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category != failing & category != flaky & category != interactive"
@@ -380,7 +403,7 @@ jobs:
             command: test
             projects: $(project)
             arguments: >-
-              $(buildArguments)
+              $(dotnetBuildOpts)
               --no-build
               -f ${{ runtime }}
               --filter "category = flaky"

--- a/eng/pipelines/stages/build-azure-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-azure-package-ci-stage.yml
@@ -152,6 +152,11 @@ parameters:
       # Reference sibling packages as C# projects.
       - Project
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 stages:
 
   - stage: build_azure_package_stage
@@ -180,6 +185,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Linux
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: linux
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
@@ -202,6 +208,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Linux Integration
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: linux_integration
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
@@ -233,6 +240,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Win
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: windows
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
@@ -255,6 +263,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: Win Integration
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: windows_integration
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
@@ -295,6 +304,7 @@ stages:
           debug: ${{ parameters.debug }}
           displayNamePrefix: macOS
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           jobNameSuffix: macos
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
@@ -331,6 +341,7 @@ stages:
             - test_azure_package_job_windows_integration
             - test_azure_package_job_macos
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
           loggingArtifactsName: ${{ parameters.loggingArtifactsName }}
           loggingPackageVersion: ${{ parameters.loggingPackageVersion }}
           referenceType: ${{ parameters.referenceType }}

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Azure.csproj
@@ -32,10 +32,22 @@
     <Version>$(AzurePackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
+
+  <!-- Unsigned: expose internals to the test assembly in any reference mode. -->
   <ItemGroup Condition="'$(SigningKeyPath)' == ''">
     <InternalsVisibleTo Include="$(AssemblyName).Test" />
+  </ItemGroup>
+
+  <!--
+    Signed + Package mode: expose internals to the test assembly signed with the test key.
+    Signed + Project mode is intentionally omitted: production-signed assemblies should not
+    grant internal access to test assemblies during local development.  Tests that need internals
+    in Project mode run unsigned; only the CI package-validation pipeline uses signed packages.
+  -->
+  <ItemGroup Condition="'$(SigningKeyPath)' != '' AND '$(ReferenceType)' == 'Package'">
+    <InternalsVisibleTo Include="$(AssemblyName).Test, PublicKey=00240000048000001401000006020000002400005253413100080000010001003D19684676DA365F331D00CE7BD4B8EF03E74102F39A5681B40622703D68F0298ECACECC723D3FFC1EA9365AF4958578550EA1EBEEC084B0B3757F3762449F5365E872802A4B548056760764FAD062BFEE81ED26183109AD46810E7E6E965419D0A10473680144D20C1BFE1027A5F586CA987523C06F5C126C44EA7D4F51EB023867A9F294315F95775ACEFD2D678186919458DFCCB4DE2E9F53AEFC766C7CBCEC474ED21C1616E5A9414D366D91D121C39F5FE6641295ADC058EF3FB10593BCDE2E82D9F217C2634909EEF496CD53AE78ABBEA572B871D72EBFC5378205950ABA97C7CCC2B9635D96933D5F9C9624D71FF53EE2094CF3A6BD38534D66E414B7" />
   </ItemGroup>
 
   <!-- Build Output ==================================================== -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/test/Azure.Test.csproj
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/test/Azure.Test.csproj
@@ -8,6 +8,13 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <!-- Assembly signing ============================================= -->
+  <!-- When a test signing key is provided, sign the test assembly so IVT from signed source works. -->
+  <PropertyGroup Condition="'$(TestSigningKeyPath)' != ''">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(TestSigningKeyPath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
   <!-- Target Frameworks =============================================== -->
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>


### PR DESCRIPTION
## Summary

Signs the `Microsoft.Data.SqlClient.Extensions.Azure` assembly and its test assembly, and wires the Azure package CI stage/job for signed internal builds.

### What's included
- Signed `InternalsVisibleTo` for the Azure test assembly in **Package** mode (kept unsigned in Project mode and when signing is disabled).
- Signing comment aligned with assembly-signing terminology.
- Azure pack/test CI job + stage wired for signed internal builds.

## 🔗 PR Stack

Part of a 6-PR stack — current PR marked 👉. Indentation shows the branch base.

- 🏗️ [#4382](https://github.com/dotnet/SqlClient/pull/4382) — Sign CI Package pipeline assemblies & tests · base: `main`
  - ✂️ [#4348](https://github.com/dotnet/SqlClient/pull/4348) — AOT-safe auth provider with feature switch & trimmer support
  - 🏷️ [#4383](https://github.com/dotnet/SqlClient/pull/4383) — Rename `STRONG_NAME_SIGNING` → `ASSEMBLY_SIGNING`
    - 🪵 [#4384](https://github.com/dotnet/SqlClient/pull/4384) — Add Logging test package & CI
    - ☁️ 👉 **[#4385](https://github.com/dotnet/SqlClient/pull/4385) — Sign Azure extension assembly & tests**
    - 🧩 [#4386](https://github.com/dotnet/SqlClient/pull/4386) — Sign `Microsoft.SqlServer.Server` assembly & CI

```mermaid
flowchart TD
    main([main])
    PR1["🏗️ #4382<br/>signing-core"]
    AOT["✂️ #4348<br/>aot"]
    PR2["🏷️ #4383<br/>rename"]
    PR3["🪵 #4384<br/>logging-tests"]
    PR4["☁️ #4385<br/>azure-signing"]
    PR5["🧩 #4386<br/>sqlserver.server"]
    main --> PR1
    PR1 --> AOT
    PR1 --> PR2
    PR2 --> PR3
    PR2 --> PR4
    PR2 --> PR5
    click PR1 "https://github.com/dotnet/SqlClient/pull/4382" _blank
    click AOT "https://github.com/dotnet/SqlClient/pull/4348" _blank
    click PR2 "https://github.com/dotnet/SqlClient/pull/4383" _blank
    click PR3 "https://github.com/dotnet/SqlClient/pull/4384" _blank
    click PR4 "https://github.com/dotnet/SqlClient/pull/4385" _blank
    click PR5 "https://github.com/dotnet/SqlClient/pull/4386" _blank
    classDef current fill:#1f6feb,stroke:#1f6feb,color:#fff;
    class PR4 current;
```

> `Azure.csproj` retains `main`'s `Microsoft.Identity.Client.Broker` package reference; only the signing block is added.

## Checklist
- [x] Tests added or updated (Azure: 22 passed / 10 integration-skipped)
- [x] Public API changes documented (none)
- [x] No breaking changes
