### PR TITLE
Sign the Microsoft.SqlServer.Server assembly and wire its package CI

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-core.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-core.yml
@@ -144,6 +144,8 @@ stages:
       buildConfiguration: ${{ parameters.buildConfiguration }}
       debug: ${{ parameters.debug }}
       dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+      isInternalBuild: ${{ parameters.isInternalBuild }}
+      referenceType: ${{ parameters.referenceType }}
 
   # Build the Logging package, and publish it to the pipeline artifacts
   # under the given artifact name.  This runs in parallel with the Secrets

--- a/eng/pipelines/jobs/pack-sqlserver-package-ci-job.yml
+++ b/eng/pipelines/jobs/pack-sqlserver-package-ci-job.yml
@@ -49,6 +49,19 @@ parameters:
     - detailed
     - diagnostic
 
+  # The C# project reference type to use when building and packing the packages.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
 jobs:
 
   - job: pack_sqlserver_package_job
@@ -82,6 +95,14 @@ jobs:
       - name: Configuration
         value: ''
 
+      # Build properties passed to dotnet pack.  Composed from a base set plus
+      # optional signing key path for internal Package-mode builds.
+      - name: buildProperties
+        ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+          value: SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }};SigningKeyPath=$(driverKeyFile.secureFilePath)
+        ${{ else }}:
+          value: SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }}
+
     steps:
 
       # Emit environment variables if debug is enabled.
@@ -94,6 +115,10 @@ jobs:
         parameters:
           debug: ${{ parameters.debug }}
 
+      # Download the assembly signing key for internal Package-mode builds.
+      - ${{ if and(eq(parameters.isInternalBuild, true), ne(parameters.referenceType, 'Project')) }}:
+        - template: /eng/pipelines/common/steps/download-assembly-signing-key.yml@self
+
       # Create the NuGet packages.
       - task: DotNetCoreCLI@2
         displayName: Create NuGet Package
@@ -103,7 +128,7 @@ jobs:
           configurationToPack: ${{ parameters.buildConfiguration }}
           packDirectory: $(dotnetPackagesDir)
           verbosityToPack: ${{ parameters.dotnetVerbosity }}
-          buildProperties: SqlServerPackageVersion=${{ parameters.sqlServerPackageVersion }}
+          buildProperties: $(buildProperties)
 
       - task: PublishPipelineArtifact@1
         displayName: Publish Pipeline Artifact

--- a/eng/pipelines/stages/build-sqlserver-package-ci-stage.yml
+++ b/eng/pipelines/stages/build-sqlserver-package-ci-stage.yml
@@ -63,6 +63,19 @@ parameters:
     - detailed
     - diagnostic
 
+  # True when building on the internal ADO.Net project.
+  - name: isInternalBuild
+    type: boolean
+    default: false
+
+  # The C# project reference type to use when building and packing the packages.
+  - name: referenceType
+    type: string
+    default: Project
+    values:
+      - Package
+      - Project
+
 stages:
 
   - stage: build_sqlserver_package_stage
@@ -81,3 +94,5 @@ stages:
           sqlServerArtifactsName: ${{ parameters.sqlServerArtifactsName }}
           sqlServerPackageVersion: ${{ parameters.sqlServerPackageVersion }}
           dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+          isInternalBuild: ${{ parameters.isInternalBuild }}
+          referenceType: ${{ parameters.referenceType }}

--- a/src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj
+++ b/src/Microsoft.SqlServer.Server/Microsoft.SqlServer.Server.csproj
@@ -16,7 +16,7 @@
     <Version>$(SqlServerPackageVersion)</Version>
   </PropertyGroup>
 
-  <!-- Strong name signing ============================================= -->
+  <!-- Assembly signing ============================================= -->
   <!-- This is done in Directory.Build.props -->
 
   <!-- Build Output ==================================================== -->


### PR DESCRIPTION
## Summary

Aligns the `Microsoft.SqlServer.Server` signing comment with the assembly-signing terminology and wires the SqlServer.Server package CI stage/job for signed internal builds.

## 🔗 PR Stack

Part of a 6-PR stack — current PR marked 👉. Indentation shows the branch base.

- 🏗️ [#4382](https://github.com/dotnet/SqlClient/pull/4382) — Sign CI Package pipeline assemblies & tests · base: `main`
  - ✂️ [#4348](https://github.com/dotnet/SqlClient/pull/4348) — AOT-safe auth provider with feature switch & trimmer support
  - 🏷️ [#4383](https://github.com/dotnet/SqlClient/pull/4383) — Rename `STRONG_NAME_SIGNING` → `ASSEMBLY_SIGNING`
    - 🪵 [#4384](https://github.com/dotnet/SqlClient/pull/4384) — Add Logging test package & CI
    - ☁️ [#4385](https://github.com/dotnet/SqlClient/pull/4385) — Sign Azure extension assembly & tests
    - 🧩 👉 **[#4386](https://github.com/dotnet/SqlClient/pull/4386) — Sign `Microsoft.SqlServer.Server` assembly & CI**

```mermaid
flowchart TD
    main([main])
    PR1["🏗️ #4382<br/>signing-core"]
    AOT["✂️ #4348<br/>aot"]
    PR2["🏷️ #4383<br/>rename"]
    PR3["🪵 #4384<br/>logging-tests"]
    PR4["☁️ #4385<br/>azure-signing"]
    PR5["🧩 #4386<br/>sqlserver.server"]
    main --> PR1
    PR1 --> AOT
    PR1 --> PR2
    PR2 --> PR3
    PR2 --> PR4
    PR2 --> PR5
    click PR1 "https://github.com/dotnet/SqlClient/pull/4382" _blank
    click AOT "https://github.com/dotnet/SqlClient/pull/4348" _blank
    click PR2 "https://github.com/dotnet/SqlClient/pull/4383" _blank
    click PR3 "https://github.com/dotnet/SqlClient/pull/4384" _blank
    click PR4 "https://github.com/dotnet/SqlClient/pull/4385" _blank
    click PR5 "https://github.com/dotnet/SqlClient/pull/4386" _blank
    classDef current fill:#1f6feb,stroke:#1f6feb,color:#fff;
    class PR5 current;
```

## Checklist
- [x] Signed + unsigned compile verified
- [x] Public API changes documented (none)
- [x] No breaking changes
