### PR TITLE
[7.0.2] Bump all SqlClient family versions to 7.0.2

### DIFF
--- a/eng/pipelines/libraries/ci-build-variables.yml
+++ b/eng/pipelines/libraries/ci-build-variables.yml
@@ -24,43 +24,43 @@ variables:
 
   # Abstractions library assembly file version
   - name: abstractionsAssemblyFileVersion
-    value: 1.0.0.$(assemblyBuildNumber)
+    value: 7.0.2.$(assemblyBuildNumber)
 
   # Abstractions library NuGet package version
   - name: abstractionsPackageVersion
-    value: 1.0.0.$(Build.BuildNumber)-ci
+    value: 7.0.2.$(Build.BuildNumber)-ci
 
   # AKV provider assembly file version
   - name: akvAssemblyFileVersion
-    value: 7.0.0.$(assemblyBuildNumber)
+    value: 7.0.2.$(assemblyBuildNumber)
 
   # AKV provider NuGet package version
   - name: akvPackageVersion
-    value: 7.0.0.$(Build.BuildNumber)-ci
+    value: 7.0.2.$(Build.BuildNumber)-ci
 
   # Azure library assembly file version
   - name: azureAssemblyFileVersion
-    value: 1.0.0.$(assemblyBuildNumber)
+    value: 7.0.2.$(assemblyBuildNumber)
 
   # Azure library NuGet package version
   - name: azurePackageVersion
-    value: 1.0.0.$(Build.BuildNumber)-ci
+    value: 7.0.2.$(Build.BuildNumber)-ci
 
   # Logging library assembly file version
   - name: loggingAssemblyFileVersion
-    value: 1.0.0.$(assemblyBuildNumber)
+    value: 7.0.2.$(assemblyBuildNumber)
 
   # Logging library NuGet package version
   - name: loggingPackageVersion
-    value: 1.0.0.$(Build.BuildNumber)-ci
+    value: 7.0.2.$(Build.BuildNumber)-ci
 
   # MDS library assembly file version
   - name: mdsAssemblyFileVersion
-    value: 7.0.0.$(assemblyBuildNumber)
+    value: 7.0.2.$(assemblyBuildNumber)
 
   # MDS library NuGet package version
   - name: mdsPackageVersion
-    value: 7.0.0.$(Build.BuildNumber)-ci
+    value: 7.0.2.$(Build.BuildNumber)-ci
 
   # Local NuGet feed directory where downloaded pipeline artifacts are placed.
   # NuGet.config references this as a local package source for restore.

--- a/eng/pipelines/onebranch/variables/common-variables.yml
+++ b/eng/pipelines/onebranch/variables/common-variables.yml
@@ -66,15 +66,15 @@ variables:
 
   # The NuGet package version for GA releases (non-preview).
   - name: abstractionsPackageVersion
-    value: '1.0.0'
+    value: '7.0.2'
 
   # The NuGet package version for preview releases.
   - name: abstractionsPackagePreviewVersion
-    value: 1.0.0-preview1.$(Build.BuildNumber)
+    value: 7.0.2-preview1.$(Build.BuildNumber)
 
   # The AssemblyFileVersion for all assemblies in the Abstractions package.
   - name: abstractionsAssemblyFileVersion
-    value: 1.0.0.$(assemblyBuildNumber)
+    value: 7.0.2.$(assemblyBuildNumber)
 
   # ----------------------------------------------------------------------------
   # MDS Package Versions
@@ -84,7 +84,7 @@ variables:
 
   # The NuGet package version for GA releases (non-preview).
   - name: mdsPackageVersion
-    value: '7.0.1'
+    value: '7.0.2'
 
   # The NuGet package version for preview releases.
   #
@@ -97,7 +97,7 @@ variables:
 
   # The AssemblyFileVersion for all assemblies in the MDS package.
   - name: mdsAssemblyFileVersion
-    value: 7.0.1.$(assemblyBuildNumber)
+    value: 7.0.2.$(assemblyBuildNumber)
 
   # The path to the NuGet packaging specification file used to generate the MDS NuGet package.
   - name: nuspecPath
@@ -111,15 +111,15 @@ variables:
 
   # The NuGet package version for GA releases (non-preview).
   - name: loggingPackageVersion
-    value: '1.0.0'
+    value: '7.0.2'
 
   # The NuGet package version for preview releases.
   - name: loggingPackagePreviewVersion
-    value: 1.0.0-preview1.$(Build.BuildNumber)
+    value: 7.0.2-preview1.$(Build.BuildNumber)
 
   # The AssemblyFileVersion for all assemblies in the Logging package.
   - name: loggingAssemblyFileVersion
-    value: 1.0.0.$(assemblyBuildNumber)
+    value: 7.0.2.$(assemblyBuildNumber)
 
   # ----------------------------------------------------------------------------
   # Azure Package Versions
@@ -129,15 +129,15 @@ variables:
 
   # The NuGet package version for GA releases (non-preview).
   - name: azurePackageVersion
-    value: '1.0.0'
+    value: '7.0.2'
 
   # The NuGet package version for preview releases.
   - name: azurePackagePreviewVersion
-    value: 1.0.0-preview1.$(Build.BuildNumber)
+    value: 7.0.2-preview1.$(Build.BuildNumber)
 
   # The AssemblyFileVersion for all assemblies in the Azure package.
   - name: azureAssemblyFileVersion
-    value: 1.0.0.$(assemblyBuildNumber)
+    value: 7.0.2.$(assemblyBuildNumber)
 
   # ----------------------------------------------------------------------------
   # SqlServer.Server Package Versions
@@ -165,15 +165,15 @@ variables:
 
   # The NuGet package version for GA releases (non-preview).
   - name: akvPackageVersion
-    value: '7.0.0'
+    value: '7.0.2'
 
   # The NuGet package version for preview releases.
   - name: akvPackagePreviewVersion
-    value: 7.0.0-preview1.$(Build.BuildNumber)
+    value: 7.0.2-preview1.$(Build.BuildNumber)
 
   # The AssemblyFileVersion for all assemblies in the AKV Provider package.
   - name: akvAssemblyFileVersion
-    value: 7.0.0.$(assemblyBuildNumber)
+    value: 7.0.2.$(assemblyBuildNumber)
 
   # ----------------------------------------------------------------------------
   # MDS Symbols Publishing

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/AbstractionsVersions.props
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/AbstractionsVersions.props
@@ -41,7 +41,7 @@
     -->
 
     <!-- The default major version number. -->
-    <AbstractionsDefaultMajorVersion>1</AbstractionsDefaultMajorVersion>
+    <AbstractionsDefaultMajorVersion>7</AbstractionsDefaultMajorVersion>
 
     <!-- Determine the package version. -->
     <_OurPackageVersion Condition="'$(AbstractionsPackageVersion)' != ''">$(AbstractionsPackageVersion)</_OurPackageVersion>

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/AzureVersions.props
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/AzureVersions.props
@@ -40,7 +40,7 @@
     -->
 
     <!-- The default major version number. -->
-    <AzureDefaultMajorVersion>1</AzureDefaultMajorVersion>
+    <AzureDefaultMajorVersion>7</AzureDefaultMajorVersion>
 
     <!-- Determine the package version. -->
     <_OurPackageVersion Condition="'$(AzurePackageVersion)' != ''">$(AzurePackageVersion)</_OurPackageVersion>

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/src/LoggingVersions.props
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/src/LoggingVersions.props
@@ -41,7 +41,7 @@
     -->
 
     <!-- The default major version number. -->
-    <LoggingDefaultMajorVersion>1</LoggingDefaultMajorVersion>
+    <LoggingDefaultMajorVersion>7</LoggingDefaultMajorVersion>
 
     <!-- Determine the package version. -->
     <_OurPackageVersion Condition="'$(LoggingPackageVersion)' != ''">$(LoggingPackageVersion)</_OurPackageVersion>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -31,7 +31,7 @@
 
   <!-- MDS Package Properties -->
   <PropertyGroup>
-    <MdsVersionDefault>7.0.1</MdsVersionDefault>
+    <MdsVersionDefault>7.0.2</MdsVersionDefault>
 
     <MdsPackageVersion Condition="'$(MdsPackageVersion)' == ''">$(MdsVersionDefault).$(BuildNumber)-dev</MdsPackageVersion>
 


### PR DESCRIPTION
## Summary

Sweeps the version numbers to **7.0.2** for the SqlClient, Logging, Abstractions, Azure, and AKV Provider packages. SqlServer.Server is intentionally left unchanged.

> [!IMPORTANT]
> **AssemblyVersion (binding identity) change for the extension assemblies.**
> Bumping the `DefaultMajorVersion` from `1` to `7` for **Abstractions**, **Logging**, and **Azure** raises their `AssemblyVersion` from `1.0.0.0` to `7.0.0.0`. `AssemblyVersion` is the strong-name binding identity, so this is a **breaking identity change** for those three assemblies:
> - Consumers compiled against the `1.0.0.0` assemblies will not bind to the `7.0.0.0` assemblies without recompiling (or, on .NET Framework, adding `bindingRedirect` entries).
> - Any place that hard-codes the old identity (e.g. `typeof(...).Assembly.FullName`, strong-name references, or fully-qualified type names in config) must be updated.
> - This intentionally aligns the extension assembly identities with the 7.x product line.
>
> By contrast, **SqlClient** stays at `AssemblyVersion 7.0.0.0` — the `7.0.1` → `7.0.2` move only changes the package/file version, **not** the binding identity, so it is *not* a breaking change. The AKV Provider was already on major `7`, so its identity is unchanged. Only the **FileVersion**/package version moves to `7.0.2` for the non-breaking packages.

## Changes

- **OneBranch pipeline** (`eng/pipelines/onebranch/variables/common-variables.yml`) — package, preview, and assembly file versions bumped to `7.0.2` for Abstractions, MDS, Logging, Azure, and AKV Provider.
- **Classic CI pipeline** (`eng/pipelines/libraries/ci-build-variables.yml`) — assembly file version and package version bumped to `7.0.2` for the same packages.
- **`tools/props/Versions.props`** — `MdsVersionDefault` `7.0.1` → `7.0.2`.
- **Extension version props** (`AbstractionsVersions.props`, `LoggingVersions.props`, `AzureVersions.props`) — `DefaultMajorVersion` `1` → `7`, raising their `AssemblyVersion` to `7.0.0.0`.

## Notes

- The AKV Provider's `AkvDefaultMajorVersion` was already `7`, so no change was needed in `AkvProviderVersions.props`; its `7.0.2` values are supplied by the pipeline variables above.
- SqlServer.Server versions are unchanged (still `1.0.0`).

## Checklist

- [x] PR Project run: [17314](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=157548&view=results)
- [x] PR Package run: [17314](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=157549&view=results)
- [x] CI Project run: [17414](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=157749&view=results)
- [x] CI Package run: [17415](https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=157750&view=results)
- [x] Non-Official run: [26174.1](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=157753&view=results)
