### PR TITLE
[6.1.6] Set SqlClient 6.1.6 version numbers

### DIFF
--- a/eng/pipelines/onebranch/variables/common-variables.yml
+++ b/eng/pipelines/onebranch/variables/common-variables.yml
@@ -31,7 +31,7 @@ variables:
   - name: Minor
     value: '1'
   - name: Patch
-    value: '5'
+    value: '6'
 
   - name: NugetPackageVersion
     value: '$(Major).$(Minor).$(Patch)'
@@ -41,7 +41,7 @@ variables:
   # maintain this variable such that these testing preview builds receive newer version numbers
   # than previous builds.
   - name: PreviewNugetPackageVersion
-    value: 6.1.6-preview1
+    value: 6.1.7-preview1
 
   # GOTCHA: We're intentionally omitting the '.' between Minor and Patch because the BuildNumber
   # already contains a '.' and assembly file versions must only contain a maximum of three '.'

--- a/eng/pipelines/onebranch/variables/common-variables.yml
+++ b/eng/pipelines/onebranch/variables/common-variables.yml
@@ -68,7 +68,7 @@ variables:
   - name: akvVersionMinor
     value: '1'
   - name: akvVersionPatch
-    value: '2'
+    value: '3'
   - name: akvVersionPreview
     value: ''
 

--- a/src/Microsoft.Data.SqlClient/tests/StressTests/Directory.Packages.props
+++ b/src/Microsoft.Data.SqlClient/tests/StressTests/Directory.Packages.props
@@ -21,7 +21,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <MdsVersion>6.1.4</MdsVersion>
+        <MdsVersion>6.1.5</MdsVersion>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/tools/props/Versions.props
+++ b/tools/props/Versions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="Current" DefaultTargets="Build"
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MdsVersionDefault>6.1.5</MdsVersionDefault>
+    <MdsVersionDefault>6.1.6</MdsVersionDefault>
     <BuildNumber Condition="'$(BuildNumber)' == ''">0</BuildNumber>
 
     <!--

--- a/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
+++ b/tools/specs/add-ons/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec
@@ -25,19 +25,19 @@ Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyStoreProvider.SqlColumnEncrypti
     <tags>sqlclient microsoft.data.sqlclient azurekeyvaultprovider akvprovider alwaysencrypted</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Microsoft.Data.SqlClient" version="[6.1.5,7.0.0)" />
+        <dependency id="Microsoft.Data.SqlClient" version="[6.1.6,7.0.0)" />
         <dependency id="Azure.Core" version="1.50.0" />
         <dependency id="Azure.Security.KeyVault.Keys" version="4.8.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Microsoft.Data.SqlClient" version="[6.1.5,7.0.0)" />
+        <dependency id="Microsoft.Data.SqlClient" version="[6.1.6,7.0.0)" />
         <dependency id="Azure.Core" version="1.50.0" />
         <dependency id="Azure.Security.KeyVault.Keys" version="4.8.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="8.0.1" />
       </group>
       <group targetFramework="net9.0">
-        <dependency id="Microsoft.Data.SqlClient" version="[6.1.5,7.0.0)" />
+        <dependency id="Microsoft.Data.SqlClient" version="[6.1.6,7.0.0)" />
         <dependency id="Azure.Core" version="1.50.0" />
         <dependency id="Azure.Security.KeyVault.Keys" version="4.8.0" />
         <dependency id="Microsoft.Extensions.Caching.Memory" version="9.0.11" />


### PR DESCRIPTION
## Description
Sets the version numbers in preparation for the **6.1.6** release (and the **AKV Provider 6.1.3** release), following the same pattern as #4162 (6.1.5).

## Changes

### Microsoft.Data.SqlClient (6.1.6)
- `common-variables.yml`: bumped `Patch` `5` → `6`; updated `PreviewNugetPackageVersion` `6.1.6-preview1` → `6.1.7-preview1`
- `Versions.props`: `MdsVersionDefault` `6.1.5` → `6.1.6`
- `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider.nuspec`: MDS dependency `[6.1.5,7.0.0)` → `[6.1.6,7.0.0)` (all TFM groups)
- StressTests `Directory.Packages.props`: `MdsVersion` `6.1.4` → `6.1.5` (last published version)

### Azure Key Vault Provider (6.1.3)
- `common-variables.yml`: bumped `akvVersionPatch` `2` → `3`

  The last published AKV version (6.1.2) only enabled strong-name signing. Since then the provider has accrued a dependency refresh (#3843 — `Azure.Core` 1.47.1 → 1.50.0, `Azure.Security.KeyVault.Keys` 4.7.0 → 4.8.0, `Microsoft.Extensions.Caching.Memory` → 9.0.11, removed unused `System.Text.Encodings.Web`, pinned dependency versions) and build fixes (#4250 — strong-name signing now keys off `SigningKeyPath`). These are packaging/dependency changes only; no functional or API changes. Since 6.1.2 is already on NuGet, the version must move to 6.1.3.

## Notes

- Shared dependencies between MDS 6.1.6 and AKV 6.1.3 (`Azure.Core` 1.50.0, `Microsoft.Extensions.Caching.Memory`) match across all target frameworks — no version conflicts.
