### PR TITLE
[7.0.3] Fix | Reenable SqlBulkCopy in least-privilege environments

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -514,7 +514,7 @@ namespace Microsoft.Data.SqlClient
             //
             // See: https://learn.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql
             //
-            // All of this is wrapped in an test against HAS_PERMS_BY_NAME. This test verifies that
+            // All of this is wrapped in a test against HAS_PERMS_BY_NAME. This test verifies that
             // the user possesses the necessary permissions to access sys.all_columns. If they do not
             // @Column_Names will remain NULL (and be coalesced to *) and SqlBulkCopy will degrade
             // gracefully, silently dropping support for hidden columns and column aliases.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -472,11 +472,12 @@ namespace Microsoft.Data.SqlClient
             }
             else if (!string.IsNullOrEmpty(CatalogName))
             {
-                CatalogName = SqlServerEscapeHelper.EscapeStringAsLiteral(SqlServerEscapeHelper.EscapeIdentifier(CatalogName));
+                CatalogName = SqlServerEscapeHelper.EscapeIdentifier(CatalogName);
             }
 
             string objectName = ADP.BuildMultiPartName(parts);
             string escapedObjectName = SqlServerEscapeHelper.EscapeStringAsLiteral(objectName);
+            string catalogNameStringLiteral = CatalogName is null ? null : SqlServerEscapeHelper.EscapeStringAsLiteral(CatalogName);
             // Specify the column names explicitly. This is to ensure that we can map to hidden
             // columns (e.g. columns in temporal tables.) If the target table doesn't exist,
             // OBJECT_ID will return NULL and @Column_Names will remain non-null. The subsequent
@@ -512,6 +513,11 @@ namespace Microsoft.Data.SqlClient
             // we use STRING_AGG in that case and the COALESCE method otherwise.
             //
             // See: https://learn.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql
+            //
+            // All of this is wrapped in an test against HAS_PERMS_BY_NAME. This test verifies that
+            // the user possesses the necessary permissions to access sys.all_columns. If they do not
+            // @Column_Names will remain NULL (and be coalesced to *) and SqlBulkCopy will degrade
+            // gracefully, silently dropping support for hidden columns and column aliases.
             return $"""
 SELECT @@TRANCOUNT;
 
@@ -521,6 +527,7 @@ DECLARE @Column_Name_Query_FILTER NVARCHAR(MAX);
 DECLARE @Column_Name_Query_SORT NVARCHAR(MAX);
 DECLARE @Column_Name_Query NVARCHAR(MAX);
 DECLARE @Column_Names NVARCHAR(MAX) = NULL;
+DECLARE @Has_Sys_All_Columns_Permissions INT = HAS_PERMS_BY_NAME('{catalogNameStringLiteral}.[sys].[all_columns]', 'OBJECT', 'SELECT');
 
 IF CAST(SERVERPROPERTY('EngineEdition') AS INT) = 6
 BEGIN
@@ -533,17 +540,21 @@ BEGIN
     SET @Column_Name_Query_SORT = N'ORDER BY [column_id] ASC';
 END
 
-IF EXISTS (SELECT TOP 1 * FROM sys.all_columns WHERE [object_id] = OBJECT_ID('sys.all_columns') AND [name] = 'graph_type')
+IF @Has_Sys_All_Columns_Permissions = 1
 BEGIN
-    SET @Column_Name_Query_FILTER = N'WHERE [object_id] = @Object_ID AND COALESCE([graph_type], 0) NOT IN (1, 3, 4, 6, 7)';
-END
-ELSE
-BEGIN
-    SET @Column_Name_Query_FILTER = N'WHERE [object_id] = @Object_ID';
-END
-SET @Column_Name_Query = @Column_Name_Query_SELECT + ' FROM {CatalogName}.[sys].[all_columns] ' + @Column_Name_Query_FILTER + ' ' + @Column_Name_Query_SORT + ';'
+    IF EXISTS (SELECT TOP 1 * FROM sys.all_columns WHERE [object_id] = OBJECT_ID('sys.all_columns') AND [name] = 'graph_type')
+    BEGIN
+        SET @Column_Name_Query_FILTER = N'WHERE [object_id] = @Object_ID AND COALESCE([graph_type], 0) NOT IN (1, 3, 4, 6, 7)';
+    END
+    ELSE
+    BEGIN
+        SET @Column_Name_Query_FILTER = N'WHERE [object_id] = @Object_ID';
+    END
+    SET @Column_Name_Query = @Column_Name_Query_SELECT + ' FROM {catalogNameStringLiteral}.[sys].[all_columns] ' + @Column_Name_Query_FILTER + ' ' + @Column_Name_Query_SORT + ';'
 
-EXEC sp_executesql @Column_Name_Query, N'@Object_ID INT, @Column_Names NVARCHAR(MAX) OUTPUT', @Object_ID = @Object_ID, @Column_Names = @Column_Names OUTPUT;
+    EXEC sp_executesql @Column_Name_Query, N'@Object_ID INT, @Column_Names NVARCHAR(MAX) OUTPUT', @Object_ID = @Object_ID, @Column_Names = @Column_Names OUTPUT;
+END
+
 SELECT @Column_Names = COALESCE(@Column_Names, '*');
 
 SET FMTONLY ON;

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/DatabaseObject.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/DatabaseObject.cs
@@ -1,0 +1,282 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace Microsoft.Data.SqlClient.Tests.Common.Fixtures.DatabaseObjects;
+
+/// <summary>
+/// Base class for a transient database object (such as a table, type or
+/// stored procedure.)
+/// </summary>
+/// <typeparam name="TState">
+/// The type of the internal state accessible to derived types at the point of object creation
+/// via the <see cref="State"/> property.
+/// </typeparam>
+public abstract class DatabaseObject<TState> : IDisposable
+{
+    private readonly bool _shouldDrop;
+
+    protected SqlConnection Connection { get; }
+
+    protected TState State { get; }
+
+    public string Name { get; }
+
+    public string UnescapedName => Name.Substring(1, Name.Length - 2).Replace("]]", "]");
+
+    protected DatabaseObject(SqlConnection connection, string name, string definition, TState state, bool shouldCreate, bool shouldDrop)
+    {
+        _shouldDrop = shouldDrop;
+
+        Connection = connection;
+        State = state;
+        Name = name;
+
+        if (shouldCreate)
+        {
+            EnsureConnectionOpen();
+            DropObject();
+            CreateObject(definition);
+        }
+    }
+
+    private void EnsureConnectionOpen()
+    {
+        const int MaxWaits = 2;
+        int counter = MaxWaits;
+
+        if (Connection.State is System.Data.ConnectionState.Closed)
+        {
+            Connection.Open();
+        }
+        while (counter-- > 0 && Connection.State is System.Data.ConnectionState.Connecting)
+        {
+            Thread.Sleep(80);
+        }
+    }
+
+    /// <summary>
+    /// Generate a new GUID and return the characters from its 1st and 4th
+    /// parts, as shown here:
+    ///
+    /// <code>
+    ///   7ff01cb8-88c7-11f0-b433-00155d7e531e
+    ///   ^^^^^^^^           ^^^^
+    /// </code>
+    ///
+    /// These 12 characters are concatenated together without any
+    /// separators.  These 2 parts typically comprise a timestamp and clock
+    /// sequence, most likely to be unique for tests that generate names in
+    /// quick succession.
+    /// </summary>
+    private static string GetGuidParts()
+    {
+        var guid = Guid.NewGuid().ToString();
+        // GOTCHA: The slice operator is inclusive of the start index and
+        // exclusive of the end index!
+        return guid.Substring(0, 8) + guid.Substring(19, 4);
+    }
+
+    /// <summary>
+    /// Generate a long unique database object name, whose maximum length is
+    /// 96 characters, with the format:
+    ///
+    ///   <c>{Prefix}_{GuidParts}_{UserName}_{MachineName}</c>
+    ///
+    /// The Prefix will be truncated to satisfy the overall maximum length.
+    ///
+    /// The GUID Parts will be the characters from the 1st and 4th blocks
+    /// from a traditional string representation, as shown here:
+    ///
+    /// <code>
+    ///   7ff01cb8-88c7-11f0-b433-00155d7e531e
+    ///   ^^^^^^^^           ^^^^
+    /// </code>
+    ///
+    /// These 2 parts typically comprise a timestamp and clock sequence,
+    /// most likely to be unique for tests that generate names in quick
+    /// succession.  The 12 characters are concatenated together without any
+    /// separators.
+    ///
+    /// The UserName and MachineName are obtained from the Environment,
+    /// and will be truncated to satisfy the maximum overall length.
+    /// </summary>
+    ///
+    /// <param name="prefix">
+    /// The prefix to use when generating the unique name, truncated to at
+    /// most 32 characters.
+    ///
+    /// This should not contain any characters that cannot be used in
+    /// database object names.  See:
+    ///
+    /// https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver17#rules-for-regular-identifiers
+    /// </param>
+    ///
+    /// <param name="escape">
+    /// When true, the entire generated name will be enclosed in square
+    /// brackets, for example:
+    ///
+    ///   <c>[MyPrefix_7ff01cb811f0_test_user_ci_agent_machine_name]</c>
+    /// </param>
+    ///
+    /// <returns>
+    /// A unique database object name, no more than 96 characters long.
+    /// </returns>
+    public static string GenerateLongName(string prefix, bool escape = true)
+    {
+        StringBuilder name = new(96);
+
+        if (escape)
+        {
+            name.Append('[');
+        }
+
+        if (prefix.Length > 32)
+        {
+            prefix = prefix.Substring(0, 32);
+        }
+
+        name.Append(prefix);
+        name.Append('_');
+        name.Append(GetGuidParts());
+        name.Append('_');
+
+        var suffix =
+          Environment.UserName + '_' +
+          Environment.MachineName;
+
+        int maxSuffixLength = 96 - name.Length;
+        if (escape)
+        {
+            --maxSuffixLength;
+        }
+        if (suffix.Length > maxSuffixLength)
+        {
+            suffix = suffix.Substring(0, maxSuffixLength);
+        }
+
+        name.Append(suffix);
+
+        if (escape)
+        {
+            name.Append(']');
+        }
+
+        return name.ToString();
+    }
+
+    /// <summary>
+    /// Generate a short unique database object name, whose maximum length
+    /// is 30 characters, with the format:
+    ///
+    ///   <c>{Prefix}_{GuidParts}</c>
+    ///
+    /// The Prefix will be truncated to satisfy the overall maximum length.
+    ///
+    /// The GUID parts will be the characters from the 1st and 4th blocks
+    /// from a traditional string representation, as shown here:
+    ///
+    /// <code>
+    ///   7ff01cb8-88c7-11f0-b433-00155d7e531e
+    ///   ^^^^^^^^           ^^^^
+    /// </code>
+    ///
+    /// These 2 parts typically comprise a timestamp and clock sequence,
+    /// most likely to be unique for tests that generate names in quick
+    /// succession.  The 12 characters are concatenated together without any
+    /// separators.
+    /// </summary>
+    ///
+    /// <param name="prefix">
+    /// The prefix to use when generating the unique name, truncated to at
+    /// most 18 characters when withBracket is false, and 16 characters when
+    /// withBracket is true.
+    ///
+    /// This should not contain any characters that cannot be used in
+    /// database object names.  See:
+    ///
+    /// https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver17#rules-for-regular-identifiers
+    /// </param>
+    ///
+    /// <param name="escape">
+    /// When true, the entire generated name will be enclosed in square
+    /// brackets, for example:
+    ///
+    ///   <c>[MyPrefix_7ff01cb811f0]</c>
+    /// </param>
+    ///
+    /// <returns>
+    /// A unique database object name, no more than 30 characters long.
+    /// </returns>
+    public static string GenerateShortName(string prefix, bool escape = true)
+    {
+        StringBuilder name = new(30);
+
+        if (escape)
+        {
+            name.Append('[');
+        }
+
+        int maxPrefixLength = escape ? 16 : 18;
+        if (prefix.Length > maxPrefixLength)
+        {
+            prefix = prefix.Substring(0, maxPrefixLength);
+        }
+
+        name.Append(prefix);
+        name.Append('_');
+        name.Append(GetGuidParts());
+
+        if (escape)
+        {
+            name.Append(']');
+        }
+
+        return name.ToString();
+    }
+
+    /// <summary>
+    /// Creates the object with a given definition.
+    /// </summary>
+    /// <param name="definition">Definition of the object to create.</param>
+    /// <remarks>
+    /// By the time this is called, <see cref="Connection"/> will be open.
+    /// </remarks>
+    protected abstract void CreateObject(string definition);
+
+    /// <summary>
+    /// Drops the object created by <see cref="CreateObject"/>.
+    /// </summary>
+    /// <remarks>
+    /// By the time this is called, <see cref="Connection"/> will be open.
+    /// Must not throw an exception if the object does not exist.
+    /// </remarks>
+    protected abstract void DropObject();
+
+    public void Dispose()
+    {
+        if (_shouldDrop)
+        {
+            EnsureConnectionOpen();
+            DropObject();
+        }
+        // This explicitly does not drop the wrapped SqlConnection; this is sometimes
+        // used in a loop to create multiple UDTs.
+
+        GC.SuppressFinalize(this);
+    }
+}
+
+/// <summary>
+/// Base class for a transient database object (such as a table, type or
+/// stored procedure.)
+/// </summary>
+public abstract class DatabaseObject : DatabaseObject<object?>
+{
+    protected DatabaseObject(SqlConnection connection, string name, string definition, bool shouldCreate, bool shouldDrop)
+        : base(connection, name, definition, state: null, shouldCreate, shouldDrop)
+    {
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/DatabaseObject.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/DatabaseObject.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Text;
+using System.Threading;
 
 namespace Microsoft.Data.SqlClient.Tests.Common.Fixtures.DatabaseObjects;
 

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/DatabaseUser.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/DatabaseUser.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Data.SqlClient.Tests.Common.Fixtures.DatabaseObjects;
+
+/// <summary>
+/// A transient database user, created at the start of its scope and dropped when disposed.
+/// </summary>
+/// <remarks>
+/// This class assumes that the associated server login already exists.
+/// </remarks>
+public sealed class DatabaseUser : DatabaseObject<string>
+{
+    public string DatabaseName => State;
+
+    /// <summary>
+    /// Initializes a new instance of the DatabaseUser class using the specified SQL connection
+    /// and associated server login.
+    /// </summary>
+    /// <param name="connection">The SQL connection used to interact with the database.</param>
+    /// <param name="database">The name of the database where the user will be created.</param>
+    /// <param name="login">The server login which the database user will be associated with.</param>
+    public DatabaseUser(SqlConnection connection, string database, ServerLogin login)
+        : base(connection, login.Name, $"FOR LOGIN {login.Name}", state: database, shouldCreate: true, shouldDrop: true)
+    {
+    }
+
+    protected override void CreateObject(string definition)
+    {
+        using SqlCommand createCommand = new($"CREATE USER {Name} {definition}", Connection);
+
+        ExecuteCommandInDatabase(createCommand);
+    }
+
+    protected override void DropObject()
+    {
+        using SqlCommand dropCommand = new($"IF USER_ID('{UnescapedName}') IS NOT NULL DROP USER {Name}", Connection);
+
+        ExecuteCommandInDatabase(dropCommand);
+    }
+
+    private void ExecuteCommandInDatabase(SqlCommand command)
+    {
+        // In some cases, we want to manage a database user in a different database to the one that the connection
+        // currently has open. In such a case, we need to change the database context for the command execution
+        // and then restore it afterwards.
+        string? originalDatabase = DatabaseName == command.Connection.Database ? null : command.Connection.Database;
+
+        try
+        {
+            if (originalDatabase is not null)
+            {
+                command.Connection.ChangeDatabase(DatabaseName);
+            }
+
+            command.ExecuteNonQuery();
+        }
+        finally
+        {
+            if (originalDatabase is not null)
+            {
+                command.Connection.ChangeDatabase(originalDatabase);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/DatabaseUser.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/DatabaseUser.cs
@@ -35,7 +35,8 @@ public sealed class DatabaseUser : DatabaseObject<string>
 
     protected override void DropObject()
     {
-        using SqlCommand dropCommand = new($"IF USER_ID('{UnescapedName}') IS NOT NULL DROP USER {Name}", Connection);
+        using SqlCommand dropCommand = new($"IF USER_ID(@User_Name) IS NOT NULL DROP USER {Name}", Connection);
+        dropCommand.Parameters.AddWithValue("@User_Name", UnescapedName);
 
         ExecuteCommandInDatabase(dropCommand);
     }

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/ServerLogin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/ServerLogin.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Security.Cryptography;
 
 namespace Microsoft.Data.SqlClient.Tests.Common.Fixtures.DatabaseObjects;

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/ServerLogin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/ServerLogin.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography;
+
+namespace Microsoft.Data.SqlClient.Tests.Common.Fixtures.DatabaseObjects;
+
+/// <summary>
+/// A transient server login, created at the start of its scope and dropped when disposed.
+/// </summary>
+public sealed class ServerLogin : DatabaseObject<string>
+{
+    public string Password => State;
+
+    /// <summary>
+    /// Initializes a new instance of the ServerLogin class using the specified SQL connection, login name prefix, and default database.
+    /// The login will be created with a randomly generated password that meets SQL Server's password complexity requirements.
+    /// </summary>
+    /// <param name="connection">The SQL connection used to interact with the database.</param>
+    /// <param name="namePrefix">The prefix for the login name.</param>
+    /// <param name="defaultDatabase">The default database for the login. If null, not set.</param>
+    public ServerLogin(SqlConnection connection, string namePrefix, string? defaultDatabase = null)
+        : this(connection, GenerateLongName(namePrefix), GeneratePassword(), defaultDatabase)
+    {
+    }
+
+    private ServerLogin(SqlConnection connection, string namePrefix, string password, string? defaultDatabase)
+        : base(connection, namePrefix, GenerateDefinition(password, defaultDatabase), state: password, shouldCreate: true, shouldDrop: true)
+    {
+    }
+
+    private static string GenerateDefinition(string password, string? defaultDatabase) =>
+        $"WITH PASSWORD='{password}'" +
+            (string.IsNullOrEmpty(defaultDatabase) ? string.Empty : $", DEFAULT_DATABASE=[{defaultDatabase}]");
+
+    /// <summary>
+    /// Generates a password which meets the SQL Server password complexity requirements, which are:
+    /// <list type="number">
+    /// <item>Minimum length of 8 characters</item>
+    /// <item>Must contain characters from three of the following four categories:</item>
+    /// <list type="number">
+    /// <item>Uppercase letters (A-Z)</item>
+    /// <item>Lowercase letters (a-z)</item>
+    /// <item>Digits (0-9)</item>
+    /// <item>Non-alphanumeric characters (e.g. !, $, #, %)</item>
+    /// </list>
+    /// </list>
+    /// </summary>
+    /// <returns>A compliant password.</returns>
+    private static string GeneratePassword()
+    {
+        const int PasswordLength = 16;
+        const char UpperCaseStart = 'A';
+        const char LowerCaseStart = 'a';
+        const char DigitsStart = '0';
+
+        // First 5 characters are uppercase letters, next 5 are lowercase letters, and the last 6 are digits
+        Span<char> passwordDigits = stackalloc char[PasswordLength];
+        byte[] randomBytes = new byte[PasswordLength];
+        using RandomNumberGenerator rndGen = RandomNumberGenerator.Create();
+
+        rndGen.GetBytes(randomBytes);
+        for(int i = 0; i < 5; i++)
+        {
+            passwordDigits[i] = (char)(UpperCaseStart + Scale(randomBytes[i], byte.MaxValue, 26));
+        }
+        for (int i = 5; i < 10; i++)
+        {
+            passwordDigits[i] = (char)(LowerCaseStart + Scale(randomBytes[i], byte.MaxValue, 26));
+        }
+        for (int i = 10; i < PasswordLength; i++)
+        {
+            passwordDigits[i] = (char)(DigitsStart + Scale(randomBytes[i], byte.MaxValue, 10));
+        }
+
+        return passwordDigits.ToString();
+
+        // Scales a byte value from the range [0, 255) to the range [0, newMaximum)
+        static int Scale(byte value, int existingMaximum, int newMaximum)
+        {
+            return (int)((double)value / (existingMaximum + 1) * newMaximum);
+        }
+    }
+
+    protected override void CreateObject(string definition)
+    {
+        using SqlCommand createCommand = new($"CREATE LOGIN {Name} {definition}", Connection);
+
+        createCommand.ExecuteNonQuery();
+    }
+
+    protected override void DropObject()
+    {
+        using SqlCommand dropCommand = new($"IF SUSER_ID('{UnescapedName}') IS NOT NULL DROP LOGIN {Name}", Connection);
+
+        dropCommand.ExecuteNonQuery();
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/ServerLogin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/ServerLogin.cs
@@ -93,7 +93,8 @@ public sealed class ServerLogin : DatabaseObject<string>
 
     protected override void DropObject()
     {
-        using SqlCommand dropCommand = new($"IF SUSER_ID('{UnescapedName}') IS NOT NULL DROP LOGIN {Name}", Connection);
+        using SqlCommand dropCommand = new($"IF SUSER_ID(@Login_Name) IS NOT NULL DROP LOGIN {Name}", Connection);
+        dropCommand.Parameters.AddWithValue("@Login_Name", UnescapedName);
 
         dropCommand.ExecuteNonQuery();
     }

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/Table.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/Table.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Data.SqlClient.Tests.Common.Fixtures.DatabaseObjects;
+
+/// <summary>
+/// A transient table, created at the start of its scope and dropped when disposed.
+/// </summary>
+public sealed class Table : DatabaseObject
+{
+    /// <summary>
+    /// Initializes a new instance of the Table class using the specified SQL connection, table name prefix, and table
+    /// definition.
+    /// </summary>
+    /// <remarks>
+    /// If a table with the specified name already exists, it will be dropped automatically before
+    /// creation.
+    /// </remarks>
+    /// <param name="connection">The SQL connection used to interact with the database.</param>
+    /// <param name="prefix">The prefix for the table name. Can begin with '#' or '##' to indicate a temporary table.</param>
+    /// <param name="definition">The SQL definition describing the structure of the table, including columns and data types.</param>
+    public Table(SqlConnection connection, string prefix, string definition)
+        : base(connection, GenerateLongName(prefix), definition, shouldCreate: true, shouldDrop: true)
+    {
+    }
+
+    protected override void CreateObject(string definition)
+    {
+        using SqlCommand createCommand = new($"CREATE TABLE {Name} {definition}", Connection);
+
+        createCommand.ExecuteNonQuery();
+    }
+
+    protected override void DropObject()
+    {
+        using SqlCommand dropCommand = new($"IF (OBJECT_ID('{Name}') IS NOT NULL) DROP TABLE {Name}", Connection);
+
+        dropCommand.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// Deletes all data from the table.
+    /// </summary>
+    public void DeleteData()
+    {
+        using SqlCommand deleteCommand = new($"DELETE FROM {Name}", Connection);
+
+        deleteCommand.ExecuteNonQuery();
+    }
+
+    /// <summary>
+    /// Truncates the table.
+    /// </summary>
+    public void Truncate()
+    {
+        using SqlCommand truncateCommand = new($"TRUNCATE TABLE {Name}", Connection);
+
+        truncateCommand.ExecuteNonQuery();
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/Table.cs
+++ b/src/Microsoft.Data.SqlClient/tests/Common/Fixtures/DatabaseObjects/Table.cs
@@ -34,7 +34,8 @@ public sealed class Table : DatabaseObject
 
     protected override void DropObject()
     {
-        using SqlCommand dropCommand = new($"IF (OBJECT_ID('{Name}') IS NOT NULL) DROP TABLE {Name}", Connection);
+        using SqlCommand dropCommand = new($"IF (OBJECT_ID(@Table_Name) IS NOT NULL) DROP TABLE {Name}", Connection);
+        dropCommand.Parameters.AddWithValue("@Table_Name", Name);
 
         dropCommand.ExecuteNonQuery();
     }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // SQL Server capabilities
         private static bool? s_isDataClassificationSupported;
         private static bool? s_isVectorSupported;
+        private static bool? s_isSqlAuthenticationSupported;
 
         // Login permissions
         private static bool? s_isSysAdmin;
@@ -171,7 +172,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             IsSysAdmin || IsSecurityAdmin;
 
         public static bool CanUseSqlAuthentication =>
-            IsSysAdmin && GetAuthenticationMode() == 2;
+            s_isSqlAuthenticationSupported ??= IsTCPConnStringSetup() &&
+                SupportsSqlAuthentication();
 
         static DataTestUtility()
         {
@@ -487,16 +489,16 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return command.ExecuteScalar() is int result && result == 1;
         }
 
-        public static int GetAuthenticationMode()
+        public static bool SupportsSqlAuthentication()
         {
             using SqlConnection connection = new(TCPConnectionString);
 
             connection.Open();
-            using SqlCommand command = new("EXEC xp_instance_regread N'HKEY_LOCAL_MACHINE', N'Software\\Microsoft\\MSSQLServer\\MSSQLServer', N'LoginMode'", connection);
+            using SqlCommand command = new("select SERVERPROPERTY('IsIntegratedSecurityOnly'), ISNULL(SERVERPROPERTY('IsExternalAuthenticationOnly'), 0)", connection);
             using SqlDataReader reader = command.ExecuteReader();
 
             reader.Read();
-            return reader.GetInt32(1);
+            return reader.GetInt32(0) == 0 && reader.GetInt32(1) == 0;
         }
 
         public static bool IsAdmin

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -95,6 +95,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         private static bool? s_isDataClassificationSupported;
         private static bool? s_isVectorSupported;
 
+        // Login permissions
+        private static bool? s_isSysAdmin;
+        private static bool? s_isSecurityAdmin;
+
         // Azure Synapse EngineEditionId == 6
         // More could be read at https://learn.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql?view=sql-server-ver16#propertyname
         public static bool IsAzureSynapse
@@ -154,6 +158,20 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         public static bool IsSqlVectorSupported =>
             s_isVectorSupported ??= IsTCPConnStringSetup() &&
                 IsTypePresent("vector");
+
+        public static bool IsSysAdmin =>
+            s_isSysAdmin ??= IsTCPConnStringSetup() &&
+                IsServerRoleMember("sysadmin");
+
+        public static bool IsSecurityAdmin =>
+            s_isSecurityAdmin ??= IsTCPConnStringSetup() &&
+                IsServerRoleMember("securityadmin");
+
+        public static bool CanCreateLogins =>
+            IsSysAdmin || IsSecurityAdmin;
+
+        public static bool CanUseSqlAuthentication =>
+            IsSysAdmin && GetAuthenticationMode() == 2;
 
         static DataTestUtility()
         {
@@ -455,6 +473,30 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             command.Parameters.AddWithValue("@name", typeName);
 
             return (int)command.ExecuteScalar() > 0;
+        }
+
+        public static bool IsServerRoleMember(string roleName)
+        {
+            using SqlConnection connection = new(TCPConnectionString);
+            using SqlCommand command = new("SELECT IS_SRVROLEMEMBER(@role)", connection);
+
+            connection.Open();
+            command.Parameters.AddWithValue("@role", roleName);
+
+            // IS_SRVROLEMEMBER returns 1 if the caller is a member of the specified server role, 0 if not, and DBNull.Value if the role is not valid.
+            return command.ExecuteScalar() is int result && result == 1;
+        }
+
+        public static int GetAuthenticationMode()
+        {
+            using SqlConnection connection = new(TCPConnectionString);
+
+            connection.Open();
+            using SqlCommand command = new("EXEC xp_instance_regread N'HKEY_LOCAL_MACHINE', N'Software\\Microsoft\\MSSQLServer\\MSSQLServer', N'LoginMode'", connection);
+            using SqlDataReader reader = command.ExecuteReader();
+
+            reader.Read();
+            return reader.GetInt32(1);
         }
 
         public static bool IsAdmin

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Extensions/CodeAnalysis.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Extensions/CodeAnalysis.netfx.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NETFRAMEWORK
+
+namespace System.Diagnostics.CodeAnalysis;
+
+// These classes are provided to provide compile-time support for Microsoft.CodeAnalysis
+// attributes. These attributes are native to netcore and available for netfx as a nuget
+// package - but only for net472. As such, until net462 support is dropped, these placeholder
+// classes will need to exist if we want to use them for static analysis.
+
+#nullable enable
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+internal sealed class MemberNotNullAttribute : Attribute
+{
+    public MemberNotNullAttribute(string member) => Members = [member];
+
+    public MemberNotNullAttribute(params string[] members) => Members = members;
+
+    public string[] Members { get; }
+}
+#endif

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Extensions/CodeAnalysis.netfx.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Extensions/CodeAnalysis.netfx.cs
@@ -6,7 +6,7 @@
 
 namespace System.Diagnostics.CodeAnalysis;
 
-// These classes are provided to provide compile-time support for Microsoft.CodeAnalysis
+// These classes are provided to provide compile-time support for System.Diagnostics.CodeAnalysis
 // attributes. These attributes are native to netcore and available for netfx as a nuget
 // package - but only for net472. As such, until net462 support is dropped, these placeholder
 // classes will need to exist if we want to use them for static analysis.

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/Microsoft.Data.SqlClient.ManualTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- @TODO: Use full assembly name here -->
     <AssemblyName>ManualTests</AssemblyName>
@@ -45,6 +45,7 @@
     <Compile Include="DataCommon\SystemDataResourceManager.cs" />
     <Compile Include="DataCommon\UsernamePasswordProvider.cs" />
     <Compile Include="DataCommon\XEventScope.cs" />
+    <Compile Include="Extensions\CodeAnalysis.netfx.cs" />
     <Compile Include="Extensions\StreamExtensions.netfx.cs" />
     <Compile Include="SQL\Common\AsyncDebugScope.cs" />
     <Compile Include="SQL\Common\ConnectionPoolWrapper.cs" />
@@ -179,6 +180,7 @@
     <Compile Include="SQL\SqlBulkCopyTest\Transaction3.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\Transaction4.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\TransactionTestAsync.cs" />
+    <Compile Include="SQL\SqlBulkCopyTest\UnprivilegedLogin.cs" />
     <Compile Include="SQL\SqlBulkCopyTest\WriteToServerTest.cs" />
     <Compile Include="SQL\SqlDSEnumeratorTest\SqlDataSourceEnumeratorTest.cs" />
   </ItemGroup>

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReader.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReader.cs
@@ -40,6 +40,10 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         using (DbDataReader reader = srcCmd.ExecuteReader())
                         {
                             IDictionary stats;
+                            long expectedIduCount = DataTestUtility.IsAzureSynapse || DataTestUtility.IsAtLeastSQL2017() ? 2 : 0;
+                            long expectedSelectCount = DataTestUtility.IsAzureSynapse ? 4 : 13;
+                            long expectedSelectRows = DataTestUtility.IsAzureSynapse ? 4 : 15;
+                            long expectedTransactions = DataTestUtility.IsAzureSynapse || DataTestUtility.IsAtLeastSQL2017() ? 2 : 0;
                             using (SqlBulkCopy bulkcopy = new SqlBulkCopy(dstConn))
                             {
                                 bulkcopy.DestinationTableName = dstTable;
@@ -60,12 +64,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                             DataTestUtility.AssertEqualsWithDescription((long)3, stats["BuffersReceived"], "Unexpected BuffersReceived value.");
                             DataTestUtility.AssertEqualsWithDescription((long)3, stats["BuffersSent"], "Unexpected BuffersSent value.");
-                            DataTestUtility.AssertEqualsWithDescription((long)0, stats["IduCount"], "Unexpected IduCount value.");
-                            DataTestUtility.AssertEqualsWithDescription((long)11, stats["SelectCount"], "Unexpected SelectCount value.");
+                            DataTestUtility.AssertEqualsWithDescription(expectedIduCount, stats["IduCount"], "Unexpected IduCount value.");
+                            DataTestUtility.AssertEqualsWithDescription(expectedSelectCount, stats["SelectCount"], "Unexpected SelectCount value.");
                             DataTestUtility.AssertEqualsWithDescription((long)3, stats["ServerRoundtrips"], "Unexpected ServerRoundtrips value.");
-                            DataTestUtility.AssertEqualsWithDescription((long)14, stats["SelectRows"], "Unexpected SelectRows value.");
+                            DataTestUtility.AssertEqualsWithDescription(expectedSelectRows, stats["SelectRows"], "Unexpected SelectRows value.");
                             DataTestUtility.AssertEqualsWithDescription((long)2, stats["SumResultSets"], "Unexpected SumResultSets value.");
-                            DataTestUtility.AssertEqualsWithDescription((long)0, stats["Transactions"], "Unexpected Transactions value.");
+                            DataTestUtility.AssertEqualsWithDescription(expectedTransactions, stats["Transactions"], "Unexpected Transactions value.");
                         }
                     }
                 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReader.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/CopyAllFromReader.cs
@@ -40,10 +40,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                         using (DbDataReader reader = srcCmd.ExecuteReader())
                         {
                             IDictionary stats;
-                            long expectedIduCount = DataTestUtility.IsAzureSynapse || DataTestUtility.IsAtLeastSQL2017() ? 2 : 0;
-                            long expectedSelectCount = DataTestUtility.IsAzureSynapse ? 4 : 13;
+                            long expectedSelectCount = DataTestUtility.IsAzureSynapse ? 3 : 12;
                             long expectedSelectRows = DataTestUtility.IsAzureSynapse ? 4 : 15;
-                            long expectedTransactions = DataTestUtility.IsAzureSynapse || DataTestUtility.IsAtLeastSQL2017() ? 2 : 0;
                             using (SqlBulkCopy bulkcopy = new SqlBulkCopy(dstConn))
                             {
                                 bulkcopy.DestinationTableName = dstTable;
@@ -64,12 +62,12 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
                             DataTestUtility.AssertEqualsWithDescription((long)3, stats["BuffersReceived"], "Unexpected BuffersReceived value.");
                             DataTestUtility.AssertEqualsWithDescription((long)3, stats["BuffersSent"], "Unexpected BuffersSent value.");
-                            DataTestUtility.AssertEqualsWithDescription(expectedIduCount, stats["IduCount"], "Unexpected IduCount value.");
+                            DataTestUtility.AssertEqualsWithDescription((long)0, stats["IduCount"], "Unexpected IduCount value.");
                             DataTestUtility.AssertEqualsWithDescription(expectedSelectCount, stats["SelectCount"], "Unexpected SelectCount value.");
                             DataTestUtility.AssertEqualsWithDescription((long)3, stats["ServerRoundtrips"], "Unexpected ServerRoundtrips value.");
                             DataTestUtility.AssertEqualsWithDescription(expectedSelectRows, stats["SelectRows"], "Unexpected SelectRows value.");
                             DataTestUtility.AssertEqualsWithDescription((long)2, stats["SumResultSets"], "Unexpected SumResultSets value.");
-                            DataTestUtility.AssertEqualsWithDescription(expectedTransactions, stats["Transactions"], "Unexpected Transactions value.");
+                            DataTestUtility.AssertEqualsWithDescription((long)0, stats["Transactions"], "Unexpected Transactions value.");
                         }
                     }
                 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/UnprivilegedLogin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/UnprivilegedLogin.cs
@@ -30,6 +30,8 @@ public sealed class UnprivilegedLogin : IDisposable
         DataTestUtility.AreConnStringsSetup() && DataTestUtility.IsNotAzureServer()
             && DataTestUtility.CanCreateLogins && DataTestUtility.CanUseSqlAuthentication;
 
+    public static bool IsAtLeastSQL2017 => DataTestUtility.IsAtLeastSQL2017();
+
     public UnprivilegedLogin()
     {
         // xUnit will instantiate the class before evaluating the test condition - make sure that we don't
@@ -133,7 +135,7 @@ public sealed class UnprivilegedLogin : IDisposable
         Assert.Equal(BulkCopyRowCount, resultantRowCount);
     }
 
-    [ConditionalFact(nameof(CanRunTests))]
+    [ConditionalFact(nameof(CanRunTests), nameof(IsAtLeastSQL2017))]
     public void BulkCopyWithoutMetadataPermission_FailsWhenUsingAliases()
     {
         AssertEnvironmentCreated();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/UnprivilegedLogin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/UnprivilegedLogin.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SqlBulkCopyTests;
 /// handle column aliases. These tests verify that bulk copy operations can handle such situations
 /// gracefully, falling back and ignoring column aliases.
 /// </summary>
-[Trait("Set", "2")]
 public sealed class UnprivilegedLogin : IDisposable
 {
     private readonly SqlConnection? _managementConnection;

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/UnprivilegedLogin.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/SqlBulkCopyTest/UnprivilegedLogin.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Data.SqlClient.Tests.Common.Fixtures.DatabaseObjects;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SqlBulkCopyTests;
+
+#nullable enable
+
+/// <summary>
+/// Some unprivileged users may not have permissions to query sys.all_columns, which is used to
+/// handle column aliases. These tests verify that bulk copy operations can handle such situations
+/// gracefully, falling back and ignoring column aliases.
+/// </summary>
+[Trait("Set", "2")]
+public sealed class UnprivilegedLogin : IDisposable
+{
+    private readonly SqlConnection? _managementConnection;
+    private readonly ServerLogin? _unprivilegedLogin;
+    private readonly DatabaseUser? _unprivilegedMasterUser;
+    private readonly DatabaseUser? _unprivilegedAppUser;
+
+    private readonly string? _unprivilegedConnectionString;
+
+    public static bool CanRunTests =>
+        DataTestUtility.AreConnStringsSetup() && DataTestUtility.IsNotAzureServer()
+            && DataTestUtility.CanCreateLogins && DataTestUtility.CanUseSqlAuthentication;
+
+    public UnprivilegedLogin()
+    {
+        // xUnit will instantiate the class before evaluating the test condition - make sure that we don't
+        // attempt to make use of these capabilities if the server doesn't support them.
+        // This has the expected nullability implications, so AssertEnvironmentCreated needs to be called
+        // before any test logic. The compiler asserts these for us.
+        if (!CanRunTests)
+        {
+            return;
+        }
+
+        // We require two connections: a "management" connection which has permissions to create logins,
+        // create users and modify permissions; and an "unprivileged" connection, which is used to perform
+        // the actual tests. The user associated with the latter connection will be denied SELECT permissions
+        // over master.sys.all_columns.
+        _managementConnection = new SqlConnection(DataTestUtility.TCPConnectionString);
+        _managementConnection.Open();
+
+        _unprivilegedLogin = new ServerLogin(_managementConnection, nameof(UnprivilegedLogin), _managementConnection.Database);
+        _unprivilegedAppUser = new DatabaseUser(_managementConnection, _managementConnection.Database, _unprivilegedLogin);
+        _unprivilegedMasterUser = new DatabaseUser(_managementConnection, "master", _unprivilegedLogin);
+
+        using (SqlCommand permissionsModificationCommand = _managementConnection.CreateCommand())
+        {
+            permissionsModificationCommand.CommandText = $"DENY SELECT ON [master].[sys].[all_columns] TO {_unprivilegedMasterUser.Name}";
+            permissionsModificationCommand.ExecuteNonQuery();
+
+            permissionsModificationCommand.CommandText = $"DENY SELECT ON [{_managementConnection.Database}].[sys].[all_columns] TO {_unprivilegedAppUser.Name}";
+            permissionsModificationCommand.ExecuteNonQuery();
+        }
+
+        SqlConnectionStringBuilder tcpConnectionBuilder = new(DataTestUtility.TCPConnectionString)
+        {
+            IntegratedSecurity = false,
+            UserID = _unprivilegedLogin.UnescapedName,
+            Password = _unprivilegedLogin.Password,
+            // Disable connection pooling - we'll be dropping this login once the tests complete, and this can only happen once all connections
+            // using it are closed.
+            Pooling = false
+        };
+
+        _unprivilegedConnectionString = tcpConnectionBuilder.ConnectionString;
+    }
+
+    /// <summary>
+    /// This method enables nullability assertions to operate as expected. It'll always pass if CanRunTests is
+    /// true - the constructor will have initialized the relevant fields.
+    /// </summary>
+    [MemberNotNull(nameof(_managementConnection),
+        nameof(_unprivilegedLogin),
+        nameof(_unprivilegedMasterUser),
+        nameof(_unprivilegedAppUser),
+        nameof(_unprivilegedConnectionString))]
+    private void AssertEnvironmentCreated()
+    {
+        Assert.NotNull(_managementConnection);
+        Assert.NotNull(_unprivilegedLogin);
+        Assert.NotNull(_unprivilegedMasterUser);
+        Assert.NotNull(_unprivilegedAppUser);
+        Assert.NotNull(_unprivilegedConnectionString);
+    }
+
+    /// <summary>
+    /// Verifies that a bulk copy operation succeeds when performed by a user with only SELECT and INSERT permissions,
+    /// without requiring access to metadata views.
+    /// </summary>
+    [ConditionalFact(nameof(CanRunTests))]
+    public void BulkCopyWithoutMetadataPermission_Succeeds()
+    {
+        AssertEnvironmentCreated();
+
+        const int BulkCopyRowCount = 5;
+
+        using DataTable srcDataTable = new()
+        {
+            Columns = { new DataColumn("Description", typeof(string)) }
+        };
+        using Table dstTable = new(_managementConnection, nameof(BulkCopyWithoutMetadataPermission_Succeeds), "([Description] VARCHAR(100))");
+        using (SqlCommand permissionsConfigurationCommand = new($"GRANT SELECT, INSERT ON {dstTable.Name} TO {_unprivilegedAppUser.Name}", _managementConnection))
+        {
+            permissionsConfigurationCommand.ExecuteNonQuery();
+        }
+
+        using SqlBulkCopy nodeCopy = new(_unprivilegedConnectionString);
+
+        for (int i = 0; i < BulkCopyRowCount; i++)
+        {
+            srcDataTable.Rows.Add($"Description {i}");
+        }
+
+        nodeCopy.DestinationTableName = dstTable.Name;
+        nodeCopy.ColumnMappings.Add("Description", "Description");
+        nodeCopy.WriteToServer(srcDataTable);
+
+        int resultantRowCount;
+        using (SqlCommand rowCountQuery = new($"SELECT COUNT(*) FROM {dstTable.Name}", _managementConnection))
+        {
+            resultantRowCount = (int)rowCountQuery.ExecuteScalar();
+        }
+
+        Assert.Equal(BulkCopyRowCount, resultantRowCount);
+    }
+
+    [ConditionalFact(nameof(CanRunTests))]
+    public void BulkCopyWithoutMetadataPermission_FailsWhenUsingAliases()
+    {
+        AssertEnvironmentCreated();
+
+        using DataTable edges = new DataTable()
+        {
+            Columns = { new DataColumn("To_ID", typeof(string)), new DataColumn("From_ID", typeof(string)), new DataColumn("Description", typeof(string)) }
+        };
+
+        // Use the management connection to create the source and the destination tables, grant the
+        // unprivileged user permissions over them and insert some sample data into the source table.
+        using Table srcNodeTable = new(_managementConnection, nameof(BulkCopyWithoutMetadataPermission_FailsWhenUsingAliases), "([Name] VARCHAR(100)) AS NODE");
+        using Table dstEdgeTable = new(_managementConnection, nameof(BulkCopyWithoutMetadataPermission_FailsWhenUsingAliases), "([Description] VARCHAR(100)) AS EDGE");
+        using (SqlCommand permissionsConfigurationCommand = _managementConnection.CreateCommand())
+        {
+            permissionsConfigurationCommand.CommandText = $"GRANT SELECT, INSERT ON {srcNodeTable.Name} TO {_unprivilegedAppUser.Name}";
+            permissionsConfigurationCommand.ExecuteNonQuery();
+
+            permissionsConfigurationCommand.CommandText = $"GRANT SELECT, INSERT ON {dstEdgeTable.Name} TO {_unprivilegedAppUser.Name}";
+            permissionsConfigurationCommand.ExecuteNonQuery();
+        }
+
+        string sampleNodeDataCommand = @$"INSERT INTO {srcNodeTable.Name} ([Name]) SELECT LEFT([name], 100) FROM sys.sysobjects";
+        using (SqlCommand insertSampleNodes = new(sampleNodeDataCommand, _managementConnection))
+        {
+            insertSampleNodes.ExecuteNonQuery();
+        }
+
+        using (SqlCommand nodeQuery = new($"SELECT $node_id FROM {srcNodeTable.Name}", _managementConnection))
+        using (SqlDataReader reader = nodeQuery.ExecuteReader())
+        {
+            bool firstRead = reader.Read();
+            string toId;
+            string fromId;
+
+            Assert.True(firstRead);
+            toId = reader.GetString(0);
+
+            while (reader.Read())
+            {
+                fromId = reader.GetString(0);
+
+                edges.Rows.Add(toId, fromId, "Test Description");
+                toId = fromId;
+            }
+        }
+
+        // With all source data populated, try to use the unprivileged connection to perform a bulk copy
+        // using aliases in the column mappings. This should fail - the permissions error will be caught,
+        // and SqlBulkCopy should simply report that the destination column doesn't exist.
+        using SqlBulkCopy edgeCopy = new(_unprivilegedConnectionString);
+
+        edgeCopy.DestinationTableName = dstEdgeTable.Name;
+        edgeCopy.ColumnMappings.Add("To_ID", "$to_id");
+        edgeCopy.ColumnMappings.Add("From_ID", "$from_id");
+        edgeCopy.ColumnMappings.Add("Description", "Description");
+
+        Action failingEdgeCopy = () => edgeCopy.WriteToServer(edges);
+        InvalidOperationException missingColumnException = Assert.Throws<InvalidOperationException>(failingEdgeCopy);
+
+        Assert.Contains("'$to_id,$from_id'", missingColumnException.Message);
+    }
+
+    public void Dispose()
+    {
+        _unprivilegedAppUser?.Dispose();
+        _unprivilegedMasterUser?.Dispose();
+        _unprivilegedLogin?.Dispose();
+        _managementConnection?.Dispose();
+    }
+}


### PR DESCRIPTION
## Description

This PR ports #4306 to the 7.0 branch, and this contains the full description. 
The automated test uses the RAII primitives, so I've also needed to include these.

## Issues

Fixes #4370.
Ports #4306.

## Testing

Automated tests ported from #4306, with one addition.