### PR TITLE
Cleanup | Sort Modifiers

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Interop/Windows/Handles/SafeLibraryHandle.netcore.cs
+++ b/src/Microsoft.Data.SqlClient/src/Interop/Windows/Handles/SafeLibraryHandle.netcore.cs
@@ -8,11 +8,11 @@ using Microsoft.Win32.SafeHandles;
 
 namespace Interop.Windows.Handles
 {
-    sealed internal class SafeLibraryHandle : SafeHandleZeroOrMinusOneIsInvalid
+    internal sealed class SafeLibraryHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         internal SafeLibraryHandle() : base(true) { }
 
-        override protected bool ReleaseHandle()
+        protected override bool ReleaseHandle()
         {
             return Kernel32.Kernel32.FreeLibrary(handle);
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/AdapterUtil.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Data.Common
 
         #endregion
 
-        static private void TraceException(string trace, Exception e)
+        private static void TraceException(string trace, Exception e)
         {
             Debug.Assert(e != null, "TraceException: null Exception");
             if (e is not null)
@@ -1030,7 +1030,7 @@ namespace Microsoft.Data.Common
 #region Stream
         internal static Exception StreamClosed([CallerMemberName] string method = "") => InvalidOperation(StringsHelper.GetString(Strings.ADP_StreamClosed, method));
 
-        static internal Exception InvalidSeekOrigin(string parameterName) => ArgumentOutOfRange(StringsHelper.GetString(Strings.ADP_InvalidSeekOrigin), parameterName);
+        internal static Exception InvalidSeekOrigin(string parameterName) => ArgumentOutOfRange(StringsHelper.GetString(Strings.ADP_InvalidSeekOrigin), parameterName);
 
         internal static IOException ErrorReadingFromStream(Exception internalException) => IO(StringsHelper.GetString(Strings.SqlMisc_StreamErrorMessage), internalException);
 #endregion
@@ -1157,7 +1157,7 @@ namespace Microsoft.Data.Common
 
 #region IDbCommand
         // IDbCommand.CommandType
-        static internal ArgumentOutOfRangeException InvalidCommandType(CommandType value)
+        internal static ArgumentOutOfRangeException InvalidCommandType(CommandType value)
         {
 #if DEBUG
             switch (value)
@@ -1442,16 +1442,16 @@ namespace Microsoft.Data.Common
         internal static InvalidOperationException InvalidMixedUsageOfAccessTokenAndIntegratedSecurity()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndIntegratedSecurity));
 
-        static internal InvalidOperationException InvalidMixedUsageOfAccessTokenAndUserIDPassword()
+        internal static InvalidOperationException InvalidMixedUsageOfAccessTokenAndUserIDPassword()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndUserIDPassword));
 
-        static internal InvalidOperationException InvalidMixedUsageOfAccessTokenAndAuthentication()
+        internal static InvalidOperationException InvalidMixedUsageOfAccessTokenAndAuthentication()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndAuthentication));
 
-        static internal Exception InvalidMixedUsageOfCredentialAndAccessToken()
+        internal static Exception InvalidMixedUsageOfCredentialAndAccessToken()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfCredentialAndAccessToken));
 
-        static internal Exception InvalidMixedUsageOfAccessTokenAndTokenCallback()
+        internal static Exception InvalidMixedUsageOfAccessTokenAndTokenCallback()
             => InvalidOperation(StringsHelper.GetString(Strings.ADP_InvalidMixedUsageOfAccessTokenAndTokenCallback));
 
         internal static Exception InvalidMixedUsageOfAccessTokenCallbackAndAuthentication()

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/IpAddressPreferenceUtilities.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/ConnectionString/IpAddressPreferenceUtilities.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.Common.ConnectionString
         /// <summary>
         /// IP Address Preference.
         /// </summary>
-        private readonly static Dictionary<string, SqlConnectionIPAddressPreference> s_preferenceNames = new(StringComparer.InvariantCultureIgnoreCase);
+        private static readonly Dictionary<string, SqlConnectionIPAddressPreference> s_preferenceNames = new(StringComparer.InvariantCultureIgnoreCase);
 
         static IpAddressPreferenceUtilities()
         {
@@ -27,7 +27,7 @@ namespace Microsoft.Data.Common.ConnectionString
         ///  Convert a string value to the corresponding IPAddressPreference.
         /// </summary>
         /// <param name="value">The string representation of the enumeration name to convert.</param>
-        /// <param name="result">When this method returns, `result` contains an object of type `SqlConnectionIPAddressPreference` whose value is represented by `value` if the operation succeeds. 
+        /// <param name="result">When this method returns, `result` contains an object of type `SqlConnectionIPAddressPreference` whose value is represented by `value` if the operation succeeds.
         /// If the parse operation fails, `result` contains the default value of the `SqlConnectionIPAddressPreference` type.</param>
         /// <returns>`true` if the value parameter was converted successfully; otherwise, `false`.</returns>
         internal static bool TryConvertToIPAddressPreference(string value, out SqlConnectionIPAddressPreference result)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/NameValuePair.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/Common/NameValuePair.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Data.Common
     [Serializable]
     internal sealed class NameValuePair
     {
-        readonly private string _name;
-        readonly private string _value;
+        private readonly string _name;
+        private readonly string _value;
         [OptionalField(VersionAdded = 2)]
-        readonly private int _length;
+        private readonly int _length;
         private NameValuePair _next;
 
         internal NameValuePair(string name, string value, int length)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbReferenceCollection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbReferenceCollection.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Data.ProviderBase
             _lastItemIndex = 0;
         }
 
-        abstract public void Add(object value, int refInfo);
+        public abstract void Add(object value, int refInfo);
 
         protected void AddItem(object value, int refInfo)
         {
@@ -220,9 +220,9 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        abstract protected void NotifyItem(int refInfo, object value);
+        protected abstract void NotifyItem(int refInfo, object value);
 
-        abstract public void Remove(object value);
+        public abstract void Remove(object value);
 
         protected void RemoveItem(object value)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolAuthenticationContext.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolAuthenticationContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
     /// Represents the context of an authentication attempt when using the new active directory based authentication mechanisms.
     /// All data members, except_isUpdateInProgressCounter, should be immutable.
     /// </summary>
-    sealed internal class DbConnectionPoolAuthenticationContext
+    internal sealed class DbConnectionPoolAuthenticationContext
     {
         /// <summary>
         /// The value expected in _isUpdateInProgress if a thread has taken a lock on this context,

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolAuthenticationContextKey.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolAuthenticationContextKey.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
     /// Represents the key of dbConnectionPoolAuthenticationContext.
     /// All data members should be immutable and so, hashCode is pre-computed.
     /// </summary>
-    sealed internal class DbConnectionPoolAuthenticationContextKey
+    internal sealed class DbConnectionPoolAuthenticationContextKey
     {
         /// <summary>
         /// Security Token Service Authority.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolGroup.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/DbConnectionPoolGroup.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
     // and once no pools remain, change state from Active->Idle->Disabled
     // Once Disabled, factory can remove its reference to the pool entry
 
-    sealed internal class DbConnectionPoolGroup
+    internal sealed class DbConnectionPoolGroup
     {
         private readonly SqlConnectionOptions _connectionOptions;
         private readonly ConnectionPoolKey _poolKey;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Reliability/SqlConfigurableRetryFactory.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.SqlClient
     /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConfigurableRetryFactory.xml' path='docs/members[@name="SqlConfigurableRetryFactory"]/SqlConfigurableRetryFactory/*' />
     public sealed class SqlConfigurableRetryFactory
     {
-        private readonly static object s_syncObject = new();
+        private static readonly object s_syncObject = new();
 
         /// Default known transient error numbers.
         // We use a HashSet internally for O(1) lookup performance in the hot path. The public API exposes a ReadOnlyCollection.
@@ -50,7 +50,7 @@ namespace Microsoft.Data.SqlClient
                     1222,   // Lock request time out period exceeded.
                     4060,   // Cannot open database "%.*ls" requested by the login. The login failed.
                     4221,   // Login to read-secondary failed due to long wait on 'HADR_DATABASE_WAIT_FOR_TRANSITION_TO_VERSIONING'. The replica is not available for login because row versions are missing for transactions that were in-flight when the replica was recycled. The issue can be resolved by rolling back or committing the active transactions on the primary replica. Occurrences of this condition can be minimized by avoiding long write transactions on the primary.
-                    10060,  // An error has occurred while establishing a connection to the server. When connecting to SQL Server, this failure may be caused by the fact that under the default settings SQL Server does not allow remote connections. (provider: TCP Provider, error: 0 - A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.) (Microsoft SQL Server, Error: 10060)    
+                    10060,  // An error has occurred while establishing a connection to the server. When connecting to SQL Server, this failure may be caused by the fact that under the default settings SQL Server does not allow remote connections. (provider: TCP Provider, error: 0 - A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.) (Microsoft SQL Server, Error: 10060)
                     10928,  // Resource ID: %d. The %s limit for the database is %d and has been reached. For more information, see http://go.microsoft.com/fwlink/?LinkId=267637.
                     10929,  // Resource ID: %d. The %s minimum guarantee is %d, maximum limit is %d and the current usage for the database is %d. However, the server is currently too busy to support requests greater than %d for this database. For more information, see http://go.microsoft.com/fwlink/?LinkId=267637. Otherwise, please try again later.
                     40143,  // The service has encountered an error processing your request. Please try again.
@@ -74,7 +74,7 @@ namespace Microsoft.Data.SqlClient
                                            retryLogicOption != null ? new SqlExponentialIntervalEnumerator(retryLogicOption.DeltaTime, retryLogicOption.MaxTimeInterval, retryLogicOption.MinTimeInterval) : null);
 
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConfigurableRetryFactory.xml' path='docs/members[@name="SqlConfigurableRetryFactory"]/CreateIncrementalRetryProvider/*' />
-        public static SqlRetryLogicBaseProvider CreateIncrementalRetryProvider(SqlRetryLogicOption retryLogicOption) 
+        public static SqlRetryLogicBaseProvider CreateIncrementalRetryProvider(SqlRetryLogicOption retryLogicOption)
             => InternalCreateRetryProvider(retryLogicOption,
                                             retryLogicOption != null ? new SqlIncrementalIntervalEnumerator(retryLogicOption.DeltaTime, retryLogicOption.MaxTimeInterval, retryLogicOption.MinTimeInterval) : null);
 
@@ -109,7 +109,7 @@ namespace Microsoft.Data.SqlClient
         /// <summary>
         /// Verifies the provider which is not null and doesn't include SqlNoneIntervalEnumerator enumerator object.
         /// </summary>
-        internal static bool IsRetriable(SqlRetryLogicBaseProvider provider) 
+        internal static bool IsRetriable(SqlRetryLogicBaseProvider provider)
             => provider is not null && (provider.RetryLogic is null || provider.RetryLogic.RetryIntervalEnumerator is not SqlNoneIntervalEnumerator);
 
         /// Return true if the exception is a transient fault.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Data.SqlClient.Server
         internal static readonly SmiMetaData DefaultDateTimeOffset = new SmiMetaData(SqlDbType.DateTimeOffset, 10, 0, 7, SqlCompareOptions.None);     // SqlDbType.DateTimeOffset
         // No default for generic UDT
 
-        internal static SmiMetaData DefaultNVarChar => 
+        internal static SmiMetaData DefaultNVarChar =>
             new SmiMetaData(
                 DefaultNVarChar_NoCollation.SqlDbType,
                 DefaultNVarChar_NoCollation.MaxLength,
@@ -530,7 +530,7 @@ namespace Microsoft.Data.SqlClient.Server
             _extendedProperties = smdDflt._extendedProperties;  // This is ok due to immutability
         }
 
-        virtual internal string TraceString(int indent)
+        internal virtual string TraceString(int indent)
         {
             string indentStr = new string(' ', indent);
             string fields = string.Empty;
@@ -847,7 +847,7 @@ namespace Microsoft.Data.SqlClient.Server
 
     // SmiStorageMetaData
     //
-    //  This class represents the addition of storage-level attributes to the hierarchy (i.e. attributes from 
+    //  This class represents the addition of storage-level attributes to the hierarchy (i.e. attributes from
     //  underlying table, source variables, or whatever).
     //
     //  Most values use Null (either IsNullable == true or CLR null) to indicate "Not specified" state.  Selection

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCachedBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCachedBuffer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.SqlClient
                     cachedBytes = null;
                 }
             }
- 
+
             if (cachedBytes == null)
             {
                 cachedBytes = new List<byte[]>();
@@ -128,7 +128,7 @@ namespace Microsoft.Data.SqlClient
 
         private static void AddByteOrderMark(byte[] byteArr, List<byte[]> cachedBytes)
         {
-            // Need to find out if we should add byte order mark or not. 
+            // Need to find out if we should add byte order mark or not.
             // We need to add this if we are getting ntext xml, not if we are getting binary xml
             // Binary Xml always begins with the bytes 0xDF and 0xFF
             // If we aren't getting these, then we are getting Unicode xml
@@ -144,7 +144,7 @@ namespace Microsoft.Data.SqlClient
             return new SqlCachedStream(this);
         }
 
-        override public string ToString()
+        public override string ToString()
         {
             if (IsNull)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1240,14 +1240,14 @@ namespace Microsoft.Data.SqlClient
         // PUBLIC METHODS
         //
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/BeginTransaction2/*' />
-        new public SqlTransaction BeginTransaction()
+        public new SqlTransaction BeginTransaction()
         {
             // this is just a delegate. The actual method tracks executiontime
             return BeginTransaction(IsolationLevel.Unspecified, null);
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/BeginTransactionIso/*' />
-        new public SqlTransaction BeginTransaction(IsolationLevel iso)
+        public new SqlTransaction BeginTransaction(IsolationLevel iso)
         {
             // this is just a delegate. The actual method tracks executiontime
             return BeginTransaction(iso, null);
@@ -1265,7 +1265,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/BeginDbTransaction/*' />
         [SuppressMessage("Microsoft.Reliability", "CA2004:RemoveCallsToGCKeepAlive")]
-        override protected DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
         {
             using (SqlClientEventScope.Create("SqlConnection.BeginDbTransaction | API | Object Id {0}, Isolation Level {1}", ObjectID, (int)isolationLevel))
             {
@@ -1469,7 +1469,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/CreateCommand/*' />
-        new public SqlCommand CreateCommand()
+        public new SqlCommand CreateCommand()
         {
             return new SqlCommand(null, this);
         }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionOptions.cs
@@ -984,7 +984,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        static internal Dictionary<string, string> NetlibMapping()
+        internal static Dictionary<string, string> NetlibMapping()
         {
             const int NetLibCount = 8;
 
@@ -1007,7 +1007,7 @@ namespace Microsoft.Data.SqlClient
             }
             return hash;
         }
-        static internal bool ValidProtocol(string protocol)
+        internal static bool ValidProtocol(string protocol)
         {
             return protocol switch
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataAdapter.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Data.SqlClient
         [DefaultValue(null)]
         [ResCategory(nameof(Strings.DataCategory_Update))]
         [ResDescription(nameof(Strings.DbDataAdapter_DeleteCommand))]
-        new public SqlCommand DeleteCommand
+        public new SqlCommand DeleteCommand
         {
             get { return _deleteCommand; }
             set { _deleteCommand = value; }
@@ -85,7 +85,7 @@ namespace Microsoft.Data.SqlClient
         [DefaultValue(null)]
         [ResCategory(nameof(Strings.DataCategory_Update))]
         [ResDescription(nameof(Strings.DbDataAdapter_InsertCommand))]
-        new public SqlCommand InsertCommand
+        public new SqlCommand InsertCommand
         {
             get { return _insertCommand; }
             set { _insertCommand = value; }
@@ -102,7 +102,7 @@ namespace Microsoft.Data.SqlClient
         [DefaultValue(null)]
         [ResCategory(nameof(Strings.DataCategory_Fill))]
         [ResDescription(nameof(Strings.DbDataAdapter_SelectCommand))]
-        new public SqlCommand SelectCommand
+        public new SqlCommand SelectCommand
         {
             get { return _selectCommand; }
             set { _selectCommand = value; }
@@ -119,7 +119,7 @@ namespace Microsoft.Data.SqlClient
         [DefaultValue(null)]
         [ResCategory(nameof(Strings.DataCategory_Update))]
         [ResDescription(nameof(Strings.DbDataAdapter_UpdateCommand))]
-        new public SqlCommand UpdateCommand
+        public new SqlCommand UpdateCommand
         {
             get { return _updateCommand; }
             set { _updateCommand = value; }
@@ -285,7 +285,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataAdapter.xml' path='docs/members[@name="SqlDataAdapter"]/OnRowUpdated/*' />
-        override protected void OnRowUpdated(RowUpdatedEventArgs value)
+        protected override void OnRowUpdated(RowUpdatedEventArgs value)
         {
             SqlRowUpdatedEventHandler handler = (SqlRowUpdatedEventHandler)Events[s_eventRowUpdated];
             if (handler != null && value is SqlRowUpdatedEventArgs args)
@@ -296,7 +296,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataAdapter.xml' path='docs/members[@name="SqlDataAdapter"]/OnRowUpdating/*' />
-        override protected void OnRowUpdating(RowUpdatingEventArgs value)
+        protected override void OnRowUpdating(RowUpdatingEventArgs value)
         {
             SqlRowUpdatingEventHandler handler = (SqlRowUpdatingEventHandler)Events[s_eventRowUpdating];
             if (handler != null && value is SqlRowUpdatingEventArgs args)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Data.SqlClient
         public SensitivityClassification SensitivityClassification { get; internal set; }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/Depth/*' />
-        override public int Depth
+        public override int Depth
         {
             get
             {
@@ -174,7 +174,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/FieldCount/*' />
         // fields/attributes collection
-        override public int FieldCount
+        public override int FieldCount
         {
             get
             {
@@ -197,7 +197,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/HasRows/*' />
-        override public bool HasRows
+        public override bool HasRows
         {
             get
             {
@@ -215,7 +215,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/IsClosed/*' />
-        override public bool IsClosed
+        public override bool IsClosed
         {
             get
             {
@@ -363,7 +363,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/RecordsAffected/*' />
-        override public int RecordsAffected
+        public override int RecordsAffected
         {
             get
             {
@@ -406,7 +406,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/VisibleFieldCount/*' />
-        override public int VisibleFieldCount
+        public override int VisibleFieldCount
         {
             get
             {
@@ -425,7 +425,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/ItemI/*' />
         // this operator
-        override public object this[int i]
+        public override object this[int i]
         {
             get
             {
@@ -434,7 +434,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/ItemName/*' />
-        override public object this[string name]
+        public override object this[string name]
         {
             get
             {
@@ -1093,7 +1093,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        virtual internal void CloseReaderFromConnection()
+        internal virtual void CloseReaderFromConnection()
         {
             var parser = _parser;
             Debug.Assert(parser == null || parser.State != TdsParserState.OpenNotLoggedIn, "Reader on a connection that is not logged in");
@@ -1169,7 +1169,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDataTypeName/*' />
-        override public string GetDataTypeName(int i)
+        public override string GetDataTypeName(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -1222,7 +1222,7 @@ namespace Microsoft.Data.SqlClient
             return dataTypeName;
         }
 
-        virtual internal SqlBuffer.StorageType GetVariantInternalStorageType(int i)
+        internal virtual SqlBuffer.StorageType GetVariantInternalStorageType(int i)
         {
             Debug.Assert(_data != null, "Attempting to get variant internal storage type");
             Debug.Assert(i < _data.Length, "Reading beyond data length?");
@@ -1231,7 +1231,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetEnumerator/*' />
-        override public IEnumerator GetEnumerator()
+        public override IEnumerator GetEnumerator()
         {
             return new DbEnumerator(this, IsCommandBehavior(CommandBehavior.CloseConnection));
         }
@@ -1240,7 +1240,7 @@ namespace Microsoft.Data.SqlClient
 #if !NETFRAMEWORK
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
-        override public Type GetFieldType(int i)
+        public override Type GetFieldType(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -1314,7 +1314,7 @@ namespace Microsoft.Data.SqlClient
             };
         }
 
-        virtual internal int GetLocaleId(int i)
+        internal virtual int GetLocaleId(int i)
         {
             _SqlMetaData sqlMetaData = MetaData[i];
             int lcid;
@@ -1348,7 +1348,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetName/*' />
-        override public string GetName(int i)
+        public override string GetName(int i)
         {
             CheckMetaDataIsReady(columnIndex: i);
 
@@ -1360,7 +1360,7 @@ namespace Microsoft.Data.SqlClient
 #if NET
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.PublicFields)]
 #endif
-        override public Type GetProviderSpecificFieldType(int i)
+        public override Type GetProviderSpecificFieldType(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -1424,7 +1424,7 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetOrdinal/*' />
         // named field access
-        override public int GetOrdinal(string name)
+        public override int GetOrdinal(string name)
         {
             SqlStatistics statistics = null;
             try
@@ -1444,13 +1444,13 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetProviderSpecificValue/*' />
-        override public object GetProviderSpecificValue(int i)
+        public override object GetProviderSpecificValue(int i)
         {
             return GetSqlValue(i);
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetProviderSpecificValues/*' />
-        override public int GetProviderSpecificValues(object[] values)
+        public override int GetProviderSpecificValues(object[] values)
         {
             return GetSqlValues(values);
         }
@@ -1482,14 +1482,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetBoolean/*' />
-        override public bool GetBoolean(int i)
+        public override bool GetBoolean(int i)
         {
             ReadColumn(i);
             return _data[i].Boolean;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetXmlReader/*' />
-        virtual public XmlReader GetXmlReader(int i)
+        public virtual XmlReader GetXmlReader(int i)
         {
             // NOTE: sql_variant can not contain a XML data type: http://msdn.microsoft.com/en-us/library/ms173829.aspx
             // If this ever changes, the following code should be changed to be like GetStream/GetTextReader
@@ -1529,7 +1529,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetStream/*' />
-        override public Stream GetStream(int i)
+        public override Stream GetStream(int i)
         {
             CheckDataIsReady(columnIndex: i);
 
@@ -1577,14 +1577,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetByte/*' />
-        override public byte GetByte(int i)
+        public override byte GetByte(int i)
         {
             ReadColumn(i);
             return _data[i].Byte;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetBytes/*' />
-        override public long GetBytes(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
+        public override long GetBytes(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
         {
             SqlStatistics statistics = null;
             long cbBytes = 0;
@@ -1613,7 +1613,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Used (indirectly) by SqlCommand.CompleteXmlReader
-        virtual internal long GetBytesInternal(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
+        internal virtual long GetBytesInternal(int i, long dataIndex, byte[] buffer, int bufferIndex, int length)
         {
             if (_currentTask != null)
             {
@@ -1953,7 +1953,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetTextReader/*' />
-        override public TextReader GetTextReader(int i)
+        public override TextReader GetTextReader(int i)
         {
             CheckDataIsReady(columnIndex: i);
 
@@ -2027,13 +2027,13 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetChar/*' />
         [EditorBrowsable(EditorBrowsableState.Never)]
-        override public char GetChar(int i)
+        public override char GetChar(int i)
         {
             throw ADP.NotSupported();
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetChars/*' />
-        override public long GetChars(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
+        public override long GetChars(int i, long dataIndex, char[] buffer, int bufferIndex, int length)
         {
             SqlStatistics statistics = null;
 
@@ -2336,7 +2336,7 @@ namespace Microsoft.Data.SqlClient
 #endif
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDateTime/*' />
-        override public DateTime GetDateTime(int i)
+        public override DateTime GetDateTime(int i)
         {
             ReadColumn(i);
 
@@ -2358,77 +2358,77 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDecimal/*' />
-        override public decimal GetDecimal(int i)
+        public override decimal GetDecimal(int i)
         {
             ReadColumn(i);
             return _data[i].Decimal;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDouble/*' />
-        override public double GetDouble(int i)
+        public override double GetDouble(int i)
         {
             ReadColumn(i);
             return _data[i].Double;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetFloat/*' />
-        override public float GetFloat(int i)
+        public override float GetFloat(int i)
         {
             ReadColumn(i);
             return _data[i].Single;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetGuid/*' />
-        override public Guid GetGuid(int i)
+        public override Guid GetGuid(int i)
         {
             ReadColumn(i);
             return _data[i].Guid;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetInt16/*' />
-        override public short GetInt16(int i)
+        public override short GetInt16(int i)
         {
             ReadColumn(i);
             return _data[i].Int16;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetInt32/*' />
-        override public int GetInt32(int i)
+        public override int GetInt32(int i)
         {
             ReadColumn(i);
             return _data[i].Int32;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetInt64/*' />
-        override public long GetInt64(int i)
+        public override long GetInt64(int i)
         {
             ReadColumn(i);
             return _data[i].Int64;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlBoolean/*' />
-        virtual public SqlBoolean GetSqlBoolean(int i)
+        public virtual SqlBoolean GetSqlBoolean(int i)
         {
             ReadColumn(i);
             return _data[i].SqlBoolean;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlBinary/*' />
-        virtual public SqlBinary GetSqlBinary(int i)
+        public virtual SqlBinary GetSqlBinary(int i)
         {
             ReadColumn(i, setTimeout: true, allowPartiallyReadColumn: true);
             return _data[i].SqlBinary;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlByte/*' />
-        virtual public SqlByte GetSqlByte(int i)
+        public virtual SqlByte GetSqlByte(int i)
         {
             ReadColumn(i);
             return _data[i].SqlByte;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlBytes/*' />
-        virtual public SqlBytes GetSqlBytes(int i)
+        public virtual SqlBytes GetSqlBytes(int i)
         {
             ReadColumn(i);
             SqlBinary data = _data[i].SqlBinary;
@@ -2436,7 +2436,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlChars/*' />
-        virtual public SqlChars GetSqlChars(int i)
+        public virtual SqlChars GetSqlChars(int i)
         {
             ReadColumn(i);
             SqlString data;
@@ -2453,70 +2453,70 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDateTime/*' />
-        virtual public SqlDateTime GetSqlDateTime(int i)
+        public virtual SqlDateTime GetSqlDateTime(int i)
         {
             ReadColumn(i);
             return _data[i].SqlDateTime;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDecimal/*' />
-        virtual public SqlDecimal GetSqlDecimal(int i)
+        public virtual SqlDecimal GetSqlDecimal(int i)
         {
             ReadColumn(i);
             return _data[i].SqlDecimal;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlGuid/*' />
-        virtual public SqlGuid GetSqlGuid(int i)
+        public virtual SqlGuid GetSqlGuid(int i)
         {
             ReadColumn(i);
             return _data[i].SqlGuid;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlDouble/*' />
-        virtual public SqlDouble GetSqlDouble(int i)
+        public virtual SqlDouble GetSqlDouble(int i)
         {
             ReadColumn(i);
             return _data[i].SqlDouble;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlInt16/*' />
-        virtual public SqlInt16 GetSqlInt16(int i)
+        public virtual SqlInt16 GetSqlInt16(int i)
         {
             ReadColumn(i);
             return _data[i].SqlInt16;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlInt32/*' />
-        virtual public SqlInt32 GetSqlInt32(int i)
+        public virtual SqlInt32 GetSqlInt32(int i)
         {
             ReadColumn(i);
             return _data[i].SqlInt32;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlInt64/*' />
-        virtual public SqlInt64 GetSqlInt64(int i)
+        public virtual SqlInt64 GetSqlInt64(int i)
         {
             ReadColumn(i);
             return _data[i].SqlInt64;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlMoney/*' />
-        virtual public SqlMoney GetSqlMoney(int i)
+        public virtual SqlMoney GetSqlMoney(int i)
         {
             ReadColumn(i);
             return _data[i].SqlMoney;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlSingle/*' />
-        virtual public SqlSingle GetSqlSingle(int i)
+        public virtual SqlSingle GetSqlSingle(int i)
         {
             ReadColumn(i);
             return _data[i].SqlSingle;
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlString/*' />
-        virtual public SqlString GetSqlString(int i)
+        public virtual SqlString GetSqlString(int i)
         {
             ReadColumn(i);
 
@@ -2529,7 +2529,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlXml/*' />
-        virtual public SqlXml GetSqlXml(int i)
+        public virtual SqlXml GetSqlXml(int i)
         {
             ReadColumn(i);
             SqlXml sx = null;
@@ -2540,7 +2540,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlJson/*' />
-        virtual public SqlJson GetSqlJson(int i)
+        public virtual SqlJson GetSqlJson(int i)
         {
             ReadColumn(i);
             SqlJson json = _data[i].IsNull ? SqlJson.Null : _data[i].SqlJson;
@@ -2548,7 +2548,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlVector/*' />
-        virtual public SqlVector<T> GetSqlVector<T>(int i) where T : unmanaged
+        public virtual SqlVector<T> GetSqlVector<T>(int i) where T : unmanaged
         {
             if (typeof(T) != typeof(float))
             {
@@ -2560,7 +2560,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlValue/*' />
-        virtual public object GetSqlValue(int i)
+        public virtual object GetSqlValue(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -2628,7 +2628,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetSqlValues/*' />
-        virtual public int GetSqlValues(object[] values)
+        public virtual int GetSqlValues(object[] values)
         {
             SqlStatistics statistics = null;
             try
@@ -2657,7 +2657,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetString/*' />
-        override public string GetString(int i)
+        public override string GetString(int i)
         {
             ReadColumn(i);
             // Convert 2008 value to string if type system knob is 2005 or earlier
@@ -2670,7 +2670,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetFieldValue/*' />
-        override public T GetFieldValue<T>(int i)
+        public override T GetFieldValue<T>(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -2687,7 +2687,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetValue/*' />
-        override public object GetValue(int i)
+        public override object GetValue(int i)
         {
             SqlStatistics statistics = null;
             try
@@ -2704,7 +2704,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetTimeSpan/*' />
-        virtual public TimeSpan GetTimeSpan(int i)
+        public virtual TimeSpan GetTimeSpan(int i)
         {
             ReadColumn(i);
 
@@ -2726,7 +2726,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetDateTimeOffset/*' />
-        virtual public DateTimeOffset GetDateTimeOffset(int i)
+        public virtual DateTimeOffset GetDateTimeOffset(int i)
         {
             ReadColumn(i);
 
@@ -3069,7 +3069,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetValues/*' />
-        override public int GetValues(object[] values)
+        public override int GetValues(object[] values)
         {
             SqlStatistics statistics = null;
             bool sequentialAccess = IsCommandBehavior(CommandBehavior.SequentialAccess);
@@ -3316,7 +3316,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/IsDBNull/*' />
-        override public bool IsDBNull(int i)
+        public override bool IsDBNull(int i)
         {
 #if NETFRAMEWORK
             if ((IsCommandBehavior(CommandBehavior.SequentialAccess)) && ((_sharedState._nextColumnHeaderToRead > i + 1) || (_lastColumnWithDataChunkRead > i)))
@@ -3349,7 +3349,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/NextResult/*' />
-        override public bool NextResult()
+        public override bool NextResult()
         {
             if (_currentTask != null)
             {
@@ -4994,7 +4994,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/IsDBNullAsync/*' />
-        override public Task<bool> IsDBNullAsync(int i, CancellationToken cancellationToken)
+        public override Task<bool> IsDBNullAsync(int i, CancellationToken cancellationToken)
         {
             try
             {
@@ -5129,7 +5129,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlDataReader.xml' path='docs/members[@name="SqlDataReader"]/GetFieldValueAsync/*' />
-        override public Task<T> GetFieldValueAsync<T>(int i, CancellationToken cancellationToken)
+        public override Task<T> GetFieldValueAsync<T>(int i, CancellationToken cancellationToken)
         {
             try
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlException.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Data.SqlClient
         public byte State => Errors.Count > 0 ? Errors[0].State : default;
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlException.xml' path='docs/members[@name="SqlException"]/Source/*' />
-        override public string Source => DbConnectionStringDefaults.ApplicationName;
+        public override string Source => DbConnectionStringDefaults.ApplicationName;
 
 
         #if NET

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInfoMessageEvent.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInfoMessageEvent.cs
@@ -29,6 +29,6 @@ namespace Microsoft.Data.SqlClient
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlInfoMessageEventArgs.xml' path='docs/members[@name="SqlInfoMessageEventArgs"]/ToString/*' />
         // MDAC 68482
-        override public string ToString() => Message;
+        public override string ToString() => Message;
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlInternalTransaction.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.SqlClient
         Context = 5,     // only valid in proc.
     }
 
-    sealed internal class SqlInternalTransaction
+    internal sealed class SqlInternalTransaction
     {
         internal const long NullTransactionId = 0;
 
@@ -456,7 +456,7 @@ namespace Microsoft.Data.SqlClient
             _parent = null;
         }
 
-        internal string TraceString() => string.Format(/*IFormatProvider*/ null, 
+        internal string TraceString() => string.Format(/*IFormatProvider*/ null,
             "(ObjId={0}, tranId={1}, state={2}, type={3}, open={4}, disp={5}",
             ObjectID, _transactionId, _transactionState, _transactionType, _openResultCount, _disposing);
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlQueryMetadataCache.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.SqlClient
     /// <summary>
     /// <para> Implements a cache of query parameter metadata that is used to avoid the extra roundtrip to the server for every execution of the same query.</para>
     /// </summary>
-    sealed internal class SqlQueryMetadataCache
+    internal sealed class SqlQueryMetadataCache
     {
         private const int CacheSize = 2000; // Cache size in number of entries.
         private const int CacheTrimThreshold = 300; // Threshold above the cache size when we start trimming.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlReferenceCollection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlReferenceCollection.cs
@@ -9,7 +9,7 @@ using Microsoft.Data.ProviderBase;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlReferenceCollection : DbReferenceCollection
+    internal sealed class SqlReferenceCollection : DbReferenceCollection
     {
         private sealed class FindLiveReaderContext
         {
@@ -30,7 +30,7 @@ namespace Microsoft.Data.SqlClient
         internal const int CommandTag = 2;
         internal const int BulkCopyTag = 3;
 
-        private readonly static Func<SqlDataReader, bool> s_hasOpenReaderFunc = HasOpenReaderPredicate;
+        private static readonly Func<SqlDataReader, bool> s_hasOpenReaderFunc = HasOpenReaderPredicate;
         private static FindLiveReaderContext s_cachedFindLiveReaderContext;
 
         public override void Add(object value, int tag)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlRowUpdatedEvent.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlRowUpdatedEvent.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlRowUpdatedEventArgs.xml' path='docs/members[@name="SqlRowUpdatedEventArgs"]/Command/*' />
-        new public SqlCommand Command
+        public new SqlCommand Command
         {
             get
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlRowUpdatingEvent.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlRowUpdatingEvent.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Data.SqlClient
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlRowUpdatingEventArgs.xml' path='docs/members[@name="SqlRowUpdatingEventArgs"]/Command/*' />
-        new public SqlCommand Command
+        public new SqlCommand Command
         {
             get { return (base.Command as SqlCommand); }
             set { base.Command = value; }
         }
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlRowUpdatingEventArgs.xml' path='docs/members[@name="SqlRowUpdatingEventArgs"]/BaseCommand/*' />
-        override protected IDbCommand BaseCommand
+        protected override IDbCommand BaseCommand
         {
             get { return base.BaseCommand; }
             set { base.BaseCommand = (value as SqlCommand); }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSequentialTextReader.cs
@@ -13,7 +13,7 @@ using Microsoft.Data.Common;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlSequentialTextReader : System.IO.TextReader
+    internal sealed class SqlSequentialTextReader : System.IO.TextReader
     {
         private SqlDataReader _reader;  // The SqlDataReader that we are reading data from
         private readonly int _columnIndex;       // The index of out column in the table
@@ -417,7 +417,7 @@ namespace Microsoft.Data.SqlClient
             {
                 _leftOverByteBufferUsed = inBufferCount - bytesUsed;
                 _leftOverBytes = ArrayPool<byte>.Shared.Rent(_leftOverByteBufferUsed);
-                
+
                 Buffer.BlockCopy(inBuffer, bytesUsed, _leftOverBytes, 0, _leftOverByteBufferUsed);
             }
             else
@@ -494,7 +494,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlUnicodeEncoding : UnicodeEncoding
+    internal sealed class SqlUnicodeEncoding : UnicodeEncoding
     {
         private static readonly SqlUnicodeEncoding s_singletonEncoding = new();
 
@@ -517,7 +517,7 @@ namespace Microsoft.Data.SqlClient
             get { return s_singletonEncoding; }
         }
 
-        sealed private class SqlUnicodeDecoder : Decoder
+        private sealed class SqlUnicodeDecoder : Decoder
         {
             public override int GetCharCount(byte[] bytes, int index, int count)
             {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlStream.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlStream.cs
@@ -13,7 +13,7 @@ using Microsoft.Data.SqlTypes;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class SqlStream : Stream
+    internal sealed class SqlStream : Stream
     {
         private SqlDataReader _reader; // reader we will stream off
         private readonly int _columnOrdinal;
@@ -93,7 +93,7 @@ namespace Microsoft.Data.SqlClient
                 throw ADP.ArgumentOutOfRange(nameof(count));
             }
 
-            // Need to find out if we should add byte order mark or not. 
+            // Need to find out if we should add byte order mark or not.
             // We need to add this if we are getting ntext xml, not if we are getting binary xml
             // Binary Xml always begins with the bytes 0xDF and 0xFF
             // If we aren't getting these, then we are getting unicode xml
@@ -265,9 +265,9 @@ namespace Microsoft.Data.SqlClient
 
     // XmlTextReader does not read all the bytes off the network buffers, so we have to cache it here in the random access
     // case. This causes double buffering and is a perf hit, but this is not the high perf way for accessing this type of data.
-    // In the case of sequential access, we do not have to do any buffering since the XmlTextReader we return can become 
+    // In the case of sequential access, we do not have to do any buffering since the XmlTextReader we return can become
     // invalid as soon as we move off the current column.
-    sealed internal class SqlCachedStream : Stream
+    internal sealed class SqlCachedStream : Stream
     {
         private int _currentPosition;   // Position within the current array byte
         private int _currentArrayIndex; // Index into the _cachedBytes List
@@ -475,7 +475,7 @@ namespace Microsoft.Data.SqlClient
         }
     }
 
-    sealed internal class SqlStreamingXml
+    internal sealed class SqlStreamingXml
     {
         private static readonly XmlWriterSettings s_writerSettings = new() { CloseOutput = true, ConformanceLevel = ConformanceLevel.Fragment };
 
@@ -580,7 +580,7 @@ namespace Microsoft.Data.SqlClient
             return (long)cnt;
         }
 
-        // This method duplicates the work of XmlWriter.WriteNode except that it reads one element at a time 
+        // This method duplicates the work of XmlWriter.WriteNode except that it reads one element at a time
         // instead of reading the entire node like XmlWriter.
         private void WriteXmlElement()
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlSymmetricKeyCache.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.SqlClient
     /// <summary>
     /// <para> Implements a cache of Symmetric Keys (once they are decrypted).Useful for rapidly decrypting multiple data values.</para>
     /// </summary>
-    sealed internal class SqlSymmetricKeyCache
+    internal sealed class SqlSymmetricKeyCache
     {
         private readonly MemoryCache _cache;
         private static readonly SqlSymmetricKeyCache _singletonInstance = new();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -85,16 +85,16 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_InvalidSSPIPacketSize));
         }
-        static internal Exception NullEmptyTransactionName()
+        internal static Exception NullEmptyTransactionName()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_NullEmptyTransactionName));
         }
 
-        static internal Exception UserInstanceFailoverNotCompatible()
+        internal static Exception UserInstanceFailoverNotCompatible()
         {
             return ADP.Argument(StringsHelper.GetString(Strings.SQL_UserInstanceFailoverNotCompatible));
         }
-        static internal Exception CredentialsNotProvided(SqlAuthenticationMethod auth)
+        internal static Exception CredentialsNotProvided(SqlAuthenticationMethod auth)
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_CredentialsNotProvided, DbConnectionStringUtilities.AuthenticationTypeToString(auth)));
         }
@@ -636,7 +636,7 @@ namespace Microsoft.Data.SqlClient
         //
         // SQL.SqlDelegatedTransaction
         //
-        static internal Exception CannotCompleteDelegatedTransactionWithOpenResults(
+        internal static Exception CannotCompleteDelegatedTransactionWithOpenResults(
             SqlConnectionInternal internalConnection,
             bool marsOn)
         {
@@ -1860,7 +1860,7 @@ namespace Microsoft.Data.SqlClient
         // Merged Provider
         //
 
-        static internal Exception ContextConnectionIsUnsupported()
+        internal static Exception ContextConnectionIsUnsupported()
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ContextConnectionIsUnsupported));
         }
@@ -1909,7 +1909,7 @@ namespace Microsoft.Data.SqlClient
 
     }
 
-    sealed internal class SQLMessage
+    internal sealed class SQLMessage
     {
         private SQLMessage() { /* prevent utility class from being instantiated*/ }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.windows.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserSafeHandles.windows.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Data.SqlClient
 
         public override bool IsInvalid => (IntPtr.Zero == base.handle);
 
-        override protected bool ReleaseHandle()
+        protected override bool ReleaseHandle()
         {
             if (base.handle != IntPtr.Zero)
             {
@@ -224,7 +224,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected bool ReleaseHandle()
+        protected override bool ReleaseHandle()
         {
             // NOTE: The SafeHandle class guarantees this will be called exactly once.
             IntPtr ptr = base.handle;
@@ -267,7 +267,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        override protected bool ReleaseHandle()
+        protected override bool ReleaseHandle()
         {
             // NOTE: The SafeHandle class guarantees this will be called exactly once.
             IntPtr ptr = base.handle;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStateObject.cs
@@ -25,7 +25,7 @@ using System.Runtime.ConstrainedExecution;
 
 namespace Microsoft.Data.SqlClient
 {
-    sealed internal class LastIOTimer
+    internal sealed class LastIOTimer
     {
         internal long _value;
     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParserStaticMethods.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.SqlClient
         // Static methods
         //
 
-        static internal void AliasRegistryLookup(ref string host, ref string protocol)
+        internal static void AliasRegistryLookup(ref string host, ref string protocol)
         {
             if (!string.IsNullOrEmpty(host))
             {
@@ -86,12 +86,12 @@ namespace Microsoft.Data.SqlClient
 
         // Obfuscate password to be sent to SQL Server
         // Blurb from the TDS spec at https://msdn.microsoft.com/en-us/library/dd304523.aspx
-        // "Before submitting a password from the client to the server, for every byte in the password buffer 
-        // starting with the position pointed to by IbPassword, the client SHOULD first swap the four high bits 
-        // with the four low bits and then do a bit-XOR with 0xA5 (10100101). After reading a submitted password, 
-        // for every byte in the password buffer starting with the position pointed to by IbPassword, the server SHOULD 
+        // "Before submitting a password from the client to the server, for every byte in the password buffer
+        // starting with the position pointed to by IbPassword, the client SHOULD first swap the four high bits
+        // with the four low bits and then do a bit-XOR with 0xA5 (10100101). After reading a submitted password,
+        // for every byte in the password buffer starting with the position pointed to by IbPassword, the server SHOULD
         // first do a bit-XOR with 0xA5 (10100101) and then swap the four high bits with the four low bits."
-        // The password exchange during Login phase happens over a secure channel i.e. SSL/TLS 
+        // The password exchange during Login phase happens over a secure channel i.e. SSL/TLS
         // Note: The same logic is used in SNIPacketSetData (SniManagedWrapper) to encrypt passwords stored in SecureString
         //       If this logic changed, SNIPacketSetData needs to be changed as well
         internal static byte[] ObfuscatePassword(string password)
@@ -164,7 +164,7 @@ namespace Microsoft.Data.SqlClient
 
         private static byte[] s_nicAddress = null;
 
-        static internal byte[] GetNetworkPhysicalAddressForTdsLoginOnly()
+        internal static byte[] GetNetworkPhysicalAddressForTdsLoginOnly()
         {
             if (s_nicAddress != null)
             {


### PR DESCRIPTION
## Description
While waiting on some 🤖 analysis, I was looking through my old branches to see what's worth keeping what's too outdated to keep around. This was one of those branches I had intended to send out but never did. It's a very simple PR that just happens to touch about 107 lines of code.

Much of the original codebase contained "inconsistent" declaration modifiers. This PR cleans them up so that they are all in consistent order. I completely ignored all other possible changes except for these, so it should be a quick skim to approve it.

## Testing
Everything still compiles. There are no functional changes, just syntactic cleanup, so pr pipeline should be sufficient.