### PR TITLE
Refactor ForceNewConnection

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Data.ProviderBase
             SqlConnectionFactory connectionFactory,
             TaskCompletionSource<DbConnectionInternal> retry,
             TimeoutTimer timeout) =>
-            TryOpenConnectionInternal(outerConnection, connectionFactory, retry, timeout);
+            TryOpenConnectionInternal(outerConnection, connectionFactory, retry, forceNewConnection: false,timeout);
 
         /// <inheritdoc/>
         internal override void ResetConnection() => throw ADP.ClosedConnectionError();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionClosed.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Data.ProviderBase
             SqlConnectionFactory connectionFactory,
             TaskCompletionSource<DbConnectionInternal> retry,
             TimeoutTimer timeout) =>
-            TryOpenConnectionInternal(outerConnection, connectionFactory, retry, forceNewConnection: false,timeout);
+            TryOpenConnectionInternal(outerConnection, connectionFactory, retry, forceNewConnection: false, timeout);
 
         /// <inheritdoc/>
         internal override void ResetConnection() => throw ADP.ClosedConnectionError();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -925,6 +925,7 @@ namespace Microsoft.Data.ProviderBase
             DbConnection outerConnection,
             SqlConnectionFactory connectionFactory,
             TaskCompletionSource<DbConnectionInternal> retry,
+            bool forceNewConnection,
             TimeoutTimer timeout)
         {
             // ?->Connecting: prevent set_ConnectionString during Open
@@ -934,7 +935,13 @@ namespace Microsoft.Data.ProviderBase
                 try
                 {
                     connectionFactory.PermissionDemand(outerConnection);
-                    if (!connectionFactory.TryGetConnection(outerConnection, retry, this, timeout, out openConnection))
+                    if (!connectionFactory.TryGetConnection(
+                            outerConnection, 
+                            retry, 
+                            this, 
+                            timeout, 
+                            forceNewConnection, 
+                            out openConnection))
                     {
                         return false;
                     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/ProviderBase/DbConnectionInternal.cs
@@ -735,11 +735,6 @@ namespace Microsoft.Data.ProviderBase
             }
         }
 
-        internal virtual void PrepareForReplaceConnection()
-        {
-            // By default, there is no preparation required
-        }
-
         /// <summary>
         /// Stamps <see cref="ReturnedTime"/> with the current UTC time. The pool calls this from its
         /// return-to-pool path only when it intends the idle-timeout machinery to act on the value;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Connection/SqlConnectionInternal.cs
@@ -1969,7 +1969,7 @@ namespace Microsoft.Data.SqlClient.Connection
             TaskCompletionSource<DbConnectionInternal> retry,
             TimeoutTimer timeout)
         {
-            return TryOpenConnectionInternal(outerConnection, connectionFactory, retry, timeout);
+            return TryOpenConnectionInternal(outerConnection, connectionFactory, retry, forceNewConnection: true, timeout);
         }
 
         internal void ValidateConnectionForExecute(SqlCommand command)

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/ConnectionPool/WaitHandleDbConnectionPool.cs
@@ -1203,7 +1203,6 @@ namespace Microsoft.Data.SqlClient.ConnectionPool
             {
                 SqlClientDiagnostics.Metrics.SoftConnectRequest();
                 PrepareConnection(owningObject, newConnection, oldConnection.EnlistedTransaction);
-                oldConnection.PrepareForReplaceConnection();
                 oldConnection.DeactivateConnection();
                 oldConnection.Dispose();
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1666,7 +1666,7 @@ namespace Microsoft.Data.SqlClient
                     commandTimeoutExpiration = ADP.TimerCurrent() + ADP.TimerFromSeconds(timeout);
                 }
 
-                // Calling close will request a cancellation on this token source, cancelling the reconnection.
+                // Calling Close will request a cancellation on this token source, cancelling the reconnection.
                 // Ideally, however, the reconnect should be directly awaited, making it impossible to have a
                 // concurrent call to Close.
                 // TODO: Note that we do not respect the command timeout in this context. Instead, the reconnect gets
@@ -2258,8 +2258,8 @@ namespace Microsoft.Data.SqlClient
         /// The inner connection is snapshotted after the open call so downstream parser access uses a single observed
         /// instance and does not rely on a second racy read of <see cref="InnerConnection"/>.
         /// 
-        /// forceNewConnection may only be true when the connection is already open and needs to be replaced. If the connection has never,
-        /// been opened, passing true will result in an exception. It may only be false when the connection has never been opened or is 
+        /// forceNewConnection may only be true when the connection is already open and needs to be replaced. If the connection has never
+        /// been opened, passing true will result in an exception. It may only be false when the connection has never been opened or is
         /// currently disconnected. If the connection is currently open, passing false will result in an exception. See SqlConnection state
         /// transitions and subclasses for more details.
         /// </remarks>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1595,8 +1595,8 @@ namespace Microsoft.Data.SqlClient
         public override void Open() =>
             Open(SqlConnectionOverrides.None);
 
-        private bool TryOpenWithRetry(TaskCompletionSource<DbConnectionInternal> retry, SqlConnectionOverrides overrides)
-            => RetryLogicProvider.Execute(this, () => TryOpen(retry, false, overrides));
+        private bool TryOpenWithRetry(TaskCompletionSource<DbConnectionInternal> retry, bool forceNewConnection,SqlConnectionOverrides overrides)
+            => RetryLogicProvider.Execute(this, () => TryOpen(retry, forceNewConnection, overrides));
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OpenWithOverrides/*' />
         public void Open(SqlConnectionOverrides overrides)
@@ -1616,7 +1616,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
 
-                    if (!(IsProviderRetriable ? TryOpenWithRetry(null, overrides) : TryOpen(null, false, overrides)))
+                    if (!(IsProviderRetriable ? TryOpenWithRetry(null, false, overrides) : TryOpen(null, false, overrides)))
                     {
                         throw ADP.InternalError(ADP.InternalErrorCode.SynchronousConnectReturnedPending);
                     }
@@ -1696,7 +1696,7 @@ namespace Microsoft.Data.SqlClient
                             {
                                 await InternalOpenAsync(SqlConnectionOverrides.None, true, ctoken).ConfigureAwait(false);
                             }
-                            
+
                             // On success, increment the reconnect count - we don't really care if it rolls over since it is approx.
                             _reconnectCount = unchecked(_reconnectCount + 1);
 #if DEBUG

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1595,7 +1595,7 @@ namespace Microsoft.Data.SqlClient
         public override void Open() =>
             Open(SqlConnectionOverrides.None);
 
-        private bool TryOpenWithRetry(TaskCompletionSource<DbConnectionInternal> retry, bool forceNewConnection,SqlConnectionOverrides overrides)
+        private bool TryOpenWithRetry(TaskCompletionSource<DbConnectionInternal> retry, bool forceNewConnection, SqlConnectionOverrides overrides)
             => RetryLogicProvider.Execute(this, () => TryOpen(retry, forceNewConnection, overrides));
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OpenWithOverrides/*' />
@@ -1690,11 +1690,11 @@ namespace Microsoft.Data.SqlClient
                         {
                             if (IsProviderRetriable)
                             {
-                                await InternalOpenWithRetryAsync(SqlConnectionOverrides.None, true, ctoken).ConfigureAwait(false);
+                                await InternalOpenWithRetryAsync(SqlConnectionOverrides.None, forceNewConnection: true, ctoken).ConfigureAwait(false);
                             }
                             else
                             {
-                                await InternalOpenAsync(SqlConnectionOverrides.None, true, ctoken).ConfigureAwait(false);
+                                await InternalOpenAsync(SqlConnectionOverrides.None, forceNewConnection: true, ctoken).ConfigureAwait(false);
                             }
 
                             // On success, increment the reconnect count - we don't really care if it rolls over since it is approx.
@@ -1917,8 +1917,8 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OpenAsyncWithOverrides/*' />
         public Task OpenAsync(SqlConnectionOverrides overrides, CancellationToken cancellationToken)
             => IsProviderRetriable ?
-                InternalOpenWithRetryAsync(overrides, false, cancellationToken) :
-                InternalOpenAsync(overrides, false, cancellationToken);
+                InternalOpenWithRetryAsync(overrides, forceNewConnection: false, cancellationToken) :
+                InternalOpenAsync(overrides, forceNewConnection: false, cancellationToken);
 
         private Task InternalOpenWithRetryAsync(SqlConnectionOverrides overrides, bool forceNewConnection, CancellationToken cancellationToken)
             => RetryLogicProvider.ExecuteAsync(this, () => InternalOpenAsync(overrides, forceNewConnection, cancellationToken), cancellationToken);
@@ -2258,7 +2258,7 @@ namespace Microsoft.Data.SqlClient
         /// The inner connection is snapshotted after the open call so downstream parser access uses a single observed
         /// instance and does not rely on a second racy read of <see cref="InnerConnection"/>.
         /// 
-        /// forceNewConnection may only be true when the connection is already open and needs to be replaced. If the connection has never
+        /// forceNewConnection may only be true when the connection is already open (or was open) and needs to be replaced. If the connection has never
         /// been opened, passing true will result in an exception. It may only be false when the connection has never been opened or is
         /// currently disconnected. If the connection is currently open, passing false will result in an exception. See SqlConnection state
         /// transitions and subclasses for more details.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1688,7 +1688,15 @@ namespace Microsoft.Data.SqlClient
 #endif
                         try
                         {
-                            await ReconnectAsync(ctoken).ConfigureAwait(false);
+                            if (IsProviderRetriable)
+                            {
+                                await InternalOpenWithRetryAsync(SqlConnectionOverrides.None, true, ctoken).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                await InternalOpenAsync(SqlConnectionOverrides.None, true, ctoken).ConfigureAwait(false);
+                            }
+                            
                             // On success, increment the reconnect count - we don't really care if it rolls over since it is approx.
                             _reconnectCount = unchecked(_reconnectCount + 1);
 #if DEBUG
@@ -1911,40 +1919,6 @@ namespace Microsoft.Data.SqlClient
             => IsProviderRetriable ?
                 InternalOpenWithRetryAsync(overrides, false, cancellationToken) :
                 InternalOpenAsync(overrides, false, cancellationToken);
-
-        /// <summary>
-        /// Re-establishes the underlying physical connection for an already-open <see cref="SqlConnection"/>,
-        /// replacing its current (broken) inner connection with a fresh one while preserving the outer
-        /// <see cref="SqlConnection"/> object. Used by the connection-resiliency reconnect path.
-        /// </summary>
-        /// <param name="cancellationToken">A token that cancels the reconnect attempt.</param>
-        /// <returns>A task that completes when the connection has been re-established.</returns>
-        /// <remarks>
-        /// Unlike <see cref="OpenAsync(CancellationToken)"/>, this forces a new underlying connection (it must
-        /// only be called when the connection is already open), so the replacement flows through
-        /// <see cref="TryOpenInner"/> with <c>forceNewConnection</c> set to <see langword="true"/>.
-        /// </remarks>
-        internal Task ReconnectAsync(CancellationToken cancellationToken)
-            => ReconnectAsync(SqlConnectionOverrides.None, cancellationToken);
-
-        /// <summary>
-        /// Re-establishes the underlying physical connection for an already-open <see cref="SqlConnection"/>,
-        /// replacing its current (broken) inner connection with a fresh one while preserving the outer
-        /// <see cref="SqlConnection"/> object. Used by the connection-resiliency reconnect path.
-        /// </summary>
-        /// <param name="overrides">Options that relax some of the checks performed when opening the connection.</param>
-        /// <param name="cancellationToken">A token that cancels the reconnect attempt.</param>
-        /// <returns>A task that completes when the connection has been re-established.</returns>
-        /// <remarks>
-        /// Unlike <see cref="OpenAsync(SqlConnectionOverrides, CancellationToken)"/>, this forces a new
-        /// underlying connection (it must only be called when the connection is already open), so the
-        /// replacement flows through <see cref="TryOpenInner"/> with <c>forceNewConnection</c> set to
-        /// <see langword="true"/>. The provider retry logic is applied when <see cref="IsProviderRetriable"/>.
-        /// </remarks>
-        internal Task ReconnectAsync(SqlConnectionOverrides overrides, CancellationToken cancellationToken)
-            => IsProviderRetriable ?
-                InternalOpenWithRetryAsync(overrides, true, cancellationToken) :
-                InternalOpenAsync(overrides, true, cancellationToken);
 
         private Task InternalOpenWithRetryAsync(SqlConnectionOverrides overrides, bool forceNewConnection, CancellationToken cancellationToken)
             => RetryLogicProvider.ExecuteAsync(this, () => InternalOpenAsync(overrides, forceNewConnection, cancellationToken), cancellationToken);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1912,9 +1912,35 @@ namespace Microsoft.Data.SqlClient
                 InternalOpenWithRetryAsync(overrides, false, cancellationToken) :
                 InternalOpenAsync(overrides, false, cancellationToken);
 
+        /// <summary>
+        /// Re-establishes the underlying physical connection for an already-open <see cref="SqlConnection"/>,
+        /// replacing its current (broken) inner connection with a fresh one while preserving the outer
+        /// <see cref="SqlConnection"/> object. Used by the connection-resiliency reconnect path.
+        /// </summary>
+        /// <param name="cancellationToken">A token that cancels the reconnect attempt.</param>
+        /// <returns>A task that completes when the connection has been re-established.</returns>
+        /// <remarks>
+        /// Unlike <see cref="OpenAsync(CancellationToken)"/>, this forces a new underlying connection (it must
+        /// only be called when the connection is already open), so the replacement flows through
+        /// <see cref="TryOpenInner"/> with <c>forceNewConnection</c> set to <see langword="true"/>.
+        /// </remarks>
         internal Task ReconnectAsync(CancellationToken cancellationToken)
             => ReconnectAsync(SqlConnectionOverrides.None, cancellationToken);
 
+        /// <summary>
+        /// Re-establishes the underlying physical connection for an already-open <see cref="SqlConnection"/>,
+        /// replacing its current (broken) inner connection with a fresh one while preserving the outer
+        /// <see cref="SqlConnection"/> object. Used by the connection-resiliency reconnect path.
+        /// </summary>
+        /// <param name="overrides">Options that relax some of the checks performed when opening the connection.</param>
+        /// <param name="cancellationToken">A token that cancels the reconnect attempt.</param>
+        /// <returns>A task that completes when the connection has been re-established.</returns>
+        /// <remarks>
+        /// Unlike <see cref="OpenAsync(SqlConnectionOverrides, CancellationToken)"/>, this forces a new
+        /// underlying connection (it must only be called when the connection is already open), so the
+        /// replacement flows through <see cref="TryOpenInner"/> with <c>forceNewConnection</c> set to
+        /// <see langword="true"/>. The provider retry logic is applied when <see cref="IsProviderRetriable"/>.
+        /// </remarks>
         internal Task ReconnectAsync(SqlConnectionOverrides overrides, CancellationToken cancellationToken)
             => IsProviderRetriable ?
                 InternalOpenWithRetryAsync(overrides, true, cancellationToken) :
@@ -2107,7 +2133,7 @@ namespace Microsoft.Data.SqlClient
                 _result = result;
                 _overrides = overrides;
                 _registration = registration;
-                _forceNewConnection = false;
+                _forceNewConnection = forceNewConnection;
                 SqlClientEventSource.Log.TryTraceEvent("SqlConnection.OpenAsyncRetry | Info | Object Id {0}", _parent?.ObjectID);
             }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnection.cs
@@ -1223,8 +1223,6 @@ namespace Microsoft.Data.SqlClient
             get => _reconnectCount;
         }
 
-        internal bool ForceNewConnection { get; set; }
-
 #if NET
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OnStateChange/*' />
         protected override void OnStateChange(StateChangeEventArgs stateChange)
@@ -1598,7 +1596,7 @@ namespace Microsoft.Data.SqlClient
             Open(SqlConnectionOverrides.None);
 
         private bool TryOpenWithRetry(TaskCompletionSource<DbConnectionInternal> retry, SqlConnectionOverrides overrides)
-            => RetryLogicProvider.Execute(this, () => TryOpen(retry, overrides));
+            => RetryLogicProvider.Execute(this, () => TryOpen(retry, false, overrides));
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OpenWithOverrides/*' />
         public void Open(SqlConnectionOverrides overrides)
@@ -1618,7 +1616,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     statistics = SqlStatistics.StartTimer(Statistics);
 
-                    if (!(IsProviderRetriable ? TryOpenWithRetry(null, overrides) : TryOpen(null, overrides)))
+                    if (!(IsProviderRetriable ? TryOpenWithRetry(null, overrides) : TryOpen(null, false, overrides)))
                     {
                         throw ADP.InternalError(ADP.InternalErrorCode.SynchronousConnectReturnedPending);
                     }
@@ -1667,6 +1665,12 @@ namespace Microsoft.Data.SqlClient
                 {
                     commandTimeoutExpiration = ADP.TimerCurrent() + ADP.TimerFromSeconds(timeout);
                 }
+
+                // Calling close will request a cancellation on this token source, cancelling the reconnection.
+                // Ideally, however, the reconnect should be directly awaited, making it impossible to have a
+                // concurrent call to Close.
+                // TODO: Note that we do not respect the command timeout in this context. Instead, the reconnect gets
+                // a full connect timeout. Investigate if this should be changed.
                 _reconnectionCancellationSource = cts;
                 CancellationToken ctoken = cts.Token;
                 int retryCount = _connectRetryCount; // take a snapshot: could be changed by modifying the connection string
@@ -1684,8 +1688,7 @@ namespace Microsoft.Data.SqlClient
 #endif
                         try
                         {
-                            ForceNewConnection = true;
-                            await OpenAsync(ctoken).ConfigureAwait(false);
+                            await ReconnectAsync(ctoken).ConfigureAwait(false);
                             // On success, increment the reconnect count - we don't really care if it rolls over since it is approx.
                             _reconnectCount = unchecked(_reconnectCount + 1);
 #if DEBUG
@@ -1697,7 +1700,6 @@ namespace Microsoft.Data.SqlClient
 #if NETFRAMEWORK
                             _impersonateIdentity = null;
 #endif
-                            ForceNewConnection = false;
                         }
 
                         SqlClientEventSource.Log.TryTraceEvent("SqlConnection.ReconnectAsync | Info | Reconnection succeeded. Client Connection Id {0} -> {1}", _originalConnectionId, ClientConnectionId);
@@ -1907,13 +1909,21 @@ namespace Microsoft.Data.SqlClient
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlConnection.xml' path='docs/members[@name="SqlConnection"]/OpenAsyncWithOverrides/*' />
         public Task OpenAsync(SqlConnectionOverrides overrides, CancellationToken cancellationToken)
             => IsProviderRetriable ?
-                InternalOpenWithRetryAsync(overrides, cancellationToken) :
-                InternalOpenAsync(overrides, cancellationToken);
+                InternalOpenWithRetryAsync(overrides, false, cancellationToken) :
+                InternalOpenAsync(overrides, false, cancellationToken);
 
-        private Task InternalOpenWithRetryAsync(SqlConnectionOverrides overrides, CancellationToken cancellationToken)
-            => RetryLogicProvider.ExecuteAsync(this, () => InternalOpenAsync(overrides, cancellationToken), cancellationToken);
+        internal Task ReconnectAsync(CancellationToken cancellationToken)
+            => ReconnectAsync(SqlConnectionOverrides.None, cancellationToken);
 
-        private Task InternalOpenAsync(SqlConnectionOverrides overrides, CancellationToken cancellationToken)
+        internal Task ReconnectAsync(SqlConnectionOverrides overrides, CancellationToken cancellationToken)
+            => IsProviderRetriable ?
+                InternalOpenWithRetryAsync(overrides, true, cancellationToken) :
+                InternalOpenAsync(overrides, true, cancellationToken);
+
+        private Task InternalOpenWithRetryAsync(SqlConnectionOverrides overrides, bool forceNewConnection, CancellationToken cancellationToken)
+            => RetryLogicProvider.ExecuteAsync(this, () => InternalOpenAsync(overrides, forceNewConnection, cancellationToken), cancellationToken);
+
+        private Task InternalOpenAsync(SqlConnectionOverrides overrides, bool forceNewConnection, CancellationToken cancellationToken)
         {
             long scopeID = SqlClientEventSource.Log.TryPoolerScopeEnterEvent("SqlConnection.InternalOpenAsync | API | Object Id {0}", ObjectID);
             SqlClientEventSource.Log.TryCorrelationTraceEvent("SqlConnection.InternalOpenAsync | API | Correlation | Object Id {0}, Activity Id {1}", ObjectID, ActivityCorrelator.Current);
@@ -1955,7 +1965,7 @@ namespace Microsoft.Data.SqlClient
 
                     try
                     {
-                        completed = TryOpen(completion, overrides);
+                        completed = TryOpen(completion, forceNewConnection, overrides);
                     }
                     catch (Exception e)
                     {
@@ -1975,7 +1985,7 @@ namespace Microsoft.Data.SqlClient
                         {
                             registration = cancellationToken.Register(s_openAsyncCancel, completion);
                         }
-                        OpenAsyncRetry retry = new OpenAsyncRetry(this, completion, result, overrides, registration);
+                        OpenAsyncRetry retry = new OpenAsyncRetry(this, completion, result, overrides, registration, forceNewConnection);
                         _currentCompletion = new Tuple<TaskCompletionSource<DbConnectionInternal>, Task>(completion, result.Task);
                         completion.Task.ContinueWith(retry.Retry, TaskScheduler.Default);
                         return result.Task;
@@ -2088,14 +2098,16 @@ namespace Microsoft.Data.SqlClient
             private TaskCompletionSource<object> _result;
             private SqlConnectionOverrides _overrides;
             private CancellationTokenRegistration _registration;
+            private bool _forceNewConnection;
 
-            public OpenAsyncRetry(SqlConnection parent, TaskCompletionSource<DbConnectionInternal> retry, TaskCompletionSource<object> result, SqlConnectionOverrides overrides, CancellationTokenRegistration registration)
+            public OpenAsyncRetry(SqlConnection parent, TaskCompletionSource<DbConnectionInternal> retry, TaskCompletionSource<object> result, SqlConnectionOverrides overrides, CancellationTokenRegistration registration, bool forceNewConnection)
             {
                 _parent = parent;
                 _retry = retry;
                 _result = result;
                 _overrides = overrides;
                 _registration = registration;
+                _forceNewConnection = false;
                 SqlClientEventSource.Log.TryTraceEvent("SqlConnection.OpenAsyncRetry | Info | Object Id {0}", _parent?.ObjectID);
             }
 
@@ -2130,7 +2142,7 @@ namespace Microsoft.Data.SqlClient
                             // protect continuation from races with close and cancel
                             lock (_parent.InnerConnection)
                             {
-                                result = _parent.TryOpen(_retry, _overrides);
+                                result = _parent.TryOpen(_retry, _forceNewConnection, _overrides);
                             }
                             if (result)
                             {
@@ -2176,7 +2188,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        private bool TryOpen(TaskCompletionSource<DbConnectionInternal> retry, SqlConnectionOverrides overrides = SqlConnectionOverrides.None)
+        private bool TryOpen(TaskCompletionSource<DbConnectionInternal> retry, bool forceNewConnection, SqlConnectionOverrides overrides = SqlConnectionOverrides.None)
         {
             bool result = false;
 
@@ -2206,13 +2218,13 @@ namespace Microsoft.Data.SqlClient
                 {
                     if (_impersonateIdentity.User == identity.User)
                     {
-                        result = TryOpenInner(retry);
+                        result = TryOpenInner(retry, forceNewConnection);
                     }
                     else
                     {
                         using (WindowsImpersonationContext context = _impersonateIdentity.Impersonate())
                         {
-                            result = TryOpenInner(retry);
+                            result = TryOpenInner(retry, forceNewConnection);
                         }
                     }
                 }
@@ -2227,10 +2239,10 @@ namespace Microsoft.Data.SqlClient
                 {
                     _lastIdentity = null;
                 }
-                result = TryOpenInner(retry);
+                result = TryOpenInner(retry, forceNewConnection);
             }
 #else
-            result = TryOpenInner(retry);
+            result = TryOpenInner(retry, forceNewConnection);
 #endif
 
             return result;
@@ -2240,12 +2252,18 @@ namespace Microsoft.Data.SqlClient
         /// Completes the inner open/replace operation and initializes parser state for the active inner connection.
         /// </summary>
         /// <param name="retry">Retry continuation used by async open paths.</param>
+        /// <param name="forceNewConnection">Provide true to forcibly overwrite the existing connection. Provide false if connecting for the first time.</param>
         /// <returns><see langword="true"/> when open initialization completed synchronously; otherwise <see langword="false"/>.</returns>
         /// <remarks>
         /// The inner connection is snapshotted after the open call so downstream parser access uses a single observed
         /// instance and does not rely on a second racy read of <see cref="InnerConnection"/>.
+        /// 
+        /// forceNewConnection may only be true when the connection is already open and needs to be replaced. If the connection has never,
+        /// been opened, passing true will result in an exception. It may only be false when the connection has never been opened or is 
+        /// currently disconnected. If the connection is currently open, passing false will result in an exception. See SqlConnection state
+        /// transitions and subclasses for more details.
         /// </remarks>
-        internal bool TryOpenInner(TaskCompletionSource<DbConnectionInternal> retry)
+        internal bool TryOpenInner(TaskCompletionSource<DbConnectionInternal> retry, bool forceNewConnection)
         {
             // Create a single TimeoutTimer that represents the overall connection-open budget for this
             // attempt. The timer is threaded through every layer (inner connection state transitions,
@@ -2257,7 +2275,7 @@ namespace Microsoft.Data.SqlClient
             TimeoutTimer timeout = TimeoutTimer.StartNew(
                 TimeSpan.FromSeconds(ConnectionOptions?.ConnectTimeout ?? ADP.DefaultConnectionTimeout));
 
-            if (ForceNewConnection)
+            if (forceNewConnection)
             {
                 if (!InnerConnection.TryReplaceConnection(this, ConnectionFactory, retry, timeout))
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -318,6 +318,7 @@ namespace Microsoft.Data.SqlClient
             TaskCompletionSource<DbConnectionInternal> retry,
             DbConnectionInternal oldConnection,
             TimeoutTimer timeout,
+            bool forceNewConnection,
             out DbConnectionInternal connection)
         {
             Debug.Assert(owningConnection is not null, "null owningConnection?");
@@ -419,7 +420,7 @@ namespace Microsoft.Data.SqlClient
                 }
                 else
                 {
-                    if (((SqlConnection)owningConnection).ForceNewConnection)
+                    if (forceNewConnection)
                     {
                         Debug.Assert(oldConnection is not DbConnectionClosed, "Force new connection, but there is no old connection");
                         

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -777,7 +777,6 @@ namespace Microsoft.Data.SqlClient
                         
                         if (oldConnection?.State == ConnectionState.Open)
                         {
-                            oldConnection.PrepareForReplaceConnection();
                             oldConnection.Dispose();
                         }
                         

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionConcurrentOpenTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionConcurrentOpenTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
 
             Exception ex = Assert.ThrowsAny<Exception>(() =>
             {
-                connection.TryOpenInner(completedRetry, false);
+                connection.TryOpenInner(completedRetry, forceNewConnection: false);
             });
 
             Assert.True(

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionConcurrentOpenTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionConcurrentOpenTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Data;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Data.ProviderBase;
 using Microsoft.Data.SqlClient.Connection;
@@ -26,9 +25,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
     /// </summary>
     public class SqlConnectionConcurrentOpenTests
     {
-        private static readonly MethodInfo s_tryOpenInner = typeof(SqlConnection)
-            .GetMethod("TryOpenInner", BindingFlags.Instance | BindingFlags.NonPublic)!;
-
         private static DbConnectionInternal GetConnectingSingleton()
         {
             return DbConnectionClosedConnecting.SingletonInstance;
@@ -41,18 +37,6 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
             DbConnectionInternal current = connection.InnerConnection;
             bool swapped = connection.SetInnerConnectionFrom(innerConnectionValue, current);
             Assert.True(swapped, $"CAS failed: expected current state {current.GetType().Name} but it changed concurrently.");
-        }
-
-        private static bool InvokeTryOpenInner(SqlConnection connection, TaskCompletionSource<DbConnectionInternal> retry)
-        {
-            try
-            {
-                return (bool)s_tryOpenInner.Invoke(connection, [retry])!;
-            }
-            catch (TargetInvocationException tie) when (tie.InnerException != null)
-            {
-                throw tie.InnerException;
-            }
         }
 
         [Fact]
@@ -102,7 +86,7 @@ namespace Microsoft.Data.SqlClient.UnitTests.Microsoft.Data.SqlClient
 
             Exception ex = Assert.ThrowsAny<Exception>(() =>
             {
-                InvokeTryOpenInner(connection, completedRetry);
+                connection.TryOpenInner(completedRetry, false);
             });
 
             Assert.True(

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionStateTransitionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionStateTransitionTests.cs
@@ -27,7 +27,7 @@ public class SqlConnectionStateTransitionTests
         bool initialized = connection.SetInnerConnectionFrom(new TestRaceDbConnectionInternal(), DbConnectionClosedNeverOpened.SingletonInstance);
         Assert.True(initialized);
 
-        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => connection.TryOpenInner(null, false));
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => connection.TryOpenInner(null, forceNewConnection: false));
         Assert.NotNull(exception);
         Assert.Same(DbConnectionClosedPreviouslyOpened.SingletonInstance, connection.InnerConnection);
     }
@@ -42,7 +42,7 @@ public class SqlConnectionStateTransitionTests
         bool initialized = connection.SetInnerConnectionFrom(new TestRaceDbConnectionInternal(), DbConnectionClosedNeverOpened.SingletonInstance);
         Assert.True(initialized);
 
-        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => connection.TryOpenInner(null, true));
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => connection.TryOpenInner(null, forceNewConnection: true));
         Assert.NotNull(exception);
         Assert.Same(DbConnectionClosedPreviouslyOpened.SingletonInstance, connection.InnerConnection);
     }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionStateTransitionTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/Microsoft/Data/SqlClient/SqlConnectionStateTransitionTests.cs
@@ -24,11 +24,10 @@ public class SqlConnectionStateTransitionTests
     public void TryOpenInner_WhenInnerConnectionChangesAfterTryOpen_ThrowsInvalidOperation()
     {
         using SqlConnection connection = new();
-        connection.ForceNewConnection = false;
         bool initialized = connection.SetInnerConnectionFrom(new TestRaceDbConnectionInternal(), DbConnectionClosedNeverOpened.SingletonInstance);
         Assert.True(initialized);
 
-        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => connection.TryOpenInner(null));
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => connection.TryOpenInner(null, false));
         Assert.NotNull(exception);
         Assert.Same(DbConnectionClosedPreviouslyOpened.SingletonInstance, connection.InnerConnection);
     }
@@ -40,11 +39,10 @@ public class SqlConnectionStateTransitionTests
     public void TryOpenInner_WhenInnerConnectionChangesAfterTryReplace_ThrowsInvalidOperation()
     {
         using SqlConnection connection = new();
-        connection.ForceNewConnection = true;
         bool initialized = connection.SetInnerConnectionFrom(new TestRaceDbConnectionInternal(), DbConnectionClosedNeverOpened.SingletonInstance);
         Assert.True(initialized);
 
-        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => connection.TryOpenInner(null));
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => connection.TryOpenInner(null, true));
         Assert.NotNull(exception);
         Assert.Same(DbConnectionClosedPreviouslyOpened.SingletonInstance, connection.InnerConnection);
     }


### PR DESCRIPTION
This PR is a refactor in service of #AB44829

Idle connection resiliency is a feature that replaces broken connections in-line before running a command. It utilizes a "replace" flow that follows the normal "open" flow but with a `ForceNewConnection` property set on `SqlConnection`. At certain critical points, we branch on this property to "create new" or "replace". These are really the same thing, but are exposed in a mutually exclusive way on the DbConnectionInternal subtypes. There's always one that works and the other throws NotImplementedException or InvalidOperationException.

It's very hard to understand where the property is set and when it might change. This PR removes the property and passes the desired behavior as a boolean argument.