### PR TITLE
Tests: SNIClose close-during-async-IO regression tests AB#43847 

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseDeadlockTest.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests
+{
+    /// <summary>
+    /// Live-server regression test for ADO.Net work item 43847 / ICM 775308542:
+    /// "SNIClose can deadlock with in-flight async I/O during connection close".
+    ///
+    /// <para>
+    /// This is the MARS-enabled counterpart to the in-process
+    /// <c>SNICloseDeadlockTest</c> unit tests. The native <c>Dispose()</c> path
+    /// in <c>TdsParserStateObjectNative</c> carries a long-standing "UNDONE"
+    /// note about needing to block for pending callbacks on <b>logical</b>
+    /// (MARS) connections during close. The in-process TDS test server does not
+    /// support MARS, so exercising the SMUX logical-session close path requires
+    /// a real SQL Server.
+    /// </para>
+    ///
+    /// <para>
+    /// The test enables MARS and starts an asynchronous read of a batch that the
+    /// server deliberately withholds (<c>WAITFOR DELAY</c>). This guarantees the
+    /// client's async read is genuinely in flight on a MARS logical session at
+    /// the moment the connection is closed. The close is performed on a worker
+    /// thread under a bounded wait: a deadlock manifests as the wait timing out,
+    /// which fails the test. A healthy close aborts the in-flight command and
+    /// returns promptly.
+    /// </para>
+    /// </summary>
+    [Trait("Set", "1")]
+    public class MarsCloseDeadlockTest
+    {
+        /// <summary>
+        /// How long the server withholds the response. Must comfortably exceed
+        /// <see cref="CloseBudget"/> so that a prompt close is attributable to
+        /// the close path aborting the command, not to the query completing on
+        /// its own.
+        /// </summary>
+        private const string StallDelay = "00:00:30";
+
+        /// <summary>
+        /// Upper bound for how long a non-deadlocked close should take. Close of
+        /// a connection with an in-flight command is effectively instantaneous;
+        /// this budget only distinguishes "completed" from "deadlocked" without
+        /// hanging the run on a slow agent.
+        /// </summary>
+        private static readonly TimeSpan CloseBudget = TimeSpan.FromSeconds(15);
+
+        /// <summary>
+        /// How long to wait to confirm the async read is genuinely pending (not
+        /// completed) before closing. Small relative to <see cref="StallDelay"/>.
+        /// </summary>
+        private static readonly TimeSpan PendingConfirmDelay = TimeSpan.FromSeconds(3);
+
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void CloseOrDispose_WithPendingMarsAsyncRead_DoesNotDeadlock(bool disposeInsteadOfClose)
+        {
+            // Enable MARS so the async read runs over a SMUX logical session, and
+            // disable pooling so Close()/Dispose() tears down the physical
+            // connection (reaching SNIClose) instead of returning it to the pool.
+            string connectionString =
+                new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString)
+                {
+                    MultipleActiveResultSets = true,
+                    Pooling = false,
+                }.ConnectionString;
+
+            SqlConnection connection = new(connectionString);
+            connection.Open();
+
+            SqlCommand command =
+                new($"WAITFOR DELAY '{StallDelay}'; SELECT 1;", connection);
+
+            // Start an async read that will pend: the server withholds the
+            // response for StallDelay, so this Task will not complete until we
+            // either wait out the delay or tear down the connection.
+            Task<SqlDataReader> readTask = command.ExecuteReaderAsync();
+
+            // Confirm the read is genuinely in flight before we close: it must
+            // not have completed and the connection must still be open.
+            Assert.False(
+                readTask.Wait(PendingConfirmDelay),
+                "The async read completed before the server released the " +
+                "response; the read was not in flight at close time.");
+            Assert.Equal(ConnectionState.Open, connection.State);
+
+            // Close/dispose the connection on a worker thread while the MARS
+            // async read is in flight. This is the operation that can deadlock
+            // in SNIClose.
+            Task closeTask = Task.Run(() =>
+            {
+                if (disposeInsteadOfClose)
+                {
+                    connection.Dispose();
+                }
+                else
+                {
+                    connection.Close();
+                }
+            });
+
+            bool closedInTime = closeTask.Wait(CloseBudget);
+
+            // Observe the read task so its (expected) failure is not unobserved.
+            try
+            {
+                readTask.Wait(CloseBudget);
+            }
+            catch
+            {
+                // The pending read is expected to fault or cancel once the
+                // connection is torn down. That is not what this test asserts.
+            }
+            finally
+            {
+                command.Dispose();
+                connection.Dispose();
+            }
+
+            Assert.True(
+                closedInTime,
+                $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not " +
+                $"complete within {CloseBudget.TotalSeconds:N0}s while a MARS " +
+                "async read was in flight. This indicates the SNIClose deadlock " +
+                "(ADO.Net #43847 / ICM 775308542).");
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseDeadlockTest.cs
@@ -122,7 +122,14 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             finally
             {
                 command.Dispose();
-                connection.Dispose();
+                // Only perform potentially-blocking cleanup if the close
+                // completed. If it deadlocked (closedInTime == false), calling
+                // Dispose() here could also block indefinitely and defeat the
+                // bounded-wait regression signal asserted below.
+                if (closedInTime)
+                {
+                    connection.Dispose();
+                }
             }
 
             Assert.True(

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseDeadlockTest.cs
@@ -74,70 +74,88 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 }.ConnectionString;
 
             SqlConnection connection = new(connectionString);
-            connection.Open();
-
-            SqlCommand command =
-                new($"WAITFOR DELAY '{StallDelay}'; SELECT 1;", connection);
-
-            // Start an async read that will pend: the server withholds the
-            // response for StallDelay, so this Task will not complete until we
-            // either wait out the delay or tear down the connection.
-            Task<SqlDataReader> readTask = command.ExecuteReaderAsync();
-
-            // Confirm the read is genuinely in flight before we close: it must
-            // not have completed and the connection must still be open.
-            Assert.False(
-                readTask.Wait(PendingConfirmDelay),
-                "The async read completed before the server released the " +
-                "response; the read was not in flight at close time.");
-            Assert.Equal(ConnectionState.Open, connection.State);
-
-            // Close/dispose the connection on a worker thread while the MARS
-            // async read is in flight. This is the operation that can deadlock
-            // in SNIClose.
-            Task closeTask = Task.Run(() =>
-            {
-                if (disposeInsteadOfClose)
-                {
-                    connection.Dispose();
-                }
-                else
-                {
-                    connection.Close();
-                }
-            });
-
-            bool closedInTime = closeTask.Wait(CloseBudget);
-
-            // Observe the read task so its (expected) failure is not unobserved.
+            SqlCommand command = null;
+            Task<SqlDataReader> readTask = null;
+            bool closeAttempted = false;
+            bool closedInTime = false;
             try
             {
-                readTask.Wait(CloseBudget);
-            }
-            catch
-            {
-                // The pending read is expected to fault or cancel once the
-                // connection is torn down. That is not what this test asserts.
+                connection.Open();
+
+                command = new($"WAITFOR DELAY '{StallDelay}'; SELECT 1;", connection);
+
+                // Start an async read that will pend: the server withholds the
+                // response for StallDelay, so this Task will not complete until
+                // we either wait out the delay or tear down the connection.
+                readTask = command.ExecuteReaderAsync();
+
+                // Confirm the read is genuinely in flight before we close: it
+                // must not have completed and the connection must still be open.
+                Assert.False(
+                    readTask.Wait(PendingConfirmDelay),
+                    "The async read completed before the server released the " +
+                    "response; the read was not in flight at close time.");
+                Assert.Equal(ConnectionState.Open, connection.State);
+
+                // Close/dispose the connection on a dedicated, long-running
+                // thread while the MARS async read is in flight. This is the
+                // operation that can deadlock in SNIClose. A dedicated thread
+                // (rather than a thread-pool thread via Task.Run) ensures a
+                // hypothetical regression parks this one thread instead of
+                // starving the shared thread pool.
+                closeAttempted = true;
+                Task closeTask = Task.Factory.StartNew(
+                    () =>
+                    {
+                        if (disposeInsteadOfClose)
+                        {
+                            connection.Dispose();
+                        }
+                        else
+                        {
+                            connection.Close();
+                        }
+                    },
+                    TaskCreationOptions.LongRunning);
+
+                closedInTime = closeTask.Wait(CloseBudget);
+
+                Assert.True(
+                    closedInTime,
+                    $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not " +
+                    $"complete within {CloseBudget.TotalSeconds:N0}s while a MARS " +
+                    "async read was in flight. This indicates the SNIClose deadlock " +
+                    "(ADO.Net #43847 / ICM 775308542).");
             }
             finally
             {
-                command.Dispose();
-                // Only perform potentially-blocking cleanup if the close
-                // completed. If it deadlocked (closedInTime == false), calling
-                // Dispose() here could also block indefinitely and defeat the
-                // bounded-wait regression signal asserted below.
-                if (closedInTime)
+                // Observe the pending read so its (expected) fault is not
+                // unobserved, even if a precondition assert above threw.
+                if (readTask != null)
+                {
+                    try
+                    {
+                        readTask.Wait(CloseBudget);
+                    }
+                    catch
+                    {
+                        // The pending read is expected to fault or cancel once
+                        // the connection is torn down. That is not what this
+                        // test asserts.
+                    }
+                }
+
+                command?.Dispose();
+
+                // Dispose the connection unless a close deadlock was actually
+                // detected (in which case Dispose() could also block). Disposing
+                // is safe when the close worker never started or when it
+                // completed.
+                if (!closeAttempted || closedInTime)
                 {
                     connection.Dispose();
                 }
             }
-
-            Assert.True(
-                closedInTime,
-                $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not " +
-                $"complete within {CloseBudget.TotalSeconds:N0}s while a MARS " +
-                "async read was in flight. This indicates the SNIClose deadlock " +
-                "(ADO.Net #43847 / ICM 775308542).");
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseDeadlockTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Data;
 using System.Threading.Tasks;
@@ -74,8 +76,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 }.ConnectionString;
 
             SqlConnection connection = new(connectionString);
-            SqlCommand command = null;
-            Task<SqlDataReader> readTask = null;
+            SqlCommand? command = null;
+            Task<SqlDataReader>? readTask = null;
             bool closeAttempted = false;
             bool closedInTime = false;
             try

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseStressTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseStressTest.cs
@@ -38,8 +38,9 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// How long each server-side batch withholds its response. Must comfortably
         /// exceed <see cref="CloseBudget"/> so a prompt close is attributable to the
         /// close path aborting the command, not the query completing on its own.
+        /// Kept at 4x <see cref="CloseBudget"/> so the boundary is unambiguous.
         /// </summary>
-        private const string StallDelay = "00:00:30";
+        private const string StallDelay = "00:02:00";
 
         /// <summary>
         /// Upper bound for how long a batch of concurrent, non-deadlocked closes

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseStressTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseStressTest.cs
@@ -1,0 +1,164 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests
+{
+    /// <summary>
+    /// Concurrency-stress companion to <see cref="MarsCloseDeadlockTest"/> for
+    /// ADO.Net #43847 / ICM 775308542.
+    ///
+    /// <para>
+    /// Where <c>MarsCloseDeadlockTest</c> closes a single connection with one
+    /// in-flight MARS async read, this test opens <b>many</b> MARS connections -
+    /// each with an in-flight read - and closes them all <b>simultaneously</b>
+    /// (rendezvous on a <see cref="Barrier"/>), repeated over several iterations.
+    /// Piling concurrent closes onto the SMUX logical-session teardown path
+    /// widens the window for the close race called out by the long-standing
+    /// "Comment CloseMARSSession / UNDONE" note in the native <c>Dispose()</c>.
+    /// </para>
+    ///
+    /// <para>
+    /// Each batch of closes is awaited under a bounded wait: a deadlock manifests
+    /// as the wait timing out, which fails the test. A healthy close aborts the
+    /// in-flight commands and returns promptly.
+    /// </para>
+    /// </summary>
+    [Trait("Set", "1")]
+    public class MarsCloseStressTest
+    {
+        /// <summary>
+        /// How long each server-side batch withholds its response. Must comfortably
+        /// exceed <see cref="CloseBudget"/> so a prompt close is attributable to the
+        /// close path aborting the command, not the query completing on its own.
+        /// </summary>
+        private const string StallDelay = "00:00:30";
+
+        /// <summary>
+        /// Upper bound for how long a batch of concurrent, non-deadlocked closes
+        /// should take. Generous only to avoid false positives on slow agents.
+        /// </summary>
+        private static readonly TimeSpan CloseBudget = TimeSpan.FromSeconds(30);
+
+        /// <summary>Number of close-storm iterations.</summary>
+        private const int Iterations = 8;
+
+        /// <summary>MARS connections opened and closed together per iteration.</summary>
+        private const int ConnectionsPerIteration = 16;
+
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MarsConcurrentCloseStress_DoesNotDeadlock(bool disposeInsteadOfClose)
+        {
+            // Enable MARS so each async read runs over a SMUX logical session, and
+            // disable pooling so Close()/Dispose() tears down the physical
+            // connection (reaching SNIClose) instead of returning it to the pool.
+            string connectionString =
+                new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString)
+                {
+                    MultipleActiveResultSets = true,
+                    Pooling = false,
+                }.ConnectionString;
+
+            for (int iter = 0; iter < Iterations; iter++)
+            {
+                SqlConnection[] connections = new SqlConnection[ConnectionsPerIteration];
+                SqlCommand?[] commands = new SqlCommand?[ConnectionsPerIteration];
+                Task<SqlDataReader>?[] readTasks = new Task<SqlDataReader>?[ConnectionsPerIteration];
+                bool allClosed = false;
+                try
+                {
+                    for (int k = 0; k < ConnectionsPerIteration; k++)
+                    {
+                        connections[k] = new SqlConnection(connectionString);
+                        connections[k].Open();
+                        commands[k] = new SqlCommand($"WAITFOR DELAY '{StallDelay}'; SELECT 1;", connections[k]);
+                        readTasks[k] = commands[k]!.ExecuteReaderAsync();
+                    }
+
+                    // Confirm every read is genuinely in flight before closing.
+                    for (int k = 0; k < ConnectionsPerIteration; k++)
+                    {
+                        Assert.False(
+                            readTasks[k]!.Wait(TimeSpan.FromMilliseconds(50)),
+                            $"iteration {iter}, connection {k}: the async read completed before " +
+                            "close; it was not in flight.");
+                    }
+
+                    // Fire all closes at once through a barrier so they pile up on
+                    // the close path concurrently.
+                    using Barrier gate = new(ConnectionsPerIteration);
+                    Task[] closeTasks = new Task[ConnectionsPerIteration];
+                    for (int k = 0; k < ConnectionsPerIteration; k++)
+                    {
+                        int idx = k;
+                        closeTasks[k] = Task.Factory.StartNew(
+                            () =>
+                            {
+                                gate.SignalAndWait();
+                                if (disposeInsteadOfClose)
+                                {
+                                    connections[idx].Dispose();
+                                }
+                                else
+                                {
+                                    connections[idx].Close();
+                                }
+                            },
+                            TaskCreationOptions.LongRunning);
+                    }
+
+                    allClosed = Task.WaitAll(closeTasks, CloseBudget);
+
+                    Assert.True(
+                        allClosed,
+                        $"iteration {iter}: {ConnectionsPerIteration} concurrent MARS " +
+                        $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} calls did not all " +
+                        $"complete within {CloseBudget.TotalSeconds:N0}s. This indicates the " +
+                        "SNIClose deadlock (ADO.Net #43847 / ICM 775308542).");
+                }
+                finally
+                {
+                    for (int k = 0; k < ConnectionsPerIteration; k++)
+                    {
+                        if (readTasks[k] != null)
+                        {
+                            try
+                            {
+                                readTasks[k]!.Wait(TimeSpan.FromSeconds(5));
+                            }
+                            catch
+                            {
+                                // Reads are expected to fault or cancel on teardown.
+                            }
+                        }
+
+                        commands[k]?.Dispose();
+
+                        // Only dispose connections if the closes completed; a
+                        // deadlocked connection's Dispose() could also block.
+                        if (allClosed)
+                        {
+                            try
+                            {
+                                connections[k]?.Dispose();
+                            }
+                            catch
+                            {
+                                // Ignore teardown faults.
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Net;
 using System.Net.Sockets;

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
@@ -122,80 +122,98 @@ public class SNICloseDeadlockTest
         };
 
         SqlConnection connection = new(builder.ConnectionString);
-        connection.Open();
-
-        SqlCommand command = new("SELECT 1", connection);
-
-        // Start an async read that will pend: the server stalls in
-        // CreateQueryResponse, so this Task will not complete until we either
-        // release the server or tear down the connection.
-        Task<SqlDataReader> readTask = command.ExecuteReaderAsync();
-
-        // Ensure the async read is genuinely in flight before we close.
-        Assert.True(
-            batchReceived.Wait(HandshakeBudget),
-            "The server never received the SQL batch, so the async read was " +
-            "not in flight; the test cannot exercise the close-with-pending-IO path.");
-
-        // The server is stalled withholding the response, so the client's async
-        // read must still be pending: the Task cannot have completed and the
-        // connection must still be open. If either of these is false, the read
-        // is not actually in flight and the test is not exercising the
-        // close-with-pending-IO path.
-        Assert.False(
-            readTask.IsCompleted,
-            "The async read completed before the server released the response; " +
-            "the read was not in flight at close time.");
-        Assert.Equal(System.Data.ConnectionState.Open, connection.State);
-
-        // Close/dispose the connection on a worker thread while the async read
-        // is in flight. This is the operation that can deadlock in SNIClose.
-        Task closeTask = Task.Run(() =>
-        {
-            if (disposeInsteadOfClose)
-            {
-                connection.Dispose();
-            }
-            else
-            {
-                connection.Close();
-            }
-        });
-
-        bool closedInTime = closeTask.Wait(CloseBudget);
-
-        // Always release the stalled server thread so it can unwind and the
-        // server can be disposed cleanly, regardless of the outcome above.
-        releaseResponse.Set();
-
-        // Observe the read task so its (expected) failure is not unobserved.
+        SqlCommand? command = null;
+        Task<SqlDataReader>? readTask = null;
+        bool closeAttempted = false;
+        bool closedInTime = false;
         try
         {
-            readTask.Wait(CloseBudget);
-        }
-        catch
-        {
-            // The pending read is expected to fault or cancel once the
-            // connection is torn down. That is not what this test asserts.
+            connection.Open();
+
+            command = new("SELECT 1", connection);
+
+            // Start an async read that will pend: the server stalls in
+            // CreateQueryResponse, so this Task will not complete until we
+            // either release the server or tear down the connection.
+            readTask = command.ExecuteReaderAsync();
+
+            // Ensure the async read is genuinely in flight before we close.
+            Assert.True(
+                batchReceived.Wait(HandshakeBudget),
+                "The server never received the SQL batch, so the async read was " +
+                "not in flight; the test cannot exercise the close-with-pending-IO path.");
+
+            // The server is stalled withholding the response, so the client's
+            // async read must still be pending: the Task cannot have completed
+            // and the connection must still be open. If either of these is
+            // false, the read is not actually in flight and the test is not
+            // exercising the close-with-pending-IO path.
+            Assert.False(
+                readTask.IsCompleted,
+                "The async read completed before the server released the response; " +
+                "the read was not in flight at close time.");
+            Assert.Equal(System.Data.ConnectionState.Open, connection.State);
+
+            // Close/dispose the connection on a dedicated, long-running thread
+            // while the async read is in flight. This is the operation that can
+            // deadlock in SNIClose. A dedicated thread (rather than a
+            // thread-pool thread via Task.Run) ensures a hypothetical regression
+            // parks this one thread instead of starving the shared thread pool.
+            closeAttempted = true;
+            Task closeTask = Task.Factory.StartNew(
+                () =>
+                {
+                    if (disposeInsteadOfClose)
+                    {
+                        connection.Dispose();
+                    }
+                    else
+                    {
+                        connection.Close();
+                    }
+                },
+                TaskCreationOptions.LongRunning);
+
+            closedInTime = closeTask.Wait(CloseBudget);
+
+            Assert.True(
+                closedInTime,
+                $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete " +
+                $"within {CloseBudget.TotalSeconds:N0}s while an async read was in flight. " +
+                "This indicates the SNIClose deadlock (ADO.Net #43847 / ICM 775308542).");
         }
         finally
         {
-            command.Dispose();
-            // Only perform potentially-blocking cleanup if the close completed.
-            // If it deadlocked (closedInTime == false), calling Dispose() here
-            // could also block indefinitely and defeat the bounded-wait
-            // regression signal asserted below.
-            if (closedInTime && !disposeInsteadOfClose)
+            // Always release the stalled server thread, even if a precondition
+            // assert above threw, so the using-scoped server can be disposed
+            // without blocking on the query engine.
+            releaseResponse.Set();
+
+            // Observe the pending read so its (expected) fault is not unobserved.
+            if (readTask != null)
+            {
+                try
+                {
+                    readTask.Wait(CloseBudget);
+                }
+                catch
+                {
+                    // The pending read is expected to fault or cancel once the
+                    // connection is torn down. That is not what this test asserts.
+                }
+            }
+
+            command?.Dispose();
+
+            // Dispose the connection unless a close deadlock was actually
+            // detected (in which case Dispose() could also block indefinitely
+            // and defeat the bounded-wait regression signal). Disposing is safe
+            // when the close worker never started or when it completed.
+            if (!closeAttempted || closedInTime)
             {
                 connection.Dispose();
             }
         }
-
-        Assert.True(
-            closedInTime,
-            $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete " +
-            $"within {CloseBudget.TotalSeconds:N0}s while an async read was in flight. " +
-            "This indicates the SNIClose deadlock (ADO.Net #43847 / ICM 775308542).");
     }
 
     /// <summary>
@@ -268,56 +286,79 @@ public class SNICloseDeadlockTest
         };
 
         SqlConnection connection = new(builder.ConnectionString);
-
-        // Begin connection establishment. This will not complete because the
-        // server never answers the pre-login handshake.
-        Task openTask = connection.OpenAsync();
-
-        // Wait until the server has received the client's pre-login, i.e. the
-        // client's handshake read is in flight.
-        Assert.True(
-            clientConnected.Wait(HandshakeBudget),
-            "The server never received the client's pre-login packet, so the " +
-            "handshake read was not in flight; the test cannot exercise the " +
-            "close-during-handshake path.");
-
-        // Close/dispose the connection on a worker thread while the handshake
-        // read is in flight. This is the operation that can deadlock.
-        Task closeTask = Task.Run(() =>
-        {
-            if (disposeInsteadOfClose)
-            {
-                connection.Dispose();
-            }
-            else
-            {
-                connection.Close();
-            }
-        });
-
-        bool closedInTime = closeTask.Wait(CloseBudget);
-
-        // Release the server thread so it can unwind cleanly regardless of the
-        // outcome above.
-        releaseServer.Set();
-
-        // Observe the open task so its (expected) failure is not unobserved.
+        Task? openTask = null;
+        bool closeAttempted = false;
+        bool closedInTime = false;
         try
         {
-            openTask.Wait(CloseBudget);
-        }
-        catch
-        {
-            // OpenAsync is expected to fault or cancel once the connection is
-            // torn down. That is not what this test asserts.
+            // Begin connection establishment. This will not complete because
+            // the server never answers the pre-login handshake.
+            openTask = connection.OpenAsync();
+
+            // Wait until the server has received the client's pre-login, i.e.
+            // the client's handshake read is in flight.
+            Assert.True(
+                clientConnected.Wait(HandshakeBudget),
+                "The server never received the client's pre-login packet, so the " +
+                "handshake read was not in flight; the test cannot exercise the " +
+                "close-during-handshake path.");
+
+            // Close/dispose the connection on a dedicated, long-running thread
+            // while the handshake read is in flight. This is the operation that
+            // can deadlock. A dedicated thread (rather than a thread-pool thread
+            // via Task.Run) ensures a hypothetical regression parks this one
+            // thread instead of starving the shared thread pool.
+            closeAttempted = true;
+            Task closeTask = Task.Factory.StartNew(
+                () =>
+                {
+                    if (disposeInsteadOfClose)
+                    {
+                        connection.Dispose();
+                    }
+                    else
+                    {
+                        connection.Close();
+                    }
+                },
+                TaskCreationOptions.LongRunning);
+
+            closedInTime = closeTask.Wait(CloseBudget);
+
+            Assert.True(
+                closedInTime,
+                $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete " +
+                $"within {CloseBudget.TotalSeconds:N0}s while a pre-login response " +
+                "read was in flight. This indicates the SNIClose deadlock " +
+                "(ADO.Net #43847 / ICM 775308542).");
         }
         finally
         {
-            // Only perform potentially-blocking cleanup if the close completed.
-            // If it deadlocked (closedInTime == false), calling Dispose() here
-            // could also block indefinitely and defeat the bounded-wait
-            // regression signal asserted below.
-            if (closedInTime && !disposeInsteadOfClose)
+            // Always release the server loop and stop the listener, even if a
+            // precondition assert above threw, so the background server task
+            // cannot stay blocked and the listening socket is not leaked into
+            // subsequent tests.
+            releaseServer.Set();
+            listener.Stop();
+
+            // Observe the open task so its (expected) failure is not unobserved.
+            if (openTask != null)
+            {
+                try
+                {
+                    openTask.Wait(CloseBudget);
+                }
+                catch
+                {
+                    // OpenAsync is expected to fault or cancel once the
+                    // connection is torn down. That is not what this test asserts.
+                }
+            }
+
+            // Dispose the connection unless a close deadlock was actually
+            // detected (in which case Dispose() could also block). Disposing is
+            // safe when the close worker never started or when it completed.
+            if (!closeAttempted || closedInTime)
             {
                 connection.Dispose();
             }
@@ -330,16 +371,7 @@ public class SNICloseDeadlockTest
             {
                 // Ignore server teardown faults.
             }
-
-            listener.Stop();
         }
-
-        Assert.True(
-            closedInTime,
-            $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete " +
-            $"within {CloseBudget.TotalSeconds:N0}s while a pre-login response " +
-            "read was in flight. This indicates the SNIClose deadlock " +
-            "(ADO.Net #43847 / ICM 775308542).");
     }
 
     /// <summary>
@@ -464,54 +496,78 @@ public class SNICloseDeadlockTest
         };
 
         SqlConnection connection = new(builder.ConnectionString);
-
-        // Begin connection establishment. This will not complete because the
-        // server never finishes the TLS handshake.
-        Task openTask = connection.OpenAsync();
-
-        // Wait until the client is inside the TLS handshake with a pending read.
-        Assert.True(
-            handshakeInFlight.Wait(HandshakeBudget),
-            "The client never reached the TLS handshake, so no SNI read was in " +
-            "flight; the test cannot exercise the close-during-TLS-handshake path.");
-
-        // Close/dispose the connection on a worker thread while the TLS
-        // handshake read is in flight. This is the operation that can deadlock.
-        Task closeTask = Task.Run(() =>
-        {
-            if (disposeInsteadOfClose)
-            {
-                connection.Dispose();
-            }
-            else
-            {
-                connection.Close();
-            }
-        });
-
-        bool closedInTime = closeTask.Wait(CloseBudget);
-
-        // Release the server thread so it can unwind cleanly regardless of the
-        // outcome above.
-        releaseServer.Set();
-
-        // Observe the open task so its (expected) failure is not unobserved.
+        Task? openTask = null;
+        bool closeAttempted = false;
+        bool closedInTime = false;
         try
         {
-            openTask.Wait(CloseBudget);
-        }
-        catch
-        {
-            // OpenAsync is expected to fault or cancel once the connection is
-            // torn down. That is not what this test asserts.
+            // Begin connection establishment. This will not complete because
+            // the server never finishes the TLS handshake.
+            openTask = connection.OpenAsync();
+
+            // Wait until the client is inside the TLS handshake with a pending
+            // read.
+            Assert.True(
+                handshakeInFlight.Wait(HandshakeBudget),
+                "The client never reached the TLS handshake, so no SNI read was in " +
+                "flight; the test cannot exercise the close-during-TLS-handshake path.");
+
+            // Close/dispose the connection on a dedicated, long-running thread
+            // while the TLS handshake read is in flight. This is the operation
+            // that can deadlock. A dedicated thread (rather than a thread-pool
+            // thread via Task.Run) ensures a hypothetical regression parks this
+            // one thread instead of starving the shared thread pool.
+            closeAttempted = true;
+            Task closeTask = Task.Factory.StartNew(
+                () =>
+                {
+                    if (disposeInsteadOfClose)
+                    {
+                        connection.Dispose();
+                    }
+                    else
+                    {
+                        connection.Close();
+                    }
+                },
+                TaskCreationOptions.LongRunning);
+
+            closedInTime = closeTask.Wait(CloseBudget);
+
+            Assert.True(
+                closedInTime,
+                $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete " +
+                $"within {CloseBudget.TotalSeconds:N0}s while a TLS handshake read was " +
+                "in flight. This indicates the SNIClose deadlock " +
+                "(ADO.Net #43847 / ICM 775308542).");
         }
         finally
         {
-            // Only perform potentially-blocking cleanup if the close completed.
-            // If it deadlocked (closedInTime == false), calling Dispose() here
-            // could also block indefinitely and defeat the bounded-wait
-            // regression signal asserted below.
-            if (closedInTime && !disposeInsteadOfClose)
+            // Always release the server loop and stop the listener, even if a
+            // precondition assert above threw, so the background server task
+            // cannot stay blocked and the listening socket is not leaked into
+            // subsequent tests.
+            releaseServer.Set();
+            listener.Stop();
+
+            // Observe the open task so its (expected) failure is not unobserved.
+            if (openTask != null)
+            {
+                try
+                {
+                    openTask.Wait(CloseBudget);
+                }
+                catch
+                {
+                    // OpenAsync is expected to fault or cancel once the
+                    // connection is torn down. That is not what this test asserts.
+                }
+            }
+
+            // Dispose the connection unless a close deadlock was actually
+            // detected (in which case Dispose() could also block). Disposing is
+            // safe when the close worker never started or when it completed.
+            if (!closeAttempted || closedInTime)
             {
                 connection.Dispose();
             }
@@ -524,15 +580,6 @@ public class SNICloseDeadlockTest
             {
                 // Ignore server teardown faults.
             }
-
-            listener.Stop();
         }
-
-        Assert.True(
-            closedInTime,
-            $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete " +
-            $"within {CloseBudget.TotalSeconds:N0}s while a TLS handshake read was " +
-            "in flight. This indicates the SNIClose deadlock " +
-            "(ADO.Net #43847 / ICM 775308542).");
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
@@ -32,14 +32,17 @@ namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
 /// stalls after receiving the client's SQL batch. This guarantees that the
 /// client's async read for the response is genuinely in flight at the moment
 /// the connection is closed. The close is performed on a worker thread and
-/// wrapped in a bounded wait: a deadlock manifests as the wait timing out,
-/// which fails the test. After the fix, the close completes promptly.
+/// wrapped in a bounded wait: a healthy close completes promptly, whereas a
+/// deadlock manifests as the wait timing out, which fails the test.
 /// </para>
 ///
 /// <para>
-/// <b>Expected state:</b> these tests are expected to FAIL (time out) against
-/// the current, unfixed close path and PASS once the drain-before-close fix is
-/// implemented.
+/// <b>Expected state:</b> these tests PASS against the current code base.
+/// Microsoft.Data.SqlClient does not suffer from this deadlock: the close path
+/// drains (or cancels) the in-flight async I/O and completes well within the
+/// bounded wait. They therefore serve as regression guards - if a future change
+/// reintroduced the SNIClose deadlock, the bounded wait would time out and the
+/// tests would fail.
 /// </para>
 /// </summary>
 public class SNICloseDeadlockTest
@@ -187,7 +190,11 @@ public class SNICloseDeadlockTest
         finally
         {
             command.Dispose();
-            if (!disposeInsteadOfClose)
+            // Only perform potentially-blocking cleanup if the close completed.
+            // If it deadlocked (closedInTime == false), calling Dispose() here
+            // could also block indefinitely and defeat the bounded-wait
+            // regression signal asserted below.
+            if (closedInTime && !disposeInsteadOfClose)
             {
                 connection.Dispose();
             }
@@ -324,7 +331,11 @@ public class SNICloseDeadlockTest
         }
         finally
         {
-            if (!disposeInsteadOfClose)
+            // Only perform potentially-blocking cleanup if the close completed.
+            // If it deadlocked (closedInTime == false), calling Dispose() here
+            // could also block indefinitely and defeat the bounded-wait
+            // regression signal asserted below.
+            if (closedInTime && !disposeInsteadOfClose)
             {
                 connection.Dispose();
             }
@@ -523,7 +534,11 @@ public class SNICloseDeadlockTest
         }
         finally
         {
-            if (!disposeInsteadOfClose)
+            // Only perform potentially-blocking cleanup if the close completed.
+            // If it deadlocked (closedInTime == false), calling Dispose() here
+            // could also block indefinitely and defeat the bounded-wait
+            // regression signal asserted below.
+            if (closedInTime && !disposeInsteadOfClose)
             {
                 connection.Dispose();
             }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
@@ -94,19 +94,10 @@ public class SNICloseDeadlockTest
         }
     }
 
-    [Fact]
-    public void CloseConnection_WithPendingAsyncRead_DoesNotDeadlock()
-    {
-        RunPendingAsyncReadCloseScenario(disposeInsteadOfClose: false);
-    }
-
-    [Fact]
-    public void DisposeConnection_WithPendingAsyncRead_DoesNotDeadlock()
-    {
-        RunPendingAsyncReadCloseScenario(disposeInsteadOfClose: true);
-    }
-
-    private static void RunPendingAsyncReadCloseScenario(bool disposeInsteadOfClose)
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CloseOrDispose_WithPendingAsyncRead_DoesNotDeadlock(bool disposeInsteadOfClose)
     {
         using ManualResetEventSlim batchReceived = new(false);
         using ManualResetEventSlim releaseResponse = new(false);
@@ -207,18 +198,6 @@ public class SNICloseDeadlockTest
             "This indicates the SNIClose deadlock (ADO.Net #43847 / ICM 775308542).");
     }
 
-    [Fact]
-    public void CloseConnection_DuringPreLoginHandshake_DoesNotDeadlock()
-    {
-        RunPendingHandshakeCloseScenario(disposeInsteadOfClose: false);
-    }
-
-    [Fact]
-    public void DisposeConnection_DuringPreLoginHandshake_DoesNotDeadlock()
-    {
-        RunPendingHandshakeCloseScenario(disposeInsteadOfClose: true);
-    }
-
     /// <summary>
     /// Reproduces the ICM scenario more faithfully: the connection is torn down
     /// while it is still in the middle of connection establishment (the
@@ -232,7 +211,10 @@ public class SNICloseDeadlockTest
     /// handshake-phase close path manifests as the wait timing out.
     /// </para>
     /// </summary>
-    private static void RunPendingHandshakeCloseScenario(bool disposeInsteadOfClose)
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CloseOrDispose_DuringPreLoginHandshake_DoesNotDeadlock(bool disposeInsteadOfClose)
     {
         using ManualResetEventSlim clientConnected = new(false);
         using ManualResetEventSlim releaseServer = new(false);
@@ -394,18 +376,6 @@ public class SNICloseDeadlockTest
         0x01,                               // ENCRYPTION = ENCRYPT_ON
     };
 
-    [Fact]
-    public void CloseConnection_DuringTlsHandshake_DoesNotDeadlock()
-    {
-        RunPendingTlsHandshakeCloseScenario(disposeInsteadOfClose: false);
-    }
-
-    [Fact]
-    public void DisposeConnection_DuringTlsHandshake_DoesNotDeadlock()
-    {
-        RunPendingTlsHandshakeCloseScenario(disposeInsteadOfClose: true);
-    }
-
     /// <summary>
     /// Reproduces the ICM scenario faithfully: the connection is torn down while
     /// the client is inside the TLS handshake over TDS, with an SNI read pending
@@ -423,7 +393,10 @@ public class SNICloseDeadlockTest
     /// manifests as the wait timing out.
     /// </para>
     /// </summary>
-    private static void RunPendingTlsHandshakeCloseScenario(bool disposeInsteadOfClose)
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CloseOrDispose_DuringTlsHandshake_DoesNotDeadlock(bool disposeInsteadOfClose)
     {
         using ManualResetEventSlim handshakeInFlight = new(false);
         using ManualResetEventSlim releaseServer = new(false);

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.SqlServer.TDS;
@@ -141,6 +143,17 @@ public class SNICloseDeadlockTest
             "The server never received the SQL batch, so the async read was " +
             "not in flight; the test cannot exercise the close-with-pending-IO path.");
 
+        // The server is stalled withholding the response, so the client's async
+        // read must still be pending: the Task cannot have completed and the
+        // connection must still be open. If either of these is false, the read
+        // is not actually in flight and the test is not exercising the
+        // close-with-pending-IO path.
+        Assert.False(
+            readTask.IsCompleted,
+            "The async read completed before the server released the response; " +
+            "the read was not in flight at close time.");
+        Assert.Equal(System.Data.ConnectionState.Open, connection.State);
+
         // Close/dispose the connection on a worker thread while the async read
         // is in flight. This is the operation that can deadlock in SNIClose.
         Task closeTask = Task.Run(() =>
@@ -185,5 +198,353 @@ public class SNICloseDeadlockTest
             $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete " +
             $"within {CloseBudget.TotalSeconds:N0}s while an async read was in flight. " +
             "This indicates the SNIClose deadlock (ADO.Net #43847 / ICM 775308542).");
+    }
+
+    [Fact]
+    public void CloseConnection_DuringPreLoginHandshake_DoesNotDeadlock()
+    {
+        RunPendingHandshakeCloseScenario(disposeInsteadOfClose: false);
+    }
+
+    [Fact]
+    public void DisposeConnection_DuringPreLoginHandshake_DoesNotDeadlock()
+    {
+        RunPendingHandshakeCloseScenario(disposeInsteadOfClose: true);
+    }
+
+    /// <summary>
+    /// Reproduces the ICM scenario more faithfully: the connection is torn down
+    /// while it is still in the middle of connection establishment (the
+    /// pre-login / TLS handshake), rather than after a successful login.
+    ///
+    /// <para>
+    /// A bare TCP listener accepts the socket and reads the client's pre-login
+    /// packet but deliberately never sends a response. This leaves the client's
+    /// async read for the pre-login/handshake response in flight. The close is
+    /// performed on a worker thread under a bounded wait; a deadlock in the
+    /// handshake-phase close path manifests as the wait timing out.
+    /// </para>
+    /// </summary>
+    private static void RunPendingHandshakeCloseScenario(bool disposeInsteadOfClose)
+    {
+        using ManualResetEventSlim clientConnected = new(false);
+        using ManualResetEventSlim releaseServer = new(false);
+
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        // Server: accept the socket, read the client's pre-login bytes, then
+        // withhold any response so the client's handshake read stays pending.
+        Task serverTask = Task.Run(() =>
+        {
+            using TcpClient acceptedClient = listener.AcceptTcpClient();
+            using NetworkStream stream = acceptedClient.GetStream();
+
+            try
+            {
+                // Read one byte of the client's pre-login packet. Once this
+                // returns the client has sent its pre-login and posted its
+                // async read for the response. We only need to know data
+                // arrived, so a single byte is sufficient.
+                stream.ReadByte();
+            }
+            catch
+            {
+                // The client may tear down the socket; ignore.
+            }
+
+            clientConnected.Set();
+
+            // Hold the socket open (withholding the response) until the test
+            // releases us, so the client's read cannot complete naturally.
+            releaseServer.Wait();
+        });
+
+        SqlConnectionStringBuilder builder = new()
+        {
+            DataSource = $"127.0.0.1,{port}",
+            // Force TLS negotiation intent during the handshake, matching the
+            // ICM scenario.
+            Encrypt = SqlConnectionEncryptOption.Mandatory,
+            TrustServerCertificate = true,
+            // Long timeout so the connect attempt does not abort on its own
+            // before we get a chance to close it.
+            ConnectTimeout = 60,
+            ConnectRetryCount = 0,
+            Pooling = false,
+#if NETFRAMEWORK
+            TransparentNetworkIPResolution = false,
+#endif
+        };
+
+        SqlConnection connection = new(builder.ConnectionString);
+
+        // Begin connection establishment. This will not complete because the
+        // server never answers the pre-login handshake.
+        Task openTask = connection.OpenAsync();
+
+        // Wait until the server has received the client's pre-login, i.e. the
+        // client's handshake read is in flight.
+        Assert.True(
+            clientConnected.Wait(HandshakeBudget),
+            "The server never received the client's pre-login packet, so the " +
+            "handshake read was not in flight; the test cannot exercise the " +
+            "close-during-handshake path.");
+
+        // Close/dispose the connection on a worker thread while the handshake
+        // read is in flight. This is the operation that can deadlock.
+        Task closeTask = Task.Run(() =>
+        {
+            if (disposeInsteadOfClose)
+            {
+                connection.Dispose();
+            }
+            else
+            {
+                connection.Close();
+            }
+        });
+
+        bool closedInTime = closeTask.Wait(CloseBudget);
+
+        // Release the server thread so it can unwind cleanly regardless of the
+        // outcome above.
+        releaseServer.Set();
+
+        // Observe the open task so its (expected) failure is not unobserved.
+        try
+        {
+            openTask.Wait(CloseBudget);
+        }
+        catch
+        {
+            // OpenAsync is expected to fault or cancel once the connection is
+            // torn down. That is not what this test asserts.
+        }
+        finally
+        {
+            if (!disposeInsteadOfClose)
+            {
+                connection.Dispose();
+            }
+
+            try
+            {
+                serverTask.Wait(CloseBudget);
+            }
+            catch
+            {
+                // Ignore server teardown faults.
+            }
+
+            listener.Stop();
+        }
+
+        Assert.True(
+            closedInTime,
+            $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete " +
+            $"within {CloseBudget.TotalSeconds:N0}s while a pre-login response " +
+            "read was in flight. This indicates the SNIClose deadlock " +
+            "(ADO.Net #43847 / ICM 775308542).");
+    }
+
+    /// <summary>
+    /// A minimal, protocol-valid TDS PRELOGIN response advertising ENCRYPT_ON
+    /// so that a client which requested encryption proceeds into the TLS
+    /// handshake. Offsets are relative to the start of the payload (immediately
+    /// after the 8-byte TDS packet header):
+    ///
+    /// <code>
+    ///   Option table:
+    ///     VERSION     token 0x00, offset 11 (0x000B), length 6
+    ///     ENCRYPTION  token 0x01, offset 17 (0x0011), length 1
+    ///     TERMINATOR  0xFF
+    ///   Data:
+    ///     VERSION     6 bytes (17.0.0.0)
+    ///     ENCRYPTION  1 byte  (0x01 = ENCRYPT_ON)
+    /// </code>
+    /// </summary>
+    private static readonly byte[] s_preLoginEncryptOnResponse =
+    {
+        // ---- TDS packet header (8 bytes) ----
+        0x12,       // Type: PRELOGIN
+        0x01,       // Status: EOM
+        0x00, 0x1A, // Length: 26 (8 header + 18 payload), big-endian
+        0x00, 0x00, // SPID
+        0x01,       // PacketID
+        0x00,       // Window
+        // ---- PRELOGIN option table ----
+        0x00, 0x00, 0x0B, 0x00, 0x06, // VERSION: offset 11, length 6
+        0x01, 0x00, 0x11, 0x00, 0x01, // ENCRYPTION: offset 17, length 1
+        0xFF,                         // TERMINATOR
+        // ---- Option data ----
+        0x11, 0x00, 0x00, 0x00, 0x00, 0x00, // VERSION 17.0.0.0
+        0x01,                               // ENCRYPTION = ENCRYPT_ON
+    };
+
+    [Fact]
+    public void CloseConnection_DuringTlsHandshake_DoesNotDeadlock()
+    {
+        RunPendingTlsHandshakeCloseScenario(disposeInsteadOfClose: false);
+    }
+
+    [Fact]
+    public void DisposeConnection_DuringTlsHandshake_DoesNotDeadlock()
+    {
+        RunPendingTlsHandshakeCloseScenario(disposeInsteadOfClose: true);
+    }
+
+    /// <summary>
+    /// Reproduces the ICM scenario faithfully: the connection is torn down while
+    /// the client is inside the TLS handshake over TDS, with an SNI read pending
+    /// for the server's handshake response.
+    ///
+    /// <para>
+    /// A bare TCP listener speaks just enough of the TDS pre-login exchange to
+    /// drive the client into the TLS handshake: it reads the client's PRELOGIN
+    /// packet, replies with a PRELOGIN response advertising ENCRYPT_ON, then
+    /// reads the client's TLS ClientHello (delivered as a TDS pre-login packet)
+    /// and deliberately never sends a ServerHello. At that point the client is
+    /// blocked inside <c>SslStream.AuthenticateAsClient</c> with an SNI read in
+    /// flight on the SSL-over-TDS transport. The close is performed on a worker
+    /// thread under a bounded wait; a deadlock in the handshake-phase close path
+    /// manifests as the wait timing out.
+    /// </para>
+    /// </summary>
+    private static void RunPendingTlsHandshakeCloseScenario(bool disposeInsteadOfClose)
+    {
+        using ManualResetEventSlim handshakeInFlight = new(false);
+        using ManualResetEventSlim releaseServer = new(false);
+
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        // Server: complete the pre-login exchange advertising encryption, read
+        // the client's TLS ClientHello, then withhold the ServerHello so the
+        // client's handshake read stays pending.
+        Task serverTask = Task.Run(() =>
+        {
+            using TcpClient acceptedClient = listener.AcceptTcpClient();
+            using NetworkStream stream = acceptedClient.GetStream();
+
+            byte[] buffer = new byte[4096];
+            try
+            {
+                // Read the client's PRELOGIN packet.
+                int read = stream.Read(buffer, 0, buffer.Length);
+                if (read <= 0)
+                {
+                    return;
+                }
+
+                // Advertise ENCRYPT_ON so the client begins the TLS handshake.
+                stream.Write(s_preLoginEncryptOnResponse, 0, s_preLoginEncryptOnResponse.Length);
+                stream.Flush();
+
+                // Read the first byte of the client's TLS ClientHello (wrapped
+                // in a TDS pre-login packet). A byte here proves the client
+                // accepted the pre-login response and entered the TLS handshake;
+                // it is now awaiting the ServerHello with its SNI read pending.
+                if (stream.ReadByte() < 0)
+                {
+                    // Client tore down without sending a ClientHello: the
+                    // handshake was never actually in flight.
+                    return;
+                }
+
+                handshakeInFlight.Set();
+
+                // Withhold the ServerHello until the test releases us.
+                releaseServer.Wait();
+            }
+            catch
+            {
+                // The client may tear down the socket mid-handshake; ignore.
+            }
+        });
+
+        SqlConnectionStringBuilder builder = new()
+        {
+            DataSource = $"127.0.0.1,{port}",
+            // Require encryption so the client performs the TLS handshake.
+            Encrypt = SqlConnectionEncryptOption.Mandatory,
+            TrustServerCertificate = true,
+            ConnectTimeout = 60,
+            ConnectRetryCount = 0,
+            Pooling = false,
+#if NETFRAMEWORK
+            TransparentNetworkIPResolution = false,
+#endif
+        };
+
+        SqlConnection connection = new(builder.ConnectionString);
+
+        // Begin connection establishment. This will not complete because the
+        // server never finishes the TLS handshake.
+        Task openTask = connection.OpenAsync();
+
+        // Wait until the client is inside the TLS handshake with a pending read.
+        Assert.True(
+            handshakeInFlight.Wait(HandshakeBudget),
+            "The client never reached the TLS handshake, so no SNI read was in " +
+            "flight; the test cannot exercise the close-during-TLS-handshake path.");
+
+        // Close/dispose the connection on a worker thread while the TLS
+        // handshake read is in flight. This is the operation that can deadlock.
+        Task closeTask = Task.Run(() =>
+        {
+            if (disposeInsteadOfClose)
+            {
+                connection.Dispose();
+            }
+            else
+            {
+                connection.Close();
+            }
+        });
+
+        bool closedInTime = closeTask.Wait(CloseBudget);
+
+        // Release the server thread so it can unwind cleanly regardless of the
+        // outcome above.
+        releaseServer.Set();
+
+        // Observe the open task so its (expected) failure is not unobserved.
+        try
+        {
+            openTask.Wait(CloseBudget);
+        }
+        catch
+        {
+            // OpenAsync is expected to fault or cancel once the connection is
+            // torn down. That is not what this test asserts.
+        }
+        finally
+        {
+            if (!disposeInsteadOfClose)
+            {
+                connection.Dispose();
+            }
+
+            try
+            {
+                serverTask.Wait(CloseBudget);
+            }
+            catch
+            {
+                // Ignore server teardown faults.
+            }
+
+            listener.Stop();
+        }
+
+        Assert.True(
+            closedInTime,
+            $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete " +
+            $"within {CloseBudget.TotalSeconds:N0}s while a TLS handshake read was " +
+            "in flight. This indicates the SNIClose deadlock " +
+            "(ADO.Net #43847 / ICM 775308542).");
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
@@ -250,22 +250,31 @@ public class SNICloseDeadlockTest
 
             try
             {
-                // Read one byte of the client's pre-login packet. Once this
-                // returns the client has sent its pre-login and posted its
-                // async read for the response. We only need to know data
+                // Read one byte of the client's pre-login packet. A byte here
+                // proves the client actually sent its pre-login and posted its
+                // async read for the response; we only need to know data
                 // arrived, so a single byte is sufficient.
-                stream.ReadByte();
+                if (stream.ReadByte() < 0)
+                {
+                    // Client tore down without sending pre-login bytes: the
+                    // handshake read was never actually in flight. Leave
+                    // clientConnected unset so the test's precondition wait
+                    // fails instead of producing a false positive.
+                    return;
+                }
+
+                clientConnected.Set();
+
+                // Hold the socket open (withholding the response) until the test
+                // releases us, so the client's read cannot complete naturally.
+                releaseServer.Wait();
             }
             catch
             {
-                // The client may tear down the socket; ignore.
+                // The client may tear down the socket; ignore. clientConnected
+                // stays unset unless a pre-login byte was actually observed
+                // above, so a failed read cannot masquerade as a pending one.
             }
-
-            clientConnected.Set();
-
-            // Hold the socket open (withholding the response) until the test
-            // releases us, so the client's read cannot complete naturally.
-            releaseServer.Wait();
         });
 
         SqlConnectionStringBuilder builder = new()

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SqlServer.TDS;
+using Microsoft.SqlServer.TDS.EndPoint;
+using Microsoft.SqlServer.TDS.Servers;
+using Microsoft.SqlServer.TDS.SQLBatch;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
+
+/// <summary>
+/// Regression tests for ADO.Net work item 43847 / ICM 775308542:
+/// "SNIClose can deadlock with in-flight async I/O during connection close".
+///
+/// <para>
+/// These tests reproduce the ordering hazard where a connection is closed or
+/// disposed while an asynchronous network read is still pending. The close
+/// path must drain (or cancel) the in-flight async I/O before releasing the
+/// SNI handle; if it releases the handle first, the closing thread and the
+/// pending completion callback can wait on each other and deadlock.
+/// </para>
+///
+/// <para>
+/// Each test uses an in-process TDS server whose query engine deliberately
+/// stalls after receiving the client's SQL batch. This guarantees that the
+/// client's async read for the response is genuinely in flight at the moment
+/// the connection is closed. The close is performed on a worker thread and
+/// wrapped in a bounded wait: a deadlock manifests as the wait timing out,
+/// which fails the test. After the fix, the close completes promptly.
+/// </para>
+///
+/// <para>
+/// <b>Expected state:</b> these tests are expected to FAIL (time out) against
+/// the current, unfixed close path and PASS once the drain-before-close fix is
+/// implemented.
+/// </para>
+/// </summary>
+public class SNICloseDeadlockTest
+{
+    /// <summary>
+    /// Upper bound for how long a non-deadlocked close should take. Close of a
+    /// healthy connection is effectively instantaneous; this generous budget
+    /// exists only to distinguish "completed" from "deadlocked" on slow CI
+    /// agents without hanging the whole test run.
+    /// </summary>
+    private static readonly TimeSpan CloseBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Upper bound for waiting on the server to receive the client's batch,
+    /// i.e. for the client's async read to become pending.
+    /// </summary>
+    private static readonly TimeSpan HandshakeBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// A query engine that signals when a SQL batch has arrived and then blocks
+    /// (withholding the response) until the test releases it. While it is
+    /// blocked, the client's async read for the response remains in flight.
+    /// </summary>
+    private sealed class StallingQueryEngine : QueryEngine
+    {
+        private readonly ManualResetEventSlim _batchReceived;
+        private readonly ManualResetEventSlim _releaseResponse;
+
+        public StallingQueryEngine(
+            TdsServerArguments arguments,
+            ManualResetEventSlim batchReceived,
+            ManualResetEventSlim releaseResponse)
+            : base(arguments)
+        {
+            _batchReceived = batchReceived;
+            _releaseResponse = releaseResponse;
+        }
+
+        protected override TDSMessageCollection CreateQueryResponse(
+            ITDSServerSession session,
+            TDSSQLBatchToken batchRequest)
+        {
+            // The client has sent the batch and posted an async receive for the
+            // response by the time we get here. Signal the test, then stall so
+            // the client's read stays in flight while the connection is closed.
+            _batchReceived.Set();
+            _releaseResponse.Wait();
+            return base.CreateQueryResponse(session, batchRequest);
+        }
+    }
+
+    [Fact]
+    public void CloseConnection_WithPendingAsyncRead_DoesNotDeadlock()
+    {
+        RunPendingAsyncReadCloseScenario(disposeInsteadOfClose: false);
+    }
+
+    [Fact]
+    public void DisposeConnection_WithPendingAsyncRead_DoesNotDeadlock()
+    {
+        RunPendingAsyncReadCloseScenario(disposeInsteadOfClose: true);
+    }
+
+    private static void RunPendingAsyncReadCloseScenario(bool disposeInsteadOfClose)
+    {
+        using ManualResetEventSlim batchReceived = new(false);
+        using ManualResetEventSlim releaseResponse = new(false);
+
+        TdsServerArguments arguments = new();
+        using TdsServer server = new(
+            new StallingQueryEngine(arguments, batchReceived, releaseResponse),
+            arguments);
+        server.Start();
+
+        SqlConnectionStringBuilder builder = new()
+        {
+            DataSource = $"localhost,{server.EndPoint.Port}",
+            Encrypt = SqlConnectionEncryptOption.Optional,
+            // Disable pooling so Close()/Dispose() tears down the physical
+            // connection (and reaches SNIClose) instead of returning it to the
+            // pool.
+            Pooling = false,
+#if NETFRAMEWORK
+            TransparentNetworkIPResolution = false,
+#endif
+        };
+
+        SqlConnection connection = new(builder.ConnectionString);
+        connection.Open();
+
+        SqlCommand command = new("SELECT 1", connection);
+
+        // Start an async read that will pend: the server stalls in
+        // CreateQueryResponse, so this Task will not complete until we either
+        // release the server or tear down the connection.
+        Task<SqlDataReader> readTask = command.ExecuteReaderAsync();
+
+        // Ensure the async read is genuinely in flight before we close.
+        Assert.True(
+            batchReceived.Wait(HandshakeBudget),
+            "The server never received the SQL batch, so the async read was " +
+            "not in flight; the test cannot exercise the close-with-pending-IO path.");
+
+        // Close/dispose the connection on a worker thread while the async read
+        // is in flight. This is the operation that can deadlock in SNIClose.
+        Task closeTask = Task.Run(() =>
+        {
+            if (disposeInsteadOfClose)
+            {
+                connection.Dispose();
+            }
+            else
+            {
+                connection.Close();
+            }
+        });
+
+        bool closedInTime = closeTask.Wait(CloseBudget);
+
+        // Always release the stalled server thread so it can unwind and the
+        // server can be disposed cleanly, regardless of the outcome above.
+        releaseResponse.Set();
+
+        // Observe the read task so its (expected) failure is not unobserved.
+        try
+        {
+            readTask.Wait(CloseBudget);
+        }
+        catch
+        {
+            // The pending read is expected to fault or cancel once the
+            // connection is torn down. That is not what this test asserts.
+        }
+        finally
+        {
+            command.Dispose();
+            if (!disposeInsteadOfClose)
+            {
+                connection.Dispose();
+            }
+        }
+
+        Assert.True(
+            closedInTime,
+            $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete " +
+            $"within {CloseBudget.TotalSeconds:N0}s while an async read was in flight. " +
+            "This indicates the SNIClose deadlock (ADO.Net #43847 / ICM 775308542).");
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseHandshakeCancellationTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseHandshakeCancellationTest.cs
@@ -1,0 +1,180 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
+
+/// <summary>
+/// Regression test for the connection-teardown paths related to ADO.Net #43847 /
+/// ICM 775308542. Where <see cref="SNICloseDeadlockTest"/> tears the connection
+/// down with an <b>external</b> <c>Close()</c>/<c>Dispose()</c>, this drives the
+/// driver's <b>internal</b> abort/close path by cancelling <c>OpenAsync</c> while
+/// the TLS handshake read is in flight.
+///
+/// <para>
+/// A bare TCP listener completes just enough of the pre-login exchange to push
+/// the client into the TLS handshake (it advertises ENCRYPT_ON, reads the
+/// client's ClientHello, then withholds the ServerHello). The client's
+/// <c>OpenAsync</c> is then cancelled while that handshake read is pending. The
+/// cancellation must abort the in-flight I/O and complete the operation promptly;
+/// a deadlock in the internal close path manifests as the bounded wait timing
+/// out, which fails the test.
+/// </para>
+/// </summary>
+public class SNICloseHandshakeCancellationTest
+{
+    /// <summary>
+    /// Upper bound for how long the cancelled OpenAsync should take to settle.
+    /// Generous so it only distinguishes "completed" from "deadlocked".
+    /// </summary>
+    private static readonly TimeSpan CloseBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Upper bound for waiting until the client's TLS handshake read is pending.
+    /// </summary>
+    private static readonly TimeSpan HandshakeBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// A minimal, protocol-valid TDS PRELOGIN response advertising ENCRYPT_ON so
+    /// a client that requested encryption proceeds into the TLS handshake.
+    /// </summary>
+    private static readonly byte[] s_preLoginEncryptOnResponse =
+    {
+        // ---- TDS packet header (8 bytes) ----
+        0x12,       // Type: PRELOGIN
+        0x01,       // Status: EOM
+        0x00, 0x1A, // Length: 26 (8 header + 18 payload), big-endian
+        0x00, 0x00, // SPID
+        0x01,       // PacketID
+        0x00,       // Window
+        // ---- PRELOGIN option table ----
+        0x00, 0x00, 0x0B, 0x00, 0x06, // VERSION: offset 11, length 6
+        0x01, 0x00, 0x11, 0x00, 0x01, // ENCRYPTION: offset 17, length 1
+        0xFF,                         // TERMINATOR
+        // ---- Option data ----
+        0x11, 0x00, 0x00, 0x00, 0x00, 0x00, // VERSION 17.0.0.0
+        0x01,                               // ENCRYPTION = ENCRYPT_ON
+    };
+
+    [Fact]
+    public void CancelOpenAsyncDuringTlsHandshake_DoesNotDeadlock()
+    {
+        using ManualResetEventSlim handshakeInFlight = new(false);
+        using ManualResetEventSlim releaseServer = new(false);
+
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        // Server: complete the pre-login exchange advertising encryption, read the
+        // client's TLS ClientHello, then withhold the ServerHello so the client's
+        // handshake read stays pending.
+        Task serverTask = Task.Run(() =>
+        {
+            using TcpClient acceptedClient = listener.AcceptTcpClient();
+            using NetworkStream stream = acceptedClient.GetStream();
+            byte[] buffer = new byte[4096];
+            try
+            {
+                int read = stream.Read(buffer, 0, buffer.Length);
+                if (read <= 0)
+                {
+                    return;
+                }
+
+                stream.Write(s_preLoginEncryptOnResponse, 0, s_preLoginEncryptOnResponse.Length);
+                stream.Flush();
+
+                // A byte here proves the client entered the TLS handshake and is
+                // awaiting the ServerHello with its read pending.
+                if (stream.ReadByte() < 0)
+                {
+                    return;
+                }
+
+                handshakeInFlight.Set();
+                releaseServer.Wait();
+            }
+            catch
+            {
+                // The client may tear down the socket mid-handshake; ignore.
+            }
+        });
+
+        SqlConnectionStringBuilder builder = new()
+        {
+            DataSource = $"127.0.0.1,{port}",
+            Encrypt = SqlConnectionEncryptOption.Mandatory,
+            TrustServerCertificate = true,
+            ConnectTimeout = 60,
+            ConnectRetryCount = 0,
+            Pooling = false,
+#if NETFRAMEWORK
+            TransparentNetworkIPResolution = false,
+#endif
+        };
+
+        SqlConnection connection = new(builder.ConnectionString);
+        using CancellationTokenSource cts = new();
+        Task? openTask = null;
+        bool cancelAttempted = false;
+        bool settledInTime = false;
+        try
+        {
+            openTask = connection.OpenAsync(cts.Token);
+
+            Assert.True(
+                handshakeInFlight.Wait(HandshakeBudget),
+                "The client never reached the TLS handshake; no read was in flight to cancel.");
+
+            // Cancel while the handshake read is pending: this drives the driver's
+            // internal abort/close path against the in-flight I/O.
+            cancelAttempted = true;
+            cts.Cancel();
+
+            try
+            {
+                settledInTime = openTask.Wait(CloseBudget);
+            }
+            catch (AggregateException)
+            {
+                // OpenAsync faulting/cancelling is the expected outcome; what
+                // matters is that it *settled* rather than hanging.
+                settledInTime = true;
+            }
+
+            Assert.True(
+                settledInTime,
+                $"OpenAsync did not settle within {CloseBudget.TotalSeconds:N0}s after cancellation while a " +
+                "TLS handshake read was in flight. This indicates a deadlock in the internal close path " +
+                "(ADO.Net #43847 / ICM 775308542).");
+        }
+        finally
+        {
+            releaseServer.Set();
+            listener.Stop();
+
+            if (openTask != null)
+            {
+                try { openTask.Wait(CloseBudget); } catch { /* expected fault/cancel */ }
+            }
+
+            // Dispose unless a deadlock was detected (Dispose could also block).
+            if (!cancelAttempted || settledInTime)
+            {
+                connection.Dispose();
+            }
+
+            try { serverTask.Wait(CloseBudget); } catch { /* ignore */ }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseRaceDeadlockTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseRaceDeadlockTest.cs
@@ -1,0 +1,192 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SqlServer.TDS;
+using Microsoft.SqlServer.TDS.EndPoint;
+using Microsoft.SqlServer.TDS.Servers;
+using Microsoft.SqlServer.TDS.SQLBatch;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests.SimulatedServerTests;
+
+/// <summary>
+/// Race variant of the SNIClose close-during-I/O regression tests
+/// (ADO.Net #43847 / ICM 775308542).
+///
+/// <para>
+/// The sibling <c>SNICloseDeadlockTest</c> closes over a <b>quiescent</b>
+/// pending read: the server stays silent, so the close path simply cancels the
+/// in-flight read and no completion callback is executing at close time. This
+/// test instead <b>releases the server's response at the same instant the
+/// connection is closed</b> (rendezvous on a <see cref="Barrier"/>), so the
+/// read's completion callback fires concurrently with <c>SNIClose</c> - the
+/// exact ordering hazard the deadlock is about. It repeats many iterations to
+/// widen the race window.
+/// </para>
+///
+/// <para>
+/// The close runs on a dedicated long-running thread under a bounded wait: a
+/// deadlock manifests as the wait timing out, which fails the test. A healthy
+/// close completes promptly.
+/// </para>
+/// </summary>
+public class SNICloseRaceDeadlockTest
+{
+    /// <summary>
+    /// Upper bound for how long a non-deadlocked close should take. Generous so
+    /// it only distinguishes "completed" from "deadlocked" on slow CI agents.
+    /// </summary>
+    private static readonly TimeSpan CloseBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Upper bound for waiting on the server to receive the client's batch, i.e.
+    /// for the client's async read to become pending.
+    /// </summary>
+    private static readonly TimeSpan HandshakeBudget = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// A query engine that signals when a SQL batch arrives and then withholds
+    /// the response until released, so the test controls exactly when the
+    /// client's read completion fires.
+    /// </summary>
+    private sealed class ReleasableQueryEngine : QueryEngine
+    {
+        private readonly ManualResetEventSlim _batchReceived;
+        private readonly ManualResetEventSlim _releaseResponse;
+
+        public ReleasableQueryEngine(
+            TdsServerArguments arguments,
+            ManualResetEventSlim batchReceived,
+            ManualResetEventSlim releaseResponse)
+            : base(arguments)
+        {
+            _batchReceived = batchReceived;
+            _releaseResponse = releaseResponse;
+        }
+
+        protected override TDSMessageCollection CreateQueryResponse(
+            ITDSServerSession session,
+            TDSSQLBatchToken batchRequest)
+        {
+            _batchReceived.Set();
+            _releaseResponse.Wait();
+            return base.CreateQueryResponse(session, batchRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ResponseCompletionRacesClose_DoesNotDeadlock(bool disposeInsteadOfClose)
+    {
+        const int iterations = 100;
+
+        for (int i = 0; i < iterations; i++)
+        {
+            using ManualResetEventSlim batchReceived = new(false);
+            using ManualResetEventSlim releaseResponse = new(false);
+
+            TdsServerArguments arguments = new();
+            using TdsServer server = new(
+                new ReleasableQueryEngine(arguments, batchReceived, releaseResponse),
+                arguments);
+            server.Start();
+
+            SqlConnectionStringBuilder builder = new()
+            {
+                DataSource = $"localhost,{server.EndPoint.Port}",
+                Encrypt = SqlConnectionEncryptOption.Optional,
+                // Disable pooling so Close()/Dispose() tears down the physical
+                // connection (reaching SNIClose) instead of returning it to the pool.
+                Pooling = false,
+#if NETFRAMEWORK
+                TransparentNetworkIPResolution = false,
+#endif
+            };
+
+            SqlConnection connection = new(builder.ConnectionString);
+            SqlCommand? command = null;
+            Task<SqlDataReader>? readTask = null;
+            bool closeAttempted = false;
+            bool closedInTime = false;
+            try
+            {
+                connection.Open();
+
+                command = new("SELECT 1", connection);
+                readTask = command.ExecuteReaderAsync();
+
+                Assert.True(
+                    batchReceived.Wait(HandshakeBudget),
+                    $"iteration {i}: the server never received the SQL batch, so the " +
+                    "async read was not in flight.");
+
+                // Close on a dedicated, long-running thread, gated on a barrier;
+                // release the server response at the same instant so the read's
+                // completion callback fires concurrently with SNIClose.
+                using Barrier gate = new(2);
+
+                closeAttempted = true;
+                Task closeTask = Task.Factory.StartNew(
+                    () =>
+                    {
+                        gate.SignalAndWait();
+                        if (disposeInsteadOfClose)
+                        {
+                            connection.Dispose();
+                        }
+                        else
+                        {
+                            connection.Close();
+                        }
+                    },
+                    TaskCreationOptions.LongRunning);
+
+                gate.SignalAndWait();
+                releaseResponse.Set();
+
+                closedInTime = closeTask.Wait(CloseBudget);
+
+                Assert.True(
+                    closedInTime,
+                    $"iteration {i}: {(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not " +
+                    $"complete within {CloseBudget.TotalSeconds:N0}s while a response completion " +
+                    "raced close. This indicates the SNIClose deadlock (ADO.Net #43847 / ICM 775308542).");
+            }
+            finally
+            {
+                // Always release the (possibly still-stalled) server thread so
+                // the using-scoped server can be disposed without blocking.
+                releaseResponse.Set();
+
+                if (readTask != null)
+                {
+                    try
+                    {
+                        readTask.Wait(CloseBudget);
+                    }
+                    catch
+                    {
+                        // The pending read is expected to fault or cancel once the
+                        // connection is torn down. That is not what this test asserts.
+                    }
+                }
+
+                command?.Dispose();
+
+                // Dispose unless a close deadlock was actually detected (in which
+                // case Dispose() could also block and defeat the regression signal).
+                if (!closeAttempted || closedInTime)
+                {
+                    connection.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/tools/SniCloseLegacyRepro/AssemblyInfo.cs
+++ b/tools/SniCloseLegacyRepro/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+// This diagnostic harness includes tests that mutate PROCESS-GLOBAL state (e.g.
+// ThreadPool.SetMin/MaxThreads in the starvation experiments) and heavy soak
+// tests. Running collections in parallel lets those perturb unrelated tests
+// (starving their connections), so we run serially - matching the container
+// runner, which uses `xunit.console.exe -parallel none`.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tools/SniCloseLegacyRepro/Compat.cs
+++ b/tools/SniCloseLegacyRepro/Compat.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using LegacyBuilder = System.Data.SqlClient.SqlConnectionStringBuilder;
+
+namespace SniCloseLegacyRepro.Compat
+{
+    /// <summary>
+    /// Minimal stand-in for Microsoft.Data.SqlClient's SqlConnectionEncryptOption
+    /// enum, which does not exist in the legacy System.Data.SqlClient driver.
+    /// </summary>
+    public enum SqlConnectionEncryptOption
+    {
+        Optional,
+        Mandatory,
+        Strict,
+    }
+
+    /// <summary>
+    /// A connection-string builder facade over the LEGACY driver's (sealed)
+    /// SqlConnectionStringBuilder. It exposes only the keywords the linked test
+    /// files use, and accepts the Microsoft.Data-style
+    /// <see cref="SqlConnectionEncryptOption"/> enum for <c>Encrypt</c> so those
+    /// files compile unchanged. The legacy builder is sealed, so this uses
+    /// composition rather than inheritance.
+    /// </summary>
+    public sealed class ShimSqlConnectionStringBuilder
+    {
+        private readonly LegacyBuilder _inner;
+
+        public ShimSqlConnectionStringBuilder() => _inner = new LegacyBuilder();
+
+        public ShimSqlConnectionStringBuilder(string connectionString) =>
+            _inner = new LegacyBuilder(connectionString);
+
+        public string ConnectionString => _inner.ConnectionString;
+
+        public string DataSource
+        {
+            get => _inner.DataSource;
+            set => _inner.DataSource = value;
+        }
+
+        public bool Pooling
+        {
+            get => _inner.Pooling;
+            set => _inner.Pooling = value;
+        }
+
+        public bool TrustServerCertificate
+        {
+            get => _inner.TrustServerCertificate;
+            set => _inner.TrustServerCertificate = value;
+        }
+
+        public int ConnectTimeout
+        {
+            get => _inner.ConnectTimeout;
+            set => _inner.ConnectTimeout = value;
+        }
+
+        public int ConnectRetryCount
+        {
+            get => _inner.ConnectRetryCount;
+            set => _inner.ConnectRetryCount = value;
+        }
+
+        public bool MultipleActiveResultSets
+        {
+            get => _inner.MultipleActiveResultSets;
+            set => _inner.MultipleActiveResultSets = value;
+        }
+
+#if NETFRAMEWORK
+        // Only present on the in-box (netfx) legacy builder; the tests guard its
+        // use with #if NETFRAMEWORK, so this facade matches that guard.
+        public bool TransparentNetworkIPResolution
+        {
+            get => _inner.TransparentNetworkIPResolution;
+            set => _inner.TransparentNetworkIPResolution = value;
+        }
+#endif
+
+        /// <summary>
+        /// Maps the Microsoft.Data encryption enum onto the legacy boolean
+        /// <c>Encrypt</c> keyword: Optional =&gt; false; Mandatory/Strict =&gt; true.
+        /// </summary>
+        public SqlConnectionEncryptOption Encrypt
+        {
+            get => _inner.Encrypt
+                ? SqlConnectionEncryptOption.Mandatory
+                : SqlConnectionEncryptOption.Optional;
+            set => _inner.Encrypt = value != SqlConnectionEncryptOption.Optional;
+        }
+    }
+}
+
+namespace Microsoft.Data.SqlClient.ManualTesting.Tests
+{
+    /// <summary>
+    /// Stand-in for the real test-infrastructure DataTestUtility, providing just
+    /// the members the linked MARS test and the stress tests reference. The live
+    /// connection string is taken from the SNICLOSE_CONNSTR environment variable.
+    /// </summary>
+    public static class DataTestUtility
+    {
+        public static string TCPConnectionString =>
+            Environment.GetEnvironmentVariable("SNICLOSE_CONNSTR") ?? string.Empty;
+
+        public static bool AreConnStringsSetup() =>
+            !string.IsNullOrWhiteSpace(TCPConnectionString);
+
+        public static bool IsNotAzureSynapse() => true;
+    }
+}

--- a/tools/SniCloseLegacyRepro/Directory.Build.props
+++ b/tools/SniCloseLegacyRepro/Directory.Build.props
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!--
+    Standalone diagnostic tool. Like the sibling apps, it purposely does NOT
+    import any parent Directory.Build.props, insulating it from the repo's
+    src/test build conventions. Package versions are centrally managed via the
+    sibling Directory.Packages.props.
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+</Project>

--- a/tools/SniCloseLegacyRepro/Directory.Packages.props
+++ b/tools/SniCloseLegacyRepro/Directory.Packages.props
@@ -1,0 +1,22 @@
+<Project>
+
+  <!--
+    Central Package Management for this standalone tool.
+
+    Import the shared SqlClient tests package versions (xunit,
+    Microsoft.NET.Test.Sdk, Microsoft.DotNet.XUnitExtensions,
+    xunit.runner.console, ...); that file transitively imports the repo-root
+    production versions. This mirrors how the sibling Extensions test apps pull
+    in the shared test dependency versions.
+
+    The legacy System.Data.SqlClient package is not part of the shared set, so it
+    is pinned here. The .NET (Core) target can still sweep older builds per-run
+    via the SqlClientLegacyVersion property (applied with VersionOverride).
+  -->
+  <Import Project="../../src/Microsoft.Data.SqlClient/tests/Directory.Packages.props" />
+
+  <ItemGroup>
+    <PackageVersion Include="System.Data.SqlClient" Version="4.9.1" />
+  </ItemGroup>
+
+</Project>

--- a/tools/SniCloseLegacyRepro/GlobalUsings.cs
+++ b/tools/SniCloseLegacyRepro/GlobalUsings.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// -----------------------------------------------------------------------------
+// Global using aliases that let the linked test files (which use bare
+// Microsoft.Data.SqlClient type names) bind to the LEGACY System.Data.SqlClient
+// driver instead.
+//
+// How this works: the linked files live in namespaces under
+// Microsoft.Data.SqlClient.*, so an unqualified name like "SqlConnection" is
+// resolved by walking the enclosing namespaces. Because this assembly does NOT
+// reference Microsoft.Data.SqlClient, none of those namespaces define these
+// types, so name resolution falls through to these global aliases.
+//
+// SqlConnectionStringBuilder and SqlConnectionEncryptOption are aliased to shim
+// types (see Compat.cs) because the legacy builder's Encrypt property is a bool,
+// whereas the tests assign the Microsoft.Data-only SqlConnectionEncryptOption
+// enum. The shim reconciles that difference.
+// -----------------------------------------------------------------------------
+
+global using SqlConnection = System.Data.SqlClient.SqlConnection;
+global using SqlCommand = System.Data.SqlClient.SqlCommand;
+global using SqlDataReader = System.Data.SqlClient.SqlDataReader;
+global using SqlConnectionStringBuilder = SniCloseLegacyRepro.Compat.ShimSqlConnectionStringBuilder;
+global using SqlConnectionEncryptOption = SniCloseLegacyRepro.Compat.SqlConnectionEncryptOption;

--- a/tools/SniCloseLegacyRepro/README.md
+++ b/tools/SniCloseLegacyRepro/README.md
@@ -236,6 +236,25 @@ from a plain client-side ordering bug reachable from managed timing alone, and
 toward something more environment-specific in the original incident (e.g. exact
 network/timing conditions, or a native-layer interaction not exercised here).
 
+### Additional reproduction attempts (`ReproAttempts.cs`)
+
+Harness-only, exploratory variants targeting conditions the shared tests do not
+create. On the exact 4.7.4081.0 bits at 4 CPUs, **none reproduces the issue**:
+
+- **Close under thread-pool starvation** → no deadlock.
+- **Sync-over-async on a single-threaded `SynchronizationContext`** (classic
+  ASP.NET shape) → no captured-context deadlock.
+- **Cancel `OpenAsync` during the TLS handshake** (internal abort/close path)
+  → settles promptly, no deadlock.
+- **`Open()` under client thread-pool starvation** (real, out-of-process server;
+  plain and TLS) → **`Open()` succeeds**. Starvation is *not* the reproduction.
+
+> A note on a false lead: an *in-process* TDS test server shares the client's
+> thread pool, so saturating the pool starves the **server** and makes `Open()`
+> time out - a test artifact. Against a real out-of-process server the driver's
+> `Open()` is robust under the same starvation, so the timeout does not indicate
+> a driver defect.
+
 ---
 
 ## Isolation notes

--- a/tools/SniCloseLegacyRepro/README.md
+++ b/tools/SniCloseLegacyRepro/README.md
@@ -1,0 +1,251 @@
+# SniCloseLegacyRepro
+
+Diagnostic harness that runs **SNIClose / MARS close-during-I/O deadlock tests** against the
+**legacy `System.Data.SqlClient`** driver, to see whether the deadlock from **ICM 775308542 /
+ADO.Net #43847** ("SNIClose can deadlock with in-flight async I/O during connection close")
+reproduces there.
+
+---
+
+## Background
+
+ICM 775308542 / ADO.Net #43847 concern a potential SNIClose deadlock with
+in-flight async I/O during connection close in the **retired, in-box
+`System.Data.SqlClient`**. The environment reported in the ICM:
+
+| | Reported environment (ICM) |
+|---|---|
+| OS | Windows Server 2016 (10.0.14393) |
+| Runtime | .NET Framework 4.7 (CLR 4.0.30319) |
+| Driver | in-box `System.Data.dll` **4.7.4081.0** |
+| CPUs | 4 |
+
+`System.Data.SqlClient` is retired, so the fix (if any) is being investigated in
+`Microsoft.Data.SqlClient` via #43847. The branch adds regression tests on the
+MDS side; this harness points those same tests at the legacy driver.
+
+---
+
+## How it works
+
+Rather than re-implementing the tests, the project **links the real test source
+files** and swaps only the driver reference:
+
+- **Linked tests** (compiled verbatim, not copied):
+  - `SNICloseDeadlockTest.cs` (from `tests/UnitTests/SimulatedServerTests`) —
+    3 in-process tests: pending async read (via the in-repo TDS test server),
+    pre-login handshake, and TLS handshake (both via raw `TcpListener`).
+  - `SNICloseRaceDeadlockTest.cs` (same folder) — releases the server response
+    at the same instant as close so the read completion races `SNIClose`
+    (×100 iterations).
+  - `MarsCloseDeadlockTest.cs` (from `tests/ManualTests/SQL/AsyncTest`) —
+    live-server MARS pending-read test.
+  - `MarsCloseStressTest.cs` (same folder) — many MARS connections with
+    in-flight reads, all closed simultaneously over several iterations
+    (live server).
+- **Compat shim** makes the legacy driver satisfy the linked files' bare
+  `Microsoft.Data.SqlClient` type names:
+  - `GlobalUsings.cs` — global `using` aliases mapping `SqlConnection`,
+    `SqlCommand`, `SqlDataReader` to `System.Data.SqlClient`, and
+    `SqlConnectionStringBuilder` / `SqlConnectionEncryptOption` to the shims.
+  - `Compat.cs` — a `SqlConnectionEncryptOption` enum stand-in, a
+    `SqlConnectionStringBuilder` facade over the (sealed) legacy builder that
+    accepts the enum-typed `Encrypt`, and a `DataTestUtility` stand-in that
+    reads the connection string from `SNICLOSE_CONNSTR`.
+
+All four test files are the **real driver tests**; this project only links them
+and swaps the driver reference. (The race/stress tests were originally prototyped
+here and have since been promoted into the driver test projects.)
+
+The bare-name binding trick: the linked files sit in `Microsoft.Data.SqlClient.*`
+namespaces, and because this project does **not** reference MDS, unqualified
+names like `SqlConnection` fall through to the global aliases in `GlobalUsings.cs`.
+
+### Why `xunit.runner.json` (shadowCopy: false) matters
+
+`Microsoft.DotNet.XUnitExtensions` (which provides `[ConditionalTheory]`) ships a
+**delay-signed** beta assembly. On .NET Framework, xUnit's default shadow copy
+re-verifies the strong name from the shadow-copy directory and fails with
+`FileLoadException: strong name could not be verified`. The real test projects
+ship `xunit.runner.json` with `shadowCopy: false`; this harness **links that same
+file** so the delay-signed assembly loads from its build-output location (where
+.NET Framework's strong-name bypass applies).
+
+---
+
+## Target frameworks
+
+`net462;net47;net472;net481;net10.0`
+
+- **.NET Framework targets** use the **in-box** `System.Data.dll`.
+- **.NET (Core) target** (`net10.0`) uses the **`System.Data.SqlClient` NuGet
+  package** (version parametrized — see below).
+
+> **Important:** the in-box `System.Data.dll` is *machine-global* for the whole
+> 4.x line — only one physical DLL exists per machine. On this dev box that is
+> 4.8.1, so every netfx target binds 4.8.1 at runtime; the older TFMs only change
+> compile-time references and framework "quirk" behaviors, **not** the DLL bits.
+> To run the exact reported 4.7.4081.0 bits you need an environment isolated to
+> .NET 4.7.2 (see [Testing older in-box DLLs](#testing-older-in-box-dlls-containers)).
+
+---
+
+## Running
+
+From the repo root.
+
+### In-process tests only (no SQL Server)
+
+```powershell
+dotnet test .\tools\SniCloseLegacyRepro
+# or a single framework:
+dotnet test .\tools\SniCloseLegacyRepro -f net481
+```
+
+The live MARS test and the MARS stress test are skipped when no connection
+string is set.
+
+### With a live SQL Server (enables MARS + stress tests)
+
+Set `SNICLOSE_CONNSTR` yourself so the password is not routed through tooling:
+
+```powershell
+$env:SNICLOSE_CONNSTR = "Server=127.0.0.1,1434;Database=master;User ID=<user>;Password=<pwd>;TrustServerCertificate=true;Connect Timeout=15"
+dotnet test .\tools\SniCloseLegacyRepro -f net481
+Remove-Item Env:\SNICLOSE_CONNSTR   # clear when done
+```
+
+### Sweeping legacy NuGet versions (net10.0 only)
+
+The `.NET (Core)` target's package version is parametrized via
+`$(SqlClientLegacyVersion)` (default `4.9.1`). The versions must exist on a
+restore feed.
+
+```powershell
+foreach ($v in '4.5.3','4.6.1','4.7.0','4.8.6','4.9.1') {
+  dotnet test .\tools\SniCloseLegacyRepro -f net10.0 -p:SqlClientLegacyVersion=$v
+}
+```
+
+### Emulating the reported 4-CPU box
+
+Pin the test process (and its child `testhost`) to 4 cores:
+
+```powershell
+$p = Start-Process dotnet -ArgumentList 'test','.\tools\SniCloseLegacyRepro','-f','net47','--no-build' -PassThru -NoNewWindow
+$p.ProcessorAffinity = [IntPtr]0xF   # cores 0-3
+$p.WaitForExit()
+```
+
+---
+
+## Testing older in-box DLLs (containers)
+
+Because the in-box `System.Data.dll` is machine-global, the faithful way to test
+older bits is an isolated environment. Use the official .NET Framework images —
+the **framework version tag controls `System.Data.dll`**; the **Windows base tag
+controls the OS + native `sni.dll`**.
+
+```
+mcr.microsoft.com/dotnet/framework/runtime:<fwver>-windowsservercore-<base>
+```
+
+| Image tag | `System.Data.dll` ≈ | Role |
+|---|---|---|
+| `4.6.2-windowsservercore-ltsc2016` | 4.7.4081.0 (see note) | — |
+| `4.7-windowsservercore-ltsc2016` | **4.7.4081.0** | **ICM match** |
+| `4.7.2-windowsservercore-ltsc2016` | 4.7.4081.0 | ICM match |
+| `4.8-windowsservercore-ltsc2019` | 4.8.4690.0 | newer |
+| `4.8.1-windowsservercore-ltsc2022` | 4.8.9xxx | this dev box |
+
+> **.NET Framework 4.x is a single, in-place, monotonic runtime.** The `ltsc2016`
+> base OS is already serviced to 4.7.2, so its in-box `System.Data.dll` is
+> **4.7.4081.0** — and a lower framework tag (e.g. `4.6.2`) cannot downgrade it.
+> On this base, every tag at or below 4.7.2 resolves to the same 4.7.4081.0 DLL,
+> which happens to be the reported version (the practical floor). Getting
+> a genuinely older DLL (e.g. 4.6.x) would require an *unserviced* older base OS
+> image, which MCR does not publish.
+
+Verify the DLL version inside a container:
+
+```powershell
+(Get-Item C:\Windows\Microsoft.NET\Framework64\v4.0.30319\System.Data.dll).VersionInfo.FileVersion
+```
+
+### `run-in-container.ps1`
+
+The framework `runtime` images have **no `dotnet` CLI**, so `dotnet test` will not
+work there. The `run-in-container.ps1` helper handles this: it builds `-f net47`
+on the host, stages `xunit.console.exe` (from `xunit.runner.console`) next to the
+build output, and runs the tests in the container so they bind the container's
+old in-box `System.Data.dll`.
+
+```powershell
+# in-process tests only (no SQL Server):
+.\run-in-container.ps1
+
+# faithful ICM match: 4.7.4081.0 + 4 processors, live MARS + stress:
+$env:SNICLOSE_CONNSTR = "Server=127.0.0.1,1434;Database=master;User ID=sa;Password=***;TrustServerCertificate=true"
+.\run-in-container.ps1 -Cpus 4
+
+# a different framework image:
+.\run-in-container.ps1 -Image mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
+```
+
+**Networking:** a Windows container cannot reach the host's loopback, and
+`host.docker.internal` is not injected for hyperv-isolated Windows containers.
+The script targets the Docker NAT gateway (the host's `vEthernet (nat)` IP, e.g.
+`172.17.224.1`) and rewrites the connection string to it. Because the SQL Server
+(a Linux container published to host loopback) does not listen on that IP, add a
+one-time **elevated** host bridge:
+
+```powershell
+netsh interface portproxy add v4tov4 listenaddress=172.17.224.1 listenport=1434 connectaddress=127.0.0.1 connectport=1434
+New-NetFirewallRule -DisplayName "SQL 1434 from Windows containers" -Direction Inbound -LocalAddress 172.17.224.1 -LocalPort 1434 -Protocol TCP -Action Allow
+# teardown:
+#   netsh interface portproxy delete v4tov4 listenaddress=172.17.224.1 listenport=1434
+#   Remove-NetFirewallRule -DisplayName "SQL 1434 from Windows containers"
+```
+
+---
+
+## Findings
+
+Across every configuration tested, the deadlock **does not reproduce** (all
+tests pass), including:
+
+- in-box `System.Data.dll` 4.8.1 on `net462` / `net47` / `net472` / `net481`
+  (host dev box)
+- 4-CPU-pinned runs
+- the completion-races-close and MARS concurrency stress variants
+- the full `System.Data.SqlClient` NuGet lineage on `net10.0`
+  (4.5.3, 4.6.1, 4.7.0, 4.8.6, 4.9.1)
+- **the reported (ICM) environment**, reproduced faithfully in a container:
+  Windows Server 2016 base (`ltsc2016`) · .NET Framework 4.7 · in-box
+  `System.Data.dll` **4.7.4081.0** · **4 processors** (`--cpu-count 4`) · live
+  MARS + concurrency stress against SQL Server 2025 → **12/12 pass**.
+- container `ltsc2019` · .NET Framework 4.8 · `System.Data.dll` 4.8.4690.0 ·
+  4 processors · live MARS + stress → **12/12 pass**.
+
+So the SNIClose close-during-I/O deadlock does not reproduce even in a
+bit-for-bit reconstruction of the reported ICM environment. Because that
+*exact* `System.Data.dll` (4.7.4081.0) also passes, there is no
+version boundary / "fixed in a later servicing build" explanation: the synthetic
+tests simply do not trigger whatever the original incident hit. That points away
+from a plain client-side ordering bug reachable from managed timing alone, and
+toward something more environment-specific in the original incident (e.g. exact
+network/timing conditions, or a native-layer interaction not exercised here).
+
+---
+
+## Isolation notes
+
+- Uses Central Package Management via its own `Directory.Build.props`
+  (`ManagePackageVersionsCentrally=true`) and `Directory.Packages.props`, which
+  imports the shared SqlClient tests package versions. The legacy
+  `System.Data.SqlClient` package is pinned there; the net10.0 target overrides
+  it per-run via `VersionOverride` / `-p:SqlClientLegacyVersion=…`.
+- Legacy `System.Data.SqlClient` versions are served from the repo's governed
+  feed (no extra `NuGet.config`).
+- References the driver-agnostic in-repo TDS test-server projects
+  (`tests/tools/TDS/*`).

--- a/tools/SniCloseLegacyRepro/ReproAttempts.cs
+++ b/tools/SniCloseLegacyRepro/ReproAttempts.cs
@@ -1,0 +1,595 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+// -----------------------------------------------------------------------------
+// Tier-2 reproduction ATTEMPTS for ICM 775308542 / ADO.Net #43847 (harness-only,
+// exploratory - not promoted to the driver test suite unless one reproduces).
+//
+// The shared SNIClose/MARS tests conclusively show that a single connection
+// closed while one async I/O is in flight does NOT deadlock, even on the
+// customer's exact in-box System.Data.dll (4.7.4081.0) at 4 CPUs. These variants
+// target conditions those tests do not create, which better match the reported
+// symptom ("initial TLS handshake failure" under a 4-proc production load):
+//
+//   1. ThreadPoolStarvation  - the worker pool is saturated (as on a small,
+//      busy box) when the connection is closed, so an async completion callback
+//      cannot obtain a thread while the close path runs.
+//   2. SyncOverAsyncContext  - a single-threaded SynchronizationContext (as in
+//      classic ASP.NET) is blocked on an async SqlClient operation via .Result;
+//      if the driver captures the context for a continuation, it deadlocks.
+//   3. CancelOpenDuringTls   - OpenAsync is cancelled while the TLS handshake
+//      read is in flight, driving the driver's INTERNAL abort/close path
+//      (rather than an external Close on another thread).
+//   4. OpenUnderStarvation   - does client thread-pool starvation cause a
+//      connection/handshake failure? Against a REAL server it does NOT: the
+//      driver's Open() is robust. (An in-process test server shares the pool
+//      and would be co-starved - a test artifact, not driver behavior.)
+//
+// All waits are bounded, so a genuine deadlock is reported as a failed
+// bounded-wait rather than hanging the run.
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SqlServer.TDS;
+using Microsoft.SqlServer.TDS.EndPoint;
+using Microsoft.SqlServer.TDS.Servers;
+using Microsoft.SqlServer.TDS.SQLBatch;
+using Microsoft.Data.SqlClient.ManualTesting.Tests; // DataTestUtility shim (live connection string)
+using Xunit;
+
+namespace SniCloseLegacyRepro
+{
+    /// <summary>Shared helpers for the reproduction attempts.</summary>
+    internal static class ReproSupport
+    {
+        public static readonly TimeSpan CloseBudget = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan HandshakeBudget = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// A query engine that signals when a SQL batch arrives and then withholds
+        /// the response until released.
+        /// </summary>
+        public sealed class StallingQueryEngine : QueryEngine
+        {
+            private readonly ManualResetEventSlim _batchReceived;
+            private readonly ManualResetEventSlim _release;
+
+            public StallingQueryEngine(
+                TdsServerArguments arguments,
+                ManualResetEventSlim batchReceived,
+                ManualResetEventSlim release)
+                : base(arguments)
+            {
+                _batchReceived = batchReceived;
+                _release = release;
+            }
+
+            protected override TDSMessageCollection CreateQueryResponse(
+                ITDSServerSession session,
+                TDSSQLBatchToken batchRequest)
+            {
+                _batchReceived.Set();
+                _release.Wait();
+                return base.CreateQueryResponse(session, batchRequest);
+            }
+        }
+
+        /// <summary>
+        /// A minimal, protocol-valid TDS PRELOGIN response advertising ENCRYPT_ON
+        /// so a client that requested encryption proceeds into the TLS handshake.
+        /// </summary>
+        public static readonly byte[] PreLoginEncryptOnResponse =
+        {
+            0x12, 0x01, 0x00, 0x1A, 0x00, 0x00, 0x01, 0x00,
+            0x00, 0x00, 0x0B, 0x00, 0x06,
+            0x01, 0x00, 0x11, 0x00, 0x01,
+            0xFF,
+            0x11, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x01,
+        };
+    }
+
+    /// <summary>
+    /// A single-threaded synchronization context that pumps posted callbacks on
+    /// one dedicated (background) thread - the shape that makes classic ASP.NET
+    /// sync-over-async deadlock.
+    /// </summary>
+    internal sealed class SingleThreadedSynchronizationContext : SynchronizationContext, IDisposable
+    {
+        private readonly BlockingCollection<(SendOrPostCallback callback, object? state)> _queue = new();
+        private readonly Thread _thread;
+
+        public SingleThreadedSynchronizationContext()
+        {
+            _thread = new Thread(Pump) { IsBackground = true, Name = "SingleThreadedSyncCtx" };
+            _thread.Start();
+        }
+
+        private void Pump()
+        {
+            SetSynchronizationContext(this);
+            try
+            {
+                foreach ((SendOrPostCallback callback, object? state) in _queue.GetConsumingEnumerable())
+                {
+                    callback(state);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Queue completed while blocked; normal shutdown.
+            }
+        }
+
+        public override void Post(SendOrPostCallback d, object? state) => _queue.Add((d, state));
+
+        public override void Send(SendOrPostCallback d, object? state) =>
+            throw new NotSupportedException();
+
+        /// <summary>Queue an action to run on the context thread.</summary>
+        public void Run(Action action) => Post(_ => action(), null);
+
+        public void Dispose()
+        {
+            try
+            {
+                _queue.CompleteAdding();
+            }
+            catch
+            {
+                // Ignore.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Attempt 1: close a connection with an in-flight async read while the
+    /// worker thread pool is fully saturated, so an async completion callback
+    /// cannot obtain a thread while the close path runs.
+    /// </summary>
+    public class ThreadPoolStarvationReproTests
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void CloseWithPendingReadUnderThreadPoolStarvation_DoesNotDeadlock(bool disposeInsteadOfClose)
+        {
+            ThreadPool.GetMinThreads(out int minW, out int minIo);
+            ThreadPool.GetMaxThreads(out int maxW, out int maxIo);
+
+            using ManualResetEventSlim releaseWorkers = new(false);
+            using ManualResetEventSlim batchReceived = new(false);
+            using ManualResetEventSlim releaseResponse = new(false);
+            int busy = 0;
+            bool poolConstrained = false;
+            try
+            {
+                TdsServerArguments arguments = new();
+                using TdsServer server = new(
+                    new ReproSupport.StallingQueryEngine(arguments, batchReceived, releaseResponse),
+                    arguments);
+                server.Start();
+
+                SqlConnectionStringBuilder builder = new()
+                {
+                    DataSource = $"localhost,{server.EndPoint.Port}",
+                    Encrypt = SqlConnectionEncryptOption.Optional,
+                    Pooling = false,
+#if NETFRAMEWORK
+                    TransparentNetworkIPResolution = false,
+#endif
+                };
+
+                SqlConnection connection = new(builder.ConnectionString);
+                SqlCommand? command = null;
+                Task<SqlDataReader>? readTask = null;
+                bool closeAttempted = false;
+                bool closedInTime = false;
+                try
+                {
+                    // Open and start the read while the pool is healthy, so the
+                    // starvation below isolates the CLOSE path (not connection
+                    // establishment, which is starvation-sensitive on its own).
+                    connection.Open();
+                    command = new("SELECT 1", connection);
+                    readTask = command.ExecuteReaderAsync();
+
+                    Assert.True(
+                        batchReceived.Wait(ReproSupport.HandshakeBudget),
+                        "The server never received the batch; the async read was not in flight.");
+
+                    // Now saturate a small, busy-box worker pool so any async
+                    // completion the close path depends on cannot obtain a thread.
+                    int poolSize = Math.Max(2, Math.Min(4, Environment.ProcessorCount));
+                    ThreadPool.SetMinThreads(poolSize, poolSize);
+                    ThreadPool.SetMaxThreads(poolSize, poolSize);
+                    poolConstrained = true;
+                    for (int i = 0; i < poolSize; i++)
+                    {
+                        ThreadPool.QueueUserWorkItem(_ =>
+                        {
+                            Interlocked.Increment(ref busy);
+                            releaseWorkers.Wait();
+                        });
+                    }
+                    SpinWait.SpinUntil(() => Volatile.Read(ref busy) >= poolSize, TimeSpan.FromSeconds(10));
+
+                    closeAttempted = true;
+                    Task closeTask = Task.Factory.StartNew(
+                        () =>
+                        {
+                            if (disposeInsteadOfClose)
+                            {
+                                connection.Dispose();
+                            }
+                            else
+                            {
+                                connection.Close();
+                            }
+                        },
+                        TaskCreationOptions.LongRunning);
+
+                    closedInTime = closeTask.Wait(ReproSupport.CloseBudget);
+
+                    Assert.True(
+                        closedInTime,
+                        $"{(disposeInsteadOfClose ? "Dispose()" : "Close()")} did not complete within " +
+                        $"{ReproSupport.CloseBudget.TotalSeconds:N0}s while the thread pool was saturated " +
+                        "(possible SNIClose deadlock / thread-starvation).");
+                }
+                finally
+                {
+                    // Free the pool first so the pending read and any close-path
+                    // continuations can drain, then release the server.
+                    releaseWorkers.Set();
+                    if (poolConstrained)
+                    {
+                        ThreadPool.SetMinThreads(minW, minIo);
+                        ThreadPool.SetMaxThreads(maxW, maxIo);
+                    }
+                    releaseResponse.Set();
+
+                    if (readTask != null)
+                    {
+                        try { readTask.Wait(ReproSupport.CloseBudget); } catch { /* expected */ }
+                    }
+                    command?.Dispose();
+                    if (!closeAttempted || closedInTime)
+                    {
+                        connection.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                releaseWorkers.Set();
+                ThreadPool.SetMinThreads(minW, minIo);
+                ThreadPool.SetMaxThreads(maxW, maxIo);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Attempt 2: block a single-threaded synchronization context on an async
+    /// SqlClient read via <c>.Result</c>. If any driver continuation captures the
+    /// context, the post-back cannot run and the operation deadlocks.
+    /// </summary>
+    public class SyncOverAsyncContextReproTests
+    {
+        [Fact]
+        public void SyncOverAsyncOnSingleThreadedContext_DoesNotDeadlock()
+        {
+            using ManualResetEventSlim batchReceived = new(false);
+            using ManualResetEventSlim releaseResponse = new(false);
+            using ManualResetEventSlim scenarioDone = new(false);
+            Exception? scenarioError = null;
+
+            TdsServerArguments arguments = new();
+            using TdsServer server = new(
+                new ReproSupport.StallingQueryEngine(arguments, batchReceived, releaseResponse),
+                arguments);
+            server.Start();
+
+            SqlConnectionStringBuilder builder = new()
+            {
+                DataSource = $"localhost,{server.EndPoint.Port}",
+                Encrypt = SqlConnectionEncryptOption.Optional,
+                Pooling = false,
+#if NETFRAMEWORK
+                TransparentNetworkIPResolution = false,
+#endif
+            };
+
+            // Once the read is in flight, release the server so its completion
+            // fires and the continuation must post back to the (blocked) context.
+            Task releaser = Task.Run(() =>
+            {
+                if (batchReceived.Wait(ReproSupport.HandshakeBudget))
+                {
+                    releaseResponse.Set();
+                }
+            });
+
+            using SingleThreadedSynchronizationContext context = new();
+            SqlConnection? connection = null;
+            context.Run(() =>
+            {
+                try
+                {
+                    connection = new SqlConnection(builder.ConnectionString);
+                    connection.Open();
+                    using SqlCommand command = new("SELECT 1", connection);
+
+                    // Sync-over-async on the single-threaded context: blocks the
+                    // pump thread. Deadlocks iff a continuation captured the context.
+                    using SqlDataReader reader = command.ExecuteReaderAsync().GetAwaiter().GetResult();
+                    while (reader.Read())
+                    {
+                        // Drain.
+                    }
+                }
+                catch (Exception ex)
+                {
+                    scenarioError = ex;
+                }
+                finally
+                {
+                    scenarioDone.Set();
+                }
+            });
+
+            bool completed = scenarioDone.Wait(ReproSupport.CloseBudget);
+
+            // Best-effort cleanup; if we deadlocked, the context thread is parked
+            // (background) and the connection is stuck - do not block on it.
+            try { releaser.Wait(TimeSpan.FromSeconds(5)); } catch { /* ignore */ }
+            if (completed)
+            {
+                try { connection?.Dispose(); } catch { /* ignore */ }
+            }
+
+            Assert.True(
+                completed,
+                $"Sync-over-async on a single-threaded SynchronizationContext did not complete within " +
+                $"{ReproSupport.CloseBudget.TotalSeconds:N0}s. This indicates a captured-context deadlock in " +
+                "the driver's async read path (ADO.Net #43847 / ICM 775308542).");
+
+            // If it completed, it should have completed cleanly (or with an
+            // expected SqlException), not via some other failure mode.
+            Assert.True(
+                scenarioError is null or System.Data.SqlClient.SqlException,
+                $"Unexpected error on the context thread: {scenarioError}");
+        }
+    }
+
+    /// <summary>
+    /// Attempt 3: cancel <c>OpenAsync</c> while the TLS handshake read is in
+    /// flight, exercising the driver's INTERNAL abort/close path concurrently
+    /// with the handshake I/O (rather than an external Close on another thread).
+    /// </summary>
+    public class HandshakeCancellationReproTests
+    {
+        [Fact]
+        public void CancelOpenAsyncDuringTlsHandshake_DoesNotDeadlock()
+        {
+            using ManualResetEventSlim handshakeInFlight = new(false);
+            using ManualResetEventSlim releaseServer = new(false);
+
+            TcpListener listener = new(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+            Task serverTask = Task.Run(() =>
+            {
+                using TcpClient acceptedClient = listener.AcceptTcpClient();
+                using NetworkStream stream = acceptedClient.GetStream();
+                byte[] buffer = new byte[4096];
+                try
+                {
+                    int read = stream.Read(buffer, 0, buffer.Length);
+                    if (read <= 0)
+                    {
+                        return;
+                    }
+
+                    stream.Write(ReproSupport.PreLoginEncryptOnResponse, 0, ReproSupport.PreLoginEncryptOnResponse.Length);
+                    stream.Flush();
+
+                    // Read the first byte of the client's TLS ClientHello, then
+                    // withhold the ServerHello so the handshake read stays pending.
+                    if (stream.ReadByte() < 0)
+                    {
+                        return;
+                    }
+
+                    handshakeInFlight.Set();
+                    releaseServer.Wait();
+                }
+                catch
+                {
+                    // Client may tear down mid-handshake; ignore.
+                }
+            });
+
+            SqlConnectionStringBuilder builder = new()
+            {
+                DataSource = $"127.0.0.1,{port}",
+                Encrypt = SqlConnectionEncryptOption.Mandatory,
+                TrustServerCertificate = true,
+                ConnectTimeout = 60,
+                ConnectRetryCount = 0,
+                Pooling = false,
+#if NETFRAMEWORK
+                TransparentNetworkIPResolution = false,
+#endif
+            };
+
+            SqlConnection connection = new(builder.ConnectionString);
+            using CancellationTokenSource cts = new();
+            Task? openTask = null;
+            bool cancelAttempted = false;
+            bool settledInTime = false;
+            try
+            {
+                openTask = connection.OpenAsync(cts.Token);
+
+                Assert.True(
+                    handshakeInFlight.Wait(ReproSupport.HandshakeBudget),
+                    "The client never reached the TLS handshake; no read was in flight to cancel.");
+
+                // Cancel while the handshake read is pending: this drives the
+                // driver's internal abort/close path against the in-flight I/O.
+                cancelAttempted = true;
+                cts.Cancel();
+
+                try
+                {
+                    settledInTime = openTask.Wait(ReproSupport.CloseBudget);
+                }
+                catch (AggregateException)
+                {
+                    // OpenAsync faulting/cancelling is the expected outcome; what
+                    // matters is that it *settled* rather than hanging.
+                    settledInTime = true;
+                }
+
+                Assert.True(
+                    settledInTime,
+                    $"OpenAsync did not settle within {ReproSupport.CloseBudget.TotalSeconds:N0}s after " +
+                    "cancellation while a TLS handshake read was in flight (possible SNIClose deadlock).");
+            }
+            finally
+            {
+                releaseServer.Set();
+                listener.Stop();
+
+                if (openTask != null)
+                {
+                    try { openTask.Wait(ReproSupport.CloseBudget); } catch { /* expected fault/cancel */ }
+                }
+
+                if (!cancelAttempted || settledInTime)
+                {
+                    connection.Dispose();
+                }
+
+                try { serverTask.Wait(ReproSupport.CloseBudget); } catch { /* ignore */ }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Attempt 4: does client-side thread-pool starvation cause a CONNECTION
+    /// failure? This checks the hypothesis that the reported "connection/
+    /// handshake failure under load" is thread starvation rather than an
+    /// SNIClose deadlock.
+    ///
+    /// <para>
+    /// IMPORTANT: an in-process TDS test server shares the client's thread pool,
+    /// so saturating the pool starves the SERVER and makes Open() time out - a
+    /// test artifact, not driver behavior. These tests therefore require a real,
+    /// out-of-process SQL Server (SNICLOSE_CONNSTR). The observed result is that
+    /// Open() SUCCEEDS under client thread-pool starvation, i.e. starvation is
+    /// NOT the reproduction.
+    /// </para>
+    /// </summary>
+    public class OpenUnderThreadPoolStarvationReproTests
+    {
+        private static readonly TimeSpan HardBudget = TimeSpan.FromSeconds(60);
+
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
+        [InlineData(false)] // Encrypt = Optional
+        [InlineData(true)]  // Encrypt = Mandatory (drives the TLS handshake)
+        public void SyncOpenAgainstRealServerUnderThreadPoolStarvation_Succeeds(bool encrypt)
+        {
+            string cs = new SqlConnectionStringBuilder(DataTestUtility.TCPConnectionString)
+            {
+                Encrypt = encrypt ? SqlConnectionEncryptOption.Mandatory : SqlConnectionEncryptOption.Optional,
+                TrustServerCertificate = true,
+                Pooling = false,
+                ConnectTimeout = 30,
+            }.ConnectionString;
+
+            RunStarvedOpen(cs, out bool settled, out bool timedOut, out Exception? error);
+
+            Assert.True(
+                settled,
+                $"Open() did not settle within {HardBudget.TotalSeconds:N0}s under thread-pool starvation " +
+                "(it hung).");
+            Assert.True(
+                error is null,
+                $"Open() against a real server failed under client thread-pool starvation: {error}");
+            Assert.False(
+                timedOut,
+                "Open() timed out under client thread-pool starvation against a real server.");
+        }
+
+        private static void RunStarvedOpen(string connectionString, out bool settled, out bool timedOut, out Exception? error)
+        {
+            ThreadPool.GetMinThreads(out int minW, out int minIo);
+            ThreadPool.GetMaxThreads(out int maxW, out int maxIo);
+            // Not disposed: saturating workers may still be parked on it when the
+            // method returns; disposing would race them into ObjectDisposedException.
+            ManualResetEventSlim releaseWorkers = new(false);
+            int busy = 0;
+            settled = false;
+            timedOut = false;
+            error = null;
+            try
+            {
+                // Constrain the pool to a small, busy-box size and occupy every
+                // worker thread so any continuation the driver needs is starved.
+                int poolSize = Math.Max(2, Math.Min(4, Environment.ProcessorCount));
+                ThreadPool.SetMinThreads(poolSize, poolSize);
+                ThreadPool.SetMaxThreads(poolSize, poolSize);
+                for (int i = 0; i < poolSize; i++)
+                {
+                    ThreadPool.QueueUserWorkItem(_ =>
+                    {
+                        Interlocked.Increment(ref busy);
+                        releaseWorkers.Wait();
+                    });
+                }
+                SpinWait.SpinUntil(() => Volatile.Read(ref busy) >= poolSize, TimeSpan.FromSeconds(10));
+
+                Exception? captured = null;
+                Thread openThread = new(() =>
+                {
+                    try
+                    {
+                        using SqlConnection conn = new(connectionString);
+                        conn.Open();
+                        conn.Close();
+                    }
+                    catch (Exception ex)
+                    {
+                        captured = ex;
+                    }
+                })
+                { IsBackground = true, Name = "StarvedOpen" };
+
+                openThread.Start();
+                settled = openThread.Join(HardBudget);
+                error = captured;
+                timedOut = captured is System.Data.SqlClient.SqlException sqlEx
+                    && (sqlEx.Number == -2
+                        || sqlEx.Message.IndexOf("timeout", StringComparison.OrdinalIgnoreCase) >= 0
+                        || sqlEx.Message.IndexOf("timed out", StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+            finally
+            {
+                releaseWorkers.Set();
+                ThreadPool.SetMinThreads(minW, minIo);
+                ThreadPool.SetMaxThreads(maxW, maxIo);
+            }
+        }
+    }
+}

--- a/tools/SniCloseLegacyRepro/ReproAttempts.cs
+++ b/tools/SniCloseLegacyRepro/ReproAttempts.cs
@@ -22,11 +22,32 @@
 //      if the driver captures the context for a continuation, it deadlocks.
 //   3. CancelOpenDuringTls   - OpenAsync is cancelled while the TLS handshake
 //      read is in flight, driving the driver's INTERNAL abort/close path
-//      (rather than an external Close on another thread).
+//      (rather than an external Close on another thread). PROMOTED to the driver
+//      test suite as SNICloseHandshakeCancellationTest (linked in via the
+//      harness csproj), so it also runs against the legacy driver here.
 //   4. OpenUnderStarvation   - does client thread-pool starvation cause a
 //      connection/handshake failure? Against a REAL server it does NOT: the
 //      driver's Open() is robust. (An in-process test server shares the pool
 //      and would be co-starved - a test artifact, not driver behavior.)
+//
+// After the ICM dump was obtained, the real mechanism was identified: a
+// RE-ENTRANT SNIClose (Close() called synchronously from within
+// ReadAsyncCallback via the command-timeout -> failed-attention-write path, so
+// SNIClose spins in WaitForActiveCallbacks waiting for the callback it runs in).
+// Two further attempts target that mechanism:
+//
+//   5. CallbackReentrancy    - async read + short command timeout + a proxy that
+//      breaks the client's write. A regression guard for the MDS asyncClose fix;
+//      does not deterministically force the legacy re-entrancy (see its notes).
+//   6. ReentrantSNICloseSoak - many concurrent workers RST connections at ~the
+//      command-timeout instant, hunting the race probabilistically. OPT-IN
+//      (set SNICLOSE_SOAK_ENABLE) because it is heavy and, when it fires, poisons
+//      the process. It fired ONCE in a full-suite run on the legacy in-box driver
+//      (net462/47x/48x) but NOT on the Core NuGet lineage (net10.0) - a clean
+//      driver-lineage split consistent with the real bug - yet it did not recur
+//      in subsequent runs. So it confirms the mechanism is reachable but is not a
+//      reliable reproduction (matching the SQL EE's "very difficult to capture").
+//      The definitive evidence remains the dump + the asyncClose code review.
 //
 // All waits are bounded, so a genuine deadlock is reported as a failed
 // bounded-wait rather than hanging the run.
@@ -34,6 +55,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -81,20 +103,6 @@ namespace SniCloseLegacyRepro
                 return base.CreateQueryResponse(session, batchRequest);
             }
         }
-
-        /// <summary>
-        /// A minimal, protocol-valid TDS PRELOGIN response advertising ENCRYPT_ON
-        /// so a client that requested encryption proceeds into the TLS handshake.
-        /// </summary>
-        public static readonly byte[] PreLoginEncryptOnResponse =
-        {
-            0x12, 0x01, 0x00, 0x1A, 0x00, 0x00, 0x01, 0x00,
-            0x00, 0x00, 0x0B, 0x00, 0x06,
-            0x01, 0x00, 0x11, 0x00, 0x01,
-            0xFF,
-            0x11, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x01,
-        };
     }
 
     /// <summary>
@@ -371,122 +379,6 @@ namespace SniCloseLegacyRepro
     }
 
     /// <summary>
-    /// Attempt 3: cancel <c>OpenAsync</c> while the TLS handshake read is in
-    /// flight, exercising the driver's INTERNAL abort/close path concurrently
-    /// with the handshake I/O (rather than an external Close on another thread).
-    /// </summary>
-    public class HandshakeCancellationReproTests
-    {
-        [Fact]
-        public void CancelOpenAsyncDuringTlsHandshake_DoesNotDeadlock()
-        {
-            using ManualResetEventSlim handshakeInFlight = new(false);
-            using ManualResetEventSlim releaseServer = new(false);
-
-            TcpListener listener = new(IPAddress.Loopback, 0);
-            listener.Start();
-            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
-
-            Task serverTask = Task.Run(() =>
-            {
-                using TcpClient acceptedClient = listener.AcceptTcpClient();
-                using NetworkStream stream = acceptedClient.GetStream();
-                byte[] buffer = new byte[4096];
-                try
-                {
-                    int read = stream.Read(buffer, 0, buffer.Length);
-                    if (read <= 0)
-                    {
-                        return;
-                    }
-
-                    stream.Write(ReproSupport.PreLoginEncryptOnResponse, 0, ReproSupport.PreLoginEncryptOnResponse.Length);
-                    stream.Flush();
-
-                    // Read the first byte of the client's TLS ClientHello, then
-                    // withhold the ServerHello so the handshake read stays pending.
-                    if (stream.ReadByte() < 0)
-                    {
-                        return;
-                    }
-
-                    handshakeInFlight.Set();
-                    releaseServer.Wait();
-                }
-                catch
-                {
-                    // Client may tear down mid-handshake; ignore.
-                }
-            });
-
-            SqlConnectionStringBuilder builder = new()
-            {
-                DataSource = $"127.0.0.1,{port}",
-                Encrypt = SqlConnectionEncryptOption.Mandatory,
-                TrustServerCertificate = true,
-                ConnectTimeout = 60,
-                ConnectRetryCount = 0,
-                Pooling = false,
-#if NETFRAMEWORK
-                TransparentNetworkIPResolution = false,
-#endif
-            };
-
-            SqlConnection connection = new(builder.ConnectionString);
-            using CancellationTokenSource cts = new();
-            Task? openTask = null;
-            bool cancelAttempted = false;
-            bool settledInTime = false;
-            try
-            {
-                openTask = connection.OpenAsync(cts.Token);
-
-                Assert.True(
-                    handshakeInFlight.Wait(ReproSupport.HandshakeBudget),
-                    "The client never reached the TLS handshake; no read was in flight to cancel.");
-
-                // Cancel while the handshake read is pending: this drives the
-                // driver's internal abort/close path against the in-flight I/O.
-                cancelAttempted = true;
-                cts.Cancel();
-
-                try
-                {
-                    settledInTime = openTask.Wait(ReproSupport.CloseBudget);
-                }
-                catch (AggregateException)
-                {
-                    // OpenAsync faulting/cancelling is the expected outcome; what
-                    // matters is that it *settled* rather than hanging.
-                    settledInTime = true;
-                }
-
-                Assert.True(
-                    settledInTime,
-                    $"OpenAsync did not settle within {ReproSupport.CloseBudget.TotalSeconds:N0}s after " +
-                    "cancellation while a TLS handshake read was in flight (possible SNIClose deadlock).");
-            }
-            finally
-            {
-                releaseServer.Set();
-                listener.Stop();
-
-                if (openTask != null)
-                {
-                    try { openTask.Wait(ReproSupport.CloseBudget); } catch { /* expected fault/cancel */ }
-                }
-
-                if (!cancelAttempted || settledInTime)
-                {
-                    connection.Dispose();
-                }
-
-                try { serverTask.Wait(ReproSupport.CloseBudget); } catch { /* ignore */ }
-            }
-        }
-    }
-
-    /// <summary>
     /// Attempt 4: does client-side thread-pool starvation cause a CONNECTION
     /// failure? This checks the hypothesis that the reported "connection/
     /// handshake failure under load" is thread starvation rather than an
@@ -590,6 +482,484 @@ namespace SniCloseLegacyRepro
                 ThreadPool.SetMinThreads(minW, minIo);
                 ThreadPool.SetMaxThreads(maxW, maxIo);
             }
+        }
+    }
+
+    /// <summary>
+    /// A transparent TCP proxy that forwards bytes between a client and a backend
+    /// TDS server, and can - on demand - break the CLIENT's write path while
+    /// leaving its pending read outstanding. It does this via
+    /// <c>Shutdown(SocketShutdown.Receive)</c> on the client-facing socket: the
+    /// client's next write (the timeout attention) then arrives at a
+    /// receive-shutdown socket and is answered with a TCP RST, so the client's
+    /// <c>SNIWritePacket</c> fails - the exact condition from the ICM dump.
+    /// </summary>
+    internal sealed class AttentionBreakingProxy : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly IPEndPoint _backend;
+        private Socket? _clientSocket;
+        private Socket? _backendSocket;
+        private volatile bool _broken;
+
+        public int Port { get; }
+
+        public AttentionBreakingProxy(IPEndPoint backend)
+        {
+            _backend = backend;
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            Task.Run(AcceptAndPump);
+        }
+
+        /// <summary>
+        /// Break the client's write direction: subsequent client writes RST while
+        /// its pending read stays outstanding (the backend sends nothing).
+        /// </summary>
+        public void BreakClientWrites()
+        {
+            _broken = true;
+            try
+            {
+                // SD_RECEIVE: data the client sends afterwards (the attention) is
+                // answered with a TCP RST, failing the client's write, while the
+                // client's pending read remains outstanding.
+                _clientSocket?.Shutdown(SocketShutdown.Receive);
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+
+        private void AcceptAndPump()
+        {
+            try
+            {
+                _clientSocket = _listener.AcceptSocket();
+                _backendSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                _backendSocket.Connect(_backend);
+
+                // client -> backend on a worker; backend -> client on this thread.
+                Task.Run(() => Pump(_clientSocket, _backendSocket, clientToBackend: true));
+                Pump(_backendSocket, _clientSocket, clientToBackend: false);
+            }
+            catch
+            {
+                // Teardown races are expected; ignore.
+            }
+        }
+
+        private void Pump(Socket from, Socket to, bool clientToBackend)
+        {
+            byte[] buffer = new byte[8192];
+            try
+            {
+                while (true)
+                {
+                    int n = from.Receive(buffer);
+                    if (n <= 0)
+                    {
+                        break;
+                    }
+
+                    // Once broken, stop forwarding client bytes to the backend; the
+                    // client's write will RST on its receive-shutdown socket.
+                    if (clientToBackend && _broken)
+                    {
+                        break;
+                    }
+
+                    to.Send(buffer, 0, n, SocketFlags.None);
+                }
+            }
+            catch
+            {
+                // Expected on RST / teardown.
+            }
+        }
+
+        public void Dispose()
+        {
+            try { _listener.Stop(); } catch { /* ignore */ }
+            try { _clientSocket?.Dispose(); } catch { /* ignore */ }
+            try { _backendSocket?.Dispose(); } catch { /* ignore */ }
+        }
+    }
+
+    /// <summary>
+    /// Attempt 5 (matches the ICM dump's mechanism): the reported deadlock is a
+    /// RE-ENTRANT SNIClose. An async read times out; the driver sends an
+    /// attention from within <c>ReadAsyncCallback</c>; the attention
+    /// <c>SNIWritePacket</c> fails; the legacy driver then calls
+    /// <c>SqlConnection.Close()</c> SYNCHRONOUSLY on the callback thread, so
+    /// <c>SNIClose</c> spins in <c>SNI_Conn::WaitForActiveCallbacks()</c> waiting
+    /// for the very callback it is running within - a self-deadlock.
+    ///
+    /// <para>
+    /// Microsoft.Data.SqlClient defers the close off the callback thread via its
+    /// <c>asyncClose</c> path (ThrowExceptionAndWarning wraps the close in
+    /// <c>Task.Factory.StartNew</c>), so the read settles promptly and this test
+    /// passes - a regression guard for that fix.
+    /// </para>
+    ///
+    /// <para>
+    /// NOTE: this exercises the async-read-timeout + broken-write path and asserts
+    /// no deadlock, but it does NOT deterministically force the re-entrant close
+    /// on the legacy driver: that requires the exact TCP state from the dump
+    /// (the attention write fails while the read stays pending - a half-broken
+    /// connection), which is very hard to synthesize (a RST kills both
+    /// directions; the SQL EE analysis likewise noted it is "very difficult to
+    /// capture"). The definitive evidence is the dump plus the code review of the
+    /// <c>asyncClose</c> deferral in Microsoft.Data.SqlClient.
+    /// </para>
+    /// </summary>
+    public class SNICloseCallbackReentrancyReproTests
+    {
+        private static readonly TimeSpan SettleBudget = TimeSpan.FromSeconds(45);
+        private static readonly TimeSpan BatchBudget = TimeSpan.FromSeconds(30);
+
+        [Fact]
+        public void CloseFromReadCallbackOnAttentionFailure_DoesNotDeadlock()
+        {
+            using ManualResetEventSlim batchReceived = new(false);
+            using ManualResetEventSlim releaseResponse = new(false);
+
+            TdsServerArguments arguments = new();
+            using TdsServer server = new(
+                new ReproSupport.StallingQueryEngine(arguments, batchReceived, releaseResponse),
+                arguments);
+            server.Start();
+
+            using AttentionBreakingProxy proxy = new(new IPEndPoint(IPAddress.Loopback, server.EndPoint.Port));
+
+            SqlConnectionStringBuilder builder = new()
+            {
+                DataSource = $"127.0.0.1,{proxy.Port}",
+                Encrypt = SqlConnectionEncryptOption.Optional,
+                // MARS off and pooling off, matching the reported configuration and
+                // ensuring Close() tears down the physical connection (reaching SNIClose).
+                Pooling = false,
+#if NETFRAMEWORK
+                TransparentNetworkIPResolution = false,
+#endif
+            };
+
+            SqlConnection connection = new(builder.ConnectionString);
+            SqlCommand? command = null;
+            Task<SqlDataReader>? readTask = null;
+            bool settledInTime = false;
+            try
+            {
+                connection.Open();
+
+                // Short command timeout so the pending async read times out, which
+                // drives OnTimeoutCore -> SendAttention from within ReadAsyncCallback.
+                command = new("SELECT 1", connection) { CommandTimeout = 2 };
+                readTask = command.ExecuteReaderAsync();
+
+                Assert.True(
+                    batchReceived.Wait(BatchBudget),
+                    "The server never received the batch; the async read was not in flight.");
+
+                // Break the client's write path so the timeout attention's
+                // SNIWritePacket fails, forcing Close() from within ReadAsyncCallback.
+                proxy.BreakClientWrites();
+
+                try
+                {
+                    settledInTime = readTask.Wait(SettleBudget);
+                }
+                catch (AggregateException)
+                {
+                    // Faulting/cancelling is the healthy outcome; what matters is it settled.
+                    settledInTime = true;
+                }
+
+                Assert.True(
+                    settledInTime,
+                    $"ExecuteReaderAsync did not settle within {SettleBudget.TotalSeconds:N0}s after the " +
+                    "command-timeout attention write failed. This indicates the re-entrant SNIClose " +
+                    "deadlock: Close() called from within ReadAsyncCallback -> SNIClose -> " +
+                    "WaitForActiveCallbacks (ADO.Net #43847 / ICM 775308542).");
+            }
+            finally
+            {
+                releaseResponse.Set();
+                command?.Dispose();
+                // Only dispose the connection if we did NOT deadlock; a deadlocked
+                // connection's Dispose() would also hang in SNIClose.
+                if (settledInTime)
+                {
+                    try { connection.Dispose(); } catch { /* ignore */ }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// A transparent TCP proxy that relays bytes between a client and a backend
+    /// TDS server and can hard-RST the client connection on demand
+    /// (LingerState 0 + Close), used by the soak to break the connection at a
+    /// timed offset relative to the async read's command timeout.
+    /// </summary>
+    internal sealed class RstProxy : IDisposable
+    {
+        private readonly TcpListener _listener;
+        private readonly IPEndPoint _backend;
+        private Socket? _clientSocket;
+        private Socket? _backendSocket;
+
+        public int Port { get; }
+
+        public RstProxy(IPEndPoint backend)
+        {
+            _backend = backend;
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            Task.Run(AcceptAndPump);
+        }
+
+        /// <summary>Hard-reset the client connection (sends a TCP RST).</summary>
+        public void Rst()
+        {
+            try
+            {
+                Socket? s = _clientSocket;
+                if (s != null)
+                {
+                    s.LingerState = new LingerOption(true, 0);
+                    s.Close();
+                }
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+
+        private void AcceptAndPump()
+        {
+            try
+            {
+                _clientSocket = _listener.AcceptSocket();
+                _backendSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                _backendSocket.Connect(_backend);
+                Task.Run(() => Pump(_clientSocket, _backendSocket));
+                Pump(_backendSocket, _clientSocket);
+            }
+            catch
+            {
+                // Teardown races are expected; ignore.
+            }
+        }
+
+        private static void Pump(Socket from, Socket to)
+        {
+            byte[] buffer = new byte[8192];
+            try
+            {
+                while (true)
+                {
+                    int n = from.Receive(buffer);
+                    if (n <= 0)
+                    {
+                        break;
+                    }
+                    to.Send(buffer, 0, n, SocketFlags.None);
+                }
+            }
+            catch
+            {
+                // Expected on RST / teardown.
+            }
+        }
+
+        public void Dispose()
+        {
+            try { _listener.Stop(); } catch { /* ignore */ }
+            try { _clientSocket?.Dispose(); } catch { /* ignore */ }
+            try { _backendSocket?.Dispose(); } catch { /* ignore */ }
+        }
+    }
+
+    /// <summary>
+    /// Soak that hunts for the re-entrant SNIClose deadlock probabilistically.
+    /// Many concurrent workers repeatedly open a connection, start an async read
+    /// that the server stalls, and RST the connection at ~the command-timeout
+    /// instant (with jitter), trying to land in the tiny window where the SNI
+    /// read timeout has fired but the timeout attention has not yet been written -
+    /// so the attention <c>SNIWritePacket</c> fails and the legacy driver closes
+    /// synchronously from within <c>ReadAsyncCallback</c>. A hang (a read that
+    /// never settles) means the re-entrant <c>SNIClose</c> was hit.
+    ///
+    /// <para>
+    /// Tunable via environment variables:
+    ///   SNICLOSE_SOAK_WORKERS (default 16; the ICM saw a "~36-thread" condition),
+    ///   SNICLOSE_SOAK_SECONDS (default 60).
+    /// The test fails if it reproduces (green = did not reproduce this run).
+    /// </para>
+    /// </summary>
+    public class ReentrantSNICloseSoakTests
+    {
+        private sealed class BoundedStallQueryEngine : QueryEngine
+        {
+            private readonly int _stallMs;
+
+            public BoundedStallQueryEngine(TdsServerArguments arguments, int stallMs)
+                : base(arguments)
+            {
+                _stallMs = stallMs;
+            }
+
+            protected override TDSMessageCollection CreateQueryResponse(
+                ITDSServerSession session,
+                TDSSQLBatchToken batchRequest)
+            {
+                // Stall every query long enough that the client's short command
+                // timeout fires first; the (eventual) response goes to an already
+                // RST-torn-down connection and the handler thread unwinds.
+                Thread.Sleep(_stallMs);
+                return base.CreateQueryResponse(session, batchRequest);
+            }
+        }
+
+        private static int EnvInt(string name, int fallback) =>
+            int.TryParse(Environment.GetEnvironmentVariable(name), out int v) && v > 0 ? v : fallback;
+
+        /// <summary>
+        /// Gate: the soak is opt-in (set SNICLOSE_SOAK_ENABLE) because it is
+        /// heavy, rarely fires, and - when it DOES reproduce - poisons the
+        /// process (hung SNIClose threads cascade into later tests). Skipped by
+        /// default so normal harness runs stay clean and deterministic.
+        /// </summary>
+        public static bool SoakEnabled() =>
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SNICLOSE_SOAK_ENABLE"));
+
+        [ConditionalFact(typeof(ReentrantSNICloseSoakTests), nameof(SoakEnabled))]
+        public void ConcurrentTimeoutWithRstNearTimeout_DoesNotReentrantlyDeadlock()
+        {
+            int workers = EnvInt("SNICLOSE_SOAK_WORKERS", 16);
+            TimeSpan soak = TimeSpan.FromSeconds(EnvInt("SNICLOSE_SOAK_SECONDS", 60));
+            const int commandTimeoutSec = 1;
+            const int stallMs = 6000;
+            TimeSpan perOpBudget = TimeSpan.FromSeconds(20);
+
+            TdsServerArguments arguments = new();
+            using TdsServer server = new(new BoundedStallQueryEngine(arguments, stallMs), arguments);
+            server.Start();
+            IPEndPoint backend = new(IPAddress.Loopback, server.EndPoint.Port);
+
+            using CancellationTokenSource cts = new(soak);
+            long attempts = 0;
+            string? hangInfo = null;
+            object gate = new();
+
+            void Worker(int id)
+            {
+                Random rng = new(unchecked(id * 397 ^ Environment.TickCount));
+                while (!cts.IsCancellationRequested && Volatile.Read(ref hangInfo) is null)
+                {
+                    RstProxy? proxy = null;
+                    SqlConnection? conn = null;
+                    SqlCommand? cmd = null;
+                    Task<SqlDataReader>? readTask = null;
+                    bool settled = false;
+                    try
+                    {
+                        proxy = new RstProxy(backend);
+                        string cs = new SqlConnectionStringBuilder
+                        {
+                            DataSource = $"127.0.0.1,{proxy.Port}",
+                            Encrypt = SqlConnectionEncryptOption.Optional,
+                            Pooling = false,
+                            ConnectTimeout = 15,
+#if NETFRAMEWORK
+                            TransparentNetworkIPResolution = false,
+#endif
+                        }.ConnectionString;
+
+                        conn = new SqlConnection(cs);
+                        conn.Open();
+                        cmd = new SqlCommand("SELECT 1", conn) { CommandTimeout = commandTimeoutSec };
+                        readTask = cmd.ExecuteReaderAsync();
+                        Interlocked.Increment(ref attempts);
+
+                        // Fire the RST at ~the command-timeout instant, with jitter,
+                        // trying to land just after the SNI read timeout but before
+                        // (or during) the attention write.
+                        int rstDelayMs = commandTimeoutSec * 1000 + rng.Next(-40, 100);
+                        RstProxy captured = proxy;
+                        _ = Task.Delay(rstDelayMs).ContinueWith(_ =>
+                        {
+                            try { captured.Rst(); } catch { /* ignore */ }
+                        });
+
+                        try
+                        {
+                            settled = readTask.Wait(perOpBudget);
+                        }
+                        catch (AggregateException)
+                        {
+                            settled = true; // faulted/cancelled = healthy
+                        }
+
+                        if (!settled)
+                        {
+                            lock (gate)
+                            {
+                                hangInfo ??= $"worker {id}: ExecuteReaderAsync did not settle within " +
+                                    $"{perOpBudget.TotalSeconds:N0}s (attempt #{Interlocked.Read(ref attempts)})";
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        // Per-iteration connect/read failures under the RST storm are expected.
+                    }
+                    finally
+                    {
+                        cmd?.Dispose();
+                        // Only tear down if this iteration settled; a hung connection's
+                        // Dispose() would also block in SNIClose.
+                        if (settled)
+                        {
+                            try { conn?.Dispose(); } catch { /* ignore */ }
+                            try { proxy?.Dispose(); } catch { /* ignore */ }
+                        }
+                    }
+                }
+            }
+
+            Thread[] threads = new Thread[workers];
+            for (int i = 0; i < workers; i++)
+            {
+                int id = i;
+                threads[i] = new Thread(() => Worker(id)) { IsBackground = true, Name = $"SoakWorker{id}" };
+                threads[i].Start();
+            }
+
+            // Wait until the soak window elapses or a hang is detected, then give
+            // workers a moment to unwind.
+            DateTime deadline = DateTime.UtcNow + soak + perOpBudget + TimeSpan.FromSeconds(10);
+            while (DateTime.UtcNow < deadline
+                   && Volatile.Read(ref hangInfo) is null
+                   && threads.Any(t => t.IsAlive))
+            {
+                Thread.Sleep(500);
+            }
+            foreach (Thread t in threads)
+            {
+                t.Join(TimeSpan.FromSeconds(2));
+            }
+
+            Assert.True(
+                Volatile.Read(ref hangInfo) is null,
+                $"Reproduced the re-entrant SNIClose deadlock: {hangInfo}. Total attempts: " +
+                $"{Interlocked.Read(ref attempts)}. (close from within ReadAsyncCallback -> SNIClose -> " +
+                "WaitForActiveCallbacks; ADO.Net #43847 / ICM 775308542).");
         }
     }
 }

--- a/tools/SniCloseLegacyRepro/SniCloseLegacyRepro.csproj
+++ b/tools/SniCloseLegacyRepro/SniCloseLegacyRepro.csproj
@@ -1,0 +1,113 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Diagnostic xUnit harness that runs SNIClose / MARS close-during-IO deadlock tests against the
+    LEGACY System.Data.SqlClient driver, to observe whether the deadlock (ICM 775308542 / ADO.Net
+    #43847) reproduces there.
+
+      * net462/net47/net472/net481 -> in-box System.Data.SqlClient (System.Data.dll)
+      * net10.0                     -> System.Data.SqlClient NuGet package
+
+    Rather than re-implementing the tests, this project LINKS the real test source files directly
+    (see the <Compile Include Link=...> items below) and supplies a small compatibility shim
+    (Compat.cs + GlobalUsings.cs) so the bare Microsoft.Data.SqlClient type names in those files
+    bind to the legacy driver.  See README.md for full usage, including running inside .NET
+    Framework Windows containers to bind older in-box System.Data.dll versions.
+
+    Run: dotnet test tools/SniCloseLegacyRepro                        (in-process tests only)
+      $env:SNICLOSE_CONNSTR="Server=...;User ID=...;Password=..."  (enables live MARS + stress)
+      dotnet test tools/SniCloseLegacyRepro
+
+    This project uses Central Package Management via the sibling
+    Directory.Packages.props (which imports the shared SqlClient tests versions) and
+    Directory.Build.props. The legacy System.Data.SqlClient package versions are served from the
+    repo's governed feed, so no extra NuGet.config is needed.
+  -->
+
+  <PropertyGroup>
+    <!-- .NET Framework targets exercise the in-box System.Data.dll (the driver
+         the ICM was reported against). NOTE: the in-box System.Data.dll is
+         machine-global for the whole 4.x line - only ONE physical DLL exists per
+         machine (here 4.8.1). Multi-targeting older netfx TFMs changes the
+         compile-time reference set and the runtime framework "quirk" behaviors
+         keyed off the app's TargetFrameworkAttribute, but does NOT swap in an
+         older System.Data.dll. Reproducing the exact reported older DLL bits
+         requires a machine/VM with only that older .NET Framework installed. -->
+    <TargetFrameworks>net462;net47;net472;net481;net10.0</TargetFrameworks>
+    <!-- Legacy System.Data.SqlClient NuGet version used by the .NET (Core)
+         target; override to sweep older builds, e.g.
+           dotnet test -f net10.0 -p:SqlClientLegacyVersion=4.6.1 -->
+    <SqlClientLegacyVersion Condition="'$(SqlClientLegacyVersion)' == ''">4.9.1</SqlClientLegacyVersion>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <!-- This is a diagnostic scratch tool; do not gate it on repo-wide analyzers/warnings. -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <RunAnalyzers>false</RunAnalyzers>
+    <!-- CS0618: the legacy System.Data.SqlClient package types are [Obsolete] -
+         that deprecated driver is exactly what is under test here. -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+  </PropertyGroup>
+
+  <!-- Test SDK + xUnit. Versions come from the sibling Directory.Packages.props
+       (which imports the shared SqlClient tests versions).
+       Microsoft.DotNet.XUnitExtensions provides [ConditionalTheory]. Its beta
+       build is delay-signed, so on .NET Framework it must NOT be shadow-copied
+       (shadow copying re-verifies the strong name, which fails). We ship the
+       same xunit.runner.json the real tests use (shadowCopy: false) to avoid
+       that, exactly like the real UnitTests/ManualTests projects. -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" ExcludeAssets="compile" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
+    <!-- Console runner (xunit.console.exe) so the net47 build can run inside a
+         .NET Framework-only Windows container, which has no dotnet CLI. Only
+         provides tools/, so it has no compile impact. -->
+    <PackageReference Include="xunit.runner.console" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <!-- Link the SAME xunit.runner.json the real test projects ship, rather than
+       maintaining a copy. Its shadowCopy:false setting is what lets the
+       delay-signed XUnitExtensions load on .NET Framework (net481). -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/tools/Microsoft.Data.SqlClient.TestUtilities/xunit.runner.json">
+      <Link>xunit.runner.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <!-- .NET Framework targets: use the in-box legacy driver (System.Data.dll). -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Reference Include="System.Data" />
+  </ItemGroup>
+
+  <!-- .NET (Core) target: use the legacy driver from its deprecated NuGet
+       package. The base version is centrally managed; $(SqlClientLegacyVersion)
+       overrides it per-run to sweep older builds. -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <PackageReference Include="System.Data.SqlClient" VersionOverride="$(SqlClientLegacyVersion)" />
+  </ItemGroup>
+
+  <!-- Driver-agnostic in-process TDS test server used by the pending-read tests. -->
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS/TDS.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.EndPoint/TDS.EndPoint.csproj" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/tools/TDS/TDS.Servers/TDS.Servers.csproj" />
+  </ItemGroup>
+
+  <!-- Link the REAL test files verbatim (shared, not copied). -->
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseDeadlockTest.cs"
+             Link="Shared/SNICloseDeadlockTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseRaceDeadlockTest.cs"
+             Link="Shared/SNICloseRaceDeadlockTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseDeadlockTest.cs"
+             Link="Shared/MarsCloseDeadlockTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseStressTest.cs"
+             Link="Shared/MarsCloseStressTest.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tools/SniCloseLegacyRepro/SniCloseLegacyRepro.csproj
+++ b/tools/SniCloseLegacyRepro/SniCloseLegacyRepro.csproj
@@ -104,6 +104,8 @@
              Link="Shared/SNICloseDeadlockTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseRaceDeadlockTest.cs"
              Link="Shared/SNICloseRaceDeadlockTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/UnitTests/SimulatedServerTests/SNICloseHandshakeCancellationTest.cs"
+             Link="Shared/SNICloseHandshakeCancellationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseDeadlockTest.cs"
              Link="Shared/MarsCloseDeadlockTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)../../src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/AsyncTest/MarsCloseStressTest.cs"

--- a/tools/SniCloseLegacyRepro/run-in-container.ps1
+++ b/tools/SniCloseLegacyRepro/run-in-container.ps1
@@ -90,6 +90,12 @@ else {
     Write-Host "No connection string: live MARS + stress tests will be skipped." -ForegroundColor Yellow
 }
 
+# Forward soak tuning knobs if set on the host.
+foreach ($name in 'SNICLOSE_SOAK_WORKERS', 'SNICLOSE_SOAK_SECONDS') {
+    $val = [Environment]::GetEnvironmentVariable($name)
+    if ($val) { $envArgs += @('-e', "$name=$val") }
+}
+
 Write-Host "Running tests in $Image (isolation=hyperv) ..." -ForegroundColor Cyan
 $cpuArgs = @()
 if ($Cpus -gt 0) {

--- a/tools/SniCloseLegacyRepro/run-in-container.ps1
+++ b/tools/SniCloseLegacyRepro/run-in-container.ps1
@@ -1,0 +1,104 @@
+# Runs the net47 build of this harness inside a .NET Framework Windows container,
+# so the tests bind the container's OLD in-box System.Data.dll (e.g. 4.7.4081.0)
+# instead of the host's. The framework container has no dotnet CLI, so we run the
+# tests with xunit.console.exe.
+#
+# Examples:
+#   # in-process tests only (no SQL Server needed):
+#   .\run-in-container.ps1
+#
+#   # include the live MARS + stress tests against a host SQL Server:
+#   $env:SNICLOSE_CONNSTR = "Server=127.0.0.1,1434;Database=master;User ID=sa;Password=***;TrustServerCertificate=true"
+#   .\run-in-container.ps1
+#
+#   # a different framework image / version:
+#   .\run-in-container.ps1 -Image mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
+
+[CmdletBinding()]
+param(
+    [string]$Framework = 'net47',
+    [string]$Image = 'mcr.microsoft.com/dotnet/framework/runtime:4.7-windowsservercore-ltsc2016',
+    [string]$ConnectionString = $env:SNICLOSE_CONNSTR,
+    # Container-reachable host IP that the loopback SQL Server is bridged to.
+    # Defaults to the Docker NAT gateway (the host's 'vEthernet (nat)' adapter).
+    [string]$SqlHost,
+    [string]$RunnerVersion = '2.9.3',
+    # Constrain the hyperv container VM to this many processors (0 = unconstrained).
+    # The ICM environment had 4 procs; races can be CPU-count sensitive.
+    [int]$Cpus = 0,
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = 'Stop'
+$projDir = $PSScriptRoot
+$proj = Join-Path $projDir 'SniCloseLegacyRepro.csproj'
+
+# --- Build the net47 output (host-side; independent of the docker engine) ------
+if (-not $SkipBuild) {
+    Write-Host "Building $Framework ..." -ForegroundColor Cyan
+    dotnet build $proj -c Debug -f $Framework | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Build failed." }
+}
+
+$outDir = Join-Path $projDir "bin\Debug\$Framework"
+if (-not (Test-Path (Join-Path $outDir 'SniCloseLegacyRepro.dll'))) {
+    throw "Build output not found: $outDir (build first, or omit -SkipBuild)."
+}
+
+# --- Stage xunit.console.exe next to the test assembly -------------------------
+# The framework container has no dotnet CLI, so run tests with the console runner.
+$gp = (dotnet nuget locals global-packages --list) -replace '^.*?:\s*', ''
+$runnerTools = Join-Path $gp "xunit.runner.console\$RunnerVersion\tools\$Framework"
+if (-not (Test-Path $runnerTools)) {
+    $runnerTools = Join-Path $gp "xunit.runner.console\$RunnerVersion\tools\net472"
+}
+if (-not (Test-Path (Join-Path $runnerTools 'xunit.console.exe'))) {
+    throw "xunit.console.exe not found under $runnerTools. Is xunit.runner.console $RunnerVersion restored?"
+}
+Copy-Item (Join-Path $runnerTools '*') $outDir -Force
+
+# --- Ensure Docker is on the Windows engine -----------------------------------
+$null = docker context use desktop-windows 2>$null
+$serverOs = docker version --format '{{.Server.Os}}' 2>$null
+if ($serverOs -ne 'windows') {
+    throw "Docker is not on the Windows engine (Server OS='$serverOs'). Switch with: & 'C:\Program Files\Docker\Docker\DockerCli.exe' -SwitchWindowsEngine"
+}
+
+# --- Build the container args --------------------------------------------------
+# A Windows container cannot reach the host's loopback SQL Server directly, and
+# host.docker.internal is not injected for hyperv-isolated Windows containers.
+# Instead we target the Docker NAT gateway IP (the host's 'vEthernet (nat)'
+# adapter); a one-time elevated host portproxy must bridge that IP to loopback:
+#   netsh interface portproxy add v4tov4 listenaddress=<natIP> listenport=1434 `
+#     connectaddress=127.0.0.1 connectport=1434
+$envArgs = @()
+if ($ConnectionString) {
+    if (-not $SqlHost) {
+        $SqlHost = Get-NetIPAddress -InterfaceAlias 'vEthernet (nat)' -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+            Select-Object -First 1 -ExpandProperty IPAddress
+    }
+    if (-not $SqlHost) {
+        throw "Could not determine a container-reachable host IP; pass -SqlHost explicitly."
+    }
+    $cs = $ConnectionString `
+        -replace '127\.0\.0\.1', $SqlHost `
+        -replace '(?i)(?<=[=;\s])localhost(?=[,;]|$)', $SqlHost
+    $envArgs = @('-e', "SNICLOSE_CONNSTR=$cs")
+    Write-Host "Live tests enabled (SQL Server via $SqlHost; requires a host portproxy to 127.0.0.1)." -ForegroundColor Cyan
+}
+else {
+    Write-Host "No connection string: live MARS + stress tests will be skipped." -ForegroundColor Yellow
+}
+
+Write-Host "Running tests in $Image (isolation=hyperv) ..." -ForegroundColor Cyan
+$cpuArgs = @()
+if ($Cpus -gt 0) {
+    $cpuArgs = @('--cpu-count', "$Cpus")
+    Write-Host "Container VM constrained to $Cpus processor(s)." -ForegroundColor Cyan
+}
+docker run --rm --isolation=hyperv @cpuArgs @envArgs -v "${outDir}:C:\app" -w 'C:\app' $Image `
+    C:\app\xunit.console.exe C:\app\SniCloseLegacyRepro.dll -parallel none
+
+$code = $LASTEXITCODE
+Write-Host "xunit.console.exe exit code: $code" -ForegroundColor $(if ($code -eq 0) { 'Green' } else { 'Red' })
+exit $code

--- a/tools/SniCloseLegacyRepro/run-in-container.ps1
+++ b/tools/SniCloseLegacyRepro/run-in-container.ps1
@@ -1,3 +1,7 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+
 # Runs the net47 build of this harness inside a .NET Framework Windows container,
 # so the tests bind the container's OLD in-box System.Data.dll (e.g. 4.7.4081.0)
 # instead of the host's. The framework container has no dotnet CLI, so we run the


### PR DESCRIPTION
## Summary

Investigation and regression tests for [AB#43847](https://sqlclientdrivers.visualstudio.com/b49eac2d-45b3-4951-899d-b8637b46f89a/_workitems/edit/43847) — "SNIClose can deadlock with in-flight async I/O during connection close" (ICM 775308542).

The original incident was reported against the retired **System.Data.SqlClient**. This work (a) determines the root cause from the incident dump, (b) verifies whether the same deadlock exists in current **Microsoft.Data.SqlClient** (MDS), and (c) adds regression tests plus a dedicated legacy-driver repro harness.

**Conclusion: the deadlock is _not_ present in Microsoft.Data.SqlClient.** MDS defers the connection close off the I/O callback thread (`asyncClose`), so `SNIClose` never runs re-entrantly and the self-deadlock cannot occur. The bug is specific to the in-box `System.Data.SqlClient` code path.

## Root cause (from the ICM dump)

The hang is a **re-entrant `SNIClose`** self-deadlock in legacy `System.Data.SqlClient`:

1. `ReadAsyncCallback` → `OnTimeoutCore` → `SendAttention` → `SNIWritePacket` **fails** (the socket is half-broken: writes fail while the read stays pending).
2. `ThrowExceptionAndWarning` calls `SqlConnection.Close()` **synchronously on the callback thread**.
3. `Close` → `SNIClose` → `SNI_Conn::WaitForActiveCallbacks()` spins (`Sleep(100)`) waiting for `REF_ActiveCallbacks` to drain — but the currently-executing `ReadAsyncCallback` _is_ that outstanding reference. It can never drain from within itself → permanent self-deadlock.
4. The stuck thread holds the parser lock; a second thread (`EndExecuteReaderAsync` → `CloseSession` → `ResetCancelAndProcessAttention`) blocks on it, cascading into hung IOCP threads. New connections' pre-login TLS reads then time out ("SSL Provider - wait operation timed out").

### Why MDS is not affected

In MDS, `OnTimeoutCore` uses an `asyncClose` flag: a failed `SendAttention` is caught (the task is cancelled and the break deferred), and `ThrowExceptionAndWarning` (`TdsParser.cs`) with `asyncClose: true` wraps the close in `Task.Factory.StartNew`. `SNIClose` therefore runs **off** the callback thread, the active-callback reference drains normally, and there is no re-entrancy.

## Tests added

### UnitTests — in-process TDS server
- **`SNICloseDeadlockTest.cs`** — post-login query-read, pre-login stall, and TLS-over-TDS handshake close scenarios (Close/Dispose), each asserting the async read is genuinely pending at close.
- **`SNICloseRaceDeadlockTest.cs`** — race-timing variant of the close-during-async-read path.
- **`SNICloseHandshakeCancellationTest.cs`** (new) — `CancelOpenAsyncDuringTlsHandshake_DoesNotDeadlock`: a raw `TcpListener` advertises `ENCRYPT_ON` and withholds the ServerHello; the client's `OpenAsync(token)` is cancelled mid-handshake and must settle promptly. Promoted here from the legacy harness so it runs against real MDS.

### ManualTests — live SQL Server
- **`MarsCloseDeadlockTest.cs`** / **`MarsCloseStressTest.cs`** — MARS smux logical-session close/dispose with a pending async read (`WAITFOR DELAY`), which requires a real server because the in-process test server does not support MARS.

Each scenario closes on a worker thread under a bounded wait; a deadlock would manifest as the wait timing out.

## Legacy repro harness — `tools/SniCloseLegacyRepro/`

A dedicated xUnit harness that runs the **same driver test files** against the retired **System.Data.SqlClient** to confirm the incident lineage and probe for the re-entrant close:

- Multi-targets `net462;net47;net472;net481;net10.0`; selectable legacy package version via `SqlClientLegacyVersion` (default 4.9.1), plus the in-box `System.Data.dll` on netfx.
- Compatibility shims (`Compat.cs`, `GlobalUsings.cs`) adapt the driver tests (which target the MDS API) to the legacy `System.Data.SqlClient` surface.
- `ReproAttempts.cs` holds six exploratory Tier-2 strategies (thread-pool starvation, sync-over-async contexts, attention-breaking / RST proxies, callback re-entrancy) hunting the "write fails while read stays pending" window.
- **`ReentrantSNICloseSoak`** — a heavy probabilistic soak, gated opt-in behind `SNICLOSE_SOAK_ENABLE`. It fired **once** on the legacy **in-box netfx** driver (`net462/47x/48x`, with a net462 cascade) but **not** on the Core NuGet lineage (`net10.0`) — a clean driver-lineage split consistent with the real bug. It did not recur, matching the SQL EE assessment that the race is "very difficult to capture." The definitive evidence remains the dump plus the `asyncClose` code review.
- Runs on the host and in Windows containers (`run-in-container.ps1`) against `ltsc` images with a live SQL Server bridged over the container NAT gateway.

The harness lives under `tools/` and is not part of the shipping product or default CI.

## Validation

| Suite | Targets | Result |
|-------|---------|--------|
| Driver SNIClose UnitTests (incl. promoted handshake test) | net462, net8.0, net9.0, net10.0 | pass (9/9 each) |
| Driver MARS ManualTests | all TFMs | compile + pass (live server) |
| Legacy harness | net462, net47, net472, net481, net10.0 | 19 pass, 1 skip (gated soak), 0 fail |
| Legacy harness in containers | ltsc 4.6.2 / 4.7 / 4.8 | 20 total, 0 fail, 1 skip each |

Notes:
- Harness runs use `DisableTestParallelization` (the thread-pool-starvation repros mutate the global `ThreadPool`); this matches the container runner's `-parallel none` and makes runs deterministic.
- The in-box native `TdsParserStateObjectNative.Dispose()` still carries an `UNDONE` comment about blocking for pending callbacks on logical (MARS) connections, and `DisposeCounters()` waits on `_readingCount` but not `_pendingCallbacks`. These are latent hardening opportunities, but no live deadlock was found in current MDS.

## Checklist
- [x] Tests added
- [x] Root cause identified (re-entrant `SNIClose` in legacy `System.Data.SqlClient`; MDS mitigated via `asyncClose` deferral)
- [ ] Public API changes documented (none)
- [x] Verified against reported repro (original repro was System.Data.SqlClient; confirmed non-reproducible in current MDS)
- [x] No breaking changes