### PR TITLE
APIScan remediation: remove obsolete SharedTokenCacheUsername, fix masked CS0618 pragma, migrate obsolete ManagedIdentityCredential ctor

### DIFF
--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
@@ -873,7 +873,6 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
             if (tokenCredentialKey._clientId is not null)
             {
                 defaultAzureCredentialOptions.ManagedIdentityClientId = tokenCredentialKey._clientId;
-                defaultAzureCredentialOptions.SharedTokenCacheUsername = tokenCredentialKey._clientId;
                 defaultAzureCredentialOptions.WorkloadIdentityClientId = tokenCredentialKey._clientId;
             }
 

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/ActiveDirectoryAuthenticationProvider.cs
@@ -120,7 +120,7 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
 
     /// <summary>
     /// The Entra ID application client id used by this provider instance. Exposed as <c>internal</c> for tests.
-    /// The client id is used in the redirect URI when WAM broker mode is enabled, so it must match the client id configured 
+    /// The client id is used in the redirect URI when WAM broker mode is enabled, so it must match the client id configured
     /// in the app registration for the Entra ID application to successfully broker with WAM on Windows.
     /// </summary>
     internal string ApplicationClientId => _applicationClientId;
@@ -182,7 +182,7 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
     // PublicClientAppKey cache (IWin32WindowFunc is part of its equality), so the same logical
     // identity ends up with two IPublicClientApplication instances depending on which setter
     // the caller used. Mark [Obsolete] in a future release once we have a migration window.
-    
+
     /// <include file='../doc/ActiveDirectoryAuthenticationProvider.xml' path='docs/members[@name="ActiveDirectoryAuthenticationProvider"]/SetIWin32WindowFunc/*'/>
     public void SetIWin32WindowFunc(Func<System.Windows.Forms.IWin32Window> iWin32WindowFunc) => _iWin32WindowFunc = iWin32WindowFunc;
     #endif
@@ -373,7 +373,7 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
                 {
                     #pragma warning disable CS0618 // Type or member is obsolete
                     result = await app.AcquireTokenByUsernamePassword(scopes, parameters.UserId, parameters.Password)
-                    #pragma warning disable CS0618 // Type or member is obsolete
+                    #pragma warning restore CS0618 // Type or member is obsolete
                         .WithCorrelationId(parameters.ConnectionId)
                         .ExecuteAsync(cancellationToken: cts.Token)
                         .ConfigureAwait(false);
@@ -900,14 +900,24 @@ public sealed partial class ActiveDirectoryAuthenticationProvider : SqlAuthentic
             return new TokenCredentialData(cred, GetHash(secret));
         }
 
-        TokenCredentialOptions tokenCredentialOptions = new() { AuthorityHost = new Uri(tokenCredentialKey._authority) };
-
         if (tokenCredentialKey._tokenCredentialType == typeof(ManagedIdentityCredential))
         {
-            return new TokenCredentialData(new ManagedIdentityCredential(tokenCredentialKey._clientId, tokenCredentialOptions), GetHash(secret));
+            // A null or empty client id indicates a system-assigned managed identity; a
+            // non-empty client id selects a specific user-assigned managed identity.
+            ManagedIdentityId managedIdentityId = string.IsNullOrEmpty(tokenCredentialKey._clientId)
+                ? ManagedIdentityId.SystemAssigned
+                : ManagedIdentityId.FromUserAssignedClientId(tokenCredentialKey._clientId);
+            ManagedIdentityCredentialOptions managedIdentityCredentialOptions = new(managedIdentityId)
+            {
+                AuthorityHost = new Uri(tokenCredentialKey._authority)
+            };
+
+            return new TokenCredentialData(new ManagedIdentityCredential(managedIdentityCredentialOptions), GetHash(secret));
         }
         else if (tokenCredentialKey._tokenCredentialType == typeof(ClientSecretCredential))
         {
+            TokenCredentialOptions tokenCredentialOptions = new() { AuthorityHost = new Uri(tokenCredentialKey._authority) };
+
             return new TokenCredentialData(new ClientSecretCredential(tokenCredentialKey._audience, tokenCredentialKey._clientId, secret, tokenCredentialOptions), GetHash(secret));
         }
         else if (tokenCredentialKey._tokenCredentialType == typeof(WorkloadIdentityCredential))


### PR DESCRIPTION
## Description

APIScan remediation for `Microsoft.Data.SqlClient.Extensions.Azure`
(`ActiveDirectoryAuthenticationProvider.cs`). Three related changes:

1. **Remove obsolete `SharedTokenCacheUsername` assignment** (APIScan WI 42859 netstandard2.0 / WI 42860 net462 — same source line).
   - `DefaultAzureCredentialOptions.SharedTokenCacheUsername` is `[Obsolete]` + `[EditorBrowsable(Never)]` in the repo-pinned Azure.Identity (1.18.0) and undocumented on learn.microsoft.com.
   - `SharedTokenCacheCredential` is no longer in `DefaultAzureCredential`'s default chain, so the assignment was a no-op. The client id is still propagated via `ManagedIdentityClientId` and `WorkloadIdentityClientId` for the in-chain credentials.

2. **Fix a masked `CS0618` pragma.** An unbalanced `#pragma warning disable CS0618` (a second `disable` where a `restore` was intended) left obsolete-member warnings suppressed for the remainder of the file. Corrected to `#pragma warning restore CS0618` so obsolete usages surface again (the project builds with `TreatWarningsAsErrors=true`).

3. **Migrate a now-unmasked obsolete API.** Fixing the pragma exposed a genuine obsolete usage: `ManagedIdentityCredential(string clientId, TokenCredentialOptions)`. Migrated to the supported `ManagedIdentityCredential(ManagedIdentityCredentialOptions)` constructor.

### API changes / backwards compatibility

No public API changes. Behavior of the managed-identity path is preserved exactly:

- Identity selection uses `string.IsNullOrEmpty(clientId)` → null-or-empty client id maps to `ManagedIdentityId.SystemAssigned`, otherwise `ManagedIdentityId.FromUserAssignedClientId(clientId)` — matching the obsolete constructor's internal logic.
- `AuthorityHost` is carried over via `ManagedIdentityCredentialOptions` (which derives from `TokenCredentialOptions`).
- The shared `TokenCredentialOptions` local is moved into the `ClientSecretCredential` branch, its only remaining consumer.

## Issues

APIScan work items WI 42859 / WI 42860 (obsolete `SharedTokenCacheUsername`). Branch tracks WI 43668 remediation.

## Testing

- Project rebuilds clean with `TreatWarningsAsErrors=true` on `net462` and `netstandard2.0` (0 warnings / 0 errors). Before the pragma fix, the obsolete usages were silently compiled; after it, they correctly fail the build unless remediated — verified by temporarily reintroducing the removed line and observing `error CS0618`.
- `Azure.Test` suite run: 21 passed, 9 skipped. The 2 failures are `ActiveDirectoryInteractiveTests.TestConnection`, which require a live interactive Entra ID sign-in against a real server and fail in a headless environment; they are unrelated to this change (which only touches credential construction, not interactive auth).

## Notes

Draft while CI validates across all target frameworks.
