### PR TITLE
[v7.1.0-preview2] Release Notes and vBump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,6 @@ See the [full release notes](release-notes/7.1/7.1.0-preview2.md) for detailed d
 - Added a `Connection Idle Timeout` connection-string keyword and matching `SqlConnectionStringBuilder.IdleTimeout` property to evict idle connections in pool v2 (default `300` seconds; `0` disables). Enforcement is opt-in via `Switch.Microsoft.Data.SqlClient.UseLegacyIdleTimeoutBehavior=false`; the default preserves the historical pooling behavior.
   ([#4295](https://github.com/dotnet/SqlClient/pull/4295))
 
-- Added Windows Account Manager (WAM) broker support for the supported Entra ID authentication modes on Windows, including the new `ActiveDirectoryAuthenticationProviderOptions` type, an `ActiveDirectoryAuthenticationProvider(ActiveDirectoryAuthenticationProviderOptions)` constructor, a cross-platform `SetParentActivityOrWindowFunc(Func<object>?)`, and a `useWamBroker` configuration attribute.
-  ([#4288](https://github.com/dotnet/SqlClient/pull/4288))
-
 ### Changed
 
 - The `Connect Timeout` budget is now propagated through pool acquisition via a shared `TimeoutTimer`, so time spent waiting in the pool is deducted from the overall timeout. Adds a dependency on `Microsoft.Bcl.TimeProvider`.
@@ -80,11 +77,12 @@ See the [full release notes](release-notes/7.1/7.1.0-preview2.md) for detailed d
 - `SqlVector<float>` now serializes and deserializes multibyte values as little-endian explicitly.
   ([#3861](https://github.com/dotnet/SqlClient/pull/3861))
 
-- Updated `Microsoft.Identity.Client` (and added `Microsoft.Identity.Client.Broker`) to `4.84.2` to enable WAM, and updated the bundled .NET 10 SDK to `10.0.300`.
-  ([#4287](https://github.com/dotnet/SqlClient/pull/4287),
-   [#4288](https://github.com/dotnet/SqlClient/pull/4288))
+- Updated the bundled .NET 10 SDK to `10.0.300`.
+  ([#4287](https://github.com/dotnet/SqlClient/pull/4287))
 
-- Re-shipped `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider`, `Microsoft.Data.SqlClient.Extensions.Azure`, `Microsoft.Data.SqlClient.Extensions.Abstractions`, and `Microsoft.Data.SqlClient.Internal.Logging` as `7.1.0-preview2` (version alignment only, no functional changes). See release notes for [AKV](release-notes/add-ons/AzureKeyVaultProvider/7.1/7.1.0-preview2.md), [Azure](release-notes/Extensions/Azure/7.1/7.1.0-preview2.md), [Abstractions](release-notes/Extensions/Abstractions/7.1/7.1.0-preview2.md), and [Logging](release-notes/Internal/Logging/7.1/7.1.0-preview2.md).
+- Re-shipped `Microsoft.Data.SqlClient.Extensions.Azure` as `7.1.0-preview2`, adding Windows Account Manager (WAM) broker support for Entra ID authentication on Windows. See [release notes](release-notes/Extensions/Azure/7.1/7.1.0-preview2.md).
+
+- Re-shipped `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider`, `Microsoft.Data.SqlClient.Extensions.Abstractions`, and `Microsoft.Data.SqlClient.Internal.Logging` as `7.1.0-preview2` (version alignment only, no functional changes). See release notes for [AKV](release-notes/add-ons/AzureKeyVaultProvider/7.1/7.1.0-preview2.md), [Abstractions](release-notes/Extensions/Abstractions/7.1/7.1.0-preview2.md), and [Logging](release-notes/Internal/Logging/7.1/7.1.0-preview2.md).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,123 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 > **Note:** Releases are sorted in reverse chronological order (newest first).
 
+## [Preview Release 7.1.0-preview2] - 2026-07-09
+
+This update brings the following changes since the [7.1.0-preview1](release-notes/7.1/7.1.0-preview1.md) release.
+See the [full release notes](release-notes/7.1/7.1.0-preview2.md) for detailed descriptions.
+
+> **Important — package version alignment:** Starting with the [7.0.2](release-notes/7.0/7.0.2.md) release, the `Microsoft.Data.SqlClient` driver and its companion packages share a single aligned version. Preview 2 of the `7.1` line continues this alignment; the following packages now ship together as `7.1.0-preview2`:
+>
+> - `Microsoft.Data.SqlClient`
+> - `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider`
+> - `Microsoft.Data.SqlClient.Extensions.Azure`
+> - `Microsoft.Data.SqlClient.Extensions.Abstractions`
+> - `Microsoft.Data.SqlClient.Internal.Logging`
+>
+> (`Microsoft.SqlServer.Server` continues to version independently and remains at `1.0.0`.)
+>
+> Applications that reference `Microsoft.Data.SqlClient.Extensions.Azure` must upgrade it to `7.1.0-preview2` when upgrading `Microsoft.Data.SqlClient` to `7.1.0-preview2`.
+>
+> **Compatibility guarantee:** All aligned assemblies ship with `FileVersion 7.1.0.x` and `AssemblyVersion 7.0.0.0`. The `AssemblyVersion` is unchanged from [7.0.2](release-notes/7.0/7.0.2.md), so upgrading from `7.0.2` to `7.1.0-preview2` does **not** require any new .NET Framework strong-name binding redirects. See the 7.0.2 release notes for the original `AssemblyVersion` alignment (the one-time breaking change that raised `AssemblyVersion` from `1.0.0.0` to `7.0.0.0` for `Extensions.Azure`, `Extensions.Abstractions`, and `Internal.Logging`; `AzureKeyVaultProvider` was already on `7.x`).
+
+### Added
+
+- Added `SqlConnection.GetSchemaAsync` overloads mirroring the existing synchronous shapes.
+  ([#3005](https://github.com/dotnet/SqlClient/pull/3005))
+
+- Added SQL Graph column-alias support (`$node_id`, `$edge_id`, `$from_id`, `$to_id`) as destination columns in `SqlBulkCopy`.
+  ([#3677](https://github.com/dotnet/SqlClient/pull/3677))
+
+- `SqlBatchCommand.CommandBehavior` (a driver-specific property that existed since batching was introduced but was previously ignored) is now honored during `SqlBatch` execution, and `SqlBatch.ExecuteReader` now respects the `CommandBehavior` value passed to it.
+  ([#4125](https://github.com/dotnet/SqlClient/pull/4125))
+
+- Added a `Connection Idle Timeout` connection-string keyword and matching `SqlConnectionStringBuilder.IdleTimeout` property to evict idle connections in pool v2 (default `300` seconds; `0` disables). Enforcement is opt-in via `Switch.Microsoft.Data.SqlClient.UseLegacyIdleTimeoutBehavior=false`; the default preserves the historical pooling behavior.
+  ([#4295](https://github.com/dotnet/SqlClient/pull/4295))
+
+- Added Windows Account Manager (WAM) broker support for the supported Entra ID authentication modes on Windows, including the new `ActiveDirectoryAuthenticationProviderOptions` type, an `ActiveDirectoryAuthenticationProvider(ActiveDirectoryAuthenticationProviderOptions)` constructor, a cross-platform `SetParentActivityOrWindowFunc(Func<object>?)`, and a `useWamBroker` configuration attribute.
+  ([#4288](https://github.com/dotnet/SqlClient/pull/4288))
+
+### Changed
+
+- The `Connect Timeout` budget is now propagated through pool acquisition via a shared `TimeoutTimer`, so time spent waiting in the pool is deducted from the overall timeout. Adds a dependency on `Microsoft.Bcl.TimeProvider`.
+  ([#4270](https://github.com/dotnet/SqlClient/pull/4270))
+
+- Implemented pool shutdown for `ChannelDbConnectionPool` and added automatic pool size reduction (pruning) for the channel-based pool.
+  ([#4302](https://github.com/dotnet/SqlClient/pull/4302),
+   [#4304](https://github.com/dotnet/SqlClient/pull/4304))
+
+- Hardened `SqlConnection` internal state transitions with `Interlocked.CompareExchange` guards.
+  ([#4267](https://github.com/dotnet/SqlClient/pull/4267))
+
+- Removed legacy connection-options inheritance from internal APIs and simplified `TryOpenConnection` / `TryReplaceConnection` / pool interfaces.
+  ([#4235](https://github.com/dotnet/SqlClient/pull/4235),
+   [#4237](https://github.com/dotnet/SqlClient/pull/4237),
+   [#4261](https://github.com/dotnet/SqlClient/pull/4261),
+   [#4415](https://github.com/dotnet/SqlClient/pull/4415))
+
+- Added the SQL Server 2025 `json` data type to the `DataTypes` schema table returned by `SqlConnection.GetSchema`.
+  ([#3858](https://github.com/dotnet/SqlClient/pull/3858))
+
+- Added async generic helpers to reduce sync/async duplication.
+  ([#4334](https://github.com/dotnet/SqlClient/pull/4334))
+
+- Use hardcoded LCID mappings when decoding strings.
+  ([#4212](https://github.com/dotnet/SqlClient/pull/4212))
+
+- Reduced allocations by skipping lock acquisition on `SqlErrorCollection` counters when no errors exist, and by avoiding stack-trace materialization on expected `null`-return paths.
+  ([#4099](https://github.com/dotnet/SqlClient/pull/4099),
+   [#4102](https://github.com/dotnet/SqlClient/pull/4102),
+   [#4157](https://github.com/dotnet/SqlClient/pull/4157))
+
+- Improved accuracy of `EnclaveDiffieHellmanInfo.Size`.
+  ([#4346](https://github.com/dotnet/SqlClient/pull/4346))
+
+- `SqlVector<float>` now serializes and deserializes multibyte values as little-endian explicitly.
+  ([#3861](https://github.com/dotnet/SqlClient/pull/3861))
+
+- Updated `Microsoft.Identity.Client` (and added `Microsoft.Identity.Client.Broker`) to `4.84.2` to enable WAM, and updated the bundled .NET 10 SDK to `10.0.300`.
+  ([#4287](https://github.com/dotnet/SqlClient/pull/4287),
+   [#4288](https://github.com/dotnet/SqlClient/pull/4288))
+
+- Re-shipped `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider`, `Microsoft.Data.SqlClient.Extensions.Azure`, `Microsoft.Data.SqlClient.Extensions.Abstractions`, and `Microsoft.Data.SqlClient.Internal.Logging` as `7.1.0-preview2` (version alignment only, no functional changes). See release notes for [AKV](release-notes/add-ons/AzureKeyVaultProvider/7.1/7.1.0-preview2.md), [Azure](release-notes/Extensions/Azure/7.1/7.1.0-preview2.md), [Abstractions](release-notes/Extensions/Abstractions/7.1/7.1.0-preview2.md), and [Logging](release-notes/Internal/Logging/7.1/7.1.0-preview2.md).
+
+### Fixed
+
+- Fixed a `NullReferenceException` in `SqlCommand.Cancel()` when the active connection has already been torn down.
+  ([#4372](https://github.com/dotnet/SqlClient/pull/4372))
+
+- Fixed Always Encrypted column master key signature verification incorrectly reusing cached results after a prior verification failure.
+  ([#4339](https://github.com/dotnet/SqlClient/pull/4339))
+
+- Fixed missing bounds checks on TDS token and feature-extension-acknowledgment data lengths that could allow a spoofing server to trigger unbounded allocations.
+  ([#4340](https://github.com/dotnet/SqlClient/pull/4340))
+
+- Fixed `SqlBulkCopy` failing in least-privilege environments.
+  ([#4306](https://github.com/dotnet/SqlClient/pull/4306))
+
+- Fixed Always Encrypted reads of `CekMdVersion` and `EkValueCount` to align with the TDS specification.
+  ([#4240](https://github.com/dotnet/SqlClient/pull/4240))
+
+- Fixed `LoginWithFailover` to validate parser state before continuing.
+  ([#4140](https://github.com/dotnet/SqlClient/pull/4140))
+
+- Fixed the SPN used during login to use the resolved port instead of the instance name when `Protocol=None` or `Protocol=Admin`.
+  ([#4180](https://github.com/dotnet/SqlClient/pull/4180))
+
+- Fixed a race in `SqlConnection.TryOpenInner` that could surface as `InvalidCastException`; the same race now returns a deterministic `InvalidOperationException`.
+  ([#4179](https://github.com/dotnet/SqlClient/pull/4179))
+
+- Fixed several `CancellationTokenSource` leaks across `SqlDataReader`, `SqlConnection` reconnect, `SqlCommand` reconnect timeout, and sequential-stream helpers.
+  ([#4009](https://github.com/dotnet/SqlClient/pull/4009))
+
+- Fixed server certificate documentation.
+  ([#4408](https://github.com/dotnet/SqlClient/pull/4408))
+
+### Removed
+
+- **Breaking:** Removed SQL Server 7.0 and SQL Server 2000 support, along with the `TypeSystem.SQLServer2000` enum value and the `Type System Version=SQL Server 2000` connection-string value. Connection strings that specify this value now throw `ArgumentException` when the connection is opened. Supported values are `Latest`, `SQL Server 2005`, `SQL Server 2008`, and `SQL Server 2012`.
+  ([#4015](https://github.com/dotnet/SqlClient/pull/4015))
+
 ## [Stable Release 7.0.2] - 2026-06-24
 
 This update brings the following changes since the [7.0.1](release-notes/7.0/7.0.1.md) release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,6 @@ See the [full release notes](release-notes/7.1/7.1.0-preview2.md) for detailed d
 - The `Connect Timeout` budget can now be propagated through pool acquisition via a shared `TimeoutTimer`, so time spent waiting in the pool is deducted from the overall timeout. Enforcement is opt-in via `Switch.Microsoft.Data.SqlClient.UseOverallConnectTimeoutForPoolWait=true`; the default (`false`) preserves the historical behavior where pool waits do not count against `Connect Timeout`. Adds a dependency on `Microsoft.Bcl.TimeProvider`.
   ([#4270](https://github.com/dotnet/SqlClient/pull/4270))
 
-- Implemented pool shutdown for `ChannelDbConnectionPool` and added automatic pool size reduction (pruning) for the channel-based pool.
-  ([#4302](https://github.com/dotnet/SqlClient/pull/4302),
-   [#4304](https://github.com/dotnet/SqlClient/pull/4304))
-
 - Hardened `SqlConnection` internal state transitions with `Interlocked.CompareExchange` guards.
   ([#4267](https://github.com/dotnet/SqlClient/pull/4267))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,12 +36,12 @@ See the [full release notes](release-notes/7.1/7.1.0-preview2.md) for detailed d
 - `SqlBatchCommand.CommandBehavior` (a driver-specific property that existed since batching was introduced but was previously ignored) is now honored during `SqlBatch` execution, and `SqlBatch.ExecuteReader` now respects the `CommandBehavior` value passed to it.
   ([#4125](https://github.com/dotnet/SqlClient/pull/4125))
 
-- Added a `Connection Idle Timeout` connection-string keyword and matching `SqlConnectionStringBuilder.IdleTimeout` property to evict idle connections in pool v2 (default `300` seconds; `0` disables). Enforcement is opt-in via `Switch.Microsoft.Data.SqlClient.UseLegacyIdleTimeoutBehavior=false`; the default preserves the historical pooling behavior.
+- Added a `Connection Idle Timeout` connection-string keyword and matching `SqlConnectionStringBuilder.IdleTimeout` property to evict idle pooled connections (default `300` seconds; `0` disables). Enforcement is opt-in via `Switch.Microsoft.Data.SqlClient.UseLegacyIdleTimeoutBehavior=false`; the default preserves the historical pooling behavior. When enabled, idle-timeout enforcement applies to the existing connection pool as well.
   ([#4295](https://github.com/dotnet/SqlClient/pull/4295))
 
 ### Changed
 
-- The `Connect Timeout` budget is now propagated through pool acquisition via a shared `TimeoutTimer`, so time spent waiting in the pool is deducted from the overall timeout. Adds a dependency on `Microsoft.Bcl.TimeProvider`.
+- The `Connect Timeout` budget can now be propagated through pool acquisition via a shared `TimeoutTimer`, so time spent waiting in the pool is deducted from the overall timeout. Enforcement is opt-in via `Switch.Microsoft.Data.SqlClient.UseOverallConnectTimeoutForPoolWait=true`; the default (`false`) preserves the historical behavior where pool waits do not count against `Connect Timeout`. Adds a dependency on `Microsoft.Bcl.TimeProvider`.
   ([#4270](https://github.com/dotnet/SqlClient/pull/4270))
 
 - Implemented pool shutdown for `ChannelDbConnectionPool` and added automatic pool size reduction (pruning) for the channel-based pool.

--- a/eng/pipelines/libraries/ci-build-variables.yml
+++ b/eng/pipelines/libraries/ci-build-variables.yml
@@ -24,11 +24,11 @@ variables:
 
   # Abstractions library assembly file version
   - name: abstractionsAssemblyFileVersion
-    value: 1.1.0.$(assemblyBuildNumber)
+    value: 7.1.0.$(assemblyBuildNumber)
 
   # Abstractions library NuGet package version
   - name: abstractionsPackageVersion
-    value: 1.1.0-preview1ci$(Build.BuildNumber)
+    value: 7.1.0-preview2ci$(Build.BuildNumber)
 
   # AKV provider assembly file version
   - name: akvAssemblyFileVersion
@@ -36,30 +36,30 @@ variables:
 
   # AKV provider NuGet package version
   - name: akvPackageVersion
-    value: 7.1.0-preview1ci$(Build.BuildNumber)
+    value: 7.1.0-preview2ci$(Build.BuildNumber)
 
   # Azure library assembly file version
   - name: azureAssemblyFileVersion
-    value: 1.1.0.$(assemblyBuildNumber)
+    value: 7.1.0.$(assemblyBuildNumber)
 
   # Azure library NuGet package version
   - name: azurePackageVersion
-    value: 1.1.0-preview1ci$(Build.BuildNumber)
+    value: 7.1.0-preview2ci$(Build.BuildNumber)
 
   # Logging library assembly file version
   - name: loggingAssemblyFileVersion
-    value: 1.1.0.$(assemblyBuildNumber)
+    value: 7.1.0.$(assemblyBuildNumber)
 
   # Logging library NuGet package version
   - name: loggingPackageVersion
-    value: 1.1.0-preview1ci$(Build.BuildNumber)
+    value: 7.1.0-preview2ci$(Build.BuildNumber)
 
   # MDS library NuGet package version
   # NOTE: This differs from the other structures! MdsVersions.props will deconstruct a provided
   #    package version and build an assembly version from it. If the build number is included
   #    before the "-" the build number will be appended again, generating an invalid file version.
   - name: mdsPackageVersion
-    value: 7.1.0-preview1ci$(AssemblyBuildNumber)
+    value: 7.1.0-preview2ci$(AssemblyBuildNumber)
 
   # SqlServer library NuGet package version
   # NOTE: SqlServer's version props derive file version from the package version by appending the

--- a/eng/pipelines/onebranch/variables/package-variables.yml
+++ b/eng/pipelines/onebranch/variables/package-variables.yml
@@ -53,13 +53,13 @@ variables:
     value: 'drop_build_abstractions_build_package_Abstractions'
 
   - name: abstractionsFileVersion
-    value: '1.0.0.$(_assemblyBuildNumber)'
+    value: '7.1.0.$(_assemblyBuildNumber)'
 
   - name: abstractionsPackageVersion
     ${{ if parameters.isPreview }}:
-      value: '1.0.0-preview1.$(Build.BuildNumber)'
+      value: '7.1.0-preview2.$(Build.BuildNumber)'
     ${{ else }}:
-      value: '1.0.0'
+      value: '7.1.0'
 
   # ------------------------------------------------------------------------
   # AKV Provider Package
@@ -68,13 +68,13 @@ variables:
     value: 'drop_build_addons_build_package_AkvProvider'
 
   - name: akvProviderFileVersion
-    value: '7.0.0.$(_assemblyBuildNumber)'
+    value: '7.1.0.$(_assemblyBuildNumber)'
 
   - name: akvProviderPackageVersion
     ${{ if parameters.isPreview }}:
-      value: '7.0.0-preview1.$(Build.BuildNumber)'
+      value: '7.1.0-preview2.$(Build.BuildNumber)'
     ${{ else }}:
-      value: '7.0.0'
+      value: '7.1.0'
 
   # ------------------------------------------------------------------------
   # Azure Package
@@ -83,13 +83,13 @@ variables:
     value: 'drop_build_dependent_build_package_Azure'
 
   - name: azureFileVersion
-    value: '1.0.0.$(_assemblyBuildNumber)'
+    value: '7.1.0.$(_assemblyBuildNumber)'
 
   - name: azurePackageVersion
     ${{ if parameters.isPreview }}:
-      value: '1.0.0-preview1.$(Build.BuildNumber)'
+      value: '7.1.0-preview2.$(Build.BuildNumber)'
     ${{ else }}:
-      value: '1.0.0'
+      value: '7.1.0'
 
   # ------------------------------------------------------------------------
   # Logging Package
@@ -98,13 +98,13 @@ variables:
     value: 'drop_build_independent_build_package_Logging'
 
   - name: loggingFileVersion
-    value: '1.0.0.$(_assemblyBuildNumber)'
+    value: '7.1.0.$(_assemblyBuildNumber)'
 
   - name: loggingPackageVersion
     ${{ if parameters.isPreview }}:
-      value: '1.0.0-preview1.$(Build.BuildNumber)'
+      value: '7.1.0-preview2.$(Build.BuildNumber)'
     ${{ else }}:
-      value: '1.0.0'
+      value: '7.1.0'
 
   # ------------------------------------------------------------------------
   # SqlClient Package
@@ -117,7 +117,7 @@ variables:
 
   - name: sqlClientPackageVersion
     ${{ if parameters.isPreview }}:
-      value: '7.1.0-preview1.$(Build.BuildNumber)'
+      value: '7.1.0-preview2.$(Build.BuildNumber)'
     ${{ else }}:
       value: '7.1.0'
 

--- a/release-notes/7.1/7.1.0-preview2.md
+++ b/release-notes/7.1/7.1.0-preview2.md
@@ -97,22 +97,6 @@ This update brings the following changes since the [7.1.0-preview1](7.1.0-previe
 
 - Default behavior is unchanged: pool waits do not count against `Connect Timeout` unless the new switch is enabled. When enabled, `Open`/`OpenAsync` under heavy pool contention may surface timeouts sooner than before. Successful opens are unaffected.
 
-#### Automatic Pool Pruning and Shutdown for the Channel-Based Pool
-
-*What Changed:*
-
-- Implemented pool shutdown for `ChannelDbConnectionPool` and hardened the shutdown path for `WaitHandleDbConnectionPool`, and added automatic pool size reduction (pruning) for the channel-based pool.
-  ([#4302](https://github.com/dotnet/SqlClient/pull/4302),
-   [#4304](https://github.com/dotnet/SqlClient/pull/4304))
-
-*Who Benefits:*
-
-- Applications using pool v2 reclaim idle connections automatically instead of holding the pool at high-water mark for the lifetime of the process.
-
-*Impact:*
-
-- Connection Pooling v2 is still experimental, but its long-running behavior now matches the classic pool more closely.
-
 #### Other changes
 
 - Added the SQL Server 2025 `json` data type to the `DataTypes` collection returned by `SqlConnection.GetSchema`. ([#3858](https://github.com/dotnet/SqlClient/pull/3858))

--- a/release-notes/7.1/7.1.0-preview2.md
+++ b/release-notes/7.1/7.1.0-preview2.md
@@ -1,0 +1,242 @@
+# Release Notes
+
+## Preview Release 7.1.0-preview2 - 2026-07-09
+
+This update brings the following changes since the [7.1.0-preview1](7.1.0-preview1.md) release:
+
+> **Important — package version alignment:** Starting with the [7.0.2](../7.0/7.0.2.md) release, the `Microsoft.Data.SqlClient` driver and its companion packages share a single aligned version. Preview 2 of the `7.1` line continues this alignment; the following packages ship together as `7.1.0-preview2`:
+>
+> - `Microsoft.Data.SqlClient`
+> - `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider`
+> - `Microsoft.Data.SqlClient.Extensions.Azure`
+> - `Microsoft.Data.SqlClient.Extensions.Abstractions`
+> - `Microsoft.Data.SqlClient.Internal.Logging`
+>
+> (`Microsoft.SqlServer.Server` continues to version independently and remains at `1.0.0`.)
+>
+> Applications must reference the same versions of `Microsoft.Data.SqlClient` and its extensions for best compatibility. In particular, applications that reference `Microsoft.Data.SqlClient.Extensions.Azure` must upgrade it to `7.1.0-preview2` when upgrading `Microsoft.Data.SqlClient` to `7.1.0-preview2`.
+>
+> **Compatibility guarantee:** All aligned assemblies ship with `FileVersion 7.1.0.x` and `AssemblyVersion 7.0.0.0`. The `AssemblyVersion` is unchanged from [7.0.2](../7.0/7.0.2.md), so upgrading from `7.0.2` to `7.1.0-preview2` does **not** require any new .NET Framework strong-name binding redirects. See the 7.0.2 release notes for the original `AssemblyVersion` alignment (the one-time breaking change that raised `AssemblyVersion` from `1.0.0.0` to `7.0.0.0` for `Extensions.Azure`, `Extensions.Abstractions`, and `Internal.Logging`; `AzureKeyVaultProvider` was already on `7.x`).
+
+### Added
+
+#### `SqlConnection.GetSchemaAsync`
+
+*What Changed:*
+
+- Added asynchronous overloads of `SqlConnection.GetSchema` that mirror the existing synchronous shapes and honor a supplied `CancellationToken`. The .NET Framework schema code paths were also unified with the .NET Core implementation.
+  ([#3005](https://github.com/dotnet/SqlClient/pull/3005))
+
+*Who Benefits:*
+
+- Applications that enumerate database metadata (databases, tables, columns, procedures, etc.) as part of a request pipeline can now do so without blocking a thread on synchronous I/O.
+
+*Impact:*
+
+- New `GetSchemaAsync(...)` overloads are additive; existing `GetSchema(...)` calls are unchanged.
+
+#### SQL Graph Column Aliases in `SqlBulkCopy`
+
+*What Changed:*
+
+- `SqlBulkCopy` column mappings now accept the SQL Graph pseudo-column aliases `$node_id`, `$edge_id`, `$from_id`, and `$to_id` as destination column names and transparently map them to the underlying physical columns.
+  ([#3677](https://github.com/dotnet/SqlClient/pull/3677))
+
+*Who Benefits:*
+
+- Applications that bulk-load SQL Graph node or edge tables can now map source fields directly to the friendly graph aliases instead of pre-computing the internal physical column names.
+
+*Impact:*
+
+- Existing mappings continue to work; if a physical column with the same name as an alias already exists, the physical column keeps priority.
+
+#### `SqlBatchCommand.CommandBehavior` Is Now Honored
+
+*What Changed:*
+
+- The `SqlBatchCommand.CommandBehavior` property (which existed since batching was introduced but was previously ignored) is now plumbed through the batch execution path so per-command behaviors are honored inside a `SqlBatch`. `SqlBatch.ExecuteReader` also now respects the `CommandBehavior` value passed to it.
+  ([#4125](https://github.com/dotnet/SqlClient/pull/4125))
+
+*Who Benefits:*
+
+- Applications composing heterogeneous batches (for example, mixing `SchemaOnly` metadata queries with data-returning statements) can now express per-command reader behavior without splitting the batch.
+
+*Impact:*
+
+- Batches that previously set `SqlBatchCommand.CommandBehavior` but relied on it being ignored will now see that value applied. Batches that left it at the default (`CommandBehavior.Default`) are unaffected.
+
+#### Configurable Idle Connection Timeout for Pool v2
+
+*What Changed:*
+
+- Added a `Connection Idle Timeout` connection-string keyword and matching `SqlConnectionStringBuilder.IdleTimeout` property that let pool v2 evict pooled connections whose idle time exceeds the configured value. The default is `300` seconds; setting `0` disables idle expiration, and negative values throw `ArgumentException`. Enforcement is gated on the new `Switch.Microsoft.Data.SqlClient.UseLegacyIdleTimeoutBehavior` AppContext switch, which defaults to `true` to preserve historical pooling behavior; set it to `false` to enable idle-timeout enforcement against both pool implementations.
+  ([#4295](https://github.com/dotnet/SqlClient/pull/4295))
+
+*Who Benefits:*
+
+- Applications running against Azure SQL Database and other elastic backends can bound connection idle time to align with server-side session recycling and reduce stale-connection failures.
+
+*Impact:*
+
+- Default behavior is unchanged: the new keyword is parsed but not enforced until the legacy switch is turned off. Connection Pooling v2 remains experimental.
+
+#### WAM Broker Support for Entra ID Authentication
+
+*What Changed:*
+
+- Added Windows Account Manager (WAM) broker support for the supported Entra ID authentication modes (`Integrated`, `Interactive`, `DeviceCodeFlow`, and the deprecated `Password`) in `Microsoft.Data.SqlClient.Extensions.Azure`. Introduces the new `ActiveDirectoryAuthenticationProviderOptions` type (with `UseWamBroker`, `ApplicationClientId`, and `DeviceCodeFlowCallback`), a new `ActiveDirectoryAuthenticationProvider(ActiveDirectoryAuthenticationProviderOptions)` constructor, a cross-platform `SetParentActivityOrWindowFunc(Func<object>?)`, and a `useWamBroker` attribute on the `<SqlClientAuthenticationProviders>` configuration section.
+  ([#4288](https://github.com/dotnet/SqlClient/pull/4288))
+
+*Who Benefits:*
+
+- Windows users get single sign-on, Windows Hello, and conditional-access support through the OS broker. Device Code Flow now uses its own token-lifetime timeout instead of inheriting `Connect Timeout`, fixing spurious `"The operation was canceled."` failures when the user takes longer than a few seconds to enter the device code.
+
+*Impact:*
+
+- WAM is enabled by default when the driver's built-in client id is used. With a custom client id, WAM is opt-in via `UseWamBroker` or the `useWamBroker` config attribute. Non-Windows platforms never invoke the broker. Existing constructors remain source- and binary-compatible.
+- Adding WAM broker support materially increases the on-disk footprint of `Microsoft.Data.SqlClient.Extensions.Azure` because it pulls in the `Microsoft.Identity.Client.Broker` package and its native OS-broker components. See [#4410](https://github.com/dotnet/SqlClient/issues/4410) for tracking.
+
+### Changed
+
+#### Connection Timeout Now Propagates Through the Pool
+
+*What Changed:*
+
+- Replaced raw `TimeSpan` timeouts with a shared `TimeoutTimer` across `SqlConnection.Open[Async]`, pool acquisition, and physical connection creation, so the `Connect Timeout` budget is deducted as a request waits in the pool. Introduces a dependency on `Microsoft.Bcl.TimeProvider`.
+  ([#4270](https://github.com/dotnet/SqlClient/pull/4270))
+
+*Who Benefits:*
+
+- Applications that observe pool contention now see the configured `Connect Timeout` respected end-to-end instead of the budget effectively restarting when a physical connection is eventually opened.
+
+*Impact:*
+
+- Under heavy pool contention, `Open`/`OpenAsync` may surface timeouts sooner than before. Successful opens are unaffected.
+
+#### Automatic Pool Pruning and Shutdown for the Channel-Based Pool
+
+*What Changed:*
+
+- Implemented pool shutdown for `ChannelDbConnectionPool` and hardened the shutdown path for `WaitHandleDbConnectionPool`, and added automatic pool size reduction (pruning) for the channel-based pool.
+  ([#4302](https://github.com/dotnet/SqlClient/pull/4302),
+   [#4304](https://github.com/dotnet/SqlClient/pull/4304))
+
+*Who Benefits:*
+
+- Applications using pool v2 reclaim idle connections automatically instead of holding the pool at high-water mark for the lifetime of the process.
+
+*Impact:*
+
+- Connection Pooling v2 is still experimental, but its long-running behavior now matches the classic pool more closely.
+
+#### Other changes
+
+- Added the SQL Server 2025 `json` data type to the `DataTypes` collection returned by `SqlConnection.GetSchema`. ([#3858](https://github.com/dotnet/SqlClient/pull/3858))
+- Refactored `SqlConnection` internal state transitions to use `Interlocked.CompareExchange` guards, hardening the driver against races surfaced by concurrent open/close/reconnect. ([#4267](https://github.com/dotnet/SqlClient/pull/4267))
+- Removed legacy connection-options inheritance from internal APIs, simplifying `TryOpenConnection`, `TryReplaceConnection`, and the pool interfaces. ([#4237](https://github.com/dotnet/SqlClient/pull/4237), [#4261](https://github.com/dotnet/SqlClient/pull/4261), [#4235](https://github.com/dotnet/SqlClient/pull/4235))
+- Refactored `ForceNewConnection` handling. ([#4415](https://github.com/dotnet/SqlClient/pull/4415))
+- Added Async generic helpers to reduce duplication across sync/async code paths. ([#4334](https://github.com/dotnet/SqlClient/pull/4334))
+- Use hardcoded LCID mappings when decoding strings, avoiding repeated culture lookups. ([#4212](https://github.com/dotnet/SqlClient/pull/4212))
+- Reduced allocations by avoiding lock acquisition on `SqlErrorCollection` counters when no errors exist, and by avoiding stack-trace materialization for expected `null`-return paths. ([#4157](https://github.com/dotnet/SqlClient/pull/4157), [#4099](https://github.com/dotnet/SqlClient/pull/4099), [#4102](https://github.com/dotnet/SqlClient/pull/4102))
+- Improved `EnclaveDiffieHellmanInfo.Size` accuracy. ([#4346](https://github.com/dotnet/SqlClient/pull/4346))
+- `SqlVector<float>` now serializes and deserializes little-endian multibyte values explicitly for consistent behavior across architectures. ([#3861](https://github.com/dotnet/SqlClient/pull/3861))
+- Updated `Microsoft.Identity.Client` and added `Microsoft.Identity.Client.Broker` at `4.84.2` to enable WAM. Updated the bundled .NET 10 SDK to `10.0.300`. ([#4288](https://github.com/dotnet/SqlClient/pull/4288), [#4287](https://github.com/dotnet/SqlClient/pull/4287))
+
+### Fixed
+
+- Fixed a `NullReferenceException` in `SqlCommand.Cancel()` when the active connection has already been torn down. ([#4372](https://github.com/dotnet/SqlClient/pull/4372))
+- Fixed Always Encrypted column master key signature verification incorrectly reusing cached results after a prior verification failure. ([#4339](https://github.com/dotnet/SqlClient/pull/4339))
+- Fixed missing bounds checks on TDS token and feature-extension-acknowledgment data lengths that could allow a spoofing server to trigger unbounded allocations. ([#4340](https://github.com/dotnet/SqlClient/pull/4340))
+- Fixed `SqlBulkCopy` failing in least-privilege environments where the caller lacks permission to run the previous metadata query path. ([#4306](https://github.com/dotnet/SqlClient/pull/4306))
+- Fixed Always Encrypted reads of `CekMdVersion` and `EkValueCount` to align with the TDS specification. ([#4240](https://github.com/dotnet/SqlClient/pull/4240))
+- Fixed `LoginWithFailover` to validate parser state before continuing, preventing null-reference failures during failover login. ([#4140](https://github.com/dotnet/SqlClient/pull/4140))
+- Fixed the SPN used during login to use the resolved port instead of the instance name when `Protocol=None` or `Protocol=Admin` is specified. ([#4180](https://github.com/dotnet/SqlClient/pull/4180))
+- Fixed a race in `SqlConnection.TryOpenInner` that could surface as `InvalidCastException`; the same race now returns a deterministic `InvalidOperationException`. ([#4179](https://github.com/dotnet/SqlClient/pull/4179))
+- Fixed several `CancellationTokenSource` leaks in `SqlDataReader`, `SqlConnection`, `SqlCommand` reconnect paths, and the sequential-stream helpers. ([#4009](https://github.com/dotnet/SqlClient/pull/4009))
+- Documentation fix for server certificate configuration. ([#4408](https://github.com/dotnet/SqlClient/pull/4408))
+
+### Removed
+
+#### SQL Server 7.0 and 2000 Support
+
+*What Changed:*
+
+- Removed dead protocol-level code paths for SQL Server 7.0 and SQL Server 2000, along with the now-orphaned `SQL Server 2000` type-system compatibility option. The `TypeSystem.SQLServer2000` enum value and the `Type System Version=SQL Server 2000` connection-string branch are gone.
+  ([#4015](https://github.com/dotnet/SqlClient/pull/4015))
+
+*Who Benefits:*
+
+- The driver no longer carries dead legacy code, and the documented connection-string surface (`Latest`, `SQL Server 2005`, `SQL Server 2008`, `SQL Server 2012`) now matches the implementation exactly.
+
+*Impact:*
+
+- **Breaking:** A connection string that specifies `Type System Version=SQL Server 2000` now throws `ArgumentException` when the connection is opened, instead of being accepted. Applications currently using this value should switch to a supported value such as `Latest`. There is no change to which servers the driver will connect to — SQL Server 7.0 and 2000 were already rejected during login version negotiation.
+
+## Target Platform Support
+
+- .NET Framework 4.6.2+ (Windows x86, Windows x64, Windows ARM64)
+- .NET 8.0+ (Windows x86, Windows x64, Windows ARM, Windows ARM64, Linux, macOS)
+
+### Dependencies
+
+#### .NET 9.0
+
+- Microsoft.Bcl.Cryptography 9.0.13
+- Microsoft.Data.SqlClient.Extensions.Abstractions 7.1.0-preview2
+- Microsoft.Data.SqlClient.Internal.Logging 7.1.0-preview2
+- Microsoft.Data.SqlClient.SNI.runtime 6.0.2
+- Microsoft.Extensions.Caching.Memory 9.0.13
+- Microsoft.IdentityModel.JsonWebTokens 8.16.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 8.16.0
+- Microsoft.SqlServer.Server 1.0.0
+- System.Configuration.ConfigurationManager 9.0.13
+- System.Security.Cryptography.Pkcs 9.0.13
+
+#### .NET 8.0
+
+- Microsoft.Bcl.Cryptography 8.0.0
+- Microsoft.Data.SqlClient.Extensions.Abstractions 7.1.0-preview2
+- Microsoft.Data.SqlClient.Internal.Logging 7.1.0-preview2
+- Microsoft.Data.SqlClient.SNI.runtime 6.0.2
+- Microsoft.Extensions.Caching.Memory 8.0.1
+- Microsoft.IdentityModel.JsonWebTokens 8.16.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 8.16.0
+- Microsoft.SqlServer.Server 1.0.0
+- System.Configuration.ConfigurationManager 8.0.1
+- System.Security.Cryptography.Pkcs 8.0.1
+
+#### .NET Standard 2.0
+
+- Microsoft.Bcl.Cryptography 8.0.0
+- Microsoft.Bcl.TimeProvider 8.0.1
+- Microsoft.Data.SqlClient.Extensions.Abstractions 7.1.0-preview2
+- Microsoft.Data.SqlClient.Internal.Logging 7.1.0-preview2
+- Microsoft.Data.SqlClient.SNI.runtime 6.0.2
+- Microsoft.Extensions.Caching.Memory 8.0.1
+- Microsoft.IdentityModel.JsonWebTokens 8.16.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 8.16.0
+- Microsoft.SqlServer.Server 1.0.0
+- System.Configuration.ConfigurationManager 8.0.1
+- System.Security.Cryptography.Pkcs 8.0.1
+- System.Text.Json 10.0.3
+- System.Threading.Channels 10.0.3
+
+#### .NET Framework 4.6.2+
+
+- Microsoft.Bcl.Cryptography 8.0.0
+- Microsoft.Bcl.TimeProvider 8.0.1
+- Microsoft.Data.SqlClient.Extensions.Abstractions 7.1.0-preview2
+- Microsoft.Data.SqlClient.Internal.Logging 7.1.0-preview2
+- Microsoft.Data.SqlClient.SNI 6.0.2
+- Microsoft.Extensions.Caching.Memory 8.0.1
+- Microsoft.IdentityModel.JsonWebTokens 8.16.0
+- Microsoft.IdentityModel.Protocols.OpenIdConnect 8.16.0
+- System.Buffers 4.6.1
+- System.Data.Common 4.3.0
+- System.Diagnostics.DiagnosticSource 10.0.3
+- System.Memory 4.6.3
+- System.Runtime.InteropServices.RuntimeInformation 4.3.0
+- System.Security.Cryptography.Pkcs 8.0.1
+- System.Text.Json 10.0.3
+- System.Threading.Channels 10.0.3
+- System.ValueTuple 4.6.2

--- a/release-notes/7.1/7.1.0-preview2.md
+++ b/release-notes/7.1/7.1.0-preview2.md
@@ -80,22 +80,6 @@ This update brings the following changes since the [7.1.0-preview1](7.1.0-previe
 
 - Default behavior is unchanged: the new keyword is parsed but not enforced until the legacy switch is turned off. Connection Pooling v2 remains experimental.
 
-#### WAM Broker Support for Entra ID Authentication
-
-*What Changed:*
-
-- Added Windows Account Manager (WAM) broker support for the supported Entra ID authentication modes (`Integrated`, `Interactive`, `DeviceCodeFlow`, and the deprecated `Password`) in `Microsoft.Data.SqlClient.Extensions.Azure`. Introduces the new `ActiveDirectoryAuthenticationProviderOptions` type (with `UseWamBroker`, `ApplicationClientId`, and `DeviceCodeFlowCallback`), a new `ActiveDirectoryAuthenticationProvider(ActiveDirectoryAuthenticationProviderOptions)` constructor, a cross-platform `SetParentActivityOrWindowFunc(Func<object>?)`, and a `useWamBroker` attribute on the `<SqlClientAuthenticationProviders>` configuration section.
-  ([#4288](https://github.com/dotnet/SqlClient/pull/4288))
-
-*Who Benefits:*
-
-- Windows users get single sign-on, Windows Hello, and conditional-access support through the OS broker. Device Code Flow now uses its own token-lifetime timeout instead of inheriting `Connect Timeout`, fixing spurious `"The operation was canceled."` failures when the user takes longer than a few seconds to enter the device code.
-
-*Impact:*
-
-- WAM is enabled by default when the driver's built-in client id is used. With a custom client id, WAM is opt-in via `UseWamBroker` or the `useWamBroker` config attribute. Non-Windows platforms never invoke the broker. Existing constructors remain source- and binary-compatible.
-- Adding WAM broker support materially increases the on-disk footprint of `Microsoft.Data.SqlClient.Extensions.Azure` because it pulls in the `Microsoft.Identity.Client.Broker` package and its native OS-broker components. See [#4410](https://github.com/dotnet/SqlClient/issues/4410) for tracking.
-
 ### Changed
 
 #### Connection Timeout Now Propagates Through the Pool
@@ -140,7 +124,7 @@ This update brings the following changes since the [7.1.0-preview1](7.1.0-previe
 - Reduced allocations by avoiding lock acquisition on `SqlErrorCollection` counters when no errors exist, and by avoiding stack-trace materialization for expected `null`-return paths. ([#4157](https://github.com/dotnet/SqlClient/pull/4157), [#4099](https://github.com/dotnet/SqlClient/pull/4099), [#4102](https://github.com/dotnet/SqlClient/pull/4102))
 - Improved `EnclaveDiffieHellmanInfo.Size` accuracy. ([#4346](https://github.com/dotnet/SqlClient/pull/4346))
 - `SqlVector<float>` now serializes and deserializes little-endian multibyte values explicitly for consistent behavior across architectures. ([#3861](https://github.com/dotnet/SqlClient/pull/3861))
-- Updated `Microsoft.Identity.Client` and added `Microsoft.Identity.Client.Broker` at `4.84.2` to enable WAM. Updated the bundled .NET 10 SDK to `10.0.300`. ([#4288](https://github.com/dotnet/SqlClient/pull/4288), [#4287](https://github.com/dotnet/SqlClient/pull/4287))
+- Updated the bundled .NET 10 SDK to `10.0.300`. ([#4287](https://github.com/dotnet/SqlClient/pull/4287))
 
 ### Fixed
 

--- a/release-notes/7.1/7.1.0-preview2.md
+++ b/release-notes/7.1/7.1.0-preview2.md
@@ -65,11 +65,11 @@ This update brings the following changes since the [7.1.0-preview1](7.1.0-previe
 
 - Batches that previously set `SqlBatchCommand.CommandBehavior` but relied on it being ignored will now see that value applied. Batches that left it at the default (`CommandBehavior.Default`) are unaffected.
 
-#### Configurable Idle Connection Timeout for Pool v2
+#### Configurable Idle Connection Timeout
 
 *What Changed:*
 
-- Added a `Connection Idle Timeout` connection-string keyword and matching `SqlConnectionStringBuilder.IdleTimeout` property that let pool v2 evict pooled connections whose idle time exceeds the configured value. The default is `300` seconds; setting `0` disables idle expiration, and negative values throw `ArgumentException`. Enforcement is gated on the new `Switch.Microsoft.Data.SqlClient.UseLegacyIdleTimeoutBehavior` AppContext switch, which defaults to `true` to preserve historical pooling behavior; set it to `false` to enable idle-timeout enforcement against both pool implementations.
+- Added a `Connection Idle Timeout` connection-string keyword and matching `SqlConnectionStringBuilder.IdleTimeout` property that let the connection pool evict pooled connections whose idle time exceeds the configured value. The default is `300` seconds; setting `0` disables idle expiration, and negative values throw `ArgumentException`. Enforcement is gated on the new `Switch.Microsoft.Data.SqlClient.UseLegacyIdleTimeoutBehavior` AppContext switch, which defaults to `true` to preserve historical pooling behavior; set it to `false` to enable idle-timeout enforcement.
   ([#4295](https://github.com/dotnet/SqlClient/pull/4295))
 
 *Who Benefits:*
@@ -78,7 +78,7 @@ This update brings the following changes since the [7.1.0-preview1](7.1.0-previe
 
 *Impact:*
 
-- Default behavior is unchanged: the new keyword is parsed but not enforced until the legacy switch is turned off. Connection Pooling v2 remains experimental.
+- Default behavior is unchanged: the new keyword is parsed but not enforced until the legacy switch is turned off. When enabled, idle-timeout enforcement applies to the existing connection pool as well.
 
 ### Changed
 
@@ -86,16 +86,16 @@ This update brings the following changes since the [7.1.0-preview1](7.1.0-previe
 
 *What Changed:*
 
-- Replaced raw `TimeSpan` timeouts with a shared `TimeoutTimer` across `SqlConnection.Open[Async]`, pool acquisition, and physical connection creation, so the `Connect Timeout` budget is deducted as a request waits in the pool. Introduces a dependency on `Microsoft.Bcl.TimeProvider`.
+- Replaced raw `TimeSpan` timeouts with a shared `TimeoutTimer` across `SqlConnection.Open[Async]`, pool acquisition, and physical connection creation, so the `Connect Timeout` budget can be deducted as a request waits in the pool. Introduces a dependency on `Microsoft.Bcl.TimeProvider`. Enforcement is gated on the new `Switch.Microsoft.Data.SqlClient.UseOverallConnectTimeoutForPoolWait` AppContext switch, which defaults to `false` to preserve historical behavior; set it to `true` to have pool waits count against the caller's `Connect Timeout` budget.
   ([#4270](https://github.com/dotnet/SqlClient/pull/4270))
 
 *Who Benefits:*
 
-- Applications that observe pool contention now see the configured `Connect Timeout` respected end-to-end instead of the budget effectively restarting when a physical connection is eventually opened.
+- Applications that observe pool contention can opt in via the new switch to have the configured `Connect Timeout` respected end-to-end instead of the budget effectively restarting when a physical connection is eventually opened.
 
 *Impact:*
 
-- Under heavy pool contention, `Open`/`OpenAsync` may surface timeouts sooner than before. Successful opens are unaffected.
+- Default behavior is unchanged: pool waits do not count against `Connect Timeout` unless the new switch is enabled. When enabled, `Open`/`OpenAsync` under heavy pool contention may surface timeouts sooner than before. Successful opens are unaffected.
 
 #### Automatic Pool Pruning and Shutdown for the Channel-Based Pool
 

--- a/release-notes/7.1/README.md
+++ b/release-notes/7.1/README.md
@@ -5,3 +5,4 @@ The following Microsoft.Data.SqlClient 7.1 releases have been shipped:
 | Release Date | Version        |               Notes                |
 |:-------------|:---------------|:----------------------------------:|
 | 2026-04-29   | 7.1.0-preview1 | [Release Notes](7.1.0-preview1.md) |
+| 2026-07-09   | 7.1.0-preview2 | [Release Notes](7.1.0-preview2.md) |

--- a/release-notes/Extensions/Abstractions/7.1/7.1.0-preview2.md
+++ b/release-notes/Extensions/Abstractions/7.1/7.1.0-preview2.md
@@ -6,7 +6,7 @@ This release continues version-alignment of `Microsoft.Data.SqlClient.Extensions
 
 There are no functional or API changes in this release. See the core [Microsoft.Data.SqlClient 7.1.0-preview2](../../../7.1/7.1.0-preview2.md) release notes for the driver-family changes shipped alongside this version.
 
-> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x` and `AssemblyVersion 7.0.0.0`, unchanged from `7.0.2`.
+> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x`. The `AssemblyVersion 7.0.0.0` remains unchanged from the `7.0.2` release.
 
 ## Target Platform Support
 

--- a/release-notes/Extensions/Abstractions/7.1/7.1.0-preview2.md
+++ b/release-notes/Extensions/Abstractions/7.1/7.1.0-preview2.md
@@ -1,0 +1,19 @@
+# Release Notes
+
+## Preview Release 7.1.0-preview2 - 2026-07-09
+
+This release continues version-alignment of `Microsoft.Data.SqlClient.Extensions.Abstractions` with the core `Microsoft.Data.SqlClient` driver version (`7.1.0-preview2`). The previous release of this package was [7.0.2](../7.0/7.0.2.md).
+
+There are no functional or API changes in this release. See the core [Microsoft.Data.SqlClient 7.1.0-preview2](../../../7.1/7.1.0-preview2.md) release notes for the driver-family changes shipped alongside this version.
+
+> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x` and `AssemblyVersion 7.0.0.0`, unchanged from `7.0.2`.
+
+## Target Platform Support
+
+- .NET Standard 2.0
+
+### Dependencies
+
+#### .NET Standard 2.0
+
+- Microsoft.Data.SqlClient.Internal.Logging 7.1.0-preview2

--- a/release-notes/Extensions/Abstractions/7.1/README.md
+++ b/release-notes/Extensions/Abstractions/7.1/README.md
@@ -1,0 +1,8 @@
+# Microsoft.Data.SqlClient.Extensions.Abstractions 7.1 Releases
+
+The following `Microsoft.Data.SqlClient.Extensions.Abstractions`
+7.1 releases have been shipped:
+
+| Release Date | Description | Notes |
+| :-- | :-- | :--: |
+| 2026-07-09 | 7.1.0-preview2 | [Release Notes](7.1.0-preview2.md) |

--- a/release-notes/Extensions/Azure/7.1/7.1.0-preview2.md
+++ b/release-notes/Extensions/Azure/7.1/7.1.0-preview2.md
@@ -6,7 +6,7 @@ This release continues version-alignment of `Microsoft.Data.SqlClient.Extensions
 
 There are no functional or API changes in this release. See the [7.0.2 release notes](../7.0/7.0.2.md) for details on the WAM broker support for Entra ID authentication that was added in the previous release, and see the core [Microsoft.Data.SqlClient 7.1.0-preview2](../../../7.1/7.1.0-preview2.md) release notes for the driver-family changes shipped alongside this version.
 
-> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x` and `AssemblyVersion 7.0.0.0`, unchanged from `7.0.2`.
+> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x`. The `AssemblyVersion 7.0.0.0` remains unchanged from the `7.0.2` release.
 
 ## Target Platform Support
 

--- a/release-notes/Extensions/Azure/7.1/7.1.0-preview2.md
+++ b/release-notes/Extensions/Azure/7.1/7.1.0-preview2.md
@@ -2,11 +2,48 @@
 
 ## Preview Release 7.1.0-preview2 - 2026-07-09
 
-This release continues version-alignment of `Microsoft.Data.SqlClient.Extensions.Azure` with the core `Microsoft.Data.SqlClient` driver version (`7.1.0-preview2`). The previous release of this package was [7.0.2](../7.0/7.0.2.md).
-
-There are no functional or API changes in this release. See the [7.0.2 release notes](../7.0/7.0.2.md) for details on the WAM broker support for Entra ID authentication that was added in the previous release, and see the core [Microsoft.Data.SqlClient 7.1.0-preview2](../../../7.1/7.1.0-preview2.md) release notes for the driver-family changes shipped alongside this version.
+This release adds Windows Account Manager (WAM) broker support for Microsoft Entra ID authentication on Windows and continues version-alignment of `Microsoft.Data.SqlClient.Extensions.Azure` with the core `Microsoft.Data.SqlClient` driver version (`7.1.0-preview2`). The previous release of this package was [7.0.2](../7.0/7.0.2.md). See the core [Microsoft.Data.SqlClient 7.1.0-preview2](../../../7.1/7.1.0-preview2.md) release notes for the driver-family changes shipped alongside this version.
 
 > **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x`. The `AssemblyVersion 7.0.0.0` remains unchanged from the `7.0.2` release.
+
+### Added
+
+#### WAM Broker Support for Entra ID Authentication (Windows only)
+
+*What Changed:*
+
+- Added Windows Account Manager (WAM) broker support for the supported Entra ID authentication modes (`ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`, `ActiveDirectoryDeviceCodeFlow`, and the deprecated `ActiveDirectoryPassword`). Introduces a new `ActiveDirectoryAuthenticationProviderOptions` type (with `UseWamBroker`, `ApplicationClientId`, and `DeviceCodeFlowCallback`), a new `ActiveDirectoryAuthenticationProvider(ActiveDirectoryAuthenticationProviderOptions)` constructor overload, a cross-platform `SetParentActivityOrWindowFunc(Func<object>?)` method (superseding the .NET Framework-only `SetIWin32WindowFunc`), and a `useWamBroker` attribute on the `<SqlClientAuthenticationProviders>` configuration section.
+  ([#4288](https://github.com/dotnet/SqlClient/pull/4288),
+   [#4388](https://github.com/dotnet/SqlClient/pull/4388))
+
+*Who Benefits:*
+
+- Windows users get single sign-on with the signed-in Windows account, Windows Hello, and Conditional Access support through the OS broker. Device Code Flow now uses its own token-lifetime timeout instead of inheriting `Connect Timeout`, fixing spurious `"The operation was canceled."` failures when the user takes longer than a few seconds to enter the device code.
+
+*Impact:*
+
+- WAM is enabled by default when the driver's built-in client id is used. With a custom client id, WAM is opt-in via `ActiveDirectoryAuthenticationProviderOptions.UseWamBroker` or the `useWamBroker` config attribute. Non-Windows platforms never invoke the broker.
+- Existing `ActiveDirectoryAuthenticationProvider` constructors remain source- and binary-compatible.
+- Adding WAM broker support materially increases the on-disk footprint of `Microsoft.Data.SqlClient.Extensions.Azure` because it pulls in the `Microsoft.Identity.Client.Broker` package and its native OS-broker components. See [#4410](https://github.com/dotnet/SqlClient/issues/4410) for tracking.
+
+```c#
+var options = new ActiveDirectoryAuthenticationProviderOptions
+{
+    ApplicationClientId = "<your-app-client-id>",
+    UseWamBroker = true, // Windows only
+};
+var provider = new ActiveDirectoryAuthenticationProvider(options);
+SqlAuthenticationProvider.SetProvider(SqlAuthenticationMethod.ActiveDirectoryInteractive, provider);
+```
+
+- A new `AzureSqlConnector` sample demonstrating interactive Entra ID authentication with and without the WAM broker is available under [doc/apps/AzureSqlConnector](../../../../doc/apps/AzureSqlConnector/README.md).
+
+### Changed
+
+- Updated Dependencies
+  ([#4288](https://github.com/dotnet/SqlClient/pull/4288)):
+  - Added `Microsoft.Identity.Client.Broker` v4.84.2 (required for WAM broker support).
+  - Updated `Microsoft.Identity.Client` to v4.84.2.
 
 ## Target Platform Support
 

--- a/release-notes/Extensions/Azure/7.1/7.1.0-preview2.md
+++ b/release-notes/Extensions/Azure/7.1/7.1.0-preview2.md
@@ -1,0 +1,36 @@
+# Release Notes
+
+## Preview Release 7.1.0-preview2 - 2026-07-09
+
+This release continues version-alignment of `Microsoft.Data.SqlClient.Extensions.Azure` with the core `Microsoft.Data.SqlClient` driver version (`7.1.0-preview2`). The previous release of this package was [7.0.2](../7.0/7.0.2.md).
+
+There are no functional or API changes in this release. See the [7.0.2 release notes](../7.0/7.0.2.md) for details on the WAM broker support for Entra ID authentication that was added in the previous release, and see the core [Microsoft.Data.SqlClient 7.1.0-preview2](../../../7.1/7.1.0-preview2.md) release notes for the driver-family changes shipped alongside this version.
+
+> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x` and `AssemblyVersion 7.0.0.0`, unchanged from `7.0.2`.
+
+## Target Platform Support
+
+- .NET Standard 2.0
+- .NET Framework 4.6.2+
+
+### Dependencies
+
+#### .NET Standard 2.0
+
+- Azure.Core 1.51.1
+- Azure.Identity 1.18.0
+- Microsoft.Data.SqlClient.Extensions.Abstractions 7.1.0-preview2
+- Microsoft.Data.SqlClient.Internal.Logging 7.1.0-preview2
+- Microsoft.Extensions.Caching.Memory 8.0.1
+- Microsoft.Identity.Client 4.84.2
+- Microsoft.Identity.Client.Broker 4.84.2
+
+#### .NET Framework 4.6.2+
+
+- Azure.Core 1.51.1
+- Azure.Identity 1.18.0
+- Microsoft.Data.SqlClient.Extensions.Abstractions 7.1.0-preview2
+- Microsoft.Data.SqlClient.Internal.Logging 7.1.0-preview2
+- Microsoft.Extensions.Caching.Memory 8.0.1
+- Microsoft.Identity.Client 4.84.2
+- Microsoft.Identity.Client.Broker 4.84.2

--- a/release-notes/Extensions/Azure/7.1/README.md
+++ b/release-notes/Extensions/Azure/7.1/README.md
@@ -1,0 +1,8 @@
+# Microsoft.Data.SqlClient.Extensions.Azure 7.1 Releases
+
+The following `Microsoft.Data.SqlClient.Extensions.Azure`
+7.1 releases have been shipped:
+
+| Release Date | Description | Notes |
+| :-- | :-- | :--: |
+| 2026-07-09 | 7.1.0-preview2 | [Release Notes](7.1.0-preview2.md) |

--- a/release-notes/Internal/Logging/7.1/7.1.0-preview2.md
+++ b/release-notes/Internal/Logging/7.1/7.1.0-preview2.md
@@ -9,7 +9,7 @@ This release continues version-alignment of `Microsoft.Data.SqlClient.Internal.L
 
 There are no functional or API changes in this release. See the core [Microsoft.Data.SqlClient 7.1.0-preview2](../../../7.1/7.1.0-preview2.md) release notes for the driver-family changes shipped alongside this version.
 
-> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x` and `AssemblyVersion 7.0.0.0`, unchanged from `7.0.2`.
+> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x`. The `AssemblyVersion 7.0.0.0` remains unchanged from the `7.0.2` release.
 
 ## Target Platform Support
 

--- a/release-notes/Internal/Logging/7.1/7.1.0-preview2.md
+++ b/release-notes/Internal/Logging/7.1/7.1.0-preview2.md
@@ -1,0 +1,22 @@
+# Release Notes
+
+## Preview Release 7.1.0-preview2 - 2026-07-09
+
+> **Note:** This package is for internal use by other Microsoft.Data.SqlClient packages only
+> and should not be referenced directly by application code.
+
+This release continues version-alignment of `Microsoft.Data.SqlClient.Internal.Logging` with the core `Microsoft.Data.SqlClient` driver version (`7.1.0-preview2`). The previous release of this package was [7.0.2](../7.0/7.0.2.md).
+
+There are no functional or API changes in this release. See the core [Microsoft.Data.SqlClient 7.1.0-preview2](../../../7.1/7.1.0-preview2.md) release notes for the driver-family changes shipped alongside this version.
+
+> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x` and `AssemblyVersion 7.0.0.0`, unchanged from `7.0.2`.
+
+## Target Platform Support
+
+- .NET Standard 2.0
+
+### Dependencies
+
+#### .NET Standard 2.0
+
+- None

--- a/release-notes/Internal/Logging/7.1/README.md
+++ b/release-notes/Internal/Logging/7.1/README.md
@@ -1,0 +1,11 @@
+# Microsoft.Data.SqlClient.Internal.Logging 7.1 Releases
+
+> **Note:** This package is for internal use by other Microsoft.Data.SqlClient packages only
+> and should not be referenced directly by application code.
+
+The following `Microsoft.Data.SqlClient.Internal.Logging`
+7.1 releases have been shipped:
+
+| Release Date | Description | Notes |
+| :-- | :-- | :--: |
+| 2026-07-09 | 7.1.0-preview2 | [Release Notes](7.1.0-preview2.md) |

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -27,6 +27,7 @@ The latest stable release is
 
 ## Release Information
 
+- [Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider 7.1](add-ons/AzureKeyVaultProvider/7.1)
 - [Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider 7.0](add-ons/AzureKeyVaultProvider/7.0)
 - [Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider 6.1](add-ons/AzureKeyVaultProvider/6.1)
 - [Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider 6.0](add-ons/AzureKeyVaultProvider/6.0)
@@ -44,6 +45,7 @@ The latest release is
 
 ## Release Information
 
+- [Microsoft.Data.SqlClient.Extensions.Abstractions 7.1](Extensions/Abstractions/7.1)
 - [Microsoft.Data.SqlClient.Extensions.Abstractions 7.0](Extensions/Abstractions/7.0)
 - [Microsoft.Data.SqlClient.Extensions.Abstractions 1.0](Extensions/Abstractions/1.0)
 
@@ -54,6 +56,7 @@ The latest release is
 
 ## Release Information
 
+- [Microsoft.Data.SqlClient.Extensions.Azure 7.1](Extensions/Azure/7.1)
 - [Microsoft.Data.SqlClient.Extensions.Azure 7.0](Extensions/Azure/7.0)
 - [Microsoft.Data.SqlClient.Extensions.Azure 1.0](Extensions/Azure/1.0)
 
@@ -65,6 +68,7 @@ The latest release is
 
 ## Release Information
 
+- [Microsoft.Data.SqlClient.Internal.Logging 7.1](Internal/Logging/7.1)
 - [Microsoft.Data.SqlClient.Internal.Logging 7.0](Internal/Logging/7.0)
 - [Microsoft.Data.SqlClient.Internal.Logging 1.0](Internal/Logging/1.0)
 

--- a/release-notes/add-ons/AzureKeyVaultProvider/7.1/7.1.0-preview2.md
+++ b/release-notes/add-ons/AzureKeyVaultProvider/7.1/7.1.0-preview2.md
@@ -6,7 +6,7 @@ This release continues version-alignment of `Microsoft.Data.SqlClient.AlwaysEncr
 
 There are no functional or API changes in this release. See the core [Microsoft.Data.SqlClient 7.1.0-preview2](../../../7.1/7.1.0-preview2.md) release notes for the driver-family changes shipped alongside this version.
 
-> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x` and `AssemblyVersion 7.0.0.0`, unchanged from `7.0.2`.
+> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x`. The `AssemblyVersion 7.0.0.0` remains unchanged from the `7.0.2` release.
 
 ## Target Platform Support
 

--- a/release-notes/add-ons/AzureKeyVaultProvider/7.1/7.1.0-preview2.md
+++ b/release-notes/add-ons/AzureKeyVaultProvider/7.1/7.1.0-preview2.md
@@ -1,0 +1,23 @@
+# Release Notes
+
+## Preview Release 7.1.0-preview2 - 2026-07-09
+
+This release continues version-alignment of `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider` with the core `Microsoft.Data.SqlClient` driver version (`7.1.0-preview2`). The previous release of this package was [7.0.2](../7.0/7.0.2.md).
+
+There are no functional or API changes in this release. See the core [Microsoft.Data.SqlClient 7.1.0-preview2](../../../7.1/7.1.0-preview2.md) release notes for the driver-family changes shipped alongside this version.
+
+> **Version alignment:** This package's version continues to track the core `Microsoft.Data.SqlClient` driver version. See the [7.0.2 release notes](../../../7.0/7.0.2.md) for the initial alignment announcement. This assembly ships with `FileVersion 7.1.0.x` and `AssemblyVersion 7.0.0.0`, unchanged from `7.0.2`.
+
+## Target Platform Support
+
+- .NET Standard 2.0
+
+### Dependencies
+
+#### .NET Standard 2.0
+
+- Azure.Core 1.51.1
+- Azure.Security.KeyVault.Keys 4.9.0
+- Microsoft.Data.SqlClient 7.1.0-preview2
+- Microsoft.Data.SqlClient.Internal.Logging 7.1.0-preview2
+- Microsoft.Extensions.Caching.Memory 8.0.1

--- a/release-notes/add-ons/AzureKeyVaultProvider/7.1/README.md
+++ b/release-notes/add-ons/AzureKeyVaultProvider/7.1/README.md
@@ -1,0 +1,8 @@
+# Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider 7.1 Releases
+
+The following `Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider`
+7.1 releases have been shipped:
+
+| Release Date | Description | Notes |
+| :-- | :-- | :--: |
+| 2026-07-09 | 7.1.0-preview2 | [Release Notes](7.1.0-preview2.md) |

--- a/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/Versions.props
+++ b/src/Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider/src/Versions.props
@@ -29,7 +29,7 @@
       This is the *next* version to release of AkvProvider. Update this after a version is released.
       @TODO: Determine how versions should be updated in release branches vs main
     -->
-    <AkvProviderVersionDefault>7.1.0-preview1</AkvProviderVersionDefault>
+    <AkvProviderVersionDefault>7.1.0-preview2</AkvProviderVersionDefault>
   </PropertyGroup>
 
   <!-- Determine file version and package version based on what was provided. -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Versions.props
+++ b/src/Microsoft.Data.SqlClient.Extensions/Abstractions/src/Versions.props
@@ -30,7 +30,7 @@
       decided.
       @TODO: Determine how versions should be updated in release branches vs main
     -->
-    <AbstractionsVersionDefault>1.1.0-preview1</AbstractionsVersionDefault>
+    <AbstractionsVersionDefault>7.1.0-preview2</AbstractionsVersionDefault>
   </PropertyGroup>
 
   <!-- Determine file version and package version based on what was provided. -->

--- a/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Versions.props
+++ b/src/Microsoft.Data.SqlClient.Extensions/Azure/src/Versions.props
@@ -29,7 +29,7 @@
       This is the *next* version to release of Azure. Update this when the next version is decided.
       @TODO: Determine how versions should be updated in release branches vs main
     -->
-    <AzureVersionDefault>1.1.0-preview1</AzureVersionDefault>
+    <AzureVersionDefault>7.1.0-preview2</AzureVersionDefault>
   </PropertyGroup>
 
   <!-- Determine file version and package version based on what was provided. -->

--- a/src/Microsoft.Data.SqlClient.Internal/Logging/src/Versions.props
+++ b/src/Microsoft.Data.SqlClient.Internal/Logging/src/Versions.props
@@ -30,7 +30,7 @@
       decided.
       @TODO: Determine how versions should be updated in release branches vs main
     -->
-    <LoggingVersionDefault>1.1.0-preview1</LoggingVersionDefault>
+    <LoggingVersionDefault>7.1.0-preview2</LoggingVersionDefault>
   </PropertyGroup>
 
   <!-- Determine file version and package version based on what was provided. -->

--- a/src/Microsoft.Data.SqlClient/Versions.props
+++ b/src/Microsoft.Data.SqlClient/Versions.props
@@ -29,7 +29,7 @@
       This is the *next* version to release of SqlClient. Update this after a version is released.
       @TODO: Determine how versions should be updated in release branches vs main
     -->
-    <SqlClientVersionDefault>7.1.0-preview1</SqlClientVersionDefault>
+    <SqlClientVersionDefault>7.1.0-preview2</SqlClientVersionDefault>
   </PropertyGroup>
 
   <!-- Determine file version and package version based on what was provided. -->


### PR DESCRIPTION
## Description
* vBump in `Versions.props`, OneBranch pipelines, and CI/PR pipelines to v7.1.0-preview2
* Release notes for v7.1.0-preview2 (release date 2026-07-09)
* Includes new top-level `CHANGELOG.md` entry and updated `release-notes/7.1/README.md` index