### PR TITLE
PR Pipeline | Fix Test Result Publishing

### DIFF
--- a/eng/pipelines/pr/steps/publish-test-results-step.yml
+++ b/eng/pipelines/pr/steps/publish-test-results-step.yml
@@ -45,10 +45,9 @@ steps:
     displayName: 'Publish Test Results'
     inputs:
       buildConfiguration: ${{ parameters.buildConfiguration }}
+      failTaskOnMissingResultsFile: true
       mergeTestResults: true
-      testResultsFiles: |
-        ${{ parameters.testResultsPath }}/*.trx
-        ${{ parameters.testResultsPath }}/**/*.coverage
+      testResultsFiles: ${{ parameters.testResultsPath }}/*.trx
       testResultsFormat: VSTest
       testRunTitle: "${{ parameters.platformDisplayName }}_${{ parameters.testDisplayName }}"
     condition: succeededOrFailed()


### PR DESCRIPTION
## Description
@paulmedynski mentioned this morning that test results aren't being published for the PR pipeline. Turns out the test result publishing step was silently passing despite failing to process the test results file. Turns out it was processing the coverage file as if it was a test results file. To fix, I just removed the coverage glob from the test results publishing step. I've also configured the pipeline to fail the test publishing step if no test results were found.

## Issues
N/A

## Testing
Test run passed - https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=159683&view=results 
https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=159683&view=ms.vss-test-web.build-test-results-tab