### PR TITLE
Pin Microsoft.SqlServer.Server package version to 1.0.0

### DIFF
--- a/eng/pipelines/onebranch/variables/package-variables.yml
+++ b/eng/pipelines/onebranch/variables/package-variables.yml
@@ -131,7 +131,4 @@ variables:
     value: '1.0.0.$(_assemblyBuildNumber)'
 
   - name: sqlServerPackageVersion
-    ${{ if parameters.isPreview }}:
-      value: '1.0.0-preview1.$(Build.BuildNumber)'
-    ${{ else }}:
-      value: '1.0.0'
+    value: '1.0.0'

--- a/src/Microsoft.SqlServer.Server/Versions.props
+++ b/src/Microsoft.SqlServer.Server/Versions.props
@@ -30,7 +30,7 @@
       decided.
       @TODO: Determine how versions should be updated in release branches vs main
     -->
-    <SqlServerVersionDefault>1.1.0-preview1</SqlServerVersionDefault>
+    <SqlServerVersionDefault>1.0.0</SqlServerVersionDefault>
   </PropertyGroup>
 
   <!-- Determine file version and package version based on what was provided. -->


### PR DESCRIPTION
MDS release builds were pulling '1.0.0-preview1.<buildNumber>' as the SqlServer sibling package version via -p:PackageVersionSqlServer, which does not exist on the internal feed and breaks 'Restore SqlServer package' during MDS pack. Also aligns the Versions.props fallback (SqlServerVersionDefault) so a build without the pipeline override still resolves to a shipping version.

Verification through non-official pipeline: https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=159853&view=results