### PR TITLE
Filter fatal exceptions from Task.FromException in async paths

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1356,20 +1356,9 @@ DROP TABLE #Column_Aliases
                 {
                     _hasMoreRowToCopy = ReadFromRowSource(); // Synchronous calls for DataRows and DataTable won't block. For IDataReader, it may block.
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (_isAsyncBulkCopy && ADP.IsCatchableExceptionType(ex))
                 {
-                    if (_isAsyncBulkCopy)
-                    {
-                        if (!ADP.IsCatchableExceptionType(ex))
-                        {
-                            throw;
-                        }
-                        return Task.FromException<bool>(ex);
-                    }
-                    else
-                    {
-                        throw;
-                    }
+                    return Task.FromException<bool>(ex);
                 }
                 finally
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlBulkCopy.cs
@@ -1360,6 +1360,10 @@ DROP TABLE #Column_Aliases
                 {
                     if (_isAsyncBulkCopy)
                     {
+                        if (!ADP.IsCatchableExceptionType(ex))
+                        {
+                            throw;
+                        }
                         return Task.FromException<bool>(ex);
                     }
                     else
@@ -2530,7 +2534,7 @@ DROP TABLE #Column_Aliases
                     source.SetResult(null);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ADP.IsCatchableExceptionType(ex))
             {
                 if (source != null)
                 {
@@ -2739,7 +2743,7 @@ DROP TABLE #Column_Aliases
                     source.TrySetResult(null); // This is set only on the last call of async copy. But may not be set if everything runs synchronously.
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ADP.IsCatchableExceptionType(ex))
             {
                 if (source != null)
                 {
@@ -2816,7 +2820,7 @@ DROP TABLE #Column_Aliases
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ADP.IsCatchableExceptionType(ex))
             {
                 if (source != null)
                 {
@@ -2888,7 +2892,7 @@ DROP TABLE #Column_Aliases
                     return CopyBatchesAsyncContinuedOnSuccess(internalResults, updateBulkCommandText, cts, source);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ADP.IsCatchableExceptionType(ex))
             {
                 if (source != null)
                 {
@@ -2950,7 +2954,7 @@ DROP TABLE #Column_Aliases
                     return source.Task;
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ADP.IsCatchableExceptionType(ex))
             {
                 if (source != null)
                 {
@@ -3122,7 +3126,7 @@ DROP TABLE #Column_Aliases
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ADP.IsCatchableExceptionType(ex))
             {
                 _localColumnMappings = null;
 
@@ -3299,7 +3303,7 @@ DROP TABLE #Column_Aliases
                     WriteToServerInternalRestContinuedAsync(internalResults, cts, source); // internalResults is valid here.
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ADP.IsCatchableExceptionType(ex))
             {
                 if (source != null)
                 {
@@ -3376,7 +3380,7 @@ DROP TABLE #Column_Aliases
                     return resultTask;
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ADP.IsCatchableExceptionType(ex))
             {
                 if (source != null)
                 {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Reader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Reader.cs
@@ -381,7 +381,7 @@ namespace Microsoft.Data.SqlClient
                 _stateObj.ReadSni(completion);
             }
             // @TODO: CER Exception Handling was removed here (see GH#3581)
-            catch (Exception e)
+            catch (Exception e) when (ADP.IsCatchableExceptionType(e))
             {
                 // Similarly, if an exception occurs put the stateObj back into the pool.
                 // and reset async cache information to allow a second async execute

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Xml.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlCommand.Xml.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Data.SqlClient
                 _stateObj.ReadSni(completion);
             }
             // @TODO: CER Exception Handling was removed here (see GH#3581)
-            catch (Exception e)
+            catch (Exception e) when (ADP.IsCatchableExceptionType(e))
             {
                 // Similarly, if an exception occurs put the stateObj back into the pool.
                 // and reset async cache information to allow a second async execute

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataReader.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlDataReader.cs
@@ -5476,7 +5476,7 @@ namespace Microsoft.Data.SqlClient
                 {
                     task = context.Execute(null, context);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ADP.IsCatchableExceptionType(ex))
                 {
                     task = Task.FromException<T>(ex);
                 }


### PR DESCRIPTION
## Summary

Multiple sites in `SqlBulkCopy`, `SqlDataReader.InvokeAsyncCall`, `SqlCommand.Reader`, and `SqlCommand.Xml` catch `Exception` broadly and wrap it in `Task.FromException<T>()` or `TrySetException()` without filtering fatal exceptions. This means `OutOfMemoryException`, `StackOverflowException`, `ThreadAbortException`, etc. get silently captured into faulted Tasks instead of propagating synchronously.

## Changes

| File | Fix |
|------|-----|
| `SqlBulkCopy.cs` | Added `when (ADP.IsCatchableExceptionType(ex))` filter to 8 catch blocks that wrap exceptions into `Task.FromException` or `TrySetException` |
| `SqlDataReader.cs` (`InvokeAsyncCall`) | Added `when (ADP.IsCatchableExceptionType(ex))` exception filter |
| `SqlCommand.Reader.cs` | Added `when (ADP.IsCatchableExceptionType(e))` exception filter |
| `SqlCommand.Xml.cs` | Added `when (ADP.IsCatchableExceptionType(e))` exception filter |

## Precedent

This matches the existing pattern already used in `SqlDataReader` at multiple other sites (e.g., `ReadNextAsync`, `IsDBNullAsync`, `GetFieldValueAsync`):
```csharp
catch (Exception ex) when (ADP.IsCatchableExceptionType(ex))
{
    return Task.FromException<bool>(ex);
}
```

## What was NOT changed

Sites in **task continuations / callbacks** (`TdsParserStateObject` SNI callbacks, `AsyncHelper` continuations, `SqlCommand` retry continuations) were intentionally left unchanged. In those contexts, rethrowing would crash the unobserved-task handler or the thread-pool thread; the `TrySetException` call is the correct behavior since the exception originated asynchronously.

Similarly, sites in `SqlSequentialTextReader` and `SqlSequentialStream` that call `TrySetException` **and then rethrow** were left unchanged — the fatal exception already propagates.

## Testing

- Build verified on net8.0 (0 warnings, 0 errors)
- No new tests needed — this is a defensive guard that only affects behavior under fatal runtime conditions