### PR TITLE
Cleanup | Deduplicate enclave attestation session caching logic

### DIFF
--- a/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml
@@ -17,8 +17,8 @@
       <param name="enclaveAttestationInfo">
         The information the provider uses to attest the enclave and generate a symmetric key for the session. The format of this information is specific to the enclave attestation protocol.
       </param>
-      <param name="clientDiffieHellmanKey">
-        A Diffie-Hellman algorithm object that encapsulates a client-side key pair.
+      <param name="attestationParameters">
+        A set of parameters for the attestation process, including the client's Diffie-Hellman key pair.
       </param>
       <param name="enclaveSessionParameters">
         The set of parameters required for an enclave session.

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -106,7 +106,8 @@ namespace Microsoft.Data.SqlClient
                         byte[] sharedSecret = GetSharedSecret(attestInfo.Identity, nonce, attestInfo.EnclaveType, attestInfo.EnclaveDHInfo, attestationParameters.ClientDiffieHellmanKey);
 
                         // add session to cache
-                        sqlEnclaveSession = AddEnclaveSessionToCache(enclaveSessionParameters, sharedSecret, attestInfo.SessionId, out counter);
+                        sqlEnclaveSession = new SqlEnclaveSession(sharedSecret, attestInfo.SessionId);
+                        AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
                     }
                     else
                     {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -109,32 +109,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
-        {
-            sqlEnclaveSession = null;
-            counter = 0;
-            try
-            {
-                ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
-                sqlEnclaveSession = GetEnclaveSessionFromCache(enclaveSessionParameters, out counter);
-                if (sqlEnclaveSession == null)
-                {
-                    // Add session to cache
-                    sqlEnclaveSession = CreateEnclaveSessionCore(attestationInfo, attestationParameters, enclaveSessionParameters, customData, customDataLength);
-                    AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
-                }
-            }
-            finally
-            {
-                // As per current design, we want to minimize the number of create session calls. To achieve this we block all the GetEnclaveSession calls until the first call to
-                // GetEnclaveSession -> GetAttestationParameters -> CreateEnclaveSession completes or the event timeout happen.
-                // Case 1: When the first request successfully creates the session, then all outstanding GetEnclaveSession will use the current session.
-                // Case 2: When the first request unable to create the enclave session (may be due to some error or the first request doesn't require enclave computation) then in those case we set the event timeout to 0.
-                UpdateEnclaveSessionLockStatus(sqlEnclaveSession);
-            }
-        }
-
         // When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
         internal override void InvalidateEnclaveSession(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSessionToInvalidate)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -80,7 +80,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellman clientDHKey, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             sqlEnclaveSession = null;
             counter = 0;
@@ -103,7 +103,7 @@ namespace Microsoft.Data.SqlClient
                         VerifyAzureAttestationInfo(enclaveSessionParameters.AttestationUrl, attestInfo.EnclaveType, attestInfo.AttestationToken.AttestationToken, attestInfo.Identity, nonce);
 
                         // Set up shared secret and validate signature
-                        byte[] sharedSecret = GetSharedSecret(attestInfo.Identity, nonce, attestInfo.EnclaveType, attestInfo.EnclaveDHInfo, clientDHKey);
+                        byte[] sharedSecret = GetSharedSecret(attestInfo.Identity, nonce, attestInfo.EnclaveType, attestInfo.EnclaveDHInfo, attestationParameters.ClientDiffieHellmanKey);
 
                         // add session to cache
                         sqlEnclaveSession = AddEnclaveSessionToCache(enclaveSessionParameters, sharedSecret, attestInfo.SessionId, out counter);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -108,12 +108,6 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.AttestationFailed(Strings.FailToCreateEnclaveSession);
             }
         }
-
-        // When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
-        internal override void InvalidateEnclaveSession(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSessionToInvalidate)
-        {
-            InvalidateEnclaveSessionHelper(enclaveSessionParameters, enclaveSessionToInvalidate);
-        }
         #endregion
 
         #region Internal Class

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -86,7 +86,27 @@ namespace Microsoft.Data.SqlClient
             byte[] customData,
             int customDataLength)
         {
-            throw new NotImplementedException();
+            if (!string.IsNullOrEmpty(enclaveSessionParameters.AttestationUrl) && customData != null && customDataLength > 0)
+            {
+                byte[] nonce = customData;
+
+                IdentityModelEventSource.ShowPII = true;
+
+                // Deserialize the payload
+                AzureAttestationInfo attestInfo = new AzureAttestationInfo(enclaveAttestationInfo);
+
+                // Validate the attestation info
+                VerifyAzureAttestationInfo(enclaveSessionParameters.AttestationUrl, attestInfo.EnclaveType, attestInfo.AttestationToken.AttestationToken, attestInfo.Identity, nonce);
+
+                // Set up shared secret and validate signature
+                byte[] sharedSecret = GetSharedSecret(attestInfo.Identity, nonce, attestInfo.EnclaveType, attestInfo.EnclaveDHInfo, attestationParameters.ClientDiffieHellmanKey);
+
+                return new SqlEnclaveSession(sharedSecret, attestInfo.SessionId);
+            }
+            else
+            {
+                throw SQL.AttestationFailed(Strings.FailToCreateEnclaveSession);
+            }
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
@@ -100,29 +120,9 @@ namespace Microsoft.Data.SqlClient
                 sqlEnclaveSession = GetEnclaveSessionFromCache(enclaveSessionParameters, out counter);
                 if (sqlEnclaveSession == null)
                 {
-                    if (!string.IsNullOrEmpty(enclaveSessionParameters.AttestationUrl) && customData != null && customDataLength > 0)
-                    {
-                        byte[] nonce = customData;
-
-                        IdentityModelEventSource.ShowPII = true;
-
-                        // Deserialize the payload
-                        AzureAttestationInfo attestInfo = new AzureAttestationInfo(attestationInfo);
-
-                        // Validate the attestation info
-                        VerifyAzureAttestationInfo(enclaveSessionParameters.AttestationUrl, attestInfo.EnclaveType, attestInfo.AttestationToken.AttestationToken, attestInfo.Identity, nonce);
-
-                        // Set up shared secret and validate signature
-                        byte[] sharedSecret = GetSharedSecret(attestInfo.Identity, nonce, attestInfo.EnclaveType, attestInfo.EnclaveDHInfo, attestationParameters.ClientDiffieHellmanKey);
-
-                        // add session to cache
-                        sqlEnclaveSession = new SqlEnclaveSession(sharedSecret, attestInfo.SessionId);
-                        AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
-                    }
-                    else
-                    {
-                        throw SQL.AttestationFailed(Strings.FailToCreateEnclaveSession);
-                    }
+                    // Add session to cache
+                    sqlEnclaveSession = CreateEnclaveSessionCore(attestationInfo, attestationParameters, enclaveSessionParameters, customData, customDataLength);
+                    AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
                 }
             }
             finally

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/AzureAttestationBasedEnclaveProvider.cs
@@ -79,6 +79,16 @@ namespace Microsoft.Data.SqlClient
             return new SqlEnclaveAttestationParameters(AzureBasedAttestationProtocolId, attestationParam, clientDHKey);
         }
 
+        protected override SqlEnclaveSession CreateEnclaveSessionCore(
+            byte[] enclaveAttestationInfo,
+            SqlEnclaveAttestationParameters attestationParameters,
+            EnclaveSessionParameters enclaveSessionParameters,
+            byte[] customData,
+            int customDataLength)
+        {
+            throw new NotImplementedException();
+        }
+
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
         internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.Crypto.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveDelegate.Crypto.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -47,7 +47,7 @@ namespace Microsoft.Data.SqlClient
 
                 sqlColumnEncryptionEnclaveProvider.CreateEnclaveSession(
                     attestationInfo,
-                    attestationParameters.ClientDiffieHellmanKey,
+                    attestationParameters,
                     enclaveSessionParameters,
                     customData,
                     customDataLength,

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Reset the session lock status
-        protected void UpdateEnclaveSessionLockStatus(SqlEnclaveSession sqlEnclaveSession)
+        private void UpdateEnclaveSessionLockStatus(SqlEnclaveSession sqlEnclaveSession)
         {
             // As per current design, we want to minimize the number of create session calls. To achieve this we block all the GetEnclaveSession calls until the first call to
             // GetEnclaveSession -> GetAttestationParameters -> CreateEnclaveSession completes or the event timeout happens.
@@ -226,7 +226,6 @@ namespace Microsoft.Data.SqlClient
         }
 
         protected abstract SqlEnclaveSession CreateEnclaveSessionCore(byte[] enclaveAttestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength);
-
     }
     #endregion
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
@@ -194,6 +194,8 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        protected abstract SqlEnclaveSession CreateEnclaveSessionCore(byte[] enclaveAttestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength);
+
         // Helper method to remove the enclave session from the cache
         protected void InvalidateEnclaveSessionHelper(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSessionToInvalidate)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        // When overridden in a derived class, calls CreateEnclaveSessionCore to create an enclave session and stores the session information in the cache.
+        // Calls CreateEnclaveSessionCore to create an enclave session and stores the session information in the cache.
         internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             sqlEnclaveSession = null;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -207,9 +207,9 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Helper method for adding the enclave session to the session cache
-        protected SqlEnclaveSession AddEnclaveSessionToCache(EnclaveSessionParameters enclaveSessionParameters, byte[] sharedSecret, long sessionId, out long counter)
+        protected void AddEnclaveSessionToCache(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSession, out long counter)
         {
-            return SessionCache.CreateSession(enclaveSessionParameters, sharedSecret, sessionId, out counter);
+            SessionCache.CreateSession(enclaveSessionParameters, enclaveSession, out counter);
         }
     }
     #endregion

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
@@ -181,12 +181,12 @@ namespace Microsoft.Data.SqlClient
             try
             {
                 ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
-                sqlEnclaveSession = GetEnclaveSessionFromCache(enclaveSessionParameters, out counter);
+                sqlEnclaveSession = SessionCache.GetEnclaveSession(enclaveSessionParameters, out counter);
                 if (sqlEnclaveSession == null)
                 {
                     // Add session to cache
                     sqlEnclaveSession = CreateEnclaveSessionCore(attestationInfo, attestationParameters, enclaveSessionParameters, customData, customDataLength);
-                    AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
+                    SessionCache.CreateSession(enclaveSessionParameters, sqlEnclaveSession, out counter);
                 }
             }
             finally
@@ -201,7 +201,7 @@ namespace Microsoft.Data.SqlClient
 
         internal override void InvalidateEnclaveSession(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSessionToInvalidate)
         {
-            InvalidateEnclaveSessionHelper(enclaveSessionParameters, enclaveSessionToInvalidate);
+            SessionCache.InvalidateSession(enclaveSessionParameters, enclaveSessionToInvalidate);
         }
 
         // Reset the session lock status
@@ -227,23 +227,6 @@ namespace Microsoft.Data.SqlClient
 
         protected abstract SqlEnclaveSession CreateEnclaveSessionCore(byte[] enclaveAttestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength);
 
-        // Helper method to remove the enclave session from the cache
-        protected void InvalidateEnclaveSessionHelper(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSessionToInvalidate)
-        {
-            SessionCache.InvalidateSession(enclaveSessionParameters, enclaveSessionToInvalidate);
-        }
-
-        // Helper method for getting the enclave session from the session cache
-        protected SqlEnclaveSession GetEnclaveSessionFromCache(EnclaveSessionParameters enclaveSessionParameters, out long counter)
-        {
-            return SessionCache.GetEnclaveSession(enclaveSessionParameters, out counter);
-        }
-
-        // Helper method for adding the enclave session to the session cache
-        protected void AddEnclaveSessionToCache(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSession, out long counter)
-        {
-            SessionCache.CreateSession(enclaveSessionParameters, enclaveSession, out counter);
-        }
     }
     #endregion
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
@@ -199,6 +199,11 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        internal override void InvalidateEnclaveSession(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSessionToInvalidate)
+        {
+            InvalidateEnclaveSessionHelper(enclaveSessionParameters, enclaveSessionToInvalidate);
+        }
+
         // Reset the session lock status
         protected void UpdateEnclaveSessionLockStatus(SqlEnclaveSession sqlEnclaveSession)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
@@ -173,6 +173,32 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
+        internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        {
+            sqlEnclaveSession = null;
+            counter = 0;
+            try
+            {
+                ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
+                sqlEnclaveSession = GetEnclaveSessionFromCache(enclaveSessionParameters, out counter);
+                if (sqlEnclaveSession == null)
+                {
+                    // Add session to cache
+                    sqlEnclaveSession = CreateEnclaveSessionCore(attestationInfo, attestationParameters, enclaveSessionParameters, customData, customDataLength);
+                    AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
+                }
+            }
+            finally
+            {
+                // As per current design, we want to minimize the number of create session calls. To achieve this we block all the GetEnclaveSession calls until the first call to
+                // GetEnclaveSession -> GetAttestationParameters -> CreateEnclaveSession completes or the event timeout happen.
+                // Case 1: When the first request successfully creates the session, then all outstanding GetEnclaveSession will use the current session.
+                // Case 2: When the first request unable to create the enclave session (may be due to some error or the first request doesn't require enclave computation) then in those case we set the event timeout to 0.
+                UpdateEnclaveSessionLockStatus(sqlEnclaveSession);
+            }
+        }
+
         // Reset the session lock status
         protected void UpdateEnclaveSessionLockStatus(SqlEnclaveSession sqlEnclaveSession)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveProviderBase.cs
@@ -88,6 +88,9 @@ namespace Microsoft.Data.SqlClient
         #endregion
 
         #region protected methods
+        // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session and creates an enclave session.
+        protected abstract SqlEnclaveSession CreateEnclaveSessionCore(byte[] enclaveAttestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength);
+
         // Helper method to get the enclave session from the cache if present
         protected void GetEnclaveSessionHelper(EnclaveSessionParameters enclaveSessionParameters, bool shouldGenerateNonce, bool isRetry, out SqlEnclaveSession sqlEnclaveSession, out long counter, out byte[] customData, out int customDataLength)
         {
@@ -173,7 +176,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
+        // When overridden in a derived class, calls CreateEnclaveSessionCore to create an enclave session and stores the session information in the cache.
         internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             sqlEnclaveSession = null;
@@ -224,8 +227,6 @@ namespace Microsoft.Data.SqlClient
                 }
             }
         }
-
-        protected abstract SqlEnclaveSession CreateEnclaveSessionCore(byte[] enclaveAttestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength);
     }
     #endregion
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveSessionCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveSessionCache.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        // Creates a new SqlEnclaveSession and adds it to the cache
+        // Adds a new SqlEnclaveSession to the cache
         internal void CreateSession(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSession, out long counter)
         {
             string cacheKey = GenerateCacheKey(enclaveSessionParameters);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveSessionCache.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/EnclaveSessionCache.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -55,19 +55,15 @@ namespace Microsoft.Data.SqlClient
         }
 
         // Creates a new SqlEnclaveSession and adds it to the cache
-        internal SqlEnclaveSession CreateSession(EnclaveSessionParameters enclaveSessionParameters, byte[] sharedSecret, long sessionId, out long counter)
+        internal void CreateSession(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSession, out long counter)
         {
             string cacheKey = GenerateCacheKey(enclaveSessionParameters);
-            SqlEnclaveSession enclaveSession = null;
             lock (enclaveCacheLock)
             {
-                enclaveSession = new SqlEnclaveSession(sharedSecret, sessionId);
                 enclaveMemoryCache.Set<SqlEnclaveSession>(cacheKey, enclaveSession,
                     absoluteExpirationRelativeToNow: s_enclaveCacheTimeout);
                 counter = Interlocked.Increment(ref _counter);
             }
-
-            return enclaveSession;
         }
 
         // Generates the cache key for the enclave session cache

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
@@ -77,15 +77,5 @@ namespace Microsoft.Data.SqlClient
 
             return new SqlEnclaveSession(sharedSecret, sessionId);
         }
-
-        /// <summary>
-        /// When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
-        /// </summary>
-        /// <param name="enclaveSessionParameters">The set of parameters required for enclave session.</param>
-        /// <param name="enclaveSessionToInvalidate">The session to be invalidated.</param>
-        internal override void InvalidateEnclaveSession(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSessionToInvalidate)
-        {
-            InvalidateEnclaveSessionHelper(enclaveSessionParameters, enclaveSessionToInvalidate);
-        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
@@ -78,29 +78,6 @@ namespace Microsoft.Data.SqlClient
             return new SqlEnclaveSession(sharedSecret, sessionId);
         }
 
-        // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
-        {
-            sqlEnclaveSession = null;
-            counter = 0;
-            try
-            {
-                ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
-                sqlEnclaveSession = GetEnclaveSessionFromCache(enclaveSessionParameters, out counter);
-
-                if (sqlEnclaveSession == null)
-                {
-                    sqlEnclaveSession = CreateEnclaveSessionCore(attestationInfo, attestationParameters, enclaveSessionParameters, customData, customDataLength);
-
-                    AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
-                }
-            }
-            finally
-            {
-                UpdateEnclaveSessionLockStatus(sqlEnclaveSession);
-            }
-        }
-
         /// <summary>
         /// When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
         /// </summary>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
@@ -79,12 +79,9 @@ namespace Microsoft.Data.SqlClient
                     using ECDiffieHellman ecdh = KeyConverter.CreateECDiffieHellmanFromPublicKeyBlob(trustedModuleDHPublicKey);
                     sharedSecret = KeyConverter.DeriveKey(attestationParameters.ClientDiffieHellmanKey, ecdh.PublicKey);
                     long sessionId = BitConverter.ToInt64(enclaveSessionHandle, 0);
-                    sqlEnclaveSession = AddEnclaveSessionToCache(enclaveSessionParameters, sharedSecret, sessionId, out counter);
 
-                    if (sqlEnclaveSession is null)
-                    {
-                        throw SQL.AttestationFailed(Strings.FailToCreateEnclaveSession);
-                    }
+                    sqlEnclaveSession = new SqlEnclaveSession(sharedSecret, sessionId);
+                    AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
                 }
             }
             finally

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
@@ -30,6 +30,16 @@ namespace Microsoft.Data.SqlClient
             return new SqlEnclaveAttestationParameters(NoneAttestationProtocolId, Array.Empty<byte>(), clientDHKey);
         }
 
+        protected override SqlEnclaveSession CreateEnclaveSessionCore(
+            byte[] enclaveAttestationInfo,
+            SqlEnclaveAttestationParameters attestationParameters,
+            EnclaveSessionParameters enclaveSessionParameters,
+            byte[] customData,
+            int customDataLength)
+        {
+            throw new NotImplementedException();
+        }
+
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates an enclave session and stores the session information in the cache.
         internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
@@ -37,15 +37,50 @@ namespace Microsoft.Data.SqlClient
             byte[] customData,
             int customDataLength)
         {
-            throw new NotImplementedException();
+            // For None attestation: enclave does not send public key, and sends an empty attestation info.
+            // The only non-trivial content it sends is the session setup info (DH pubkey of enclave.)
+
+            // Read AttestationInfo
+            int attestationInfoOffset = 0;
+            uint sizeOfTrustedModuleAttestationInfoBuffer = BitConverter.ToUInt32(enclaveAttestationInfo, attestationInfoOffset);
+            attestationInfoOffset += sizeof(UInt32);
+            int sizeOfTrustedModuleAttestationInfoBufferInt = checked((int)sizeOfTrustedModuleAttestationInfoBuffer);
+            Debug.Assert(sizeOfTrustedModuleAttestationInfoBuffer == 0);
+
+            // read secure session info
+            uint sizeOfSecureSessionInfoResponse = BitConverter.ToUInt32(enclaveAttestationInfo, attestationInfoOffset);
+            attestationInfoOffset += sizeof(UInt32);
+
+            byte[] enclaveSessionHandle = new byte[EnclaveSessionHandleSize];
+            Buffer.BlockCopy(enclaveAttestationInfo, attestationInfoOffset, enclaveSessionHandle, 0, EnclaveSessionHandleSize);
+            attestationInfoOffset += EnclaveSessionHandleSize;
+
+            uint sizeOfTrustedModuleDHPublicKeyBuffer = BitConverter.ToUInt32(enclaveAttestationInfo, attestationInfoOffset);
+            attestationInfoOffset += sizeof(UInt32);
+            uint sizeOfTrustedModuleDHPublicKeySignatureBuffer = BitConverter.ToUInt32(enclaveAttestationInfo, attestationInfoOffset);
+            attestationInfoOffset += sizeof(UInt32);
+            int sizeOfTrustedModuleDHPublicKeyBufferInt = checked((int)sizeOfTrustedModuleDHPublicKeyBuffer);
+
+            byte[] trustedModuleDHPublicKey = new byte[sizeOfTrustedModuleDHPublicKeyBuffer];
+            Buffer.BlockCopy(enclaveAttestationInfo, attestationInfoOffset, trustedModuleDHPublicKey, 0,
+                sizeOfTrustedModuleDHPublicKeyBufferInt);
+            attestationInfoOffset += sizeOfTrustedModuleDHPublicKeyBufferInt;
+
+            byte[] trustedModuleDHPublicKeySignature = new byte[sizeOfTrustedModuleDHPublicKeySignatureBuffer];
+            Buffer.BlockCopy(enclaveAttestationInfo, attestationInfoOffset, trustedModuleDHPublicKeySignature, 0,
+                checked((int)sizeOfTrustedModuleDHPublicKeySignatureBuffer));
+
+            byte[] sharedSecret;
+            using ECDiffieHellman ecdh = KeyConverter.CreateECDiffieHellmanFromPublicKeyBlob(trustedModuleDHPublicKey);
+            sharedSecret = KeyConverter.DeriveKey(attestationParameters.ClientDiffieHellmanKey, ecdh.PublicKey);
+            long sessionId = BitConverter.ToInt64(enclaveSessionHandle, 0);
+
+            return new SqlEnclaveSession(sharedSecret, sessionId);
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates an enclave session and stores the session information in the cache.
         internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
-            // for None attestation: enclave does not send public key, and sends an empty attestation info
-            // The only non-trivial content it sends is the session setup info (DH pubkey of enclave)
-
             sqlEnclaveSession = null;
             counter = 0;
             try
@@ -55,42 +90,8 @@ namespace Microsoft.Data.SqlClient
 
                 if (sqlEnclaveSession == null)
                 {
-                    // Read AttestationInfo
-                    int attestationInfoOffset = 0;
-                    uint sizeOfTrustedModuleAttestationInfoBuffer = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
-                    attestationInfoOffset += sizeof(UInt32);
-                    int sizeOfTrustedModuleAttestationInfoBufferInt = checked((int)sizeOfTrustedModuleAttestationInfoBuffer);
-                    Debug.Assert(sizeOfTrustedModuleAttestationInfoBuffer == 0);
+                    sqlEnclaveSession = CreateEnclaveSessionCore(attestationInfo, attestationParameters, enclaveSessionParameters, customData, customDataLength);
 
-                    // read secure session info
-                    uint sizeOfSecureSessionInfoResponse = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
-                    attestationInfoOffset += sizeof(UInt32);
-
-                    byte[] enclaveSessionHandle = new byte[EnclaveSessionHandleSize];
-                    Buffer.BlockCopy(attestationInfo, attestationInfoOffset, enclaveSessionHandle, 0, EnclaveSessionHandleSize);
-                    attestationInfoOffset += EnclaveSessionHandleSize;
-
-                    uint sizeOfTrustedModuleDHPublicKeyBuffer = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
-                    attestationInfoOffset += sizeof(UInt32);
-                    uint sizeOfTrustedModuleDHPublicKeySignatureBuffer = BitConverter.ToUInt32(attestationInfo, attestationInfoOffset);
-                    attestationInfoOffset += sizeof(UInt32);
-                    int sizeOfTrustedModuleDHPublicKeyBufferInt = checked((int)sizeOfTrustedModuleDHPublicKeyBuffer);
-
-                    byte[] trustedModuleDHPublicKey = new byte[sizeOfTrustedModuleDHPublicKeyBuffer];
-                    Buffer.BlockCopy(attestationInfo, attestationInfoOffset, trustedModuleDHPublicKey, 0,
-                        sizeOfTrustedModuleDHPublicKeyBufferInt);
-                    attestationInfoOffset += sizeOfTrustedModuleDHPublicKeyBufferInt;
-
-                    byte[] trustedModuleDHPublicKeySignature = new byte[sizeOfTrustedModuleDHPublicKeySignatureBuffer];
-                    Buffer.BlockCopy(attestationInfo, attestationInfoOffset, trustedModuleDHPublicKeySignature, 0,
-                        checked((int)sizeOfTrustedModuleDHPublicKeySignatureBuffer));
-
-                    byte[] sharedSecret;
-                    using ECDiffieHellman ecdh = KeyConverter.CreateECDiffieHellmanFromPublicKeyBlob(trustedModuleDHPublicKey);
-                    sharedSecret = KeyConverter.DeriveKey(attestationParameters.ClientDiffieHellmanKey, ecdh.PublicKey);
-                    long sessionId = BitConverter.ToInt64(enclaveSessionHandle, 0);
-
-                    sqlEnclaveSession = new SqlEnclaveSession(sharedSecret, sessionId);
                     AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
                 }
             }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/NoneAttestationEnclaveProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -31,7 +31,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellman clientDHKey, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             // for None attestation: enclave does not send public key, and sends an empty attestation info
             // The only non-trivial content it sends is the session setup info (DH pubkey of enclave)
@@ -77,7 +77,7 @@ namespace Microsoft.Data.SqlClient
 
                     byte[] sharedSecret;
                     using ECDiffieHellman ecdh = KeyConverter.CreateECDiffieHellmanFromPublicKeyBlob(trustedModuleDHPublicKey);
-                    sharedSecret = KeyConverter.DeriveKey(clientDHKey, ecdh.PublicKey);
+                    sharedSecret = KeyConverter.DeriveKey(attestationParameters.ClientDiffieHellmanKey, ecdh.PublicKey);
                     long sessionId = BitConverter.ToInt64(enclaveSessionHandle, 0);
                     sqlEnclaveSession = AddEnclaveSessionToCache(enclaveSessionParameters, sharedSecret, sessionId, out counter);
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Security.Cryptography;
-
 namespace Microsoft.Data.SqlClient
 {
     /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml' path='docs/members[@name="SqlColumnEncryptionEnclaveProvider"]/SqlColumnEncryptionEnclaveProvider/*'/>

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlColumnEncryptionEnclaveProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlClient
         internal abstract SqlEnclaveAttestationParameters GetAttestationParameters(string attestationUrl, byte[] customData, int customDataLength);
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml' path='docs/members[@name="SqlColumnEncryptionEnclaveProvider"]/CreateEnclaveSession/*'/>
-        internal abstract void CreateEnclaveSession(byte[] enclaveAttestationInfo, ECDiffieHellman clientDiffieHellmanKey, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter);
+        internal abstract void CreateEnclaveSession(byte[] enclaveAttestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter);
 
         /// <include file='../../../../../../doc/snippets/Microsoft.Data.SqlClient/SqlColumnEncryptionEnclaveProvider.xml' path='docs/members[@name="SqlColumnEncryptionEnclaveProvider"]/InvalidateEnclaveSession/*'/>
         internal abstract void InvalidateEnclaveSession(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSession);

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -121,7 +121,6 @@ namespace Microsoft.Data.SqlClient
                 // Set up shared secret and validate signature
                 byte[] sharedSecret = GetSharedSecret(info.Identity, info.EnclaveDHInfo, attestationParameters.ClientDiffieHellmanKey);
 
-                // add session to cache
                 return new SqlEnclaveSession(sharedSecret, info.SessionId);
             }
             else

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -107,7 +107,27 @@ namespace Microsoft.Data.SqlClient
             byte[] customData,
             int customDataLength)
         {
-            throw new NotImplementedException();
+            if (!string.IsNullOrEmpty(enclaveSessionParameters.AttestationUrl))
+            {
+                // Deserialize the payload
+                AttestationInfo info = new AttestationInfo(enclaveAttestationInfo);
+
+                // Verify enclave policy matches expected policy
+                VerifyEnclavePolicy(info.EnclaveReportPackage);
+
+                // Perform Attestation per VSM protocol
+                VerifyAttestationInfo(enclaveSessionParameters.AttestationUrl, info.HealthReport, info.EnclaveReportPackage);
+
+                // Set up shared secret and validate signature
+                byte[] sharedSecret = GetSharedSecret(info.Identity, info.EnclaveDHInfo, attestationParameters.ClientDiffieHellmanKey);
+
+                // add session to cache
+                return new SqlEnclaveSession(sharedSecret, info.SessionId);
+            }
+            else
+            {
+                throw SQL.AttestationFailed(Strings.FailToCreateEnclaveSession);
+            }
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
@@ -121,28 +141,9 @@ namespace Microsoft.Data.SqlClient
                 sqlEnclaveSession = GetEnclaveSessionFromCache(enclaveSessionParameters, out counter);
                 if (sqlEnclaveSession == null)
                 {
-                    if (!string.IsNullOrEmpty(enclaveSessionParameters.AttestationUrl))
-                    {
-                        // Deserialize the payload
-                        AttestationInfo info = new AttestationInfo(attestationInfo);
+                    sqlEnclaveSession = CreateEnclaveSessionCore(attestationInfo, attestationParameters, enclaveSessionParameters, customData, customDataLength);
 
-                        // Verify enclave policy matches expected policy
-                        VerifyEnclavePolicy(info.EnclaveReportPackage);
-
-                        // Perform Attestation per VSM protocol
-                        VerifyAttestationInfo(enclaveSessionParameters.AttestationUrl, info.HealthReport, info.EnclaveReportPackage);
-
-                        // Set up shared secret and validate signature
-                        byte[] sharedSecret = GetSharedSecret(info.Identity, info.EnclaveDHInfo, attestationParameters.ClientDiffieHellmanKey);
-
-                        // add session to cache
-                        sqlEnclaveSession = new SqlEnclaveSession(sharedSecret, info.SessionId);
-                        AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
-                    }
-                    else
-                    {
-                        throw SQL.AttestationFailed(Strings.FailToCreateEnclaveSession);
-                    }
+                    AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
                 }
             }
             finally

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -130,28 +130,6 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
-        // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
-        {
-            sqlEnclaveSession = null;
-            counter = 0;
-            try
-            {
-                ThreadRetryCache.Remove(Thread.CurrentThread.ManagedThreadId.ToString());
-                sqlEnclaveSession = GetEnclaveSessionFromCache(enclaveSessionParameters, out counter);
-                if (sqlEnclaveSession == null)
-                {
-                    sqlEnclaveSession = CreateEnclaveSessionCore(attestationInfo, attestationParameters, enclaveSessionParameters, customData, customDataLength);
-
-                    AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
-                }
-            }
-            finally
-            {
-                UpdateEnclaveSessionLockStatus(sqlEnclaveSession);
-            }
-        }
-
         // When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
         internal override void InvalidateEnclaveSession(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSessionToInvalidate)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -126,7 +126,8 @@ namespace Microsoft.Data.SqlClient
                         byte[] sharedSecret = GetSharedSecret(info.Identity, info.EnclaveDHInfo, attestationParameters.ClientDiffieHellmanKey);
 
                         // add session to cache
-                        sqlEnclaveSession = AddEnclaveSessionToCache(enclaveSessionParameters, sharedSecret, info.SessionId, out counter);
+                        sqlEnclaveSession = new SqlEnclaveSession(sharedSecret, info.SessionId);
+                        AddEnclaveSessionToCache(enclaveSessionParameters, sqlEnclaveSession, out counter);
                     }
                     else
                     {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -100,6 +100,16 @@ namespace Microsoft.Data.SqlClient
             return new SqlEnclaveAttestationParameters(VsmHGSProtocolId, Array.Empty<byte>(), clientDHKey);
         }
 
+        protected override SqlEnclaveSession CreateEnclaveSessionCore(
+            byte[] enclaveAttestationInfo,
+            SqlEnclaveAttestationParameters attestationParameters,
+            EnclaveSessionParameters enclaveSessionParameters,
+            byte[] customData,
+            int customDataLength)
+        {
+            throw new NotImplementedException();
+        }
+
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
         internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -129,13 +129,6 @@ namespace Microsoft.Data.SqlClient
                 throw SQL.AttestationFailed(Strings.FailToCreateEnclaveSession);
             }
         }
-
-        // When overridden in a derived class, looks up and evicts an enclave session from the enclave session cache, if the provider implements session caching.
-        internal override void InvalidateEnclaveSession(EnclaveSessionParameters enclaveSessionParameters, SqlEnclaveSession enclaveSessionToInvalidate)
-        {
-            InvalidateEnclaveSessionHelper(enclaveSessionParameters, enclaveSessionToInvalidate);
-        }
-
         #endregion
 
         #region Private helpers

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/VirtualSecureModeEnclaveProviderBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -101,7 +101,7 @@ namespace Microsoft.Data.SqlClient
         }
 
         // When overridden in a derived class, performs enclave attestation, generates a symmetric key for the session, creates a an enclave session and stores the session information in the cache.
-        internal override void CreateEnclaveSession(byte[] attestationInfo, ECDiffieHellman clientDHKey, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
+        internal override void CreateEnclaveSession(byte[] attestationInfo, SqlEnclaveAttestationParameters attestationParameters, EnclaveSessionParameters enclaveSessionParameters, byte[] customData, int customDataLength, out SqlEnclaveSession sqlEnclaveSession, out long counter)
         {
             sqlEnclaveSession = null;
             counter = 0;
@@ -123,7 +123,7 @@ namespace Microsoft.Data.SqlClient
                         VerifyAttestationInfo(enclaveSessionParameters.AttestationUrl, info.HealthReport, info.EnclaveReportPackage);
 
                         // Set up shared secret and validate signature
-                        byte[] sharedSecret = GetSharedSecret(info.Identity, info.EnclaveDHInfo, clientDHKey);
+                        byte[] sharedSecret = GetSharedSecret(info.Identity, info.EnclaveDHInfo, attestationParameters.ClientDiffieHellmanKey);
 
                         // add session to cache
                         sqlEnclaveSession = AddEnclaveSessionToCache(enclaveSessionParameters, sharedSecret, info.SessionId, out counter);


### PR DESCRIPTION
## Description

This is one of two foundational PRs, and it eases the resolution of several issues.

At present, we have three enclave attestation providers:
* `AzureAttestationEnclaveProvider`
* `NoneAttestationEnclaveProvider`
* `HostGuardianServiceEnclaveProvider`

All three of these inherit, directly or indirectly, from a common base class (`EnclaveProviderBase`) which in turn inherits from `SqlColumnEncryptionEnclaveProvider`.

At present, SqlColumnEncryptionEnclaveProvider requires its derived classes to take responsibility for caching `SqlEnclaveSession` instances. `EnclaveProviderBase` provides a series of helpers, and the three derived classes call them. Their logic is almost identical - `InvalidateEnclaveSession` calls `InvalidateEnclaveSessionHelper` in every implementation, while every implementation of `CreateEnclaveSession` has the same basic pattern of handling locking, trying to get a session from the cache using `GetEnclaveSessionHelper`, then parsing the `enclaveAttestationInfo` byte array if no such session exists.

The primary motive for this PR is to simplify the various enclave attestation provider derived classes. All of them support caching, and all of them have the same boilerplate caching logic. I've thus pushed most of that responsibility away from the derived classes, into the base `EnclaveProviderBase` class. The only caching-related responsibility which remains in the derived classes is `GetEnclaveSession`, and this calls `GetEnclaveSessionHelper` in the base class; I've not moved this because `GetEnclaveSessionHelper` isn't currently in a fit shape to move, and making it such would blur a simple mechanical refactor into a change to the enclave providers' calling contract.

Taking a wider look, however: while the attestation provider might want to signal that it doesn't support caching, responsibility for the caching itself should lie within the dedicated `EnclaveSessionCache` type. I'm planning to follow this PR up with a second one which builds on this consolidation work and moves the now-consolidated caching implementation into the cache. Doing so will also remove any need for the `EnclaveProviderBase` type to exist.

### Oddity: `GetEnclaveSession`

I'm calling this out because I'm conscious that it looks very odd to move all of the caching logic into `EnclaveProviderBase`, but then to leave this method unchanged. The key reason here is that `GetEnclaveSession` performs two functions: if a cached enclave session exists, it'll retrieve it; if it doesn't exist and the `generateCustomData` parameter is set, it'll populate the `customData` and the `customDataLength` parameters. This is the client-side nonce.

There are a few problems with this:
1. This nonce is used to begin the enclave attestation handshake, and its population logic is in the wrong place. We have `GetAttestationParameters` for this, and we weaken the calling contract when we populate variables independently to this.
2. The nonce is an implementation detail of `AzureAttestationEnclaveProvider`. The base class shouldn't care about that detail.

I plan to move this generation logic into `SqlEnclaveAttestationParameters`, but doing so means that I'm changing the calling contract of the enclave providers. I don't want to do that inside this mechanical refactoring PR.

### Follow-up PR (and end state)

In the follow-up PR, we'll remove the `EnclaveProviderBase` type; the three enclave attestation providers will be able to inherit from `SqlColumnEncryptionEnclaveProvider`. `SqlEnclaveAttestationParameters` will also be changed, to avoid exposing the `ECDiffieHellman` type (which doesn't exist in a netstandard2.0 target) and to include the client-side nonce.

With those responsibilities gone, `SqlColumnEncryptionEnclaveProvider` will only need two methods: `CreateEnclaveSession` and `GetAttestationParameters`. The upcoming async support for the enclave attestation provider will only need to add a `CreateEnclaveSessionAsync` method.

Most importantly, however: we'll have severed the dependency between the enclave attestation providers and the internals of SqlClient. This opens the way to moving the base `SqlColumnEncryptionEnclaveProvider` class and its associated types into the Abstractions package (and the `AzureAttestationEnclaveProvider` type into the Azure package.)

### Scope

It's worth noting that each of the enclave providers parses `enclaveAttestationInfo` by performing various `Buffer.BlockCopy` calls between byte arrays, allocating as it goes. I'm not planning to change that in this PR or its follow-up; these PRs are common work which will simplify a couple of Always Encrypted issues, and I don't want them to drift into general sets of performance improvements.

## Issues

This intersects with a few issues.
#4017: shrinks the API surface we'd need to expose.
#4425: while this is simply extracting common functionality rather than making a performance improvement, it does prepare to remove a layer of unnecessary inheritance.
#3672: narrowing the scope of `CreateEnclaveSession` method and its async counterpart makes unit testing slightly easier.

## Testing

Existing tests continue to pass. Common code is simply being moved away from the derived types and into their common base type, so no new tests have been written. Once I start actually consolidating the caching functionality into `EnclaveSessionCache`, I'll write tests for this.