### PR TITLE
Fix | Write DateOnly instances to sql_variant columns of table-valued parameters as date values

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlDataRecord.cs
@@ -477,6 +477,12 @@ namespace Microsoft.Data.SqlClient.Server
             }
         }
 
+        internal SmiMetaData GetVariantInternalMetaData(int ordinal)
+        {
+            ThrowIfInvalidOrdinal(ordinal);
+            return _recordBuffer.GetVariantType(ordinal);
+        }
+
         /// <include file='../../../../../../../doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml' path='docs/members[@name="SqlDataRecord"]/System.Data.IDataRecord.GetData/*' />
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         IDataReader System.Data.IDataRecord.GetData(int ordinal) => throw ADP.NotSupported();

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlRecordBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlRecordBuffer.cs
@@ -463,7 +463,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
             set
             {
-                Debug.Assert(value != null && (value.SqlDbType == SqlDbType.Money || value.SqlDbType == SqlDbType.NVarChar || value.SqlDbType == SqlDbType.Date),
+                Debug.Assert(value != null && (value.SqlDbType is SqlDbType.Money or SqlDbType.NVarChar or SqlDbType.Date),
                     "Invalid metadata");
 
                 _metadata = value;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlRecordBuffer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlRecordBuffer.cs
@@ -463,7 +463,7 @@ namespace Microsoft.Data.SqlClient.Server
             }
             set
             {
-                Debug.Assert(value != null && (value.SqlDbType == SqlDbType.Money || value.SqlDbType == SqlDbType.NVarChar),
+                Debug.Assert(value != null && (value.SqlDbType == SqlDbType.Money || value.SqlDbType == SqlDbType.NVarChar || value.SqlDbType == SqlDbType.Date),
                     "Invalid metadata");
 
                 _metadata = value;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
@@ -1044,10 +1044,6 @@ namespace Microsoft.Data.SqlClient.Server
                         result = GetSqlValue200(getters, ordinal, metaData);
                         break;
                     case SqlDbType.Date:
-                    #if NET
-                        result = DateOnly.FromDateTime(GetDateTime_Unchecked(getters, ordinal));
-                        break;
-                    #endif
                     case SqlDbType.DateTime2:
                         result = GetDateTime_Unchecked(getters, ordinal);
                         break;
@@ -2037,9 +2033,35 @@ namespace Microsoft.Data.SqlClient.Server
                             SetSqlXml_Unchecked(setters, i, record.GetSqlXml(i));    // perf improvement?
                             break;
                         case SqlDbType.Variant:
-                            object o = record.GetSqlValue(i);
+                            SmiMetaData variantMetadata = record.GetVariantInternalMetaData(i);
+                            SqlBuffer.StorageType storageType;
+                            object o;
+
+                            // We cannot transport a DateOnly instance using the GetSqlValue method. This is because
+                            // GetSqlValue will return a SqlDateTime, which has a much tighter range of expected
+                            // values (so trying to send DateOnly.MinValue will overflow.) Instead, use GetValue (which
+                            // will return a DateTime, with identical ranges of expected values.)
+                            if (variantMetadata.SqlDbType is SqlDbType.Date)
+                            {
+                                storageType = SqlBuffer.StorageType.Date;
+                                o = record.GetValue(i);
+                            }
+                            else
+                            {
+                                storageType = SqlBuffer.StorageType.Empty;
+                                o = record.GetSqlValue(i);
+                            }
+
                             ExtendedClrTypeCode typeCode = MetaDataUtilsSmi.DetermineExtendedTypeCode(o);
-                            SetCompatibleValueV200(setters, i, metaData[i], o, typeCode, 0, null /* no peekahead */);
+
+                            if (storageType is not SqlBuffer.StorageType.Empty)
+                            {
+                                SetCompatibleValueV200(setters, i, metaData[i], o, typeCode, 0, null /* no peekahead */, storageType);
+                            }
+                            else
+                            {
+                                SetCompatibleValueV200(setters, i, metaData[i], o, typeCode, 0, null /* no peekahead */);
+                            }
                             break;
                         case SqlDbType.Udt:
                             Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.SqlBytes));

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
@@ -1044,6 +1044,10 @@ namespace Microsoft.Data.SqlClient.Server
                         result = GetSqlValue200(getters, ordinal, metaData);
                         break;
                     case SqlDbType.Date:
+                    #if NET
+                        result = DateOnly.FromDateTime(GetDateTime_Unchecked(getters, ordinal));
+                        break;
+                    #endif
                     case SqlDbType.DateTime2:
                         result = GetDateTime_Unchecked(getters, ordinal);
                         break;
@@ -1504,7 +1508,7 @@ namespace Microsoft.Data.SqlClient.Server
                     }
 #if NET
                 case ExtendedClrTypeCode.DateOnly:
-                    SetDateTime_Checked(setters, ordinal, metaData, ((DateOnly)value).ToDateTime(new TimeOnly(0, 0)));
+                    SetDate_Checked(setters, ordinal, metaData, ((DateOnly)value).ToDateTime(new TimeOnly(0, 0)));
                     break;
                 case ExtendedClrTypeCode.TimeOnly:
                     SetTimeSpan_Checked(setters, ordinal, metaData, ((TimeOnly)value).ToTimeSpan());
@@ -3135,8 +3139,11 @@ namespace Microsoft.Data.SqlClient.Server
 
         private static void SetDate_Unchecked(ITypedSettersV3 setters, int ordinal, SmiMetaData metaData, DateTime value)
         {
-            Debug.Assert(metaData.SqlDbType == SqlDbType.Variant, "Invalid type. This should be called only when the type is variant.");
-            setters.SetVariantMetaData(ordinal, SmiMetaData.DefaultDate);
+            if (metaData.SqlDbType == SqlDbType.Variant)
+            {
+                setters.SetVariantMetaData(ordinal, SmiMetaData.DefaultDate);
+            }
+
             setters.SetDateTime(ordinal, value);
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/DateTimeVariantTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -987,12 +987,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         {
             #if NET
             yield return new object[] { DateOnly.MinValue, "date",
-                new Dictionary<TestVariations, ExceptionChecker> {
-                    { TestVariations.TestSimpleParameter_Variant, SqlDateTimeOverflow },
-                    { TestVariations.TestSqlDataRecordParameterToTVP_Variant, SqlDateTimeOverflow },
-                    { TestVariations.TestSqlDataReaderParameterToTVP_Variant, SqlDateTimeOverflow },
-                    { TestVariations.SqlBulkCopyDataTable_Variant, SqlDateTimeOverflow },
-                    { TestVariations.SqlBulkCopyDataRow_Variant, SqlDateTimeOverflow }},
+                new Dictionary<TestVariations, ExceptionChecker>(),
                 new Dictionary<TestVariations, object>()
                 {
                     { TestVariations.TestSimpleParameter_Type, new DateTime(0) },
@@ -1014,12 +1009,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                 },
                 new Dictionary<TestVariations, string>()};
             yield return new object[] { DateOnly.MaxValue, "date",
-                new Dictionary<TestVariations, ExceptionChecker> {
-                    { TestVariations.TestSimpleParameter_Variant, SqlDateTimeOverflow },
-                    { TestVariations.TestSqlDataRecordParameterToTVP_Variant, SqlDateTimeOverflow },
-                    { TestVariations.TestSqlDataReaderParameterToTVP_Variant, SqlDateTimeOverflow },
-                    { TestVariations.SqlBulkCopyDataTable_Variant, SqlDateTimeOverflow },
-                    { TestVariations.SqlBulkCopyDataRow_Variant, SqlDateTimeOverflow }},
+                new Dictionary<TestVariations, ExceptionChecker>(),
                 new Dictionary<TestVariations, object>()
                 {
                     { TestVariations.TestSimpleParameter_Type, new DateTime(3155378112000000000) },
@@ -1040,9 +1030,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
                     { TestVariations.SqlBulkCopyDataRow_Variant, new DateTime(3155378112000000000) }
                 },
                 new Dictionary<TestVariations, string>()
-                {
-                    {TestVariations.TestSqlDataRecordParameterToTVP_Variant, "datetime"}
-                }
             };
             #endif
             yield return new object[] { DateTime.MinValue, "date",


### PR DESCRIPTION
## Description

This builds on #4294, and handles the only other issue I saw while investigating #3934.

If a user-defined table type exists with a column of type `sql_variant`, client applications can insert a `DateOnly` instance into this. It's supposed to be sent with a type of `date`, but is actually sent as a `datetime`.

Besides a point around correctness, it presents an issue when sending `DateOnly` instances which are valid values for `date` but not for `datetime`: these values overflow.

This PR fixes the issue, transporting all `DateOnly` instances with the `date` type on modern .NET. On .NET Framework, there's no `DateOnly` type - and thus there's no way for the client to encapsulate a `date` value within a `sql_variant` column.

@ErikEJ, this covers the only other way to write `DateOnly` instances to SQL Server and should hopefully completely close #3934. SqlClient will continue to read `DateTime` instances by default, but this is needed for backwards compatibility purposes.

NB: similar issues also exist with `TimeOnly` instances. TdsParser assumes that only `TimeSpan` instances will be written as times, so there are failures to cast in a few different places.

## Issues

Builds on #4294. Possible resolution to #3934.

## Testing

#4294 added the relevant tests, with an exemption carved out for this use case. I've removed the exemption and verified that it covers the test case.