### PR TITLE
Documentation | Correct SqlDataRecord, SqlMetaData documentation

### DIFF
--- a/doc/samples/SqlDataRecord.cs
+++ b/doc/samples/SqlDataRecord.cs
@@ -2,10 +2,9 @@
 namespace SqlDataRecordCS;
 
 using System;
+using System.Collections.Generic;
 using System.Data;
-using System.Data.Sql;
-using System.Data.SqlTypes;
-using Microsoft.SqlServer.Server;
+using Microsoft.Data.SqlClient.Server;
 
 public sealed partial class SqlDataRecordTester
 {
@@ -13,41 +12,40 @@ public sealed partial class SqlDataRecordTester
    {
    }
 
-[SqlProcedure]
-public static void CallTestMethods()
-{
-   CreateNewRecord();
-   CreateNewRecord1();
-
-}
-
 //<Snippet1>
+//using System;
+//using System.Collections.Generic;
+//using System.Data;
 //using Microsoft.Data.SqlClient.Server;
 
-[SqlProcedure]
-public static void CreateNewRecord()
+// Stream rows to SQL Server as a table-valued parameter.
+public static IEnumerable<SqlDataRecord> GetRecords()
 {
-
-   // Variables.
-   SqlDataRecord record;    
+    // Re-use a single SqlDataRecord instance rather than allocating a new one for each row.
+    // Each row's values are read before SqlCommand advances to the next one.
+    SqlDataRecord record;
       
-   // Create a new record with the column metadata. The constructor is 
-   // able to accept a variable number of parameters. 
-   record = new SqlDataRecord(new SqlMetaData[] { new SqlMetaData("Column1", SqlDbType.NVarChar, 12), 
+    // Create a new record with the column metadata. The constructor is 
+    // able to accept a variable number of parameters. 
+    record = new SqlDataRecord(new SqlMetaData[] { new SqlMetaData("Column1", SqlDbType.NVarChar, 12), 
                                                   new SqlMetaData("Column2", SqlDbType.Int), 
                                                   new SqlMetaData("Column3", SqlDbType.DateTime) });
 
-   // Set the record fields.
-   record.SetString(0, "Hello World!");
-   record.SetInt32(1, 42);
-   record.SetDateTime(2, DateTime.Now);
+    // Set the record fields.
+    record.SetString(0, "Hello World!");
+    record.SetInt32(1, 42);
+    record.SetDateTime(2, DateTime.Now);
 
-   // Send the record to the calling program.
-   SqlContext.Pipe.Send(record);
+    // Set the fields of the first record and stream it to SQL Server.
+    yield return record;
+
+    // Set the fields of the second record and stream it to SQL Server.
+    record.SetInt32(1, 0);
+    yield return record;
 }
 //</Snippet1>
 
-public static void CreateNewRecord1()
+public static void CreateNewRecord()
 {
 
 //<Snippet2>
@@ -65,15 +63,11 @@ column2Info = new SqlMetaData("Column2", SqlDbType.Int);
 // Create a new record with the column metadata.      
 record = new SqlDataRecord(new SqlMetaData[] { column1Info, 
                                                   column2Info });
-//</Snippet2>
-
 // Set the record fields.
 record.SetString(0, "Hello World!");
 record.SetInt32(1, 42);
 
-// Send the record to the calling program.
-SqlContext.Pipe.Send(record);
-   
+//</Snippet2>
 }
 }
 #endif

--- a/doc/samples/SqlDataRecord.cs
+++ b/doc/samples/SqlDataRecord.cs
@@ -36,7 +36,7 @@ public static IEnumerable<SqlDataRecord> GetRecords()
     record.SetInt32(1, 42);
     record.SetDateTime(2, DateTime.Now);
 
-    // Set the fields of the first record and stream it to SQL Server.
+    // Stream the first record to SQL Server.
     yield return record;
 
     // Set the fields of the second record and stream it to SQL Server.

--- a/doc/samples/SqlMetaData.cs
+++ b/doc/samples/SqlMetaData.cs
@@ -2,10 +2,9 @@
 namespace SqlMetaDataCS;
 
 using System;
+using System.Collections.Generic;
 using System.Data;
-using System.Data.Sql;
-using System.Data.SqlTypes;
-using Microsoft.SqlServer.Server;
+using Microsoft.Data.SqlClient.Server;
 
 public sealed partial class SqlMetaDataTester
 {
@@ -14,10 +13,12 @@ public sealed partial class SqlMetaDataTester
     }
 
     //<Snippet1>
+    // using System;
+    // using System.Collections.Generic;
+    // using System.Data;
     // using Microsoft.Data.SqlClient.Server;
 
-    [SqlProcedure]
-    public static void CreateNewRecord()
+    public static IEnumerable<SqlDataRecord> ReturnNewRecords()
     {
         // Variables.
         SqlMetaData column1Info;
@@ -35,13 +36,15 @@ public sealed partial class SqlMetaDataTester
                                                   column2Info,
                                                   column3Info });
 
-        // Set the record fields.
+        // Set the fields of the first record and stream it to SQL Server.
         record.SetString(0, "Hello World!");
         record.SetInt32(1, 42);
         record.SetDateTime(2, DateTime.Now);
+        yield return record;
 
-        // Send the record to the calling program.
-        SqlContext.Pipe.Send(record);
+        // Set the fields of the second record and stream it to SQL Server.
+        record.SetInt32(1, 0);
+        yield return record;
     }
     //</Snippet1>
 

--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
@@ -1,4 +1,4 @@
-﻿<docs>
+<docs>
   <members name="SqlDataRecord">
     <SqlDataRecord>
       <summary>
@@ -6,25 +6,28 @@
       </summary>
       <remarks>
         <para>
-          This class is used together with <see cref="T:Microsoft.SqlServer.Server.SqlPipe" /> to send result sets to the client from managed code stored-procedures.
+          This class describes a single row of a table-valued parameter. Construct one from an array of <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects which describe the column metadata of the record, populate it with the <b>Set&lt;Type&gt;</b> methods and assign it (or an <see cref="T:System.Collections.Generic.IEnumerable{Microsoft.Data.SqlClient.Server.SqlDataRecord}" /> for multiple rows) to <see cref="P:Microsoft.Data.SqlClient.SqlParameter.Value" />.
         </para>
         <para>
-          When writing common language runtime (CLR) applications, you should re-use existing <b>SqlDataRecord</b> objects instead of creating new ones every time. Creating many new <b>SqlDataRecord</b> objects could severely deplete memory and adversely affect performance.
+          For best performance when sending multiple rows, re-use a single <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance across an <see cref="T:System.Collections.Generic.IEnumerable{Microsoft.Data.SqlClient.Server.SqlDataRecord}" /> iterator: set new column values and <see langword="yield return" /> the same instance for each row. <see cref="T:Microsoft.Data.SqlClient.SqlCommand" /> will read each record before advancing to the next.
         </para>
       </remarks>
       <example>
         <para>
-          The following example shows how to create several <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects, which describe the column metadata of a record, and creating a <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" />. The column values of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> are set and the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> is sent to the calling program by using the <see cref="T:Microsoft.SqlServer.Server.SqlContext" /> class.
+          The following example shows how to create several <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects describing the column metadata of a record, then to create a re-usable <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance. The column values of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> are set and the same <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> can be used to stream multiple rows to SQL Server as a table-valued parameter.
         </para>
         <!-- SqlDataRecord #1 -->
         <code language="c#">
+          using System;
+          using System.Collections.Generic;
+          using System.Data;
           using Microsoft.Data.SqlClient.Server;
-          
-          [Microsoft.Data.SqlClient.Server.SqlProcedure]
-          public static void CreateNewRecord()
+
+          // Stream rows to SQL Server as a table-valued parameter.
+          public static IEnumerable&lt;SqlDataRecord&gt; CreateNewRecord()
           {
-          
-             // Variables.
+             // Re-use a single SqlDataRecord instance rather than allocating a new one for each row.
+             // Each row's values are read before SqlCommand advances to the next one.
              SqlDataRecord record;    
                 
              // Create a new record with the column metadata. The constructor is 
@@ -38,8 +41,12 @@
              record.SetInt32(1, 42);
              record.SetDateTime(2, DateTime.Now);
           
-             // Send the record to the calling program.
-             SqlContext.Pipe.Send(record);
+             // Set the fields of the first record and stream it to SQL Server.
+             yield return record;
+
+             // Set the fields of the second record and stream it to SQL Server.
+             record.SetInt32(1, 0);
+             yield return record;
           }
         </code>
       </example>
@@ -75,9 +82,6 @@
           // Set the record fields.
           record.SetString(0, "Hello World!");
           record.SetInt32(1, 42);
-          
-          // Send the record to the calling program.
-          SqlContext.Pipe.Send(record);
         </code>
       </example>
       <exception cref="T:System.ArgumentNullException">

--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
@@ -6,10 +6,10 @@
       </summary>
       <remarks>
         <para>
-          This class describes a single row of a table-valued parameter. Construct one from an array of <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects which describe the column metadata of the record, populate it with the <b>Set&lt;Type&gt;</b> methods and assign it (or an <see cref="T:System.Collections.Generic.IEnumerable{Microsoft.Data.SqlClient.Server.SqlDataRecord}" /> for multiple rows) to <see cref="P:Microsoft.Data.SqlClient.SqlParameter.Value" />.
+          This class describes a single row of a table-valued parameter. Construct one from an array of <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects which describe the column metadata of the record, populate it with the <b>Set&lt;Type&gt;</b> methods and assign it (or an <c>IEnumerable&lt;SqlDataRecord&gt;</c> for multiple rows) to <see cref="P:Microsoft.Data.SqlClient.SqlParameter.Value" />.
         </para>
         <para>
-          For best performance when sending multiple rows, re-use a single <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance across an <see cref="T:System.Collections.Generic.IEnumerable{Microsoft.Data.SqlClient.Server.SqlDataRecord}" /> iterator: set new column values and <see langword="yield return" /> the same instance for each row. <see cref="T:Microsoft.Data.SqlClient.SqlCommand" /> will read each record before advancing to the next.
+          For best performance when sending multiple rows, re-use a single <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance across an <c>IEnumerable&lt;SqlDataRecord&gt;</c> iterator: set new column values and <see langword="yield return" /> the same instance for each row. <see cref="T:Microsoft.Data.SqlClient.SqlCommand" /> will read each record before advancing to the next.
         </para>
       </remarks>
       <example>
@@ -41,7 +41,7 @@
              record.SetInt32(1, 42);
              record.SetDateTime(2, DateTime.Now);
           
-             // Set the fields of the first record and stream it to SQL Server.
+             // Stream the first record to SQL Server.
              yield return record;
 
              // Set the fields of the second record and stream it to SQL Server.

--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlDataRecord.xml
@@ -6,7 +6,7 @@
       </summary>
       <remarks>
         <para>
-          This class describes a single row of a table-valued parameter. Construct one from an array of <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects which describe the column metadata of the record, populate it with the <b>Set&lt;Type&gt;</b> methods and assign it (or an <c>IEnumerable&lt;SqlDataRecord&gt;</c> for multiple rows) to <see cref="P:Microsoft.Data.SqlClient.SqlParameter.Value" />.
+          This class describes a single row of a table-valued parameter. Construct one from an array of <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects which describe the column metadata of the record, populate it with the <b>Set&lt;Type&gt;</b> methods, include it in an <c>IEnumerable&lt;SqlDataRecord&gt;</c> and assign that <c>IEnumerable&lt;SqlDataRecord&gt;</c> to <see cref="P:Microsoft.Data.SqlClient.SqlParameter.Value" />.
         </para>
         <para>
           For best performance when sending multiple rows, re-use a single <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> instance across an <c>IEnumerable&lt;SqlDataRecord&gt;</c> iterator: set new column values and <see langword="yield return" /> the same instance for each row. <see cref="T:Microsoft.Data.SqlClient.SqlCommand" /> will read each record before advancing to the next.

--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml
@@ -1,19 +1,21 @@
-﻿<docs>
+<docs>
   <members name="SqlMetaData">
     <SqlMetaData>
       <summary>
-        Specifies and retrieves metadata information from parameters and columns of <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> objects. This class cannot be inherited.
+        Specifies the metadata information of a columns used by a <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> objects. This class cannot be inherited.
       </summary>
       <example>
         <para>
-          The following example shows the creation of several <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects, which describe the column metadata of a record, and the creation of a <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" />. The column values of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> are set and the <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> is sent to the calling program using the <see cref="T:Microsoft.SqlServer.Server.SqlContext" /> class.
+          The following example shows the creation of several <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects, which describe the column metadata of a record, and the generation of a stream of <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> records. These <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> records can be streamed to SQL Server as a table-valued parameter by assigning the return value of the method to the <see cref="P:Microsoft.Data.SqlClient.SqlParameter.Value" /> property.
         </para>
         <!-- SqlMetaData #1 -->
         <code language="c#">
+          using System;
+          using System.Collections.Generic;
+          using System.Data;
           using Microsoft.Data.SqlClient.Server;
-      
-          [Microsoft.Data.SqlClient.Server.SqlProcedure]
-          public static void CreateNewRecord()
+
+          public static IEnumerable&lt;SqlDataRecord&gt; ReturnNewRecords()
           {
               // Variables.
               SqlMetaData column1Info;
@@ -32,16 +34,21 @@
                 column2Info,
                 column3Info });
       
-              // Set the record fields.
+              // Set the fields of the first record and stream it to SQL Server.
               record.SetString(0, "Hello World!");
               record.SetInt32(1, 42);
               record.SetDateTime(2, DateTime.Now);
+              yield return record;
       
-              // Send the record to the calling program.
-              SqlContext.Pipe.Send(record);
+              // Set the fields of the second record and stream it to SQL Server.
+              record.SetInt32(1, 0);
+              yield return record;
           }
         </code>
       </example>
+      <remarks>
+        <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instances are typically built once and reused to construct many <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> objects which are streamed to SQL Server as a table-valued parameter. For more information, see <see href="https://learn.microsoft.com/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+      </remarks>
     </SqlMetaData>
     <ctor>
       <summary>
@@ -456,7 +463,7 @@
         The SQL Server type name for <paramref name="userDefinedType" />.
       </param>
       <summary>
-        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, user-defined type (UDT), and SQLServer type.
+        Initializes a new instance of the <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> class with the specified column name, user-defined type (UDT), and SQL Server type.
       </summary>
     </ctorNameDbTypeUserDefinedTypeServerTypeName>
     <ctorNameDbTypeMaxLengthLocaleCompareOptions>

--- a/doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml
+++ b/doc/snippets/Microsoft.Data.SqlClient.Server/SqlMetaData.xml
@@ -2,8 +2,11 @@
   <members name="SqlMetaData">
     <SqlMetaData>
       <summary>
-        Specifies the metadata information of a columns used by a <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> objects. This class cannot be inherited.
+        Specifies the metadata information of a column used by a <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> object. This class cannot be inherited.
       </summary>
+      <remarks>
+        <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instances are typically built once and reused to construct many <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> objects which are streamed to SQL Server as a table-valued parameter. For more information, see <see href="https://learn.microsoft.com/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
+      </remarks>
       <example>
         <para>
           The following example shows the creation of several <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> objects, which describe the column metadata of a record, and the generation of a stream of <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> records. These <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> records can be streamed to SQL Server as a table-valued parameter by assigning the return value of the method to the <see cref="P:Microsoft.Data.SqlClient.SqlParameter.Value" /> property.
@@ -46,9 +49,6 @@
           }
         </code>
       </example>
-      <remarks>
-        <see cref="T:Microsoft.Data.SqlClient.Server.SqlMetaData" /> instances are typically built once and reused to construct many <see cref="T:Microsoft.Data.SqlClient.Server.SqlDataRecord" /> objects which are streamed to SQL Server as a table-valued parameter. For more information, see <see href="https://learn.microsoft.com/sql/connect/ado-net/sql/table-valued-parameters">Table-Valued Parameters</see>.
-      </remarks>
     </SqlMetaData>
     <ctor>
       <summary>


### PR DESCRIPTION
## Description

The existing documentation for both types is located here:
* [`SqlDataRecord`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.server.sqldatarecord?view=sqlclient-dotnet-core-7.0)
* [`SqlMetaData`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.server.sqlmetadata?view=sqlclient-dotnet-core-7.0)

These pages are incorrect - they refer to the `SqlContext` and the `SqlPipe` types, which have never existed. There's also an open issue which asks for more information on whether it's valid for users to reuse `SqlDataRecord` instances.

This PR corrects the documentation for these two types, addressing #1805 in the process.

It might also be worthwhile backporting this to the other release branches, this is just documenting their existing behaviour.

## Issues

Fixes #1805.

## Testing

This isn't a functional change - just a change to documentation.