### PR TITLE
Fix moved step template paths in sqlclient-package.yml pipeline

### DIFF
--- a/eng/pipelines/ci/package/sqlclient-package.yml
+++ b/eng/pipelines/ci/package/sqlclient-package.yml
@@ -117,12 +117,12 @@ jobs:
           displayName: '[Debug] Print Environment Variables'
 
       # Install the .NET SDK from global.json.
-      - template: /eng/pipelines/steps/install-dotnet.yml@self
+      - template: /eng/pipelines/common/steps/install-dotnet.yml@self
         parameters:
           debug: ${{ parameters.debug }}
 
       # Restore dotnet local tools (pwsh, apicompat, etc.).
-      - template: /eng/pipelines/steps/restore-dotnet-tools.yml@self
+      - template: /eng/pipelines/common/steps/restore-dotnet-tools.yml@self
 
       # Clean any pre-existing .nupkg / .snupkg files from the packages/ directory
       # to ensure we only publish packages produced by this run.


### PR DESCRIPTION
## Summary

The `sqlclient-package.yml` packaging pipeline referenced two step templates at `/eng/pipelines/steps/`, but those templates were moved to `/eng/pipelines/common/steps/` in #4326 (2026-06-03). This caused the pipeline to fail with:

> File /eng/pipelines/steps/install-dotnet.yml not found in repository ... branch refs/heads/internal/main

## Changes

Updated the two `template:` references in `eng/pipelines/ci/package/sqlclient-package.yml`:

- `/eng/pipelines/steps/install-dotnet.yml` → `/eng/pipelines/common/steps/install-dotnet.yml`
- `/eng/pipelines/steps/restore-dotnet-tools.yml` → `/eng/pipelines/common/steps/restore-dotnet-tools.yml`

## Checklist

- [x] Verified against the actual template locations in the repo
- [x] [sqlclient-package](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build?definitionId=2277&_a=summary) pipeline runs:
  - [x] Ubuntu24/Release:  [19401](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=160443&view=results)
  - [x] Win25/Debug:  [19402](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=160444&view=results)