### PR TITLE
PR Pipeline | Enable LocalDB Tests

### DIFF
--- a/eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml
+++ b/eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml
@@ -180,7 +180,7 @@ jobs:
           $config.LocalDbAppName = "${{ parameters.localDbAppName }}"
           $config.LocalDbSharedInstanceName = "${{ parameters.localDbSharedInstanceName }}"
           $config.ManagedIdentitySupported = $true
-          $config.SupportsIntegratedSecurity = $false
+          $config.SupportsIntegratedSecurity = $true
           $config.UserManagedIdentityClientId = "${{ parameters.userManagedIdentityClientId }}"
 
           if ("${{ parameters.platformOperatingSystem  }}" -eq "Windows") {

--- a/eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml
+++ b/eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml
@@ -98,6 +98,10 @@ parameters:
   - name: isLocalServer
     type: boolean
 
+  # Whether to enable LocalDB when configuring a local Windows SQL Server.
+  - name: enableLocalDB
+    type: boolean
+
   # Name of the local DB application name for localdb tests, this value will be stored in the
   # config.jsonc
   - name: localDbAppName
@@ -111,6 +115,10 @@ parameters:
   # Manual test set to execute.
   - name: testSet
     type: string
+
+  # Whether integrated security is supported by this test configuration.
+  - name: supportsIntegratedSecurity
+    type: boolean
 
   # Name of the user managed identity client ID. This value will be stored in config.jsonc for use
   # in AKV tests and substituted in for Azure connection string user IDs.
@@ -153,7 +161,10 @@ jobs:
       - ${{ if eq(parameters.isLocalServer, true) }}:
         - template: /eng/pipelines/pr/steps/configure-sqlserver-step.yml@self
           parameters:
+            enableLocalDB: ${{ parameters.enableLocalDB }}
             fileStreamDirectory: ${{ parameters.fileStreamDirectory }}
+            localDbAppName: ${{ parameters.localDbAppName }}
+            localDbSharedInstanceName: ${{ parameters.localDbSharedInstanceName }}
             operatingSystem: ${{ parameters.platformOperatingSystem }}
             saPassword: $(saPassword)
 
@@ -180,7 +191,7 @@ jobs:
           $config.LocalDbAppName = "${{ parameters.localDbAppName }}"
           $config.LocalDbSharedInstanceName = "${{ parameters.localDbSharedInstanceName }}"
           $config.ManagedIdentitySupported = $true
-          $config.SupportsIntegratedSecurity = $true
+          $config.SupportsIntegratedSecurity = [System.Convert]::ToBoolean("${{ parameters.supportsIntegratedSecurity }}")
           $config.UserManagedIdentityClientId = "${{ parameters.userManagedIdentityClientId }}"
 
           if ("${{ parameters.platformOperatingSystem  }}" -eq "Windows") {

--- a/eng/pipelines/pr/stages/test-stages.yml
+++ b/eng/pipelines/pr/stages/test-stages.yml
@@ -201,6 +201,11 @@ stages:
               userManagedIdentityClientId: ${{ parameters.manualTestUserManagedIdentityClientId }}
 
           # TestSqlClientManual - LocalDB
+          # Note: connection strings are explicitly set to empty to only allow the localDB tests to
+          # run. LocalDB tests require the localdb app name to be provided and supportsIntegratedSecurity
+          # to be true. If the connection strings (from the library, which as of 7/26 does not use
+          # integrated auth) are provided with supportsIntegratedSecurity set to true, other tests
+          # will fail.
           - ${{ if eq(platform.operatingSystem, 'Windows') }}:
             - template: /eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml@self
               parameters:

--- a/eng/pipelines/pr/stages/test-stages.yml
+++ b/eng/pipelines/pr/stages/test-stages.yml
@@ -191,12 +191,44 @@ stages:
               configDisplayName: "localhost"
               connectionStringNp: ${{ parameters.manualTestConnectionStringNpLocalhost }}
               connectionStringTcp: ${{ parameters.manualTestConnectionStringTcpLocalhost }}
+              enableLocalDB: false
               fileStreamDirectory: ${{ parameters.manualTestFileStreamDirectory }}
               isLocalServer: true
               localDbAppName: ${{ parameters.manualTestLocalDbAppName }}
               localDbSharedInstanceName: ${{ parameters.manualTestLocalDbSharedInstanceName }}
+              supportsIntegratedSecurity: false
               testSet: "123"
               userManagedIdentityClientId: ${{ parameters.manualTestUserManagedIdentityClientId }}
+
+          # TestSqlClientManual - LocalDB
+          - ${{ if eq(platform.operatingSystem, 'Windows') }}:
+            - template: /eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml@self
+              parameters:
+                buildConfiguration: ${{ parameters.buildConfiguration }}
+                buildSuffix: ${{ parameters.buildSuffix }}
+                dotnetVerbosity: ${{ parameters.dotnetVerbosity }}
+                stageNameSecrets: ${{ parameters.stageNameSecrets }}
+                testResultsArtifactBaseName: ${{ parameters.testResultsArtifactBaseName }}
+
+                platformDisplayName: ${{ platform.displayName }}
+                platformDotnet: ${{ platform.dotnet }}
+                platformImage: ${{ platform.image }}
+                platformOperatingSystem: ${{ platform.operatingSystem }}
+                poolName: ${{ parameters.poolName }}
+
+                azureKeyVaultTenantId: ${{ parameters.manualTestAzureKeyVaultTenantId }}
+                azureKeyVaultUrl: ${{ parameters.manualTestAzureKeyVaultUrl }}
+                configDisplayName: "localdb"
+                connectionStringNp: ""
+                connectionStringTcp: ""
+                enableLocalDB: true
+                fileStreamDirectory: ${{ parameters.manualTestFileStreamDirectory }}
+                isLocalServer: true
+                localDbAppName: ${{ parameters.manualTestLocalDbAppName }}
+                localDbSharedInstanceName: ${{ parameters.manualTestLocalDbSharedInstanceName }}
+                supportsIntegratedSecurity: true
+                testSet: "123"
+                userManagedIdentityClientId: ${{ parameters.manualTestUserManagedIdentityClientId }}
 
           # TestSqlClientManual - Azure
           - template: /eng/pipelines/pr/jobs/test-sqlclientmanual-job.yml@self
@@ -218,10 +250,12 @@ stages:
               configDisplayName: "azure"
               connectionStringNp: ${{ parameters.manualTestConnectionStringNpAzure }}
               connectionStringTcp: ${{ parameters.manualTestConnectionStringTcpAzure }}
+              enableLocalDB: false
               fileStreamDirectory: ${{ parameters.manualTestFileStreamDirectory }}
               isLocalServer: false
               localDbAppName: ${{ parameters.manualTestLocalDbAppName }}
               localDbSharedInstanceName: ${{ parameters.manualTestLocalDbSharedInstanceName }}
+              supportsIntegratedSecurity: false
               testSet: "123"
               userManagedIdentityClientId: ${{ parameters.manualTestUserManagedIdentityClientId }}
 
@@ -245,10 +279,12 @@ stages:
               configDisplayName: "localhost_ae"
               connectionStringNp: ${{ parameters.manualTestConnectionStringNpLocalhost }}
               connectionStringTcp: ${{ parameters.manualTestConnectionStringTcpLocalhost }}
+              enableLocalDB: false
               fileStreamDirectory: ${{ parameters.manualTestFileStreamDirectory }}
               isLocalServer: true
               localDbAppName: ${{ parameters.manualTestLocalDbAppName }}
               localDbSharedInstanceName: ${{ parameters.manualTestLocalDbSharedInstanceName }}
+              supportsIntegratedSecurity: false
               testSet: "AE"
               userManagedIdentityClientId: ${{ parameters.manualTestUserManagedIdentityClientId }}
 

--- a/eng/pipelines/pr/steps/configure-sqlserver-step.yml
+++ b/eng/pipelines/pr/steps/configure-sqlserver-step.yml
@@ -6,8 +6,17 @@
 
 parameters:
 
+  - name: enableLocalDB
+    type: boolean
+
   # Path to use for file stream tests. This only applies to Windows test runs.
   - name: fileStreamDirectory
+    type: string
+
+  - name: localDbAppName
+    type: string
+
+  - name: localDbSharedInstanceName
     type: string
 
   - name: operatingSystem
@@ -21,7 +30,10 @@ steps:
   - ${{ if eq(parameters.operatingSystem, 'Windows') }}:
       - template: /eng/pipelines/pr/steps/configure-sqlserver-windows-step.yml@self
         parameters:
+          enableLocalDB: ${{ parameters.enableLocalDB }}
           fileStreamDirectory: ${{ parameters.fileStreamDirectory }}
+          localDbAppName: ${{ parameters.localDbAppName }}
+          localDbSharedInstanceName: ${{ parameters.localDbSharedInstanceName }}
           saPassword: ${{ parameters.saPassword }}
 
   - ${{ elseif eq(parameters.operatingSystem, 'Linux') }}:

--- a/eng/pipelines/pr/steps/configure-sqlserver-windows-step.yml
+++ b/eng/pipelines/pr/steps/configure-sqlserver-windows-step.yml
@@ -10,8 +10,17 @@
 
 parameters:
 
+  - name: enableLocalDB
+    type: boolean
+
   # Path to use for file stream tests.
   - name: fileStreamDirectory
+    type: string
+
+  - name: localDbAppName
+    type: string
+
+  - name: localDbSharedInstanceName
     type: string
 
   # Password to use for the SA account. This should be generated from the generate-secrets-stage.
@@ -113,3 +122,15 @@ steps:
       Invoke-Sqlcmd -ServerInstance "$machineName" -Database "master" -InputFile $scriptPath
     displayName: 'Create Northwind Database [Win]'
     retryCountOnTaskFailure: 1
+
+  # Start and share the LocalDB instance.
+  - ${{ if eq(parameters.enableLocalDB, true) }}:
+    - powershell: |
+        SqlLocalDB info
+        SqlLocalDB info ${{ parameters.localDbAppName }}
+        SqlLocalDB share ${{ parameters.localDbAppName }} ${{ parameters.localDbSharedInstanceName }}
+        SqlLocalDB start ${{ parameters.localDbAppName }}
+        SqlLocalDB info ${{ parameters.localDbAppName }}
+
+        sqlcmd -S "(localdb)\.\${{ parameters.localDbSharedInstanceName }}" -q "SELECT @@VERSION"
+      displayName: 'Enable LocalDB [Win]'

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/CancellationTokenSourceDisposalTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/CancellationTokenSourceDisposalTest.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SequentialStream_DisposedBeforeReaderClose_DoesNotThrow(string connectionString)
@@ -58,6 +59,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             reader.Close();
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SequentialTextReader_DisposedBeforeReaderClose_DoesNotThrow(string connectionString)
@@ -84,6 +86,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             reader.Close();
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SequentialStream_DisposedThenReaderAdvanced_DoesNotThrow(string connectionString)
@@ -108,6 +111,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.True(reader.Read());
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void DataReader_MultipleCloseAndDispose_DoesNotThrow(string connectionString)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/CancellationTokenSourceDisposalTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/CancellationTokenSourceDisposalTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SequentialStream_DisposedBeforeReaderClose_DoesNotThrow(string connectionString)
         {
             using SqlConnection connection = new SqlConnection(connectionString);
@@ -59,7 +59,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SequentialTextReader_DisposedBeforeReaderClose_DoesNotThrow(string connectionString)
         {
             using SqlConnection connection = new SqlConnection(connectionString);
@@ -85,7 +85,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SequentialStream_DisposedThenReaderAdvanced_DoesNotThrow(string connectionString)
         {
             using SqlConnection connection = new SqlConnection(connectionString);
@@ -109,7 +109,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void DataReader_MultipleCloseAndDispose_DoesNotThrow(string connectionString)
         {
             using SqlConnection connection = new SqlConnection(connectionString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -40,147 +40,147 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void RowBuffer_ReadsBufferCorrectly(string connectionString)
         {
             RowBuffer(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void InvalidRead_ThrowsInvalidOperationException(string connectionString)
         {
             InvalidRead(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void VariantRead_ReadsVariantDataCorrectly(string connectionString)
         {
             VariantRead(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void TypeRead_ReadsTypedDataCorrectly(string connectionString)
         {
             TypeRead(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SqlTypeRead_ReadsSqlTypesCorrectly(string connectionString)
         {
             SQLTypeRead(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void GetValueOfTRead_ReadsGenericTypesCorrectly(string connectionString)
         {
             GetValueOfTRead(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void MultipleResults_ReadsMultipleBatchesCorrectly(string connectionString)
         {
             MultipleResults(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void NumericRead_ReadsLargeNumericValues(string connectionString)
         {
             NumericRead(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void TimestampRead_ReadsBinaryTimestamp(string connectionString)
         {
             TimestampRead(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void OrphanReader_HandlesConnectionCloseCorrectly(string connectionString)
         {
             OrphanReader(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void BufferSize_HandlesVariableBufferSizes(string connectionString)
         {
             BufferSize(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void ExecuteXmlReader_ReadsXmlDataCorrectly(string connectionString)
         {
             ExecuteXmlReaderTest(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SequentialAccess_ReadsDataSequentially(string connectionString)
         {
             SequentialAccess(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void HasRows_ReportsCorrectly(string connectionString)
         {
             HasRowsTest(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void CloseConnection_ClosesReaderWithConnection(string connectionString)
         {
             CloseConnection(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void OpenConnection_OpensSuccessfully(string connectionString)
         {
             OpenConnection(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SqlCharsBytes_QueriesWithSqlTypes(string connectionString)
         {
             SqlCharsBytesTest(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void GetStream_ReturnsStreamCorrectly(string connectionString)
         {
             GetStream(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void GetTextReader_ReturnsTextReaderCorrectly(string connectionString)
         {
             GetTextReader(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void GetXmlReader_ReturnsXmlReaderCorrectly(string connectionString)
         {
             GetXmlReader(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         [Trait("Category", "flaky")]
         public static void ReadStream_ReadsStreamDataCorrectly(string connectionString)
         {
@@ -188,28 +188,28 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void ReadTextReader_ReadsTextCorrectly(string connectionString)
         {
             ReadTextReader(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void StreamingBlobDataTypes_ReadsAllBlobTypes(string connectionString)
         {
             StreamingBlobDataTypes(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void OutOfOrderGetChars_ReadsColumnsOutOfOrder(string connectionString)
         {
             OutOfOrderGetChars(connectionString);
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotNamedInstance))]
-        [MemberData(nameof(ConnectionStrings))]
+        [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public void TestXEventsStreaming_StreamsXEventsCorrectly(string connectionString)
         {
             TestXEventsStreaming(connectionString);

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/DataStreamTest/DataStreamTest.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void RowBuffer_ReadsBufferCorrectly(string connectionString)
@@ -46,6 +47,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             RowBuffer(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void InvalidRead_ThrowsInvalidOperationException(string connectionString)
@@ -53,6 +55,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             InvalidRead(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void VariantRead_ReadsVariantDataCorrectly(string connectionString)
@@ -60,6 +63,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             VariantRead(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void TypeRead_ReadsTypedDataCorrectly(string connectionString)
@@ -67,6 +71,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             TypeRead(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SqlTypeRead_ReadsSqlTypesCorrectly(string connectionString)
@@ -74,6 +79,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             SQLTypeRead(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void GetValueOfTRead_ReadsGenericTypesCorrectly(string connectionString)
@@ -81,6 +87,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             GetValueOfTRead(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void MultipleResults_ReadsMultipleBatchesCorrectly(string connectionString)
@@ -88,6 +95,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             MultipleResults(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void NumericRead_ReadsLargeNumericValues(string connectionString)
@@ -95,6 +103,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             NumericRead(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void TimestampRead_ReadsBinaryTimestamp(string connectionString)
@@ -102,6 +111,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             TimestampRead(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void OrphanReader_HandlesConnectionCloseCorrectly(string connectionString)
@@ -109,6 +119,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             OrphanReader(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void BufferSize_HandlesVariableBufferSizes(string connectionString)
@@ -116,6 +127,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             BufferSize(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void ExecuteXmlReader_ReadsXmlDataCorrectly(string connectionString)
@@ -123,6 +135,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             ExecuteXmlReaderTest(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SequentialAccess_ReadsDataSequentially(string connectionString)
@@ -130,6 +143,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             SequentialAccess(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void HasRows_ReportsCorrectly(string connectionString)
@@ -137,6 +151,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             HasRowsTest(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void CloseConnection_ClosesReaderWithConnection(string connectionString)
@@ -144,6 +159,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             CloseConnection(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void OpenConnection_OpensSuccessfully(string connectionString)
@@ -151,6 +167,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             OpenConnection(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void SqlCharsBytes_QueriesWithSqlTypes(string connectionString)
@@ -158,6 +175,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             SqlCharsBytesTest(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void GetStream_ReturnsStreamCorrectly(string connectionString)
@@ -172,6 +190,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             GetTextReader(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void GetXmlReader_ReturnsXmlReaderCorrectly(string connectionString)
@@ -179,6 +198,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             GetXmlReader(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         [Trait("Category", "flaky")]
@@ -187,6 +207,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             ReadStream(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void ReadTextReader_ReadsTextCorrectly(string connectionString)
@@ -194,6 +215,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             ReadTextReader(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void StreamingBlobDataTypes_ReadsAllBlobTypes(string connectionString)
@@ -201,6 +223,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             StreamingBlobDataTypes(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public static void OutOfOrderGetChars_ReadsColumnsOutOfOrder(string connectionString)
@@ -208,6 +231,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             OutOfOrderGetChars(connectionString);
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureServer), nameof(DataTestUtility.IsNotNamedInstance))]
         [MemberData(nameof(ConnectionStrings), DisableDiscoveryEnumeration = true)]
         public void TestXEventsStreaming_StreamsXEventsCorrectly(string connectionString)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/MARSSessionPoolingTest/MarsSessionPoolingTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/MARSSessionPoolingTest/MarsSessionPoolingTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         // Synapse: Catalog view 'dm_exec_connections' is not supported in this version.
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.StoredProcedure)]
         public void ExecuteScalar_DisposeCommand(CommandType commandType)
@@ -48,7 +48,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.StoredProcedure)]
         public void ExecuteScalar_CloseConnection(CommandType commandType)
@@ -77,7 +77,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.StoredProcedure)]
         public void ExecuteNonQuery_DisposeCommand(CommandType commandType)
@@ -105,7 +105,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.StoredProcedure)]
         public void ExecuteNonQuery_CloseConnection(CommandType commandType)
@@ -134,7 +134,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.StoredProcedure)]
         public void ExecuteReader_CloseReader(CommandType commandType)
@@ -163,7 +163,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.StoredProcedure)]
         public void ExecuteReader_DisposeReader(CommandType commandType)
@@ -193,7 +193,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Trait("Category", "flaky")]
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.StoredProcedure)]
         public void ExecuteReader_GarbageCollectReader(CommandType commandType)
@@ -231,7 +231,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         [Trait("Category", "flaky")] // Assert.Equal() Failure: Values differ
                                      // Expected: 5
                                      // Actual:   4
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.StoredProcedure)]
         public void ExecuteReader_DisposeCommand(CommandType commandType)
@@ -272,7 +272,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.StoredProcedure)]
         public void ExecuteReader_CloseConnection(CommandType commandType)
@@ -302,7 +302,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [Trait("Category", "flaky")]
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse), nameof(DataTestUtility.IsNotManagedInstance))]
         [InlineData(CommandType.Text)]
         [InlineData(CommandType.StoredProcedure)]
         public void ExecuteReader_NoCloses(CommandType commandType)

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/OutputParameterTests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/OutputParameterTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         /// </summary>
         /// <param name="collation">Name of a SQL Server collation which encodes text in the given code page.</param>
         /// <param name="codePage">ID of the codepage which should be used by SQL Server and the driver to encode and decode text.</param>
-        [Theory]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(OutputParameterCodePages))]
         public void CollatedStringInOutputParameter_DecodesSuccessfully(string collation, int codePage)
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -568,7 +568,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
-        [MemberData(nameof(TestScaledDecimalParameter_Data))]
+        [MemberData(nameof(TestScaledDecimalParameter_Data), DisableDiscoveryEnumeration = true)]
         public static void TestScaledDecimalTVP_CommandSP(string connectionString, bool truncateScaledDecimal)
         {
             using LocalAppContextSwitchesHelper appContextSwitchesHelper = new();

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -485,7 +485,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.Throws<OverflowException>(() => rdr.GetDecimal(0));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [ClassData(typeof(ConnectionStringsProvider))]
         public static void TestScaledDecimalParameter_CommandInsert(string connectionString, bool truncateScaledDecimal)
         {
@@ -516,7 +516,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.True(ValidateInsertedValues(connection, decimalTable.Name, truncateScaledDecimal), $"Invalid test happened with connection string [{connection.ConnectionString}]");
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [ClassData(typeof(ConnectionStringsProvider))]
         public static void TestScaledDecimalParameter_BulkCopy(string connectionString, bool truncateScaledDecimal)
         {

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -485,8 +485,23 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.Throws<OverflowException>(() => rdr.GetDecimal(0));
         }
 
+        public static TheoryData<string, bool> TestScaledDecimalParameter_Data
+        {
+            get
+            {
+                TheoryData<string, bool> result = new();
+                foreach (string connectionString in DataTestUtility.ConnectionStrings)
+                {
+                    result.Add(connectionString, false); // Truncate scaled decimal disabled
+                    result.Add(connectionString, true);  // Truncate scaled decimal enabled
+                }
+
+                return result;
+            }
+        }
+
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [ClassData(typeof(ConnectionStringsProvider))]
+        [MemberData(nameof(TestScaledDecimalParameter_Data), DisableDiscoveryEnumeration = true)]
         public static void TestScaledDecimalParameter_CommandInsert(string connectionString, bool truncateScaledDecimal)
         {
             using LocalAppContextSwitchesHelper appContextSwitchesHelper = new();
@@ -517,7 +532,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
-        [ClassData(typeof(ConnectionStringsProvider))]
+        [MemberData(nameof(TestScaledDecimalParameter_Data), DisableDiscoveryEnumeration = true)]
         public static void TestScaledDecimalParameter_BulkCopy(string connectionString, bool truncateScaledDecimal)
         {
             using LocalAppContextSwitchesHelper appContextSwitchesHelper = new();
@@ -549,8 +564,8 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
 
         // Synapse: Parse error at line: 2, column: 8: Incorrect syntax near 'TYPE'.
         [Trait("Category", "flaky")]
-        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.IsNotAzureSynapse))]
-        [ClassData(typeof(ConnectionStringsProvider))]
+        [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
+        [MemberData(nameof(TestScaledDecimalParameter_Data))]
         public static void TestScaledDecimalTVP_CommandSP(string connectionString, bool truncateScaledDecimal)
         {
             using LocalAppContextSwitchesHelper appContextSwitchesHelper = new();
@@ -627,19 +642,6 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             return !exceptionHit;
         }
 
-        public class ConnectionStringsProvider : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                foreach (var cnnString in DataTestUtility.ConnectionStrings)
-                {
-                    yield return new object[] { cnnString, false };
-                    yield return new object[] { cnnString, true };
-                }
-            }
-
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
         #endregion
         #endregion
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/ParameterTest/ParametersTest.cs
@@ -500,6 +500,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             }
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(TestScaledDecimalParameter_Data), DisableDiscoveryEnumeration = true)]
         public static void TestScaledDecimalParameter_CommandInsert(string connectionString, bool truncateScaledDecimal)
@@ -531,6 +532,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             Assert.True(ValidateInsertedValues(connection, decimalTable.Name, truncateScaledDecimal), $"Invalid test happened with connection string [{connection.ConnectionString}]");
         }
 
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup))]
         [MemberData(nameof(TestScaledDecimalParameter_Data), DisableDiscoveryEnumeration = true)]
         public static void TestScaledDecimalParameter_BulkCopy(string connectionString, bool truncateScaledDecimal)
@@ -563,6 +565,7 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
         }
 
         // Synapse: Parse error at line: 2, column: 8: Incorrect syntax near 'TYPE'.
+        // Enumeration is disabled to prevent generating empty test set when connection strings are not setup.
         [Trait("Category", "flaky")]
         [ConditionalTheory(typeof(DataTestUtility), nameof(DataTestUtility.AreConnStringsSetup), nameof(DataTestUtility.IsNotAzureSynapse))]
         [MemberData(nameof(TestScaledDecimalParameter_Data))]


### PR DESCRIPTION
## Description
As it turns out, the LocalDB tests were not being executed in the new sqlclient-pr pipeline. This is because the LocalDB tests require the localdb app names to be populated in config AND the supportsIntegratedAuth flag to be set to true. However, the supportsIntegratedAuth was being set to false because the connection strings for azure and localhost tests did not use integrated auth (azure uses managed identity, localhost uses username/password). The supportsIntegratedAuth flag is also mingled with other test such that just setting it to true causes failures with the aforementioned connection strings.

To resolve this and enable localdb testing, I've updated the test stages to include a separate run of manual test project **with the connection strings left blank** and the supportsIntegratedAuth set to true. This adds an extra 5-7min job to the stage which runs in parallel.

To enable this, I had to also modify some existing tests. There were some tests that would fail if the connection strings were empty. These fell into a couple categories:
* Tests that had the `AreConnStringsSetup` conditional theory, but had member/class data that generated 1+ test cases per connection string. Since there were no connection strings, no tests were generated, resulting in a "no data available" test failure. Fixed by disabling enumeration at discovery (comments explaining why were wadded).
* Tests that relied on a connection string but did not have the `AreConnStringsSetup`. Most of these had some other condition that implied a connection (eg, `IsNotAzureSynapse`) but due to the implementation ended up being evaluated as `true` (eg, `!IsAzureSynapse` which boils down to a check of `null == 6`, which meant `!false` which is `true`). Fixed by adding the `AreConnStringsAdded` condition.

_In retrospect, it's possible that we could get localdb tests running as part of the azure manual test run. The error that came from enabling `supportsIntegratedAuth` was due to the connection string being parsed for `password` fields. Since they do not exist on the azure connection strings, *maybe* they'd work for localdb testing._

## Testing

* ✅ public -> https://sqlclientdrivers.visualstudio.com/public/_build/results?buildId=160512&view=results
* ✅  private -> https://dev.azure.com/SqlClientDrivers/ADO.Net/_build/results?buildId=160521&view=results
* ✅  due diligince sqlclient-nonofficial -> https://dev.azure.com/SqlClientDrivers/ADO.Net/_build/results?buildId=160522&view=results