### PR TITLE
Introduce new performance benchmark runners

### DIFF
--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -494,7 +494,7 @@ The top-level flags control global runner behavior:
 | --- | --- |
 | `UseManagedSniOnWindows` | Enables the managed SNI implementation on Windows instead of native SNI. |
 | `UseOptimizedAsyncBehaviour` | Enables packet multiplexing and other async optimizations in SqlClient. |
-| `WaitForProfiler` | Pauses at startup and prints the process ID so you can attach an external profiler (e.g. `dotnet-trace`) before benchmarks run. Not needed on Windows, since ETW is attached automatically there. |
+| `WaitForProfiler` | Pauses at startup and prints the process ID so you can attach an external profiler (e.g. `dotnet-trace`) before benchmarks run. |
 | `UseNativeMemoryAndETWProfiler` | Attaches the `NativeMemoryProfiler` and `EtwProfiler` BenchmarkDotNet diagnosers. Windows only; has no effect on other OSes. |
 
 Some benchmarks (e.g. `DataTypeReaderRunner`, `DataTypeReaderAsyncRunner`) also

--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -466,6 +466,9 @@ settings:
 {
   "ConnectionString": "Server=tcp:localhost; Integrated Security=true; Initial Catalog=sqlclient-perf-db;",
   "UseManagedSniOnWindows": false,
+  "UseOptimizedAsyncBehaviour": true,
+  "WaitForProfiler": false,
+  "UseNativeMemoryAndETWProfiler": false,
   "Benchmarks":
   {
     "SqlConnectionRunnerConfig":
@@ -485,6 +488,20 @@ settings:
 Individual benchmarks may be enabled or disabled, and each has several
 benchmarking options for fine tuning.
 
+The top-level flags control global runner behavior:
+
+| Flag | Description |
+| --- | --- |
+| `UseManagedSniOnWindows` | Enables the managed SNI implementation on Windows instead of native SNI. |
+| `UseOptimizedAsyncBehaviour` | Enables packet multiplexing and other async optimizations in SqlClient. |
+| `WaitForProfiler` | Pauses at startup and prints the process ID so you can attach an external profiler (e.g. `dotnet-trace`) before benchmarks run. Not needed on Windows, since ETW is attached automatically there. |
+| `UseNativeMemoryAndETWProfiler` | Attaches the `NativeMemoryProfiler` and `EtwProfiler` BenchmarkDotNet diagnosers. Windows only; has no effect on other OSes. |
+
+Some benchmarks (e.g. `DataTypeReaderRunner`, `DataTypeReaderAsyncRunner`) also
+read per-type test values from `datatypes.json` in the `PerformanceTests`
+directory. Like `runnerconfig.jsonc`, this file's location can be overridden
+with the `DATATYPES_CONFIG` environment variable.
+
 After making edits to `runnerconfig.jsonc` you must perform a build which will
 copy the file into the `artifacts` directory alongside the benchmark DLL.  By
 default, the benchmarks look for `runnerconfig.jsonc` in the same directory as
@@ -493,7 +510,8 @@ the DLL.
 Optionally, to avoid polluting your git workspace and requiring a build after
 each config change, copy `runnerconfig.jsonc` to a new file, make your edits
 there, and then specify the new file with the RUNNER_CONFIG environment
-variable.
+variable. The same approach works for `datatypes.json` via the
+`DATATYPES_CONFIG` environment variable.
 
 PowerShell:
 

--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -452,8 +452,9 @@ $ sqlcmd -S localhost -U sa -P password
 ```
 
 The default `runnerconfig.jsonc` expects a database named `sqlclient-perf-db`,
-but you may change the config to use any existing database.  All tables in
-the database will be dropped when running the benchmarks.
+but you may change the config to use any existing database.  The benchmarks
+create and drop their own tables (typically prefixed with `perf_`) in this
+database; other existing tables are left untouched.
 
 ### Configure Runner
 

--- a/BUILDGUIDE.md
+++ b/BUILDGUIDE.md
@@ -451,13 +451,13 @@ $ sqlcmd -S localhost -U sa -P password
 1> quit
 ```
 
-The default `runnerconfig.json` expects a database named `sqlclient-perf-db`,
+The default `runnerconfig.jsonc` expects a database named `sqlclient-perf-db`,
 but you may change the config to use any existing database.  All tables in
 the database will be dropped when running the benchmarks.
 
 ### Configure Runner
 
-Configure the benchmarks by editing the `runnerconfig.json` file directly in the
+Configure the benchmarks by editing the `runnerconfig.jsonc` file directly in the
 `PerformanceTests` directory with an appropriate connection string and benchmark
 settings:
 
@@ -484,36 +484,36 @@ settings:
 Individual benchmarks may be enabled or disabled, and each has several
 benchmarking options for fine tuning.
 
-After making edits to `runnerconfig.json` you must perform a build which will
+After making edits to `runnerconfig.jsonc` you must perform a build which will
 copy the file into the `artifacts` directory alongside the benchmark DLL.  By
-default, the benchmarks look for `runnerconfig.json` in the same directory as
+default, the benchmarks look for `runnerconfig.jsonc` in the same directory as
 the DLL.
 
 Optionally, to avoid polluting your git workspace and requiring a build after
-each config change, copy `runnerconfig.json` to a new file, make your edits
+each config change, copy `runnerconfig.jsonc` to a new file, make your edits
 there, and then specify the new file with the RUNNER_CONFIG environment
 variable.
 
 PowerShell:
 
 ```pwsh
-> copy runnerconfig.json $HOME\.configs\runnerconfig.json
+> copy runnerconfig.jsonc $HOME\.configs\runnerconfig.jsonc
 
-# Make edits to $HOME\.configs\runnerconfig.json
+# Make edits to $HOME\.configs\runnerconfig.jsonc
 
 # You must set the RUNNER_CONFIG environment variable for the current shell.
-> $env:RUNNER_CONFIG="${HOME}\.configs\runnerconfig.json"
+> $env:RUNNER_CONFIG="${HOME}\.configs\runnerconfig.jsonc"
 ```
 
 Bash:
 
 ```bash
-$ cp runnerconfig.json ~/.configs/runnerconfig.json
+$ cp runnerconfig.jsonc ~/.configs/runnerconfig.jsonc
 
-# Make edits to ~/.configs/runnerconfig.json
+# Make edits to ~/.configs/runnerconfig.jsonc
 
 # Optionally export RUNNER_CONFIG.
-$ export RUNNER_CONFIG=~/.configs/runnerconfig.json
+$ export RUNNER_CONFIG=~/.configs/runnerconfig.jsonc
 ```
 
 ### Run Benchmarks
@@ -533,5 +533,5 @@ Bash:
 # copy prepared by the build.
 $ dotnet run -c Release -f net9.0
 
-$ RUNNER_CONFIG=~/.configs/runnerconfig.json dotnet run -c Release -f net9.0
+$ RUNNER_CONFIG=~/.configs/runnerconfig.jsonc dotnet run -c Release -f net9.0
 ```

--- a/src/Microsoft.Data.SqlClient/tests/Directory.Packages.props
+++ b/src/Microsoft.Data.SqlClient/tests/Directory.Packages.props
@@ -14,6 +14,7 @@
   <!-- SqlClient test dependencies. -->
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.13" />
     <PackageVersion Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.15.0" />
     <PackageVersion Include="Microsoft.SqlServer.Types" Version="170.1000.7" />

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/AsyncLargeDataReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/AsyncLargeDataReadRunner.cs
@@ -86,13 +86,12 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess);
             while (await reader.ReadAsync())
             {
+                using var stream = reader.GetStream(0);
                 byte[] buffer = new byte[8192];
-                long offset = 0;
-                long bytesRead;
+                int bytesRead;
                 do
                 {
-                    bytesRead = reader.GetBytes(0, offset, buffer, 0, buffer.Length);
-                    offset += bytesRead;
+                    bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length);
                 } while (bytesRead > 0);
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/AsyncLargeDataReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/AsyncLargeDataReadRunner.cs
@@ -24,6 +24,14 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         [Params(1_048_576, 5_242_880, 10_485_760, 20_971_520)]
         public int DataSizeBytes { get; set; }
 
+        /// <summary>
+        /// Size of the client-side read buffer used to drain the VARBINARY(MAX) column.
+        /// Kept small (8 KB) and large (1 MB) to observe whether buffer size relative to
+        /// the payload materially changes throughput.
+        /// </summary>
+        [Params(8_192, 1_048_576)]
+        public int ReadBufferBytes { get; set; }
+
         [GlobalSetup]
         public void Setup()
         {
@@ -38,13 +46,24 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
                 $"CREATE TABLE {_tableName} (Id INT IDENTITY PRIMARY KEY, Data VARBINARY(MAX))", conn);
             createCmd.ExecuteNonQuery();
 
-            // Insert a single row with random bytes of the specified size
-            byte[] data = new byte[DataSizeBytes];
-            Random.Shared.NextBytes(data);
-
+            // Generate the payload entirely server-side via CRYPT_GEN_RANDOM so we don't
+            // allocate a multi-megabyte byte[] on the client and don't ship the payload
+            // over the wire just to seed the benchmark.
             using var insertCmd = new SqlCommand(
-                $"INSERT INTO {_tableName} (Data) VALUES (@data)", conn);
-            insertCmd.Parameters.Add("@data", SqlDbType.VarBinary, -1).Value = data;
+                $@"INSERT INTO {_tableName} (Data)
+                   SELECT SUBSTRING(
+                       CONVERT(
+                           varbinary(max),
+                           REPLICATE(
+                               CONVERT(varchar(max), CRYPT_GEN_RANDOM(8000), 2),
+                               (@dataSizeBytes + 7999) / 8000
+                           ),
+                           2
+                       ),
+                       1,
+                       @dataSizeBytes
+                   );", conn);
+            insertCmd.Parameters.Add("@dataSizeBytes", SqlDbType.Int).Value = DataSizeBytes;
             insertCmd.ExecuteNonQuery();
         }
 
@@ -67,7 +86,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             using var reader = cmd.ExecuteReader(CommandBehavior.SequentialAccess);
             while (reader.Read())
             {
-                byte[] buffer = new byte[8192];
+                byte[] buffer = new byte[ReadBufferBytes];
                 long offset = 0;
                 long bytesRead;
                 do
@@ -88,7 +107,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             while (await reader.ReadAsync())
             {
                 using var stream = reader.GetStream(0);
-                byte[] buffer = new byte[8192];
+                byte[] buffer = new byte[ReadBufferBytes];
                 int bytesRead;
                 do
                 {

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/AsyncLargeDataReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/AsyncLargeDataReadRunner.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public void Setup()
         {
             _connectionString = s_config.ConnectionString;
-            _tableName = $"[perf_AsyncLargeData_{Environment.MachineName}_{Guid.NewGuid():N}]";
+            string machineHash = ((uint)Environment.MachineName.GetHashCode()).ToString("x8");
+            _tableName = $"[perf_AsyncLargeData_{machineHash}_{Guid.NewGuid():N}]";
 
             using var conn = new SqlConnection(_connectionString);
             conn.Open();

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/AsyncLargeDataReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/AsyncLargeDataReadRunner.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Benchmarks for sync vs async reading of large VARBINARY(MAX) values.
+    /// Reproduces issues #593 and #1562.
+    /// </summary>
+    public class AsyncLargeDataReadRunner : BaseRunner
+    {
+        private string _tableName;
+        private string _connectionString;
+
+        /// <summary>
+        /// Size of the data to read in bytes.
+        /// </summary>
+        [Params(1_048_576, 5_242_880, 10_485_760, 20_971_520)]
+        public int DataSizeBytes { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _connectionString = s_config.ConnectionString;
+            _tableName = $"[perf_AsyncLargeData_{Environment.MachineName}_{Guid.NewGuid():N}]";
+
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+
+            using var createCmd = new SqlCommand(
+                $"CREATE TABLE {_tableName} (Id INT IDENTITY PRIMARY KEY, Data VARBINARY(MAX))", conn);
+            createCmd.ExecuteNonQuery();
+
+            // Insert a single row with random bytes of the specified size
+            byte[] data = new byte[DataSizeBytes];
+            Random.Shared.NextBytes(data);
+
+            using var insertCmd = new SqlCommand(
+                $"INSERT INTO {_tableName} (Data) VALUES (@data)", conn);
+            insertCmd.Parameters.Add("@data", SqlDbType.VarBinary, -1).Value = data;
+            insertCmd.ExecuteNonQuery();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+            using var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_tableName}", conn);
+            cmd.ExecuteNonQuery();
+            SqlConnection.ClearAllPools();
+        }
+
+        [Benchmark]
+        public void ReadLargeDataSync()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+            using var cmd = new SqlCommand($"SELECT Data FROM {_tableName}", conn);
+            using var reader = cmd.ExecuteReader(CommandBehavior.SequentialAccess);
+            while (reader.Read())
+            {
+                byte[] buffer = new byte[8192];
+                long offset = 0;
+                long bytesRead;
+                do
+                {
+                    bytesRead = reader.GetBytes(0, offset, buffer, 0, buffer.Length);
+                    offset += bytesRead;
+                } while (bytesRead > 0);
+            }
+        }
+
+        [Benchmark]
+        public async Task ReadLargeDataAsync()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand($"SELECT Data FROM {_tableName}", conn);
+            using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess);
+            while (await reader.ReadAsync())
+            {
+                byte[] buffer = new byte[8192];
+                long offset = 0;
+                long bytesRead;
+                do
+                {
+                    bytesRead = reader.GetBytes(0, offset, buffer, 0, buffer.Length);
+                    offset += bytesRead;
+                } while (bytesRead > 0);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/BeginTransactionRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/BeginTransactionRunner.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             _connection = new SqlConnection(s_config.ConnectionString);
             _connection.Open();
 
-            _tableName = $"[perf_TxnBench_{Environment.MachineName}_{Guid.NewGuid():N}]";
-
+            string machineHash = ((uint)Environment.MachineName.GetHashCode()).ToString("x8");
+            _tableName = $"[perf_TxnBench_{machineHash}_{Guid.NewGuid():N}]";
             using var cmd = new SqlCommand(
                 $"CREATE TABLE {_tableName} (Id INT IDENTITY PRIMARY KEY, Value INT)", _connection);
             cmd.ExecuteNonQuery();

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/BeginTransactionRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/BeginTransactionRunner.cs
@@ -40,6 +40,17 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             SqlConnection.ClearAllPools();
         }
 
+        // Truncate the table between iterations so every iteration inserts into an empty
+        // table. Without this, the table grows across iterations (and across benchmarks,
+        // since they share the same connection/table), which would skew the measured
+        // BeginTransaction overhead as row count increases.
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            using var cmd = new SqlCommand($"TRUNCATE TABLE {_tableName}", _connection);
+            cmd.ExecuteNonQuery();
+        }
+
         [Benchmark]
         public void WithTransaction()
         {

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/BeginTransactionRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/BeginTransactionRunner.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Benchmarks measuring BeginTransaction round-trip latency.
+    /// Reproduces issue #1554.
+    /// </summary>
+    public class BeginTransactionRunner : BaseRunner
+    {
+        private SqlConnection _connection;
+        private string _tableName;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _connection = new SqlConnection(s_config.ConnectionString);
+            _connection.Open();
+
+            _tableName = $"[perf_TxnBench_{Environment.MachineName}_{Guid.NewGuid():N}]";
+
+            using var cmd = new SqlCommand(
+                $"CREATE TABLE {_tableName} (Id INT IDENTITY PRIMARY KEY, Value INT)", _connection);
+            cmd.ExecuteNonQuery();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            using var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_tableName}", _connection);
+            cmd.ExecuteNonQuery();
+            _connection.Close();
+            _connection.Dispose();
+            SqlConnection.ClearAllPools();
+        }
+
+        [Benchmark]
+        public void WithTransaction()
+        {
+            using var txn = _connection.BeginTransaction();
+            using var cmd = new SqlCommand($"INSERT INTO {_tableName} (Value) VALUES (1)", _connection, txn);
+            cmd.ExecuteNonQuery();
+            txn.Commit();
+        }
+
+        [Benchmark]
+        public void WithoutTransaction()
+        {
+            using var cmd = new SqlCommand($"INSERT INTO {_tableName} (Value) VALUES (1)", _connection);
+            cmd.ExecuteNonQuery();
+        }
+
+        [Benchmark]
+        public async Task WithTransactionAsync()
+        {
+            using var txn = (SqlTransaction)await _connection.BeginTransactionAsync();
+            using var cmd = new SqlCommand($"INSERT INTO {_tableName} (Value) VALUES (1)", _connection, txn);
+            await cmd.ExecuteNonQueryAsync();
+            await txn.CommitAsync();
+        }
+
+        [Benchmark]
+        public async Task WithoutTransactionAsync()
+        {
+            using var cmd = new SqlCommand($"INSERT INTO {_tableName} (Value) VALUES (1)", _connection);
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/CancellationTokenReadAsyncRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/CancellationTokenReadAsyncRunner.cs
@@ -48,12 +48,12 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             };
 
             var dt = new System.Data.DataTable();
-            dt.Columns.Add("Id", typeof(int));
             dt.Columns.Add("Value", typeof(int));
             for (int i = 0; i < s_rowCount; i++)
             {
-                dt.Rows.Add(i, i * 2);
+                dt.Rows.Add(i * 2);
             }
+            bulkCopy.ColumnMappings.Add("Value", "Value");
             bulkCopy.WriteToServer(dt);
 
             _query = $"SELECT Id, Value FROM {_tableName}";

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/CancellationTokenReadAsyncRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/CancellationTokenReadAsyncRunner.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         private string _tableName;
         private string _connectionString;
         private string _query;
+        private CancellationTokenSource _cts;
+        private CancellationToken _token;
 
         /// <summary>
         /// Whether to pass a CancellationToken to ReadAsync.
@@ -69,15 +71,34 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             SqlConnection.ClearAllPools();
         }
 
+        // Allocate the CancellationTokenSource in [IterationSetup] / dispose it in
+        // [IterationCleanup] so the CTS alloc/dispose cost is excluded from the measurement
+        // and only the per-row ReadAsync(CancellationToken) overhead is captured.
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            if (UseCancellationToken)
+            {
+                _cts = new CancellationTokenSource();
+                _token = _cts.Token;
+            }
+            else
+            {
+                _cts = null;
+                _token = CancellationToken.None;
+            }
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            _cts?.Dispose();
+            _cts = null;
+        }
+
         [Benchmark]
         public async Task ReadAsyncWithOrWithoutToken()
         {
-            using var cts = UseCancellationToken ? new CancellationTokenSource() : null;
-            var token = cts?.Token ?? CancellationToken.None;
-
-            // Note: When UseCancellationToken=true, this benchmark includes the cost of
-            // allocating/disposing a CancellationTokenSource in addition to the per-row
-            // ReadAsync(CancellationToken) overhead being measured.
             using var conn = new SqlConnection(_connectionString);
             await conn.OpenAsync();
             using var cmd = new SqlCommand(_query, conn);
@@ -85,7 +106,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
 
             if (UseCancellationToken)
             {
-                while (await reader.ReadAsync(token))
+                while (await reader.ReadAsync(_token))
                 { }
             }
             else

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/CancellationTokenReadAsyncRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/CancellationTokenReadAsyncRunner.cs
@@ -75,10 +75,13 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             using var cts = UseCancellationToken ? new CancellationTokenSource() : null;
             var token = cts?.Token ?? CancellationToken.None;
 
+            // Only the ReadAsync loop below should observe the CancellationToken overhead
+            // this benchmark is measuring, so Open/ExecuteReaderAsync intentionally run
+            // without a token here.
             using var conn = new SqlConnection(_connectionString);
-            await conn.OpenAsync(token);
+            await conn.OpenAsync();
             using var cmd = new SqlCommand(_query, conn);
-            using var reader = await cmd.ExecuteReaderAsync(token);
+            using var reader = await cmd.ExecuteReaderAsync();
 
             if (UseCancellationToken)
             {

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/CancellationTokenReadAsyncRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/CancellationTokenReadAsyncRunner.cs
@@ -1,0 +1,95 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Benchmarks measuring CancellationToken overhead during ReadAsync iteration.
+    /// Reproduces issue #2408.
+    /// </summary>
+    public class CancellationTokenReadAsyncRunner : BaseRunner
+    {
+        private static long s_rowCount;
+        private string _tableName;
+        private string _connectionString;
+        private string _query;
+
+        /// <summary>
+        /// Whether to pass a CancellationToken to ReadAsync.
+        /// </summary>
+        [Params(true, false)]
+        public bool UseCancellationToken { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            s_rowCount = s_config.Benchmarks.CancellationTokenReadAsyncRunnerConfig.RowCount;
+            _connectionString = s_config.ConnectionString;
+            _tableName = $"[perf_CancelToken_{Environment.MachineName}_{Guid.NewGuid():N}]";
+
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+
+            using var createCmd = new SqlCommand(
+                $"CREATE TABLE {_tableName} (Id INT IDENTITY PRIMARY KEY, Value INT)", conn);
+            createCmd.ExecuteNonQuery();
+
+            // Bulk insert rows
+            using var bulkCopy = new SqlBulkCopy(conn)
+            {
+                DestinationTableName = _tableName,
+                BatchSize = 10000
+            };
+
+            var dt = new System.Data.DataTable();
+            dt.Columns.Add("Id", typeof(int));
+            dt.Columns.Add("Value", typeof(int));
+            for (int i = 0; i < s_rowCount; i++)
+            {
+                dt.Rows.Add(i, i * 2);
+            }
+            bulkCopy.WriteToServer(dt);
+
+            _query = $"SELECT Id, Value FROM {_tableName}";
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+            using var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_tableName}", conn);
+            cmd.ExecuteNonQuery();
+            SqlConnection.ClearAllPools();
+        }
+
+        [Benchmark]
+        public async Task ReadAsyncWithOrWithoutToken()
+        {
+            using var cts = UseCancellationToken ? new CancellationTokenSource() : null;
+            var token = cts?.Token ?? CancellationToken.None;
+
+            using var conn = new SqlConnection(_connectionString);
+            await conn.OpenAsync(token);
+            using var cmd = new SqlCommand(_query, conn);
+            using var reader = await cmd.ExecuteReaderAsync(token);
+
+            if (UseCancellationToken)
+            {
+                while (await reader.ReadAsync(token))
+                { }
+            }
+            else
+            {
+                while (await reader.ReadAsync())
+                { }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/CancellationTokenReadAsyncRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/CancellationTokenReadAsyncRunner.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         {
             s_rowCount = s_config.Benchmarks.CancellationTokenReadAsyncRunnerConfig.RowCount;
             _connectionString = s_config.ConnectionString;
-            _tableName = $"[perf_CancelToken_{Environment.MachineName}_{Guid.NewGuid():N}]";
-
+            string machineHash = ((uint)Environment.MachineName.GetHashCode()).ToString("x8");
+            _tableName = $"[perf_CancelToken_{machineHash}_{Guid.NewGuid():N}]";
             using var conn = new SqlConnection(_connectionString);
             conn.Open();
 
@@ -75,9 +75,9 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             using var cts = UseCancellationToken ? new CancellationTokenSource() : null;
             var token = cts?.Token ?? CancellationToken.None;
 
-            // Only the ReadAsync loop below should observe the CancellationToken overhead
-            // this benchmark is measuring, so Open/ExecuteReaderAsync intentionally run
-            // without a token here.
+            // Note: When UseCancellationToken=true, this benchmark includes the cost of
+            // allocating/disposing a CancellationTokenSource in addition to the per-row
+            // ReadAsync(CancellationToken) overhead being measured.
             using var conn = new SqlConnection(_connectionString);
             await conn.OpenAsync();
             using var cmd = new SqlCommand(_query, conn);

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
@@ -44,8 +44,11 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             _connectionString = s_config.ConnectionString +
                 $";Pooling=True;Max Pool Size={MaxPoolSize};Min Pool Size=5;Connect Timeout=60";
 
-            // Create a small table for query workloads
-            _tableName = $"[perf_PoolStress_{Environment.MachineName}_{Guid.NewGuid():N}]";
+            // Create a small table for query workloads.
+            // Hash the machine name instead of using it verbatim: hostnames can be long enough
+            // to push the identifier past SQL Server's 128-character limit.
+            string machineHash = Math.Abs(Environment.MachineName.GetHashCode()).ToString("x8");
+            _tableName = $"[perf_PoolStress_{machineHash}_{Guid.NewGuid():N}]";
             using var conn = new SqlConnection(_connectionString);
             conn.Open();
             using var cmd = new SqlCommand(

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
@@ -81,16 +80,19 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         /// <summary>
         /// Pure open/close churn — every task opens a pooled connection, immediately closes it,
         /// and repeats. Measures raw pool checkout/return throughput under contention.
+        /// The per-task loop count scales with MaxPoolSize so total checkouts stay proportional
+        /// to pool capacity regardless of how the [Params] values change.
         /// </summary>
         [Benchmark]
         public async Task RapidFireOpenClose()
         {
+            int iterationsPerTask = Math.Max(20, MaxPoolSize / Math.Max(1, Parallelism) * 4);
             var tasks = new Task[Parallelism];
             for (int i = 0; i < Parallelism; i++)
             {
                 tasks[i] = Task.Run(async () =>
                 {
-                    for (int j = 0; j < 20; j++)
+                    for (int j = 0; j < iterationsPerTask; j++)
                     {
                         using var conn = new SqlConnection(_connectionString);
                         await conn.OpenAsync();

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
@@ -241,24 +241,21 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
 
         /// <summary>
         /// Bursty traffic pattern — sends waves of connections with pauses between bursts,
-        /// simulating real web server traffic patterns where requests cluster.
+        /// simulating real web server traffic patterns where requests cluster. Each burst
+        /// spins up <see cref="Parallelism"/> concurrent tasks so the configured parallelism
+        /// level actually drives the observed concurrency.
         /// </summary>
         [Benchmark]
         public async Task BurstyTrafficPattern()
         {
-            int burstCount = 5;
-            int tasksPerBurst = Parallelism / burstCount;
-            if (tasksPerBurst < 1)
-            {
-                tasksPerBurst = 1;
-            }
+            const int burstCount = 5;
 
             for (int burst = 0; burst < burstCount; burst++)
             {
-                var tasks = new Task[tasksPerBurst];
-                for (int i = 0; i < tasksPerBurst; i++)
+                var tasks = new Task[Parallelism];
+                for (int i = 0; i < Parallelism; i++)
                 {
-                    int seed = burst * tasksPerBurst + i;
+                    int seed = burst * Parallelism + i;
                     tasks[i] = Task.Run(async () =>
                     {
                         var rng = new Random(seed);

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
@@ -46,8 +45,9 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
 
             // Create a small table for query workloads.
             // Hash the machine name instead of using it verbatim: hostnames can be long enough
-            // to push the identifier past SQL Server's 128-character limit.
-            string machineHash = Math.Abs(Environment.MachineName.GetHashCode()).ToString("x8");
+            // to push the identifier past SQL Server's 128-character limit. Cast to uint rather
+            // than using Math.Abs, which throws OverflowException when the hash is int.MinValue.
+            string machineHash = ((uint)Environment.MachineName.GetHashCode()).ToString("x8");
             _tableName = $"[perf_PoolStress_{machineHash}_{Guid.NewGuid():N}]";
             using var conn = new SqlConnection(_connectionString);
             conn.Open();

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
@@ -1,0 +1,280 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Stress-tests the connection pool with randomized parallel access patterns:
+    /// - Massive concurrent open/close churn
+    /// - Randomized hold durations simulating real workloads
+    /// - Mixed sync/async callers competing for pooled connections
+    /// - Connection reuse with interleaved queries
+    /// - Pool exhaustion and recovery under pressure
+    ///
+    /// Related issues: #601, #979, #3356
+    /// </summary>
+    public class ConnectionPoolStressRunner : BaseRunner
+    {
+        private string _connectionString;
+        private string _tableName;
+
+        /// <summary>
+        /// Number of concurrent tasks hammering the pool.
+        /// </summary>
+        [Params(10, 20, 25)]
+        public int Parallelism { get; set; }
+
+        /// <summary>
+        /// Max pool size — controls how many physical connections the pool can hold.
+        /// When Parallelism exceeds this, tasks must wait for a free connection.
+        /// </summary>
+        [Params(50, 100)]
+        public int MaxPoolSize { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _connectionString = s_config.ConnectionString +
+                $";Pooling=True;Max Pool Size={MaxPoolSize};Min Pool Size=5;Connect Timeout=60";
+
+            // Create a small table for query workloads
+            _tableName = $"[perf_PoolStress_{Environment.MachineName}_{Guid.NewGuid():N}]";
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+            using var cmd = new SqlCommand(
+                $"CREATE TABLE {_tableName} (Id INT IDENTITY PRIMARY KEY, Val INT)", conn);
+            cmd.ExecuteNonQuery();
+
+            // Seed a few rows so SELECT queries return data
+            using var insert = new SqlCommand(
+                $"INSERT INTO {_tableName} (Val) VALUES (1),(2),(3),(4),(5)", conn);
+            insert.ExecuteNonQuery();
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            SqlConnection.ClearAllPools();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+            using var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_tableName}", conn);
+            cmd.ExecuteNonQuery();
+            conn.Close();
+            SqlConnection.ClearAllPools();
+        }
+
+        /// <summary>
+        /// Pure open/close churn — every task opens a pooled connection, immediately closes it,
+        /// and repeats. Measures raw pool checkout/return throughput under contention.
+        /// </summary>
+        [Benchmark]
+        public async Task RapidFireOpenClose()
+        {
+            var tasks = new Task[Parallelism];
+            for (int i = 0; i < Parallelism; i++)
+            {
+                tasks[i] = Task.Run(async () =>
+                {
+                    for (int j = 0; j < 20; j++)
+                    {
+                        using var conn = new SqlConnection(_connectionString);
+                        await conn.OpenAsync();
+                        // immediate return to pool
+                    }
+                });
+            }
+            await Task.WhenAll(tasks);
+        }
+
+        /// <summary>
+        /// Randomized hold — each task opens a connection, holds it for a random duration
+        /// (0-50ms), optionally runs a query, then returns it. Simulates realistic mixed
+        /// workloads where some connections are held briefly and others longer.
+        /// </summary>
+        [Benchmark]
+        public async Task RandomizedHoldAndQuery()
+        {
+            var tasks = new Task[Parallelism];
+            for (int i = 0; i < Parallelism; i++)
+            {
+                int seed = i;
+                tasks[i] = Task.Run(async () =>
+                {
+                    var rng = new Random(seed);
+                    for (int j = 0; j < 10; j++)
+                    {
+                        using var conn = new SqlConnection(_connectionString);
+                        await conn.OpenAsync();
+
+                        // ~50% of the time, execute a lightweight query while holding the connection
+                        if (rng.Next(2) == 0)
+                        {
+                            using var cmd = new SqlCommand($"SELECT TOP 1 Val FROM {_tableName}", conn);
+                            _ = await cmd.ExecuteScalarAsync();
+                        }
+
+                        // Random hold time: 0-50ms
+                        int holdMs = rng.Next(51);
+                        if (holdMs > 0)
+                        {
+                            await Task.Delay(holdMs);
+                        }
+                    }
+                });
+            }
+            await Task.WhenAll(tasks);
+        }
+
+        /// <summary>
+        /// Mixed sync and async — half the tasks use sync Open/ExecuteReader,
+        /// the other half use async. Stresses the pool lock paths that differ
+        /// between sync and async checkout.
+        /// </summary>
+        [Benchmark]
+        public async Task MixedSyncAsyncContention()
+        {
+            var tasks = new Task[Parallelism];
+            for (int i = 0; i < Parallelism; i++)
+            {
+                bool useAsync = i % 2 == 0;
+                tasks[i] = Task.Run(async () =>
+                {
+                    for (int j = 0; j < 10; j++)
+                    {
+                        using var conn = new SqlConnection(_connectionString);
+                        if (useAsync)
+                        {
+                            await conn.OpenAsync();
+                            using var cmd = new SqlCommand($"SELECT COUNT(*) FROM {_tableName}", conn);
+                            _ = await cmd.ExecuteScalarAsync();
+                        }
+                        else
+                        {
+                            conn.Open();
+                            using var cmd = new SqlCommand($"SELECT COUNT(*) FROM {_tableName}", conn);
+                            _ = cmd.ExecuteScalar();
+                        }
+                    }
+                });
+            }
+            await Task.WhenAll(tasks);
+        }
+
+        /// <summary>
+        /// Connection reuse with multiple commands — each task opens one connection and
+        /// executes many sequential queries before returning it. Measures pool efficiency
+        /// when connections are held for multi-step operations (like EF SaveChanges).
+        /// </summary>
+        [Benchmark]
+        public async Task MultiCommandReuse()
+        {
+            var tasks = new Task[Parallelism];
+            for (int i = 0; i < Parallelism; i++)
+            {
+                int seed = i;
+                tasks[i] = Task.Run(async () =>
+                {
+                    var rng = new Random(seed);
+                    using var conn = new SqlConnection(_connectionString);
+                    await conn.OpenAsync();
+
+                    // Execute a burst of 5-15 commands on the same connection
+                    int commandCount = rng.Next(5, 16);
+                    for (int c = 0; c < commandCount; c++)
+                    {
+                        using var cmd = new SqlCommand($"SELECT Val FROM {_tableName} WHERE Id = @id", conn);
+                        cmd.Parameters.AddWithValue("@id", rng.Next(1, 6));
+                        using var reader = await cmd.ExecuteReaderAsync();
+                        while (await reader.ReadAsync()) { }
+                    }
+                });
+            }
+            await Task.WhenAll(tasks);
+        }
+
+        /// <summary>
+        /// Pool exhaustion and recovery — spawns more tasks than MaxPoolSize so some must
+        /// wait. Measures how well the pool handles back-pressure when all connections are
+        /// checked out and callers are queued.
+        /// </summary>
+        [Benchmark]
+        public async Task PoolExhaustionRecovery()
+        {
+            // Ensure we exceed pool capacity
+            int taskCount = Math.Max(Parallelism, MaxPoolSize * 2);
+            var tasks = new Task[taskCount];
+            for (int i = 0; i < taskCount; i++)
+            {
+                int seed = i;
+                tasks[i] = Task.Run(async () =>
+                {
+                    var rng = new Random(seed);
+                    using var conn = new SqlConnection(_connectionString);
+                    await conn.OpenAsync();
+
+                    // Hold the connection for 10-100ms to create pool pressure
+                    using var cmd = new SqlCommand($"SELECT TOP 1 Val FROM {_tableName}", conn);
+                    _ = await cmd.ExecuteScalarAsync();
+
+                    await Task.Delay(rng.Next(10, 101));
+                });
+            }
+            await Task.WhenAll(tasks);
+        }
+
+        /// <summary>
+        /// Bursty traffic pattern — sends waves of connections with pauses between bursts,
+        /// simulating real web server traffic patterns where requests cluster.
+        /// </summary>
+        [Benchmark]
+        public async Task BurstyTrafficPattern()
+        {
+            int burstCount = 5;
+            int tasksPerBurst = Parallelism / burstCount;
+            if (tasksPerBurst < 1)
+            {
+                tasksPerBurst = 1;
+            }
+
+            for (int burst = 0; burst < burstCount; burst++)
+            {
+                var tasks = new Task[tasksPerBurst];
+                for (int i = 0; i < tasksPerBurst; i++)
+                {
+                    int seed = burst * tasksPerBurst + i;
+                    tasks[i] = Task.Run(async () =>
+                    {
+                        var rng = new Random(seed);
+                        using var conn = new SqlConnection(_connectionString);
+                        await conn.OpenAsync();
+
+                        // Each connection in the burst does 1-5 queries
+                        int queryCount = rng.Next(1, 6);
+                        for (int q = 0; q < queryCount; q++)
+                        {
+                            using var cmd = new SqlCommand($"SELECT Val FROM {_tableName}", conn);
+                            using var reader = await cmd.ExecuteReaderAsync();
+                            while (await reader.ReadAsync()) { }
+                        }
+                    });
+                }
+                await Task.WhenAll(tasks);
+
+                // Brief pause between bursts (simulates request clustering)
+                await Task.Delay(5);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
     /// Benchmarks comparing read performance of JSON vs VARCHAR(MAX) columns.
     /// Reproduces issue #3499.
     /// Note: JSON column type requires SQL Server 2025+ or Azure SQL.
-    /// This runner is disabled by default in runnerconfig.json.
+    /// This runner is disabled by default in runnerconfig.jsonc.
     /// </summary>
     public class JsonVsVarcharReadRunner : BaseRunner
     {
@@ -61,20 +61,21 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
 
             // Bulk insert identical data into both tables
             var dt = new System.Data.DataTable();
-            dt.Columns.Add("Id", typeof(int));
             dt.Columns.Add("Data", typeof(string));
             for (int i = 0; i < s_rowCount; i++)
             {
-                dt.Rows.Add(i, sampleJson);
+                dt.Rows.Add(sampleJson);
             }
 
             using (var bulkCopy = new SqlBulkCopy(conn) { DestinationTableName = _jsonTableName, BatchSize = 10000 })
             {
+                bulkCopy.ColumnMappings.Add("Data", "Data");
                 bulkCopy.WriteToServer(dt);
             }
 
             using (var bulkCopy = new SqlBulkCopy(conn) { DestinationTableName = _varcharTableName, BatchSize = 10000 })
             {
+                bulkCopy.ColumnMappings.Add("Data", "Data");
                 bulkCopy.WriteToServer(dt);
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             s_rowCount = s_config.Benchmarks.JsonVsVarcharReadRunnerConfig.RowCount;
             _connectionString = s_config.ConnectionString;
 
-            string suffix = $"{Environment.MachineName}_{Guid.NewGuid():N}";
+            string machineHash = ((uint)Environment.MachineName.GetHashCode()).ToString("x8");
+            string suffix = $"{machineHash}_{Guid.NewGuid():N}";
             _jsonTableName = $"[perf_Json_{suffix}]";
             _varcharTableName = $"[perf_Varchar_{suffix}]";
 

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Data;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
@@ -85,10 +84,17 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         {
             using var conn = new SqlConnection(_connectionString);
             conn.Open();
+
             using (var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_jsonTableName}", conn))
+            {
                 cmd.ExecuteNonQuery();
+            }
+            
             using (var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_varcharTableName}", conn))
+            {
                 cmd.ExecuteNonQuery();
+            }
+            
             SqlConnection.ClearAllPools();
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
@@ -106,9 +106,21 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             conn.Open();
             using var cmd = new SqlCommand($"SELECT Data FROM {ActiveTableName}", conn);
             using var reader = cmd.ExecuteReader();
-            while (reader.Read())
+            if (ColumnType == "JSON")
             {
-                _ = reader.GetString(0);
+                // Exercise the SqlJson accessor path so the JSON case captures
+                // JSON-type handling overhead rather than the shared string path.
+                while (reader.Read())
+                {
+                    _ = reader.GetSqlJson(0).Value;
+                }
+            }
+            else
+            {
+                while (reader.Read())
+                {
+                    _ = reader.GetString(0);
+                }
             }
         }
 
@@ -119,9 +131,19 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             await conn.OpenAsync();
             using var cmd = new SqlCommand($"SELECT Data FROM {ActiveTableName}", conn);
             using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            if (ColumnType == "JSON")
             {
-                _ = await reader.GetFieldValueAsync<string>(0);
+                while (await reader.ReadAsync())
+                {
+                    _ = reader.GetSqlJson(0).Value;
+                }
+            }
+            else
+            {
+                while (await reader.ReadAsync())
+                {
+                    _ = await reader.GetFieldValueAsync<string>(0);
+                }
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/JsonVsVarcharReadRunner.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Benchmarks comparing read performance of JSON vs VARCHAR(MAX) columns.
+    /// Reproduces issue #3499.
+    /// Note: JSON column type requires SQL Server 2025+ or Azure SQL.
+    /// This runner is disabled by default in runnerconfig.json.
+    /// </summary>
+    public class JsonVsVarcharReadRunner : BaseRunner
+    {
+        private static long s_rowCount;
+        private string _jsonTableName;
+        private string _varcharTableName;
+        private string _connectionString;
+
+        /// <summary>
+        /// Which column type to read from: "JSON" or "VARCHAR".
+        /// </summary>
+        [Params("JSON", "VARCHAR")]
+        public string ColumnType { get; set; }
+
+        private string ActiveTableName => ColumnType == "JSON" ? _jsonTableName : _varcharTableName;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            s_rowCount = s_config.Benchmarks.JsonVsVarcharReadRunnerConfig.RowCount;
+            _connectionString = s_config.ConnectionString;
+
+            string suffix = $"{Environment.MachineName}_{Guid.NewGuid():N}";
+            _jsonTableName = $"[perf_Json_{suffix}]";
+            _varcharTableName = $"[perf_Varchar_{suffix}]";
+
+            string sampleJson = "{\"id\":1,\"name\":\"test\",\"values\":[1,2,3],\"nested\":{\"key\":\"value\"}}";
+
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+
+            // Create JSON table
+            using (var cmd = new SqlCommand(
+                $"CREATE TABLE {_jsonTableName} (Id INT IDENTITY PRIMARY KEY, Data JSON)", conn))
+            {
+                cmd.ExecuteNonQuery();
+            }
+
+            // Create VARCHAR(MAX) table
+            using (var cmd = new SqlCommand(
+                $"CREATE TABLE {_varcharTableName} (Id INT IDENTITY PRIMARY KEY, Data VARCHAR(MAX))", conn))
+            {
+                cmd.ExecuteNonQuery();
+            }
+
+            // Bulk insert identical data into both tables
+            var dt = new System.Data.DataTable();
+            dt.Columns.Add("Id", typeof(int));
+            dt.Columns.Add("Data", typeof(string));
+            for (int i = 0; i < s_rowCount; i++)
+            {
+                dt.Rows.Add(i, sampleJson);
+            }
+
+            using (var bulkCopy = new SqlBulkCopy(conn) { DestinationTableName = _jsonTableName, BatchSize = 10000 })
+            {
+                bulkCopy.WriteToServer(dt);
+            }
+
+            using (var bulkCopy = new SqlBulkCopy(conn) { DestinationTableName = _varcharTableName, BatchSize = 10000 })
+            {
+                bulkCopy.WriteToServer(dt);
+            }
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+            using (var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_jsonTableName}", conn))
+                cmd.ExecuteNonQuery();
+            using (var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_varcharTableName}", conn))
+                cmd.ExecuteNonQuery();
+            SqlConnection.ClearAllPools();
+        }
+
+        [Benchmark]
+        public void ReadDataSync()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+            using var cmd = new SqlCommand($"SELECT Data FROM {ActiveTableName}", conn);
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                _ = reader.GetString(0);
+            }
+        }
+
+        [Benchmark]
+        public async Task ReadDataAsync()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand($"SELECT Data FROM {ActiveTableName}", conn);
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                _ = await reader.GetFieldValueAsync<string>(0);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/MarsOverheadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/MarsOverheadRunner.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Benchmarks comparing query execution with MARS enabled vs disabled.
+    /// Reproduces issues #422 and #1283.
+    /// </summary>
+    public class MarsOverheadRunner : BaseRunner
+    {
+        private static long s_rowCount;
+        private Table _table;
+        private string _query;
+
+        /// <summary>
+        /// Whether MARS is enabled on the connection string.
+        /// </summary>
+        [Params(true, false)]
+        public bool MARS { get; set; }
+
+        private string ConnectionString => s_config.ConnectionString + $";MultipleActiveResultSets={MARS}";
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            s_rowCount = s_config.Benchmarks.MarsOverheadRunnerConfig.RowCount;
+
+            using var conn = new SqlConnection(s_config.ConnectionString);
+            conn.Open();
+
+            _table = TablePatterns.TableAll25Columns(s_datatypes, nameof(MarsOverheadRunner))
+                .CreateTable(conn)
+                .InsertBulkRows(s_rowCount, conn);
+
+            _query = $"SELECT * FROM {_table.Name}";
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            using var conn = new SqlConnection(s_config.ConnectionString);
+            conn.Open();
+            _table.DropTable(conn);
+            SqlConnection.ClearAllPools();
+        }
+
+        [Benchmark]
+        public void ExecuteReaderWithMars()
+        {
+            using var conn = new SqlConnection(ConnectionString);
+            conn.Open();
+            using var cmd = new SqlCommand(_query, conn);
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            { }
+        }
+
+        [Benchmark]
+        public async Task ExecuteReaderAsyncWithMars()
+        {
+            using var conn = new SqlConnection(ConnectionString);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(_query, conn);
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            { }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ParallelAsyncConnectionRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ParallelAsyncConnectionRunner.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Benchmarks for concurrent async connection opens to surface pool contention.
+    /// Reproduces issues #601 and #979.
+    /// </summary>
+    public class ParallelAsyncConnectionRunner : BaseRunner
+    {
+        /// <summary>
+        /// Number of concurrent connections to open.
+        /// </summary>
+        [Params(10, 50, 100)]
+        public int Concurrency { get; set; }
+
+        /// <summary>
+        /// Whether connection pooling is enabled.
+        /// </summary>
+        [Params(true, false)]
+        public bool Pooling { get; set; }
+
+        private string ConnectionString => s_config.ConnectionString + $";Pooling={Pooling};Max Pool Size=200";
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            SqlConnection.ClearAllPools();
+        }
+
+        [Benchmark]
+        public async Task OpenConnectionsConcurrently()
+        {
+            var tasks = new Task[Concurrency];
+            for (int i = 0; i < Concurrency; i++)
+            {
+                tasks[i] = OpenAndCloseConnectionAsync();
+            }
+            await Task.WhenAll(tasks);
+        }
+
+        private async Task OpenAndCloseConnectionAsync()
+        {
+            using var conn = new SqlConnection(ConnectionString);
+            await conn.OpenAsync();
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/SequentialXmlReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/SequentialXmlReadRunner.cs
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Benchmarks for XML column reads via SequentialAccess at increasing data sizes
+    /// to detect O(N²) scaling behavior.
+    /// Reproduces issue #1877.
+    /// </summary>
+    public class SequentialXmlReadRunner : BaseRunner
+    {
+        private string _tableName;
+        private string _connectionString;
+        private string _query;
+
+        /// <summary>
+        /// Size of the XML data in kilobytes.
+        /// </summary>
+        [Params(10, 100, 500, 1000)]
+        public int XmlSizeKB { get; set; }
+
+        /// <summary>
+        /// Whether to use CommandBehavior.SequentialAccess.
+        /// </summary>
+        [Params(true, false)]
+        public bool UseSequentialAccess { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _connectionString = s_config.ConnectionString;
+            _tableName = $"[perf_SeqXml_{Environment.MachineName}_{Guid.NewGuid():N}]";
+
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+
+            using var createCmd = new SqlCommand(
+                $"CREATE TABLE {_tableName} (Id INT IDENTITY PRIMARY KEY, Data XML)", conn);
+            createCmd.ExecuteNonQuery();
+
+            // Generate XML of approximately XmlSizeKB kilobytes
+            string xmlData = GenerateXml(XmlSizeKB * 1024);
+
+            using var insertCmd = new SqlCommand(
+                $"INSERT INTO {_tableName} (Data) VALUES (@data)", conn);
+            insertCmd.Parameters.Add("@data", SqlDbType.Xml).Value = xmlData;
+            insertCmd.ExecuteNonQuery();
+
+            _query = $"SELECT Data FROM {_tableName}";
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+            using var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_tableName}", conn);
+            cmd.ExecuteNonQuery();
+            SqlConnection.ClearAllPools();
+        }
+
+        [Benchmark]
+        public void ReadXml()
+        {
+            var behavior = UseSequentialAccess ? CommandBehavior.SequentialAccess : CommandBehavior.Default;
+
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+            using var cmd = new SqlCommand(_query, conn);
+            using var reader = cmd.ExecuteReader(behavior);
+            while (reader.Read())
+            {
+                _ = reader.GetString(0);
+            }
+        }
+
+        private static string GenerateXml(int targetBytes)
+        {
+            var sb = new StringBuilder(targetBytes + 256);
+            sb.Append("<root>");
+            int index = 0;
+            while (sb.Length < targetBytes)
+            {
+                sb.Append($"<item id=\"{index}\">This is element number {index} with some padding data to increase size.</item>");
+                index++;
+            }
+            sb.Append("</root>");
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/SequentialXmlReadRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/SequentialXmlReadRunner.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public void Setup()
         {
             _connectionString = s_config.ConnectionString;
-            _tableName = $"[perf_SeqXml_{Environment.MachineName}_{Guid.NewGuid():N}]";
-
+            string machineHash = ((uint)Environment.MachineName.GetHashCode()).ToString("x8");
+            _tableName = $"[perf_SeqXml_{machineHash}_{Guid.NewGuid():N}]";
             using var conn = new SqlConnection(_connectionString);
             conn.Open();
 

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/BenchmarkConfig.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/BenchmarkConfig.cs
@@ -12,23 +12,45 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
 {
     public static class BenchmarkConfig
     {
-        public static ManualConfig s_instance(RunnerJob runnerJob) => 
-            DefaultConfig.Instance
-            .WithOption(ConfigOptions.DisableOptimizationsValidator, true)
-            .WithOption(ConfigOptions.DontOverwriteResults, true)
-            .AddDiagnoser(MemoryDiagnoser.Default)
-            .AddDiagnoser(ThreadingDiagnoser.Default)
-            .AddExporter(MarkdownExporter.GitHub)
-            .AddJob(
-                Job.MediumRun.WithToolchain(InProcessEmitToolchain.Instance)
-                .WithLaunchCount(runnerJob.LaunchCount)
-                .WithInvocationCount(runnerJob.InvocationCount)
-                .WithIterationCount(runnerJob.IterationCount)
-                .WithWarmupCount(runnerJob.WarmupCount)
-                .WithUnrollFactor(1)
-                .WithStrategy(BenchmarkDotNet.Engines.RunStrategy.Throughput)
-                .WithEnvironmentVariable("COMPlus_gcServer", "1")
-            )
-            .WithOptions(ConfigOptions.JoinSummary);
+        /// <summary>
+        /// When set to true, attaches the NativeMemoryProfiler and EtwProfiler diagnosers
+        /// so native memory allocations and ETW traces are captured for each benchmark run.
+        /// This is only supported on Windows; the value is ignored on other OSes since the
+        /// underlying diagnosers are compiled out (see the "WINDOWS" compile constant, which
+        /// is only set when building on Windows in the PerformanceTests.csproj file).
+        /// </summary>
+        public static bool UseNativeMemoryAndEtwProfiler { get; set; }
+
+        public static ManualConfig s_instance(RunnerJob runnerJob)
+        {
+            ManualConfig config = DefaultConfig.Instance
+                .WithOption(ConfigOptions.DisableOptimizationsValidator, true)
+                .WithOption(ConfigOptions.DontOverwriteResults, true)
+                .AddDiagnoser(MemoryDiagnoser.Default)
+                .AddDiagnoser(ThreadingDiagnoser.Default)
+                .AddExporter(MarkdownExporter.GitHub)
+                .AddJob(
+                    Job.MediumRun.WithToolchain(InProcessEmitToolchain.Instance)
+                    .WithLaunchCount(runnerJob.LaunchCount)
+                    .WithInvocationCount(runnerJob.InvocationCount)
+                    .WithIterationCount(runnerJob.IterationCount)
+                    .WithWarmupCount(runnerJob.WarmupCount)
+                    .WithUnrollFactor(1)
+                    .WithStrategy(BenchmarkDotNet.Engines.RunStrategy.Throughput)
+                    .WithEnvironmentVariable("COMPlus_gcServer", "1")
+                )
+                .WithOptions(ConfigOptions.JoinSummary);
+
+#if WINDOWS
+            if (UseNativeMemoryAndEtwProfiler)
+            {
+                config = config
+                    .AddDiagnoser(NativeMemoryProfiler.Default)
+                    .AddDiagnoser(new EtwProfiler());
+            }
+#endif
+
+            return config;
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/BenchmarkConfig.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/BenchmarkConfig.cs
@@ -7,6 +7,9 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
+#if WINDOWS
+using BenchmarkDotNet.Diagnostics.Windows.Configs;
+#endif
 
 namespace Microsoft.Data.SqlClient.PerformanceTests
 {

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/BenchmarkConfig.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/BenchmarkConfig.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public static ManualConfig s_instance(RunnerJob runnerJob) => 
             DefaultConfig.Instance
             .WithOption(ConfigOptions.DisableOptimizationsValidator, true)
+            .WithOption(ConfigOptions.DontOverwriteResults, true)
             .AddDiagnoser(MemoryDiagnoser.Default)
             .AddDiagnoser(ThreadingDiagnoser.Default)
             .AddExporter(MarkdownExporter.GitHub)
@@ -26,6 +27,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
                 .WithWarmupCount(runnerJob.WarmupCount)
                 .WithUnrollFactor(1)
                 .WithStrategy(BenchmarkDotNet.Engines.RunStrategy.Throughput)
-            );
+                .WithEnvironmentVariable("COMPlus_gcServer", "1")
+            )
+            .WithOptions(ConfigOptions.JoinSummary);
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         ///
         /// If the environment variable "RUNNER_CONFIG" is set, it will be used
         /// as the path to the config file.  Otherwise, the file
-        /// "runnerconfig.json" in the current working directory will be used.
+        /// "runnerconfig.jsonc" in the current working directory will be used.
         /// </summary>
         ///
         /// <returns>
@@ -34,7 +34,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public static Config Load()
         {
             return Loader.FromJsonFile<Config>(
-                "runnerconfig.json", "RUNNER_CONFIG");
+                "runnerconfig.jsonc", "RUNNER_CONFIG");
         }
     }
 

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public bool UseManagedSniOnWindows;
         public bool UseOptimizedAsyncBehaviour;
         public bool WaitForProfiler;
+        public bool UseNativeMemoryAndETWProfiler;
         public Benchmarks Benchmarks;
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
     {
         public string ConnectionString;
         public bool UseManagedSniOnWindows;
+        public bool UseOptimizedAsyncBehaviour;
+        public bool WaitForProfiler;
         public Benchmarks Benchmarks;
 
         /// <summary>
@@ -43,6 +45,14 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public RunnerJob SqlBulkCopyRunnerConfig;
         public RunnerJob DataTypeReaderRunnerConfig;
         public RunnerJob DataTypeReaderAsyncRunnerConfig;
+        public RunnerJob AsyncLargeDataReadRunnerConfig;
+        public RunnerJob MarsOverheadRunnerConfig;
+        public RunnerJob ParallelAsyncConnectionRunnerConfig;
+        public RunnerJob CancellationTokenReadAsyncRunnerConfig;
+        public RunnerJob SequentialXmlReadRunnerConfig;
+        public RunnerJob JsonVsVarcharReadRunnerConfig;
+        public RunnerJob BeginTransactionRunnerConfig;
+        public RunnerJob ConnectionPoolStressRunnerConfig;
     }
 
     public class RunnerJob

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
@@ -38,4 +38,12 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
   </ItemGroup>
+
+  <!-- NativeMemoryProfiler relies on ETW and is only supported on Windows. -->
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
+  </ItemGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+    <DefineConstants>$(DefineConstants);WINDOWS</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Microsoft.Data.SqlClient.PerformanceTests.csproj
@@ -17,7 +17,7 @@
   <!-- Content files to copy to output directory -->
   <ItemGroup>
     <None Include="datatypes.json" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="runnerconfig.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="runnerconfig.jsonc" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!-- References ====================================================== -->

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
@@ -11,28 +11,70 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
     {
         private readonly Config _config;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Program"/> class, 
+        /// which loads the benchmark configuration and runs the benchmarks.
+        /// </summary>
         public Program()
         {
-            // Load config file
             _config = Config.Load();
-            if (_config.UseManagedSniOnWindows)
-            {
-                AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", true);
-            }
+            SetupConfigurations();
+            
             Run_SqlConnectionBenchmark();
             Run_SqlCommandBenchmark();
             Run_SqlBulkCopyBenchmark();
             Run_DataTypeReaderBenchmark();
             Run_DataTypeReaderAsyncBenchmark();
+            Run_AsyncLargeDataReadBenchmark();
+            Run_MarsOverheadBenchmark();
+            Run_ParallelAsyncConnectionBenchmark();
+            Run_CancellationTokenReadAsyncBenchmark();
+            Run_SequentialXmlReadBenchmark();
+            Run_JsonVsVarcharReadBenchmark();
+            Run_BeginTransactionBenchmark();
+            Run_ConnectionPoolStressBenchmark();
 
             // TODOs:
-            // Transactions
-            // Insert/Update queries (+CRUD)
             // Prepared/Regular Parameterized queries
-            // DataType Reader Max (large size / max columns / million row tables)
-            // DataType conversions (Implicit)
-            // MARS enabled
             // Always Encrypted
+        }
+
+        private void SetupConfigurations()
+        {
+            // If the config file specifies to use managed SNI on Windows, 
+            // enable the appropriate AppContext switch to use the managed SNI implementation.
+            if (_config.UseManagedSniOnWindows)
+            {
+                AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", true);
+            }
+
+            // If the config file specifies to use optimized async behavior, 
+            // enable packet multiplexing feature and other optimizations in SqlClient 
+            // by setting the appropriate AppContext switches.
+            if(_config.UseOptimizedAsyncBehaviour)
+            {
+                AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseCompatibilityAsyncBehaviour", false);
+                AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseCompatibilityProcessSni", false);
+            }
+
+            // If the config file specifies to wait for a profiler, 
+            // display the process ID and wait for user input before starting the benchmarks.
+            if (_config.WaitForProfiler)
+            {
+                int pid = System.Diagnostics.Process.GetCurrentProcess().Id;
+                Console.WriteLine();
+                Console.WriteLine("===========================================");
+                Console.WriteLine($"  Process ID: {pid}");
+                Console.WriteLine("===========================================");
+                Console.WriteLine();
+                Console.WriteLine("Attach your profiler now. Examples:");
+                Console.WriteLine($"  dotnet-counters monitor -p {pid}");
+                Console.WriteLine($"  dotnet-trace collect -p {pid}");
+                Console.WriteLine();
+                Console.WriteLine("Press any key to start benchmarks...");
+                Console.ReadKey(intercept: true);
+                Console.WriteLine();
+            }
         }
 
         private void Run_SqlConnectionBenchmark()
@@ -75,10 +117,73 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             }
         }
 
-        public static void Main()
+        private void Run_AsyncLargeDataReadBenchmark()
         {
-            // Run the benchmarks.
-            new Program();
+            if (_config.Benchmarks.AsyncLargeDataReadRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<AsyncLargeDataReadRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.AsyncLargeDataReadRunnerConfig));
+            }
         }
+
+        private void Run_MarsOverheadBenchmark()
+        {
+            if (_config.Benchmarks.MarsOverheadRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<MarsOverheadRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.MarsOverheadRunnerConfig));
+            }
+        }
+
+        private void Run_ParallelAsyncConnectionBenchmark()
+        {
+            if (_config.Benchmarks.ParallelAsyncConnectionRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<ParallelAsyncConnectionRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.ParallelAsyncConnectionRunnerConfig));
+            }
+        }
+
+        private void Run_CancellationTokenReadAsyncBenchmark()
+        {
+            if (_config.Benchmarks.CancellationTokenReadAsyncRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<CancellationTokenReadAsyncRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.CancellationTokenReadAsyncRunnerConfig));
+            }
+        }
+
+        private void Run_SequentialXmlReadBenchmark()
+        {
+            if (_config.Benchmarks.SequentialXmlReadRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<SequentialXmlReadRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.SequentialXmlReadRunnerConfig));
+            }
+        }
+
+        private void Run_JsonVsVarcharReadBenchmark()
+        {
+            if (_config.Benchmarks.JsonVsVarcharReadRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<JsonVsVarcharReadRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.JsonVsVarcharReadRunnerConfig));
+            }
+        }
+
+        private void Run_BeginTransactionBenchmark()
+        {
+            if (_config.Benchmarks.BeginTransactionRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<BeginTransactionRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.BeginTransactionRunnerConfig));
+            }
+        }
+
+        private void Run_ConnectionPoolStressBenchmark()
+        {
+            if (_config.Benchmarks.ConnectionPoolStressRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<ConnectionPoolStressRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.ConnectionPoolStressRunnerConfig));
+            }
+        }
+
+        /// <summary>
+        /// The main entry point for the performance tests program.
+        /// </summary>
+        public static void Main() => _ = new Program();
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
@@ -57,6 +57,11 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
                 AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseCompatibilityProcessSni", false);
             }
 
+            // If the config file specifies to use the NativeMemoryProfiler and ETW profiler,
+            // propagate the setting to BenchmarkConfig so it can attach these Windows-only
+            // diagnosers when building each benchmark's ManualConfig.
+            BenchmarkConfig.UseNativeMemoryAndEtwProfiler = _config.UseNativeMemoryAndETWProfiler;
+
             // If the config file specifies to wait for a profiler, 
             // display the process ID and wait for user input before starting the benchmarks.
             if (_config.WaitForProfiler)

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.json
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.json
@@ -1,9 +1,11 @@
 ﻿{
     "ConnectionString": "Server=tcp:localhost; Integrated Security=true; Initial Catalog=sqlclient-perf-db;",
     "UseManagedSniOnWindows": false,
+    "UseOptimizedAsyncBehaviour": true,
+    "WaitForProfiler": false,
     "Benchmarks": {
         "SqlConnectionRunnerConfig": {
-            "Enabled": true,
+            "Enabled": false,
             "LaunchCount": 1,
             "IterationCount": 50,
             "InvocationCount":30,
@@ -11,7 +13,7 @@
             "RowCount": 0
         },
         "SqlCommandRunnerConfig": {
-            "Enabled": true,
+            "Enabled": false,
             "LaunchCount": 1,
             "IterationCount": 10,
             "InvocationCount": 2,
@@ -19,7 +21,7 @@
             "RowCount": 10000
         },
         "SqlBulkCopyRunnerConfig": {
-            "Enabled": true,
+            "Enabled": false,
             "LaunchCount": 1,
             "IterationCount": 10,
             "InvocationCount": 1,
@@ -27,7 +29,7 @@
             "RowCount": 10000
         },
         "DataTypeReaderRunnerConfig": {
-            "Enabled": true,
+            "Enabled": false,
             "LaunchCount": 1,
             "IterationCount": 20,
             "InvocationCount": 2,
@@ -35,12 +37,76 @@
             "RowCount": 1000
         },
         "DataTypeReaderAsyncRunnerConfig": {
-            "Enabled": true,
+            "Enabled": false,
             "LaunchCount": 1,
             "IterationCount": 20,
             "InvocationCount": 2,
             "WarmupCount": 1,
             "RowCount": 1000
+        },
+        "AsyncLargeDataReadRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 10,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 0
+        },
+        "MarsOverheadRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 10,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 1000
+        },
+        "ParallelAsyncConnectionRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 10,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 0
+        },
+        "CancellationTokenReadAsyncRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 10,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 10000
+        },
+        "SequentialXmlReadRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 10,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 0
+        },
+        "JsonVsVarcharReadRunnerConfig": {
+            "Enabled": false,
+            "LaunchCount": 1,
+            "IterationCount": 10,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 10000
+        },
+        "BeginTransactionRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 10,
+            "InvocationCount": 2,
+            "WarmupCount": 1,
+            "RowCount": 0
+        },
+        "ConnectionPoolStressRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 5,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 0
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
@@ -6,8 +6,14 @@
     // This is useful for benchmarking packet multiplexing and async performance improvements.
     "UseOptimizedAsyncBehaviour": true,
     // Enable this flag to get prompted to attach a profiler when running the performance tests.
-    // This is useful for capturing event source traces when running a performance test.
+    // This is useful for capturing event source traces when running a performance test on all OSes.
+    // Note: This flag is not required on Windows as the ETW profiler is automatically attached 
+    // when running the performance tests on Windows.
     "WaitForProfiler": false,
+    // Enable this flag to enable the NativeMemoryProfiler and ETW profiler on Windows (only).
+    // This is useful for capturing native memory allocation traces when running a performance test on Windows.
+    // Note: This flag cannot be enabled on non-Windows OSes as the NativeMemoryProfiler is not supported on non-Windows OSes.
+    "UseNativeMemoryAndETWProfiler": false,
     // This section contains the configuration for each benchmark.
     // You can enable/disable benchmarks and configure the number of iterations, invocations, 
     // warmup runs, and row count for each benchmark.

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
@@ -6,9 +6,8 @@
     // This is useful for benchmarking packet multiplexing and async performance improvements.
     "UseOptimizedAsyncBehaviour": true,
     // Enable this flag to get prompted to attach a profiler when running the performance tests.
-    // This is useful for capturing event source traces when running a performance test on all OSes.
-    // Note: This flag is not required on Windows as the ETW profiler is automatically attached 
-    // when running the performance tests on Windows.
+    // This is useful for capturing event source traces when running a performance test on any OS.
+    // On Windows, you can also set UseNativeMemoryAndETWProfiler=true to attach ETW diagnosers automatically.
     "WaitForProfiler": false,
     // Enable this flag to enable the NativeMemoryProfiler and ETW profiler on Windows (only).
     // This is useful for capturing native memory allocation traces when running a performance test on Windows.

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
@@ -1,11 +1,19 @@
 ﻿{
     "ConnectionString": "Server=tcp:localhost; Integrated Security=true; Initial Catalog=sqlclient-perf-db;",
+    // Enable this flag to enable managed SNI on Windows.
     "UseManagedSniOnWindows": false,
+    // Enable this flag to enable optimized async behavior in SqlClient. 
+    // This is useful for benchmarking packet multiplexing and async performance improvements.
     "UseOptimizedAsyncBehaviour": true,
+    // Enable this flag to get prompted to attach a profiler when running the performance tests.
+    // This is useful for capturing event source traces when running a performance test.
     "WaitForProfiler": false,
+    // This section contains the configuration for each benchmark.
+    // You can enable/disable benchmarks and configure the number of iterations, invocations, 
+    // warmup runs, and row count for each benchmark.
     "Benchmarks": {
         "SqlConnectionRunnerConfig": {
-            "Enabled": false,
+            "Enabled": true,
             "LaunchCount": 1,
             "IterationCount": 50,
             "InvocationCount":30,
@@ -13,23 +21,23 @@
             "RowCount": 0
         },
         "SqlCommandRunnerConfig": {
-            "Enabled": false,
+            "Enabled": true,
             "LaunchCount": 1,
-            "IterationCount": 10,
+            "IterationCount": 20,
             "InvocationCount": 2,
             "WarmupCount": 1,
             "RowCount": 10000
         },
         "SqlBulkCopyRunnerConfig": {
-            "Enabled": false,
+            "Enabled": true,
             "LaunchCount": 1,
-            "IterationCount": 10,
+            "IterationCount": 20,
             "InvocationCount": 1,
             "WarmupCount": 1,
             "RowCount": 10000
         },
         "DataTypeReaderRunnerConfig": {
-            "Enabled": false,
+            "Enabled": true,
             "LaunchCount": 1,
             "IterationCount": 20,
             "InvocationCount": 2,
@@ -37,7 +45,7 @@
             "RowCount": 1000
         },
         "DataTypeReaderAsyncRunnerConfig": {
-            "Enabled": false,
+            "Enabled": true,
             "LaunchCount": 1,
             "IterationCount": 20,
             "InvocationCount": 2,
@@ -47,7 +55,7 @@
         "AsyncLargeDataReadRunnerConfig": {
             "Enabled": true,
             "LaunchCount": 1,
-            "IterationCount": 10,
+            "IterationCount": 20,
             "InvocationCount": 1,
             "WarmupCount": 1,
             "RowCount": 0
@@ -55,7 +63,7 @@
         "MarsOverheadRunnerConfig": {
             "Enabled": true,
             "LaunchCount": 1,
-            "IterationCount": 10,
+            "IterationCount": 20,
             "InvocationCount": 1,
             "WarmupCount": 1,
             "RowCount": 1000
@@ -63,7 +71,7 @@
         "ParallelAsyncConnectionRunnerConfig": {
             "Enabled": true,
             "LaunchCount": 1,
-            "IterationCount": 10,
+            "IterationCount": 20,
             "InvocationCount": 1,
             "WarmupCount": 1,
             "RowCount": 0
@@ -71,7 +79,7 @@
         "CancellationTokenReadAsyncRunnerConfig": {
             "Enabled": true,
             "LaunchCount": 1,
-            "IterationCount": 10,
+            "IterationCount": 20,
             "InvocationCount": 1,
             "WarmupCount": 1,
             "RowCount": 10000
@@ -79,7 +87,7 @@
         "SequentialXmlReadRunnerConfig": {
             "Enabled": true,
             "LaunchCount": 1,
-            "IterationCount": 10,
+            "IterationCount": 20,
             "InvocationCount": 1,
             "WarmupCount": 1,
             "RowCount": 0
@@ -87,15 +95,15 @@
         "JsonVsVarcharReadRunnerConfig": {
             "Enabled": false,
             "LaunchCount": 1,
-            "IterationCount": 10,
+            "IterationCount": 100,
             "InvocationCount": 1,
-            "WarmupCount": 1,
+            "WarmupCount": 5,
             "RowCount": 10000
         },
         "BeginTransactionRunnerConfig": {
             "Enabled": true,
             "LaunchCount": 1,
-            "IterationCount": 10,
+            "IterationCount": 20,
             "InvocationCount": 2,
             "WarmupCount": 1,
             "RowCount": 0
@@ -103,7 +111,7 @@
         "ConnectionPoolStressRunnerConfig": {
             "Enabled": true,
             "LaunchCount": 1,
-            "IterationCount": 5,
+            "IterationCount": 20,
             "InvocationCount": 1,
             "WarmupCount": 1,
             "RowCount": 0


### PR DESCRIPTION
### Summary
Adds 8 `BenchmarkDotNet` runners to `Microsoft.Data.SqlClient.PerformanceTests` covering previously-reported hot spots, plus config/wiring updates to support them.

### New runners
| Runner | Purpose | Issues |
|---|---|---|
| AsyncLargeDataReadRunner.cs | Sync vs async reads of large `VARBINARY(MAX)` (1–20 MB) | #593, #1562 |
| MarsOverheadRunner.cs | Query execution with MARS on/off | #422, #1283 |
| ParallelAsyncConnectionRunner.cs | Concurrent `OpenAsync` (10/50/100), pooling on/off | #601, #979 |
| CancellationTokenReadAsyncRunner.cs | `CancellationToken` overhead in `ReadAsync` | #2408 |
| SequentialXmlReadRunner.cs | `SequentialAccess` XML reads at increasing sizes (O(N²) check) | #1877 |
| JsonVsVarcharReadRunner.cs | `JSON` vs `VARCHAR(MAX)` reads (disabled by default, needs SQL 2025+) | #3499 |
| BeginTransactionRunner.cs | `BeginTransaction`/`Async` latency vs baseline | #1554 |
| ConnectionPoolStressRunner.cs | Pool stress: churn, random hold, mixed sync/async, reuse, exhaustion/recovery (Parallelism {10,20,25} × MaxPoolSize {50,100}) | #601, #979, #3356 |

### Supporting changes
- Program.cs — registers new runners, gated by `RunnerJob.Enabled`
- Config/Config.cs — new config fields + `RunnerJob` per runner
- Config/BenchmarkConfig.cs — `DontOverwriteResults`, `JoinSummary`, `COMPlus_gcServer=1`
- runnerconfig.jsonc — entries added for new runners (JSON runner off by default), and new configuration options.

### Validation
Ran all new runners locally (.NET 9.0 Release, Apple M3 Pro, Docker `azure-sql-edge`) — all completed successfully.

### Checklist
- [x] Tests added (perf runners)
- [x] No public API changes
- [x] Verified against SQL Server
- [x] No breaking changes