### PR TITLE
Expand connection pool benchmark coverage for ChannelDbConnectionPool

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolChurnRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolChurnRunner.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Measures the raw per-checkout overhead of the connection pool: a single thread
+    /// repeatedly opens and closes a connection against a warm pool, with no contention.
+    ///
+    /// With only one caller and a pre-warmed pool, every open is a pure pool checkout
+    /// (no physical connect, no waiting), so this benchmark isolates the CPU and
+    /// allocation cost of the pool's acquire/return path itself. It is the low-noise
+    /// counterpart to the parallel and contention runners and is the most sensitive
+    /// measure of per-operation allocations (watch the Allocated / Gen0 columns) — a key
+    /// concern for the new ChannelDbConnectionPool, which aims to avoid extra allocations
+    /// on the hot path (issue #3356).
+    ///
+    /// The pool implementation (legacy vs V2) is a process-level choice — see the remarks
+    /// on <see cref="ConnectionPoolStressRunner"/>. Run twice (UseConnectionPoolV2 false
+    /// then true) to compare.
+    ///
+    /// Related issue: #3356
+    /// </summary>
+    public class ConnectionPoolChurnRunner : BaseRunner
+    {
+        public enum AsyncBehavior
+        {
+            Sync,
+            Async
+        }
+
+        /// <summary>
+        /// Whether the connection is opened synchronously or asynchronously.
+        /// </summary>
+        [ParamsAllValues]
+        public AsyncBehavior Async { get; set; }
+
+        /// <summary>
+        /// Number of sequential open/close operations performed per invocation. Kept high
+        /// so each measured invocation captures many pool checkouts, yielding a stable
+        /// per-operation cost.
+        /// </summary>
+        [Params(1000)]
+        public int OpsPerInvocation { get; set; }
+
+        private string _connectionString;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            Console.WriteLine(
+                "[ConnectionPoolChurnRunner] Pool implementation: " +
+                (s_config.UseConnectionPoolV2
+                    ? "ChannelDbConnectionPool (V2)"
+                    : "WaitHandleDbConnectionPool (legacy)"));
+
+            var builder = new SqlConnectionStringBuilder(s_config.ConnectionString)
+            {
+                Pooling = true,
+                MaxPoolSize = 100,
+                // Pre-warm a single connection so the very first checkout is served from
+                // the pool rather than establishing a physical connection.
+                MinPoolSize = 1
+            };
+            _connectionString = builder.ConnectionString;
+
+            // Force the pool to exist and hold at least one idle connection.
+            using var warm = new SqlConnection(_connectionString);
+            warm.Open();
+            warm.Close();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            SqlConnection.ClearPool(conn);
+        }
+
+        [Benchmark]
+        public async Task RapidOpenCloseSingleThread()
+        {
+            for (int i = 0; i < OpsPerInvocation; i++)
+            {
+                using var conn = new SqlConnection(_connectionString);
+
+                if (Async is AsyncBehavior.Async)
+                {
+                    await conn.OpenAsync();
+                }
+                else
+                {
+                    conn.Open();
+                }
+                // Dispose returns the connection to the pool.
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Measures steady-state pool throughput under concurrent load — the hot path for
+    /// real applications such as web servers, where many workers repeatedly check a
+    /// connection out of a warm pool, do a small unit of work, and return it.
+    ///
+    /// This is where the legacy WaitHandleDbConnectionPool and the new
+    /// ChannelDbConnectionPool differ most (issue #3356):
+    ///
+    /// - When the pool is large enough to serve every worker, the benchmark isolates
+    ///   checkout/return overhead and lock contention on the hot path.
+    /// - When the pool is smaller than the worker count (<see cref="MaxPoolSize"/> less
+    ///   than <see cref="Parallelism"/>), workers must wait for a connection to be
+    ///   returned. This exercises the waiter wake path: the legacy pool parks on
+    ///   WaitHandle.WaitAny (a blocking wait that consumes a threadpool thread for async
+    ///   callers), while the new pool awaits the idle channel asynchronously. The
+    ///   ThreadingDiagnoser's "Completed Work Items" and "Lock Contentions" columns make
+    ///   the difference visible.
+    ///
+    /// The pool implementation (legacy vs V2) and SNI are process-level choices — see the
+    /// remarks on <see cref="ConnectionPoolStressRunner"/>. Run twice (UseConnectionPoolV2
+    /// false then true) to compare.
+    ///
+    /// Related issues: #601, #979, #3356
+    /// </summary>
+    public class ConnectionPoolContentionRunner : BaseRunner
+    {
+        public enum AsyncBehavior
+        {
+            Sync,
+            Async
+        }
+
+        /// <summary>
+        /// Whether workers check connections out synchronously or asynchronously.
+        /// </summary>
+        [ParamsAllValues]
+        public AsyncBehavior Async { get; set; }
+
+        /// <summary>
+        /// Number of concurrent workers competing for pooled connections.
+        /// </summary>
+        [Params(50)]
+        public int Parallelism { get; set; }
+
+        /// <summary>
+        /// Maximum pool size. A value greater than or equal to <see cref="Parallelism"/>
+        /// means no contention for physical connections; a smaller value forces workers to
+        /// wait for connections to be returned (pool exhaustion / back-pressure).
+        /// </summary>
+        [Params(50, 10)]
+        public int MaxPoolSize { get; set; }
+
+        /// <summary>
+        /// Number of open/query/close operations each worker performs per invocation.
+        /// </summary>
+        [Params(20)]
+        public int OpsPerWorker { get; set; }
+
+        private string _connectionString;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            Console.WriteLine(
+                "[ConnectionPoolContentionRunner] Pool implementation: " +
+                (s_config.UseConnectionPoolV2
+                    ? "ChannelDbConnectionPool (V2)"
+                    : "WaitHandleDbConnectionPool (legacy)"));
+
+            var builder = new SqlConnectionStringBuilder(s_config.ConnectionString)
+            {
+                Pooling = true,
+                MaxPoolSize = MaxPoolSize,
+                MinPoolSize = 0
+            };
+            _connectionString = builder.ConnectionString;
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            // Warm the pool up to MaxPoolSize so the measured run reflects steady-state
+            // checkout/return rather than first-time physical connection establishment.
+            WarmPool(MaxPoolSize);
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            SqlConnection.ClearPool(conn);
+        }
+
+        [Benchmark]
+        public async Task SteadyStateOpenQueryClose()
+        {
+            var tasks = new Task[Parallelism];
+            for (int i = 0; i < Parallelism; i++)
+            {
+                tasks[i] = Task.Run(async () =>
+                {
+                    for (int op = 0; op < OpsPerWorker; op++)
+                    {
+                        using var conn = new SqlConnection(_connectionString);
+
+                        if (Async is AsyncBehavior.Async)
+                        {
+                            await conn.OpenAsync();
+                            using var cmd = conn.CreateCommand();
+                            cmd.CommandText = "SELECT 1";
+                            _ = await cmd.ExecuteScalarAsync();
+                        }
+                        else
+                        {
+                            conn.Open();
+                            using var cmd = conn.CreateCommand();
+                            cmd.CommandText = "SELECT 1";
+                            _ = cmd.ExecuteScalar();
+                        }
+                        // Dispose returns the connection to the pool.
+                    }
+                });
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        private void WarmPool(int count)
+        {
+            var conns = new SqlConnection[count];
+            for (int i = 0; i < count; i++)
+            {
+                conns[i] = new SqlConnection(_connectionString);
+                conns[i].Open();
+            }
+            // Return them all to the pool so subsequent checkouts are served from idle.
+            for (int i = 0; i < count; i++)
+            {
+                conns[i].Close();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
@@ -3,281 +3,184 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace Microsoft.Data.SqlClient.PerformanceTests
 {
     /// <summary>
-    /// Stress-tests the connection pool with randomized parallel access patterns:
-    /// - Massive concurrent open/close churn
-    /// - Randomized hold durations simulating real workloads
-    /// - Mixed sync/async callers competing for pooled connections
-    /// - Connection reuse with interleaved queries
-    /// - Pool exhaustion and recovery under pressure
+    /// Captures benchmarks for SqlConnection pool checkout throughput across a matrix of:
+    /// - Warm vs. cold pools
+    /// - Sync vs. async callers
+    /// - Native vs. managed SNI (Windows-only distinction)
+    /// - Disabled, new (V2), and legacy pooling implementations
     ///
     /// Related issues: #601, #979, #3356
     /// </summary>
     public class ConnectionPoolStressRunner : BaseRunner
     {
+        public enum PoolBehavior
+        {
+            Disabled,
+            New,
+            Legacy
+        }
+
+        public enum AsyncBehavior
+        {
+            Sync,
+            Async
+        }
+
+        public enum SniBehavior
+        {
+            Native,
+            Managed
+        }
+
+        /// <summary>
+        /// Whether the pool is pre-warmed before the measured run.
+        /// </summary>
+        [ParamsAllValues]
+        public bool PoolIsWarm { get; set; }
+
+        /// <summary>
+        /// Whether callers open connections synchronously or asynchronously.
+        /// </summary>
+        [ParamsAllValues]
+        public AsyncBehavior Async { get; set; }
+
+        /// <summary>
+        /// Whether to use native or managed SNI. Only meaningful on Windows;
+        /// managed SNI is always used on non-Windows platforms.
+        /// </summary>
+        [ParamsAllValues]
+        public SniBehavior Sni { get; set; }
+
+        /// <summary>
+        /// Number of connections opened in parallel per iteration.
+        /// </summary>
+        [Params(100)]
+        public int NumConnectionsToOpen { get; set; }
+
+        /// <summary>
+        /// Which pooling implementation to exercise.
+        /// </summary>
+        [ParamsAllValues]
+        public PoolBehavior Pooling { get; set; }
+
         private string _connectionString;
-        private string _tableName;
-
-        /// <summary>
-        /// Number of concurrent tasks hammering the pool.
-        /// </summary>
-        [Params(10, 20, 25)]
-        public int Parallelism { get; set; }
-
-        /// <summary>
-        /// Max pool size — controls how many physical connections the pool can hold.
-        /// When Parallelism exceeds this, tasks must wait for a free connection.
-        /// </summary>
-        [Params(50, 100)]
-        public int MaxPoolSize { get; set; }
+        private SqlConnectionStringBuilder _connectionStringBuilder = new();
+        private IProducerConsumerCollection<SqlConnection> _connections = new ConcurrentBag<SqlConnection>();
 
         [GlobalSetup]
         public void Setup()
         {
-            _connectionString = s_config.ConnectionString +
-                $";Pooling=True;Max Pool Size={MaxPoolSize};Min Pool Size=5;Connect Timeout=60";
+            _connectionString = s_config.ConnectionString;
+        }
 
-            // Create a small table for query workloads.
-            // Hash the machine name instead of using it verbatim: hostnames can be long enough
-            // to push the identifier past SQL Server's 128-character limit. Cast to uint rather
-            // than using Math.Abs, which throws OverflowException when the hash is int.MinValue.
-            string machineHash = ((uint)Environment.MachineName.GetHashCode()).ToString("x8");
-            _tableName = $"[perf_PoolStress_{machineHash}_{Guid.NewGuid():N}]";
-            using var conn = new SqlConnection(_connectionString);
-            conn.Open();
-            using var cmd = new SqlCommand(
-                $"CREATE TABLE {_tableName} (Id INT IDENTITY PRIMARY KEY, Val INT)", conn);
-            cmd.ExecuteNonQuery();
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _connections = new ConcurrentBag<SqlConnection>();
+            _connectionStringBuilder = new SqlConnectionStringBuilder(_connectionString)
+            {
+                MaxPoolSize = 1000,
+                WorkstationID = Guid.NewGuid().ToString(),
+                Pooling = Pooling is not PoolBehavior.Disabled
+            };
 
-            // Seed a few rows so SELECT queries return data
-            using var insert = new SqlCommand(
-                $"INSERT INTO {_tableName} (Val) VALUES (1),(2),(3),(4),(5)", conn);
-            insert.ExecuteNonQuery();
+            // PoolBehavior.New opts into the ChannelDbConnectionPool (V2) implementation;
+            // the default (false) uses the legacy pool.
+            AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseConnectionPoolV2", Pooling is PoolBehavior.New);
+            AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", Sni is SniBehavior.Managed);
+
+            if (PoolIsWarm)
+            {
+                OpenConnectionsInParallel(_connectionStringBuilder.ConnectionString, NumConnectionsToOpen);
+            }
         }
 
         [IterationCleanup]
-        public void IterationCleanup()
-        {
-            SqlConnection.ClearAllPools();
-        }
-
-        [GlobalCleanup]
         public void Cleanup()
         {
-            using var conn = new SqlConnection(_connectionString);
-            conn.Open();
-            using var cmd = new SqlCommand($"DROP TABLE IF EXISTS {_tableName}", conn);
-            cmd.ExecuteNonQuery();
-            conn.Close();
-            SqlConnection.ClearAllPools();
-        }
-
-        /// <summary>
-        /// Pure open/close churn — every task opens a pooled connection, immediately closes it,
-        /// and repeats. Measures raw pool checkout/return throughput under contention.
-        /// </summary>
-        [Benchmark]
-        public async Task RapidFireOpenClose()
-        {
-            var tasks = new Task[Parallelism];
-            for (int i = 0; i < Parallelism; i++)
+            // Shut down the pool so that connections are physically closed
+            // when they are returned to the pool.
+            if (_connections.TryTake(out var first))
             {
-                tasks[i] = Task.Run(async () =>
+                first.Close();
+
+                while (_connections.TryTake(out var conn))
                 {
-                    for (int j = 0; j < 20; j++)
-                    {
-                        using var conn = new SqlConnection(_connectionString);
-                        await conn.OpenAsync();
-                        // immediate return to pool
-                    }
-                });
-            }
-            await Task.WhenAll(tasks);
-        }
-
-        /// <summary>
-        /// Randomized hold — each task opens a connection, holds it for a random duration
-        /// (0-50ms), optionally runs a query, then returns it. Simulates realistic mixed
-        /// workloads where some connections are held briefly and others longer.
-        /// </summary>
-        [Benchmark]
-        public async Task RandomizedHoldAndQuery()
-        {
-            var tasks = new Task[Parallelism];
-            for (int i = 0; i < Parallelism; i++)
-            {
-                int seed = i;
-                tasks[i] = Task.Run(async () =>
-                {
-                    var rng = new Random(seed);
-                    for (int j = 0; j < 10; j++)
-                    {
-                        using var conn = new SqlConnection(_connectionString);
-                        await conn.OpenAsync();
-
-                        // ~50% of the time, execute a lightweight query while holding the connection
-                        if (rng.Next(2) == 0)
-                        {
-                            using var cmd = new SqlCommand($"SELECT TOP 1 Val FROM {_tableName}", conn);
-                            _ = await cmd.ExecuteScalarAsync();
-                        }
-
-                        // Random hold time: 0-50ms
-                        int holdMs = rng.Next(51);
-                        if (holdMs > 0)
-                        {
-                            await Task.Delay(holdMs);
-                        }
-                    }
-                });
-            }
-            await Task.WhenAll(tasks);
-        }
-
-        /// <summary>
-        /// Mixed sync and async — half the tasks use sync Open/ExecuteReader,
-        /// the other half use async. Stresses the pool lock paths that differ
-        /// between sync and async checkout.
-        /// </summary>
-        [Benchmark]
-        public async Task MixedSyncAsyncContention()
-        {
-            var tasks = new Task[Parallelism];
-            for (int i = 0; i < Parallelism; i++)
-            {
-                bool useAsync = i % 2 == 0;
-                tasks[i] = Task.Run(async () =>
-                {
-                    for (int j = 0; j < 10; j++)
-                    {
-                        using var conn = new SqlConnection(_connectionString);
-                        if (useAsync)
-                        {
-                            await conn.OpenAsync();
-                            using var cmd = new SqlCommand($"SELECT COUNT(*) FROM {_tableName}", conn);
-                            _ = await cmd.ExecuteScalarAsync();
-                        }
-                        else
-                        {
-                            conn.Open();
-                            using var cmd = new SqlCommand($"SELECT COUNT(*) FROM {_tableName}", conn);
-                            _ = cmd.ExecuteScalar();
-                        }
-                    }
-                });
-            }
-            await Task.WhenAll(tasks);
-        }
-
-        /// <summary>
-        /// Connection reuse with multiple commands — each task opens one connection and
-        /// executes many sequential queries before returning it. Measures pool efficiency
-        /// when connections are held for multi-step operations (like EF SaveChanges).
-        /// </summary>
-        [Benchmark]
-        public async Task MultiCommandReuse()
-        {
-            var tasks = new Task[Parallelism];
-            for (int i = 0; i < Parallelism; i++)
-            {
-                int seed = i;
-                tasks[i] = Task.Run(async () =>
-                {
-                    var rng = new Random(seed);
-                    using var conn = new SqlConnection(_connectionString);
-                    await conn.OpenAsync();
-
-                    // Execute a burst of 5-15 commands on the same connection
-                    int commandCount = rng.Next(5, 16);
-                    for (int c = 0; c < commandCount; c++)
-                    {
-                        using var cmd = new SqlCommand($"SELECT Val FROM {_tableName} WHERE Id = @id", conn);
-                        cmd.Parameters.AddWithValue("@id", rng.Next(1, 6));
-                        using var reader = await cmd.ExecuteReaderAsync();
-                        while (await reader.ReadAsync()) { }
-                    }
-                });
-            }
-            await Task.WhenAll(tasks);
-        }
-
-        /// <summary>
-        /// Pool exhaustion and recovery — spawns more tasks than MaxPoolSize so some must
-        /// wait. Measures how well the pool handles back-pressure when all connections are
-        /// checked out and callers are queued.
-        /// </summary>
-        [Benchmark]
-        public async Task PoolExhaustionRecovery()
-        {
-            // Ensure we exceed pool capacity
-            int taskCount = Math.Max(Parallelism, MaxPoolSize * 2);
-            var tasks = new Task[taskCount];
-            for (int i = 0; i < taskCount; i++)
-            {
-                int seed = i;
-                tasks[i] = Task.Run(async () =>
-                {
-                    var rng = new Random(seed);
-                    using var conn = new SqlConnection(_connectionString);
-                    await conn.OpenAsync();
-
-                    // Hold the connection for 10-100ms to create pool pressure
-                    using var cmd = new SqlCommand($"SELECT TOP 1 Val FROM {_tableName}", conn);
-                    _ = await cmd.ExecuteScalarAsync();
-
-                    await Task.Delay(rng.Next(10, 101));
-                });
-            }
-            await Task.WhenAll(tasks);
-        }
-
-        /// <summary>
-        /// Bursty traffic pattern — sends waves of connections with pauses between bursts,
-        /// simulating real web server traffic patterns where requests cluster.
-        /// </summary>
-        [Benchmark]
-        public async Task BurstyTrafficPattern()
-        {
-            int burstCount = 5;
-            int tasksPerBurst = Parallelism / burstCount;
-            if (tasksPerBurst < 1)
-            {
-                tasksPerBurst = 1;
-            }
-
-            for (int burst = 0; burst < burstCount; burst++)
-            {
-                var tasks = new Task[tasksPerBurst];
-                for (int i = 0; i < tasksPerBurst; i++)
-                {
-                    int seed = burst * tasksPerBurst + i;
-                    tasks[i] = Task.Run(async () =>
-                    {
-                        var rng = new Random(seed);
-                        using var conn = new SqlConnection(_connectionString);
-                        await conn.OpenAsync();
-
-                        // Each connection in the burst does 1-5 queries
-                        int queryCount = rng.Next(1, 6);
-                        for (int q = 0; q < queryCount; q++)
-                        {
-                            using var cmd = new SqlCommand($"SELECT Val FROM {_tableName}", conn);
-                            using var reader = await cmd.ExecuteReaderAsync();
-                            while (await reader.ReadAsync()) { }
-                        }
-                    });
+                    conn.Close();
                 }
-                await Task.WhenAll(tasks);
 
-                // Brief pause between bursts (simulates request clustering)
-                await Task.Delay(5);
+                SqlConnection.ClearPool(first);
             }
+        }
+
+        [Benchmark]
+        public int ConnectionPoolWarmupBenchmark()
+        {
+            return OpenConnectionsInParallel(
+                _connectionStringBuilder.ConnectionString,
+                NumConnectionsToOpen,
+                runCommand: false,
+                returnToPool: false);
+        }
+
+        private int OpenConnectionsInParallel(
+            string connectionString,
+            int numConnectionsToOpen,
+            bool runCommand = false,
+            bool returnToPool = true)
+        {
+            var tasks = new Task[numConnectionsToOpen];
+
+            for (int i = 0; i < numConnectionsToOpen; i++)
+            {
+                tasks[i] = Task.Run(async () =>
+                {
+                    var conn = new SqlConnection(connectionString);
+
+                    if (Async is AsyncBehavior.Async)
+                    {
+                        await conn.OpenAsync(SqlConnectionOverrides.OpenWithoutRetry, CancellationToken.None);
+                    }
+                    else
+                    {
+                        conn.Open(SqlConnectionOverrides.OpenWithoutRetry);
+                    }
+
+                    if (runCommand)
+                    {
+                        using var command = conn.CreateCommand();
+                        command.CommandText = "SELECT 1";
+                        command.CommandType = System.Data.CommandType.Text;
+
+                        int result = Async is AsyncBehavior.Async
+                            ? (int)(await command.ExecuteScalarAsync() ?? 0)
+                            : (int)(command.ExecuteScalar() ?? 0);
+
+                        if (result != 1)
+                        {
+                            throw new Exception("Unexpected result from command");
+                        }
+                    }
+
+                    _connections.TryAdd(conn);
+
+                    if (returnToPool)
+                    {
+                        conn.Close();
+                    }
+                });
+            }
+
+            Task.WaitAll(tasks);
+            return tasks.Length;
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolStressRunner.cs
@@ -11,37 +11,47 @@ using BenchmarkDotNet.Attributes;
 namespace Microsoft.Data.SqlClient.PerformanceTests
 {
     /// <summary>
-    /// Captures benchmarks for SqlConnection pool checkout throughput across a matrix of:
-    /// - Warm vs. cold pools
-    /// - Sync vs. async callers
-    /// - Native vs. managed SNI (Windows-only distinction)
-    /// - Disabled, new (V2), and legacy pooling implementations
+    /// Measures the throughput of opening connections in parallel — the core scenario
+    /// the channel-based connection pool (ChannelDbConnectionPool / UseConnectionPoolV2)
+    /// is designed to improve (see issue #3356). The design goals are parallel connection
+    /// opening, reduced thread contention, and lower managed threadpool pressure, so this
+    /// runner sweeps the dimensions that expose those characteristics:
+    ///
+    /// - <see cref="PoolIsWarm"/>: cold pool (physical connects dominate) vs. warm pool
+    ///   (checkout throughput dominates). The warm-pool case is where the new pool shows
+    ///   the largest wins.
+    /// - <see cref="Async"/>: sync vs. async callers. The new pool follows async best
+    ///   practices, so async checkout is a primary target for improvement.
+    /// - <see cref="Pooling"/>: pooling on vs. off. Pooling off is the no-pool baseline.
+    /// - <see cref="NumConnectionsToOpen"/>: how many connections are opened in parallel.
+    ///
+    /// The pool implementation itself (legacy WaitHandleDbConnectionPool vs. new
+    /// ChannelDbConnectionPool) is NOT a benchmark parameter. The UseConnectionPoolV2
+    /// AppContext switch is read and cached the first time a pool is created, and every
+    /// benchmark case runs in the same process under the in-process toolchain, so the
+    /// implementation cannot be toggled per iteration. It is selected once per process via
+    /// the "UseConnectionPoolV2" flag in runnerconfig.jsonc. To compare the two pools, run
+    /// the benchmark twice: once with UseConnectionPoolV2=false (legacy) and once with
+    /// UseConnectionPoolV2=true (new). Likewise, native vs. managed SNI is selected once
+    /// per process via the "UseManagedSniOnWindows" config flag (Windows-only).
+    ///
+    /// Pair this with the ThreadingDiagnoser (enabled in BenchmarkConfig) to observe
+    /// threadpool completed-work-item counts and lock contention across the two pools.
     ///
     /// Related issues: #601, #979, #3356
     /// </summary>
     public class ConnectionPoolStressRunner : BaseRunner
     {
-        public enum PoolBehavior
-        {
-            Disabled,
-            New,
-            Legacy
-        }
-
         public enum AsyncBehavior
         {
             Sync,
             Async
         }
 
-        public enum SniBehavior
-        {
-            Native,
-            Managed
-        }
-
         /// <summary>
-        /// Whether the pool is pre-warmed before the measured run.
+        /// Whether the pool is pre-warmed (connections opened and returned) before the
+        /// measured run. A warm pool isolates checkout/return throughput; a cold pool
+        /// includes the cost of establishing physical connections.
         /// </summary>
         [ParamsAllValues]
         public bool PoolIsWarm { get; set; }
@@ -53,61 +63,63 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public AsyncBehavior Async { get; set; }
 
         /// <summary>
-        /// Whether to use native or managed SNI. Only meaningful on Windows;
-        /// managed SNI is always used on non-Windows platforms.
+        /// Whether connection pooling is enabled. When disabled, every open establishes a
+        /// new physical connection — the no-pool baseline.
         /// </summary>
-        [ParamsAllValues]
-        public SniBehavior Sni { get; set; }
+        [Params(true, false)]
+        public bool Pooling { get; set; }
 
         /// <summary>
-        /// Number of connections opened in parallel per iteration.
+        /// Number of connections opened in parallel per measured invocation.
         /// </summary>
         [Params(100)]
         public int NumConnectionsToOpen { get; set; }
 
-        /// <summary>
-        /// Which pooling implementation to exercise.
-        /// </summary>
-        [ParamsAllValues]
-        public PoolBehavior Pooling { get; set; }
-
         private string _connectionString;
-        private SqlConnectionStringBuilder _connectionStringBuilder = new();
         private IProducerConsumerCollection<SqlConnection> _connections = new ConcurrentBag<SqlConnection>();
 
         [GlobalSetup]
         public void Setup()
         {
-            _connectionString = s_config.ConnectionString;
+            // Report which pool implementation is active for this process so the results
+            // summary is self-describing (the implementation is a process-level choice,
+            // not a benchmark parameter — see the class remarks).
+            Console.WriteLine(
+                "[ConnectionPoolStressRunner] Pool implementation: " +
+                (s_config.UseConnectionPoolV2
+                    ? "ChannelDbConnectionPool (V2)"
+                    : "WaitHandleDbConnectionPool (legacy)"));
         }
 
         [IterationSetup]
         public void IterationSetup()
         {
             _connections = new ConcurrentBag<SqlConnection>();
-            _connectionStringBuilder = new SqlConnectionStringBuilder(_connectionString)
+
+            // A fresh WorkstationID per iteration produces a distinct connection string,
+            // and therefore a fresh, isolated pool — so a "cold" iteration truly starts
+            // with an empty pool and iterations don't share pooled connections.
+            var builder = new SqlConnectionStringBuilder(s_config.ConnectionString)
             {
                 MaxPoolSize = 1000,
                 WorkstationID = Guid.NewGuid().ToString(),
-                Pooling = Pooling is not PoolBehavior.Disabled
+                Pooling = Pooling
             };
+            _connectionString = builder.ConnectionString;
 
-            // PoolBehavior.New opts into the ChannelDbConnectionPool (V2) implementation;
-            // the default (false) uses the legacy pool.
-            AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseConnectionPoolV2", Pooling is PoolBehavior.New);
-            AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", Sni is SniBehavior.Managed);
-
-            if (PoolIsWarm)
+            if (PoolIsWarm && Pooling)
             {
-                OpenConnectionsInParallel(_connectionStringBuilder.ConnectionString, NumConnectionsToOpen);
+                // Open and return NumConnectionsToOpen connections so the measured run is
+                // served from a warm pool.
+                OpenConnectionsCore(_connectionString, NumConnectionsToOpen, returnToPool: true);
             }
         }
 
         [IterationCleanup]
         public void Cleanup()
         {
-            // Shut down the pool so that connections are physically closed
-            // when they are returned to the pool.
+            // Close every connection opened during setup and the measured run, then clear
+            // the pool so pooled connections are physically closed before the next iteration.
             if (_connections.TryTake(out var first))
             {
                 first.Close();
@@ -121,21 +133,21 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             }
         }
 
+        /// <summary>
+        /// Opens <see cref="NumConnectionsToOpen"/> connections in parallel and holds them
+        /// open (does not return them to the pool) so the measurement captures the cost of
+        /// acquiring that many connections concurrently.
+        /// </summary>
         [Benchmark]
-        public int ConnectionPoolWarmupBenchmark()
+        public int OpenConnectionsInParallel()
         {
-            return OpenConnectionsInParallel(
-                _connectionStringBuilder.ConnectionString,
-                NumConnectionsToOpen,
-                runCommand: false,
-                returnToPool: false);
+            return OpenConnectionsCore(_connectionString, NumConnectionsToOpen, returnToPool: false);
         }
 
-        private int OpenConnectionsInParallel(
+        private int OpenConnectionsCore(
             string connectionString,
             int numConnectionsToOpen,
-            bool runCommand = false,
-            bool returnToPool = true)
+            bool returnToPool)
         {
             var tasks = new Task[numConnectionsToOpen];
 
@@ -152,22 +164,6 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
                     else
                     {
                         conn.Open(SqlConnectionOverrides.OpenWithoutRetry);
-                    }
-
-                    if (runCommand)
-                    {
-                        using var command = conn.CreateCommand();
-                        command.CommandText = "SELECT 1";
-                        command.CommandType = System.Data.CommandType.Text;
-
-                        int result = Async is AsyncBehavior.Async
-                            ? (int)(await command.ExecuteScalarAsync() ?? 0)
-                            : (int)(command.ExecuteScalar() ?? 0);
-
-                        if (result != 1)
-                        {
-                            throw new Exception("Unexpected result from command");
-                        }
                     }
 
                     _connections.TryAdd(conn);

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
@@ -68,6 +68,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public RunnerJob JsonVsVarcharReadRunnerConfig;
         public RunnerJob BeginTransactionRunnerConfig;
         public RunnerJob ConnectionPoolStressRunnerConfig;
+        public RunnerJob ConnectionPoolContentionRunnerConfig;
+        public RunnerJob ConnectionPoolChurnRunnerConfig;
     }
 
     public class RunnerJob

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
@@ -12,6 +12,20 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public string ConnectionString;
         public bool UseManagedSniOnWindows;
         public bool UseOptimizedAsyncBehaviour;
+
+        /// <summary>
+        /// When true, selects the new channel-based connection pool
+        /// (<c>ChannelDbConnectionPool</c>) by enabling the
+        /// <c>Switch.Microsoft.Data.SqlClient.UseConnectionPoolV2</c> AppContext switch.
+        /// When false (the default), the legacy <c>WaitHandleDbConnectionPool</c> is used.
+        ///
+        /// This is a process-level setting: the switch is read and cached the first time
+        /// a pool is created, so it cannot be toggled per benchmark iteration. To compare
+        /// the two implementations, run the benchmark once with this flag false and once
+        /// with it true.
+        /// </summary>
+        public bool UseConnectionPoolV2;
+
         public bool WaitForProfiler;
         public bool UseNativeMemoryAndETWProfiler;
         public Benchmarks Benchmarks;

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
@@ -48,6 +48,14 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
                 AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", true);
             }
 
+            // If the config file specifies to use the new channel-based connection pool,
+            // enable the UseConnectionPoolV2 AppContext switch. This must be set before any
+            // connection is opened because the switch is read and cached when a pool is first
+            // created; it cannot be changed later in the process lifetime.
+            AppContext.SetSwitch(
+                "Switch.Microsoft.Data.SqlClient.UseConnectionPoolV2",
+                _config.UseConnectionPoolV2);
+
             // If the config file specifies to use optimized async behavior, 
             // enable packet multiplexing feature and other optimizations in SqlClient 
             // by setting the appropriate AppContext switches.

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             Run_JsonVsVarcharReadBenchmark();
             Run_BeginTransactionBenchmark();
             Run_ConnectionPoolStressBenchmark();
+            Run_ConnectionPoolContentionBenchmark();
+            Run_ConnectionPoolChurnBenchmark();
 
             // TODOs:
             // Prepared/Regular Parameterized queries
@@ -191,6 +193,22 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             if (_config.Benchmarks.ConnectionPoolStressRunnerConfig?.Enabled == true)
             {
                 BenchmarkRunner.Run<ConnectionPoolStressRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.ConnectionPoolStressRunnerConfig));
+            }
+        }
+
+        private void Run_ConnectionPoolContentionBenchmark()
+        {
+            if (_config.Benchmarks.ConnectionPoolContentionRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<ConnectionPoolContentionRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.ConnectionPoolContentionRunnerConfig));
+            }
+        }
+
+        private void Run_ConnectionPoolChurnBenchmark()
+        {
+            if (_config.Benchmarks.ConnectionPoolChurnRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<ConnectionPoolChurnRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.ConnectionPoolChurnRunnerConfig));
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
@@ -126,6 +126,22 @@
             "InvocationCount": 1,
             "WarmupCount": 1,
             "RowCount": 0
+        },
+        "ConnectionPoolContentionRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 15,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 0
+        },
+        "ConnectionPoolChurnRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 15,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 0
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
@@ -2,6 +2,12 @@
     "ConnectionString": "Server=tcp:localhost; Integrated Security=true; Initial Catalog=sqlclient-perf-db;",
     // Enable this flag to enable managed SNI on Windows.
     "UseManagedSniOnWindows": false,
+    // Enable this flag to select the new channel-based connection pool
+    // (ChannelDbConnectionPool) instead of the legacy WaitHandleDbConnectionPool.
+    // This is a process-level setting (the pool implementation switch is cached the
+    // first time a pool is created), so comparing the two pools requires two runs:
+    // once with this flag false (legacy) and once true (new). See issue #3356.
+    "UseConnectionPoolV2": false,
     // Enable this flag to enable optimized async behavior in SqlClient. 
     // This is useful for benchmarking packet multiplexing and async performance improvements.
     "UseOptimizedAsyncBehaviour": true,


### PR DESCRIPTION
## Summary

Expands the connection pool benchmark coverage introduced in #4447 to more thoroughly evaluate the new `ChannelDbConnectionPool` (`UseConnectionPoolV2`) against the legacy `WaitHandleDbConnectionPool`, aligned with the design goals in #3356: **parallel connection opening**, **async best practices / low threadpool pressure**, and **minimal thread/lock contention**.

> Stacks on #4447 (`dev/cheena/perf-project`). Review/merge that first.

## Motivation (from #3356 and linked issues)

The new pool targets the slow, serialized connection opening described in #601 and #979. Good performance coverage needs to exercise the dimensions where the two implementations actually diverge: cold vs warm pools, sync vs async callers, and behavior under pool exhaustion (async waiter wake path).

## Correctness fix

The pool-implementation switch (`UseConnectionPoolV2`) and the SNI switch are **read once and cached** in `LocalAppContextSwitches`. Because `BenchmarkConfig` runs every case in a single process via `InProcessEmitToolchain`, toggling those `AppContext` switches per benchmark iteration has **no effect** — every "Legacy/New" row would silently use whichever value was read first.

Fix: the pool implementation is now a **process-level** config flag (`UseConnectionPoolV2` in `runnerconfig.jsonc`, applied once in `Program.SetupConfigurations`), matching how `UseManagedSniOnWindows` and `UseOptimizedAsyncBehaviour` are already handled. Comparing the two pools is done with two runs (false then true) — which is how the #3356 charts were produced. Each runner logs the active implementation so results are self-describing.

## Benchmark coverage

| Runner | Scenario | Primary signal |
|--------|----------|----------------|
| `ConnectionPoolStressRunner` (reworked) | Burst-open N connections in parallel; cold/warm × sync/async × pooling on/off | Parallel-open / startup latency (#601, #979) |
| `ConnectionPoolContentionRunner` (new) | Steady-state open→`SELECT 1`→close across 50 workers; `MaxPoolSize` ≥ Parallelism (no wait) and ≪ Parallelism (back-pressure); sync/async | Async waiter-wake path + lock contention under exhaustion |
| `ConnectionPoolChurnRunner` (new) | Single-threaded rapid open/close on a warm pool; sync/async | Raw per-checkout overhead + per-op allocations, no contention noise |

Rate limiting (#4396), pruning (#4304), and shutdown (#4302) are time/behavior-based and are intentionally left to reliability testing (#3667) rather than microbenchmarks.

Metrics come from the existing `MemoryDiagnoser` + `ThreadingDiagnoser` (Mean, Completed Work Items, Lock Contentions, Allocated/Gen0).

## Sample results

Validated locally against SQL Server (both pools). Burst-open of 100 pooled connections (`ConnectionPoolStressRunner`):

| Scenario | Legacy | V2 | Speedup |
|----------|-------:|---:|--------:|
| Cold, Sync | 632 ms | 179 ms | ~3.5× |
| Cold, Async | 625 ms | 173 ms | ~3.6× |
| Warm, Sync | 612 ms | 141 ms | ~4.3× |
| Warm, Async | 576 ms | 144 ms | ~4.0× |

Async **Completed Work Items** also dropped ~1180 → ~324, confirming reduced threadpool pressure.

_Absolute numbers above are from a local containerized SQL instance and are illustrative, not production-representative; the harness and relative/threading metrics are the point._

## Checklist

- [x] Tests added or updated (performance benchmark runners)
- [x] Public API changes documented (none — test-only project)
- [x] Verified against a live SQL Server (both pool implementations)
- [x] No breaking changes introduced
