### PR TITLE
Rename pipeline sqlclient-package -> sqlclient-ci-package

### DIFF
--- a/eng/pipelines/ci/package/sqlclient-ci-package-pipeline.yml
+++ b/eng/pipelines/ci/package/sqlclient-ci-package-pipeline.yml
@@ -7,35 +7,27 @@
 # This pipeline builds all packages using the build.proj Pack target with ReferenceType=Package,
 # then publishes the resulting .nupkg and .snupkg files as a single pipeline artifact.
 #
-# It runs:
-#   - On pushes to GitHub main and ADO internal/main (batched)
-#   - Nightly at 00:00 UTC on both branches
+# It runs nightly at 00:20 UTC on GitHub dotnet/SqlClient main and ADO.Net dotnet-sqlclient
+# internal/main.
 #
 # On internal/main the strong-name signing key is downloaded and used to sign assemblies during the
 # build.
 #
-# GOTCHA: This pipeline definition is triggered by GitHub _and_ ADO CI.  We distinguish the two via
-# branch filters:
+# GOTCHA: This pipeline definition is triggered by GitHub _and_ ADO.NET CI.  We distinguish the two
+# via branch filters:
 #
 #   - Only the GitHub repo has a 'main' branch.
 #   - Only the ADO repo has an 'internal/main' branch.
 
 name: $(DayOfYear)$(Rev:rr)
 
-# Do not trigger this pipeline for PRs.
+# Do not trigger this pipeline for PRs or pushes.
 pr: none
+trigger: none
 
-# Trigger on pushes to main and internal/main, batching concurrent commits.
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-      - internal/main
-
-# Nightly schedule at 00:00 UTC.
+# Nightly schedule at 00:20 UTC.
 schedules:
-  - cron: '0 0 * * *'
+  - cron: '20 0 * * *'
     displayName: Nightly Build
     branches:
       include:
@@ -92,13 +84,13 @@ variables:
   # downloaded by DownloadSecureFile@1; on public builds it expands to empty.
   - name: signingKeyArg
     ${{ if eq(variables.isInternalBuild, true) }}:
-      value: '-p:SigningKeyPath="$(keyFile.secureFilePath)"'
+      value: -p:SigningKeyPath="$(driverKeyFile.secureFilePath)"
     ${{ else }}:
       value: ''
 
 jobs:
-  - job: pack_all_packages
-    displayName: Pack All Packages
+  - job: build_nuget_packages
+    displayName: Build NuGet Packages
 
     pool:
       ${{ if eq(variables.isInternalBuild, true) }}:
@@ -124,29 +116,29 @@ jobs:
       # Restore dotnet local tools (pwsh, apicompat, etc.).
       - template: /eng/pipelines/common/steps/restore-dotnet-tools.yml@self
 
-      # Clean any pre-existing .nupkg / .snupkg files from the packages/ directory
-      # to ensure we only publish packages produced by this run.
+      # Clean any pre-existing .nupkg / .snupkg files from the packages/ directory to ensure we only
+      # publish packages produced by this run.
       - pwsh: |
           Write-Host 'Cleaning packages/ directory...'
           Remove-Item -Force "$(Build.SourcesDirectory)/packages/*.nupkg" -ErrorAction SilentlyContinue
           Remove-Item -Force "$(Build.SourcesDirectory)/packages/*.snupkg" -ErrorAction SilentlyContinue
           Write-Host 'Done.'
-        displayName: Clean packages/ directory
+        displayName: Clean Packages Directory
 
       # On internal builds, download the strong-name signing key.
       - ${{ if eq(variables.isInternalBuild, true) }}:
         - task: DownloadSecureFile@1
-          displayName: Download Signing Key
+          displayName: Download Driver Signing Key
           inputs:
             secureFile: netfxKeypair.snk
-          name: keyFile
+          name: driverKeyFile
 
       # Run the Pack target via build.proj.
       - task: DotNetCoreCLI@2
-        displayName: build.proj - Pack (ReferenceType=Package)
+        displayName: Build & Pack
         inputs:
           command: build
-          projects: '$(Build.SourcesDirectory)/build.proj'
+          projects: $(Build.SourcesDirectory)/build.proj
           arguments: >-
             -t:Pack
             -p:Configuration=${{ parameters.buildConfiguration }}
@@ -161,12 +153,12 @@ jobs:
           Write-Host 'Packages produced:'
           Get-ChildItem "$(Build.SourcesDirectory)/packages/*.nupkg" -ErrorAction SilentlyContinue | Format-Table Name, Length -AutoSize -Wrap
           Get-ChildItem "$(Build.SourcesDirectory)/packages/*.snupkg" -ErrorAction SilentlyContinue | Format-Table Name, Length -AutoSize -Wrap
-        displayName: List produced packages
+        displayName: List Packages
 
       # Publish all .nupkg and .snupkg files from packages/ as a pipeline artifact.
       - task: PublishPipelineArtifact@1
-        displayName: Publish NuGet Packages
+        displayName: Publish Packages
         inputs:
-          targetPath: '$(Build.SourcesDirectory)/packages'
-          artifactName: Packages
+          targetPath: $(Build.SourcesDirectory)/packages
+          artifactName: SqlClient-Driver-Packages
           publishLocation: pipeline


### PR DESCRIPTION
## Description

- Rename the existing `sqlclient-package` pipeline to `sqlclient-ci-pipeline` to match our transition plan.
- Other minor cleanup for consistent stage/job/step names.

## Testing

The Azure DevOps pipeline configs have already been created and/or renamed/updated, and all now expect the new pipeline path/filename.

- [x] Public project - sqlclient-ci-package:
  - [x] Ubuntu 24 (Release): [19801](https://dev.azure.com/SqlClientDrivers/public/_build/results?buildId=161405&view=results)
  - [x] Win 25 (Debug): [19802](https://dev.azure.com/SqlClientDrivers/public/_build/results?buildId=161406&view=results)
- [x] ADO.Net project - sqlclient-ci-package:
  - [x] Ubuntu 24 (Release): [19801](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=161407&view=results)
  - [x] Win 25 (Debug): [19802](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=161408&view=results)
