### PR TITLE
Globalization invariant mode: Require explicit LCID when constructing SqlMetaData

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
@@ -536,6 +536,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Construction for all types that do not have variable attributes
         private void Construct(string name, SqlDbType dbType, bool useServerDefault, bool isUniqueKey, SortOrder columnSortOrder, int sortOrdinal)
         {
+            ValidateGlobalizationInvariantLcid(dbType);
             AssertNameIsValid(name);
 
             ValidateSortOrder(columnSortOrder, sortOrdinal);
@@ -586,6 +587,7 @@ namespace Microsoft.Data.SqlClient.Server
         // Construction for all types that vary by user-specified length (not Udts)
         private void Construct(string name, SqlDbType dbType, long maxLength, bool useServerDefault, bool isUniqueKey, SortOrder columnSortOrder, int sortOrdinal)
         {
+            ValidateGlobalizationInvariantLcid(dbType);
             AssertNameIsValid(name);
 
             ValidateSortOrder(columnSortOrder, sortOrdinal);
@@ -926,6 +928,16 @@ namespace Microsoft.Data.SqlClient.Server
             if ((SortOrder.Unspecified == columnSortOrder) != (DefaultSortOrdinal == sortOrdinal))
             {
                 throw SQL.MustSpecifyBothSortOrderAndOrdinal(columnSortOrder, sortOrdinal);
+            }
+        }
+
+        private static void ValidateGlobalizationInvariantLcid(SqlDbType dbType)
+        {
+            if (LocalAppContextSwitches.GlobalizationInvariantMode &&
+                (dbType is SqlDbType.Char or SqlDbType.VarChar or SqlDbType.Text
+                    or SqlDbType.NChar or SqlDbType.NVarChar or SqlDbType.NText))
+            {
+                throw SQL.GlobalizationInvariantModeRequiresLcid();
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlUtil.cs
@@ -204,6 +204,10 @@ namespace Microsoft.Data.SqlClient
         {
             return ADP.InvalidOperation(StringsHelper.GetString(Strings.SQL_ChangePasswordUseOfUnallowedKey, key));
         }
+        internal static Exception GlobalizationInvariantModeRequiresLcid()
+        {
+            return ADP.NotSupported(StringsHelper.GetString(Strings.SQL_GlobalizationInvariantModeRequiresLcid));
+        }
         internal static Exception GlobalizationInvariantModeNotSupported()
         {
             return ADP.NotSupported(StringsHelper.GetString(Strings.SQL_GlobalizationInvariantModeNotSupported));

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.Designer.cs
@@ -3337,6 +3337,15 @@ namespace System {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When Globalization Invariant Mode is enabled, SqlMetaData instances describing character or text types must specify an LCID..
+        /// </summary>
+        internal static string SQL_GlobalizationInvariantModeRequiresLcid {
+            get {
+                return ResourceManager.GetString("SQL_GlobalizationInvariantModeRequiresLcid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Instance failure..
         /// </summary>
         internal static string SQL_InstanceFailure {

--- a/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/Microsoft.Data.SqlClient/src/Resources/Strings.resx
@@ -2091,6 +2091,9 @@
   <data name="SqlAppContextSwitchManager_InvalidValue" xml:space="preserve">
     <value>Exception occurred while trying to set the AppContext Switch '{0}'={1}.</value>
   </data>
+  <data name="SQL_GlobalizationInvariantModeRequiresLcid" xml:space="preserve">
+    <value>When Globalization Invariant Mode is enabled, SqlMetaData instances describing character or text types must specify an LCID.</value>
+  </data>
   <data name="SQL_GlobalizationInvariantModeNotSupported" xml:space="preserve">
     <value>Globalization Invariant Mode is not supported.</value>
   </data>

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlMetaDataTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlMetaDataTest.cs
@@ -9,6 +9,7 @@ using System.Data.SqlTypes;
 using System.Globalization;
 using System.Reflection;
 using Microsoft.Data.SqlClient.Server;
+using Microsoft.Data.SqlClient.Tests.Common;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.Tests
@@ -227,6 +228,43 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal(SortOrder.Ascending, metaData.SortOrder);
             Assert.Equal(0, metaData.SortOrdinal);
         }
+
+        #if NET
+        [Theory]
+        [MemberData(nameof(ConstructorCharData))]
+        [MemberData(nameof(ConstructorTextData))]
+        public void ConstructorWithDefaultLocale_ThrowsInInvariantGlobalizationMode(SqlDbType dbType)
+        {
+            using LocalAppContextSwitchesHelper helper = new();
+
+            helper.GlobalizationInvariantMode = true;
+
+            Assert.Throws<NotSupportedException>(() => new SqlMetaData("col1", dbType));
+            Assert.Throws<NotSupportedException>(() => new SqlMetaData("col1", dbType, true, true, SortOrder.Ascending, 0));
+            Assert.Throws<NotSupportedException>(() => new SqlMetaData("col1", dbType, 0));
+            Assert.Throws<NotSupportedException>(() => new SqlMetaData("col1", dbType, 0, true, true, SortOrder.Ascending, 0));
+        }
+
+        [Theory]
+        [MemberData(nameof(ConstructorCharData))]
+        public void ConstructorWithMaxLengthAndExplicitLocale_DoesNotThrowInInvariantGlobalizationMode(SqlDbType dbType)
+        {
+            using LocalAppContextSwitchesHelper helper = new();
+
+            helper.GlobalizationInvariantMode = true;
+            ConstructorWithMaxLengthAndLocale(dbType);
+        }
+
+        [Theory]
+        [MemberData(nameof(ConstructorTextData))]
+        public void ConstructorWithMaxLengthTextExplicitLocale_DoesNotThrowInInvariantGlobalizationMode(SqlDbType dbType)
+        {
+            using LocalAppContextSwitchesHelper helper = new();
+
+            helper.GlobalizationInvariantMode = true;
+            ConstructorWithMaxLengthTextAndLocale(dbType);
+        }
+        #endif
 
         [Fact]
         public void ConstructorWithDefaultLocaleInvalidType_Throws()


### PR DESCRIPTION
## Description

SqlClient doesn't currently support globalization invariant mode, and we throw an exception whenever someone tries to use it in the main SqlConnection entry point. This PR closes a similar entry point when instantiating the `SqlMetaData` type.

I've explicitly been specific when closing entry points, in order to leave the door open to future support for this mode. The main reason why we can't support it was the requirement for LCID/codepage mapping, but this was removed as a secondary effect of #4212.

The result of this PR is that if globalization invariant mode is enabled, only four SqlMetaData constructors are permitted for columns of type `Text` / `NText` / `Varchar` / `NVarchar` / `Char` / `NChar`:

* `SqlMetaData(string name, SqlDbType dbType, long maxLength, byte precision, byte scale, long locale, SqlCompareOptions compareOptions, Type userDefinedType)`
* `SqlMetaData(string name, SqlDbType dbType, long maxLength, byte precision, byte scale, long localeId, SqlCompareOptions compareOptions, Type userDefinedType, bool useServerDefault, bool isUniqueKey, SortOrder columnSortOrder, int sortOrdinal)`
* `SqlMetaData(string name, SqlDbType dbType, long maxLength, long locale, SqlCompareOptions compareOptions, bool useServerDefault, bool isUniqueKey, SortOrder columnSortOrder, int sortOrdinal)`
* `SqlMetaData(string name, SqlDbType dbType, long maxLength, long locale, SqlCompareOptions compareOptions)`

These are permitted because they force the user to specify an LCID in the `locale` or the `localeId` parameter.

## Issues

Stands alone, but also lays the groundwork for #3742.

## Testing

Unit tests have been added alongside the existing ones (which are, in turn, in the wrong assembly - to be cleaned up in a follow-up PR.)