### PR TITLE
[DRAFT] Add TVP Support for JSON and Vector (float32)

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
@@ -253,6 +253,7 @@ namespace Microsoft.Data.SqlClient.Server
                     case SqlDbType.NVarChar:
                     case SqlDbType.Text:
                     case SqlDbType.VarChar:
+                    case SqlDbTypeExtensions.Json:
                         if (value.GetType() == typeof(string))
                         {
                             extendedCode = ExtendedClrTypeCode.String;
@@ -877,6 +878,7 @@ namespace Microsoft.Data.SqlClient.Server
                 case SqlDbType.TinyInt:
                 case SqlDbType.Variant:
                 case SqlDbType.Xml:
+                case SqlDbTypeExtensions.Json:
                 case SqlDbType.Date:
                     // These types require no  metadata modifies
                     break;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/MetadataUtilsSmi.cs
@@ -466,6 +466,15 @@ namespace Microsoft.Data.SqlClient.Server
                         }
 
                         break;
+                    case SqlDbTypeExtensions.Vector:
+                        // Vector values are supplied as SqlVector<T> and transferred as their raw
+                        // TDS payload bytes.
+                        if (value is ISqlVector)
+                        {
+                            extendedCode = ExtendedClrTypeCode.ByteArray;
+                        }
+
+                        break;
                     case SqlDbType.Structured:
                         if (isMultiValued)
                         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Data.SqlClient.Server
         internal static readonly SmiMetaData DefaultVariant = new SmiMetaData(SqlDbType.Variant, 8016, 0, 0, SqlCompareOptions.None);     // SqlDbType.Variant
         internal static readonly SmiMetaData DefaultXml = new SmiMetaData(SqlDbType.Xml, UnlimitedMaxLengthIndicator, 0, 0, DefaultStringCompareOptions);// SqlDbType.Xml
         internal static readonly SmiMetaData DefaultJson = new SmiMetaData(SqlDbTypeExtensions.Json, UnlimitedMaxLengthIndicator, 0, 0, DefaultStringCompareOptions);// SqlDbTypeExtensions.Json
+        internal static readonly SmiMetaData DefaultVector = new SmiMetaData(SqlDbTypeExtensions.Vector, TdsEnums.VECTOR_HEADER_SIZE, 0, 0, SqlCompareOptions.None);// SqlDbTypeExtensions.Vector
         internal static readonly SmiMetaData DefaultUdt_NoType = new SmiMetaData(SqlDbType.Udt, 0, 0, 0, SqlCompareOptions.None);     // SqlDbType.Udt
         internal static readonly SmiMetaData DefaultStructured = new SmiMetaData(SqlDbType.Structured, 0, 0, 0, SqlCompareOptions.None);     // SqlDbType.Structured
         internal static readonly SmiMetaData DefaultDate = new SmiMetaData(SqlDbType.Date, 3, 10, 0, SqlCompareOptions.None);     // SqlDbType.Date
@@ -264,6 +265,12 @@ namespace Microsoft.Data.SqlClient.Server
                 case SqlDbTypeExtensions.Json:
                 case SqlDbType.Date:
                     break;
+                case SqlDbTypeExtensions.Vector:
+                    // Vector carries a finite byte length (8-byte header + payload) and the element
+                    // type indicator (0 = float32) in scale.
+                    _maxLength = maxLength;
+                    _scale = scale;
+                    break;
                 case SqlDbType.Binary:
                 case SqlDbType.VarBinary:
                     _maxLength = maxLength;
@@ -398,7 +405,8 @@ namespace Microsoft.Data.SqlClient.Server
             // Hole in SqlDbTypes between Xml and Udt for non-WinFS scenarios.
             return (SqlDbType.BigInt <= dbType && SqlDbType.Xml >= dbType) ||
                     (SqlDbType.Udt <= dbType && SqlDbType.DateTimeOffset >= dbType) ||
-                    SqlDbTypeExtensions.Json == dbType;
+                    SqlDbTypeExtensions.Json == dbType ||
+                    SqlDbTypeExtensions.Vector == dbType;
         }
 
         // Only correct access point for defaults per SqlDbType.
@@ -474,6 +482,7 @@ namespace Microsoft.Data.SqlClient.Server
                 DefaultDateTime2,              // SqlDbType.DateTime2
                 DefaultDateTimeOffset,         // SqlDbType.DateTimeOffset
                 DefaultJson,                   // SqlDbTypeExtensions.Json (value 35)
+                DefaultVector,                 // SqlDbTypeExtensions.Vector (value 36)
             };
 
         // static array of type names ordered by corresponding SqlDbType.
@@ -517,6 +526,7 @@ namespace Microsoft.Data.SqlClient.Server
                 "datetime2",            // SqlDbType.DateTime2
                 "datetimeoffset",       // SqlDbType.DateTimeOffset
                 "json",                 // SqlDbTypeExtensions.Json (value 35)
+                "vector",               // SqlDbTypeExtensions.Vector (value 36)
             };
 
         // Internal setter to be used by constructors only!  Modifies state!

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiMetaData.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Data.SqlClient.Server
         internal static readonly SmiMetaData DefaultVarChar_NoCollation = new SmiMetaData(SqlDbType.VarChar, MaxANSICharacters, 0, 0, DefaultStringCompareOptions);// SqlDbType.VarChar
         internal static readonly SmiMetaData DefaultVariant = new SmiMetaData(SqlDbType.Variant, 8016, 0, 0, SqlCompareOptions.None);     // SqlDbType.Variant
         internal static readonly SmiMetaData DefaultXml = new SmiMetaData(SqlDbType.Xml, UnlimitedMaxLengthIndicator, 0, 0, DefaultStringCompareOptions);// SqlDbType.Xml
+        internal static readonly SmiMetaData DefaultJson = new SmiMetaData(SqlDbTypeExtensions.Json, UnlimitedMaxLengthIndicator, 0, 0, DefaultStringCompareOptions);// SqlDbTypeExtensions.Json
         internal static readonly SmiMetaData DefaultUdt_NoType = new SmiMetaData(SqlDbType.Udt, 0, 0, 0, SqlCompareOptions.None);     // SqlDbType.Udt
         internal static readonly SmiMetaData DefaultStructured = new SmiMetaData(SqlDbType.Structured, 0, 0, 0, SqlCompareOptions.None);     // SqlDbType.Structured
         internal static readonly SmiMetaData DefaultDate = new SmiMetaData(SqlDbType.Date, 3, 10, 0, SqlCompareOptions.None);     // SqlDbType.Date
@@ -260,6 +261,7 @@ namespace Microsoft.Data.SqlClient.Server
                 case SqlDbType.UniqueIdentifier:
                 case SqlDbType.Variant:
                 case SqlDbType.Xml:
+                case SqlDbTypeExtensions.Json:
                 case SqlDbType.Date:
                     break;
                 case SqlDbType.Binary:
@@ -395,7 +397,8 @@ namespace Microsoft.Data.SqlClient.Server
         {
             // Hole in SqlDbTypes between Xml and Udt for non-WinFS scenarios.
             return (SqlDbType.BigInt <= dbType && SqlDbType.Xml >= dbType) ||
-                    (SqlDbType.Udt <= dbType && SqlDbType.DateTimeOffset >= dbType);
+                    (SqlDbType.Udt <= dbType && SqlDbType.DateTimeOffset >= dbType) ||
+                    SqlDbTypeExtensions.Json == dbType;
         }
 
         // Only correct access point for defaults per SqlDbType.
@@ -470,6 +473,7 @@ namespace Microsoft.Data.SqlClient.Server
                 DefaultTime,                   // SqlDbType.Time
                 DefaultDateTime2,              // SqlDbType.DateTime2
                 DefaultDateTimeOffset,         // SqlDbType.DateTimeOffset
+                DefaultJson,                   // SqlDbTypeExtensions.Json (value 35)
             };
 
         // static array of type names ordered by corresponding SqlDbType.
@@ -512,6 +516,7 @@ namespace Microsoft.Data.SqlClient.Server
                 "time",                 // SqlDbType.Time
                 "datetime2",            // SqlDbType.DateTime2
                 "datetimeoffset",       // SqlDbType.DateTimeOffset
+                "json",                 // SqlDbTypeExtensions.Json (value 35)
             };
 
         // Internal setter to be used by constructors only!  Modifies state!

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiXetterAccessMap.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiXetterAccessMap.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Data;
 using System.Diagnostics;
 
 namespace Microsoft.Data.SqlClient.Server
@@ -109,7 +110,10 @@ namespace Microsoft.Data.SqlClient.Server
             Debug.Assert(SmiXetterTypeCode.XetBoolean <= xetterType && SmiXetterTypeCode.XetDateTimeOffset >= xetterType &&
                     SmiXetterTypeCode.GetVariantMetaData != xetterType);
 
-            return s_isSetterAccessValid[(int)metaData.SqlDbType, (int)xetterType];
+            // JSON is outside the contiguous SqlDbType range covered by this map; it accepts the same
+            // setters as NVarChar (string-based value transfer).
+            SqlDbType effectiveType = SqlDbTypeExtensions.Json == metaData.SqlDbType ? SqlDbType.NVarChar : metaData.SqlDbType;
+            return s_isSetterAccessValid[(int)effectiveType, (int)xetterType];
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiXetterAccessMap.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SmiXetterAccessMap.cs
@@ -110,9 +110,17 @@ namespace Microsoft.Data.SqlClient.Server
             Debug.Assert(SmiXetterTypeCode.XetBoolean <= xetterType && SmiXetterTypeCode.XetDateTimeOffset >= xetterType &&
                     SmiXetterTypeCode.GetVariantMetaData != xetterType);
 
-            // JSON is outside the contiguous SqlDbType range covered by this map; it accepts the same
-            // setters as NVarChar (string-based value transfer).
-            SqlDbType effectiveType = SqlDbTypeExtensions.Json == metaData.SqlDbType ? SqlDbType.NVarChar : metaData.SqlDbType;
+            // JSON and Vector are outside the contiguous SqlDbType range covered by this map;
+            // JSON accepts the same setters as NVarChar (string) and Vector the same as VarBinary (bytes).
+            SqlDbType effectiveType = metaData.SqlDbType;
+            if (SqlDbTypeExtensions.Json == effectiveType)
+            {
+                effectiveType = SqlDbType.NVarChar;
+            }
+            else if (SqlDbTypeExtensions.Vector == effectiveType)
+            {
+                effectiveType = SqlDbType.VarBinary;
+            }
             return s_isSetterAccessValid[(int)effectiveType, (int)xetterType];
         }
     }

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
@@ -92,7 +92,8 @@ namespace Microsoft.Data.SqlClient.Server
             DbType.Date,            // SqlDbType.Date
             DbType.Time,            // SqlDbType.Time
             DbType.DateTime2,       // SqlDbType.DateTime2
-            DbType.DateTimeOffset   // SqlDbType.DateTimeOffset
+            DbType.DateTimeOffset,  // SqlDbType.DateTimeOffset
+            DbType.String,          // SqlDbTypeExtensions.Json (value 35)
         };
 
 
@@ -134,6 +135,7 @@ namespace Microsoft.Data.SqlClient.Server
             new SqlMetaData("time", SqlDbType.Time, 5, 0, 7, 0, SqlCompareOptions.None),
             new SqlMetaData("datetime2", SqlDbType.DateTime2, 8, 0, 7, 0, SqlCompareOptions.None),
             new SqlMetaData("datetimeoffset", SqlDbType.DateTimeOffset, 10, 0, 7, 0, SqlCompareOptions.None),
+            new SqlMetaData("json", SqlDbTypeExtensions.Json, UnlimitedMaxLength, 0, 0, 0, DefaultStringCompareOptions),
         };
 
         private string _name;
@@ -378,6 +380,7 @@ namespace Microsoft.Data.SqlClient.Server
                 case SqlDbType.SmallInt:
                 case SqlDbType.TinyInt:
                 case SqlDbType.Xml:
+                case SqlDbTypeExtensions.Json:
                 case SqlDbType.Date:
                     Construct(name, dbType, useServerDefault, isUniqueKey, columnSortOrder, sortOrdinal);
                     break;
@@ -563,7 +566,8 @@ namespace Microsoft.Data.SqlClient.Server
                     SqlDbType.TinyInt == dbType ||
                     SqlDbType.UniqueIdentifier == dbType ||
                     SqlDbType.Variant == dbType ||
-                    SqlDbType.Xml == dbType)
+                    SqlDbType.Xml == dbType ||
+                    SqlDbTypeExtensions.Json == dbType)
             )
             {
                 throw SQL.InvalidSqlDbTypeForConstructor(dbType);
@@ -2036,7 +2040,7 @@ namespace Microsoft.Data.SqlClient.Server
 
         private void SetDefaultsForType(SqlDbType dbType)
         {
-            if (SqlDbType.BigInt <= dbType && SqlDbType.DateTimeOffset >= dbType)
+            if ((SqlDbType.BigInt <= dbType && SqlDbType.DateTimeOffset >= dbType) || SqlDbTypeExtensions.Json == dbType)
             {
                 SqlMetaData smdDflt = s_defaults[(int)dbType];
                 _sqlDbType = dbType;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/SqlMetaData.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Data.SqlClient.Server
             DbType.DateTime2,       // SqlDbType.DateTime2
             DbType.DateTimeOffset,  // SqlDbType.DateTimeOffset
             DbType.String,          // SqlDbTypeExtensions.Json (value 35)
+            DbType.Binary,          // SqlDbTypeExtensions.Vector (value 36)
         };
 
 
@@ -136,6 +137,7 @@ namespace Microsoft.Data.SqlClient.Server
             new SqlMetaData("datetime2", SqlDbType.DateTime2, 8, 0, 7, 0, SqlCompareOptions.None),
             new SqlMetaData("datetimeoffset", SqlDbType.DateTimeOffset, 10, 0, 7, 0, SqlCompareOptions.None),
             new SqlMetaData("json", SqlDbTypeExtensions.Json, UnlimitedMaxLength, 0, 0, 0, DefaultStringCompareOptions),
+            new SqlMetaData("vector", SqlDbTypeExtensions.Vector, TdsEnums.VECTOR_HEADER_SIZE, 0, 0, 0, SqlCompareOptions.None),
         };
 
         private string _name;
@@ -386,6 +388,7 @@ namespace Microsoft.Data.SqlClient.Server
                     break;
                 case SqlDbType.Binary:
                 case SqlDbType.VarBinary:
+                case SqlDbTypeExtensions.Vector:
                     Construct(name, dbType, maxLength, useServerDefault, isUniqueKey, columnSortOrder, sortOrdinal);
                     break;
                 case SqlDbType.Char:
@@ -654,6 +657,14 @@ namespace Microsoft.Data.SqlClient.Server
             {
                 // old-style lobs only allowed with Max length
                 if (SqlMetaData.Max != maxLength)
+                {
+                    throw ADP.Argument(StringsHelper.GetString(Strings.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
+                }
+            }
+            else if (SqlDbTypeExtensions.Vector == dbType)
+            {
+                // Vector max length is the total byte size (8-byte header + element payload).
+                if (maxLength < TdsEnums.VECTOR_HEADER_SIZE)
                 {
                     throw ADP.Argument(StringsHelper.GetString(Strings.ADP_InvalidDataLength2, maxLength.ToString(CultureInfo.InvariantCulture)), nameof(maxLength));
                 }
@@ -2040,7 +2051,7 @@ namespace Microsoft.Data.SqlClient.Server
 
         private void SetDefaultsForType(SqlDbType dbType)
         {
-            if ((SqlDbType.BigInt <= dbType && SqlDbType.DateTimeOffset >= dbType) || SqlDbTypeExtensions.Json == dbType)
+            if ((SqlDbType.BigInt <= dbType && SqlDbType.DateTimeOffset >= dbType) || SqlDbTypeExtensions.Json == dbType || SqlDbTypeExtensions.Vector == dbType)
             {
                 SqlMetaData smdDflt = s_defaults[(int)dbType];
                 _sqlDbType = dbType;

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
@@ -1007,6 +1007,9 @@ namespace Microsoft.Data.SqlClient.Server
                     case SqlDbTypeExtensions.Json:
                         result = GetString_Unchecked(getters, ordinal);
                         break;
+                    case SqlDbTypeExtensions.Vector:
+                        result = new Microsoft.Data.SqlTypes.SqlVector<float>(GetByteArray_Unchecked(getters, ordinal));
+                        break;
                     case SqlDbType.Xml:
                         result = GetSqlXml_Unchecked(getters, ordinal).Value;
                         break;
@@ -1164,6 +1167,9 @@ namespace Microsoft.Data.SqlClient.Server
                     case SqlDbTypeExtensions.Json:
                         result = new SqlString(GetString_Unchecked(getters, ordinal));
                         break;
+                    case SqlDbTypeExtensions.Vector:
+                        result = new Microsoft.Data.SqlTypes.SqlVector<float>(GetByteArray_Unchecked(getters, ordinal));
+                        break;
                     case SqlDbType.Xml:
                         result = GetSqlXml_Unchecked(getters, ordinal);
                         break;
@@ -1214,6 +1220,7 @@ namespace Microsoft.Data.SqlClient.Server
             DBNull.Value,       // SqlDbType.DateTime2
             DBNull.Value,       // SqlDbType.DateTimeOffset
             SqlString.Null,     // SqlDbTypeExtensions.Json (value 35)
+            SqlBinary.Null,     // SqlDbTypeExtensions.Vector (value 36)
         };
 
         internal static object NullUdtInstance(SmiMetaData metaData)
@@ -1491,6 +1498,17 @@ namespace Microsoft.Data.SqlClient.Server
                 CanAccessSetterDirectly(metaData, typeCode) ||
                 value is DataFeed
             );
+
+            // Vector values are transferred as their raw TDS payload bytes (8-byte header + elements).
+            if (SqlDbTypeExtensions.Vector == metaData.SqlDbType && value is ISqlVector vectorValue)
+            {
+                if (value is INullable nullableVector && nullableVector.IsNull)
+                {
+                    SetDBNull_Unchecked(setters, ordinal);
+                    return;
+                }
+                value = vectorValue.VectorPayload;
+            }
 
             switch (typeCode)
             {
@@ -1830,6 +1848,10 @@ namespace Microsoft.Data.SqlClient.Server
                             Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.ByteArray));
                             SetBytes_FromReader(setters, i, metaData[i], reader, 0);
                             break;
+                        case SqlDbTypeExtensions.Vector:
+                            Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.ByteArray));
+                            SetBytes_FromReader(setters, i, metaData[i], reader, 0);
+                            break;
                         case SqlDbType.VarChar:
                             Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.String));
                             SetCharsOrString_FromReader(setters, i, metaData[i], reader, 0);
@@ -2037,6 +2059,10 @@ namespace Microsoft.Data.SqlClient.Server
                             break;
                         case SqlDbType.VarBinary:
                             Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.SqlBytes));
+                            SetBytes_FromRecord(setters, i, metaData[i], record, 0);
+                            break;
+                        case SqlDbTypeExtensions.Vector:
+                            Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.ByteArray));
                             SetBytes_FromRecord(setters, i, metaData[i], record, 0);
                             break;
                         case SqlDbType.VarChar:
@@ -2545,11 +2571,19 @@ namespace Microsoft.Data.SqlClient.Server
             Debug.Assert(ExtendedClrTypeCode.First == 0 && (int)ExtendedClrTypeCode.Last == s_canAccessGetterDirectly.GetLength(0) - 1, "ExtendedClrTypeCodes does not match with __canAccessGetterDirectly");
             Debug.Assert(SqlDbType.BigInt == 0 && (int)SqlDbType.DateTimeOffset == s_canAccessGetterDirectly.GetLength(1) - 1, "SqlDbType does not match with __canAccessGetterDirectly");
             Debug.Assert(ExtendedClrTypeCode.First <= setterTypeCode && ExtendedClrTypeCode.Last >= setterTypeCode);
-            Debug.Assert((SqlDbType.BigInt <= metaData.SqlDbType && SqlDbType.DateTimeOffset >= metaData.SqlDbType) || SqlDbTypeExtensions.Json == metaData.SqlDbType);
+            Debug.Assert((SqlDbType.BigInt <= metaData.SqlDbType && SqlDbType.DateTimeOffset >= metaData.SqlDbType) || SqlDbTypeExtensions.Json == metaData.SqlDbType || SqlDbTypeExtensions.Vector == metaData.SqlDbType);
 
-            // JSON is outside the contiguous SqlDbType range covered by the access map; it accepts the
-            // same accessors as NVarChar (string-based value transfer).
-            SqlDbType effectiveGetterType = SqlDbTypeExtensions.Json == metaData.SqlDbType ? SqlDbType.NVarChar : metaData.SqlDbType;
+            // JSON and Vector are outside the contiguous SqlDbType range covered by the access map;
+            // JSON accepts the same accessors as NVarChar (string) and Vector the same as VarBinary (bytes).
+            SqlDbType effectiveGetterType = metaData.SqlDbType;
+            if (SqlDbTypeExtensions.Json == effectiveGetterType)
+            {
+                effectiveGetterType = SqlDbType.NVarChar;
+            }
+            else if (SqlDbTypeExtensions.Vector == effectiveGetterType)
+            {
+                effectiveGetterType = SqlDbType.VarBinary;
+            }
             bool returnValue = s_canAccessGetterDirectly[(int)setterTypeCode, (int)effectiveGetterType];
 
             // Additional restrictions to distinguish TVPs and Structured UDTs
@@ -2574,11 +2608,19 @@ namespace Microsoft.Data.SqlClient.Server
             Debug.Assert(ExtendedClrTypeCode.First == 0 && (int)ExtendedClrTypeCode.Last == s_canAccessSetterDirectly.GetLength(0) - 1, "ExtendedClrTypeCodes does not match with __canAccessSetterDirectly");
             Debug.Assert(SqlDbType.BigInt == 0 && (int)SqlDbType.DateTimeOffset == s_canAccessSetterDirectly.GetLength(1) - 1, "SqlDbType does not match with __canAccessSetterDirectly");
             Debug.Assert(ExtendedClrTypeCode.First <= setterTypeCode && ExtendedClrTypeCode.Last >= setterTypeCode);
-            Debug.Assert((SqlDbType.BigInt <= metaData.SqlDbType && SqlDbType.DateTimeOffset >= metaData.SqlDbType) || SqlDbTypeExtensions.Json == metaData.SqlDbType);
+            Debug.Assert((SqlDbType.BigInt <= metaData.SqlDbType && SqlDbType.DateTimeOffset >= metaData.SqlDbType) || SqlDbTypeExtensions.Json == metaData.SqlDbType || SqlDbTypeExtensions.Vector == metaData.SqlDbType);
 
-            // JSON is outside the contiguous SqlDbType range covered by the access map; it accepts the
-            // same accessors as NVarChar (string-based value transfer).
-            SqlDbType effectiveSetterType = SqlDbTypeExtensions.Json == metaData.SqlDbType ? SqlDbType.NVarChar : metaData.SqlDbType;
+            // JSON and Vector are outside the contiguous SqlDbType range covered by the access map;
+            // JSON accepts the same accessors as NVarChar (string) and Vector the same as VarBinary (bytes).
+            SqlDbType effectiveSetterType = metaData.SqlDbType;
+            if (SqlDbTypeExtensions.Json == effectiveSetterType)
+            {
+                effectiveSetterType = SqlDbType.NVarChar;
+            }
+            else if (SqlDbTypeExtensions.Vector == effectiveSetterType)
+            {
+                effectiveSetterType = SqlDbType.VarBinary;
+            }
             bool returnValue = s_canAccessSetterDirectly[(int)setterTypeCode, (int)effectiveSetterType];
 
             // Additional restrictions to distinguish TVPs and Structured UDTs

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/Server/ValueUtilsSmi.cs
@@ -1004,6 +1004,9 @@ namespace Microsoft.Data.SqlClient.Server
                         Debug.Assert(SqlDbType.Variant != metaData.SqlDbType, "Variant-within-variant causes endless recursion!");
                         result = GetValue(getters, ordinal, metaData);
                         break;
+                    case SqlDbTypeExtensions.Json:
+                        result = GetString_Unchecked(getters, ordinal);
+                        break;
                     case SqlDbType.Xml:
                         result = GetSqlXml_Unchecked(getters, ordinal).Value;
                         break;
@@ -1158,6 +1161,9 @@ namespace Microsoft.Data.SqlClient.Server
                         Debug.Assert(SqlDbType.Variant != metaData.SqlDbType, "Variant-within-variant causes endless recursion!");
                         result = GetSqlValue(getters, ordinal, metaData);
                         break;
+                    case SqlDbTypeExtensions.Json:
+                        result = new SqlString(GetString_Unchecked(getters, ordinal));
+                        break;
                     case SqlDbType.Xml:
                         result = GetSqlXml_Unchecked(getters, ordinal);
                         break;
@@ -1207,6 +1213,7 @@ namespace Microsoft.Data.SqlClient.Server
             DBNull.Value,       // SqlDbType.Time
             DBNull.Value,       // SqlDbType.DateTime2
             DBNull.Value,       // SqlDbType.DateTimeOffset
+            SqlString.Null,     // SqlDbTypeExtensions.Json (value 35)
         };
 
         internal static object NullUdtInstance(SmiMetaData metaData)
@@ -1827,6 +1834,14 @@ namespace Microsoft.Data.SqlClient.Server
                             Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.String));
                             SetCharsOrString_FromReader(setters, i, metaData[i], reader, 0);
                             break;
+                        case SqlDbTypeExtensions.Json:
+                            {
+                                Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.String));
+                                // JSON travels as a single UTF-8 PLP value (see TdsValueSetter.SetString).
+                                string jsonValue = reader.GetString(i);
+                                SetString_Unchecked(setters, i, jsonValue, 0, jsonValue.Length);
+                            }
+                            break;
                         case SqlDbType.Xml:
                             {
                                 Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.SqlXml));
@@ -2027,6 +2042,14 @@ namespace Microsoft.Data.SqlClient.Server
                         case SqlDbType.VarChar:
                             Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.String));
                             SetChars_FromRecord(setters, i, metaData[i], record, 0);
+                            break;
+                        case SqlDbTypeExtensions.Json:
+                            {
+                                Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.String));
+                                // JSON travels as a single UTF-8 PLP value (see TdsValueSetter.SetString).
+                                string jsonValue = record.GetString(i);
+                                SetString_Unchecked(setters, i, jsonValue, 0, jsonValue.Length);
+                            }
                             break;
                         case SqlDbType.Xml:
                             Debug.Assert(CanAccessSetterDirectly(metaData[i], ExtendedClrTypeCode.SqlXml));
@@ -2522,9 +2545,12 @@ namespace Microsoft.Data.SqlClient.Server
             Debug.Assert(ExtendedClrTypeCode.First == 0 && (int)ExtendedClrTypeCode.Last == s_canAccessGetterDirectly.GetLength(0) - 1, "ExtendedClrTypeCodes does not match with __canAccessGetterDirectly");
             Debug.Assert(SqlDbType.BigInt == 0 && (int)SqlDbType.DateTimeOffset == s_canAccessGetterDirectly.GetLength(1) - 1, "SqlDbType does not match with __canAccessGetterDirectly");
             Debug.Assert(ExtendedClrTypeCode.First <= setterTypeCode && ExtendedClrTypeCode.Last >= setterTypeCode);
-            Debug.Assert(SqlDbType.BigInt <= metaData.SqlDbType && SqlDbType.DateTimeOffset >= metaData.SqlDbType);
+            Debug.Assert((SqlDbType.BigInt <= metaData.SqlDbType && SqlDbType.DateTimeOffset >= metaData.SqlDbType) || SqlDbTypeExtensions.Json == metaData.SqlDbType);
 
-            bool returnValue = s_canAccessGetterDirectly[(int)setterTypeCode, (int)metaData.SqlDbType];
+            // JSON is outside the contiguous SqlDbType range covered by the access map; it accepts the
+            // same accessors as NVarChar (string-based value transfer).
+            SqlDbType effectiveGetterType = SqlDbTypeExtensions.Json == metaData.SqlDbType ? SqlDbType.NVarChar : metaData.SqlDbType;
+            bool returnValue = s_canAccessGetterDirectly[(int)setterTypeCode, (int)effectiveGetterType];
 
             // Additional restrictions to distinguish TVPs and Structured UDTs
             if (
@@ -2548,9 +2574,12 @@ namespace Microsoft.Data.SqlClient.Server
             Debug.Assert(ExtendedClrTypeCode.First == 0 && (int)ExtendedClrTypeCode.Last == s_canAccessSetterDirectly.GetLength(0) - 1, "ExtendedClrTypeCodes does not match with __canAccessSetterDirectly");
             Debug.Assert(SqlDbType.BigInt == 0 && (int)SqlDbType.DateTimeOffset == s_canAccessSetterDirectly.GetLength(1) - 1, "SqlDbType does not match with __canAccessSetterDirectly");
             Debug.Assert(ExtendedClrTypeCode.First <= setterTypeCode && ExtendedClrTypeCode.Last >= setterTypeCode);
-            Debug.Assert(SqlDbType.BigInt <= metaData.SqlDbType && SqlDbType.DateTimeOffset >= metaData.SqlDbType);
+            Debug.Assert((SqlDbType.BigInt <= metaData.SqlDbType && SqlDbType.DateTimeOffset >= metaData.SqlDbType) || SqlDbTypeExtensions.Json == metaData.SqlDbType);
 
-            bool returnValue = s_canAccessSetterDirectly[(int)setterTypeCode, (int)metaData.SqlDbType];
+            // JSON is outside the contiguous SqlDbType range covered by the access map; it accepts the
+            // same accessors as NVarChar (string-based value transfer).
+            SqlDbType effectiveSetterType = SqlDbTypeExtensions.Json == metaData.SqlDbType ? SqlDbType.NVarChar : metaData.SqlDbType;
+            bool returnValue = s_canAccessSetterDirectly[(int)setterTypeCode, (int)effectiveSetterType];
 
             // Additional restrictions to distinguish TVPs and Structured UDTs
             if (

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -11197,6 +11197,14 @@ namespace Microsoft.Data.SqlClient
                     WriteUnsignedInt(_defaultCollation._info, stateObj);
                     stateObj.WriteByte(_defaultCollation._sortId);
                     break;
+                case SqlDbTypeExtensions.Vector:
+                    // Vector TVP column TYPE_INFO: type token + total byte length (8-byte header +
+                    // payload) + element-type/scale byte (0 = float32). The value is sent as the raw
+                    // vector bytes with a ushort length prefix (non-PLP), matching the JDBC driver.
+                    stateObj.WriteByte(TdsEnums.SQLVECTOR);
+                    WriteUnsignedShort(checked((ushort)metaData.MaxLength), stateObj);
+                    stateObj.WriteByte(metaData.Scale);
+                    break;
                 case SqlDbType.Xml:
                     stateObj.WriteByte(TdsEnums.SQLXMLTYPE);
                     // Is there a schema

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsParser.cs
@@ -11188,6 +11188,15 @@ namespace Microsoft.Data.SqlClient
                     stateObj.WriteByte(TdsEnums.SQLVARIANT);
                     WriteInt(checked((int)metaData.MaxLength), stateObj);
                     break;
+                case SqlDbTypeExtensions.Json:
+                    // The SQL Server TVP protocol carries a JSON column as NVARCHAR(max) + collation,
+                    // with the value sent as UTF-16 (the server converts it to JSON on insert). This
+                    // matches the Microsoft JDBC driver's TVP/bulk representation of JSON columns.
+                    stateObj.WriteByte(TdsEnums.SQLNVARCHAR);
+                    WriteUnsignedShort(unchecked((ushort)SmiMetaData.UnlimitedMaxLengthIndicator), stateObj);
+                    WriteUnsignedInt(_defaultCollation._info, stateObj);
+                    stateObj.WriteByte(_defaultCollation._sortId);
+                    break;
                 case SqlDbType.Xml:
                     stateObj.WriteByte(TdsEnums.SQLXMLTYPE);
                     // Is there a schema

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsValueSetter.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/TdsValueSetter.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Data.SqlClient
                     case SqlDbType.Timestamp:
                     case SqlDbType.VarBinary:
                     case SqlDbType.VarChar:
+                    case SqlDbTypeExtensions.Vector:
                         _stateObj.Parser.WriteShort(TdsEnums.VARNULL, _stateObj);
                         break;
                     case SqlDbType.Udt:

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlMetaDataTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlMetaDataTest.cs
@@ -239,6 +239,33 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Contains("dbType", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
+        [Fact]
+        public void ConstructorWithJsonType_Succeeds()
+        {
+            // JSON is a valid column type for a table-valued parameter / SqlDataRecord.
+            SqlMetaData metaData = new SqlMetaData("col1", SqlDbTypeExtensions.Json);
+            Assert.Equal("col1", metaData.Name);
+            Assert.Equal(SqlDbTypeExtensions.Json, metaData.SqlDbType);
+            Assert.Equal(DbType.String, metaData.DbType);
+            Assert.Equal(SqlMetaData.Max, metaData.MaxLength);
+        }
+
+        [Fact]
+        public void SqlDataRecord_JsonColumn_RoundTripsInMemory()
+        {
+            // Validates the client-side SMI plumbing for a JSON column without a server.
+            const string json = "{\"a\":1,\"b\":[1,2,3]}";
+            SqlMetaData[] metadata = { new SqlMetaData("Data", SqlDbTypeExtensions.Json) };
+            SqlDataRecord record = new SqlDataRecord(metadata);
+
+            record.SetString(0, json);
+            Assert.Equal(json, record.GetString(0));
+            Assert.Equal(SqlDbTypeExtensions.Json, record.GetSqlMetaData(0).SqlDbType);
+
+            record.SetDBNull(0);
+            Assert.True(record.IsDBNull(0));
+        }
+
         public static IEnumerable<object[]> ConstructorCharData()
         {
             return new object[][]

--- a/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlMetaDataTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/FunctionalTests/SqlMetaDataTest.cs
@@ -9,6 +9,7 @@ using System.Data.SqlTypes;
 using System.Globalization;
 using System.Reflection;
 using Microsoft.Data.SqlClient.Server;
+using Microsoft.Data.SqlTypes;
 using Xunit;
 
 namespace Microsoft.Data.SqlClient.Tests
@@ -263,6 +264,35 @@ namespace Microsoft.Data.SqlClient.Tests
             Assert.Equal(SqlDbTypeExtensions.Json, record.GetSqlMetaData(0).SqlDbType);
 
             record.SetDBNull(0);
+            Assert.True(record.IsDBNull(0));
+        }
+
+        [Fact]
+        public void ConstructorWithVectorType_Succeeds()
+        {
+            // Vector column max length = 8-byte header + 4 bytes per float32 dimension (3 dims => 20).
+            SqlMetaData metaData = new SqlMetaData("col1", SqlDbTypeExtensions.Vector, 20);
+            Assert.Equal("col1", metaData.Name);
+            Assert.Equal(SqlDbTypeExtensions.Vector, metaData.SqlDbType);
+            Assert.Equal(DbType.Binary, metaData.DbType);
+            Assert.Equal(20, metaData.MaxLength);
+        }
+
+        [Fact]
+        public void SqlDataRecord_VectorColumn_RoundTripsInMemory()
+        {
+            // Validates the client-side SMI plumbing for a Vector column without a server.
+            float[] values = new float[] { 1.1f, 2.2f, 3.3f };
+            int byteLength = 8 + sizeof(float) * values.Length;
+            SqlMetaData[] metadata = { new SqlMetaData("V", SqlDbTypeExtensions.Vector, byteLength) };
+            SqlDataRecord record = new SqlDataRecord(metadata);
+
+            record.SetValue(0, new SqlVector<float>(values));
+            Assert.Equal(SqlDbTypeExtensions.Vector, record.GetSqlMetaData(0).SqlDbType);
+            SqlVector<float> read = Assert.IsType<SqlVector<float>>(record.GetValue(0));
+            Assert.Equal(values, read.Memory.ToArray());
+
+            record.SetValue(0, SqlVector<float>.CreateNull(values.Length));
             Assert.True(record.IsDBNull(0));
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -373,5 +373,113 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests
             spCommand.ExecuteNonQuery();
             Assert.Equal(JsonDataString, (string)outputParam.Value);
         }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
+        public void TestJsonTvpRoundTrip()
+        {
+            // Pass a table-valued parameter whose column is a JSON type, sourced from
+            // SqlDataRecord rows, and read the values back through the TVP.
+            using SqlConnection connection = new(DataTestUtility.TCPConnectionString);
+            connection.Open();
+
+            string tvpTypeName = DataTestUtility.GetLongName("JsonTvp");
+            using (SqlCommand createType = new($"CREATE TYPE {tvpTypeName} AS TABLE (Id int, Data json)", connection))
+            {
+                createType.ExecuteNonQuery();
+            }
+
+            try
+            {
+                SqlMetaData[] metadata =
+                {
+                    new SqlMetaData("Id", SqlDbType.Int),
+                    new SqlMetaData("Data", SqlDbTypeExtensions.Json),
+                };
+
+                SqlDataRecord row0 = new(metadata);
+                row0.SetInt32(0, 0);
+                row0.SetString(1, JsonDataString);
+
+                SqlDataRecord row1 = new(metadata);
+                row1.SetInt32(0, 1);
+                row1.SetDBNull(1); // NULL json
+
+                using SqlCommand command = connection.CreateCommand();
+                command.CommandText = "SELECT Id, Data FROM @tvp ORDER BY Id";
+                SqlParameter parameter = command.Parameters.AddWithValue("@tvp", new[] { row0, row1 });
+                parameter.SqlDbType = SqlDbType.Structured;
+                parameter.TypeName = tvpTypeName;
+
+                using SqlDataReader reader = command.ExecuteReader();
+
+                Assert.True(reader.Read());
+                Assert.Equal(0, reader.GetInt32(0));
+                Assert.Equal("json", reader.GetDataTypeName(1));
+                Assert.Equal(JsonDataString, reader.GetString(1));
+
+                Assert.True(reader.Read());
+                Assert.Equal(1, reader.GetInt32(0));
+                Assert.True(reader.IsDBNull(1));
+
+                Assert.False(reader.Read());
+            }
+            finally
+            {
+                using SqlCommand dropType = new($"DROP TYPE IF EXISTS {tvpTypeName}", connection);
+                dropType.ExecuteNonQuery();
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsJsonSupported))]
+        public void TestJsonTvpInsert()
+        {
+            // Insert rows into a real JSON column via a table-valued parameter, then read
+            // them back as a native JSON column.
+            using SqlConnection connection = new(DataTestUtility.TCPConnectionString);
+            connection.Open();
+
+            string tvpTypeName = DataTestUtility.GetLongName("JsonTvpIns");
+            using (SqlCommand createType = new($"CREATE TYPE {tvpTypeName} AS TABLE (Id int, Data json)", connection))
+            {
+                createType.ExecuteNonQuery();
+            }
+
+            try
+            {
+                using Table jsonTable = new(connection, nameof(TestJsonTvpInsert), "(Id int, Data json)");
+
+                SqlMetaData[] metadata =
+                {
+                    new SqlMetaData("Id", SqlDbType.Int),
+                    new SqlMetaData("Data", SqlDbTypeExtensions.Json),
+                };
+                SqlDataRecord row = new(metadata);
+                row.SetInt32(0, 1);
+                row.SetString(1, JsonDataString);
+
+                using (SqlCommand insert = connection.CreateCommand())
+                {
+                    insert.CommandText = $"INSERT INTO {jsonTable.Name} (Id, Data) SELECT Id, Data FROM @tvp";
+                    SqlParameter parameter = insert.Parameters.AddWithValue("@tvp", new[] { row });
+                    parameter.SqlDbType = SqlDbType.Structured;
+                    parameter.TypeName = tvpTypeName;
+                    int rowsAffected = insert.ExecuteNonQuery();
+                    Assert.Equal(1, rowsAffected);
+                }
+
+                using SqlCommand read = new($"SELECT Id, Data FROM {jsonTable.Name}", connection);
+                using SqlDataReader reader = read.ExecuteReader();
+                Assert.True(reader.Read());
+                Assert.Equal(1, reader.GetInt32(0));
+                Assert.Equal("json", reader.GetDataTypeName(1));
+                Assert.Equal(JsonDataString, reader.GetString(1));
+                Assert.False(reader.Read());
+            }
+            finally
+            {
+                using SqlCommand dropType = new($"DROP TYPE IF EXISTS {tvpTypeName}", connection);
+                dropType.ExecuteNonQuery();
+            }
+        }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/JsonTest/JsonTest.cs
@@ -11,6 +11,7 @@ using Xunit;
 using Xunit.Abstractions;
 using System.Text.Json;
 using Microsoft.Data.SqlTypes;
+using Microsoft.Data.SqlClient.Server;
 using Microsoft.Data.SqlClient.Tests.Common.Fixtures.DatabaseObjects;
 
 namespace Microsoft.Data.SqlClient.ManualTesting.Tests

--- a/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/VectorTest/NativeVectorFloat32Tests.cs
+++ b/src/Microsoft.Data.SqlClient/tests/ManualTests/SQL/VectorTest/NativeVectorFloat32Tests.cs
@@ -8,6 +8,7 @@ using System.Data;
 using System.Data.SqlTypes;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient.Server;
 using Microsoft.Data.SqlTypes;
 using Xunit;
 using Xunit.Abstractions;
@@ -622,6 +623,121 @@ namespace Microsoft.Data.SqlClient.ManualTesting.Tests.SQL.VectorTest
                 rowcnt++;
             }
             Assert.Equal(10, rowcnt);
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsSqlVectorSupported))]
+        public void TestVectorFloat32TvpRoundTrip()
+        {
+            // Pass VECTOR(float32) values (and a NULL vector) through a table-valued parameter
+            // sourced from SqlDataRecord rows, then read the values back through the TVP.
+            using SqlConnection conn = new SqlConnection(s_connectionString);
+            conn.Open();
+
+            string tvpTypeName = DataTestUtility.GetShortName("VecTvp");
+            using (SqlCommand createType = new SqlCommand(
+                $"CREATE TYPE {tvpTypeName} AS TABLE (Id int, VectorData vector({s_vectorDimensions}))", conn))
+            {
+                createType.ExecuteNonQuery();
+            }
+
+            try
+            {
+                // Vector column max length = 8-byte header + 4 bytes per float32 dimension.
+                int vectorByteLength = VectorFloat32TestData.VectorHeaderSize + sizeof(float) * s_vectorDimensions;
+                float[] values = VectorFloat32TestData.testData;
+
+                SqlMetaData[] metadata =
+                {
+                    new SqlMetaData("Id", SqlDbType.Int),
+                    new SqlMetaData("VectorData", SqlDbTypeExtensions.Vector, vectorByteLength),
+                };
+
+                SqlDataRecord row0 = new SqlDataRecord(metadata);
+                row0.SetInt32(0, 0);
+                row0.SetValue(1, new SqlVector<float>(values));
+
+                SqlDataRecord row1 = new SqlDataRecord(metadata);
+                row1.SetInt32(0, 1);
+                row1.SetValue(1, SqlVector<float>.CreateNull(s_vectorDimensions)); // NULL vector
+
+                using SqlCommand command = conn.CreateCommand();
+                command.CommandText = "SELECT Id, VectorData FROM @tvp ORDER BY Id";
+                SqlParameter p = command.Parameters.AddWithValue("@tvp", new[] { row0, row1 });
+                p.SqlDbType = SqlDbType.Structured;
+                p.TypeName = tvpTypeName;
+
+                using SqlDataReader reader = command.ExecuteReader();
+
+                Assert.True(reader.Read());
+                Assert.Equal(0, reader.GetInt32(0));
+                Assert.Equal(values, reader.GetSqlVector<float>(1).Memory.ToArray());
+
+                Assert.True(reader.Read());
+                Assert.Equal(1, reader.GetInt32(0));
+                Assert.True(reader.IsDBNull(1));
+
+                Assert.False(reader.Read());
+            }
+            finally
+            {
+                using SqlCommand dropType = new SqlCommand($"DROP TYPE IF EXISTS {tvpTypeName}", conn);
+                dropType.ExecuteNonQuery();
+            }
+        }
+
+        [ConditionalFact(typeof(DataTestUtility), nameof(DataTestUtility.IsSqlVectorSupported))]
+        public void TestVectorFloat32TvpInsert()
+        {
+            // Insert VECTOR(float32) rows into a real table via a table-valued parameter, then read
+            // them back as native vectors.
+            using SqlConnection conn = new SqlConnection(s_connectionString);
+            conn.Open();
+
+            string tvpTypeName = DataTestUtility.GetShortName("VecTvpIns");
+            string destTableName = DataTestUtility.GetShortName("VecTvpDest");
+            using (SqlCommand setup = new SqlCommand(
+                $"CREATE TYPE {tvpTypeName} AS TABLE (Id int, VectorData vector({s_vectorDimensions}));" +
+                $"CREATE TABLE {destTableName} (Id int, VectorData vector({s_vectorDimensions}) NULL);", conn))
+            {
+                setup.ExecuteNonQuery();
+            }
+
+            try
+            {
+                int vectorByteLength = VectorFloat32TestData.VectorHeaderSize + sizeof(float) * s_vectorDimensions;
+                float[] values = VectorFloat32TestData.testData;
+
+                SqlMetaData[] metadata =
+                {
+                    new SqlMetaData("Id", SqlDbType.Int),
+                    new SqlMetaData("VectorData", SqlDbTypeExtensions.Vector, vectorByteLength),
+                };
+                SqlDataRecord row = new SqlDataRecord(metadata);
+                row.SetInt32(0, 1);
+                row.SetValue(1, new SqlVector<float>(values));
+
+                using (SqlCommand insert = conn.CreateCommand())
+                {
+                    insert.CommandText = $"INSERT INTO {destTableName} (Id, VectorData) SELECT Id, VectorData FROM @tvp";
+                    SqlParameter p = insert.Parameters.AddWithValue("@tvp", new[] { row });
+                    p.SqlDbType = SqlDbType.Structured;
+                    p.TypeName = tvpTypeName;
+                    Assert.Equal(1, insert.ExecuteNonQuery());
+                }
+
+                using SqlCommand read = new SqlCommand($"SELECT Id, VectorData FROM {destTableName}", conn);
+                using SqlDataReader reader = read.ExecuteReader();
+                Assert.True(reader.Read());
+                Assert.Equal(1, reader.GetInt32(0));
+                Assert.Equal(values, reader.GetSqlVector<float>(1).Memory.ToArray());
+                Assert.False(reader.Read());
+            }
+            finally
+            {
+                using SqlCommand cleanup = new SqlCommand(
+                    $"DROP TABLE IF EXISTS {destTableName}; DROP TYPE IF EXISTS {tvpTypeName};", conn);
+                cleanup.ExecuteNonQuery();
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This PR is a work in progress for adding TVP support for JSON and vector(float32) datatypes.

## Issues
#3449

## Testing
Added functional and manual tests where applicable.

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)
