### PR TITLE
Expand connection pool benchmark coverage for pool implementation A/B testing

### DIFF
--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolChurnRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolChurnRunner.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Measures the raw per-checkout overhead of the connection pool: a single thread
+    /// repeatedly opens and closes a connection against a warm pool, with no contention.
+    ///
+    /// With only one caller and a pre-warmed pool, every open is a pure pool checkout
+    /// (no physical connect, no waiting), so this benchmark isolates the CPU and
+    /// allocation cost of the pool's acquire/return path itself. It is the low-noise
+    /// counterpart to the parallel and contention runners and is the most sensitive
+    /// measure of per-operation allocations (watch the Allocated / Gen0 columns) — a key
+    /// concern for the new ChannelDbConnectionPool, which aims to avoid extra allocations
+    /// on the hot path (issue #3356).
+    ///
+    /// The pool implementation (legacy vs V2) is a process-level choice — see the remarks
+    /// on <see cref="ConnectionPoolStressRunner"/>. Run twice (UseConnectionPoolV2 false
+    /// then true) to compare.
+    ///
+    /// Related issue: #3356
+    /// </summary>
+    public class ConnectionPoolChurnRunner : BaseRunner
+    {
+        public enum AsyncBehavior
+        {
+            Sync,
+            Async
+        }
+
+        /// <summary>
+        /// Whether the connection is opened synchronously or asynchronously.
+        /// </summary>
+        [ParamsAllValues]
+        public AsyncBehavior Async { get; set; }
+
+        /// <summary>
+        /// Number of sequential open/close operations performed per invocation. Kept high
+        /// so each measured invocation captures many pool checkouts, yielding a stable
+        /// per-operation cost.
+        /// </summary>
+        [Params(1000)]
+        public int OpsPerInvocation { get; set; }
+
+        private string _connectionString;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            Console.WriteLine(
+                "[ConnectionPoolChurnRunner] Pool implementation: " +
+                (s_config.UseConnectionPoolV2
+                    ? "ChannelDbConnectionPool (V2)"
+                    : "WaitHandleDbConnectionPool (legacy)"));
+
+            var builder = new SqlConnectionStringBuilder(s_config.ConnectionString)
+            {
+                Pooling = true,
+                MaxPoolSize = 100,
+                // Pre-warm a single connection so the very first checkout is served from
+                // the pool rather than establishing a physical connection.
+                MinPoolSize = 1
+            };
+            _connectionString = builder.ConnectionString;
+
+            // Force the pool to exist and hold at least one idle connection.
+            using var warm = new SqlConnection(_connectionString);
+            warm.Open();
+            warm.Close();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            SqlConnection.ClearPool(conn);
+        }
+
+        [Benchmark]
+        public async Task RapidOpenCloseSingleThread()
+        {
+            for (int i = 0; i < OpsPerInvocation; i++)
+            {
+                using var conn = new SqlConnection(_connectionString);
+
+                if (Async is AsyncBehavior.Async)
+                {
+                    await conn.OpenAsync();
+                }
+                else
+                {
+                    conn.Open();
+                }
+                // Dispose returns the connection to the pool.
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolChurnRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolChurnRunner.cs
@@ -28,18 +28,6 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
     /// </summary>
     public class ConnectionPoolChurnRunner : BaseRunner
     {
-        public enum AsyncBehavior
-        {
-            Sync,
-            Async
-        }
-
-        /// <summary>
-        /// Whether the connection is opened synchronously or asynchronously.
-        /// </summary>
-        [ParamsAllValues]
-        public AsyncBehavior Async { get; set; }
-
         /// <summary>
         /// Number of sequential open/close operations performed per invocation. Kept high
         /// so each measured invocation captures many pool checkouts, yielding a stable
@@ -83,20 +71,23 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         }
 
         [Benchmark]
-        public async Task RapidOpenCloseSingleThread()
+        public void RapidOpenCloseSingleThread()
         {
             for (int i = 0; i < OpsPerInvocation; i++)
             {
                 using var conn = new SqlConnection(_connectionString);
+                conn.Open();
+                // Dispose returns the connection to the pool.
+            }
+        }
 
-                if (Async is AsyncBehavior.Async)
-                {
-                    await conn.OpenAsync();
-                }
-                else
-                {
-                    conn.Open();
-                }
+        [Benchmark]
+        public async Task RapidOpenCloseSingleThreadAsync()
+        {
+            for (int i = 0; i < OpsPerInvocation; i++)
+            {
+                using var conn = new SqlConnection(_connectionString);
+                await conn.OpenAsync();
                 // Dispose returns the connection to the pool.
             }
         }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
@@ -34,18 +34,6 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
     /// </summary>
     public class ConnectionPoolContentionRunner : BaseRunner
     {
-        public enum AsyncBehavior
-        {
-            Sync,
-            Async
-        }
-
-        /// <summary>
-        /// Whether workers check connections out synchronously or asynchronously.
-        /// </summary>
-        [ParamsAllValues]
-        public AsyncBehavior Async { get; set; }
-
         /// <summary>
         /// Number of concurrent workers competing for pooled connections.
         /// </summary>
@@ -107,36 +95,41 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             var tasks = new Task[Parallelism];
             for (int i = 0; i < Parallelism; i++)
             {
-                if (Async is AsyncBehavior.Async)
+                tasks[i] = Task.Run(() =>
                 {
-                    tasks[i] = Task.Run(async () =>
+                    for (int op = 0; op < OpsPerWorker; op++)
                     {
-                        for (int op = 0; op < OpsPerWorker; op++)
-                        {
-                            using var conn = new SqlConnection(_connectionString);
-                            await conn.OpenAsync();
-                            using var cmd = conn.CreateCommand();
-                            cmd.CommandText = "SELECT 1";
-                            _ = await cmd.ExecuteScalarAsync();
-                            // Dispose returns the connection to the pool.
-                        }
-                    });
-                }
-                else
+                        using var conn = new SqlConnection(_connectionString);
+                        conn.Open();
+                        using var cmd = conn.CreateCommand();
+                        cmd.CommandText = "SELECT 1";
+                        _ = cmd.ExecuteScalar();
+                        // Dispose returns the connection to the pool.
+                    }
+                });
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        [Benchmark]
+        public async Task SteadyStateOpenQueryCloseAsync()
+        {
+            var tasks = new Task[Parallelism];
+            for (int i = 0; i < Parallelism; i++)
+            {
+                tasks[i] = Task.Run(async () =>
                 {
-                    tasks[i] = Task.Run(() =>
+                    for (int op = 0; op < OpsPerWorker; op++)
                     {
-                        for (int op = 0; op < OpsPerWorker; op++)
-                        {
-                            using var conn = new SqlConnection(_connectionString);
-                            conn.Open();
-                            using var cmd = conn.CreateCommand();
-                            cmd.CommandText = "SELECT 1";
-                            _ = cmd.ExecuteScalar();
-                            // Dispose returns the connection to the pool.
-                        }
-                    });
-                }
+                        using var conn = new SqlConnection(_connectionString);
+                        await conn.OpenAsync();
+                        using var cmd = conn.CreateCommand();
+                        cmd.CommandText = "SELECT 1";
+                        _ = await cmd.ExecuteScalarAsync();
+                        // Dispose returns the connection to the pool.
+                    }
+                });
             }
 
             await Task.WhenAll(tasks);

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Data.SqlClient.PerformanceTests
+{
+    /// <summary>
+    /// Measures steady-state pool throughput under concurrent load — the hot path for
+    /// real applications such as web servers, where many workers repeatedly check a
+    /// connection out of a warm pool, do a small unit of work, and return it.
+    ///
+    /// This is where the legacy WaitHandleDbConnectionPool and the new
+    /// ChannelDbConnectionPool differ most (issue #3356):
+    ///
+    /// - When the pool is large enough to serve every worker, the benchmark isolates
+    ///   checkout/return overhead and lock contention on the hot path.
+    /// - When the pool is smaller than the worker count (<see cref="MaxPoolSize"/> less
+    ///   than <see cref="Parallelism"/>), workers must wait for a connection to be
+    ///   returned. This exercises the waiter wake path: the legacy pool parks on
+    ///   WaitHandle.WaitAny (a blocking wait that consumes a threadpool thread for async
+    ///   callers), while the new pool awaits the idle channel asynchronously. The
+    ///   ThreadingDiagnoser's "Completed Work Items" and "Lock Contentions" columns make
+    ///   the difference visible.
+    ///
+    /// The pool implementation (legacy vs V2) and SNI are process-level choices — see the
+    /// remarks on <see cref="ConnectionPoolStressRunner"/>. Run twice (UseConnectionPoolV2
+    /// false then true) to compare.
+    ///
+    /// Related issues: #601, #979, #3356
+    /// </summary>
+    public class ConnectionPoolContentionRunner : BaseRunner
+    {
+        public enum AsyncBehavior
+        {
+            Sync,
+            Async
+        }
+
+        /// <summary>
+        /// Whether workers check connections out synchronously or asynchronously.
+        /// </summary>
+        [ParamsAllValues]
+        public AsyncBehavior Async { get; set; }
+
+        /// <summary>
+        /// Number of concurrent workers competing for pooled connections.
+        /// </summary>
+        [Params(50)]
+        public int Parallelism { get; set; }
+
+        /// <summary>
+        /// Maximum pool size. A value greater than or equal to <see cref="Parallelism"/>
+        /// means no contention for physical connections; a smaller value forces workers to
+        /// wait for connections to be returned (pool exhaustion / back-pressure).
+        /// </summary>
+        [Params(50, 10)]
+        public int MaxPoolSize { get; set; }
+
+        /// <summary>
+        /// Number of open/query/close operations each worker performs per invocation.
+        /// </summary>
+        [Params(20)]
+        public int OpsPerWorker { get; set; }
+
+        private string _connectionString;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            Console.WriteLine(
+                "[ConnectionPoolContentionRunner] Pool implementation: " +
+                (s_config.UseConnectionPoolV2
+                    ? "ChannelDbConnectionPool (V2)"
+                    : "WaitHandleDbConnectionPool (legacy)"));
+
+            var builder = new SqlConnectionStringBuilder(s_config.ConnectionString)
+            {
+                Pooling = true,
+                MaxPoolSize = MaxPoolSize,
+                MinPoolSize = 0
+            };
+            _connectionString = builder.ConnectionString;
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            // Warm the pool up to MaxPoolSize so the measured run reflects steady-state
+            // checkout/return rather than first-time physical connection establishment.
+            WarmPool(MaxPoolSize);
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            using var conn = new SqlConnection(_connectionString);
+            SqlConnection.ClearPool(conn);
+        }
+
+        [Benchmark]
+        public async Task SteadyStateOpenQueryClose()
+        {
+            var tasks = new Task[Parallelism];
+            for (int i = 0; i < Parallelism; i++)
+            {
+                tasks[i] = Task.Run(async () =>
+                {
+                    for (int op = 0; op < OpsPerWorker; op++)
+                    {
+                        using var conn = new SqlConnection(_connectionString);
+
+                        if (Async is AsyncBehavior.Async)
+                        {
+                            await conn.OpenAsync();
+                            using var cmd = conn.CreateCommand();
+                            cmd.CommandText = "SELECT 1";
+                            _ = await cmd.ExecuteScalarAsync();
+                        }
+                        else
+                        {
+                            conn.Open();
+                            using var cmd = conn.CreateCommand();
+                            cmd.CommandText = "SELECT 1";
+                            _ = cmd.ExecuteScalar();
+                        }
+                        // Dispose returns the connection to the pool.
+                    }
+                });
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        private void WarmPool(int count)
+        {
+            var conns = new SqlConnection[count];
+            for (int i = 0; i < count; i++)
+            {
+                conns[i] = new SqlConnection(_connectionString);
+                conns[i].Open();
+            }
+            // Return them all to the pool so subsequent checkouts are served from idle.
+            for (int i = 0; i < count; i++)
+            {
+                conns[i].Close();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
@@ -41,11 +41,13 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public int Parallelism { get; set; }
 
         /// <summary>
-        /// Maximum pool size. A value greater than or equal to <see cref="Parallelism"/>
-        /// means no contention for physical connections; a smaller value forces workers to
-        /// wait for connections to be returned (pool exhaustion / back-pressure).
+        /// Maximum pool size, exercised across three regimes relative to
+        /// <see cref="Parallelism"/>: larger than the worker count (idle spare
+        /// connections, no contention), equal to it (fully subscribed, no contention), and
+        /// smaller than it (pool exhaustion forces workers to wait for a connection to be
+        /// returned — back-pressure).
         /// </summary>
-        [Params(50, 10)]
+        [Params(100, 50, 10)]
         public int MaxPoolSize { get; set; }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         }
 
         [Benchmark]
-        public async Task SteadyStateOpenQueryClose()
+        public Task SteadyStateOpenQueryClose()
         {
             var tasks = new Task[Parallelism];
             for (int i = 0; i < Parallelism; i++)
@@ -111,11 +111,11 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
                 });
             }
 
-            await Task.WhenAll(tasks);
+            return Task.WhenAll(tasks);
         }
 
         [Benchmark]
-        public async Task SteadyStateOpenQueryCloseAsync()
+        public Task SteadyStateOpenQueryCloseAsync()
         {
             var tasks = new Task[Parallelism];
             for (int i = 0; i < Parallelism; i++)
@@ -134,7 +134,7 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
                 });
             }
 
-            await Task.WhenAll(tasks);
+            return Task.WhenAll(tasks);
         }
 
         private void WarmPool(int count)

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/BenchmarkRunners/ConnectionPoolContentionRunner.cs
@@ -107,29 +107,36 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             var tasks = new Task[Parallelism];
             for (int i = 0; i < Parallelism; i++)
             {
-                tasks[i] = Task.Run(async () =>
+                if (Async is AsyncBehavior.Async)
                 {
-                    for (int op = 0; op < OpsPerWorker; op++)
+                    tasks[i] = Task.Run(async () =>
                     {
-                        using var conn = new SqlConnection(_connectionString);
-
-                        if (Async is AsyncBehavior.Async)
+                        for (int op = 0; op < OpsPerWorker; op++)
                         {
+                            using var conn = new SqlConnection(_connectionString);
                             await conn.OpenAsync();
                             using var cmd = conn.CreateCommand();
                             cmd.CommandText = "SELECT 1";
                             _ = await cmd.ExecuteScalarAsync();
+                            // Dispose returns the connection to the pool.
                         }
-                        else
+                    });
+                }
+                else
+                {
+                    tasks[i] = Task.Run(() =>
+                    {
+                        for (int op = 0; op < OpsPerWorker; op++)
                         {
+                            using var conn = new SqlConnection(_connectionString);
                             conn.Open();
                             using var cmd = conn.CreateCommand();
                             cmd.CommandText = "SELECT 1";
                             _ = cmd.ExecuteScalar();
+                            // Dispose returns the connection to the pool.
                         }
-                        // Dispose returns the connection to the pool.
-                    }
-                });
+                    });
+                }
             }
 
             await Task.WhenAll(tasks);
@@ -138,15 +145,23 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         private void WarmPool(int count)
         {
             var conns = new SqlConnection[count];
-            for (int i = 0; i < count; i++)
+            try
             {
-                conns[i] = new SqlConnection(_connectionString);
-                conns[i].Open();
+                for (int i = 0; i < count; i++)
+                {
+                    conns[i] = new SqlConnection(_connectionString);
+                    conns[i].Open();
+                }
             }
-            // Return them all to the pool so subsequent checkouts are served from idle.
-            for (int i = 0; i < count; i++)
+            finally
             {
-                conns[i].Close();
+                // Close and dispose every connection so they return to the pool and
+                // are not retained until GC (which would add allocation/GC noise).
+                for (int i = 0; i < count; i++)
+                {
+                    conns[i]?.Close();
+                    conns[i]?.Dispose();
+                }
             }
         }
     }

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Config/Config.cs
@@ -12,6 +12,20 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public string ConnectionString;
         public bool UseManagedSniOnWindows;
         public bool UseOptimizedAsyncBehaviour;
+
+        /// <summary>
+        /// When true, selects the new channel-based connection pool
+        /// (<c>ChannelDbConnectionPool</c>) by enabling the
+        /// <c>Switch.Microsoft.Data.SqlClient.UseConnectionPoolV2</c> AppContext switch.
+        /// When false (the default), the legacy <c>WaitHandleDbConnectionPool</c> is used.
+        ///
+        /// This is a process-level setting: the switch is read and cached the first time
+        /// a pool is created, so it cannot be toggled per benchmark iteration. To compare
+        /// the two implementations, run the benchmark once with this flag false and once
+        /// with it true.
+        /// </summary>
+        public bool UseConnectionPoolV2;
+
         public bool WaitForProfiler;
         public bool UseNativeMemoryAndETWProfiler;
         public Benchmarks Benchmarks;
@@ -54,6 +68,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
         public RunnerJob JsonVsVarcharReadRunnerConfig;
         public RunnerJob BeginTransactionRunnerConfig;
         public RunnerJob ConnectionPoolStressRunnerConfig;
+        public RunnerJob ConnectionPoolContentionRunnerConfig;
+        public RunnerJob ConnectionPoolChurnRunnerConfig;
     }
 
     public class RunnerJob

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             Run_JsonVsVarcharReadBenchmark();
             Run_BeginTransactionBenchmark();
             Run_ConnectionPoolStressBenchmark();
+            Run_ConnectionPoolContentionBenchmark();
+            Run_ConnectionPoolChurnBenchmark();
 
             // TODOs:
             // Prepared/Regular Parameterized queries
@@ -47,6 +49,14 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             {
                 AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", true);
             }
+
+            // If the config file specifies to use the new channel-based connection pool,
+            // enable the UseConnectionPoolV2 AppContext switch. This must be set before any
+            // connection is opened because the switch is read and cached when a pool is first
+            // created; it cannot be changed later in the process lifetime.
+            AppContext.SetSwitch(
+                "Switch.Microsoft.Data.SqlClient.UseConnectionPoolV2",
+                _config.UseConnectionPoolV2);
 
             // If the config file specifies to use optimized async behavior, 
             // enable packet multiplexing feature and other optimizations in SqlClient 
@@ -183,6 +193,22 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
             if (_config.Benchmarks.ConnectionPoolStressRunnerConfig?.Enabled == true)
             {
                 BenchmarkRunner.Run<ConnectionPoolStressRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.ConnectionPoolStressRunnerConfig));
+            }
+        }
+
+        private void Run_ConnectionPoolContentionBenchmark()
+        {
+            if (_config.Benchmarks.ConnectionPoolContentionRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<ConnectionPoolContentionRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.ConnectionPoolContentionRunnerConfig));
+            }
+        }
+
+        private void Run_ConnectionPoolChurnBenchmark()
+        {
+            if (_config.Benchmarks.ConnectionPoolChurnRunnerConfig?.Enabled == true)
+            {
+                BenchmarkRunner.Run<ConnectionPoolChurnRunner>(BenchmarkConfig.s_instance(_config.Benchmarks.ConnectionPoolChurnRunnerConfig));
             }
         }
 

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/Program.cs
@@ -50,10 +50,10 @@ namespace Microsoft.Data.SqlClient.PerformanceTests
                 AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWindows", true);
             }
 
-            // If the config file specifies to use the new channel-based connection pool,
-            // enable the UseConnectionPoolV2 AppContext switch. This must be set before any
-            // connection is opened because the switch is read and cached when a pool is first
-            // created; it cannot be changed later in the process lifetime.
+            // Set the UseConnectionPoolV2 AppContext switch from config (true or false).
+            // This must be set before any connection is opened because the switch is read
+            // and cached when a pool is first created; it cannot be changed later in the
+            // process lifetime.
             AppContext.SetSwitch(
                 "Switch.Microsoft.Data.SqlClient.UseConnectionPoolV2",
                 _config.UseConnectionPoolV2);

--- a/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
+++ b/src/Microsoft.Data.SqlClient/tests/PerformanceTests/runnerconfig.jsonc
@@ -2,6 +2,12 @@
     "ConnectionString": "Server=tcp:localhost; Integrated Security=true; Initial Catalog=sqlclient-perf-db;",
     // Enable this flag to enable managed SNI on Windows.
     "UseManagedSniOnWindows": false,
+    // Enable this flag to select the new channel-based connection pool
+    // (ChannelDbConnectionPool) instead of the legacy WaitHandleDbConnectionPool.
+    // This is a process-level setting (the pool implementation switch is cached the
+    // first time a pool is created), so comparing the two pools requires two runs:
+    // once with this flag false (legacy) and once true (new). See issue #3356.
+    "UseConnectionPoolV2": false,
     // Enable this flag to enable optimized async behavior in SqlClient. 
     // This is useful for benchmarking packet multiplexing and async performance improvements.
     "UseOptimizedAsyncBehaviour": true,
@@ -117,6 +123,22 @@
             "Enabled": true,
             "LaunchCount": 1,
             "IterationCount": 20,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 0
+        },
+        "ConnectionPoolContentionRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 15,
+            "InvocationCount": 1,
+            "WarmupCount": 1,
+            "RowCount": 0
+        },
+        "ConnectionPoolChurnRunnerConfig": {
+            "Enabled": true,
+            "LaunchCount": 1,
+            "IterationCount": 15,
             "InvocationCount": 1,
             "WarmupCount": 1,
             "RowCount": 0


### PR DESCRIPTION
## Summary

Builds on the connection pool benchmarks added in #4447 (now merged to `main`) to make the suite useful for **evaluating the new `ChannelDbConnectionPool` (`UseConnectionPoolV2`) against the legacy `WaitHandleDbConnectionPool`**, aligned with the design goals in #3356: parallel connection opening, async best practices (low threadpool pressure), and minimal lock contention.

## What's added

- **Process-level `UseConnectionPoolV2` config flag** (`runnerconfig.jsonc` -> `Config` -> `Program`). It sets the `Switch.Microsoft.Data.SqlClient.UseConnectionPoolV2` AppContext switch once at startup.
  - The pool-implementation switch is read and **cached** when the first pool is created, so it cannot be toggled per benchmark iteration (BenchmarkDotNet runs all cases in-process). Comparing the two pools therefore requires **two runs** — flag `false` (legacy) then `true` (V2). This flag applies to every pool benchmark in the suite, including the existing `ConnectionPoolStressRunner` and `ParallelAsyncConnectionRunner`.
- **`ConnectionPoolChurnRunner`** — single-threaded, no-contention open/close on a warm pool. Isolates the raw per-checkout CPU and allocation cost of the pool's acquire/return path (the low-noise counterpart to the parallel/contention runners; the most sensitive measure of per-op allocations).
- **`ConnectionPoolContentionRunner`** — steady-state open -> `SELECT 1` -> close with pure-sync vs pure-async workers and a large (no-wait) vs small (back-pressure) pool axis. Focuses on the waiter wake path and threadpool pressure (watch `Completed Work Items` / `Lock Contentions`).

The existing `ConnectionPoolStressRunner` and `ParallelAsyncConnectionRunner` are left untouched — the new flag simply lets them all be run against either pool implementation.

## Not micro-benchmarked
Rate limiting (#4396), pruning (#4304), shutdown drain (#4302), and connection resiliency (#4415) are time/behavior-based and belong in reliability tests (#3667), not hot-path microbenchmarks.

## Validation
- Built `PerformanceTests` (net8.0, Release) — 0 warnings / 0 errors.
- Ran all three pool runners locally against a live SQL Server (Azure SQL Edge) with the flag both `false` and `true`; V2 showed ~3.5-4.3x faster parallel burst-open and materially lower async `Completed Work Items`, consistent with #3356's goals.

## Checklist
- [x] Tests added or updated (benchmark runners)
- [x] Public API changes documented — N/A (no public API changes)
- [x] Verified against live SQL Server
- [x] No breaking changes

Related: #3356, #601, #979, #4447
