### PR TITLE
Standardize APIScan registration and SDL break policy in OneBranch pipelines

### DIFF
--- a/.config/guardian/.gdnbaselines
+++ b/.config/guardian/.gdnbaselines
@@ -1,0 +1,124 @@
+{
+  "hydrated": false,
+  "properties": {
+    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/baselines"
+  },
+  "version": "1.0.0",
+  "baselines": {
+    "default": {
+      "name": "default",
+      "createdDate": "2026-07-23 11:29:23Z",
+      "lastUpdatedDate": "2026-07-23 11:29:23Z"
+    }
+  },
+  "results": {
+    "40b23e076c5c65b58c7da0889f0bf58e271b1637f662060bbc7aadd5c62a7126": {
+      "signature": "40b23e076c5c65b58c7da0889f0bf58e271b1637f662060bbc7aadd5c62a7126",
+      "alternativeSignatures": [
+        "4113c2e383bc4d7206cc94ba3e16dcdaef105762c7e22060d8e7964407e048ab",
+        "41bc93496e4ace0362f89323cc166b46e7448108052b75f7dd3ae5f4d48b5ad8",
+        "357246d2ddf96dbab309e392e49d088dc5c15ec9343553876173296f02eef94c"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2026-07-23 11:29:23Z"
+    },
+    "6e0dddb2d631181c20dbbf2892aceea3fbb157b3c293a147b70f49fc4a17765b": {
+      "signature": "6e0dddb2d631181c20dbbf2892aceea3fbb157b3c293a147b70f49fc4a17765b",
+      "alternativeSignatures": [
+        "2a9d1465faa5347c1f77eb856eb21074dc1dfcca4963991fb918fa61c1c29b02",
+        "9f71983dfef73a0b5fa1ecd3d1f14b3af9067aed39c5eb8619ecd0a0f4ee33f6",
+        "bd1475a089ab85c698803c80d71e73148edfc9db706bafe3789509ea32f917f2"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2026-07-23 11:29:23Z"
+    },
+    "28f157377f5600a0ce77a1a2193653ca71c8de4cca5d24166e1363cfc1f53782": {
+      "signature": "28f157377f5600a0ce77a1a2193653ca71c8de4cca5d24166e1363cfc1f53782",
+      "alternativeSignatures": [
+        "ff91ec920d3ed908c7fdc8419f4e767216c312a3907419b65e8e11e611be0db6",
+        "cc5e7e0d3670c5b2738f2b9194d50de2b123bdae5e906729f3a9c7baa980477d",
+        "8641e063e4aff04c260660c01c71ee18d32bdb7788357eaecc420a64cb279b2d"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2026-07-23 11:29:23Z"
+    },
+    "253df4b6cde68fb64c0376d3fa5351a49ccd9136e987129a6686f003303902bb": {
+      "signature": "253df4b6cde68fb64c0376d3fa5351a49ccd9136e987129a6686f003303902bb",
+      "alternativeSignatures": [
+        "e98757960f13dfe3c2c4ef2acbbdbd782cf26a7635caae25b7fd9e9230f863f6",
+        "df606344d52fe66ab4fa386e5cc50b6ced2c8d711aa7bc5a14db61f1fad7b70f",
+        "61239d49bfbe4702066454a51c302633291f61542011ee755420f4f556ede2d6"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2026-07-23 11:29:23Z"
+    },
+    "40b7b29173191dd629e8921c99d8718cad7ebf4d6acd83d8719e2e15db3d89a3": {
+      "signature": "40b7b29173191dd629e8921c99d8718cad7ebf4d6acd83d8719e2e15db3d89a3",
+      "alternativeSignatures": [
+        "870b4398ab01cdfaa4be8605e03eaa7377a5079b79573d3290248f5d5fd6fd6c",
+        "6b690695e0e41aa7a7c79394fa5d9f6a08e6e06cffc326b7fae4a8883ff42ac6",
+        "514ed34ad14af5b3739b2804e791b1b63d88be42e658238794f467c4bf2ff140"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2026-07-23 11:29:23Z"
+    },
+    "fb0afe300269068323c4e3fab292104aa30201c545156ffee1ccf6109df3bd59": {
+      "signature": "fb0afe300269068323c4e3fab292104aa30201c545156ffee1ccf6109df3bd59",
+      "alternativeSignatures": [
+        "7bdac882cf7914eb42130101ca921f1e4c5654cc55916daf1c2b9bc51c439dfa",
+        "6e99b53e08dcbad4533fbd8a101b881fba112f31483c7e9b7b14aaa709f3cee8",
+        "fc771d2d8a5bd2dfa72695e42516ff6c504e18fd714a1462d911539ea69fe710"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2026-07-23 11:29:23Z"
+    },
+    "e3ec17e281386f24ee7650c502b034993dcfd9a5ad19089c9af3edde8321fbb9": {
+      "signature": "e3ec17e281386f24ee7650c502b034993dcfd9a5ad19089c9af3edde8321fbb9",
+      "alternativeSignatures": [
+        "0910ddd1f1c9f37b764457a39d0dd543f25fce6e5e8694f066d0092e99784b4d",
+        "ee166a838d6e6b4aa08218eb89b001689bc3ec8fb6343fdfee89834847a294d5",
+        "7beed57053ec779f46498ff84c41a9400761001ea494237fe32cfab1c829454a"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2026-07-23 11:29:23Z"
+    },
+    "0ef75f3e883bfae828f2b15b4a41963e6ea3a61306fc19767586044309bc739f": {
+      "signature": "0ef75f3e883bfae828f2b15b4a41963e6ea3a61306fc19767586044309bc739f",
+      "alternativeSignatures": [
+        "7e71c00bf08e29508821cc200dcc41556ecc570c205f8833a5a704466e80baa5",
+        "0d5b851e97bdb0eb8931e6f326718a657f9cd46092eb8a2a2d414be2147a797c",
+        "e6c0cd6ef2433a42c95a2939cce740019ecda3fcfde64a3a0f21661e6ff27f71"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2026-07-23 11:29:23Z"
+    },
+    "27cf35f7df3f630fab489573ec19318f563e042424ca30625e9fe08407d74bdf": {
+      "signature": "27cf35f7df3f630fab489573ec19318f563e042424ca30625e9fe08407d74bdf",
+      "alternativeSignatures": [
+        "55e9029f79f883ee7e23a98ee6aad0c3713e02dd67cd7a7158875cdee4c86806",
+        "a443d3867a75710110ddf675eb639080559e694d4331fd89bc1589b1a60b8777",
+        "ff040e311fa90fc602c647b539f52148605321c178fc731f30395a8a9ef3f7a9"
+      ],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2026-07-23 11:29:23Z"
+    }
+  }
+}

--- a/.github/instructions/onebranch-pipeline-design.instructions.md
+++ b/.github/instructions/onebranch-pipeline-design.instructions.md
@@ -9,7 +9,7 @@ Rules and conventions for editing the OneBranch Azure DevOps YAML pipelines that
 
 ## Pipeline Variants
 
-- `sqlclient-official.yml` — Official pipeline; uses `OneBranch.Official.CrossPlat.yml`; CI trigger on `internal/main` + daily schedule at 04:30 UTC
+- `sqlclient-official.yml` — Official pipeline; uses `OneBranch.Official.CrossPlat.yml`; runs on a daily schedule at 04:30 UTC on `internal/main`, with no activity-based trigger (`pr: none`, `trigger: none`)
 - `sqlclient-non-official.yml` — Non-Official pipeline; uses `OneBranch.NonOfficial.CrossPlat.yml`; manual only (`pr: none`, `trigger: none`)
 - Both live under `eng/pipelines/onebranch/` and extend OneBranch governed templates
 - Never parameterize the OneBranch template name — hardcode it per pipeline for PRC compliance

--- a/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
+++ b/eng/pipelines/onebranch/jobs/build-buildproj-job.yml
@@ -102,12 +102,9 @@ jobs:
 
       ob_outputDirectory: '$(JOB_OUTPUT)'
 
-      # APIScan configuration for the package being built by this job.
-      ob_sdl_apiscan_enabled: true
+      # APIScan per-job configuration for the DLL and PDB folders.
       ob_sdl_apiscan_softwareFolder: ${{ parameters.apiScanDllPath }}
       ob_sdl_apiscan_symbolsFolder: ${{ parameters.apiScanPdbPath }}
-      ob_sdl_apiscan_softwarename: ${{ parameters.packageFullName }}
-      ob_sdl_apiscan_versionNumber: ${{ parameters.fileVersion }}
 
     steps:
       - template: /eng/pipelines/onebranch/steps/script-output-environment-variables-step.yml@self

--- a/eng/pipelines/onebranch/jobs/publish-symbols-job.yml
+++ b/eng/pipelines/onebranch/jobs/publish-symbols-job.yml
@@ -61,7 +61,6 @@ jobs:
       # Disable SDL scanning — this job only uploads/publishes PDBs and produces no
       # assemblies to scan. APIScan and BinSkim are handled by the build jobs.
       ob_sdl_apiscan_enabled: false
-      ob_sdl_binskim_break: false
       ob_sdl_binskim_enabled: false
 
       # Path where the downloaded artifact will be placed.

--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -135,7 +135,7 @@ extends:
       #
       apiscan:
         # We want APIScan enabled by default for our jobs.  However, some jobs don't produce any
-        # artifacts, and they will disable APIScan via the OneBranch per-job ob_sdl_apiscan_enable
+        # artifacts, and they will disable APIScan via the OneBranch per-job ob_sdl_apiscan_enabled
         # variable.
         enabled: true
 
@@ -145,7 +145,7 @@ extends:
         # Use pre-release mode for non-official pipelines.
         modeType: prerelease
 
-        # We have a single "name" and version registered with APIScan for all of our packages.
+        # We have a single "name" registered with APIScan for all of our packages.
         #
         # https://eng.ms/docs/products/apiscan/onboard/requirements/registersoftware
         #

--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -127,14 +127,41 @@ extends:
 
     # See: https://aka.ms/obpipelines/sdl
     globalSdl:
+      # Configure APIScan behaviour:
+      #
+      # https://eng.ms/docs/products/onebranch/securitycompliancegovernanceandpolicies/sdlforcontainerizedworkflows/customizesdlforcontainerbuilds#apiscan
+      #
+      # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-mohanb/security-integration/guardian-wiki/sdl-azdo-extension/apiscan-build-task#v2
+      #
       apiscan:
-        # APIScan "software name" and version parameters are set on a per-job basis with via
-        # ob_sdl_apiscan_* variables.
+        # We want APIScan enabled by default for our jobs.  However, some jobs don't produce any
+        # artifacts, and they will disable APIScan via the OneBranch per-job ob_sdl_apiscan_enable
+        # variable.
         enabled: true
+
+        # APIScan errors should not break non-official builds.
         break: false
+
+        # Use pre-release mode for non-official pipelines.
+        modeType: prerelease
+
+        # We have a single "name" and version registered with APIScan for all of our packages.
+        #
+        # https://eng.ms/docs/products/apiscan/onboard/requirements/registersoftware
+        #
+        softwareName: Microsoft.Data.SqlClient
+
+        # Similar to the software name, we have a single version registered as well.  This has
+        # nothing to do with the NuGet package version.  It is purely an APIScan registration
+        # value that points to our backend configuration.
+        softwareVersion: '6.10'
+
+        # We want the standard level of logging.
+        verbosityLevel: standard
 
       armory:
         enabled: true
+        break: false
 
       asyncSdl:
         # Disabling this as it complicates the build process with minimal gain
@@ -142,6 +169,7 @@ extends:
 
       binskim:
         enabled: true
+        break: false
 
       codeql:
         enabled: true
@@ -157,11 +185,13 @@ extends:
 
       policheck:
         enabled: true
+        break: false
         exclusionsFile: '$(REPO_ROOT)\.config\PolicheckExclusions.xml'
 
       roslyn:
         # Note, requires RoslynAnalyzers task to be added as a separate step
         enabled: true
+        break: false
 
       publishLogs:
         enabled: true
@@ -172,11 +202,9 @@ extends:
         packageVersion: '$(Build.BuildNumber)'
 
       tsa:
-        # We disable TSA for non-official pipelines. This inhibits spurious TSA alerts and ADO task
-        # creation, since non-official builds are often done against development branches. This also
-        # forces all SDL tasks into "break" build mode.
+        # Disable TSA for non-official runs.  Developers don't need the TSA integration for
+        # manually-run non-official builds.
         enabled: false
-        configFile: '$(REPO_ROOT)/.config/tsaoptions.json'
 
     stages:
       - template: /eng/pipelines/onebranch/stages/build-stages.yml@self

--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -6,29 +6,20 @@
 
 name: $(Year:YY)$(DayOfYear)$(Rev:.r)
 
-# No activity-based triggers.
+# No activity- or schedule-based triggers.  This pipeline is run manually only.
 pr: none
 trigger: none
-
-# We run this pipeline on a daily schedule.
-schedules:
-  - cron: "30 4 * * *"
-    displayName: Daily 04:30 UTC Build
-    branches:
-      include:
-        - internal/main
-    always: true
 
 # These parameters are visible in the Azure DevOps pipeline UI when a new run is queued.
 parameters:
 
-  # When true, any SDL errors will break the build, and TSA bug filing will be disabled.  When
-  # false, SDL errors will be logged but will not break the build, and TSA bug filing will be
-  # enabled.
+  # When true, any SDL errors will break the build.  When false, SDL errors will be logged but
+  # will not break the build.  TSA bug filing is always disabled in the non-official pipeline
+  # (see the tsa block in globalSdl).
   - name: breakOnSdlError
     displayName: Break on SDL error
     type: boolean
-    default: false
+    default: true
 
   # True to enable debug information and steps.
   - name: debug
@@ -252,14 +243,30 @@ extends:
         packageVersion: '$(Build.BuildNumber)'
 
       tsa:
-        # We deliberately drive every tool's `break` value from breakOnSdlError and set TSA's
-        # `enabled` to its negation, rather than relying on OneBranch's implicit behaviour of
-        # flipping each tool's break default based on whether TSA is enabled.  We have hit bugs in
-        # that implicit break-altering logic in the past, so we set both values explicitly to keep
-        # them deterministic.
+        # TSA (Trust Services Automation) files SDL analysis findings as Azure DevOps bug work
+        # items.  It is hardcoded DISABLED in the non-official pipeline.
         #
-        # TSA bug filing is enabled when we are not breaking on SDL errors.
-        enabled: ${{ not(parameters.breakOnSdlError) }}
+        # Why disabled here:
+        #   The non-official pipeline is a manual-only, developer-helper build used to validate
+        #   SDL scans and iterate on fixes before they land.  We do not want it filing (or
+        #   updating) bug work items -- that would create churn and duplicate the bugs owned by
+        #   the official pipeline, where TSA is hardcoded enabled.  Here, findings surface
+        #   directly in the build instead, gated by breakOnSdlError.
+        #
+        # Interaction with other SDL tool defaults:
+        #   OneBranch derives each SDL tool's DEFAULT `break` value from whether TSA is enabled --
+        #   per the OneBranch "Customize SDL" docs, most tools default to `break: false` when TSA
+        #   is enabled and `break: true` when it is disabled.  We do NOT rely on that implicit
+        #   coupling: every tool above sets `break: ${{ parameters.breakOnSdlError }}` explicitly,
+        #   which overrides the TSA-derived default.  We have hit bugs in OneBranch's implicit
+        #   break-altering logic in the past, so both `tsa.enabled` and each tool's `break` are
+        #   set explicitly to keep the behaviour deterministic.
+        #
+        # Otherwise independent of breakOnSdlError:
+        #   Aside from that default-flipping, TSA and breakOnSdlError are orthogonal.  Disabling
+        #   TSA here does not by itself force breaking -- breakOnSdlError is what controls whether
+        #   findings fail the build.
+        enabled: false
         configFile: '$(REPO_ROOT)/.config/tsaoptions.json'
 
     stages:

--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -6,12 +6,30 @@
 
 name: $(Year:YY)$(DayOfYear)$(Rev:.r)
 
-# No automated triggers; this pipeline must be run manually.
+# No activity-based triggers.
 pr: none
 trigger: none
 
+# We run this pipeline on a daily schedule.
+schedules:
+  - cron: "30 4 * * *"
+    displayName: Daily 04:30 UTC Build
+    branches:
+      include:
+        - internal/main
+    always: true
+
 # These parameters are visible in the Azure DevOps pipeline UI when a new run is queued.
 parameters:
+
+  # When true, any SDL errors will break the build, and TSA bug filing will be disabled.  When
+  # false, SDL errors will be logged but will not break the build, and TSA bug filing will be
+  # enabled.
+  - name: breakOnSdlError
+    displayName: Break on SDL error
+    type: boolean
+    default: false
+
   # True to enable debug information and steps.
   - name: debug
     displayName: Enable debug output
@@ -126,7 +144,22 @@ extends:
       category: NonAzure
 
     # See: https://aka.ms/obpipelines/sdl
+    #
+    # The following SDL tasks are auto-injected by the OneBranch / 1ES Pipeline Templates and run
+    # WITHOUT any explicit globalSdl configuration.  They were verified as running in recent
+    # pipeline runs, so we intentionally do not redeclare them here:
+    #
+    #   - Component Governance / Component Detection / Secure Supply Chain
+    #     Analysis (dependency vulnerability scanning)
+    #   - AntiMalware Scanner (Binary + Source)
+    #   - 1ES Secret Scanning (SPMI)
+    #   - Generate SBoM Manifest
+    #   - CodeQL 3000 (only run when it is explicitly opted in via codeql.compiled.enabled, and
+    #     even then only on its ~72h cadence and on supported (non-PR/non-tag)
+    #     branches.)
+    #
     globalSdl:
+
       # Configure APIScan behaviour:
       #
       # https://eng.ms/docs/products/onebranch/securitycompliancegovernanceandpolicies/sdlforcontainerizedworkflows/customizesdlforcontainerbuilds#apiscan
@@ -139,8 +172,8 @@ extends:
         # variable.
         enabled: true
 
-        # APIScan errors should not break non-official builds.
-        break: false
+        # APIScan errors break the build when breakOnSdlError is set.
+        break: ${{ parameters.breakOnSdlError }}
 
         # Use pre-release mode for non-official pipelines.
         modeType: prerelease
@@ -161,7 +194,7 @@ extends:
 
       armory:
         enabled: true
-        break: false
+        break: ${{ parameters.breakOnSdlError }}
 
       asyncSdl:
         # Disabling this as it complicates the build process with minimal gain
@@ -169,11 +202,14 @@ extends:
 
       binskim:
         enabled: true
-        break: false
+        break: ${{ parameters.breakOnSdlError }}
 
       codeql:
-        enabled: true
+        # CodeQL 3000 is configured under the `compiled` key; `enabled` is a sub-property of
+        # `compiled` (not of `codeql`).  CodeQL runs asynchronously on its own platform and cannot
+        # break the build by design, so it has no `break` value.
         compiled:
+          enabled: true
 
       credscan:
         enabled: true
@@ -182,16 +218,23 @@ extends:
       eslint:
         # Only useful for repos with ECMAscript - which we do not have.
         enabled: false
+        # Break value is wired preemptively so it takes effect if eslint is ever enabled.
+        break: ${{ parameters.breakOnSdlError }}
 
       policheck:
         enabled: true
-        break: false
+        break: ${{ parameters.breakOnSdlError }}
         exclusionsFile: '$(REPO_ROOT)\.config\PolicheckExclusions.xml'
+
+      psscriptanalyzer:
+        # Static analysis of the repository's PowerShell scripts (e.g. under eng/).
+        enabled: true
+        break: ${{ parameters.breakOnSdlError }}
 
       roslyn:
         # Note, requires RoslynAnalyzers task to be added as a separate step
         enabled: true
-        break: false
+        break: ${{ parameters.breakOnSdlError }}
 
       publishLogs:
         enabled: true
@@ -202,9 +245,15 @@ extends:
         packageVersion: '$(Build.BuildNumber)'
 
       tsa:
-        # Disable TSA for non-official runs.  Developers don't need the TSA integration for
-        # manually-run non-official builds.
-        enabled: false
+        # We deliberately drive every tool's `break` value from breakOnSdlError and set TSA's
+        # `enabled` to its negation, rather than relying on OneBranch's implicit behaviour of
+        # flipping each tool's break default based on whether TSA is enabled.  We have hit bugs in
+        # that implicit break-altering logic in the past, so we set both values explicitly to keep
+        # them deterministic.
+        #
+        # TSA bug filing is enabled when we are not breaking on SDL errors.
+        enabled: ${{ not(parameters.breakOnSdlError) }}
+        configFile: '$(REPO_ROOT)/.config/tsaoptions.json'
 
     stages:
       - template: /eng/pipelines/onebranch/stages/build-stages.yml@self

--- a/eng/pipelines/onebranch/sqlclient-non-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-non-official.yml
@@ -160,6 +160,13 @@ extends:
     #
     globalSdl:
 
+      # Snapshot of the SDL analyzer findings that pre-existed the breakOnSdlError rollout, so
+      # builds only break on NEW findings.  Generated from the SDL analysis artifacts of a full
+      # non-official run and kept under .config/ alongside the other SDL tool configs
+      # (CredScan/PoliCheck/TSA).
+      baseline:
+        baselineFile: $(Build.SourcesDirectory)/.config/guardian/.gdnbaselines
+
       # Configure APIScan behaviour:
       #
       # https://eng.ms/docs/products/onebranch/securitycompliancegovernanceandpolicies/sdlforcontainerizedworkflows/customizesdlforcontainerbuilds#apiscan

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -148,15 +148,37 @@ extends:
 
     # See: https://aka.ms/obpipelines/sdl
     globalSdl:
+      # Configure APIScan behaviour:
+      #
+      # https://eng.ms/docs/products/onebranch/securitycompliancegovernanceandpolicies/sdlforcontainerizedworkflows/customizesdlforcontainerbuilds#apiscan
+      #
+      # https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-mohanb/security-integration/guardian-wiki/sdl-azdo-extension/apiscan-build-task#v2
+      #
       apiscan:
-        # APIScan "software name" and version parameters are set on a per-job basis with via
-        # ob_sdl_apiscan_* variables.
+        # We want APIScan enabled by default for our jobs.  However, some jobs don't produce any
+        # artifacts, and they will disable APIScan via the OneBranch per-job ob_sdl_apiscan_enable
+        # variable.
         enabled: true
-        # TODO(https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/42858):
-        # We have temporarily disabled breaking the build on ApiScan results until we can:
-        #   - Register our new packages with API Scan, and/or
-        #   - Publish MSDN/Learn/etc documentation for the new packages.
-        break: false
+
+        # APIScan errors should break the build.
+        break: true
+
+        # Use release mode for official pipelines.
+        modeType: release
+
+        # We have a single "name" registered with APIScan for all of our packages.
+        #
+        # https://eng.ms/docs/products/apiscan/onboard/requirements/registersoftware
+        #
+        softwareName: Microsoft.Data.SqlClient
+
+        # Similar to the software name, we have a single version registered as well.  This has
+        # nothing to do with the NuGet package version.  It is purely an APIScan registration
+        # value that points to our backend configuration.
+        softwareVersion: '6.10'
+
+        # We want the standard level of logging.
+        verbosityLevel: standard
 
       armory:
         enabled: true
@@ -201,8 +223,7 @@ extends:
         packageVersion: '$(Build.BuildNumber)'
 
       tsa:
-        # OneBranch publishes all sdl results to TSA. If TSA is disabled, all SDL tools will be
-        # forced into 'break' build mode.
+        # Ensure we publish all SDL results to TSA.
         enabled: true
         configFile: '$(REPO_ROOT)/.config/tsaoptions.json'
 

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -156,7 +156,7 @@ extends:
       #
       apiscan:
         # We want APIScan enabled by default for our jobs.  However, some jobs don't produce any
-        # artifacts, and they will disable APIScan via the OneBranch per-job ob_sdl_apiscan_enable
+        # artifacts, and they will disable APIScan via the OneBranch per-job ob_sdl_apiscan_enabled
         # variable.
         enabled: true
 

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -166,6 +166,13 @@ extends:
     #
     globalSdl:
 
+      # Snapshot of the SDL analyzer findings that pre-existed the breakOnSdlError rollout, so
+      # builds only break on NEW findings.  Generated from the SDL analysis artifacts of a full
+      # non-official run and kept under .config/ alongside the other SDL tool configs
+      # (CredScan/PoliCheck/TSA).
+      baseline:
+        baselineFile: $(Build.SourcesDirectory)/.config/guardian/.gdnbaselines
+
       # Configure APIScan behaviour:
       #
       # https://eng.ms/docs/products/onebranch/securitycompliancegovernanceandpolicies/sdlforcontainerizedworkflows/customizesdlforcontainerbuilds#apiscan

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -22,9 +22,9 @@ schedules:
 # These parameters are visible in the Azure DevOps pipeline UI when a new run is queued.
 parameters:
 
-  # When true, any SDL errors will break the build, and TSA bug filing will be disabled.  When
-  # false, SDL errors will be logged but will not break the build, and TSA bug filing will be
-  # enabled.
+  # When true, any SDL errors will break the build.  When false, SDL errors will be logged but
+  # will not break the build.  TSA bug filing is always enabled in the official pipeline and is
+  # independent of this parameter (see the tsa block in globalSdl).
   - name: breakOnSdlError
     displayName: Break on SDL error
     type: boolean

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -6,15 +6,9 @@
 
 name: $(Year:YY)$(DayOfYear)$(Rev:.r)
 
-# No PR-based triggers.
+# No activity-based triggers.
 pr: none
-
-# We trigger runs on activity on the internal/main branch, but not on any other branches.  This
-# pipeline is intended to only run against the ADO.Net dotnet-sqlclient repo.
-trigger:
-  branches:
-    include:
-      - internal/main
+trigger: none
 
 # We run this pipeline on a daily schedule.
 schedules:
@@ -27,16 +21,18 @@ schedules:
 
 # These parameters are visible in the Azure DevOps pipeline UI when a new run is queued.
 parameters:
+
+  # When true, any SDL errors will break the build, and TSA bug filing will be disabled.  When
+  # false, SDL errors will be logged but will not break the build, and TSA bug filing will be
+  # enabled.
+  - name: breakOnSdlError
+    displayName: Break on SDL error
+    type: boolean
+    default: true
+
   # True to enable debug information and steps.
   - name: debug
     displayName: Enable debug output
-    type: boolean
-    default: false
-
-  # When true, publish symbols and push NuGet packages to Production environments.  When false,
-  # symbols use PPE and NuGet packages use QA/Test.
-  - name: releaseToProduction
-    displayName: Publish Symbols and NuGet Packages to Production
     type: boolean
     default: false
 
@@ -49,6 +45,13 @@ parameters:
   # True to publish symbols to private and public servers.
   - name: publishSymbols
     displayName: Publish symbols
+    type: boolean
+    default: false
+
+  # When true, publish symbols and push NuGet packages to Production environments.  When false,
+  # symbols use PPE and NuGet packages use QA/Test.
+  - name: releaseToProduction
+    displayName: Publish Symbols and NuGet Packages to Production
     type: boolean
     default: false
 
@@ -147,7 +150,22 @@ extends:
       category: NonAzure
 
     # See: https://aka.ms/obpipelines/sdl
+    #
+    # The following SDL tasks are auto-injected by the OneBranch / 1ES Pipeline Templates and run
+    # WITHOUT any explicit globalSdl configuration.  They were verified as running in recent
+    # pipeline runs, so we intentionally do not redeclare them here:
+    #
+    #   - Component Governance / Component Detection / Secure Supply Chain
+    #     Analysis (dependency vulnerability scanning)
+    #   - AntiMalware Scanner (Binary + Source)
+    #   - 1ES Secret Scanning (SPMI)
+    #   - Generate SBoM Manifest
+    #   - CodeSign Validation (runs on the signing path; nothing is signed in non-official runs)
+    #   - CodeQL 3000 (ALWAYS enabled via the 1ESPT (Official.CrossPlat) entry point, regardless of
+    #     the codeql config below.)
+    #
     globalSdl:
+
       # Configure APIScan behaviour:
       #
       # https://eng.ms/docs/products/onebranch/securitycompliancegovernanceandpolicies/sdlforcontainerizedworkflows/customizesdlforcontainerbuilds#apiscan
@@ -160,8 +178,8 @@ extends:
         # variable.
         enabled: true
 
-        # APIScan errors should break the build.
-        break: true
+        # APIScan errors break the build when breakOnSdlError is set.
+        break: ${{ parameters.breakOnSdlError }}
 
         # Use release mode for official pipelines.
         modeType: release
@@ -182,7 +200,7 @@ extends:
 
       armory:
         enabled: true
-        break: true
+        break: ${{ parameters.breakOnSdlError }}
 
       asyncSdl:
         # Disabling this as it complicates the build process with minimal gain
@@ -190,11 +208,14 @@ extends:
 
       binskim:
         enabled: true
-        break: true
+        break: ${{ parameters.breakOnSdlError }}
 
       codeql:
-        enabled: true
+        # CodeQL 3000 is configured under the `compiled` key; `enabled` is a sub-property of
+        # `compiled` (not of `codeql`).  CodeQL runs asynchronously on its own platform and cannot
+        # break the build by design, so it has no `break` value.
         compiled:
+          enabled: true
 
       credscan:
         enabled: true
@@ -203,16 +224,23 @@ extends:
       eslint:
         # Only useful for repos with ECMAscript - which we do not have.
         enabled: false
+        # Break value is wired preemptively so it takes effect if eslint is ever enabled.
+        break: ${{ parameters.breakOnSdlError }}
 
       policheck:
         enabled: true
-        break: true
+        break: ${{ parameters.breakOnSdlError }}
         exclusionsFile: '$(REPO_ROOT)\.config\PolicheckExclusions.xml'
+
+      psscriptanalyzer:
+        # Static analysis of the repository's PowerShell scripts (e.g. under eng/).
+        enabled: true
+        break: ${{ parameters.breakOnSdlError }}
 
       roslyn:
         # Note, requires RoslynAnalyzers task to be added as a separate step
         enabled: true
-        break: true
+        break: ${{ parameters.breakOnSdlError }}
 
       publishLogs:
         enabled: true
@@ -223,8 +251,14 @@ extends:
         packageVersion: '$(Build.BuildNumber)'
 
       tsa:
-        # Ensure we publish all SDL results to TSA.
-        enabled: true
+        # We deliberately drive every tool's `break` value from breakOnSdlError and set TSA's
+        # `enabled` to its negation, rather than relying on OneBranch's implicit behaviour of
+        # flipping each tool's break default based on whether TSA is enabled.  We have hit bugs in
+        # that implicit break-altering logic in the past, so we set both values explicitly to keep
+        # them deterministic.
+        #
+        # TSA bug filing is enabled when we are not breaking on SDL errors.
+        enabled: ${{ not(parameters.breakOnSdlError) }}
         configFile: '$(REPO_ROOT)/.config/tsaoptions.json'
 
     stages:

--- a/eng/pipelines/onebranch/sqlclient-official.yml
+++ b/eng/pipelines/onebranch/sqlclient-official.yml
@@ -258,14 +258,26 @@ extends:
         packageVersion: '$(Build.BuildNumber)'
 
       tsa:
-        # We deliberately drive every tool's `break` value from breakOnSdlError and set TSA's
-        # `enabled` to its negation, rather than relying on OneBranch's implicit behaviour of
-        # flipping each tool's break default based on whether TSA is enabled.  We have hit bugs in
-        # that implicit break-altering logic in the past, so we set both values explicitly to keep
-        # them deterministic.
+        # TSA (Trust Services Automation) files SDL analysis findings as Azure DevOps bug work
+        # items.  It is hardcoded enabled in the official pipeline so that every SDL finding is
+        # always tracked as a bug, regardless of how any individual run terminates.
         #
-        # TSA bug filing is enabled when we are not breaking on SDL errors.
-        enabled: ${{ not(parameters.breakOnSdlError) }}
+        # Interaction with other SDL tool defaults:
+        #   OneBranch derives each SDL tool's DEFAULT `break` value from whether TSA is enabled --
+        #   per the OneBranch "Customize SDL" docs, most tools default to `break: false` when TSA
+        #   is enabled and `break: true` when it is disabled.  We do NOT rely on that implicit
+        #   coupling: every tool above sets `break: ${{ parameters.breakOnSdlError }}` explicitly,
+        #   which overrides the TSA-derived default.  We have hit bugs in OneBranch's implicit
+        #   break-altering logic in the past, so both `tsa.enabled` and each tool's `break` are
+        #   set explicitly to keep the behaviour deterministic.
+        #
+        # Otherwise independent of breakOnSdlError:
+        #   Aside from that default-flipping, TSA and breakOnSdlError are orthogonal.  TSA files
+        #   bugs from the complete finding set (the TSAUpload step runs after all analyzers have
+        #   produced results), while breakOnSdlError separately controls whether those same
+        #   findings also fail the build.  Enabling TSA here does not suppress breaking, and
+        #   breaking does not prevent bug filing within a job.
+        enabled: true
         configFile: '$(REPO_ROOT)/.config/tsaoptions.json'
 
     stages:

--- a/eng/pipelines/onebranch/variables/onebranch-variables.yml
+++ b/eng/pipelines/onebranch/variables/onebranch-variables.yml
@@ -51,10 +51,6 @@ variables:
   - name: CommitHead
     value: '' # the value will be extracted from the repo's head
 
-  # https://aka.ms/obpipelines/sdl
-  - name: ob_sdl_binskim_break
-    value: true
-
   - name: Packaging.EnableSBOMSigning
     value: true
 


### PR DESCRIPTION
## Description

Standardizes and modernizes the OneBranch SDL / APIScan configuration across the official and non-official pipelines. Engineering-process/CI only — no product code or public API is affected.

**APIScan registration**
- Moved APIScan registration (`softwareName`, `softwareVersion`, `modeType`, `verbosityLevel`) inline into the `globalSdl` block of both pipelines, replacing the per-job `ob_sdl_apiscan_*` variables. Only the per-job DLL/PDB folder paths remain in `build-buildproj-job`.
- Registered the actual SqlClient APIScan software version (`6.10`).

**SDL break policy — `breakOnSdlError` parameter**
- Added a `breakOnSdlError` pipeline parameter (default `true` in both pipelines) that drives the `break` value of every SDL tool: apiscan, armory, binskim, eslint, policheck, psscriptanalyzer, and roslyn.
- Setting each tool's `break` explicitly avoids relying on OneBranch's implicit "TSA-enabled flips break defaults" behavior, which we've hit bugs with before.
- Added PSScriptAnalyzer (previously not run) to scan the repo's PowerShell scripts.
- Fixed the CodeQL config nesting (`codeql.compiled.enabled: true`).
- Dropped the redundant `ob_sdl_binskim_break` variable in `onebranch-variables` and `publish-symbols-job` (BinSkim is disabled there).

**TSA bug filing (decoupled from `breakOnSdlError`)**
- Official: TSA hardcoded **enabled** — SDL findings are always filed as bug work items, independent of `breakOnSdlError`.
- Non-official: TSA hardcoded **disabled** — it is a manual developer-helper pipeline, so findings surface directly in the build (gated by `breakOnSdlError`) instead of filing/duplicating bugs.

**Baseline**
- Added `.config/guardian/.gdnbaselines` snapshotting the pre-existing suppressible findings (PoliCheck ×2, PSScriptAnalyzer ×7) so the pipelines only break on NEW findings while we burn down the existing ones ([AB#46588](https://sqlclientdrivers.visualstudio.com/ADO.Net/_workitems/edit/46588)). Referenced via `globalSdl.baseline.baselineFile` in both pipelines.

**Triggers**
- Official: `pr: none`, `trigger: none`, daily schedule at 04:30 UTC on `internal/main`.
- Non-official: manual only (`pr: none`, `trigger: none`).
- Updated `onebranch-pipeline-design.instructions.md` to match.

***GOTCHA***: With `breakOnSdlError` defaulting to `true`, the Official pipeline will _BREAK_ on any SDL errors, forcing us to fix them before releases (a good thing IMO). APIScan errors are `notSuppressible`, so Official will break until our outstanding APIScan SEL exceptions are approved.

## Testing

- [x] sqlclient-non-official — SDL break on (`breakOnSdlError: true`): [26204.1](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=162641&view=results) — surfaced the 6 APIScan errors + PSScriptAnalyzer findings, confirming the break wiring works.
- [x] sqlclient-non-official — SDL break off (`breakOnSdlError: false`): [26204.2](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=162654&view=results) — all SDL scans completed and published their analysis artifacts; the run was later canceled by an unrelated agent-connectivity timeout in the AKV build job. Baseline diff against the produced findings confirmed the 9 baselined signatures fully cover the suppressible findings (no new or stale entries).
- [ ] sqlclient-official — pending; can only run with approved PR provenance (after merge). Expected to break on APIScan until the SEL exceptions are approved.
