### PR TITLE
Fix empty error message/stack trace in merged CI test results

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -359,6 +359,21 @@
       Examples:       "1", "12", "AE", "12AE"
     -->
     <TestSet Condition="'$(TestSet)' == ''" />
+
+    <!--
+      TestArchitecture
+      Applies to:     Test* targets
+      Description:    Process architecture (e.g. x64 or x86) that the tests are being executed under.
+                      This value is only used to disambiguate the test result (trx) log file prefix so
+                      that results produced by different architectures do not share the same test names
+                      when they are published and merged together (e.g. by PublishTestResults with
+                      mergeTestResults=true). It does NOT influence the architecture the tests actually
+                      run under; that is controlled by the dotnet host selected via DotnetPath.
+      Default value:  [blank]
+      Allowed values: (x64|x86|...)
+      Example:        x86
+    -->
+    <TestArchitecture Condition="'$(TestArchitecture)' == ''" />
   </PropertyGroup>
 
   <!-- ================================================================= -->
@@ -644,6 +659,7 @@
     <!-- @TODO: Prevent from running in non-admin user mode -->
     <PropertyGroup>
       <LogFilePrefix>SqlClientFunctional-$(OS)</LogFilePrefix>
+      <LogFilePrefix Condition="'$(TestArchitecture)' != ''">$(LogFilePrefix)-$(TestArchitecture)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
 
       <DotnetCommand>
@@ -675,6 +691,7 @@
   <Target Name="TestSqlClientManual">
     <PropertyGroup>
       <LogFilePrefix>SqlClientManual-$(OS)</LogFilePrefix>
+      <LogFilePrefix Condition="'$(TestArchitecture)' != ''">$(LogFilePrefix)-$(TestArchitecture)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestSet)' != ''">$(LogFilePrefix)-$(TestSet)</LogFilePrefix>
 
@@ -721,6 +738,7 @@
   <Target Name="TestSqlClientUnit">
     <PropertyGroup>
       <LogFilePrefix>SqlClientUnit-$(OS)</LogFilePrefix>
+      <LogFilePrefix Condition="'$(TestArchitecture)' != ''">$(LogFilePrefix)-$(TestArchitecture)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
 
       <DotnetCommand>
@@ -912,6 +930,7 @@
         package version arguments are specified in this command.
       -->
       <LogFilePrefix>AbstractionsTests-$(OS)</LogFilePrefix>
+      <LogFilePrefix Condition="'$(TestArchitecture)' != ''">$(LogFilePrefix)-$(TestArchitecture)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
 
       <DotnetCommand>
@@ -1013,6 +1032,7 @@
   <Target Name="TestAzure">
     <PropertyGroup>
       <LogFilePrefix>AzureTests-$(OS)</LogFilePrefix>
+      <LogFilePrefix Condition="'$(TestArchitecture)' != ''">$(LogFilePrefix)-$(TestArchitecture)</LogFilePrefix>
       <LogFilePrefix Condition="'$(TestFramework)' != ''">$(LogFilePrefix)-$(TestFramework)</LogFilePrefix>
 
       <DotnetCommand>

--- a/eng/pipelines/common/templates/steps/run-all-tests-step.yml
+++ b/eng/pipelines/common/templates/steps/run-all-tests-step.yml
@@ -94,6 +94,7 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientUnit
@@ -104,6 +105,7 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Unit Tests ${{parameters.msbuildArchitecture }}'
@@ -121,6 +123,7 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
           -p:TestCodeCoverage=false
       ${{ else }}: # x86
         arguments: >-
@@ -133,6 +136,7 @@ steps:
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
           -p:TestCodeCoverage=false
     continueOnError: true
 
@@ -153,6 +157,7 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientFunctional
@@ -165,6 +170,7 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Functional Tests ${{parameters.msbuildArchitecture }}'
@@ -184,6 +190,7 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
           -p:TestCodeCoverage=false
       ${{ else }}: # x86
         arguments: >-
@@ -198,6 +205,7 @@ steps:
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
           -p:TestCodeCoverage=false
     continueOnError: true
 
@@ -219,6 +227,7 @@ steps:
           -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
       ${{ else }}: # x86
         arguments: >-
           -t:TestSqlClientManual
@@ -232,6 +241,7 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
   - task: DotNetCoreCLI@2
@@ -253,6 +263,7 @@ steps:
           -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
           -p:TestCodeCoverage=false
       ${{ else }}: # x86
         arguments: >-
@@ -268,6 +279,7 @@ steps:
           -p:DotnetPath=${{ parameters.dotnetx86RootPath }}
           -p:TestFilters="category=flaky"
           -p:TestResultsFolderPath=TestResults
+          -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
           -p:TestCodeCoverage=false
     continueOnError: true
 
@@ -286,6 +298,7 @@ steps:
         -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
+        -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Unit Tests'
@@ -302,6 +315,7 @@ steps:
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestFilters="category=flaky"
         -p:TestResultsFolderPath=TestResults
+        -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
         -p:TestCodeCoverage=false
     continueOnError: true
 
@@ -321,6 +335,7 @@ steps:
         -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
+        -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Flaky Functional Tests'
@@ -339,6 +354,7 @@ steps:
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestFilters="category=flaky"
         -p:TestResultsFolderPath=TestResults
+        -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
         -p:TestCodeCoverage=false
     continueOnError: true
   - task: DotNetCoreCLI@2
@@ -358,6 +374,7 @@ steps:
         -p:PackageVersionSqlClient=${{ parameters.mdsPackageVersion }}
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestResultsFolderPath=TestResults
+        -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
     retryCountOnTaskFailure: ${{parameters.retryCountOnManualTests }}
 
   - task: DotNetCoreCLI@2
@@ -378,5 +395,6 @@ steps:
         -p:PackageVersionSqlServer=${{ parameters.sqlServerPackageVersion }}
         -p:TestFilters="category=flaky"
         -p:TestResultsFolderPath=TestResults
+        -p:TestArchitecture=${{ parameters.msbuildArchitecture }}
         -p:TestCodeCoverage=false
     continueOnError: true


### PR DESCRIPTION
## Description

Failing tests in CI (e.g. `ConnectionPoolTest.ClearAllPoolsTest`) show up as Failed in Azure DevOps but with a blank **Error message** and **Stack trace** in the Debug tab, making failures impossible to diagnose from the UI.

The details are not lost by xUnit or the TRX logger; they are dropped during publish. Our publish steps use `PublishTestResults@2` with `mergeTestResults: true`. Within a single job, x64 and x86 test runs write their TRX files into the same `TestResults` folder. Because the same theory case has an identical fully-qualified name across those files, Azure DevOps collapses the duplicates on merge and overwrites/drops the per-result `ErrorInfo` (message + stack trace).

### Approach

Rather than turning off merge, this keeps merged reporting but makes each run's TRX contents unique so names no longer collide within the merged set:

- Add a new `TestArchitecture` build property to `build.proj` and append it to the TRX `LogFilePrefix` for all test targets (Functional, Manual, Unit, Abstractions, Azure). Results are now distinguished by **TFM + architecture + test set**.
- Thread `-p:TestArchitecture=${{ parameters.msbuildArchitecture }}` through every `build.proj` test invocation in `run-all-tests-step.yml` (x64, x86, and the Linux/Mac branch).

The property defaults to blank, so local/non-pipeline behavior is unchanged.

### Note for reviewers

This resolves the x64/x86 collision. A separate same-run duplicate source remains: the Manual Tests task uses `retryCountOnTaskFailure`, so a retried failing test emits another TRX with the same test names that merge still collapses. That can be addressed as a follow-up (e.g. clearing the prior attempt's TRX or publishing retries separately) if we see it in practice.

## Issues

N/A

## Testing

Engineering/CI change only; no product code affected. Verified `build.proj` remains well-formed XML and confirmed the resolved `LogFilePrefix` values via an MSBuild probe:

- no arch: `SqlClientManual-Windows_NT-net9.0-1` (unchanged)
- x64: `SqlClientManual-Windows_NT-x64-net9.0-1`
- x86: `SqlClientManual-Windows_NT-x86-net9.0-1`

Full validation happens when the pipeline runs and a failing test surfaces its error message and stack trace in the Debug tab.

## Guidelines

Please review the contribution guidelines before submitting a pull request:

- [Contributing](/CONTRIBUTING.md)
- [Code of Conduct](/CODE_OF_CONDUCT.md)
- [Best Practices](/policy/coding-best-practices.md)
- [Coding Style](/policy/coding-style.md)
- [Review Process](/policy/review-process.md)