### PR TITLE
Run legacy CI pipelines daily instead of weekdays/Thursdays

### DIFF
--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -16,8 +16,8 @@
 #
 #   - Commits to GitHub main and release/* branches
 #   - Commits to ADO internal/main and internal/release/* branches
-#   - Weekdays at 03:00 UTC on GitHub main
-#   - Thursdays at 07:00 UTC on ADO internal/main
+#   - Daily at 03:00 UTC on GitHub main
+#   - Daily at 07:00 UTC on ADO internal/main
 #
 # GOTCHA: This pipeline definition is triggered by GitHub _and_ ADO CI.  We are
 # able to define different triggers and schedules using branch filters:
@@ -66,17 +66,17 @@ trigger:
 # Trigger this pipeline on a schedule.
 schedules:
 
-  # GitHub main on weekdays
-  - cron: '0 3 * * Mon-Fri'
-    displayName: Weekday Run (Release Config)
+  # GitHub main daily.
+  - cron: '0 3 * * *'
+    displayName: Daily Run (Release Config)
     branches:
       include:
       - main
     always: true
 
-  # ADO internal/main on Thursdays.
-  - cron: '0 7 * * Thu'
-    displayName: Thursday Run (Release Config)
+  # ADO internal/main daily.
+  - cron: '0 7 * * *'
+    displayName: Daily Run (Release Config)
     branches:
       include:
       - internal/main

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -16,8 +16,8 @@
 #
 #   - Commits to GitHub main and release/* branches
 #   - Commits to ADO internal/main and internal/release/* branches
-#   - Weekdays at 01:00 UTC on GitHub main
-#   - Thursdays at 05:00 UTC on ADO internal/main
+#   - Daily at 01:00 UTC on GitHub main
+#   - Daily at 05:00 UTC on ADO internal/main
 #
 # GOTCHA: This pipeline definition is triggered by GitHub _and_ ADO CI.  We are
 # able to define different triggers and schedules using branch filters:
@@ -66,17 +66,17 @@ trigger:
 # Trigger this pipeline on a schedule.
 schedules:
 
-  # GitHub main on weekdays
-  - cron: '0 1 * * Mon-Fri'
-    displayName: Weekday Run (Release Config)
+  # GitHub main daily.
+  - cron: '0 1 * * *'
+    displayName: Daily Run (Release Config)
     branches:
       include:
       - main
     always: true
 
-  # ADO internal/main on Thursdays.
-  - cron: '0 5 * * Thu'
-    displayName: Thursday Run (Release Config)
+  # ADO internal/main daily.
+  - cron: '0 5 * * *'
+    displayName: Daily Run (Release Config)
     branches:
       include:
       - internal/main


### PR DESCRIPTION
## Description

Changes the schedules for the two legacy CI pipeline definitions to run **daily** instead of on weekdays / Thursdays. Each branch keeps its original time-of-day, so only the day-of-week cadence changes.

Motivation:  We're not getting daily signals of health from these pipelines in either Azure DevOps project, which we definitely want.

| Pipeline | Branch | Before | After |
|---|---|---|---|
| `dotnet-sqlclient-ci-project-reference-pipeline.yml` | `main` | `0 1 * * Mon-Fri` | `0 1 * * *` (daily 01:00 UTC) |
| `dotnet-sqlclient-ci-project-reference-pipeline.yml` | `internal/main` | `0 5 * * Thu` | `0 5 * * *` (daily 05:00 UTC) |
| `dotnet-sqlclient-ci-package-reference-pipeline.yml` | `main` | `0 3 * * Mon-Fri` | `0 3 * * *` (daily 03:00 UTC) |
| `dotnet-sqlclient-ci-package-reference-pipeline.yml` | `internal/main` | `0 7 * * Thu` | `0 7 * * *` (daily 07:00 UTC) |
