### PR TITLE
Reword SqlLegacyRepro placeholder connection string; add secrets instructions

### DIFF
--- a/.github/instructions/secrets.instructions.md
+++ b/.github/instructions/secrets.instructions.md
@@ -1,0 +1,104 @@
+---
+applyTo: "**"
+---
+# Secrets and Credential Handling
+
+This guide describes how to avoid committing secrets, how to write credential
+placeholders that do **not** trip secret scanners (e.g. GitHub Advanced Security
+/ 1ES push protection), and what to do when a push is blocked.
+
+## Golden Rules
+
+1. **Never commit a real secret** — passwords, connection strings with live
+   credentials, access keys, SAS tokens, client secrets, certificates/PFX
+   files, or bearer tokens. This applies to source, tests, docs, samples,
+   scripts, pipeline YAML, and config files.
+2. **Never route a secret through tooling or the model.** When a value is truly
+   secret, have the user type it directly into their terminal or set it as an
+   environment variable. Do not paste it into files, prompts, or chat.
+3. **Prefer indirection over literals.** Read credentials from environment
+   variables, a secret store (Azure Key Vault), user secrets, or CI secret
+   variables — not from committed text.
+4. **Assume public.** This repository mirrors to public GitHub via autosync.
+   Anything committed is effectively public and permanent in history.
+
+## Approved Placeholder Formats
+
+When you need to show the *shape* of a connection string or credential in code,
+docs, comments, or samples, use one of these placeholder styles. These are
+recognized as non-secrets by the scanner:
+
+| Style | Example | Use for |
+|-------|---------|---------|
+| Angle brackets | `User ID=<user>;Password=<pwd>` | Docs, READMEs, comments, samples |
+| Descriptive angle brackets | `Password=<myPassword>`, `User Id=<AppId>` | Samples that name the value |
+| Masked | `Password=********` or `Password=***` | Illustrative output / redaction |
+| Env var expansion | `Password=${SA_PASSWORD}` (bash), `Password=$(SqlPwd)` (ADO) | Scripts and pipelines |
+| Named token (docs prose) | `Password=<Secret>` | Narrative documentation |
+
+### Do NOT use these placeholder styles
+
+- **Ellipsis values** — `Password=...` or `User ID=...;Password=...`.
+  The literal `...` after `Password=` is treated as a credential value and
+  **will** trip `SEC101/037 SqlLegacyCredentials`. Use `<pwd>` instead.
+- **Realistic-looking fake secrets** — `Password=P@ssw0rd123`,
+  `Password=abc123def456`. Even fake values that look like real passwords can
+  be flagged and set a bad example.
+- **Bare word secrets** — `Password=secret`, `Password=mypassword` inside a
+  connection-string literal. Prefer `<pwd>`.
+
+### Full connection-string placeholder examples
+
+```text
+Server=<server>;Database=<db>;User ID=<user>;Password=<pwd>;TrustServerCertificate=true
+Server=tcp:<servername>.database.windows.net;Database=<dbname>;Authentication=Active Directory Service Principal;User Id=<AppId>;Password=<Secret>
+```
+
+```bash
+# Have the user set the value directly; never write the real value into a file:
+export SNICLOSE_CONNSTR="Server=<server>;User ID=<user>;Password=<pwd>"
+```
+
+## Reading Secrets at Runtime (preferred patterns)
+
+- **Environment variables**: read connection strings from an env var
+  (e.g. `SNICLOSE_CONNSTR`) so the password never lands in a committed file.
+- **SecureString / SqlCredential**: use `SqlCredential` and `SecureString`
+  rather than embedding a password in the connection string.
+- **Integrated auth**: prefer `Integrated Security=true` or an
+  `Authentication=ActiveDirectory*` mode where no password is stored.
+- **CI/CD**: reference pipeline secret variables (`$(mySecret)`), never inline
+  literals in YAML.
+
+## When a Push Is Blocked by Secret Scanning
+
+Error shape: `VS403654:BypassableBlock ... push was rejected because it contains
+one or more secrets` with a `SEC101/...` rule id and `commit`/`paths` details.
+
+1. **Locate it.** Inspect the exact committed blob:
+   `git show <commit>:<path>` and go to the reported line/columns.
+2. **Determine real vs. false positive.**
+   - *Real secret*: rotate/revoke it immediately, then remove it from the file.
+     If it is in the tip commit only, amend; if it is deeper in **unshared**
+     history, rewrite that history. Never rewrite commits already public.
+   - *False positive* (a placeholder like `Password=...`): reword to an approved
+     placeholder (`Password=<pwd>`) so future commits don't recur.
+3. **Already-public / mirrored commits.** If the flagged content lives in a
+   commit that is already on public GitHub (e.g. an autosync mirror replaying
+   `github/main`), you cannot scrub that specific commit without rewriting
+   shared/public history. For a confirmed false positive, **bypass** the block
+   via the 1ES/Advanced Security push-protection flow
+   (https://aka.ms/1esSecretScanning/PushProtectionBypassableBlock) with a clear
+   reason, or dismiss the alert as *False positive*. Then land the placeholder
+   reword going forward so new files don't trip the rule again.
+4. **Never** disable secret scanning or use `--no-verify`-style bypasses to work
+   around a *real* secret.
+
+## Common Scanner Rules to Watch
+
+| Rule | Triggers on |
+|------|-------------|
+| `SEC101/037 SqlLegacyCredentials` | `User ID=...;Password=<value>` connection-string shapes |
+| `SEC101/*` (general) | Cloud keys, SAS tokens, client secrets, PATs, bearer tokens |
+
+If in doubt, use an approved placeholder from the table above.

--- a/.github/instructions/secrets.instructions.md
+++ b/.github/instructions/secrets.instructions.md
@@ -38,14 +38,21 @@ recognized as non-secrets by the scanner:
 
 ### Do NOT use these placeholder styles
 
-- **Ellipsis values** — `Password=...` or `User ID=...;Password=...`.
-  The literal `...` after `Password=` is treated as a credential value and
-  **will** trip `SEC101/037 SqlLegacyCredentials`. Use `<pwd>` instead.
-- **Realistic-looking fake secrets** — `Password=P@ssw0rd123`,
-  `Password=abc123def456`. Even fake values that look like real passwords can
-  be flagged and set a bad example.
-- **Bare word secrets** — `Password=secret`, `Password=mypassword` inside a
-  connection-string literal. Prefer `<pwd>`.
+- **Ellipsis values** — a `Password` (or `Pwd`) key whose value is a literal
+  ellipsis, especially when paired with a `User ID` key in the same connection
+  string. The ellipsis is treated as a credential value and **will** trip
+  `SEC101/037 SqlLegacyCredentials`. Use `<pwd>` instead.
+- **Realistic-looking fake secrets** — a `Password` key set to a value that
+  looks like a real password (mixed letters, digits, and symbols). Even fake
+  values that resemble real passwords can be flagged and set a bad example.
+- **Bare word secrets** — a `Password` key set to a plain dictionary word
+  inside a connection-string literal. Prefer `<pwd>`.
+
+> **NOTE**: Ironically, this document cannot show verbatim examples of the
+> disallowed styles above — spelling out a `Password` key followed by an
+> ellipsis or realistic-looking value would itself trip `SEC101/037` and block
+> commits to this very file. That is exactly why the "don't" cases are described
+> in prose rather than shown literally.
 
 ### Full connection-string placeholder examples
 
@@ -81,8 +88,9 @@ one or more secrets` with a `SEC101/...` rule id and `commit`/`paths` details.
    - *Real secret*: rotate/revoke it immediately, then remove it from the file.
      If it is in the tip commit only, amend; if it is deeper in **unshared**
      history, rewrite that history. Never rewrite commits already public.
-   - *False positive* (a placeholder like `Password=...`): reword to an approved
-     placeholder (`Password=<pwd>`) so future commits don't recur.
+   - *False positive* (an ellipsis or other non-credential placeholder value):
+     reword to an approved placeholder (`Password=<pwd>`) so future commits
+     don't recur.
 3. **Already-public / mirrored commits.** If the flagged content lives in a
    commit that is already on public GitHub (e.g. an autosync mirror replaying
    `github/main`), you cannot scrub that specific commit without rewriting
@@ -98,7 +106,7 @@ one or more secrets` with a `SEC101/...` rule id and `commit`/`paths` details.
 
 | Rule | Triggers on |
 |------|-------------|
-| `SEC101/037 SqlLegacyCredentials` | `User ID=...;Password=<value>` connection-string shapes |
+| `SEC101/037 SqlLegacyCredentials` | Connection strings pairing a `User ID` key with a `Password`/`Pwd` value |
 | `SEC101/*` (general) | Cloud keys, SAS tokens, client secrets, PATs, bearer tokens |
 
 If in doubt, use an approved placeholder from the table above.

--- a/tools/SniCloseLegacyRepro/SniCloseLegacyRepro.csproj
+++ b/tools/SniCloseLegacyRepro/SniCloseLegacyRepro.csproj
@@ -15,7 +15,7 @@
     Framework Windows containers to bind older in-box System.Data.dll versions.
 
     Run: dotnet test tools/SniCloseLegacyRepro                        (in-process tests only)
-      $env:SNICLOSE_CONNSTR="Server=...;User ID=...;Password=..."  (enables live MARS + stress)
+      $env:SNICLOSE_CONNSTR="Server=<server>;User ID=<user>;Password=<pwd>"  (enables live MARS + stress)
       dotnet test tools/SniCloseLegacyRepro
 
     This project uses Central Package Management via the sibling


### PR DESCRIPTION
## Summary

Two related changes to stop a placeholder connection string from tripping secret scanning, and to document placeholder conventions going forward.

1. **`tools/SniCloseLegacyRepro/SniCloseLegacyRepro.csproj`** — Reworded the `SNICLOSE_CONNSTR` example in the header comment from `Server=...;User ID=...;Password=...` to angle-bracket placeholders `Server=<server>;User ID=<user>;Password=<pwd>`. The literal `Password=...` (ellipsis value) was matched by the `SEC101/037 SqlLegacyCredentials` push-protection rule as a credential. The new form matches the style already used in the sibling `README.md`, which the scanner ignores.

2. **`.github/instructions/secrets.instructions.md`** (new) — Documents:
   - Golden rules for handling secrets in a repo that mirrors to public GitHub.
   - **Approved placeholder formats** (`<pwd>`, `<myPassword>`, `********`, `${VAR}`, `<Secret>`) with full connection-string examples.
   - **Disallowed** styles — notably the `Password=...` ellipsis that trips `SEC101/037`, realistic fake secrets, and bare-word secrets.
   - Preferred runtime patterns (env vars, `SqlCredential`/`SecureString`, integrated auth, CI secret variables).
   - A playbook for when a push is blocked by secret scanning, including handling of already-public/mirrored commits.

## Notes

- This is a documentation/tooling-comment change only; no product code or public API is affected.
- The reword prevents recurrence in future files/commits but does not retroactively alter historical commits.