### PR TITLE
[6.1] Fix leftover stale Kerberos pipeline paths

### DIFF
--- a/eng/pipelines/ci/kerberos/sqlclient-ci-kerberos-pipeline.yml
+++ b/eng/pipelines/ci/kerberos/sqlclient-ci-kerberos-pipeline.yml
@@ -253,7 +253,7 @@ stages:
             displayName: Enable Network DTC Access
 
           # --- Build and test ---
-          - template: /eng/pipelines/kerberos/build-and-test-steps.yml@self
+          - template: /eng/pipelines/ci/kerberos/build-and-test-steps.yml@self
             parameters:
               buildTargets:
                 - BuildNetFx

--- a/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-package-reference-pipeline.yml
@@ -28,7 +28,7 @@ pr:
       - build.proj
       - NuGet.config
     exclude:
-      - eng/pipelines/kerberos/*
+      - eng/pipelines/ci/*
       - eng/pipelines/onebranch/*
 
 # Commit triggers for CI runs on specified branches.

--- a/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
+++ b/eng/pipelines/dotnet-sqlclient-ci-project-reference-pipeline.yml
@@ -28,7 +28,7 @@ pr:
       - build.proj
       - NuGet.config
     exclude:
-      - eng/pipelines/kerberos/*
+      - eng/pipelines/ci/*
       - eng/pipelines/onebranch/*
 
 # Commit triggers for CI runs on specified branches.


### PR DESCRIPTION
Whoops - I missed a few stale paths when moving the Kerberos pipeline.

- [ ] sqlclient-ci-kerberos: [20260724.2](https://sqlclientdrivers.visualstudio.com/ADO.Net/_build/results?buildId=162969&view=results)