### PR TITLE
Fix #1881 | Make the connection factory pruning timer demand-driven

### DIFF
--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -50,11 +50,10 @@ namespace Microsoft.Data.SqlClient
 
         // Guards every state transition of _pruningTimer.
         //
-        // Lock ordering: this lock may be taken while holding "this", a pool group lock, or
-        // either release-list lock, but the reverse is never true. StopPruningTimerIfIdle takes
-        // _pruningTimerLock first and only then peeks at the release lists, and it deliberately
-        // reads _connectionPoolGroups without taking "this" (the dictionary is swapped wholesale,
-        // so reading the reference is safe). That keeps the lock graph acyclic.
+        // Lock ordering: _pruningTimerLock is outermost. StopPruningTimerIfIdle takes it and then
+        // the release-list locks, so neither may be held when arming. It deliberately reads
+        // _connectionPoolGroups without taking "this" (the dictionary is swapped wholesale, so
+        // reading the reference is safe), which keeps the lock graph acyclic.
         private readonly object _pruningTimerLock = new object();
         private bool _pruningTimerEnabled;
         private bool _pruningTimerDisposed;
@@ -302,8 +301,10 @@ namespace Microsoft.Data.SqlClient
                 Debug.Assert(connectionPoolGroup != null, "how did we not create a pool entry?");
                 Debug.Assert(userConnectionOptions != null, "how did we not have user connection options?");
 
-                // A pool group is now registered, so there is something for the pruner to walk.
-                // Arm outside lock(this) to preserve the "this -> _pruningTimerLock" ordering.
+                // Registering a pool group is the only way pruning work enters the factory: pools
+                // and pool groups are only ever queued for release while a group is still
+                // registered, and the timer cannot disarm until every collection is empty. Armed
+                // outside lock(this) to keep _pruningTimerLock outermost.
                 EnsurePruningTimerRunning();
             }
             else if (userConnectionOptions is null)
@@ -345,10 +346,6 @@ namespace Microsoft.Data.SqlClient
                 _poolsToRelease.Add(pool);
             }
 
-            // The work is published above, before the timer lock is taken, so a concurrent
-            // disarm attempt is guaranteed to observe it.
-            EnsurePruningTimerRunning();
-            
             SqlClientDiagnostics.Metrics.EnterInactiveConnectionPool();
             SqlClientDiagnostics.Metrics.ExitActiveConnectionPool();
         }
@@ -362,10 +359,6 @@ namespace Microsoft.Data.SqlClient
             {
                 _poolGroupsToRelease.Add(poolGroup);
             }
-
-            // The work is published above, before the timer lock is taken, so a concurrent
-            // disarm attempt is guaranteed to observe it.
-            EnsurePruningTimerRunning();
 
             SqlClientDiagnostics.Metrics.EnterInactiveConnectionPoolGroup();
             SqlClientDiagnostics.Metrics.ExitActiveConnectionPoolGroup();
@@ -990,14 +983,10 @@ namespace Microsoft.Data.SqlClient
         /// Arms the pruning timer if it is not already running.
         /// </summary>
         /// <remarks>
-        /// Callers must publish their work (add to <see cref="_connectionPoolGroups"/>,
-        /// <see cref="_poolsToRelease"/> or <see cref="_poolGroupsToRelease"/>) *before* calling
-        /// this method, and must not hold that collection's lock while calling it. That ordering
-        /// is what makes the arm/disarm handshake safe: <see cref="StopPruningTimerIfIdle"/>
-        /// re-reads all three collections while holding <see cref="_pruningTimerLock"/>, so it can
-        /// never disarm on behalf of work that a producer has already published. If it does win
-        /// the race and disarm first, the producer then observes
-        /// <see cref="_pruningTimerEnabled"/> as false and re-arms.
+        /// The caller must publish the new pool group before calling this, and must not hold
+        /// lock(this). <see cref="StopPruningTimerIfIdle"/> re-reads all three collections under
+        /// <see cref="_pruningTimerLock"/>, so it can never disarm on behalf of work that has
+        /// already been published.
         /// </remarks>
         private void EnsurePruningTimerRunning()
         {

--- a/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlConnectionFactory.cs
@@ -45,6 +45,20 @@ namespace Microsoft.Data.SqlClient
         private readonly List<DbConnectionPoolGroup> _poolGroupsToRelease;
         private readonly List<IDbConnectionPool> _poolsToRelease;
         private readonly Timer _pruningTimer;
+        private readonly TimeSpan _pruningDueTime;
+        private readonly TimeSpan _pruningPeriod;
+
+        // Guards every state transition of _pruningTimer.
+        //
+        // Lock ordering: this lock may be taken while holding "this", a pool group lock, or
+        // either release-list lock, but the reverse is never true. StopPruningTimerIfIdle takes
+        // _pruningTimerLock first and only then peeks at the release lists, and it deliberately
+        // reads _connectionPoolGroups without taking "this" (the dictionary is swapped wholesale,
+        // so reading the reference is safe). That keeps the lock graph acyclic.
+        private readonly object _pruningTimerLock = new object();
+        private bool _pruningTimerEnabled;
+        private bool _pruningTimerDisposed;
+
         private Dictionary<ConnectionPoolKey, DbConnectionPoolGroup> _connectionPoolGroups;
 
         #endregion
@@ -52,18 +66,36 @@ namespace Microsoft.Data.SqlClient
         #region Constructors
         
         protected SqlConnectionFactory()
+            : this(PruningDueTime, PruningPeriod)
         {
+        }
+
+        /// <summary>
+        /// Constructs a factory with a custom pruning cadence. Intended for tests, which would
+        /// otherwise have to wait minutes for the default schedule to produce an observable
+        /// result.
+        /// </summary>
+        protected SqlConnectionFactory(TimeSpan pruningDueTime, TimeSpan pruningPeriod)
+        {
+            _pruningDueTime = pruningDueTime;
+            _pruningPeriod = pruningPeriod;
             _connectionPoolGroups = new Dictionary<ConnectionPoolKey, DbConnectionPoolGroup>();
             _poolsToRelease = new List<IDbConnectionPool>();
             _poolGroupsToRelease = new List<DbConnectionPoolGroup>();
+
+            // The timer is created disarmed. It is armed on demand whenever there is something to
+            // prune and disarmed again by the callback once everything has drained, so that an
+            // idle process is not woken every pruning period for the life of the process.
             _pruningTimer = ADP.UnsafeCreateTimer(
                 PruneConnectionPoolGroups,
                 state: null,
-                PruningDueTime,
-                PruningPeriod);
+                Timeout.InfiniteTimeSpan,
+                Timeout.InfiniteTimeSpan);
             
             #if NET
             SubscribeToAssemblyLoadContextUnload();
+            #else
+            SubscribeToAppDomainUnload();
             #endif
         }
         
@@ -74,6 +106,20 @@ namespace Microsoft.Data.SqlClient
         internal static SqlConnectionFactory Instance { get; } = new SqlConnectionFactory(); 
         
         internal int ObjectId { get; } = Interlocked.Increment(ref s_objectTypeCount);
+
+        /// <summary>
+        /// Whether the pruning timer is currently armed. Test hook.
+        /// </summary>
+        internal bool IsPruningTimerActive
+        {
+            get
+            {
+                lock (_pruningTimerLock)
+                {
+                    return _pruningTimerEnabled;
+                }
+            }
+        }
         
         #endregion
 
@@ -255,6 +301,10 @@ namespace Microsoft.Data.SqlClient
                 
                 Debug.Assert(connectionPoolGroup != null, "how did we not create a pool entry?");
                 Debug.Assert(userConnectionOptions != null, "how did we not have user connection options?");
+
+                // A pool group is now registered, so there is something for the pruner to walk.
+                // Arm outside lock(this) to preserve the "this -> _pruningTimerLock" ordering.
+                EnsurePruningTimerRunning();
             }
             else if (userConnectionOptions is null)
             {
@@ -294,6 +344,10 @@ namespace Microsoft.Data.SqlClient
                 }
                 _poolsToRelease.Add(pool);
             }
+
+            // The work is published above, before the timer lock is taken, so a concurrent
+            // disarm attempt is guaranteed to observe it.
+            EnsurePruningTimerRunning();
             
             SqlClientDiagnostics.Metrics.EnterInactiveConnectionPool();
             SqlClientDiagnostics.Metrics.ExitActiveConnectionPool();
@@ -308,6 +362,10 @@ namespace Microsoft.Data.SqlClient
             {
                 _poolGroupsToRelease.Add(poolGroup);
             }
+
+            // The work is published above, before the timer lock is taken, so a concurrent
+            // disarm attempt is guaranteed to observe it.
+            EnsurePruningTimerRunning();
 
             SqlClientDiagnostics.Metrics.EnterInactiveConnectionPoolGroup();
             SqlClientDiagnostics.Metrics.ExitActiveConnectionPoolGroup();
@@ -922,7 +980,92 @@ namespace Microsoft.Data.SqlClient
                 }
                 _connectionPoolGroups = newConnectionPoolGroups;
             }
+
+            // Everything above may have drained the last of the pending work. If so, park the
+            // timer rather than waking the process every pruning period forever.
+            StopPruningTimerIfIdle();
         }
+
+        /// <summary>
+        /// Arms the pruning timer if it is not already running.
+        /// </summary>
+        /// <remarks>
+        /// Callers must publish their work (add to <see cref="_connectionPoolGroups"/>,
+        /// <see cref="_poolsToRelease"/> or <see cref="_poolGroupsToRelease"/>) *before* calling
+        /// this method, and must not hold that collection's lock while calling it. That ordering
+        /// is what makes the arm/disarm handshake safe: <see cref="StopPruningTimerIfIdle"/>
+        /// re-reads all three collections while holding <see cref="_pruningTimerLock"/>, so it can
+        /// never disarm on behalf of work that a producer has already published. If it does win
+        /// the race and disarm first, the producer then observes
+        /// <see cref="_pruningTimerEnabled"/> as false and re-arms.
+        /// </remarks>
+        private void EnsurePruningTimerRunning()
+        {
+            lock (_pruningTimerLock)
+            {
+                if (_pruningTimerEnabled || _pruningTimerDisposed)
+                {
+                    return;
+                }
+
+                _pruningTimerEnabled = true;
+                _pruningTimer.Change(_pruningDueTime, _pruningPeriod);
+
+                SqlClientEventSource.Log.TryAdvancedTraceEvent("<prov.SqlConnectionFactory.EnsurePruningTimerRunning|RES|INFO|CPOOL> {0}, pruning timer started", ObjectId);
+            }
+        }
+
+        /// <summary>
+        /// Disarms the pruning timer if there is nothing left to prune. Called at the tail of
+        /// <see cref="PruneConnectionPoolGroups"/>.
+        /// </summary>
+        private void StopPruningTimerIfIdle()
+        {
+            lock (_pruningTimerLock)
+            {
+                if (!_pruningTimerEnabled || _pruningTimerDisposed || HasPruningWork())
+                {
+                    return;
+                }
+
+                _pruningTimerEnabled = false;
+                _pruningTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+
+                SqlClientEventSource.Log.TryAdvancedTraceEvent("<prov.SqlConnectionFactory.StopPruningTimerIfIdle|RES|INFO|CPOOL> {0}, pruning timer stopped, nothing left to prune", ObjectId);
+            }
+        }
+
+        /// <summary>
+        /// Whether any of the three collections walked by <see cref="PruneConnectionPoolGroups"/>
+        /// still hold work. Must be called while holding <see cref="_pruningTimerLock"/>.
+        /// </summary>
+        private bool HasPruningWork()
+        {
+            // _connectionPoolGroups is replaced wholesale rather than mutated in place, so reading
+            // the reference without lock(this) is safe and avoids a lock-ordering inversion.
+            if (_connectionPoolGroups.Count != 0)
+            {
+                return true;
+            }
+
+            lock (_poolsToRelease)
+            {
+                if (_poolsToRelease.Count != 0)
+                {
+                    return true;
+                }
+            }
+
+            lock (_poolGroupsToRelease)
+            {
+                return _poolGroupsToRelease.Count != 0;
+            }
+        }
+
+        /// <summary>
+        /// Runs a single pruning pass synchronously on the calling thread. Test hook.
+        /// </summary>
+        internal void RunPruningPass() => PruneConnectionPoolGroups(state: null);
         
         private void TryGetConnectionCompletedContinuation(Task<DbConnectionInternal> task, object state)
         {
@@ -957,12 +1100,20 @@ namespace Microsoft.Data.SqlClient
             }
         }
         
-        #if NET
+        /// <summary>
+        /// Disposes the pruning timer and drains the pools when the hosting assembly load context
+        /// (.NET) or app domain (.NET Framework) is going away.
+        /// </summary>
         private void Unload(object sender, EventArgs e)
         {
             try
             {
-                _pruningTimer.Dispose();
+                lock (_pruningTimerLock)
+                {
+                    _pruningTimerDisposed = true;
+                    _pruningTimerEnabled = false;
+                    _pruningTimer.Dispose();
+                }
             }
             finally
             {
@@ -970,6 +1121,7 @@ namespace Microsoft.Data.SqlClient
             }
         }
 
+        #if NET
         private void SqlConnectionFactoryAssemblyLoadContext_Unloading(AssemblyLoadContext obj)
         {
             Unload(obj, EventArgs.Empty);
@@ -979,6 +1131,12 @@ namespace Microsoft.Data.SqlClient
         {
             AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()).Unloading += 
                 SqlConnectionFactoryAssemblyLoadContext_Unloading;
+        }
+        #else
+        private void SubscribeToAppDomainUnload()
+        {
+            AppDomain.CurrentDomain.DomainUnload += Unload;
+            AppDomain.CurrentDomain.ProcessExit += Unload;
         }
         #endif
         

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SqlConnectionFactoryPruningTimerTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SqlConnectionFactoryPruningTimerTest.cs
@@ -123,14 +123,16 @@ namespace Microsoft.Data.SqlClient.UnitTests
         }
 
         /// <summary>
-        /// The timer must stay armed for every pass of the drain, so pruning cannot stall
-        /// half-drained.
+        /// The regression test for #1881: the timer must stay armed for every pass of the drain so
+        /// pruning cannot stall half-drained, then disarm once there is nothing left to prune
+        /// instead of firing forever with nothing to do.
         /// </summary>
         [Fact]
-        public void PruningTimer_StaysArmed_WhilePoolGroupIsStillDraining()
+        public void PruningTimer_StaysArmedUntilAllWorkDrains()
         {
             var factory = new TestSqlConnectionFactory();
             AddPoolGroup(factory, "Data Source=localhost;");
+            Assert.True(factory.IsPruningTimerActive);
 
             for (int pass = 1; pass < ExpectedDrainPasses; pass++)
             {
@@ -147,23 +149,6 @@ namespace Microsoft.Data.SqlClient.UnitTests
         }
 
         /// <summary>
-        /// The regression test for #1881: once everything has drained, the timer must disarm
-        /// instead of firing forever with nothing to do.
-        /// </summary>
-        [Fact]
-        public void PruningTimer_IsDisarmed_AfterAllWorkDrains()
-        {
-            var factory = new TestSqlConnectionFactory();
-            AddPoolGroup(factory, "Data Source=localhost;");
-            Assert.True(factory.IsPruningTimerActive);
-
-            int passes = DrainPruningWork(factory);
-
-            Assert.False(factory.IsPruningTimerActive);
-            Assert.Equal(ExpectedDrainPasses, passes);
-        }
-
-        /// <summary>
         /// Disarming must not be a one-way door: new connection activity has to bring pruning
         /// back, otherwise the fix would simply have disabled pruning.
         /// </summary>
@@ -172,33 +157,13 @@ namespace Microsoft.Data.SqlClient.UnitTests
         {
             var factory = new TestSqlConnectionFactory();
             AddPoolGroup(factory, "Data Source=localhost;");
-            DrainPruningWork(factory);
+            int passes = DrainPruningWork(factory);
             Assert.False(factory.IsPruningTimerActive);
+            Assert.Equal(ExpectedDrainPasses, passes);
 
             AddPoolGroup(factory, "Data Source=otherhost;");
 
             Assert.True(factory.IsPruningTimerActive);
-        }
-
-        /// <summary>
-        /// Pool groups queued for release are drained by the same timer, so queueing one must arm
-        /// it. This is the path <see cref="SqlConnection.ClearAllPools"/> ultimately drives.
-        /// </summary>
-        [Fact]
-        public void PruningTimer_IsArmed_WhenPoolGroupIsQueuedForRelease()
-        {
-            var factory = new TestSqlConnectionFactory();
-            DbConnectionPoolGroup poolGroup = AddPoolGroup(factory, "Data Source=localhost;");
-            DrainPruningWork(factory);
-            Assert.False(factory.IsPruningTimerActive);
-
-            factory.QueuePoolGroupForRelease(poolGroup);
-
-            Assert.True(factory.IsPruningTimerActive);
-
-            // ...and it must be able to quiesce again once that queue drains.
-            DrainPruningWork(factory);
-            Assert.False(factory.IsPruningTimerActive);
         }
     }
 }

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SqlConnectionFactoryPruningTimerTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SqlConnectionFactoryPruningTimerTest.cs
@@ -23,9 +23,19 @@ namespace Microsoft.Data.SqlClient.UnitTests
     public class SqlConnectionFactoryPruningTimerTest
     {
         /// <summary>
-        /// Upper bound on the number of pruning passes a single pool group needs to drain
-        /// (Active -> Idle -> Disabled/queued -> released). Generous so the tests fail with a
-        /// useful assertion rather than hanging.
+        /// Passes needed to drain a pool group that never had a pool created in it (no test here
+        /// opens a connection): 1) Active -> Idle, 2) Idle -> Disabled, which returns true in the
+        /// same pass and queues the group for release, 3) released from _poolGroupsToRelease.
+        ///
+        /// Three rather than four because Disabled and queued happen together, and the release
+        /// loop runs before the pool-group loop within a pass. Deterministic: tests drive
+        /// <see cref="SqlConnectionFactory.RunPruningPass"/> synchronously.
+        /// </summary>
+        private const int ExpectedDrainPasses = 3;
+
+        /// <summary>
+        /// Hang guard, not an expectation: a regression that leaves the timer armed should fail an
+        /// assertion rather than loop forever.
         /// </summary>
         private const int MaxPruningPasses = 10;
 
@@ -113,8 +123,8 @@ namespace Microsoft.Data.SqlClient.UnitTests
         }
 
         /// <summary>
-        /// A pool group takes several passes to walk Active -> Idle -> Disabled -> released. The
-        /// timer must stay armed for all of them.
+        /// The timer must stay armed for every pass of the drain, so pruning cannot stall
+        /// half-drained.
         /// </summary>
         [Fact]
         public void PruningTimer_StaysArmed_WhilePoolGroupIsStillDraining()
@@ -122,10 +132,18 @@ namespace Microsoft.Data.SqlClient.UnitTests
             var factory = new TestSqlConnectionFactory();
             AddPoolGroup(factory, "Data Source=localhost;");
 
-            // First pass only moves the group from Active to Idle; it is still tracked.
+            for (int pass = 1; pass < ExpectedDrainPasses; pass++)
+            {
+                factory.RunPruningPass();
+
+                Assert.True(
+                    factory.IsPruningTimerActive,
+                    $"Timer disarmed after pass {pass}, but the pool group had not drained yet.");
+            }
+
             factory.RunPruningPass();
 
-            Assert.True(factory.IsPruningTimerActive);
+            Assert.False(factory.IsPruningTimerActive);
         }
 
         /// <summary>
@@ -142,7 +160,7 @@ namespace Microsoft.Data.SqlClient.UnitTests
             int passes = DrainPruningWork(factory);
 
             Assert.False(factory.IsPruningTimerActive);
-            Assert.InRange(passes, 1, MaxPruningPasses);
+            Assert.Equal(ExpectedDrainPasses, passes);
         }
 
         /// <summary>

--- a/src/Microsoft.Data.SqlClient/tests/UnitTests/SqlConnectionFactoryPruningTimerTest.cs
+++ b/src/Microsoft.Data.SqlClient/tests/UnitTests/SqlConnectionFactoryPruningTimerTest.cs
@@ -1,0 +1,186 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Data.Common;
+using Microsoft.Data.Common.ConnectionString;
+using Microsoft.Data.ProviderBase;
+using Microsoft.Data.SqlClient.ConnectionPool;
+using Xunit;
+
+namespace Microsoft.Data.SqlClient.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the demand-driven pruning timer in <see cref="SqlConnectionFactory"/>.
+    ///
+    /// The factory is a process-wide singleton, so before
+    /// https://github.com/dotnet/SqlClient/issues/1881 its pruning timer was armed in the
+    /// constructor and never stopped, waking the process every 30 seconds for the lifetime of the
+    /// process even when there was nothing left to prune. These tests pin the arm/disarm state
+    /// machine that replaced it.
+    /// </summary>
+    public class SqlConnectionFactoryPruningTimerTest
+    {
+        /// <summary>
+        /// Upper bound on the number of pruning passes a single pool group needs to drain
+        /// (Active -> Idle -> Disabled/queued -> released). Generous so the tests fail with a
+        /// useful assertion rather than hanging.
+        /// </summary>
+        private const int MaxPruningPasses = 10;
+
+        #region Helpers
+
+        /// <summary>
+        /// A factory whose timer never actually fires on its own, so tests drive pruning
+        /// deterministically through <see cref="SqlConnectionFactory.RunPruningPass"/> instead of
+        /// racing a background thread.
+        /// </summary>
+        private sealed class TestSqlConnectionFactory : SqlConnectionFactory
+        {
+            internal TestSqlConnectionFactory()
+                : base(TimeSpan.FromDays(1), TimeSpan.FromDays(1))
+            {
+            }
+
+            protected override DbConnectionInternal CreateConnection(
+                SqlConnectionOptions options,
+                ConnectionPoolKey poolKey,
+                DbConnectionPoolGroupProviderInfo poolGroupProviderInfo,
+                IDbConnectionPool pool,
+                DbConnection owningConnection,
+                TimeoutTimer timeout)
+                => throw new NotSupportedException("These tests never open a connection.");
+        }
+
+        private static DbConnectionPoolGroup AddPoolGroup(
+            SqlConnectionFactory factory,
+            string connectionString)
+        {
+            SqlConnectionOptions userOptions = null!;
+            var key = new ConnectionPoolKey(
+                connectionString,
+                credential: null,
+                accessToken: null,
+                accessTokenCallback: null,
+                sspiContextProvider: null);
+
+            return factory.GetConnectionPoolGroup(key, poolOptions: null, ref userOptions);
+        }
+
+        /// <summary>
+        /// Runs pruning passes until the timer disarms itself, or until
+        /// <see cref="MaxPruningPasses"/> is exhausted.
+        /// </summary>
+        /// <returns>The number of passes executed.</returns>
+        private static int DrainPruningWork(SqlConnectionFactory factory)
+        {
+            int passes = 0;
+            while (factory.IsPruningTimerActive && passes < MaxPruningPasses)
+            {
+                factory.RunPruningPass();
+                passes++;
+            }
+
+            return passes;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The timer must start disarmed. A process that creates the factory but never opens a
+        /// connection should not be woken at all.
+        /// </summary>
+        [Fact]
+        public void PruningTimer_IsDisarmed_WhenFactoryIsConstructed()
+        {
+            var factory = new TestSqlConnectionFactory();
+
+            Assert.False(factory.IsPruningTimerActive);
+        }
+
+        /// <summary>
+        /// Registering a pool group creates work for the pruner, so the timer must arm.
+        /// </summary>
+        [Fact]
+        public void PruningTimer_IsArmed_WhenPoolGroupIsRegistered()
+        {
+            var factory = new TestSqlConnectionFactory();
+
+            Assert.NotNull(AddPoolGroup(factory, "Data Source=localhost;"));
+
+            Assert.True(factory.IsPruningTimerActive);
+        }
+
+        /// <summary>
+        /// A pool group takes several passes to walk Active -> Idle -> Disabled -> released. The
+        /// timer must stay armed for all of them.
+        /// </summary>
+        [Fact]
+        public void PruningTimer_StaysArmed_WhilePoolGroupIsStillDraining()
+        {
+            var factory = new TestSqlConnectionFactory();
+            AddPoolGroup(factory, "Data Source=localhost;");
+
+            // First pass only moves the group from Active to Idle; it is still tracked.
+            factory.RunPruningPass();
+
+            Assert.True(factory.IsPruningTimerActive);
+        }
+
+        /// <summary>
+        /// The regression test for #1881: once everything has drained, the timer must disarm
+        /// instead of firing forever with nothing to do.
+        /// </summary>
+        [Fact]
+        public void PruningTimer_IsDisarmed_AfterAllWorkDrains()
+        {
+            var factory = new TestSqlConnectionFactory();
+            AddPoolGroup(factory, "Data Source=localhost;");
+            Assert.True(factory.IsPruningTimerActive);
+
+            int passes = DrainPruningWork(factory);
+
+            Assert.False(factory.IsPruningTimerActive);
+            Assert.InRange(passes, 1, MaxPruningPasses);
+        }
+
+        /// <summary>
+        /// Disarming must not be a one-way door: new connection activity has to bring pruning
+        /// back, otherwise the fix would simply have disabled pruning.
+        /// </summary>
+        [Fact]
+        public void PruningTimer_IsRearmed_WhenNewPoolGroupIsRegisteredAfterDraining()
+        {
+            var factory = new TestSqlConnectionFactory();
+            AddPoolGroup(factory, "Data Source=localhost;");
+            DrainPruningWork(factory);
+            Assert.False(factory.IsPruningTimerActive);
+
+            AddPoolGroup(factory, "Data Source=otherhost;");
+
+            Assert.True(factory.IsPruningTimerActive);
+        }
+
+        /// <summary>
+        /// Pool groups queued for release are drained by the same timer, so queueing one must arm
+        /// it. This is the path <see cref="SqlConnection.ClearAllPools"/> ultimately drives.
+        /// </summary>
+        [Fact]
+        public void PruningTimer_IsArmed_WhenPoolGroupIsQueuedForRelease()
+        {
+            var factory = new TestSqlConnectionFactory();
+            DbConnectionPoolGroup poolGroup = AddPoolGroup(factory, "Data Source=localhost;");
+            DrainPruningWork(factory);
+            Assert.False(factory.IsPruningTimerActive);
+
+            factory.QueuePoolGroupForRelease(poolGroup);
+
+            Assert.True(factory.IsPruningTimerActive);
+
+            // ...and it must be able to quiesce again once that queue drains.
+            DrainPruningWork(factory);
+            Assert.False(factory.IsPruningTimerActive);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1881

`SqlConnectionFactory` is a process-wide singleton whose constructor unconditionally started a repeating timer (4 min due time, 30 s period). `PruneConnectionPoolGroups` no-ops when `_poolsToRelease`, `_poolGroupsToRelease` and `_connectionPoolGroups` are all empty, but nothing ever checked for that — so the process was woken every 30 s forever, even after every `SqlConnection` was disposed and `ClearAllPools()` was called, and even with `Pooling=False`.

The only `_pruningTimer.Dispose()` lived in `Unload()`, wrapped in `#if NET` and hooked solely to `AssemblyLoadContext.Unloading`, so it never ran in a normal app on .NET and had no counterpart at all on .NET Framework.

## Change

The timer is now created disarmed and armed only on the idle → active transition, mirroring the arm/disarm pattern already used by `PoolPruner`:

- **Armed** in `GetConnectionPoolGroup`. Registering a pool group is the only way pruning work enters the factory — pools and pool groups are queued for release only while a group is still registered, and a disabled group can never re-acquire a pool.
- **Disarmed** at the tail of `PruneConnectionPoolGroups` once all three collections drain.
- Coordinated through a dedicated `_pruningTimerLock` (outermost; the disarm path re-reads all three counts while holding it) with a `_pruningTimerDisposed` guard, so an unload racing a new connection cannot throw `ObjectDisposedException` on a background thread.

To make the state machine testable without waiting minutes, this adds a `protected` constructor overload taking the due time and period, plus `internal IsPruningTimerActive` / `RunPruningPass()`.

## Worth calling out in review

1. **Added the missing .NET Framework unload hook** (`AppDomain.DomainUnload` + `ProcessExit`), matching the existing pattern in `SqlDiagnosticListener` and `SqlClientMetrics`. Without it `_pruningTimerDisposed` is never assigned on `net462` (CS0649 under warnings-as-errors), and the timer was never disposed there at all. Slightly beyond the minimal fix, but it closes the disposal gap named in the issue title.
2. **Behaviour change:** the 4-minute due time now applies per idle → active transition rather than once per process. Equivalent for any continuously-active application, strictly better when idle.
3. An eager drain on `ClearAllPools()` is intentionally **not** included here.

No public API, connection string keyword or AppContext switch changes.

## Validation

Repro: open/close a connection, call `ClearAllPools()`, accelerate the timer by reflection, then sample tick counts.

| | ticks after drain | `_pruningTimerEnabled` | re-arm on new connection |
|---|---|---|---|
| before — `Pooling=True` | +15 per 3 s, indefinitely | — | — |
| before — `Pooling=False` | +15 per 3 s, indefinitely | — | — |
| after — `Pooling=True` | **0** | `False` | PASS |
| after — `Pooling=False` | **0** | `False` | PASS |

The pooled run drains `ReleasePool=24` / `ReleasePoolGroup=1` before quiescing, so the release paths are exercised.

Adds 4 unit tests covering the arm/disarm state machine. Full `UnitTests` suite on net9.0 shows the same pre-existing failures with and without the change (native SNI won't initialize in this environment). Builds clean on net8.0, net9.0 and net462.

- [x] Tests added or updated
- [x] Public API changes documented — n/a, no public API changes
- [x] Verified against customer repro
- [x] Ensure no breaking changes introduced

### Suggested release notes

> - Fixed the `SqlConnectionFactory` pruning timer firing every 30 seconds for the lifetime of the process after all connections were disposed, and even when `Pooling=False`. It is now started on demand and stopped once all pruning work drains. ([#4479](https://github.com/dotnet/SqlClient/pull/4479))
> - Fixed the `SqlConnectionFactory` pruning timer not being disposed at shutdown on .NET Framework. ([#4479](https://github.com/dotnet/SqlClient/pull/4479))
